### PR TITLE
fix: surface widget auth errors and modernize CMS copy

### DIFF
--- a/src/Web/packages/cms/src/lib/components/edra/shadcn/drag-handle-extended.svelte
+++ b/src/Web/packages/cms/src/lib/components/edra/shadcn/drag-handle-extended.svelte
@@ -76,9 +76,10 @@
 			.run();
 	};
 
-	const handleCopyToClipboard = () => {
+	const handleCopyToClipboard = async () => {
+		if (!currentNode) return;
 		editor.chain().setMeta('hideDragHandle', true).setNodeSelection(currentNodePos).run();
-		document.execCommand('copy');
+		await navigator.clipboard.writeText(currentNode.textContent);
 	};
 
 	const handleDelete = () => {

--- a/src/Widgets/Nocturne.Widget.Windows11/WidgetProvider.cs
+++ b/src/Widgets/Nocturne.Widget.Windows11/WidgetProvider.cs
@@ -297,6 +297,8 @@ public sealed class NocturneWidgetProvider : IWidgetProvider, IWidgetProvider2
         {
             if (_activeWidgets.TryGetValue(widgetId, out var widgetInfo))
             {
+                widgetInfo.CustomizationApiUrl = null;
+                widgetInfo.CustomizationError = null;
                 widgetInfo.CustomizationMode = connected
                     ? CustomizationState.Settings
                     : CustomizationState.EnterServerUrl;
@@ -462,9 +464,14 @@ public sealed class NocturneWidgetProvider : IWidgetProvider, IWidgetProvider2
                     var setupSettings = await _settingsStore.GetAsync();
                     dataNode = new JsonObject
                     {
-                        ["apiUrl"] = pendingAuth?.ApiUrl ?? existingCreds?.ApiUrl ?? "",
+                        ["apiUrl"] = widgetInfo.CustomizationApiUrl
+                            ?? pendingAuth?.ApiUrl
+                            ?? existingCreds?.ApiUrl
+                            ?? "",
                         ["hasCredentials"] = existingCreds != null,
                         ["unit"] = setupSettings.Unit.ToString(),
+                        ["hasError"] = !string.IsNullOrWhiteSpace(widgetInfo.CustomizationError),
+                        ["errorMessage"] = widgetInfo.CustomizationError ?? "",
                     };
                     break;
 
@@ -553,6 +560,16 @@ public sealed class NocturneWidgetProvider : IWidgetProvider, IWidgetProvider2
                         "placeholder": "https://your-server.com",
                         "value": "${apiUrl}",
                         "isRequired": true
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": "${errorMessage}",
+                        "color": "Attention",
+                        "size": "Small",
+                        "wrap": true,
+                        "maxLines": 2,
+                        "isVisible": "${hasError}",
+                        "spacing": "Small"
                     }
                 ],
                 "actions": [
@@ -1079,6 +1096,17 @@ public sealed class NocturneWidgetProvider : IWidgetProvider, IWidgetProvider2
             if (!result.Success)
             {
                 _logger.LogWarning("Failed to initiate device authorization: {Error}", result.Error);
+                lock (_widgetLock)
+                {
+                    if (_activeWidgets.TryGetValue(widgetId, out var widgetInfo))
+                    {
+                        widgetInfo.CustomizationApiUrl = apiUrl;
+                        widgetInfo.CustomizationError = string.IsNullOrWhiteSpace(result.Error)
+                            ? "Unable to connect to Nocturne server"
+                            : result.Error;
+                    }
+                }
+                UpdateWidget(widgetId);
                 return;
             }
 
@@ -1086,6 +1114,8 @@ public sealed class NocturneWidgetProvider : IWidgetProvider, IWidgetProvider2
             {
                 if (_activeWidgets.TryGetValue(widgetId, out var widgetInfo))
                 {
+                    widgetInfo.CustomizationApiUrl = null;
+                    widgetInfo.CustomizationError = null;
                     widgetInfo.CustomizationMode = CustomizationState.AwaitingAuthorization;
                 }
             }
@@ -1325,6 +1355,8 @@ public sealed class NocturneWidgetProvider : IWidgetProvider, IWidgetProvider2
         public bool IsActive { get; set; }
         public string? CustomState { get; set; }
         public CustomizationState CustomizationMode { get; set; }
+        public string? CustomizationApiUrl { get; set; }
+        public string? CustomizationError { get; set; }
 
         /// <summary>Current pinned size ("small"/"medium"/"large"); the glucose widget renders by this.</summary>
         public string Size { get; set; } = "small";


### PR DESCRIPTION
## Summary

I fixed both client-side papercuts from #660:

- I now keep the Windows widget on the connect card after a device-flow startup failure and render the returned error while preserving the entered server URL.
- I replaced the deprecated `document.execCommand('copy')` path in the CMS drag handle with the async Clipboard API and copy the selected node's text content.

## Validation

I ran:

- `pnpm --filter @nocturne/cms test` — 42 tests passed
- a focused Svelte compiler check for `drag-handle-extended.svelte`
- focused assertions for the widget error-card binding and Clipboard API path
- `git diff --check`

I did not run the Windows widget MSIX build because the project documents that it requires Visual Studio 2022 with the Windows App SDK workload.

Fixes #660
