### PR TITLE
fix(dedup): pin the tenant on the admin dedup job's background scope

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -21,6 +22,13 @@ public class DeduplicationService : IDeduplicationService
     private readonly NocturneDbContext _context;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<DeduplicationService> _logger;
+
+    /// <summary>
+    /// The ambient tenant of the scope this instance was resolved in. Null in hosts that do not
+    /// register tenant resolution; only <see cref="StartDeduplicationJobAsync"/> and the job-status
+    /// lookups need it, and they fail closed without it.
+    /// </summary>
+    private readonly ITenantAccessor? _tenantAccessor;
 
     private static readonly TimeSpan MatchingWindow = TimeSpan.FromSeconds(30);
     private static readonly long MatchingWindowMillis = (long)MatchingWindow.TotalMilliseconds;
@@ -142,6 +150,12 @@ public class DeduplicationService : IDeduplicationService
     private static readonly ConcurrentDictionary<Guid, CancellationTokenSource> _jobCancellations = new();
 
     /// <summary>
+    /// Owning tenant of each job. The job dictionaries are static and therefore shared by every
+    /// tenant in the process, so status and cancellation are matched against this before answering.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Guid, Guid> _jobTenants = new();
+
+    /// <summary>
     /// Event types that should be grouped together for deduplication.
     /// When a Basal and Temp Basal occur at the same time, they represent
     /// the same underlying event and should be deduplicated together.
@@ -166,11 +180,13 @@ public class DeduplicationService : IDeduplicationService
     public DeduplicationService(
         NocturneDbContext context,
         IServiceScopeFactory scopeFactory,
-        ILogger<DeduplicationService> logger)
+        ILogger<DeduplicationService> logger,
+        ITenantAccessor? tenantAccessor = null)
     {
         _context = context;
         _scopeFactory = scopeFactory;
         _logger = logger;
+        _tenantAccessor = tenantAccessor;
     }
 
     /// <inheritdoc />
@@ -2086,6 +2102,18 @@ public class DeduplicationService : IDeduplicationService
     /// <inheritdoc />
     public async Task<Guid> StartDeduplicationJobAsync(CancellationToken cancellationToken = default)
     {
+        // Capture the caller's tenant before leaving the request scope. Without it the background
+        // scope's DbContext is unpinned, and under FORCE row-level security every tenant-scoped
+        // table reads as empty — the job would report success having processed nothing. Fail here
+        // instead: a job that cannot see the tenant's data must not look like one that ran.
+        var tenantContext = _tenantAccessor?.Context;
+        if (tenantContext is null)
+        {
+            throw new InvalidOperationException(
+                "Cannot start a deduplication job without a resolved tenant: the background scope "
+                + "would read no rows and report a vacuous success.");
+        }
+
         var jobId = Guid.CreateVersion7();
         var cts = new CancellationTokenSource();
 
@@ -2097,6 +2125,7 @@ public class DeduplicationService : IDeduplicationService
         };
 
         _runningJobs[jobId] = status;
+        _jobTenants[jobId] = tenantContext.TenantId;
         _jobCancellations[jobId] = cts;
 
         // Start the job in the background with its own scope
@@ -2104,6 +2133,12 @@ public class DeduplicationService : IDeduplicationService
         {
             // Create a new scope for the background work to get a fresh DbContext
             await using var scope = _scopeFactory.CreateAsyncScope();
+
+            // Pin the tenant before anything is resolved from the scope: the scoped DbContext reads
+            // the accessor in its factory, so resolving the service first would bake in an empty
+            // tenant. Same ordering as DeduplicationReconciliationBackgroundService.
+            scope.ServiceProvider.GetRequiredService<ITenantAccessor>().SetTenant(tenantContext);
+
             var scopedService = scope.ServiceProvider.GetRequiredService<IDeduplicationService>();
 
             try
@@ -2163,6 +2198,9 @@ public class DeduplicationService : IDeduplicationService
         Guid jobId,
         CancellationToken cancellationToken = default)
     {
+        if (!OwnsJob(jobId))
+            return Task.FromResult<DeduplicationJobStatus?>(null);
+
         _runningJobs.TryGetValue(jobId, out var status);
         return Task.FromResult(status);
     }
@@ -2170,12 +2208,28 @@ public class DeduplicationService : IDeduplicationService
     /// <inheritdoc />
     public Task<bool> CancelJobAsync(Guid jobId, CancellationToken cancellationToken = default)
     {
+        if (!OwnsJob(jobId))
+            return Task.FromResult(false);
+
         if (_jobCancellations.TryGetValue(jobId, out var cts))
         {
             cts.Cancel();
             return Task.FromResult(true);
         }
         return Task.FromResult(false);
+    }
+
+    /// <summary>
+    /// Whether the calling scope's tenant started <paramref name="jobId"/>. Answers false for an
+    /// unknown job and for a caller with no resolved tenant, so both look exactly like a job that
+    /// does not exist.
+    /// </summary>
+    private bool OwnsJob(Guid jobId)
+    {
+        var tenantId = _tenantAccessor?.Context?.TenantId;
+        return tenantId is not null
+               && _jobTenants.TryGetValue(jobId, out var owner)
+               && owner == tenantId;
     }
 
     private async Task<(int processed, int groups, int linked, int duplicates)> DeduplicateTypeAsync<TEntity>(

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationJobTenantScopeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationJobTenantScopeTests.cs
@@ -1,0 +1,238 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Services;
+
+namespace Nocturne.Infrastructure.Data.Tests.Services;
+
+/// <summary>
+/// Tests for the tenant scoping of the admin full re-dedup job.
+/// <para>
+/// The bug these pin is only observable under PostgreSQL FORCE row-level security: a background
+/// scope with no tenant pinned sees every tenant-scoped table as empty, so the job completed in
+/// milliseconds reporting zero records processed and success. These tests run on SQLite, which has
+/// no RLS, so they cannot reproduce the empty reads — they pin the contract that produces them
+/// instead: a tenant must be captured before the job starts, and it must be pinned on the
+/// background scope before anything is resolved from it.
+/// </para>
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Deduplication")]
+public class DeduplicationJobTenantScopeTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly Guid OtherTenantId = Guid.Parse("00000000-0000-0000-0000-000000000002");
+
+    private static readonly TenantContext TestTenant =
+        new(TestTenantId, "test", "Test", true);
+    private static readonly TenantContext OtherTenant =
+        new(OtherTenantId, "other", "Other", true);
+
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _contextOptions;
+
+    public DeduplicationJobTenantScopeTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        _contextOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using var seedContext = new NocturneDbContext(_contextOptions) { TenantId = TestTenantId };
+        seedContext.Database.EnsureCreated();
+        seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+        seedContext.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task StartDeduplicationJobAsync_ThrowsWhenTheHostHasNoTenantAccessor()
+    {
+        var service = CreateService(new Mock<IServiceScopeFactory>().Object, tenantAccessor: null);
+
+        var act = async () => await service.StartDeduplicationJobAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*without a resolved tenant*");
+    }
+
+    [Fact]
+    public async Task StartDeduplicationJobAsync_ThrowsWhenNoTenantIsResolved()
+    {
+        // An unresolved accessor is what an unauthenticated or misrouted call leaves behind.
+        // Starting anyway would produce a job that scans nothing and then reports success.
+        var service = CreateService(new Mock<IServiceScopeFactory>().Object, new StubTenantAccessor(null));
+
+        var act = async () => await service.StartDeduplicationJobAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*without a resolved tenant*");
+    }
+
+    [Fact]
+    public async Task StartDeduplicationJobAsync_PinsTheCapturedTenantBeforeResolvingTheScopedService()
+    {
+        var calls = new List<string>();
+        var scopeAccessor = new RecordingTenantAccessor(calls);
+        var jobStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var scopedService = new Mock<IDeduplicationService>();
+        scopedService
+            .Setup(s => s.DeduplicateAllAsync(It.IsAny<IProgress<DeduplicationProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeduplicationResult { Success = true })
+            .Callback(() => jobStarted.TrySetResult());
+
+        var scopeFactory = CreateScopeFactory(scopeAccessor, scopedService.Object, calls);
+        var service = CreateService(scopeFactory, new StubTenantAccessor(TestTenant));
+
+        await service.StartDeduplicationJobAsync();
+
+        // The job is fire-and-forget, so wait for it rather than racing it.
+        await jobStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        scopeAccessor.Context.Should().Be(TestTenant,
+            "the background scope runs as the tenant that asked for the job");
+        calls.Should().ContainInOrder(
+            new[] { "set-tenant", "resolve-dedup-service" },
+            "the scoped DbContext reads the accessor when it is built, so the tenant must be pinned first");
+    }
+
+    [Fact]
+    public async Task GetJobStatusAsync_HidesAnotherTenantsJob()
+    {
+        var jobId = await StartJobForAsync(TestTenant);
+
+        var owner = CreateService(new Mock<IServiceScopeFactory>().Object, new StubTenantAccessor(TestTenant));
+        var stranger = CreateService(new Mock<IServiceScopeFactory>().Object, new StubTenantAccessor(OtherTenant));
+
+        (await owner.GetJobStatusAsync(jobId)).Should().NotBeNull();
+        (await stranger.GetJobStatusAsync(jobId)).Should().BeNull(
+            "the job dictionaries are static and shared by every tenant in the process");
+    }
+
+    [Fact]
+    public async Task CancelJobAsync_RefusesAnotherTenantsJob()
+    {
+        // The job must still be running when cancellation is attempted: a finished job removes its
+        // own cancellation source, and then every caller gets false whatever the tenant is.
+        var running = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var scopedService = new Mock<IDeduplicationService>();
+        scopedService
+            .Setup(s => s.DeduplicateAllAsync(It.IsAny<IProgress<DeduplicationProgress>>(), It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                running.TrySetResult();
+                await release.Task;
+                return new DeduplicationResult { Success = true };
+            });
+
+        var calls = new List<string>();
+        var scopeFactory = CreateScopeFactory(new RecordingTenantAccessor(calls), scopedService.Object, calls);
+        var owner = CreateService(scopeFactory, new StubTenantAccessor(TestTenant));
+
+        var jobId = await owner.StartDeduplicationJobAsync();
+        await running.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        try
+        {
+            var stranger = CreateService(new Mock<IServiceScopeFactory>().Object, new StubTenantAccessor(OtherTenant));
+
+            (await stranger.CancelJobAsync(jobId)).Should().BeFalse(
+                "another tenant must not be able to cancel a job it did not start");
+            (await owner.CancelJobAsync(jobId)).Should().BeTrue(
+                "the tenant that started the job can still cancel it");
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// Starts a job whose background scope resolves a mocked service, and returns its id.
+    /// </summary>
+    private async Task<Guid> StartJobForAsync(TenantContext tenant)
+    {
+        var calls = new List<string>();
+        var scopedService = new Mock<IDeduplicationService>();
+        scopedService
+            .Setup(s => s.DeduplicateAllAsync(It.IsAny<IProgress<DeduplicationProgress>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeduplicationResult { Success = true });
+
+        var scopeFactory = CreateScopeFactory(new RecordingTenantAccessor(calls), scopedService.Object, calls);
+        var service = CreateService(scopeFactory, new StubTenantAccessor(tenant));
+
+        return await service.StartDeduplicationJobAsync();
+    }
+
+    private DeduplicationService CreateService(IServiceScopeFactory scopeFactory, ITenantAccessor? tenantAccessor)
+    {
+        var context = new NocturneDbContext(_contextOptions) { TenantId = TestTenantId };
+        return new DeduplicationService(
+            context, scopeFactory, NullLogger<DeduplicationService>.Instance, tenantAccessor);
+    }
+
+    /// <summary>
+    /// A scope factory whose scope hands out <paramref name="scopeAccessor"/> and
+    /// <paramref name="scopedService"/>, recording the order they are resolved in.
+    /// </summary>
+    private static IServiceScopeFactory CreateScopeFactory(
+        ITenantAccessor scopeAccessor,
+        IDeduplicationService scopedService,
+        List<string> calls)
+    {
+        var provider = new Mock<IServiceProvider>();
+        provider.Setup(p => p.GetService(typeof(ITenantAccessor))).Returns(scopeAccessor);
+        provider.Setup(p => p.GetService(typeof(IDeduplicationService)))
+            .Returns(() =>
+            {
+                calls.Add("resolve-dedup-service");
+                return scopedService;
+            });
+
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(s => s.ServiceProvider).Returns(provider.Object);
+
+        var factory = new Mock<IServiceScopeFactory>();
+        factory.Setup(f => f.CreateScope()).Returns(scope.Object);
+        return factory.Object;
+    }
+
+    /// <summary>Accessor with a fixed context, standing in for a resolved (or unresolved) request.</summary>
+    private sealed class StubTenantAccessor(TenantContext? context) : ITenantAccessor
+    {
+        public TenantContext? Context { get; } = context;
+        public Guid TenantId => Context?.TenantId ?? Guid.Empty;
+        public bool IsResolved => Context is not null;
+        public void SetTenant(TenantContext tenantContext) =>
+            throw new NotSupportedException("The request-scope accessor is read-only in these tests.");
+    }
+
+    /// <summary>Accessor for the background scope that records when the tenant is pinned.</summary>
+    private sealed class RecordingTenantAccessor(List<string> calls) : ITenantAccessor
+    {
+        public TenantContext? Context { get; private set; }
+        public Guid TenantId => Context?.TenantId ?? Guid.Empty;
+        public bool IsResolved => Context is not null;
+
+        public void SetTenant(TenantContext tenantContext)
+        {
+            Context = tenantContext;
+            calls.Add("set-tenant");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`POST /api/v4/admin/deduplication/run` starts its job via `Task.Run` + a fresh DI scope but never pins the tenant on that scope. Under FORCE row-level security every tenant-scoped table reads as empty, so the job completes in ~0.3s reporting `totalRecordsProcessed: 0`, `success: true` — a vacuous success on any RLS deployment (observed in production on a tenant with 46k linked records). The SQLite unit tests have no RLS, so nothing caught it. This blocks the #672 remediation, which depends on this job to heal historical duplicates.

## Fix

- Capture the caller's tenant before `Task.Run`; fail fast with `InvalidOperationException` when none is resolved — a job that cannot see the tenant's data must not look like one that ran.
- Pin the captured tenant on the background scope via `ITenantAccessor.SetTenant` **before** resolving the scoped service (the scoped DbContext reads the accessor in its factory; ordering matches `DeduplicationReconciliationBackgroundService`).
- The job dictionaries are process-wide statics shared by every tenant, so status and cancel now verify job ownership: another tenant's job id answers exactly like a nonexistent one (404 / false, fail closed). Previously any tenant-admin could poll or cancel any tenant's job and read its record counts.

## Tests

5 new tests pinning the contract (no-tenant fail-fast, capture, set-before-resolve ordering, cross-tenant status/cancel refusal) — a class comment notes SQLite cannot reproduce the RLS empty-read itself. All guards mutation-checked; one initially-racy cancel test was rewritten around a TaskCompletionSource so it fails when the guard is removed.

Infra suite 557/557 green; API suite green except the known-stale `CacheIntegrationTests` failure (predates this change, untouched by this diff).

https://claude.ai/code/session_017kedFWcPuh6JRURe815646