### PR TITLE
fix(v1): echo dedup hits in the POST /api/v1/entries response

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -593,8 +593,14 @@ public class EntriesController : ControllerBase
             var processedEntries = _documentProcessingService.ProcessDocuments(validEntries);
             var processedArray = processedEntries.ToArray();
 
-            // Filter out duplicates using database-backed detection
+            // Filter out duplicates using database-backed detection. Duplicates are
+            // excluded from the write but must still be echoed in the response: v1
+            // uploaders (Loop's NightscoutKit) require one response object per
+            // submitted entry, and treat a shorter array as a failed upload — the
+            // batch is then retried forever and the client never uploads anything
+            // newer. Legacy cgm-remote-monitor echoed dedup hits back with their _id.
             var uniqueEntries = new List<Entry>();
+            var responseEntries = new List<Entry>();
             foreach (var entry in processedArray)
             {
                 var duplicate = await _entryService.CheckForDuplicateEntryAsync(
@@ -615,10 +621,12 @@ public class EntriesController : ControllerBase
                         entry.Sgv,
                         entry.Mills
                     );
+                    responseEntries.Add(duplicate);
                     continue;
                 }
 
                 uniqueEntries.Add(entry);
+                responseEntries.Add(entry);
             }
 
             _logger.LogDebug(
@@ -639,7 +647,7 @@ public class EntriesController : ControllerBase
             // Evaluate alert rules against the latest created entry
             await EvaluateAlertsAsync(createdArray, cancellationToken);
 
-            return StatusCode(201, createdArray.ToV1Responses());
+            return StatusCode(201, responseEntries.ToV1Responses());
         }
         catch (JsonException ex)
         {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V1/EntriesControllerTests.cs
@@ -9,6 +9,7 @@ using Nocturne.Core.Contracts.Legacy;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Extensions;
 using Xunit;
 
 namespace Nocturne.API.Tests.Controllers.V1;
@@ -405,5 +406,151 @@ public class EntriesControllerTests
         processedInput.Should().NotBeNull();
         processedInput.Should().HaveCount(1);
         processedInput![0].Mills.Should().Be(1686565800000);
+    }
+
+    [Fact]
+    public async Task CreateEntries_AllDuplicates_EchoesStoredEntriesWithSameCount()
+    {
+        // v1 uploaders (Loop's NightscoutKit) require one response object per submitted
+        // entry; an all-duplicate batch must echo the stored entries, not return [].
+        var submitted = new[]
+        {
+            new Entry { Sgv = 164, Mills = 1000, Device = "Dexcom G7" },
+            new Entry { Sgv = 158, Mills = 2000, Device = "Dexcom G7" },
+        };
+        var stored1 = new Entry { Id = "stored-1", Sgv = 164, Mills = 1000, Device = "Dexcom G7", Type = "sgv" };
+        var stored2 = new Entry { Id = "stored-2", Sgv = 158, Mills = 2000, Device = "Dexcom G7", Type = "sgv" };
+
+        _mockDocumentProcessingService
+            .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
+            .Returns<IEnumerable<Entry>>(entries => entries);
+
+        _mockEntryService
+            .Setup(x =>
+                x.CheckForDuplicateEntryAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<double?>(),
+                    1000L,
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(stored1);
+        _mockEntryService
+            .Setup(x =>
+                x.CheckForDuplicateEntryAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<double?>(),
+                    2000L,
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(stored2);
+
+        List<Entry>? createInput = null;
+        _mockEntryService
+            .Setup(x =>
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
+            )
+            .Callback<IEnumerable<Entry>, WriteOrigin, CancellationToken>((entries, _, _) => createInput = entries.ToList())
+            .ReturnsAsync(Array.Empty<Entry>());
+
+        // Act
+        var result = await _controller.CreateEntries(submitted);
+
+        // Assert
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(201);
+
+        var body = objectResult
+            .Value.Should()
+            .BeAssignableTo<IEnumerable<object>>()
+            .Subject.Cast<EntryV1Response>()
+            .ToList();
+        body.Should().HaveCount(2);
+        body[0].Id.Should().Be("stored-1");
+        body[1].Id.Should().Be("stored-2");
+
+        // Nothing new is written for an all-duplicate batch
+        createInput.Should().NotBeNull();
+        createInput.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateEntries_MixedDuplicateAndNew_EchoesOneResponsePerSubmittedEntry()
+    {
+        var submitted = new[]
+        {
+            new Entry { Sgv = 120, Mills = 1000, Device = "Dexcom G7" },
+            new Entry { Sgv = 130, Mills = 2000, Device = "Dexcom G7" }, // duplicate of a stored entry
+            new Entry { Sgv = 140, Mills = 3000, Device = "Dexcom G7" },
+        };
+        var storedDuplicate = new Entry { Id = "stored-dup", Sgv = 130, Mills = 2000, Device = "Dexcom G7", Type = "sgv" };
+
+        _mockDocumentProcessingService
+            .Setup(x => x.ProcessDocuments(It.IsAny<IEnumerable<Entry>>()))
+            .Returns<IEnumerable<Entry>>(entries => entries);
+
+        _mockEntryService
+            .Setup(x =>
+                x.CheckForDuplicateEntryAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<double?>(),
+                    It.IsAny<long>(),
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync((Entry?)null);
+        _mockEntryService
+            .Setup(x =>
+                x.CheckForDuplicateEntryAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<double?>(),
+                    2000L,
+                    It.IsAny<int>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(storedDuplicate);
+
+        List<Entry>? createInput = null;
+        _mockEntryService
+            .Setup(x =>
+                x.CreateEntriesAsync(It.IsAny<IEnumerable<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>())
+            )
+            .Callback<IEnumerable<Entry>, WriteOrigin, CancellationToken>((entries, _, _) => createInput = entries.ToList())
+            .ReturnsAsync((IEnumerable<Entry> entries, WriteOrigin _, CancellationToken _) => entries.ToList());
+
+        // Act
+        var result = await _controller.CreateEntries(submitted);
+
+        // Assert
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(201);
+
+        var body = objectResult
+            .Value.Should()
+            .BeAssignableTo<IEnumerable<object>>()
+            .Subject.Cast<EntryV1Response>()
+            .ToList();
+
+        // One response object per submitted entry, in submission order; the duplicate
+        // slot carries the stored entry's _id, not the resubmitted copy's.
+        body.Should().HaveCount(3);
+        body[0].Mills.Should().Be(1000);
+        body[1].Id.Should().Be("stored-dup");
+        body[2].Mills.Should().Be(3000);
+        body[0].Id.Should().NotBeNullOrEmpty();
+        body[2].Id.Should().NotBeNullOrEmpty();
+
+        // Only the two non-duplicates are written
+        createInput.Should().NotBeNull();
+        createInput!.Select(e => e.Mills).Should().Equal(1000, 3000);
     }
 }


### PR DESCRIPTION
## Problem

`POST /api/v1/entries` drops database-detected duplicates from both the write **and the response**. An all-duplicate batch returns `201` with body `[]`.

Loop's NightscoutKit hard-requires one response object per submitted entry:

```swift
guard let insertedEntries = postResponse as? [[String: Any]],
      insertedEntries.count == json.count else {
    completion(.failure(NightscoutError.invalidResponse(...)))
}
```

Any shorter response — `[]` for an all-duplicate batch, or a partial echo when even one entry dedups — fails the whole upload. Loop then never advances its glucose query anchor, replays the identical batch every ~5 minutes, and once the unacknowledged backlog crosses Loop's 1000-entry query limit, no new reading ever reaches the server again: glucose flatlines while treatments and devicestatus keep flowing. One transient network blip (entries stored, response lost) converts into a permanent wedge. This was observed in the field: a Loop user re-POSTing the same 194 KB / ~1000-entry batch for days, `sensor_glucose` frozen while every other table stayed current.

Legacy cgm-remote-monitor echoes the input docs back (its dedup is an upsert, not a response filter), so the filtered response is a v1 compat regression.

## Fix

Duplicates are still excluded from the write. The response now contains one object per submitted entry, in submission order, with each dedup hit echoing the **stored** entry (carrying its `_id`) instead of being dropped. This also self-heals wedged uploaders in the field the moment it deploys — their next replay gets a full-length echo and the anchor advances.

The `/api/v1/entries/async` variant is untouched: it returns a correlation-ID envelope, not the entries array.

Residual edge (unchanged, noted for completeness): entries dropped by the `HasMeaningfulData` filter are still absent from the response. Loop never sends such entries; tightening that would change 400-semantics and is out of scope.

## Tests

- All-duplicate batch → `201` with the stored entries echoed, nothing written.
- Mixed batch → one response object per submitted entry in order, duplicate slot carries the stored `_id`, only the non-duplicates written.

Both fail against the previous behavior. Full `Nocturne.API.Tests` suite: 4956 passed.

https://claude.ai/code/session_019A3ZStCQ2qKEmXmaUHgP8p
