### PR TITLE
feat(v4): basal injection uploader parity with bolus

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -16,10 +16,15 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 /// </summary>
 /// <remarks>
 /// Both create and update enforce the same rules: <see cref="BasalInjection.Units"/> must be in (0, 500],
-/// <see cref="BasalInjection.Timestamp"/> may not be more than five minutes in the future, the referenced
-/// <see cref="PatientInsulin"/> must exist with role <see cref="InsulinRole.Basal"/> or <see cref="InsulinRole.Both"/>,
-/// and the insulin must be active at the injection time. The server resolves <see cref="PatientInsulin"/>
-/// fresh on every write to populate the <see cref="TreatmentInsulinContext"/> snapshot.
+/// <see cref="BasalInjection.Timestamp"/> may not be more than five minutes in the future, and — when the
+/// request carries a <c>PatientInsulinId</c> — the referenced <see cref="PatientInsulin"/> must exist with
+/// role <see cref="InsulinRole.Basal"/> or <see cref="InsulinRole.Both"/> and be active at the injection
+/// time. The server resolves <see cref="PatientInsulin"/> fresh on every write to populate the
+/// <see cref="TreatmentInsulinContext"/> snapshot.
+///
+/// The insulin reference is optional, matching <see cref="BolusController"/>: uploader-style clients that
+/// know nothing about the patient's insulin catalog omit it, and the record is stored with a <c>null</c>
+/// <see cref="BasalInjection.InsulinContext"/>.
 ///
 /// On update, immutable fields (<see cref="BasalInjection.LegacyId"/>, <see cref="BasalInjection.CreatedAt"/>)
 /// are preserved from the existing record. <see cref="BasalInjection.CorrelationId"/> falls back to the
@@ -66,7 +71,7 @@ public class BasalInjectionController(
             return insulinProblem;
 
         var model = MapCreateToModel(request);
-        model.InsulinContext = BuildContext(insulin!);
+        model.InsulinContext = insulin is null ? null : BuildContext(insulin);
 
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
@@ -88,7 +93,7 @@ public class BasalInjectionController(
             return insulinProblem;
 
         var model = MapUpdateToModel(id, request, existing);
-        model.InsulinContext = BuildContext(insulin!);
+        model.InsulinContext = insulin is null ? null : BuildContext(insulin);
 
         try
         {
@@ -179,12 +184,33 @@ public class BasalInjectionController(
                 return insulinProblem;
 
             var model = MapCreateToModel(request);
-            model.InsulinContext = BuildContext(insulin!);
+            model.InsulinContext = insulin is null ? null : BuildContext(insulin);
             models.Add(model);
         }
 
         var persisted = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         return StatusCode(201, persisted.ToArray());
+    }
+
+    /// <summary>
+    /// Delete a basal injection by its external sync identifier (dataSource + syncIdentifier pair).
+    /// </summary>
+    [HttpDelete("by-sync-id")]
+    [RequireDeclaredWriteScope]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> DeleteBySyncIdentifier(
+        [FromQuery] string dataSource,
+        [FromQuery] string syncIdentifier,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(dataSource) || string.IsNullOrEmpty(syncIdentifier))
+            return BadRequest("dataSource and syncIdentifier are required");
+
+        var deleted = await ((IBasalInjectionRepository)Repository).DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, WriteOrigin.Live, ct);
+        return deleted > 0 ? NoContent() : NotFound();
     }
 
     private ObjectResult? ValidateUnitsAndTimestamp(double units, DateTimeOffset timestamp)
@@ -198,10 +224,30 @@ public class BasalInjectionController(
         return null;
     }
 
+    /// <summary>
+    /// Resolves the referenced <see cref="PatientInsulin"/>, or short-circuits when the request
+    /// omits the reference.
+    /// </summary>
+    /// <param name="patientInsulinId">
+    /// The requested insulin reference, or <c>null</c>. A <c>null</c> reference is not an error:
+    /// resolution is skipped and both tuple members come back <c>null</c>, leaving the caller to
+    /// store the injection without an insulin context (uploader parity with
+    /// <see cref="BolusController"/>).
+    /// </param>
+    /// <param name="timestamp">Injection time, checked against the insulin's active window.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// The resolved insulin and a <c>null</c> problem on success; a <c>400 Bad Request</c> problem
+    /// when a supplied reference is unknown, is not a basal insulin, or was inactive at
+    /// <paramref name="timestamp"/>.
+    /// </returns>
     private async Task<(PatientInsulin? Insulin, ObjectResult? Problem)> ResolveInsulinAsync(
-        Guid patientInsulinId, DateTimeOffset timestamp, CancellationToken ct)
+        Guid? patientInsulinId, DateTimeOffset timestamp, CancellationToken ct)
     {
-        var insulin = await insulinRepo.GetByIdAsync(patientInsulinId, ct);
+        if (patientInsulinId is not { } insulinId)
+            return (null, null);
+
+        var insulin = await insulinRepo.GetByIdAsync(insulinId, ct);
         if (insulin is null)
             return (null, Problem(detail: "PatientInsulin not found.", statusCode: 400, title: "Bad Request"));
 

--- a/src/API/Nocturne.API/Models/Requests/V4/CreateBasalInjectionRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/CreateBasalInjectionRequest.cs
@@ -40,11 +40,15 @@ public class CreateBasalInjectionRequest
     public string? SyncIdentifier { get; set; }
 
     /// <summary>
-    /// Reference to the <see cref="PatientInsulin"/> used for this injection. The referenced
-    /// insulin's role must be <c>Basal</c> or <c>Both</c>. The server resolves this to a
-    /// <see cref="TreatmentInsulinContext"/> snapshot at write time.
+    /// Optional reference to the <see cref="PatientInsulin"/> used for this injection. When
+    /// supplied, the referenced insulin must exist, carry role <c>Basal</c> or <c>Both</c>, and be
+    /// active at <see cref="Timestamp"/>; the server resolves it to a
+    /// <see cref="TreatmentInsulinContext"/> snapshot at write time and rejects the request with
+    /// <c>400 Bad Request</c> otherwise. When omitted, no insulin is resolved and the stored
+    /// record's <see cref="BasalInjection.InsulinContext"/> stays <c>null</c> — the shape uploader
+    /// clients produce when they know nothing about the patient's insulin catalog.
     /// </summary>
-    public required Guid PatientInsulinId { get; set; }
+    public Guid? PatientInsulinId { get; set; }
 
     /// <summary>
     /// Insulin units injected. Must be greater than zero.

--- a/src/API/Nocturne.API/Models/Requests/V4/UpdateBasalInjectionRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpdateBasalInjectionRequest.cs
@@ -41,11 +41,15 @@ public class UpdateBasalInjectionRequest
     public string? SyncIdentifier { get; set; }
 
     /// <summary>
-    /// Reference to the <see cref="PatientInsulin"/> used for this injection. The referenced
-    /// insulin's role must be <c>Basal</c> or <c>Both</c>. The server resolves this to a
-    /// <see cref="TreatmentInsulinContext"/> snapshot at write time.
+    /// Optional reference to the <see cref="PatientInsulin"/> used for this injection. When
+    /// supplied, the referenced insulin must exist, carry role <c>Basal</c> or <c>Both</c>, and be
+    /// active at <see cref="Timestamp"/>; the server resolves it to a
+    /// <see cref="TreatmentInsulinContext"/> snapshot at write time and rejects the request with
+    /// <c>400 Bad Request</c> otherwise. When omitted, no insulin is resolved and the record's
+    /// <see cref="BasalInjection.InsulinContext"/> is cleared to <c>null</c> — the shape uploader
+    /// clients produce when they know nothing about the patient's insulin catalog.
     /// </summary>
-    public required Guid PatientInsulinId { get; set; }
+    public Guid? PatientInsulinId { get; set; }
 
     /// <summary>
     /// Insulin units injected. Must be greater than zero.

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
@@ -375,8 +375,10 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     private async Task ResolvePatientInsulinsForBasalInjectionsAsync(
         List<BasalInjection> records, WriteOrigin origin, CancellationToken ct)
     {
+        // A null context is the uploader shape (no insulin catalog knowledge) and stays null;
+        // only the placeholder Guid.Empty context is resolved. Mirrors the bolus path above.
         var needsResolution = records
-            .Where(r => r.InsulinContext.PatientInsulinId == Guid.Empty)
+            .Where(r => r.InsulinContext is { PatientInsulinId: var id } && id == Guid.Empty)
             .ToList();
 
         if (needsResolution.Count == 0) return;
@@ -386,7 +388,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         foreach (var injection in needsResolution)
         {
             var resolved = await ResolveOrCreatePatientInsulinAsync(
-                injection.InsulinContext, InsulinRole.Basal, cache, origin, ct);
+                injection.InsulinContext!, InsulinRole.Basal, cache, origin, ct);
             injection.InsulinContext = resolved;
         }
     }

--- a/src/Core/Nocturne.Core.Models/V4/BasalInjection.cs
+++ b/src/Core/Nocturne.Core.Models/V4/BasalInjection.cs
@@ -40,9 +40,11 @@ public class BasalInjection : IV4Record, IDeviceAttributed
 
     /// <summary>
     /// Snapshot of the patient's insulin pharmacokinetic settings at injection time.
-    /// Required: long-acting injections must reference a known PatientInsulin with role Basal or Both.
+    /// Optional: populated when the write referenced a known PatientInsulin with role Basal or
+    /// Both, and left <c>null</c> when the writer (typically an uploader client) knows nothing
+    /// about the patient's insulin catalog. Same shape as <see cref="Bolus.InsulinContext"/>.
     /// </summary>
-    public TreatmentInsulinContext InsulinContext { get; set; } = null!;
+    public TreatmentInsulinContext? InsulinContext { get; set; }
 
     /// <summary>
     /// Catch-all for fields not mapped to dedicated columns.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
@@ -113,9 +113,11 @@ public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, I
 
     /// <summary>
     /// Snapshot of insulin pharmacokinetic settings at injection time (JSONB).
+    /// Null when the write carried no PatientInsulin reference — the uploader-client shape,
+    /// mirroring <see cref="BolusEntity.InsulinContextJson"/>.
     /// </summary>
     [Column("insulin_context", TypeName = "jsonb")]
-    public string InsulinContextJson { get; set; } = "{}";
+    public string? InsulinContextJson { get; set; }
 
     /// <summary>
     /// Catch-all JSONB column for fields not mapped to dedicated columns

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
@@ -17,10 +17,6 @@ public static class BasalInjectionMapper
     /// <returns>A new instance of BasalInjectionEntity.</returns>
     public static BasalInjectionEntity ToEntity(BasalInjection model)
     {
-        if (model.InsulinContext is null)
-            throw new InvalidOperationException(
-                $"BasalInjection {model.Id} has null InsulinContext; the InsulinContext property is required.");
-
         return new BasalInjectionEntity
         {
             Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
@@ -37,7 +33,9 @@ public static class BasalInjectionMapper
             SysUpdatedAt = DateTime.UtcNow,
             Units = model.Units,
             Notes = model.Notes,
-            InsulinContextJson = JsonSerializer.Serialize(model.InsulinContext),
+            InsulinContextJson = model.InsulinContext is not null
+                ? JsonSerializer.Serialize(model.InsulinContext)
+                : null,
             AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
                 ? JsonSerializer.Serialize(model.AdditionalProperties)
                 : null,
@@ -51,10 +49,6 @@ public static class BasalInjectionMapper
     /// <returns>A new instance of BasalInjection domain model.</returns>
     public static BasalInjection ToDomainModel(BasalInjectionEntity entity)
     {
-        var insulinContext = JsonSerializer.Deserialize<TreatmentInsulinContext>(entity.InsulinContextJson)
-            ?? throw new InvalidDataException(
-                $"BasalInjectionEntity {entity.Id} has invalid InsulinContext JSON: '{entity.InsulinContextJson}'.");
-
         return new BasalInjection
         {
             Id = entity.Id,
@@ -71,7 +65,9 @@ public static class BasalInjectionMapper
             ModifiedAt = entity.SysUpdatedAt,
             Units = entity.Units,
             Notes = entity.Notes,
-            InsulinContext = insulinContext,
+            InsulinContext = !string.IsNullOrEmpty(entity.InsulinContextJson)
+                ? JsonSerializer.Deserialize<TreatmentInsulinContext>(entity.InsulinContextJson)
+                : null,
             AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
                 ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
                 : null,
@@ -85,10 +81,6 @@ public static class BasalInjectionMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(BasalInjectionEntity entity, BasalInjection model)
     {
-        if (model.InsulinContext is null)
-            throw new InvalidOperationException(
-                $"BasalInjection {model.Id} has null InsulinContext; the InsulinContext property is required.");
-
         entity.Timestamp = model.Timestamp;
         entity.UtcOffset = model.UtcOffset;
         entity.Device = model.Device;
@@ -100,7 +92,9 @@ public static class BasalInjectionMapper
         entity.PatientDeviceId = model.PatientDeviceId;
         entity.Units = model.Units;
         entity.Notes = model.Notes;
-        entity.InsulinContextJson = JsonSerializer.Serialize(model.InsulinContext);
+        entity.InsulinContextJson = model.InsulinContext is not null
+            ? JsonSerializer.Serialize(model.InsulinContext)
+            : null;
         entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
             ? JsonSerializer.Serialize(model.AdditionalProperties)
             : null;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260810003927_MakeBasalInjectionInsulinContextOptional.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260810003927_MakeBasalInjectionInsulinContextOptional.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260810003927_MakeBasalInjectionInsulinContextOptional")]
+    partial class MakeBasalInjectionInsulinContextOptional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260810003927_MakeBasalInjectionInsulinContextOptional.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260810003927_MakeBasalInjectionInsulinContextOptional.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeBasalInjectionInsulinContextOptional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "insulin_context",
+                table: "basal_injections",
+                type: "jsonb",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "jsonb");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Rows written without a PatientInsulin reference hold NULL; backfill them to an empty
+            // JSON object before restoring NOT NULL, or the ALTER fails. basal_injections is
+            // tenant-scoped under FORCE ROW LEVEL SECURITY, so the update runs per tenant with the
+            // tenant GUC set. (The scaffolded defaultValue of "" is not valid jsonb, hence "{}".)
+            migrationBuilder.Sql("""
+                DO $$
+                DECLARE
+                    t_id uuid;
+                BEGIN
+                    FOR t_id IN SELECT id FROM tenants
+                    LOOP
+                        PERFORM set_config('app.current_tenant_id', t_id::text, true);
+
+                        UPDATE basal_injections
+                        SET insulin_context = '{}'::jsonb
+                        WHERE insulin_context IS NULL;
+                    END LOOP;
+                END $$;
+                """);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "insulin_context",
+                table: "basal_injections",
+                type: "jsonb",
+                nullable: false,
+                defaultValue: "{}",
+                oldClrType: typeof(string),
+                oldType: "jsonb",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -399,6 +399,16 @@ public class BasalInjectionRepository : IBasalInjectionRepository
         });
     }
 
+    /// <summary>
+    /// Soft-deletes every live basal injection matching the given (data source, sync identifier)
+    /// pair. The global query filter scopes the lookup to the current tenant and skips rows already
+    /// soft-deleted, so a repeat call for the same key returns 0.
+    /// </summary>
+    /// <param name="dataSource">The external data source name.</param>
+    /// <param name="syncIdentifier">The external sync identifier.</param>
+    /// <param name="origin">Write origin; only <see cref="WriteOrigin.Live"/> broadcasts.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The number of records soft-deleted.</returns>
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
     {
         var entities = await _context.BasalInjections

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
@@ -267,4 +267,114 @@ public class BasalInjectionControllerTests
         captured.InsulinContext.Concentration.Should().Be(100);
         captured.CorrelationId.Should().NotBeNull().And.NotBe(Guid.Empty);
     }
+
+    [Fact]
+    public async Task Create_without_PatientInsulinId_creates_row_with_null_InsulinContext()
+    {
+        BasalInjection? captured = null;
+        SetupCreatePassthrough(b => captured = b);
+
+        var controller = CreateController();
+        var request = new CreateBasalInjectionRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Units = 22,
+        };
+
+        var result = await controller.Create(request);
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        captured.Should().NotBeNull();
+        captured!.Units.Should().Be(22);
+        captured.InsulinContext.Should().BeNull(
+            "an uploader that knows nothing about the insulin catalog stores no snapshot");
+
+        // No reference to resolve, so the insulin catalog is never consulted.
+        _insulinRepoMock.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Update_without_PatientInsulinId_clears_InsulinContext()
+    {
+        var id = Guid.NewGuid();
+        var existing = new BasalInjection
+        {
+            Id = id,
+            Timestamp = DateTime.UtcNow.AddHours(-2),
+            Units = 10,
+            InsulinContext = new TreatmentInsulinContext
+            {
+                PatientInsulinId = Guid.NewGuid(),
+                InsulinName = "Tresiba",
+            },
+        };
+        _repoMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        BasalInjection? captured = null;
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, BasalInjection, WriteOrigin, CancellationToken>((_, b, _, _) => captured = b)
+            .ReturnsAsync((Guid _, BasalInjection b, WriteOrigin _, CancellationToken _) => b);
+
+        var controller = CreateController();
+        var request = new UpdateBasalInjectionRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Units = 11,
+        };
+
+        var result = await controller.Update(id, request);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        captured.Should().NotBeNull();
+        captured!.InsulinContext.Should().BeNull();
+        _insulinRepoMock.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteBySyncIdentifier_returns_204_when_a_row_was_deleted()
+    {
+        _repoMock
+            .Setup(r => r.DeleteBySyncIdentifierAsync("loop", "abc-123", It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var controller = CreateController();
+
+        var result = await controller.DeleteBySyncIdentifier("loop", "abc-123");
+
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task DeleteBySyncIdentifier_returns_404_when_nothing_matched()
+    {
+        _repoMock
+            .Setup(r => r.DeleteBySyncIdentifierAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        var controller = CreateController();
+
+        var result = await controller.DeleteBySyncIdentifier("loop", "does-not-exist");
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Theory]
+    [InlineData("", "abc-123")]
+    [InlineData("loop", "")]
+    [InlineData("", "")]
+    public async Task DeleteBySyncIdentifier_returns_400_when_a_parameter_is_missing(
+        string dataSource, string syncIdentifier)
+    {
+        var controller = CreateController();
+
+        var result = await controller.DeleteBySyncIdentifier(dataSource, syncIdentifier);
+
+        result.Should().BeOfType<BadRequestObjectResult>()
+            .Which.StatusCode.Should().Be(400);
+        _repoMock.Verify(
+            r => r.DeleteBySyncIdentifierAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/TreatmentPublisherTests.cs
@@ -522,7 +522,7 @@ public class TreatmentPublisherTests
             Times.Once);
 
         // The record should now have a real PatientInsulinId (not Guid.Empty)
-        records[0].InsulinContext.PatientInsulinId.Should().NotBe(Guid.Empty);
+        records[0].InsulinContext!.PatientInsulinId.Should().NotBe(Guid.Empty);
     }
 
     [Fact]
@@ -576,7 +576,7 @@ public class TreatmentPublisherTests
             Times.Never);
 
         // Should resolve to the existing ID
-        records[0].InsulinContext.PatientInsulinId.Should().Be(existingInsulinId);
+        records[0].InsulinContext!.PatientInsulinId.Should().Be(existingInsulinId);
     }
 
     [Fact]
@@ -613,7 +613,7 @@ public class TreatmentPublisherTests
         _mockPatientInsulinRepository.Verify(
             r => r.GetAllAsync(It.IsAny<CancellationToken>()),
             Times.Never);
-        records[0].InsulinContext.PatientInsulinId.Should().Be(existingId);
+        records[0].InsulinContext!.PatientInsulinId.Should().Be(existingId);
     }
 
     #endregion

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/BasalInjectionRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/BasalInjectionRepositoryTests.cs
@@ -58,7 +58,11 @@ public class BasalInjectionRepositoryTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private static BasalInjection MakeInjection(string dataSource, string syncIdentifier, double units = 10.0)
+    private static BasalInjection MakeInjection(
+        string dataSource,
+        string syncIdentifier,
+        double units = 10.0,
+        bool withInsulinContext = true)
     {
         return new BasalInjection
         {
@@ -66,14 +70,16 @@ public class BasalInjectionRepositoryTests : IDisposable
             DataSource = dataSource,
             SyncIdentifier = syncIdentifier,
             Units = units,
-            InsulinContext = new TreatmentInsulinContext
-            {
-                PatientInsulinId = Guid.NewGuid(),
-                InsulinName = "Tresiba",
-                Dia = 24.0,
-                Peak = 720,
-                Curve = "long-acting",
-            },
+            InsulinContext = withInsulinContext
+                ? new TreatmentInsulinContext
+                {
+                    PatientInsulinId = Guid.NewGuid(),
+                    InsulinName = "Tresiba",
+                    Dia = 24.0,
+                    Peak = 720,
+                    Curve = "long-acting",
+                }
+                : null,
         };
     }
 
@@ -124,5 +130,52 @@ public class BasalInjectionRepositoryTests : IDisposable
             .FirstOrDefaultAsync(e => e.Id == created.Id);
         raw.Should().NotBeNull();
         raw!.DeletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_round_trips_a_null_InsulinContext()
+    {
+        // Uploader shape: the client knows nothing about the patient's insulin catalog.
+        var created = await _repo.CreateAsync(
+            MakeInjection("xdrip", "sync-4", withInsulinContext: false), WriteOrigin.Live);
+
+        created.InsulinContext.Should().BeNull();
+
+        var stored = await _context.BasalInjections
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == created.Id);
+        stored.Should().NotBeNull();
+        stored!.InsulinContextJson.Should().BeNull("a missing snapshot is stored as SQL NULL, as for Bolus");
+
+        var reread = await _repo.GetByIdAsync(created.Id);
+        reread.Should().NotBeNull();
+        reread!.InsulinContext.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteBySyncIdentifierAsync_soft_deletes_the_matching_row()
+    {
+        var created = await _repo.CreateAsync(MakeInjection("aaps", "sync-5"), WriteOrigin.Live);
+
+        var deleted = await _repo.DeleteBySyncIdentifierAsync("aaps", "sync-5", WriteOrigin.Live);
+
+        deleted.Should().Be(1);
+        (await _repo.FindBySyncIdentifierAsync("aaps", "sync-5")).Should().BeNull();
+
+        var raw = await _context.BasalInjections
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(e => e.Id == created.Id);
+        raw.Should().NotBeNull();
+        raw!.DeletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteBySyncIdentifierAsync_returns_zero_when_nothing_matches()
+    {
+        await _repo.CreateAsync(MakeInjection("aaps", "sync-6"), WriteOrigin.Live);
+
+        var deleted = await _repo.DeleteBySyncIdentifierAsync("aaps", "no-such-sync-id", WriteOrigin.Live);
+
+        deleted.Should().Be(0);
     }
 }


### PR DESCRIPTION
## Why

Uploader-style clients (xDrip's Nocturne uploader, NightscoutFoundation/xDrip#4529) log basal injections but know nothing about the patient's insulin catalog. `CreateBasalInjectionRequest.PatientInsulinId` was `required`, so every catalog-less create was rejected with 400 — and there was no way to delete a basal injection by sync identifier, unlike every other treatment resource.

## What

**Optional `PatientInsulinId`** (parity with `BolusController`):
- `Guid?` on create/update requests; when omitted, insulin resolution is skipped and the record stores a null `InsulinContext`. When supplied, the existing exists/role/active-window validation is unchanged.
- Nullability threaded through `BasalInjection` → `BasalInjectionEntity` (`insulin_context` jsonb now nullable) → `BasalInjectionMapper` (serializes/deserializes null like `BolusMapper`).
- Migration included. The scaffolded `Down` would have failed at runtime (invalid-jsonb default, no backfill), so it backfills nulls to `'{}'::jsonb` per tenant under FORCE RLS before restoring NOT NULL, following the `BackfillSensorGlucosePatientDeviceId` pattern.
- `TreatmentPublisher` resolves only the `Guid.Empty` placeholder shape and leaves null contexts alone (mirrors the bolus path; previously NRE'd on null).

**`DELETE /api/v4/insulin/basal-injections/by-sync-id`** mirroring the bolus endpoint (same scope enforcement and 400/204/404 semantics). `IBasalInjectionRepository.DeleteBySyncIdentifierAsync` already existed with soft-delete + broadcast; only the API surface was missing. `V4WriteScopeGatingTests`' reflection sweep covers the new action automatically, and `sdk/filter-v4-spec.js` picks the route up on the next spec regeneration.

## Tests

8 new unit tests (create/update without reference, null-context round-trip to SQL NULL, delete-by-sync-id 204/404/400). Full unit suites green: API.Tests 4954 passed / 0 failed, Infrastructure.Data.Tests 560 passed / 0 failed. Integration tests (Aspire + Docker) not run; the migration is the one piece they'd additionally exercise.

## Follow-up

After merge, cut nocturne-java 0.2.5 so xDrip can wire `basalInjectionDeleteBySyncIdentifier` into its treatment-deletion path.