### PR TITLE
fix(dedup): match cross-source records across unbounded clock drift

### DIFF
--- a/src/Core/Nocturne.Core.Contracts/Infrastructure/IDeduplicationService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Infrastructure/IDeduplicationService.cs
@@ -15,12 +15,18 @@ public interface IDeduplicationService
     /// <param name="recordType">The type of record being deduplicated</param>
     /// <param name="mills">The timestamp of the record in milliseconds</param>
     /// <param name="criteria">Matching criteria for finding duplicates</param>
+    /// <param name="dataSource">
+    /// The data source identifier of the record being matched. Required for the wide matching
+    /// window, which only merges records from different sources; when omitted the record is
+    /// matched on the tight window alone.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The canonical ID for the matching group (existing or newly created)</returns>
     Task<Guid> GetOrCreateCanonicalIdAsync(
         RecordType recordType,
         long mills,
         MatchCriteria criteria,
+        string? dataSource = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/DeduplicationModels.cs
+++ b/src/Core/Nocturne.Core.Models/DeduplicationModels.cs
@@ -99,7 +99,14 @@ public record MatchCriteria
 /// <summary>
 /// Input for batch deduplication — one per record being ingested.
 /// </summary>
-public record DeduplicationInput(Guid RecordId, long Mills, string DataSource, MatchCriteria Criteria);
+public record DeduplicationInput(Guid RecordId, long Mills, string DataSource, MatchCriteria Criteria)
+{
+    /// <summary>
+    /// Substituted for a record that carries no data source. It names no connector, so it cannot
+    /// establish that two records came from different ones and is ineligible for wide matching.
+    /// </summary>
+    public const string UnknownDataSource = "unknown";
+}
 
 /// <summary>
 /// Stats returned from a batch deduplication call.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
@@ -255,7 +255,7 @@ public class StateSpanRepository : IStateSpanRepository
                     new(
                         RecordId: entity.Id,
                         Mills: new DateTimeOffset(entity.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                        DataSource: entity.Source ?? "unknown",
+                        DataSource: entity.Source ?? DeduplicationInput.UnknownDataSource,
                         Criteria: new MatchCriteria
                         {
                             Category = Enum.Parse<StateSpanCategory>(entity.Category, true),

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -152,7 +152,7 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
             var dedupInputs = inserted.Select(e => new DeduplicationInput(
                 RecordId: e.Id,
                 Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
+                DataSource: e.DataSource ?? DeduplicationInput.UnknownDataSource,
                 Criteria: new MatchCriteria { GlucoseValue = e.Glucose, GlucoseTolerance = 1.0 }
             )).ToList();
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -140,7 +140,7 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
             var dedupInputs = inserted.Select(e => new DeduplicationInput(
                 RecordId: e.Id,
                 Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
+                DataSource: e.DataSource ?? DeduplicationInput.UnknownDataSource,
                 Criteria: new MatchCriteria { Carbs = e.CarbInput ?? 0, CarbsTolerance = 1.0 }
             )).ToList();
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -309,7 +309,7 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
             var dedupInputs = inserted.Select(e => new DeduplicationInput(
                 RecordId: e.Id,
                 Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
+                DataSource: e.DataSource ?? DeduplicationInput.UnknownDataSource,
                 Criteria: new MatchCriteria { Insulin = e.Insulin, InsulinTolerance = 0.05 }
             )).ToList();
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -308,7 +308,7 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
             var dedupInputs = inserted.Select(e => new DeduplicationInput(
                 RecordId: e.Id,
                 Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
+                DataSource: e.DataSource ?? DeduplicationInput.UnknownDataSource,
                 Criteria: new MatchCriteria { Carbs = e.Carbs, CarbsTolerance = 1.0 }
             )).ToList();
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -171,7 +171,7 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
             var dedupInputs = inserted.Select(e => new DeduplicationInput(
                 RecordId: e.Id,
                 Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
+                DataSource: e.DataSource ?? DeduplicationInput.UnknownDataSource,
                 Criteria: new MatchCriteria { EventType = e.EventType }
             )).ToList();
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -166,7 +166,7 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
             var dedupInputs = inserted.Select(e => new DeduplicationInput(
                 RecordId: e.Id,
                 Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
+                DataSource: e.DataSource ?? DeduplicationInput.UnknownDataSource,
                 Criteria: new MatchCriteria()
             )).ToList();
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -428,7 +428,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
             var dedupInputs = inserted.Select(e => new DeduplicationInput(
                 RecordId: e.Id,
                 Mills: new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                DataSource: e.DataSource ?? "unknown",
+                DataSource: e.DataSource ?? DeduplicationInput.UnknownDataSource,
                 Criteria: new MatchCriteria { GlucoseValue = e.Mgdl, GlucoseTolerance = 1.0 }
             )).ToList();
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -382,8 +382,13 @@ public class TempBasalRepository : ITempBasalRepository
                 var dedupInputs = entities.Select(e => new DeduplicationInput(
                     RecordId: e.Id,
                     Mills: new DateTimeOffset(e.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    DataSource: e.DataSource ?? "unknown",
-                    Criteria: new MatchCriteria { Rate = e.Rate, RateTolerance = 0.05 }
+                    DataSource: e.DataSource ?? DeduplicationInput.UnknownDataSource,
+                    Criteria: new MatchCriteria
+                    {
+                        Rate = e.Rate,
+                        RateTolerance = 0.05,
+                        Duration = e.EndTimestamp.HasValue ? e.EndTimestamp.Value - e.StartTimestamp : null
+                    }
                 )).ToList();
 
                 await _deduplicationService.DeduplicateBatchAsync(RecordType.TempBasal, dedupInputs, ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -25,6 +26,46 @@ public class DeduplicationService : IDeduplicationService
     private static readonly long MatchingWindowMillis = (long)MatchingWindow.TotalMilliseconds;
 
     /// <summary>
+    /// Second-chance window used only when <see cref="MatchingWindow"/> found no match. Two
+    /// connectors reporting the same pump can disagree by minutes when one carries the raw pump
+    /// clock and the other a corrected one, and that offset drifts without bound. The wide path
+    /// buys the extra reach by dropping the tight path's value tolerances for exact equality and
+    /// requiring a single candidate group that holds no record of the incoming record's own
+    /// source, so it can only ever collapse a cross-source pair.
+    /// </summary>
+    private static readonly TimeSpan WideMatchingWindow = TimeSpan.FromMinutes(10);
+    private static readonly long WideMatchingWindowMillis = (long)WideMatchingWindow.TotalMilliseconds;
+
+    /// <summary>
+    /// Matched offset above which a cross-source match is logged at Warning rather than Debug —
+    /// 60% of <see cref="WideMatchingWindow"/>, so drift is visible while matching still works.
+    /// </summary>
+    private static readonly long CrossSourceOffsetWarningMillis =
+        (long)(WideMatchingWindow.TotalMilliseconds * 0.6);
+
+    /// <summary>
+    /// Value equality epsilon for the wide path, which admits no tolerance: a tolerance-based
+    /// match minutes away from the record risks hiding a distinct real dose.
+    /// </summary>
+    private const double ExactValueEpsilon = 1e-6;
+
+    /// <summary>
+    /// Record types eligible for <see cref="WideMatchingWindow"/>. Continuous streams
+    /// (<see cref="RecordType.SensorGlucose"/>), free-text records (<see cref="RecordType.Note"/>)
+    /// and interval records (<see cref="RecordType.StateSpan"/>) are excluded: repeating the same
+    /// value inside ten minutes is normal for them, so a wide match would merge distinct events.
+    /// </summary>
+    private static readonly HashSet<RecordType> WideMatchableTypes =
+    [
+        RecordType.Bolus,
+        RecordType.CarbIntake,
+        RecordType.DeviceEvent,
+        RecordType.BGCheck,
+        RecordType.TempBasal,
+        RecordType.BolusCalculation
+    ];
+
+    /// <summary>
     /// Maximum number of records processed per <see cref="DeduplicateBatchAsync"/> matching-window
     /// query. A connector backfill can hand the dedup pass thousands of records spanning months;
     /// sorting by event time and slicing into chunks of this size keeps each window query's time
@@ -45,6 +86,57 @@ public class DeduplicationService : IDeduplicationService
     /// when returned from <see cref="LoadRecordInfoAsync"/>.
     /// </summary>
     internal sealed record RecordInfo(MatchCriteria Criteria, bool IsDeleted);
+
+    /// <summary>
+    /// One union-find root's span across every link of every canonical group beneath it, used by
+    /// the reconcile wide pass in place of the root's primary timestamp, together with the criteria
+    /// of every canonical beneath it. <see cref="PrimaryTimestamp"/> is the root's earliest primary
+    /// and is used only for the logged offset.
+    /// </summary>
+    private sealed class WideGroupExtent(Guid root, long primaryTimestamp)
+    {
+        public Guid Root { get; } = root;
+        public long PrimaryTimestamp { get; } = primaryTimestamp;
+        public long Min { get; private set; } = long.MaxValue;
+        public long Max { get; private set; } = long.MinValue;
+        public List<MatchCriteria> Criteria { get; } = [];
+
+        public void Absorb(long min, long max)
+        {
+            Min = Math.Min(Min, min);
+            Max = Math.Max(Max, max);
+        }
+
+        public void AddCriteria(MatchCriteria criteria) => Criteria.Add(criteria);
+    }
+
+    /// <summary>
+    /// True when any canonical beneath one root exactly matches any canonical beneath the other.
+    /// A root that the tight pass built from several canonicals carries each of their values, and
+    /// the insert path compares an incoming record against every link it can see — so comparing
+    /// every pair is what agrees with it. Matching on one representative instead would both hide
+    /// a root that should have made a neighbouring pair ambiguous and miss a merge that a matching
+    /// value one canonical deeper justifies.
+    /// </summary>
+    private static bool AnyCriteriaMatch(RecordType recordType, WideGroupExtent a, WideGroupExtent b)
+    {
+        foreach (var criteriaA in a.Criteria)
+        {
+            foreach (var criteriaB in b.Criteria)
+            {
+                if (CriteriaMatch(recordType, criteriaA, criteriaB, exact: true))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Number of wide reconcile merges logged individually before the pass switches to a single
+    /// summary line. A deploy-day full job over a year of drift heals tens of thousands of pairs.
+    /// </summary>
+    private const int WideMergeLogLimit = 20;
 
     private static readonly ConcurrentDictionary<Guid, DeduplicationJobStatus> _runningJobs = new();
     private static readonly ConcurrentDictionary<Guid, CancellationTokenSource> _jobCancellations = new();
@@ -86,6 +178,7 @@ public class DeduplicationService : IDeduplicationService
         RecordType recordType,
         long mills,
         MatchCriteria criteria,
+        string? dataSource = null,
         CancellationToken cancellationToken = default)
     {
         var recordTypeStr = recordType.ToString().ToLowerInvariant();
@@ -98,109 +191,295 @@ public class DeduplicationService : IDeduplicationService
             .Where(lr => lr.SourceTimestamp >= windowStart && lr.SourceTimestamp <= windowEnd)
             .ToListAsync(cancellationToken);
 
-        if (potentialMatches.Count == 0)
-        {
-            // No matches found, create a new canonical ID
-            return Guid.CreateVersion7();
-        }
+        Guid? matched = null;
 
         // Each typed branch scans the candidate canonical groups for a value-level match within
         // the time window; the time-window membership alone is enough for notes.
-        if (recordType == RecordType.StateSpan && criteria.Category.HasValue)
+        if (potentialMatches.Count == 0)
+        {
+            // Nothing in the tight window; the wide path below is the only remaining chance.
+        }
+        else if (recordType == RecordType.StateSpan && criteria.Category.HasValue)
         {
             var categoryStr = criteria.Category.Value.ToString();
-            var match = await FindMatchingCanonicalIdAsync(
+            matched = await FindMatchingCanonicalIdAsync(
                 potentialMatches,
                 ids => _context.StateSpans.Where(s => ids.Contains(s.Id)),
                 s => string.Equals(s.Category, categoryStr, StringComparison.OrdinalIgnoreCase)
                     && (string.IsNullOrEmpty(criteria.State)
                         || string.Equals(s.State, criteria.State, StringComparison.OrdinalIgnoreCase)),
                 cancellationToken);
-            if (match.HasValue)
-                return match.Value;
         }
         else if (recordType == RecordType.SensorGlucose && criteria.GlucoseValue.HasValue)
         {
-            var match = await FindMatchingCanonicalIdAsync(
+            matched = await FindMatchingCanonicalIdAsync(
                 potentialMatches,
                 ids => _context.SensorGlucose.Where(r => ids.Contains(r.Id)),
                 r => Math.Abs(r.Mgdl - criteria.GlucoseValue.Value) <= criteria.GlucoseTolerance,
                 cancellationToken);
-            if (match.HasValue)
-                return match.Value;
         }
         else if (recordType == RecordType.Bolus && criteria.Insulin.HasValue)
         {
-            var match = await FindMatchingCanonicalIdAsync(
+            matched = await FindMatchingCanonicalIdAsync(
                 potentialMatches,
                 ids => _context.Boluses.Where(b => ids.Contains(b.Id)),
                 b => Math.Abs(b.Insulin - criteria.Insulin.Value) <= criteria.InsulinTolerance,
                 cancellationToken);
-            if (match.HasValue)
-                return match.Value;
         }
         else if (recordType == RecordType.CarbIntake && criteria.Carbs.HasValue)
         {
-            var match = await FindMatchingCanonicalIdAsync(
+            matched = await FindMatchingCanonicalIdAsync(
                 potentialMatches,
                 ids => _context.CarbIntakes.Where(c => ids.Contains(c.Id)),
                 c => Math.Abs(c.Carbs - criteria.Carbs.Value) <= criteria.CarbsTolerance,
                 cancellationToken);
-            if (match.HasValue)
-                return match.Value;
         }
         else if (recordType == RecordType.BGCheck && criteria.GlucoseValue.HasValue)
         {
-            var match = await FindMatchingCanonicalIdAsync(
+            matched = await FindMatchingCanonicalIdAsync(
                 potentialMatches,
                 ids => _context.BGChecks.Where(bg => ids.Contains(bg.Id)),
                 bg => Math.Abs(bg.Glucose - criteria.GlucoseValue.Value) <= criteria.GlucoseTolerance,
                 cancellationToken);
-            if (match.HasValue)
-                return match.Value;
         }
         else if (recordType == RecordType.DeviceEvent && !string.IsNullOrEmpty(criteria.EventType))
         {
-            var match = await FindMatchingCanonicalIdAsync(
+            matched = await FindMatchingCanonicalIdAsync(
                 potentialMatches,
                 ids => _context.DeviceEvents.Where(e => ids.Contains(e.Id)),
                 e => string.Equals(e.EventType, criteria.EventType, StringComparison.OrdinalIgnoreCase),
                 cancellationToken);
-            if (match.HasValue)
-                return match.Value;
         }
         else if (recordType == RecordType.Note)
         {
             // Notes match on time window alone.
-            if (potentialMatches.Count > 0)
-            {
-                return potentialMatches.First().CanonicalId;
-            }
+            matched = potentialMatches.First().CanonicalId;
         }
         else if (recordType == RecordType.BolusCalculation && criteria.Carbs.HasValue)
         {
-            var match = await FindMatchingCanonicalIdAsync(
+            matched = await FindMatchingCanonicalIdAsync(
                 potentialMatches,
                 ids => _context.BolusCalculations.Where(bc => ids.Contains(bc.Id)),
                 bc => Math.Abs((bc.CarbInput ?? 0) - criteria.Carbs.Value) <= criteria.CarbsTolerance,
                 cancellationToken);
-            if (match.HasValue)
-                return match.Value;
         }
         else if (recordType == RecordType.TempBasal && criteria.Rate.HasValue)
         {
-            var match = await FindMatchingCanonicalIdAsync(
+            matched = await FindMatchingCanonicalIdAsync(
                 potentialMatches,
                 ids => _context.TempBasals.Where(tb => ids.Contains(tb.Id)),
                 tb => Math.Abs(tb.Rate - criteria.Rate.Value) <= criteria.RateTolerance,
                 cancellationToken);
-            if (match.HasValue)
-                return match.Value;
         }
 
+        if (matched.HasValue)
+        {
+            var closest = potentialMatches
+                .Where(m => m.CanonicalId == matched.Value)
+                .OrderBy(m => Math.Abs(m.SourceTimestamp - mills))
+                .First();
+            LogCrossSourceMatch(recordType, dataSource, closest.DataSource, closest.SourceTimestamp - mills, wide: false);
+            return matched.Value;
+        }
+
+        var wideMatch = await TryWideMatchAsync(
+            recordType, recordTypeStr, mills, criteria, dataSource, cancellationToken);
+
         // No matching records found, create a new canonical ID
-        return Guid.CreateVersion7();
+        return wideMatch ?? Guid.CreateVersion7();
     }
+
+    /// <summary>
+    /// Second-chance match over <see cref="WideMatchingWindow"/> for a single record, run only
+    /// after the tight window found nothing. Joins a group only when exactly one candidate
+    /// canonical group in the wide window holds an exact value match and that group contains no
+    /// record from <paramref name="dataSource"/>. Every other outcome — no candidate, several
+    /// candidates, an unknown source, an ineligible record type — returns null so the caller
+    /// mints a new canonical id and the records stay separate.
+    /// </summary>
+    private async Task<Guid?> TryWideMatchAsync(
+        RecordType recordType,
+        string recordTypeStr,
+        long mills,
+        MatchCriteria criteria,
+        string? dataSource,
+        CancellationToken ct)
+    {
+        if (!WideMatchableTypes.Contains(recordType) || !CanEstablishCrossSource(dataSource))
+            return null;
+
+        var wideStart = mills - WideMatchingWindowMillis;
+        var wideEnd = mills + WideMatchingWindowMillis;
+
+        var links = await _context.LinkedRecords
+            .AsNoTracking()
+            .Where(lr => lr.RecordType == recordTypeStr)
+            .Where(lr => lr.SourceTimestamp >= wideStart && lr.SourceTimestamp <= wideEnd)
+            .ToListAsync(ct);
+
+        if (links.Count == 0)
+            return null;
+
+        var info = await LoadRecordInfoAsync(recordType, links.Select(l => l.RecordId).ToHashSet(), ct);
+        var candidates = links
+            .Where(l => info.TryGetValue(l.RecordId, out var recordInfo)
+                        && !recordInfo.IsDeleted
+                        && CriteriaMatch(recordType, recordInfo.Criteria, criteria, exact: true))
+            .ToList();
+
+        var canonicalId = SingleCandidateCanonical(candidates.Select(c => c.CanonicalId));
+        if (canonicalId is null)
+            return null;
+
+        var groupSources = await LoadGroupSourcesAsync(recordTypeStr, [canonicalId.Value], ct);
+        if (!groupSources.TryGetValue(canonicalId.Value, out var sources)
+            || !CanEstablishCrossSource(sources)
+            || sources.Contains(dataSource))
+        {
+            return null;
+        }
+
+        var closest = candidates
+            .Where(c => c.CanonicalId == canonicalId.Value)
+            .OrderBy(c => Math.Abs(c.SourceTimestamp - mills))
+            .First();
+        LogCrossSourceMatch(recordType, dataSource, closest.DataSource, closest.SourceTimestamp - mills, wide: true);
+        return canonicalId;
+    }
+
+    /// <summary>
+    /// Returns the single canonical id present in <paramref name="canonicalIds"/>, or null when
+    /// the sequence is empty or spans more than one group. Two candidate groups mean the record
+    /// cannot be attributed to one event, so the wide path refuses rather than guessing.
+    /// </summary>
+    private static Guid? SingleCandidateCanonical(IEnumerable<Guid> canonicalIds)
+    {
+        Guid? only = null;
+        foreach (var id in canonicalIds)
+        {
+            if (only is null)
+                only = id;
+            else if (only.Value != id)
+                return null;
+        }
+
+        return only;
+    }
+
+    /// <summary>
+    /// Loads the full set of data sources behind each of the given canonical groups. The whole
+    /// group is read rather than just the links inside a matching window, so a same-source record
+    /// sitting outside the window still blocks a wide match.
+    /// </summary>
+    private async Task<Dictionary<Guid, HashSet<string>>> LoadGroupSourcesAsync(
+        string recordTypeStr,
+        List<Guid> canonicalIds,
+        CancellationToken ct)
+    {
+        var sourcesByCanonical = new Dictionary<Guid, HashSet<string>>();
+        if (canonicalIds.Count == 0)
+            return sourcesByCanonical;
+
+        var rows = await _context.LinkedRecords
+            .AsNoTracking()
+            .Where(lr => lr.RecordType == recordTypeStr && canonicalIds.Contains(lr.CanonicalId))
+            .Select(lr => new { lr.CanonicalId, lr.DataSource })
+            .ToListAsync(ct);
+
+        foreach (var row in rows)
+        {
+            if (!sourcesByCanonical.TryGetValue(row.CanonicalId, out var sources))
+            {
+                sources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                sourcesByCanonical[row.CanonicalId] = sources;
+            }
+
+            sources.Add(row.DataSource);
+        }
+
+        return sourcesByCanonical;
+    }
+
+    /// <summary>
+    /// Loads the first and last link timestamp of each of the given canonical groups — the group's
+    /// extent, which after a wide join can be far wider than the gap its primary suggests.
+    /// <para>
+    /// The canonical ids travel as a client-materialized array. A full-history job has no time
+    /// bound to narrow it with, so the array is as large as the type's group count; the aggregate
+    /// itself stays a grouped index scan.
+    /// </para>
+    /// </summary>
+    private async Task<Dictionary<Guid, (long Min, long Max)>> LoadGroupExtentsAsync(
+        string recordTypeStr,
+        List<Guid> canonicalIds,
+        CancellationToken ct)
+    {
+        if (canonicalIds.Count == 0)
+            return [];
+
+        var rows = await _context.LinkedRecords
+            .AsNoTracking()
+            .Where(lr => lr.RecordType == recordTypeStr && canonicalIds.Contains(lr.CanonicalId))
+            .GroupBy(lr => lr.CanonicalId)
+            .Select(g => new
+            {
+                CanonicalId = g.Key,
+                Min = g.Min(lr => lr.SourceTimestamp),
+                Max = g.Max(lr => lr.SourceTimestamp)
+            })
+            .ToListAsync(ct);
+
+        return rows.ToDictionary(r => r.CanonicalId, r => (r.Min, r.Max));
+    }
+
+    /// <summary>
+    /// Records a match between two different data sources. Same-source and unknown-source matches
+    /// are not logged: the offset being tracked is the clock drift between connectors. Matches the
+    /// tight window already handled log at Debug; a <paramref name="wide"/> match logs at
+    /// Information, because a drift large enough to need the wide window is the condition being
+    /// watched and would be invisible at Debug in production. An offset past
+    /// <see cref="CrossSourceOffsetWarningMillis"/> logs at Warning because matching stops working
+    /// entirely once the drift passes <see cref="WideMatchingWindow"/>.
+    /// </summary>
+    private void LogCrossSourceMatch(
+        RecordType recordType,
+        string? incomingSource,
+        string? matchedSource,
+        long offsetMillis,
+        bool wide)
+    {
+        if (string.IsNullOrEmpty(incomingSource)
+            || string.IsNullOrEmpty(matchedSource)
+            || string.Equals(incomingSource, matchedSource, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var level = Math.Abs(offsetMillis) > CrossSourceOffsetWarningMillis
+            ? LogLevel.Warning
+            : wide ? LogLevel.Information : LogLevel.Debug;
+
+        _logger.Log(
+            level,
+            "Cross-source {RecordType} match at {OffsetSeconds}s between {IncomingSource} and {MatchedSource}",
+            recordType, Math.Abs(offsetMillis) / 1000.0, incomingSource, matchedSource);
+    }
+
+    /// <summary>
+    /// True when a data source can establish cross-source provenance: it is present and is not
+    /// <see cref="DeduplicationInput.UnknownDataSource"/>, which names no connector and so cannot
+    /// distinguish a second connector's copy of a dose from a manually entered second dose.
+    /// </summary>
+    private static bool CanEstablishCrossSource([NotNullWhen(true)] string? dataSource) =>
+        !string.IsNullOrEmpty(dataSource)
+        && !string.Equals(dataSource, DeduplicationInput.UnknownDataSource, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True when a canonical group's data sources can establish cross-source provenance: the group
+    /// has at least one source and none of them is the unknown sentinel.
+    /// </summary>
+    private static bool CanEstablishCrossSource(HashSet<string> sources) =>
+        sources.Count > 0 && !sources.Contains(DeduplicationInput.UnknownDataSource);
 
     /// <summary>
     /// Scans the candidate canonical groups for one whose underlying records include a value-level
@@ -369,10 +648,14 @@ public class DeduplicationService : IDeduplicationService
             return new DeduplicationBatchResult(0, 0, 0, 0);
 
         var recordTypeStr = recordType.ToString().ToLowerInvariant();
+        var wideEligible = WideMatchableTypes.Contains(recordType);
 
-        // 1. Compute union time window
-        var minMills = records.Min(r => r.Mills) - MatchingWindowMillis;
-        var maxMills = records.Max(r => r.Mills) + MatchingWindowMillis;
+        // 1. Compute union time window. Wide-eligible types load the wider window so the wide
+        //    fallback below sees the same candidates a standalone query would; the tight scan is
+        //    bounded by binary search on the tight window either way, so its results are unchanged.
+        var loadWindowMillis = wideEligible ? WideMatchingWindowMillis : MatchingWindowMillis;
+        var minMills = records.Min(r => r.Mills) - loadWindowMillis;
+        var maxMills = records.Max(r => r.Mills) + loadWindowMillis;
 
         // 2. One query: all linked_records in the window for this type.
         //    Read-only: matched against, never mutated — the new links are constructed fresh
@@ -388,6 +671,19 @@ public class DeduplicationService : IDeduplicationService
         // 3. One query: load type-specific matcher
         var referencedIds = allPotentialMatches.Select(m => m.RecordId).ToHashSet();
         var matcher = await LoadMatcherAsync(recordType, referencedIds, ct);
+
+        // 3b. Wide-path inputs, loaded only for wide-eligible types: the per-candidate criteria
+        //     the exact comparison runs against, and the data sources behind each candidate group.
+        //     groupSources is mutated as this chunk assigns records, so a second record of the same
+        //     source sees the group its predecessor just joined.
+        Dictionary<Guid, RecordInfo> wideInfo = new();
+        Dictionary<Guid, HashSet<string>> groupSources = new();
+        if (wideEligible)
+        {
+            wideInfo = await LoadRecordInfoAsync(recordType, referencedIds, ct);
+            groupSources = await LoadGroupSourcesAsync(
+                recordTypeStr, allPotentialMatches.Select(m => m.CanonicalId).Distinct().ToList(), ct);
+        }
 
         // 4. One query: which input records are already linked?
         var inputIds = records.Select(r => r.RecordId).ToList();
@@ -417,7 +713,20 @@ public class DeduplicationService : IDeduplicationService
         }
 
         var newCanonicalsSeen = new HashSet<Guid>();
-        var newCanonicalReps = new List<(long mills, Guid canonicalId, MatchCriteria criteria)>();
+        var newCanonicalReps = new List<(long mills, Guid canonicalId, MatchCriteria criteria, string dataSource)>();
+
+        // Every record this chunk assigns, joined or newly minted. allPotentialMatches is read
+        // before any link is written, so without this the wide scan would not see records assigned
+        // earlier in the same chunk — and the ambiguity guard would count fewer candidates than the
+        // persisted state holds, merging where two sequential batches would refuse. The tight path
+        // deliberately keeps using newCanonicalReps: one representative per canonical is enough
+        // there because its members match each other by transitivity.
+        var chunkAssignments = new List<(long mills, Guid canonicalId, MatchCriteria criteria, string dataSource)>();
+
+        // Canonical groups that already existed and were joined through the wide path, whose
+        // primary may need re-deriving once the new links are persisted.
+        var wideJoinedCanonicals = new HashSet<Guid>();
+
         var newLinks = new List<LinkedRecordEntity>();
         var groupsCreated = 0;
         var duplicateGroups = 0;
@@ -442,6 +751,8 @@ public class DeduplicationService : IDeduplicationService
                 {
                     canonicalId = m.CanonicalId;
                     duplicateGroups++;
+                    LogCrossSourceMatch(
+                        recordType, record.DataSource, m.DataSource, m.SourceTimestamp - record.Mills, wide: false);
                     break;
                 }
             }
@@ -451,15 +762,74 @@ public class DeduplicationService : IDeduplicationService
             // one representative per canonical is sufficient.
             if (canonicalId == null)
             {
-                foreach (var (priorMills, priorCanonical, priorCriteria) in newCanonicalReps)
+                foreach (var (priorMills, priorCanonical, priorCriteria, priorSource) in newCanonicalReps)
                 {
                     if (Math.Abs(priorMills - record.Mills) <= MatchingWindowMillis
                         && CriteriaMatch(recordType, priorCriteria, record.Criteria))
                     {
                         canonicalId = priorCanonical;
                         duplicateGroups++;
+                        LogCrossSourceMatch(
+                            recordType, record.DataSource, priorSource, priorMills - record.Mills, wide: false);
                         break;
                     }
+                }
+            }
+
+            // Wide fallback: exactly one exact-value candidate group in the wide window, holding
+            // no record of this record's own source. Records assigned earlier in this chunk are
+            // candidates too, so a wide pair split across a batch resolves the same way it would
+            // across two batches.
+            if (canonicalId == null && wideEligible && CanEstablishCrossSource(record.DataSource))
+            {
+                var wideLo = LowerBoundTimestamp(sortedTimestamps, record.Mills - WideMatchingWindowMillis);
+                var wideHi = UpperBoundTimestamp(sortedTimestamps, record.Mills + WideMatchingWindowMillis);
+
+                var wideCandidates = new List<(Guid CanonicalId, long Mills, string DataSource)>();
+                for (int i = wideLo; i < wideHi; i++)
+                {
+                    var m = allPotentialMatches[i];
+                    if (wideInfo.TryGetValue(m.RecordId, out var recordInfo)
+                        && !recordInfo.IsDeleted
+                        && CriteriaMatch(recordType, recordInfo.Criteria, record.Criteria, exact: true))
+                    {
+                        wideCandidates.Add((m.CanonicalId, m.SourceTimestamp, m.DataSource));
+                    }
+                }
+
+                foreach (var (priorMills, priorCanonical, priorCriteria, priorSource) in chunkAssignments)
+                {
+                    if (Math.Abs(priorMills - record.Mills) <= WideMatchingWindowMillis
+                        && CriteriaMatch(recordType, priorCriteria, record.Criteria, exact: true))
+                    {
+                        wideCandidates.Add((priorCanonical, priorMills, priorSource));
+                    }
+                }
+
+                var wideCanonical = SingleCandidateCanonical(wideCandidates.Select(c => c.CanonicalId));
+
+                // groupSources reflects only this context's view. A concurrent ingest of the same
+                // source into the same group can still slip past between this read and the write;
+                // that race is pre-existing and self-corrects on the next reconcile pass.
+                if (wideCanonical is not null
+                    && groupSources.TryGetValue(wideCanonical.Value, out var candidateSources)
+                    && CanEstablishCrossSource(candidateSources)
+                    && !candidateSources.Contains(record.DataSource))
+                {
+                    canonicalId = wideCanonical;
+                    duplicateGroups++;
+
+                    // Chunk-minted groups need re-deriving too: this chunk's records are not
+                    // sorted on the fast path, so a later-timestamped record can mint the group
+                    // that an earlier one then joins.
+                    wideJoinedCanonicals.Add(wideCanonical.Value);
+
+                    var closest = wideCandidates
+                        .Where(c => c.CanonicalId == wideCanonical.Value)
+                        .OrderBy(c => Math.Abs(c.Mills - record.Mills))
+                        .First();
+                    LogCrossSourceMatch(
+                        recordType, record.DataSource, closest.DataSource, closest.Mills - record.Mills, wide: true);
                 }
             }
 
@@ -487,7 +857,22 @@ public class DeduplicationService : IDeduplicationService
 
             if (isNewCanonical)
             {
-                newCanonicalReps.Add((record.Mills, canonicalId.Value, record.Criteria));
+                newCanonicalReps.Add((record.Mills, canonicalId.Value, record.Criteria, record.DataSource));
+            }
+
+            chunkAssignments.Add((record.Mills, canonicalId.Value, record.Criteria, record.DataSource));
+
+            // Keep the group's source set current within this chunk so a later same-source record
+            // sees the group it just joined and refuses to wide-match it.
+            if (wideEligible)
+            {
+                if (!groupSources.TryGetValue(canonicalId.Value, out var assignedSources))
+                {
+                    assignedSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    groupSources[canonicalId.Value] = assignedSources;
+                }
+
+                assignedSources.Add(record.DataSource);
             }
         }
 
@@ -497,6 +882,61 @@ public class DeduplicationService : IDeduplicationService
             _context.LinkedRecords.AddRange(newLinks);
             await _context.SaveChangesAsync(ct);
             _context.ChangeTracker.Clear();
+        }
+
+        // 7. A wide join reaches up to ten minutes back, so it can land earlier than the group's
+        //    primary — and unlike reconcile-merged groups, ingest-formed groups are never revisited
+        //    by MergeDuplicateGroupsAsync. Re-derive the primary here with the same survivor rule
+        //    MergeDuplicateGroupsAsync uses, or the event time the group displays would depend on
+        //    which connector synced first. Scoped to wide joins: the tight path's sticky primary is
+        //    long-standing behaviour.
+        if (wideJoinedCanonicals.Count > 0)
+        {
+            var joined = wideJoinedCanonicals.ToList();
+            var rows = await _context.LinkedRecords
+                .Where(lr => lr.RecordType == recordTypeStr && joined.Contains(lr.CanonicalId))
+                .ToListAsync(ct);
+
+            var rowInfo = await LoadRecordInfoAsync(recordType, rows.Select(r => r.RecordId).ToHashSet(), ct);
+
+            // Reads hide soft-deleted records and non-primary links alike, so promoting either a
+            // deleted record or an orphaned link would render the whole group as nothing. A record
+            // id missing from rowInfo is an orphaned link and is treated like a deleted one.
+            bool IsPromotable(LinkedRecordEntity r) =>
+                rowInfo.TryGetValue(r.RecordId, out var ri) && !ri.IsDeleted;
+
+            var repointed = false;
+            foreach (var group in rows.GroupBy(r => r.CanonicalId))
+            {
+                // Earliest promotable record, falling back to earliest overall when the group holds
+                // nothing promotable — the same survivor rule as the reconcile merge.
+                var survivor = group
+                    .Where(IsPromotable)
+                    .OrderBy(r => r.SourceTimestamp)
+                    .ThenBy(r => r.RecordId)
+                    .FirstOrDefault()
+                    ?? group
+                        .OrderBy(r => r.SourceTimestamp)
+                        .ThenBy(r => r.RecordId)
+                        .First();
+
+                // A group with no primary at all renders as nothing, so repair it while the
+                // survivor is already in hand.
+                var currentPrimary = group.FirstOrDefault(r => r.IsPrimary);
+                if (ReferenceEquals(survivor, currentPrimary))
+                    continue;
+
+                if (currentPrimary is not null)
+                    currentPrimary.IsPrimary = false;
+                survivor.IsPrimary = true;
+                repointed = true;
+            }
+
+            if (repointed)
+            {
+                await _context.SaveChangesAsync(ct);
+                _context.ChangeTracker.Clear();
+            }
         }
 
         return new DeduplicationBatchResult(
@@ -511,7 +951,9 @@ public class DeduplicationService : IDeduplicationService
     /// Two groups merge when their primary records fall within <see cref="MatchingWindowMillis"/>
     /// of each other and their <see cref="MatchCriteria"/> match; merging is transitive
     /// (union-find) and source-agnostic, mirroring insert-time <see cref="DeduplicateBatchAsync"/>
-    /// semantics. For each merged super-group the surviving primary is the earliest-timestamp
+    /// semantics. A second pass then applies the same wide rules the insert path uses, so a
+    /// cross-source pair missed at ingest (out-of-order connector syncs) heals here.
+    /// For each merged super-group the surviving primary is the earliest-timestamp
     /// non-deleted record (falling back to earliest-overall when every record is soft-deleted);
     /// all linked rows are re-pointed to the survivor's canonical id and <c>IsPrimary</c> is set
     /// on exactly the survivor.
@@ -529,6 +971,15 @@ public class DeduplicationService : IDeduplicationService
         CancellationToken ct)
     {
         var recordTypeStr = recordType.ToString().ToLowerInvariant();
+        var wideEligible = WideMatchableTypes.Contains(recordType);
+
+        // The span the candidate-bounded path actually loaded. Groups whose extent reaches within a
+        // wide window of either end may have an ambiguator just outside it, so the wide pass defers
+        // them. Null on the full path, which loads everything and has no boundary — absence rather
+        // than a sentinel value, so the deferral below cannot be reached with a bound that would
+        // overflow the subtraction.
+        long? neighbourMinTs = null;
+        long? neighbourMaxTs = null;
 
         List<LinkedRecordEntity> primaries;
         if (candidateCanonicalIds == null)
@@ -557,15 +1008,53 @@ public class DeduplicationService : IDeduplicationService
             if (candidatePrimaries.Count == 0)
                 return 0;
 
-            var minTs = candidatePrimaries.Min(p => p.SourceTimestamp) - MatchingWindowMillis;
-            var maxTs = candidatePrimaries.Max(p => p.SourceTimestamp) + MatchingWindowMillis;
+            // Wide-eligible types must see their wide neighbours too, or a drifted pair could
+            // never heal on the candidate-bounded path. The reach is twice the wide window rather
+            // than one: deciding a pair needs to see any third same-value group that would make it
+            // ambiguous, and such a group can sit a full window beyond the pair's own edge. At one
+            // window the same three groups merge or refuse depending on which one is the candidate.
+            var neighbourWindowMillis = wideEligible ? 2 * WideMatchingWindowMillis : MatchingWindowMillis;
+            var minTs = candidatePrimaries.Min(p => p.SourceTimestamp) - neighbourWindowMillis;
+            var maxTs = candidatePrimaries.Max(p => p.SourceTimestamp) + neighbourWindowMillis;
+            neighbourMinTs = minTs;
+            neighbourMaxTs = maxTs;
 
-            primaries = await _context.LinkedRecords
-                .AsNoTracking()
-                .Where(lr => lr.RecordType == recordTypeStr && lr.IsPrimary
-                             && lr.SourceTimestamp >= minTs && lr.SourceTimestamp <= maxTs)
-                .OrderBy(lr => lr.SourceTimestamp)
-                .ToListAsync(ct);
+            if (wideEligible)
+            {
+                // A wide-joined group spans up to a window, so its primary can sit outside the
+                // neighbour range while its members sit inside it. Select the groups by their links
+                // and then load those groups' primaries, so no group is ever half-visible to the
+                // extent comparison below. Second, unremarked consequence: the tight pass now sees
+                // those same extra primaries, so its reach on this path widens too — convergent,
+                // since it only lets the tight rules collapse pairs a later pass would have anyway.
+                var neighbourCanonicals = await _context.LinkedRecords
+                    .AsNoTracking()
+                    .Where(lr => lr.RecordType == recordTypeStr
+                                 && lr.SourceTimestamp >= minTs && lr.SourceTimestamp <= maxTs)
+                    .Select(lr => lr.CanonicalId)
+                    .Distinct()
+                    .ToListAsync(ct);
+
+                // Selected by canonical id alone. A timestamp bound here would be unsound at any
+                // width: everything below — the union-find, the extents, the boundary deferral —
+                // is built from this list, so a group dropped for having a distant primary is not
+                // deferred, it is invisible, and the pairs it would have made ambiguous merge.
+                primaries = await _context.LinkedRecords
+                    .AsNoTracking()
+                    .Where(lr => lr.RecordType == recordTypeStr && lr.IsPrimary
+                                 && neighbourCanonicals.Contains(lr.CanonicalId))
+                    .OrderBy(lr => lr.SourceTimestamp)
+                    .ToListAsync(ct);
+            }
+            else
+            {
+                primaries = await _context.LinkedRecords
+                    .AsNoTracking()
+                    .Where(lr => lr.RecordType == recordTypeStr && lr.IsPrimary
+                                 && lr.SourceTimestamp >= minTs && lr.SourceTimestamp <= maxTs)
+                    .OrderBy(lr => lr.SourceTimestamp)
+                    .ToListAsync(ct);
+            }
         }
 
         if (primaries.Count < 2)
@@ -613,6 +1102,212 @@ public class DeduplicationService : IDeduplicationService
             }
         }
 
+        // 3b. Wide pass, mirroring the insert path: groups the tight pass left apart may still be
+        // one event once two connectors' clocks have drifted. A pair merges only on exact values,
+        // only when each group's sole wide candidate is the other, and only when the two groups
+        // share no data source. Anything ambiguous is left as separate groups.
+        if (wideEligible)
+        {
+            // Root -> (partner root -> smallest observed offset between their primaries).
+            var widePartners = new Dictionary<Guid, Dictionary<Guid, long>>();
+            void AddWidePartner(Guid from, Guid to, long offsetMillis)
+            {
+                if (!widePartners.TryGetValue(from, out var partners))
+                {
+                    partners = new Dictionary<Guid, long>();
+                    widePartners[from] = partners;
+                }
+
+                if (!partners.TryGetValue(to, out var existing) || Math.Abs(offsetMillis) < Math.Abs(existing))
+                    partners[to] = offsetMillis;
+            }
+
+            // Pairing and ambiguity are judged on a group's whole extent, not on its primary. A
+            // group that has already absorbed a wide join spans up to a window, so a primary-only
+            // comparison would miss a group whose member — not its primary — sits beside a pair,
+            // and would merge a pair the insert path (which scans every link) would refuse.
+            var extents = await LoadGroupExtentsAsync(
+                recordTypeStr, primaries.Select(p => p.CanonicalId).Distinct().ToList(), ct);
+
+            var extentByRoot = new Dictionary<Guid, WideGroupExtent>();
+            foreach (var p in primaries)
+            {
+                var root = Find(p.CanonicalId);
+                if (!extentByRoot.TryGetValue(root, out var group))
+                {
+                    // primaries is ordered by SourceTimestamp, so the first primary seen for a root
+                    // is its earliest — a deterministic representative for the logged offset.
+                    group = new WideGroupExtent(root, p.SourceTimestamp);
+                    extentByRoot[root] = group;
+                }
+
+                // Absorb the extent whether or not the record info is present. A root's span must
+                // cover every canonical beneath it: an under-covered extent under-counts ambiguity,
+                // which is the direction that produces false merges.
+                if (extents.TryGetValue(p.CanonicalId, out var extent))
+                    group.Absorb(extent.Min, extent.Max);
+                else
+                    group.Absorb(p.SourceTimestamp, p.SourceTimestamp);
+
+                // Each canonical beneath a root contributes its own criteria. Comparing on a single
+                // representative would count partners against one value only, and a root spanning
+                // canonicals with slightly different values would then permit merges the ambiguity
+                // guard should refuse.
+                if (info.TryGetValue(p.RecordId, out var primaryInfo))
+                    group.AddCriteria(primaryInfo.Criteria);
+            }
+
+            // Ordered by extent start, so for a fixed i the gap to each later j only grows and the
+            // inner loop can stop at the first j out of range. Worst case is O(G^2) when long
+            // absorbed chains overlap; the loop still terminates, and a group only grows that wide
+            // by having already absorbed wide joins.
+            var wideGroups = extentByRoot.Values.OrderBy(g => g.Min).ThenBy(g => g.Root).ToList();
+            for (int i = 0; i < wideGroups.Count; i++)
+            {
+                for (int j = i + 1; j < wideGroups.Count
+                     && wideGroups[j].Min - wideGroups[i].Max <= WideMatchingWindowMillis; j++)
+                {
+                    if (!AnyCriteriaMatch(recordType, wideGroups[i], wideGroups[j]))
+                        continue;
+
+                    var offset = wideGroups[j].PrimaryTimestamp - wideGroups[i].PrimaryTimestamp;
+                    AddWidePartner(wideGroups[i].Root, wideGroups[j].Root, offset);
+                    AddWidePartner(wideGroups[j].Root, wideGroups[i].Root, offset);
+                }
+            }
+
+            // A group whose extent reaches within a window of either end of the load may have an
+            // ambiguator just beyond it that was never read — the neighbour margin was proven
+            // sufficient when groups were points, and an absorbed group's span breaks that proof.
+            // Defer every pair touching one; the full job, or the pass that owns the boundary
+            // group, decides it with the whole picture.
+            var boundaryRoots = new HashSet<Guid>();
+            if (neighbourMinTs is { } loadStart && neighbourMaxTs is { } loadEnd)
+            {
+                foreach (var g in wideGroups)
+                {
+                    if (g.Min - loadStart <= WideMatchingWindowMillis
+                        || loadEnd - g.Max <= WideMatchingWindowMillis)
+                    {
+                        boundaryRoots.Add(g.Root);
+                    }
+                }
+            }
+
+            if (widePartners.Count > 0)
+            {
+                // Only roots that actually have a wide partner need their sources; the rest of the
+                // loaded primaries were read as evidence for the ambiguity count, nothing more.
+                // Roots holding a candidate canonical are tracked at the same time: a candidate-
+                // bounded pass may only merge pairs it owns.
+                var partneredPrimaries = primaries
+                    .Where(p => widePartners.ContainsKey(Find(p.CanonicalId)))
+                    .ToList();
+
+                var sourcesByCanonical = await LoadGroupSourcesAsync(
+                    recordTypeStr, partneredPrimaries.Select(p => p.CanonicalId).Distinct().ToList(), ct);
+                var sourcesByRoot = new Dictionary<Guid, HashSet<string>>();
+                var candidateRoots = new HashSet<Guid>();
+                foreach (var p in partneredPrimaries)
+                {
+                    var root = Find(p.CanonicalId);
+                    if (!sourcesByRoot.TryGetValue(root, out var rootSources))
+                    {
+                        rootSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        sourcesByRoot[root] = rootSources;
+                    }
+
+                    if (sourcesByCanonical.TryGetValue(p.CanonicalId, out var canonicalSources))
+                        rootSources.UnionWith(canonicalSources);
+
+                    if (candidateCanonicalIds?.Contains(p.CanonicalId) == true)
+                        candidateRoots.Add(root);
+                }
+
+                var mergedOffsets = new List<long>();
+                foreach (var (root, partners) in widePartners)
+                {
+                    if (partners.Count != 1)
+                        continue;
+                    var (partner, offset) = partners.First();
+
+                    // AddWidePartner inserts both directions, so a mutual pair appears twice in
+                    // this loop. Act on one ordering only, or the merge would be logged twice.
+                    if (root.CompareTo(partner) >= 0)
+                        continue;
+
+                    // AddWidePartner's symmetric insertion means partner's entries always include
+                    // root, so a single reverse entry is necessarily root itself.
+                    if (!widePartners.TryGetValue(partner, out var reverse) || reverse.Count != 1)
+                        continue;
+
+                    // A candidate-bounded pass loaded neighbours around the candidates only, so a
+                    // pair of two non-candidate groups may be sitting at the edge of that load with
+                    // its own evidence horizon cut short. Leave it to the full job or to the pass
+                    // whose candidates it belongs to.
+                    if (candidateCanonicalIds != null
+                        && !candidateRoots.Contains(root)
+                        && !candidateRoots.Contains(partner))
+                    {
+                        continue;
+                    }
+
+                    // Same reasoning one step out: either group's own extent may run up against the
+                    // end of what was loaded, hiding an ambiguator entirely.
+                    if (boundaryRoots.Contains(root) || boundaryRoots.Contains(partner))
+                        continue;
+
+                    if (!sourcesByRoot.TryGetValue(root, out var rootSources)
+                        || !sourcesByRoot.TryGetValue(partner, out var partnerSources)
+                        || !CanEstablishCrossSource(rootSources)
+                        || !CanEstablishCrossSource(partnerSources)
+                        || rootSources.Overlaps(partnerSources))
+                    {
+                        continue;
+                    }
+
+                    Union(root, partner);
+                    mergedOffsets.Add(offset);
+
+                    // A full job healing a year of drift would otherwise emit one line per pair.
+                    if (mergedOffsets.Count <= WideMergeLogLimit)
+                    {
+                        LogCrossSourceMatch(
+                            recordType,
+                            string.Join(",", rootSources),
+                            string.Join(",", partnerSources),
+                            offset,
+                            wide: true);
+                    }
+                }
+
+                if (mergedOffsets.Count > WideMergeLogLimit)
+                {
+                    var offsetSeconds = mergedOffsets.Select(o => Math.Abs(o) / 1000.0).Order().ToList();
+                    var middle = offsetSeconds.Count / 2;
+                    var median = offsetSeconds.Count % 2 == 1
+                        ? offsetSeconds[middle]
+                        : (offsetSeconds[middle - 1] + offsetSeconds[middle]) / 2.0;
+
+                    // The cap keeps a deploy-day job from emitting a line per pair, but it must not
+                    // swallow the signal the Warning level exists for, so the summary carries it.
+                    var maxOffsetMillis = mergedOffsets.Max(Math.Abs);
+                    var level = maxOffsetMillis > CrossSourceOffsetWarningMillis
+                        ? LogLevel.Warning
+                        : LogLevel.Information;
+
+                    _logger.Log(
+                        level,
+                        "Wide reconcile merged {MergedPairs} {RecordType} group pairs; offset seconds min {MinOffsetSeconds}, median {MedianOffsetSeconds}, max {MaxOffsetSeconds}",
+                        offsetSeconds.Count,
+                        recordType,
+                        offsetSeconds[0],
+                        median,
+                        offsetSeconds[^1]);
+                }
+            }
+        }
+
         // 4. Group canonical ids by union root; only roots spanning >1 distinct canonical merge.
         var groupsByRoot = new Dictionary<Guid, HashSet<Guid>>();
         foreach (var p in primaries)
@@ -644,9 +1339,11 @@ public class DeduplicationService : IDeduplicationService
             var rowInfo = await LoadRecordInfoAsync(recordType, rowIds, ct);
 
             // Survivor = earliest-timestamp non-deleted record; fall back to earliest-overall
-            // only if every record in the group is soft-deleted.
+            // only if every record in the group is soft-deleted. A record id missing from rowInfo
+            // is an orphaned link: reads hide it exactly as they hide a deleted record, so it is
+            // never promotable. Same rule as the ingest path's primary re-derivation.
             bool IsDeleted(LinkedRecordEntity r) =>
-                rowInfo.TryGetValue(r.RecordId, out var ri) && ri.IsDeleted;
+                !rowInfo.TryGetValue(r.RecordId, out var ri) || ri.IsDeleted;
 
             var survivor = rows
                 .Where(r => !IsDeleted(r))
@@ -794,8 +1491,14 @@ public class DeduplicationService : IDeduplicationService
     private static MatchCriteria BuildCriteria(BolusCalculationEntity bc) =>
         new() { Carbs = bc.CarbInput ?? 0, CarbsTolerance = 1.0 };
 
+    // Duration is derived from the interval rather than stored; only the exact comparison reads it.
     private static MatchCriteria BuildCriteria(TempBasalEntity t) =>
-        new() { Rate = t.Rate, RateTolerance = 0.05 };
+        new()
+        {
+            Rate = t.Rate,
+            RateTolerance = 0.05,
+            Duration = t.EndTimestamp.HasValue ? t.EndTimestamp.Value - t.StartTimestamp : null
+        };
 
     private static MatchCriteria BuildCriteria(StateSpanEntity s) =>
         new()
@@ -1038,19 +1741,49 @@ public class DeduplicationService : IDeduplicationService
         return lo;
     }
 
-    private static bool CriteriaMatch(RecordType recordType, MatchCriteria a, MatchCriteria b)
+    /// <summary>
+    /// Per-type value comparison shared by the tight and wide paths. With <paramref name="exact"/>
+    /// the criteria tolerances are replaced by <see cref="ExactValueEpsilon"/> and each type adds
+    /// whatever the wide window needs to keep the comparison meaningful over ten minutes.
+    /// <para>
+    /// Internal so the exact-mode type guard can be pinned directly: every caller reaches it
+    /// through a <see cref="WideMatchableTypes"/> check already, so the guard is unreachable from
+    /// the public surface and would otherwise be an untestable defence.
+    /// </para>
+    /// </summary>
+    internal static bool CriteriaMatch(RecordType recordType, MatchCriteria a, MatchCriteria b, bool exact = false)
     {
+        if (exact && !WideMatchableTypes.Contains(recordType))
+            return false;
+
+        double Tolerance(double aTolerance, double bTolerance) =>
+            exact ? ExactValueEpsilon : Math.Max(aTolerance, bTolerance);
+
         return recordType switch
         {
+            // An open-ended temp basal carries no duration, and null == null would quietly reduce
+            // the exact comparison to rate alone; both intervals must be known and equal.
             RecordType.TempBasal => a.Rate.HasValue && b.Rate.HasValue
-                && Math.Abs(a.Rate.Value - b.Rate.Value) <= Math.Max(a.RateTolerance, b.RateTolerance),
+                && Math.Abs(a.Rate.Value - b.Rate.Value) <= Tolerance(a.RateTolerance, b.RateTolerance)
+                && (!exact || (a.Duration.HasValue && a.Duration == b.Duration)),
             RecordType.SensorGlucose or RecordType.BGCheck => a.GlucoseValue.HasValue && b.GlucoseValue.HasValue
-                && Math.Abs(a.GlucoseValue.Value - b.GlucoseValue.Value) <= Math.Max(a.GlucoseTolerance, b.GlucoseTolerance),
+                && Math.Abs(a.GlucoseValue.Value - b.GlucoseValue.Value) <= Tolerance(a.GlucoseTolerance, b.GlucoseTolerance),
             RecordType.Bolus => a.Insulin.HasValue && b.Insulin.HasValue
-                && Math.Abs(a.Insulin.Value - b.Insulin.Value) <= Math.Max(a.InsulinTolerance, b.InsulinTolerance),
-            RecordType.CarbIntake or RecordType.BolusCalculation => a.Carbs.HasValue && b.Carbs.HasValue
-                && Math.Abs(a.Carbs.Value - b.Carbs.Value) <= Math.Max(a.CarbsTolerance, b.CarbsTolerance),
-            RecordType.DeviceEvent => string.Equals(a.EventType, b.EventType, StringComparison.OrdinalIgnoreCase),
+                && Math.Abs(a.Insulin.Value - b.Insulin.Value) <= Tolerance(a.InsulinTolerance, b.InsulinTolerance),
+            RecordType.CarbIntake => a.Carbs.HasValue && b.Carbs.HasValue
+                && Math.Abs(a.Carbs.Value - b.Carbs.Value) <= Tolerance(a.CarbsTolerance, b.CarbsTolerance),
+            // A correction-only calculation has no carb input, which BuildCriteria reports as 0, so
+            // every such calculation in a ten-minute span would compare exactly equal to every
+            // other. Only a calculation that actually carries carbs can wide-match.
+            RecordType.BolusCalculation => a.Carbs.HasValue && b.Carbs.HasValue
+                && Math.Abs(a.Carbs.Value - b.Carbs.Value) <= Tolerance(a.CarbsTolerance, b.CarbsTolerance)
+                && (!exact || (a.Carbs.Value > 0 && b.Carbs.Value > 0)),
+            // The event type is the whole value here, so exact mode adds only a presence check.
+            // Distinguishing two same-type events relies on the single-candidate and disjoint-source
+            // guards instead: when a type genuinely repeats within ten minutes both connectors
+            // report both occurrences, which puts two candidates in range and refuses the match.
+            RecordType.DeviceEvent => (!exact || !string.IsNullOrEmpty(a.EventType))
+                && string.Equals(a.EventType, b.EventType, StringComparison.OrdinalIgnoreCase),
             RecordType.Note => true,
             RecordType.StateSpan => a.Category == b.Category
                 && (string.IsNullOrEmpty(a.State) || string.IsNullOrEmpty(b.State)
@@ -1178,7 +1911,7 @@ public class DeduplicationService : IDeduplicationService
                 e => new DeduplicationInput(
                     e.Id,
                     new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    e.DataSource ?? "unknown",
+                    e.DataSource ?? DeduplicationInput.UnknownDataSource,
                     BuildCriteria(e)),
                 "SensorGlucose", totalRecords, processed, progress, cancellationToken);
             processed += sensorGlucoseResult.processed;
@@ -1193,7 +1926,7 @@ public class DeduplicationService : IDeduplicationService
                 b => new DeduplicationInput(
                     b.Id,
                     new DateTimeOffset(b.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    b.DataSource ?? "unknown",
+                    b.DataSource ?? DeduplicationInput.UnknownDataSource,
                     BuildCriteria(b)),
                 "Boluses", totalRecords, processed, progress, cancellationToken);
             processed += bolusResult.processed;
@@ -1208,7 +1941,7 @@ public class DeduplicationService : IDeduplicationService
                 c => new DeduplicationInput(
                     c.Id,
                     new DateTimeOffset(c.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    c.DataSource ?? "unknown",
+                    c.DataSource ?? DeduplicationInput.UnknownDataSource,
                     BuildCriteria(c)),
                 "CarbIntakes", totalRecords, processed, progress, cancellationToken);
             processed += carbIntakeResult.processed;
@@ -1223,7 +1956,7 @@ public class DeduplicationService : IDeduplicationService
                 bg => new DeduplicationInput(
                     bg.Id,
                     new DateTimeOffset(bg.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    bg.DataSource ?? "unknown",
+                    bg.DataSource ?? DeduplicationInput.UnknownDataSource,
                     BuildCriteria(bg)),
                 "BGChecks", totalRecords, processed, progress, cancellationToken);
             processed += bgCheckResult.processed;
@@ -1238,7 +1971,7 @@ public class DeduplicationService : IDeduplicationService
                 d => new DeduplicationInput(
                     d.Id,
                     new DateTimeOffset(d.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    d.DataSource ?? "unknown",
+                    d.DataSource ?? DeduplicationInput.UnknownDataSource,
                     BuildCriteria(d)),
                 "DeviceEvents", totalRecords, processed, progress, cancellationToken);
             processed += deviceEventResult.processed;
@@ -1253,7 +1986,7 @@ public class DeduplicationService : IDeduplicationService
                 n => new DeduplicationInput(
                     n.Id,
                     new DateTimeOffset(n.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    n.DataSource ?? "unknown",
+                    n.DataSource ?? DeduplicationInput.UnknownDataSource,
                     BuildNoteCriteria()),
                 "Notes", totalRecords, processed, progress, cancellationToken);
             processed += noteResult.processed;
@@ -1268,7 +2001,7 @@ public class DeduplicationService : IDeduplicationService
                 bc => new DeduplicationInput(
                     bc.Id,
                     new DateTimeOffset(bc.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    bc.DataSource ?? "unknown",
+                    bc.DataSource ?? DeduplicationInput.UnknownDataSource,
                     BuildCriteria(bc)),
                 "BolusCalculations", totalRecords, processed, progress, cancellationToken);
             processed += bolusCalcResult.processed;
@@ -1283,7 +2016,7 @@ public class DeduplicationService : IDeduplicationService
                 t => new DeduplicationInput(
                     t.Id,
                     new DateTimeOffset(t.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    t.DataSource ?? "unknown",
+                    t.DataSource ?? DeduplicationInput.UnknownDataSource,
                     BuildCriteria(t)),
                 "TempBasals", totalRecords, processed, progress, cancellationToken);
             processed += tempBasalResult.processed;
@@ -1298,7 +2031,7 @@ public class DeduplicationService : IDeduplicationService
                 s => new DeduplicationInput(
                     s.Id,
                     new DateTimeOffset(s.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    s.Source ?? "unknown",
+                    s.Source ?? DeduplicationInput.UnknownDataSource,
                     BuildCriteria(s)),
                 "StateSpans", totalRecords, processed, progress, cancellationToken);
             processed += stateSpanResult.processed;
@@ -1482,6 +2215,17 @@ public class DeduplicationService : IDeduplicationService
                 RecordsLinked = totalLinked,
                 CurrentPhase = phaseName
             });
+        }
+
+        // Records linked by an earlier run are skipped above, so re-running over existing history
+        // creates no links and on its own would heal nothing. Collapsing the type's canonical
+        // groups repairs history ingested while the connectors' clocks were drifting apart.
+        // Only wide-eligible types can hold such a split — the tight window never stopped working
+        // — and this pass loads every primary of the type, which for a dense stream like
+        // SensorGlucose would be hundreds of thousands of rows for nothing.
+        if (WideMatchableTypes.Contains(recordType))
+        {
+            totalDuplicates += await MergeDuplicateGroupsAsync(recordType, null, ct);
         }
 
         return (totalProcessed, totalGroups, totalLinked, totalDuplicates);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/BolusRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/BolusRepositoryTests.cs
@@ -58,6 +58,7 @@ public class BolusRepositoryTests : IDisposable
                 It.IsAny<RecordType>(),
                 It.IsAny<long>(),
                 It.IsAny<MatchCriteria>(),
+                It.IsAny<string?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(Guid.NewGuid());
         _mockDeduplicationService

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CarbIntakeRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CarbIntakeRepositoryTests.cs
@@ -58,6 +58,7 @@ public class CarbIntakeRepositoryTests : IDisposable
                 It.IsAny<RecordType>(),
                 It.IsAny<long>(),
                 It.IsAny<MatchCriteria>(),
+                It.IsAny<string?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(Guid.NewGuid());
         _mockDeduplicationService

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -165,10 +165,11 @@ public class DeduplicationReconcileTests : IDisposable
     public async Task MergeDuplicateGroupsAsync_DoesNotMergeOutsideWindow()
     {
         var t = DateTime.UtcNow;
+        // 15 minutes apart: past the wide window, so neither pass can reach across.
         var mylife = await AddCarb(t, "mylife-connector", 50);
-        var glooko = await AddCarb(t.AddSeconds(90), "glooko-connector", 50);
+        var glooko = await AddCarb(t.AddMinutes(15), "glooko-connector", 50);
         AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
-        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(90)), "glooko-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddMinutes(15)), "glooko-connector");
         await _context.SaveChangesAsync();
 
         var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
@@ -271,6 +272,317 @@ public class DeduplicationReconcileTests : IDisposable
         // The far pair still has its two separate primaries.
         var farLinks = links.Where(l => l.RecordId == farA || l.RecordId == farB).ToList();
         farLinks.Select(l => l.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_MergesCrossSourceGroups_PastTheTightWindow()
+    {
+        var t = DateTime.UtcNow;
+        // A pair the ingest path missed because the connectors' clocks drifted 64 seconds apart.
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(64), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(64)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(l => l.IsPrimary).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_RefusesWideMerge_WithAThirdCandidateGroup()
+    {
+        var t = DateTime.UtcNow;
+        // Three same-value groups all inside each other's wide window: no group has a single
+        // candidate, so none of them merge.
+        var mylife = await AddCarb(t, "mylife-connector", 50);
+        var glooko = await AddCarb(t.AddSeconds(64), "glooko-connector", 50);
+        var libre = await AddCarb(t.AddSeconds(128), "libre-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(t.AddSeconds(64)), "glooko-connector");
+        AddPrimaryLink(RecordType.CarbIntake, libre, ToMills(t.AddSeconds(128)), "libre-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(0);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_RefusesWideMerge_ForSameSourceGroups()
+    {
+        var t = DateTime.UtcNow;
+        // One connector reporting 50g twice inside the wide window is two real meals.
+        var first = await AddCarb(t, "mylife-connector", 50);
+        var second = await AddCarb(t.AddSeconds(64), "mylife-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, first, ToMills(t), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, second, ToMills(t.AddSeconds(64)), "mylife-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(0);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_CandidatePath_DefersAPairWhoseGroupTouchesTheLoadBoundary()
+    {
+        // The neighbour margin was sized for groups that are single points. A group that has
+        // already absorbed a wide join spans a window of its own, so it can sit flush against the
+        // end of what was loaded with an ambiguator just beyond. Defer rather than guess — and the
+        // same rows must still merge once a pass can see everything.
+        var candidate = await AddCarb(WideBase, "mylife-connector", 50);
+        var spanningPrimary = await AddCarb(WideBase.AddMinutes(10), "glooko-connector", 50);
+        var spanningMember = await AddCarb(WideBase.AddMinutes(20), "libre-connector", 50);
+
+        var candidateCanonical = AddPrimaryLink(
+            RecordType.CarbIntake, candidate, ToMills(WideBase), "mylife-connector");
+        var spanningCanonical = AddPrimaryLink(
+            RecordType.CarbIntake, spanningPrimary, ToMills(WideBase.AddMinutes(10)), "glooko-connector");
+        AddLink(
+            RecordType.CarbIntake, spanningMember, ToMills(WideBase.AddMinutes(20)), "libre-connector",
+            spanningCanonical, isPrimary: false);
+        await _context.SaveChangesAsync();
+
+        var deferred = await _service.MergeDuplicateGroupsAsync(
+            RecordType.CarbIntake,
+            new HashSet<Guid> { candidateCanonical },
+            CancellationToken.None);
+
+        deferred.Should().Be(0, "the spanning group runs up against the end of the neighbour load");
+        var afterDeferral = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        afterDeferral.Select(l => l.CanonicalId).Distinct().Should().HaveCount(2);
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(1, "the full job sees the whole picture and the pair is genuinely one event");
+        var afterMerge = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        afterMerge.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_RefusesWideMerge_WhenTheAmbiguatorSitsBeyondTheCandidateLoad()
+    {
+        // Same shape, but a third same-value group sits past the end of the candidate-bounded load.
+        // The candidate pass must not merge on the strength of what it happens to have read; the
+        // full job then refuses outright, which is the answer the deferral was protecting.
+        var candidate = await AddCarb(WideBase, "mylife-connector", 50);
+        var spanningPrimary = await AddCarb(WideBase.AddMinutes(10), "glooko-connector", 50);
+        var spanningMember = await AddCarb(WideBase.AddMinutes(20), "libre-connector", 50);
+        var beyond = await AddCarb(WideBase.AddMinutes(30), "mylife-connector", 50);
+
+        var candidateCanonical = AddPrimaryLink(
+            RecordType.CarbIntake, candidate, ToMills(WideBase), "mylife-connector");
+        var spanningCanonical = AddPrimaryLink(
+            RecordType.CarbIntake, spanningPrimary, ToMills(WideBase.AddMinutes(10)), "glooko-connector");
+        AddLink(
+            RecordType.CarbIntake, spanningMember, ToMills(WideBase.AddMinutes(20)), "libre-connector",
+            spanningCanonical, isPrimary: false);
+        AddPrimaryLink(RecordType.CarbIntake, beyond, ToMills(WideBase.AddMinutes(30)), "mylife-connector");
+        await _context.SaveChangesAsync();
+
+        var deferred = await _service.MergeDuplicateGroupsAsync(
+            RecordType.CarbIntake,
+            new HashSet<Guid> { candidateCanonical },
+            CancellationToken.None);
+
+        deferred.Should().Be(0);
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(0, "the spanning group pairs with both of the others, so nothing is unambiguous");
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_CountsAmbiguityAgainstEveryCanonicalBeneathARoot()
+    {
+        // The tight pass collapses two canonicals whose values differ inside its tolerance, so the
+        // resulting root carries two slightly different values. Comparing on one representative
+        // would hide the root from the pair below and let that pair merge.
+        var tightA = await AddCarb(WideBase, "mylife-connector", 50);
+        var tightB = await AddCarb(WideBase.AddSeconds(10), "glooko-connector", 50.5);
+        var pairA = await AddCarb(WideBase.AddMinutes(2), "libre-connector", 50.5);
+        var pairB = await AddCarb(WideBase.AddMinutes(3), "dexcom-connector", 50.5);
+
+        AddPrimaryLink(RecordType.CarbIntake, tightA, ToMills(WideBase), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, tightB, ToMills(WideBase.AddSeconds(10)), "glooko-connector");
+        AddPrimaryLink(RecordType.CarbIntake, pairA, ToMills(WideBase.AddMinutes(2)), "libre-connector");
+        AddPrimaryLink(RecordType.CarbIntake, pairB, ToMills(WideBase.AddMinutes(3)), "dexcom-connector");
+        await _context.SaveChangesAsync();
+
+        await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(3,
+            "the tight pair collapses to one group; the other two stay apart because that group's second value makes them ambiguous");
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_MatchesAgainstEveryCanonicalBeneathARoot()
+    {
+        // The merge-direction companion: the root's second value is the one that matches, so
+        // comparing against a single representative would refuse a pair the insert path — which
+        // compares an incoming record against every link it can see — would have joined.
+        var tightA = await AddCarb(WideBase, "mylife-connector", 50);
+        var tightB = await AddCarb(WideBase.AddSeconds(10), "glooko-connector", 50.5);
+        var partner = await AddCarb(WideBase.AddMinutes(2), "libre-connector", 50.5);
+
+        AddPrimaryLink(RecordType.CarbIntake, tightA, ToMills(WideBase), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, tightB, ToMills(WideBase.AddSeconds(10)), "glooko-connector");
+        AddPrimaryLink(RecordType.CarbIntake, partner, ToMills(WideBase.AddMinutes(2)), "libre-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(2, "the tight pair collapses, then the wide pass folds the partner in");
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(l => l.IsPrimary).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_NeverPromotesAnOrphanedLinkToPrimary()
+    {
+        // An orphaned link points at a record that no longer exists. Reads hide it exactly as they
+        // hide a soft-deleted one, so promoting it would leave the merged group showing nothing.
+        var live = await AddCarb(WideBase.AddSeconds(30), "mylife-connector", 50);
+        var other = await AddCarb(WideBase.AddSeconds(50), "glooko-connector", 50);
+
+        var liveCanonical = AddPrimaryLink(
+            RecordType.CarbIntake, live, ToMills(WideBase.AddSeconds(30)), "mylife-connector");
+        AddLink(
+            RecordType.CarbIntake, Guid.CreateVersion7(), ToMills(WideBase), "libre-connector",
+            liveCanonical, isPrimary: false);
+        AddPrimaryLink(RecordType.CarbIntake, other, ToMills(WideBase.AddSeconds(50)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(l => l.IsPrimary).Should().Be(1);
+        links.Single(l => l.IsPrimary).RecordId.Should().Be(live,
+            "the earliest record a read can actually show survives as primary");
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_RefusesWideMerge_WhenAGroupMemberIsTheAmbiguityEvidence()
+    {
+        // An already-wide-joined group spans nineteen minutes, so its primary is a poor stand-in
+        // for where its records actually are. Its later member sits six minutes from the first of
+        // a would-be pair, which makes that pair ambiguous — the insert path scans every link and
+        // would refuse, so reconcile must refuse too.
+        var spanningPrimary = await AddCarb(WideBase, "mylife-connector", 50);
+        var spanningMember = await AddCarb(WideBase.AddMinutes(19), "glooko-connector", 50);
+        var pairA = await AddCarb(WideBase.AddMinutes(25), "mylife-connector", 50);
+        var pairB = await AddCarb(WideBase.AddMinutes(30), "glooko-connector", 50);
+
+        var spanningCanonical = AddPrimaryLink(
+            RecordType.CarbIntake, spanningPrimary, ToMills(WideBase), "mylife-connector");
+        AddLink(
+            RecordType.CarbIntake, spanningMember, ToMills(WideBase.AddMinutes(19)), "glooko-connector",
+            spanningCanonical, isPrimary: false);
+        AddPrimaryLink(RecordType.CarbIntake, pairA, ToMills(WideBase.AddMinutes(25)), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, pairB, ToMills(WideBase.AddMinutes(30)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        merged.Should().Be(0);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(3);
+    }
+
+    [Theory]
+    [InlineData(600_000, 1)]
+    [InlineData(600_001, 2)]
+    public async Task MergeDuplicateGroupsAsync_PinsWideWindowEdge(int offsetMillis, int expectedGroups)
+    {
+        var mylife = await AddCarb(WideBase, "mylife-connector", 50);
+        var glooko = await AddCarb(WideBase.AddMilliseconds(offsetMillis), "glooko-connector", 50);
+        AddPrimaryLink(RecordType.CarbIntake, mylife, ToMills(WideBase), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, glooko, ToMills(WideBase.AddMilliseconds(offsetMillis)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        await _service.MergeDuplicateGroupsAsync(RecordType.CarbIntake, null, CancellationToken.None);
+
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(expectedGroups);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task MergeDuplicateGroupsAsync_RefusesWideMerge_WithAThirdGroupBeyondTheCandidateBounds(int candidateIndex)
+    {
+        // Three same-value groups nine minutes apart. The outer two are more than a wide window
+        // apart, so only the middle group pairs with both — which makes every pair ambiguous. The
+        // deciding evidence sits up to a full window beyond the candidate's own window, so the
+        // verdict must not depend on which of the three the reconcile pass was handed.
+        var first = await AddCarb(WideBase, "mylife-connector", 50);
+        var second = await AddCarb(WideBase.AddMinutes(9), "glooko-connector", 50);
+        var third = await AddCarb(WideBase.AddMinutes(18), "mylife-connector", 50);
+        var canonicals = new[]
+        {
+            AddPrimaryLink(RecordType.CarbIntake, first, ToMills(WideBase), "mylife-connector"),
+            AddPrimaryLink(RecordType.CarbIntake, second, ToMills(WideBase.AddMinutes(9)), "glooko-connector"),
+            AddPrimaryLink(RecordType.CarbIntake, third, ToMills(WideBase.AddMinutes(18)), "mylife-connector"),
+        };
+        await _context.SaveChangesAsync();
+
+        var merged = await _service.MergeDuplicateGroupsAsync(
+            RecordType.CarbIntake,
+            new HashSet<Guid> { canonicals[candidateIndex] },
+            CancellationToken.None);
+
+        merged.Should().Be(0);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task MergeDuplicateGroupsAsync_CandidatePath_LeavesNonCandidatePairToALaterPass()
+    {
+        // A clean pair that is nobody's candidate sits near the edge of the neighbour load, so its
+        // own evidence horizon is cut short. This pass must leave it alone — and the pass that does
+        // own it must still merge it, so nothing is lost.
+        var candidate = await AddCarb(WideBase, "mylife-connector", 99);
+        var pairA = await AddCarb(WideBase.AddMinutes(15), "mylife-connector", 50);
+        var pairB = await AddCarb(WideBase.AddMinutes(16), "glooko-connector", 50);
+        var candidateCanonical = AddPrimaryLink(RecordType.CarbIntake, candidate, ToMills(WideBase), "mylife-connector");
+        var pairACanonical = AddPrimaryLink(RecordType.CarbIntake, pairA, ToMills(WideBase.AddMinutes(15)), "mylife-connector");
+        AddPrimaryLink(RecordType.CarbIntake, pairB, ToMills(WideBase.AddMinutes(16)), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        var deferred = await _service.MergeDuplicateGroupsAsync(
+            RecordType.CarbIntake,
+            new HashSet<Guid> { candidateCanonical },
+            CancellationToken.None);
+
+        deferred.Should().Be(0, "the pair belongs to a later pass, not this one");
+        var afterDeferral = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        afterDeferral.Select(l => l.CanonicalId).Distinct().Should().HaveCount(3);
+
+        var merged = await _service.MergeDuplicateGroupsAsync(
+            RecordType.CarbIntake,
+            new HashSet<Guid> { pairACanonical },
+            CancellationToken.None);
+
+        merged.Should().Be(1, "the pass that owns the pair merges it");
+        var afterMerge = await _context.LinkedRecords.IgnoreQueryFilters().Where(l => l.RecordType == "carbintake").ToListAsync();
+        afterMerge.Select(l => l.CanonicalId).Distinct().Should().HaveCount(2);
     }
 
     [Fact]
@@ -416,6 +728,12 @@ public class DeduplicationReconcileTests : IDisposable
     }
 
     /// <summary>
+    /// Fixed event time the wide-window reconcile tests are anchored on, so millisecond offsets
+    /// are exact.
+    /// </summary>
+    private static readonly DateTime WideBase = new(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
     /// Inserts a <see cref="CarbIntakeEntity"/> for the test tenant and returns its id.
     /// </summary>
     private async Task<Guid> AddCarb(DateTime timestamp, string dataSource, double carbs, DateTime? deletedAt = null)
@@ -441,6 +759,16 @@ public class DeduplicationReconcileTests : IDisposable
     private Guid AddPrimaryLink(RecordType recordType, Guid recordId, long mills, string source)
     {
         var canonicalId = Guid.CreateVersion7();
+        AddLink(recordType, recordId, mills, source, canonicalId, isPrimary: true);
+        return canonicalId;
+    }
+
+    /// <summary>
+    /// Adds a link to an existing canonical group, standing in for a group an earlier pass already
+    /// collapsed — the case where a group spans far more than its primary's timestamp suggests.
+    /// </summary>
+    private void AddLink(
+        RecordType recordType, Guid recordId, long mills, string source, Guid canonicalId, bool isPrimary) =>
         _context.LinkedRecords.Add(new LinkedRecordEntity
         {
             Id = Guid.CreateVersion7(),
@@ -450,11 +778,9 @@ public class DeduplicationReconcileTests : IDisposable
             RecordId = recordId,
             SourceTimestamp = mills,
             DataSource = source,
-            IsPrimary = true,
+            IsPrimary = isPrimary,
             SysCreatedAt = DateTime.UtcNow
         });
-        return canonicalId;
-    }
 
     /// <summary>
     /// Overrides <see cref="LinkedRecordEntity.SysCreatedAt"/> on all of the tenant's links.

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationServiceTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationServiceTests.cs
@@ -331,7 +331,7 @@ public class DeduplicationServiceTests : IDisposable
             dataSource: "glooko-connector"
         );
         var tempBasal2 = CreateTestTempBasalEntity(
-            startTimestamp: timestamp.AddMinutes(2), // 2 minutes later, well outside 30s window
+            startTimestamp: timestamp.AddMinutes(15), // well outside the 10-minute wide window
             rate: 1.2,
             origin: "Scheduled",
             dataSource: "mylife-connector"
@@ -557,7 +557,7 @@ public class DeduplicationServiceTests : IDisposable
             RecordType = "tempbasal",
             RecordId = tb.Id,
             SourceTimestamp = new DateTimeOffset(tb.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-            DataSource = tb.DataSource,
+            DataSource = tb.DataSource ?? DeduplicationInput.UnknownDataSource,
             IsPrimary = true,
             SysCreatedAt = DateTime.UtcNow
         });
@@ -758,7 +758,761 @@ public class DeduplicationServiceTests : IDisposable
 
     #endregion
 
+    #region Wide Matching Window Tests
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_MatchesCrossSourceBolus_PastTheTightWindow()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // Two connectors reporting the same pump whose clocks have drifted 64 seconds apart.
+        var mylife = CreateBolus(WideBase, 2.0, "mylife-connector");
+        var glooko = CreateBolus(WideBase + 64_000, 2.0, "glooko-connector");
+        context.Boluses.AddRange(mylife, glooko);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(mylife)]);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(glooko)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Should().HaveCount(2);
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1,
+            "the same dose reported by two connectors is one event even after the clocks drift apart");
+        links.Count(lr => lr.IsPrimary).Should().Be(1, "exactly one record in the group is primary");
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_MatchesCrossSourceDeviceEvent_PastTheTightWindow()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        var mylife = CreateDeviceEvent(WideBase, "SiteChange", "mylife-connector");
+        var glooko = CreateDeviceEvent(WideBase + 64_000, "SiteChange", "glooko-connector");
+        context.DeviceEvents.AddRange(mylife, glooko);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.DeviceEvent, [ToInput(mylife)]);
+        await service.DeduplicateBatchAsync(RecordType.DeviceEvent, [ToInput(glooko)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Should().HaveCount(2);
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(lr => lr.IsPrimary).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_MatchesCrossSourceCarbIntake_PastTheTightWindow()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        var mylife = CreateCarbIntake(WideBase, 45, "mylife-connector");
+        var glooko = CreateCarbIntake(WideBase + 64_000, 45, "glooko-connector");
+        context.CarbIntakes.AddRange(mylife, glooko);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.CarbIntake, [ToInput(mylife)]);
+        await service.DeduplicateBatchAsync(RecordType.CarbIntake, [ToInput(glooko)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Should().HaveCount(2);
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(lr => lr.IsPrimary).Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(30_000, false, 1)]
+    [InlineData(30_001, false, 2)]
+    [InlineData(30_000, true, 1)]
+    [InlineData(30_001, true, 2)]
+    public async Task DeduplicateBatchAsync_PinsTightWindowEdge(long offsetMillis, bool laterFirst, int expectedGroups)
+    {
+        // Both records carry the same source, so the wide window can never rescue the just-past
+        // case: only the tight window's inclusive bound decides the outcome. Separate batches so
+        // the second record matches through the persisted link rather than intra-batch state.
+        // laterFirst flips which end of the window the second record has to reach across.
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        var earlier = CreateBolus(WideBase, 2.0, "mylife-connector");
+        var later = CreateBolus(WideBase + offsetMillis, 2.0, "mylife-connector");
+        context.Boluses.AddRange(earlier, later);
+        await context.SaveChangesAsync();
+
+        var (first, second) = laterFirst ? (later, earlier) : (earlier, later);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(first)]);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(second)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(expectedGroups);
+    }
+
+    [Theory]
+    [InlineData(600_000, false, 1)]
+    [InlineData(600_001, false, 2)]
+    [InlineData(600_000, true, 1)]
+    [InlineData(600_001, true, 2)]
+    public async Task DeduplicateBatchAsync_PinsWideWindowEdge_AcrossBatches(long offsetMillis, bool laterFirst, int expectedGroups)
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        var earlier = CreateBolus(WideBase, 2.0, "mylife-connector");
+        var later = CreateBolus(WideBase + offsetMillis, 2.0, "glooko-connector");
+        context.Boluses.AddRange(earlier, later);
+        await context.SaveChangesAsync();
+
+        var (first, second) = laterFirst ? (later, earlier) : (earlier, later);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(first)]);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(second)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(expectedGroups);
+    }
+
+    [Theory]
+    [InlineData(600_000, 1)]
+    [InlineData(600_001, 2)]
+    public async Task DeduplicateBatchAsync_PinsWideWindowEdge_WithinOneBatch(long offsetMillis, int expectedGroups)
+    {
+        // The intra-batch arm of the wide path: the second record matches a canonical minted
+        // earlier in the same batch rather than a persisted link.
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        var mylife = CreateBolus(WideBase, 2.0, "mylife-connector");
+        var glooko = CreateBolus(WideBase + offsetMillis, 2.0, "glooko-connector");
+        context.Boluses.AddRange(mylife, glooko);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(mylife), ToInput(glooko)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(expectedGroups);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_WhenTwoGroupsShareTheValue()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // Two same-source doses of 2.0U four minutes apart stay separate groups, and both sit
+        // inside the incoming record's wide window.
+        var first = CreateBolus(WideBase, 2.0, "mylife-connector");
+        var second = CreateBolus(WideBase + 240_000, 2.0, "mylife-connector");
+        var incoming = CreateBolus(WideBase + 120_000, 2.0, "glooko-connector");
+        context.Boluses.AddRange(first, second, incoming);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(first), ToInput(second)]);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(incoming)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Should().HaveCount(3);
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(3,
+            "two candidate groups mean the dose cannot be attributed to one of them, so it stays separate");
+        var incomingCanonical = links.Single(lr => lr.RecordId == incoming.Id).CanonicalId;
+        incomingCanonical.Should().NotBe(links.Single(lr => lr.RecordId == first.Id).CanonicalId);
+        incomingCanonical.Should().NotBe(links.Single(lr => lr.RecordId == second.Id).CanonicalId);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_ForSameSourcePair()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // One connector reporting 2.0U twice, 64 seconds apart, is two real doses.
+        var first = CreateBolus(WideBase, 2.0, "mylife-connector");
+        var second = CreateBolus(WideBase + 64_000, 2.0, "mylife-connector");
+        context.Boluses.AddRange(first, second);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(first)]);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(second)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_WhenInsulinDiffersWithinTheTightTolerance()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // 0.04U apart is inside the tight path's +/-0.05U tolerance; the wide path is exact.
+        var mylife = CreateBolus(WideBase, 2.00, "mylife-connector");
+        var glooko = CreateBolus(WideBase + 64_000, 2.04, "glooko-connector");
+        context.Boluses.AddRange(mylife, glooko);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(mylife)]);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(glooko)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_ForSensorGlucose()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // Sensor glucose repeats the same value all day, so it is excluded from the wide window.
+        var mylife = CreateSensorGlucose(WideBase, 120, "mylife-connector");
+        var glooko = CreateSensorGlucose(WideBase + 64_000, 120, "glooko-connector");
+        context.SensorGlucose.AddRange(mylife, glooko);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.SensorGlucose, [ToInput(mylife)]);
+        await service.DeduplicateBatchAsync(RecordType.SensorGlucose, [ToInput(glooko)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Theory]
+    [InlineData(DeduplicationInput.UnknownDataSource)]
+    [InlineData("")]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_WhenTheIncomingDataSourceIsUnknown(string dataSource)
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // Every repository substitutes the unknown sentinel for a record with no source — a
+        // manually entered dose, typically. It names no connector, so it cannot show that this is
+        // a second connector's copy rather than a second real dose.
+        var known = CreateBolus(WideBase, 2.0, "mylife-connector");
+        var sourceless = CreateBolus(WideBase + 64_000, 2.0, "glooko-connector");
+        context.Boluses.AddRange(known, sourceless);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(known)]);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(sourceless, dataSource: dataSource)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_WhenTheCandidateGroupHasNoKnownSource()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // The sentinel is equally uninformative on the group's side of the comparison: it is not
+        // "a different connector", so it cannot be treated as disjoint from a named one.
+        var sourceless = CreateBolus(WideBase, 2.0, DeduplicationInput.UnknownDataSource);
+        var glooko = CreateBolus(WideBase + 64_000, 2.0, "glooko-connector");
+        context.Boluses.AddRange(sourceless, glooko);
+        AddPrimaryLink(context, RecordType.Bolus, sourceless.Id, WideBase, DeduplicationInput.UnknownDataSource);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(glooko)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_WhenTheOnlyCandidateIsSoftDeleted()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // A soft-deleted record is hidden from reads, so joining its group would hide the incoming
+        // record behind it.
+        var deleted = CreateBolus(WideBase, 2.0, "mylife-connector");
+        deleted.DeletedAt = DateTime.UtcNow;
+        var glooko = CreateBolus(WideBase + 64_000, 2.0, "glooko-connector");
+        context.Boluses.AddRange(deleted, glooko);
+        AddPrimaryLink(context, RecordType.Bolus, deleted.Id, WideBase, "mylife-connector");
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(glooko)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task DeduplicateBatchAsync_WideCandidateCount_IsIndependentOfBatching(bool singleBatch)
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // Two existing groups 20 minutes apart, and two incoming records between them. The first
+        // incoming record can only see the earlier group and joins it; the second sees the later
+        // group AND the group the first record just joined, which makes it ambiguous. That must
+        // hold whether the two arrive together or in sequence — the ambiguity guard counts
+        // candidates in the data, not in the batch.
+        var glookoSeed = CreateBolus(WideBase, 2.0, "glooko-connector");
+        var mylifeSeed = CreateBolus(WideBase + 1_200_000, 2.0, "mylife-connector");
+        var mylifeIncoming = CreateBolus(WideBase + 540_000, 2.0, "mylife-connector");
+        var glookoIncoming = CreateBolus(WideBase + 1_080_000, 2.0, "glooko-connector");
+        context.Boluses.AddRange(glookoSeed, mylifeSeed, mylifeIncoming, glookoIncoming);
+        AddPrimaryLink(context, RecordType.Bolus, glookoSeed.Id, WideBase, "glooko-connector");
+        AddPrimaryLink(context, RecordType.Bolus, mylifeSeed.Id, WideBase + 1_200_000, "mylife-connector");
+        await context.SaveChangesAsync();
+
+        if (singleBatch)
+        {
+            await service.DeduplicateBatchAsync(
+                RecordType.Bolus, [ToInput(mylifeIncoming), ToInput(glookoIncoming)]);
+        }
+        else
+        {
+            await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(mylifeIncoming)]);
+            await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(glookoIncoming)]);
+        }
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Should().HaveCount(4);
+
+        var glookoSeedCanonical = links.Single(lr => lr.RecordId == glookoSeed.Id).CanonicalId;
+        var mylifeSeedCanonical = links.Single(lr => lr.RecordId == mylifeSeed.Id).CanonicalId;
+        links.Single(lr => lr.RecordId == mylifeIncoming.Id).CanonicalId.Should().Be(glookoSeedCanonical,
+            "the first incoming record has exactly one candidate group");
+
+        var ambiguous = links.Single(lr => lr.RecordId == glookoIncoming.Id).CanonicalId;
+        ambiguous.Should().NotBe(glookoSeedCanonical);
+        ambiguous.Should().NotBe(mylifeSeedCanonical);
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_WideJoin_PromotesAnEarlierRecordToPrimary()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // The wide window reaches backwards as well as forwards, so a joining record can predate
+        // the group's primary. The group's event time must not depend on which connector synced
+        // first.
+        var glooko = CreateBolus(WideBase + 120_000, 2.0, "glooko-connector");
+        var mylife = CreateBolus(WideBase, 2.0, "mylife-connector");
+        context.Boluses.AddRange(glooko, mylife);
+        AddPrimaryLink(context, RecordType.Bolus, glooko.Id, WideBase + 120_000, "glooko-connector");
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(mylife)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(lr => lr.IsPrimary).Should().Be(1, "exactly one record in the group is primary");
+        links.Single(lr => lr.IsPrimary).RecordId.Should().Be(mylife.Id,
+            "the earlier record is the group's event time");
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_WideJoin_LeavesPrimaryAloneWhenTheJoinerIsLater()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        var glooko = CreateBolus(WideBase, 2.0, "glooko-connector");
+        var mylife = CreateBolus(WideBase + 120_000, 2.0, "mylife-connector");
+        context.Boluses.AddRange(glooko, mylife);
+        AddPrimaryLink(context, RecordType.Bolus, glooko.Id, WideBase, "glooko-connector");
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(mylife)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(lr => lr.IsPrimary).Should().Be(1);
+        links.Single(lr => lr.IsPrimary).RecordId.Should().Be(glooko.Id);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_WideJoin_KeepsALiveRecordPrimaryOverASoftDeletedEarlierOne()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // Reads hide soft-deleted records and non-primary links alike, so promoting the deleted
+        // record would leave the group rendering nothing at all — a real dose invisible for good.
+        var deleted = CreateBolus(WideBase, 2.0, "mylife-connector");
+        deleted.DeletedAt = DateTime.UtcNow;
+        var live = CreateBolus(WideBase + 60_000, 2.0, "glooko-connector");
+        var joiner = CreateBolus(WideBase + 120_000, 2.0, "libre-connector");
+        context.Boluses.AddRange(deleted, live, joiner);
+
+        var canonicalId = AddPrimaryLink(context, RecordType.Bolus, live.Id, WideBase + 60_000, "glooko-connector");
+        AddLink(context, RecordType.Bolus, deleted.Id, WideBase, "mylife-connector", canonicalId, isPrimary: false);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(joiner)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Should().HaveCount(3);
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(lr => lr.IsPrimary).Should().Be(1);
+        links.Single(lr => lr.IsPrimary).RecordId.Should().Be(live.Id,
+            "the earliest record that reads can actually show stays primary");
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_WideJoin_KeepsALiveRecordPrimaryOverAnOrphanedEarlierLink()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // An orphaned link points at a record that no longer exists, so promoting it would hide
+        // the group for the same reason a deleted record would.
+        var live = CreateBolus(WideBase + 60_000, 2.0, "glooko-connector");
+        var joiner = CreateBolus(WideBase + 120_000, 2.0, "libre-connector");
+        context.Boluses.AddRange(live, joiner);
+
+        var canonicalId = AddPrimaryLink(context, RecordType.Bolus, live.Id, WideBase + 60_000, "glooko-connector");
+        AddLink(context, RecordType.Bolus, Guid.CreateVersion7(), WideBase, "mylife-connector", canonicalId, isPrimary: false);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(joiner)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Count(lr => lr.IsPrimary).Should().Be(1);
+        links.Single(lr => lr.IsPrimary).RecordId.Should().Be(live.Id);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_WideJoin_PromotesTheEarlierRecordOfAChunkMintedGroup()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // A batch of 500 or fewer records is not sorted, so a bulk upload carrying two sources can
+        // mint the group on its later record and join the earlier one to it.
+        var glooko = CreateBolus(WideBase + 1_080_000, 2.0, "glooko-connector");
+        var mylife = CreateBolus(WideBase + 540_000, 2.0, "mylife-connector");
+        context.Boluses.AddRange(glooko, mylife);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(glooko), ToInput(mylife)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(lr => lr.IsPrimary).Should().Be(1);
+        links.Single(lr => lr.IsPrimary).RecordId.Should().Be(mylife.Id,
+            "the group's event time does not depend on the order records arrived in the batch");
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_MatchesCrossSourceTempBasal_WithEqualDurations()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        var start = ToUtc(WideBase);
+        var glooko = CreateTestTempBasalEntity(
+            startTimestamp: start, rate: 1.2, origin: "Scheduled", dataSource: "glooko-connector",
+            duration: TimeSpan.FromMinutes(30));
+        var mylife = CreateTestTempBasalEntity(
+            startTimestamp: start.AddSeconds(64), rate: 1.2, origin: "Scheduled", dataSource: "mylife-connector",
+            duration: TimeSpan.FromMinutes(30));
+        context.TempBasals.AddRange(glooko, mylife);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.TempBasal, [ToDeduplicationInput(glooko)]);
+        await service.DeduplicateBatchAsync(RecordType.TempBasal, [ToDeduplicationInput(mylife)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1);
+        links.Count(lr => lr.IsPrimary).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_ForOpenEndedTempBasals()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // A running temp basal has no end yet, so rate alone would be the whole comparison.
+        var start = ToUtc(WideBase);
+        var glooko = CreateTestTempBasalEntity(
+            startTimestamp: start, rate: 1.2, origin: "Scheduled", dataSource: "glooko-connector");
+        var mylife = CreateTestTempBasalEntity(
+            startTimestamp: start.AddSeconds(64), rate: 1.2, origin: "Scheduled", dataSource: "mylife-connector");
+        context.TempBasals.AddRange(glooko, mylife);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.TempBasal, [ToDeduplicationInput(glooko)]);
+        await service.DeduplicateBatchAsync(RecordType.TempBasal, [ToDeduplicationInput(mylife)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_WhenTempBasalDurationsDiffer()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        var start = ToUtc(WideBase);
+        var glooko = CreateTestTempBasalEntity(
+            startTimestamp: start, rate: 1.2, origin: "Scheduled", dataSource: "glooko-connector",
+            duration: TimeSpan.FromMinutes(30));
+        var mylife = CreateTestTempBasalEntity(
+            startTimestamp: start.AddSeconds(64), rate: 1.2, origin: "Scheduled", dataSource: "mylife-connector",
+            duration: TimeSpan.FromMinutes(45));
+        context.TempBasals.AddRange(glooko, mylife);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.TempBasal, [ToDeduplicationInput(glooko)]);
+        await service.DeduplicateBatchAsync(RecordType.TempBasal, [ToDeduplicationInput(mylife)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_RefusesWideMatch_ForCorrectionOnlyBolusCalculations()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // A correction-only calculation carries no carb input, which the criteria report as 0.
+        // Every such calculation would otherwise look exactly equal to every other.
+        var glooko = CreateBolusCalculation(WideBase, carbInput: null, "glooko-connector");
+        var mylife = CreateBolusCalculation(WideBase + 64_000, carbInput: null, "mylife-connector");
+        context.BolusCalculations.AddRange(glooko, mylife);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.BolusCalculation, [ToInput(glooko)]);
+        await service.DeduplicateBatchAsync(RecordType.BolusCalculation, [ToInput(mylife)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_MatchesCrossSourceBolusCalculation_WhenCarbsArePresent()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        var glooko = CreateBolusCalculation(WideBase, carbInput: 45, "glooko-connector");
+        var mylife = CreateBolusCalculation(WideBase + 64_000, carbInput: 45, "mylife-connector");
+        context.BolusCalculations.AddRange(glooko, mylife);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.BolusCalculation, [ToInput(glooko)]);
+        await service.DeduplicateBatchAsync(RecordType.BolusCalculation, [ToInput(mylife)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void CriteriaMatch_ExactMode_RejectsTypesOutsideTheWideWindow(bool exact, bool expected)
+    {
+        // Every production caller checks WideMatchableTypes before reaching exact mode, so this
+        // guard is unreachable through the batch and reconcile paths and can only be pinned here.
+        var a = new MatchCriteria { GlucoseValue = 120, GlucoseTolerance = 1.0 };
+        var b = new MatchCriteria { GlucoseValue = 120, GlucoseTolerance = 1.0 };
+
+        DeduplicationService.CriteriaMatch(RecordType.SensorGlucose, a, b, exact).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task DeduplicateBatchAsync_WideMatch_AdmitsOnlyTheFirstSameSourceRecordOfABatch()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // An existing glooko group at 12:02 and a mylife batch holding 12:00 and 12:04. The first
+        // mylife record joins; the second must see mylife already in the group and refuse.
+        var glooko = CreateBolus(WideBase + 120_000, 2.0, "glooko-connector");
+        var mylifeEarly = CreateBolus(WideBase, 2.0, "mylife-connector");
+        var mylifeLate = CreateBolus(WideBase + 240_000, 2.0, "mylife-connector");
+        context.Boluses.AddRange(glooko, mylifeEarly, mylifeLate);
+        await context.SaveChangesAsync();
+
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(glooko)]);
+        await service.DeduplicateBatchAsync(RecordType.Bolus, [ToInput(mylifeEarly), ToInput(mylifeLate)]);
+
+        var links = await context.LinkedRecords.ToListAsync();
+        links.Should().HaveCount(3);
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(2);
+
+        var glookoCanonical = links.Single(lr => lr.RecordId == glooko.Id).CanonicalId;
+        links.Single(lr => lr.RecordId == mylifeEarly.Id).CanonicalId.Should().Be(glookoCanonical,
+            "the first mylife record joins the glooko group");
+        links.Single(lr => lr.RecordId == mylifeLate.Id).CanonicalId.Should().NotBe(glookoCanonical,
+            "the group already holds a mylife record, so the second one stays separate");
+    }
+
+    [Fact]
+    public async Task DeduplicateAllAsync_HealsPreExistingCrossSourceGroups()
+    {
+        await using var context = NewContext();
+        var service = CreateService(context);
+
+        // History ingested while the connectors' clocks were drifting: the same dose landed in two
+        // canonical groups. Both records are already linked, so a re-run creates no links at all
+        // and only the job's merge pass can collapse them.
+        var mylife = CreateBolus(WideBase, 2.0, "mylife-connector");
+        var glooko = CreateBolus(WideBase + 64_000, 2.0, "glooko-connector");
+        context.Boluses.AddRange(mylife, glooko);
+        AddPrimaryLink(context, RecordType.Bolus, mylife.Id, WideBase, "mylife-connector");
+        AddPrimaryLink(context, RecordType.Bolus, glooko.Id, WideBase + 64_000, "glooko-connector");
+        await context.SaveChangesAsync();
+
+        var result = await service.DeduplicateAllAsync();
+
+        result.Success.Should().BeTrue();
+        var links = await context.LinkedRecords.Where(lr => lr.RecordType == "bolus").ToListAsync();
+        links.Should().HaveCount(2, "the full run links nothing new");
+        links.Select(lr => lr.CanonicalId).Distinct().Should().HaveCount(1,
+            "a full re-dedup run heals groups split by clock drift");
+        links.Count(lr => lr.IsPrimary).Should().Be(1);
+    }
+
+    #endregion
+
     #region Test Helper Methods
+
+    /// <summary>
+    /// Event time the wide-window tests are anchored on, in Unix milliseconds.
+    /// </summary>
+    private static readonly long WideBase =
+        new DateTimeOffset(new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc), TimeSpan.Zero)
+            .ToUnixTimeMilliseconds();
+
+    private NocturneDbContext NewContext()
+    {
+        var context = new NocturneDbContext(_contextOptions) { TenantId = TestTenantId };
+        return context;
+    }
+
+    private DeduplicationService CreateService(NocturneDbContext context) =>
+        new(context,
+            _serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            new Mock<ILogger<DeduplicationService>>().Object);
+
+    private static DateTime ToUtc(long mills) =>
+        DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime;
+
+    private static long ToMills(DateTime timestamp) =>
+        new DateTimeOffset(timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+    private static BolusEntity CreateBolus(long mills, double insulin, string dataSource) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = ToUtc(mills),
+            Insulin = insulin,
+            DataSource = dataSource
+        };
+
+    private static CarbIntakeEntity CreateCarbIntake(long mills, double carbs, string dataSource) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = ToUtc(mills),
+            Carbs = carbs,
+            DataSource = dataSource
+        };
+
+    private static DeviceEventEntity CreateDeviceEvent(long mills, string eventType, string dataSource) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = ToUtc(mills),
+            EventType = eventType,
+            DataSource = dataSource
+        };
+
+    /// <summary>
+    /// Seeds a primary link in its own canonical group, standing in for history linked by an
+    /// earlier ingest run, and returns that canonical id.
+    /// </summary>
+    private static Guid AddPrimaryLink(
+        NocturneDbContext context, RecordType recordType, Guid recordId, long mills, string dataSource)
+    {
+        var canonicalId = Guid.CreateVersion7();
+        AddLink(context, recordType, recordId, mills, dataSource, canonicalId, isPrimary: true);
+        return canonicalId;
+    }
+
+    /// <summary>
+    /// Seeds a link into an existing canonical group, standing in for a group an earlier run
+    /// already collapsed.
+    /// </summary>
+    private static void AddLink(
+        NocturneDbContext context,
+        RecordType recordType,
+        Guid recordId,
+        long mills,
+        string dataSource,
+        Guid canonicalId,
+        bool isPrimary) =>
+        context.LinkedRecords.Add(new LinkedRecordEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            CanonicalId = canonicalId,
+            RecordType = recordType.ToString().ToLowerInvariant(),
+            RecordId = recordId,
+            SourceTimestamp = mills,
+            DataSource = dataSource,
+            IsPrimary = isPrimary,
+            SysCreatedAt = DateTime.UtcNow
+        });
+
+    private static BolusCalculationEntity CreateBolusCalculation(long mills, double? carbInput, string dataSource) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = ToUtc(mills),
+            CarbInput = carbInput,
+            DataSource = dataSource
+        };
+
+    private static SensorGlucoseEntity CreateSensorGlucose(long mills, double mgdl, string dataSource) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = ToUtc(mills),
+            Mgdl = mgdl,
+            DataSource = dataSource
+        };
+
+    // Criteria mirror the repositories' own DeduplicationInput construction.
+    private static DeduplicationInput ToInput(BolusEntity e, string? dataSource = null) =>
+        new(e.Id, ToMills(e.Timestamp), dataSource ?? e.DataSource ?? DeduplicationInput.UnknownDataSource,
+            new MatchCriteria { Insulin = e.Insulin, InsulinTolerance = 0.05 });
+
+    private static DeduplicationInput ToInput(CarbIntakeEntity e, string? dataSource = null) =>
+        new(e.Id, ToMills(e.Timestamp), dataSource ?? e.DataSource ?? DeduplicationInput.UnknownDataSource,
+            new MatchCriteria { Carbs = e.Carbs, CarbsTolerance = 1.0 });
+
+    private static DeduplicationInput ToInput(DeviceEventEntity e, string? dataSource = null) =>
+        new(e.Id, ToMills(e.Timestamp), dataSource ?? e.DataSource ?? DeduplicationInput.UnknownDataSource,
+            new MatchCriteria { EventType = e.EventType });
+
+    private static DeduplicationInput ToInput(SensorGlucoseEntity e, string? dataSource = null) =>
+        new(e.Id, ToMills(e.Timestamp), dataSource ?? e.DataSource ?? DeduplicationInput.UnknownDataSource,
+            new MatchCriteria { GlucoseValue = e.Mgdl, GlucoseTolerance = 1.0 });
+
+    private static DeduplicationInput ToInput(BolusCalculationEntity e, string? dataSource = null) =>
+        new(e.Id, ToMills(e.Timestamp), dataSource ?? e.DataSource ?? DeduplicationInput.UnknownDataSource,
+            new MatchCriteria { Carbs = e.CarbInput ?? 0, CarbsTolerance = 1.0 });
 
     private static StateSpan CreateTestStateSpan(
         StateSpanCategory category,
@@ -785,13 +1539,21 @@ public class DeduplicationServiceTests : IDisposable
         };
     }
 
+    // Mirrors TempBasalRepository, including the duration the exact comparison reads.
     private static DeduplicationInput ToDeduplicationInput(TempBasalEntity entity)
     {
         return new DeduplicationInput(
             RecordId: entity.Id,
             Mills: new DateTimeOffset(entity.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-            DataSource: entity.DataSource ?? "unknown",
-            Criteria: new MatchCriteria { Rate = entity.Rate, RateTolerance = 0.05 });
+            DataSource: entity.DataSource ?? DeduplicationInput.UnknownDataSource,
+            Criteria: new MatchCriteria
+            {
+                Rate = entity.Rate,
+                RateTolerance = 0.05,
+                Duration = entity.EndTimestamp.HasValue
+                    ? entity.EndTimestamp.Value - entity.StartTimestamp
+                    : null
+            });
     }
 
     private static TempBasalEntity CreateTestTempBasalEntity(
@@ -799,17 +1561,20 @@ public class DeduplicationServiceTests : IDisposable
         double rate,
         string origin,
         string dataSource,
-        string? legacyId = null
+        string? legacyId = null,
+        TimeSpan? duration = null
     )
     {
         return new TempBasalEntity
         {
             Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
             StartTimestamp = startTimestamp,
+            EndTimestamp = duration.HasValue ? startTimestamp + duration.Value : null,
             Rate = rate,
             Origin = origin,
             DataSource = dataSource,
-            LegacyId = legacyId ?? $"{dataSource}_{startTimestamp.Ticks}",
+            LegacyId = legacyId ?? $"{dataSource}_{startTimestamp.Ticks}_{Guid.NewGuid():N}",
             SysCreatedAt = DateTime.UtcNow,
             SysUpdatedAt = DateTime.UtcNow
         };


### PR DESCRIPTION
## Problem

Cross-source deduplication silently stopped working for any pair of connectors whose clocks drift apart. `DeduplicationService` matches records from different sources within a fixed ±30s window; two connectors reporting the same pump can carry different time bases — one the raw pump RTC, one a corrected time — and that offset grows without bound (~0.5s/day observed; pump RTC crystal drift).

Measured on a production tenant running mylife + Glooko for the same YpsoPump:

| Week | Bolus pairs | Avg offset |
|---|---|---|
| Jun 1 | 48 | 30.5s |
| Jun 22 | 52 | 44.3s |
| Jul 13 | 49 | 52.2s |
| Aug 3 | 28 | 62.8s |

The offset crossed 30s in the first week of June; from then on **nothing cross-source matched**. Dedup doesn't delete rows — it links them and reads filter on `!IsPrimary` — so both copies of every bolus, carb intake, and device event became primary and displayed. Verified: a day with 3 real boluses (11.7 U) displayed as 6 (23.4 U). Every multi-connector tenant with drifting sources is affected; the failure is silent (sync stays "healthy", counts look plausible).

Probing both vendors' raw APIs ruled out identity-based dedup: the sources share no record IDs (Glooko's guids are minted at Glooko ingest), and even their "pump time" fields differ by exactly the drift — one side re-anchors timestamps, the other doesn't. Matching has to tolerate the drift.

## Fix

A second-chance **wide window (±10 min)** that runs only when the tight ±30s window found nothing, designed so that it can never merge two records that aren't the same physical event. A false merge hides a real insulin dose and is strictly worse than a shown duplicate, so every guard fails open:

- **Sparse types only**: Bolus, CarbIntake, DeviceEvent, BGCheck, TempBasal, BolusCalculation. Never SensorGlucose/Note/StateSpan (repeating identical values inside 10 minutes is normal for them).
- **Exact value equality** — the tight path's tolerances are dropped (ε=1e-6). Correction-only bolus calculations (no carbs) and open-ended temp basals (no duration) are excluded because their "exact value" would be vacuous. DeviceEvent matches on event type, deliberately: a genuinely repeating event type puts two candidates in the window and trips the next guard.
- **Candidate uniqueness**: exactly one candidate canonical group in the window, evaluated against a batching-independent candidate set (every assignment made earlier in the same chunk is visible to later records — the outcome cannot depend on how records were batched).
- **Cross-source only**: the candidate group must contain no record from the incoming record's own source (the whole group is consulted, not just the windowed slice). Single-connector tenants are provably unaffected. The `"unknown"` source sentinel is ineligible — manual/legacy records never wide-match.

The same rules extend to the reconcile-time group merge — with a mutual-exclusivity requirement (each group must be the other's only wide partner), distance and ambiguity measured on **group extents** (min/max across all of a group's links, since a wide-merged group can span minutes and its primary alone no longer stands in for it), a 2×window evidence horizon, and a candidate-root gate so ambiguity evidence is always fully loaded — and to the tenant-admin full re-dedup job, which is what heals the two months of already-ingested duplicate history. A record that wide-joins a group and precedes its primary takes over primary under the merge pass's survivor rule (earliest non-deleted; orphaned or deleted records are never promoted).

Observability that would have caught this in June: every cross-source match logs its offset (wide matches at Information), and offsets past 60% of the wide window log a Warning.

The tight path is semantically unchanged: same tolerances, same priorities, same primary stickiness. (On the candidate-bounded reconcile path the widened neighbour load lets the tight pass see pairs one run earlier than before — convergent, same end state.)

## Remediation

After deploy, run the tenant-admin full dedup job for affected tenants; the merge pass now collapses cross-source groups that ingest created separately while matching was broken. The job is gated to wide-eligible types, so it does not materialize CGM-scale history.

The full run is **required, not optional**: the incremental reconcile's forward-only watermark never revisits historical regions, and pairs the candidate-bounded pass defers (its evidence horizon is intentionally conservative near the load boundary) drain only through the full job. Deferral is fail-open — a deferred pair displays as a duplicate, never hides data.

## Tests

537 unit tests green (+43 on this branch across the service and reconcile suites). Window edges are pinned at 30_000/30_001 and 600_000/600_001 from both directions — flipping any boundary comparison fails a named test. The batching-independence, evidence-horizon, and candidate-gate guards each carry a mutation-verified test (two of the reconcile guards overlap, so their mutations were verified in isolation). Refusal tests assert the resulting group topology, not just counts.

https://claude.ai/code/session_017kedFWcPuh6JRURe815646
