### PR TITLE
feat(docs): make the API reference an opt-in per tenant

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
@@ -62,8 +62,7 @@ public class DemoAdminController : ControllerBase
         {
             // Re-apply the tenant defaults and the access grants: this runs on every demo
             // service start, so it repairs a tenant left without roles or a demo member by a
-            // reset that failed between wiping and re-seeding, and picks up a default added
-            // since the tenant was provisioned.
+            // reset that failed between wiping and re-seeding.
             DemoTenantService.ApplyTenantDefaults(existing);
             await db.SaveChangesAsync(ct);
             await _demoTenantService.ConfigureAccessAsync(existing.Id, ct);

--- a/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
@@ -60,9 +60,12 @@ public class DemoAdminController : ControllerBase
 
         if (existing is not null)
         {
-            // Re-apply the access grants: this runs on every demo service start, so it
-            // repairs a tenant left without roles or a demo member by a reset that
-            // failed between wiping and re-seeding.
+            // Re-apply the tenant defaults and the access grants: this runs on every demo
+            // service start, so it repairs a tenant left without roles or a demo member by a
+            // reset that failed between wiping and re-seeding, and picks up a default added
+            // since the tenant was provisioned.
+            DemoTenantService.ApplyTenantDefaults(existing);
+            await db.SaveChangesAsync(ct);
             await _demoTenantService.ConfigureAccessAsync(existing.Id, ct);
             return Ok(ToDto(existing, alreadyExisted: true));
         }
@@ -73,6 +76,7 @@ public class DemoAdminController : ControllerBase
             .FirstAsync(t => t.Id == created.Id, ct);
 
         tenant.IsDemo = true;
+        DemoTenantService.ApplyTenantDefaults(tenant);
 
         var config = new TenantDemoConfigEntity { TenantId = tenant.Id };
         db.Set<TenantDemoConfigEntity>().Add(config);

--- a/src/API/Nocturne.API/Controllers/V4/Identity/TenantSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/TenantSettingsController.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenApi.Remote.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Controllers.V4.Identity;
+
+/// <summary>
+/// Tenant-level settings a tenant's own administrators control, as opposed to the platform-admin
+/// surface in <c>PlatformAdmin.TenantController</c>. All operations require the
+/// <c>tenant.settings</c> permission.
+/// </summary>
+[ApiController]
+[Tags("Identity")]
+[Route("api/v4/tenant-settings")]
+[Produces("application/json")]
+[Authorize]
+public class TenantSettingsController : ControllerBase
+{
+    private readonly ITenantService _tenantService;
+    private readonly ITenantAccessor _tenantAccessor;
+
+    public TenantSettingsController(ITenantService tenantService, ITenantAccessor tenantAccessor)
+    {
+        _tenantService = tenantService;
+        _tenantAccessor = tenantAccessor;
+    }
+
+    /// <summary>Get this tenant's settings.</summary>
+    [HttpGet]
+    [RemoteQuery]
+    [ProducesResponseType(typeof(TenantSettingsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<TenantSettingsDto>> GetTenantSettings(CancellationToken ct)
+    {
+        if (!HasPermission(TenantPermissions.TenantSettings))
+            return Forbid();
+
+        return Ok(await _tenantService.GetSettingsAsync(_tenantAccessor.TenantId, ct));
+    }
+
+    /// <summary>
+    /// Choose whether this tenant's hosts serve the API reference and the OpenAPI specs behind it.
+    /// </summary>
+    // The demo's account is shared and obtainable without signing up, and it holds
+    // tenant.settings — so a permission gate alone would let any visitor take the demo's own
+    // reference down for everyone until the next reset.
+    [DenyDemoSubject]
+    [HttpPut("public-docs")]
+    [RemoteCommand(Invalidates = ["GetTenantSettings"])]
+    [ProducesResponseType(typeof(TenantSettingsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<TenantSettingsDto>> SetPublicDocs(
+        [FromBody] SetPublicDocsRequest request, CancellationToken ct)
+    {
+        if (!HasPermission(TenantPermissions.TenantSettings))
+            return Forbid();
+
+        return Ok(await _tenantService.SetAllowPublicDocsAsync(
+            _tenantAccessor.TenantId, request.Enabled, ct));
+    }
+
+    private bool HasPermission(string permission)
+        => TenantPermissions.HasPermission(HttpContext.GetGrantedScopes(), permission);
+}
+
+public record SetPublicDocsRequest(bool Enabled);

--- a/src/API/Nocturne.API/Controllers/V4/Identity/TenantSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/TenantSettingsController.cs
@@ -10,8 +10,7 @@ namespace Nocturne.API.Controllers.V4.Identity;
 
 /// <summary>
 /// Tenant-level settings a tenant's own administrators control, as opposed to the platform-admin
-/// surface in <c>PlatformAdmin.TenantController</c>. All operations require the
-/// <c>tenant.settings</c> permission.
+/// surface in <c>PlatformAdmin.TenantController</c>.
 /// </summary>
 [ApiController]
 [Tags("Identity")]
@@ -29,7 +28,6 @@ public class TenantSettingsController : ControllerBase
         _tenantAccessor = tenantAccessor;
     }
 
-    /// <summary>Get this tenant's settings.</summary>
     [HttpGet]
     [RemoteQuery]
     [ProducesResponseType(typeof(TenantSettingsDto), StatusCodes.Status200OK)]
@@ -42,9 +40,6 @@ public class TenantSettingsController : ControllerBase
         return Ok(await _tenantService.GetSettingsAsync(_tenantAccessor.TenantId, ct));
     }
 
-    /// <summary>
-    /// Choose whether this tenant's hosts serve the API reference and the OpenAPI specs behind it.
-    /// </summary>
     // The demo's account is shared and obtainable without signing up, and it holds
     // tenant.settings — so a permission gate alone would let any visitor take the demo's own
     // reference down for everyone until the next reset.

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -85,8 +85,8 @@ namespace Nocturne.API.Extensions;
 public static class ServiceRegistrationExtensions
 {
     /// <summary>
-    /// Rate-limiting policy applied to the documentation endpoints. Named here rather than
-    /// declared as an attribute because those endpoints are mapped, not controller actions.
+    /// Rate-limiting policy for the documentation endpoints, which are mapped rather than
+    /// controller actions and so cannot carry the attribute.
     /// </summary>
     public const string DocsRateLimitPolicy = "docs";
 
@@ -404,17 +404,13 @@ public static class ServiceRegistrationExtensions
                     )
             );
 
-            // Documentation surface (/scalar, /openapi): 30 per IP per minute. These endpoints
-            // run before tenant resolution and authentication, and the reference reads the
-            // tenants table and may write that tenant's OAuth client, so they are the one
-            // unauthenticated path that reaches the database that early.
-            //
-            // As with demo-session, the partition key is not a hard ceiling: UseForwardedHeaders
-            // runs with KnownProxies/KnownIPNetworks cleared, so RemoteIpAddress comes from
-            // X-Forwarded-For and a caller rotating it gets a fresh partition every request. What
-            // does bound the damage is elsewhere: the row can hold at most
-            // ScalarAuthProvider.MaxRedirectUris entries, and both the tenant resolution and the
-            // client id are cached, so a flood mostly costs the page render.
+            // Documentation surface (/scalar, /openapi): 30 per IP per minute. These endpoints run
+            // before tenant resolution and authentication, and the reference reads the tenants
+            // table and may write that tenant's OAuth client, so they are the one unauthenticated
+            // path that reaches the database that early. As with demo-session the partition key is
+            // no hard ceiling — it comes from X-Forwarded-For. What bounds the damage is elsewhere:
+            // the row holds at most ScalarAuthProvider.MaxRedirectUris entries, and both the tenant
+            // resolution and the client id are cached, so a flood mostly costs the page render.
             options.AddPolicy(
                 DocsRateLimitPolicy,
                 context =>

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -85,6 +85,12 @@ namespace Nocturne.API.Extensions;
 public static class ServiceRegistrationExtensions
 {
     /// <summary>
+    /// Rate-limiting policy applied to the documentation endpoints. Named here rather than
+    /// declared as an attribute because those endpoints are mapped, not controller actions.
+    /// </summary>
+    public const string DocsRateLimitPolicy = "docs";
+
+    /// <summary>
     /// Core API utility and calculation services (status, versioning, time queries,
     /// IOB/COB, predictions, statistics, etc.)
     /// </summary>
@@ -393,6 +399,31 @@ public static class ServiceRegistrationExtensions
                         {
                             PermitLimit = 5,
                             Window = TimeSpan.FromHours(1),
+                            QueueLimit = 0,
+                        }
+                    )
+            );
+
+            // Documentation surface (/scalar, /openapi): 30 per IP per minute. These endpoints
+            // run before tenant resolution and authentication, and the reference reads the
+            // tenants table and may write that tenant's OAuth client, so they are the one
+            // unauthenticated path that reaches the database that early.
+            //
+            // As with demo-session, the partition key is not a hard ceiling: UseForwardedHeaders
+            // runs with KnownProxies/KnownIPNetworks cleared, so RemoteIpAddress comes from
+            // X-Forwarded-For and a caller rotating it gets a fresh partition every request. What
+            // does bound the damage is elsewhere: the row can hold at most
+            // ScalarAuthProvider.MaxRedirectUris entries, and both the tenant resolution and the
+            // client id are cached, so a flood mostly costs the page render.
+            options.AddPolicy(
+                DocsRateLimitPolicy,
+                context =>
+                    RateLimitPartition.GetFixedWindowLimiter(
+                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                        factory: _ => new FixedWindowRateLimiterOptions
+                        {
+                            PermitLimit = 30,
+                            Window = TimeSpan.FromMinutes(1),
                             QueueLimit = 0,
                         }
                     )

--- a/src/API/Nocturne.API/Middleware/PublicDocsMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/PublicDocsMiddleware.cs
@@ -50,8 +50,8 @@ public sealed class PublicDocsMiddleware
         // (OAuth client, demo bearer token) is resolved here and stashed on Items.
         if (!await docs.TryPrepareAsync(context))
         {
-            // Same answer an unknown tenant slug gets: a tenant that has not opted in has no
-            // documentation surface, rather than one that exists and refuses.
+            // The answer an unknown slug gets elsewhere in the app: a tenant that has not opted
+            // in has no documentation surface, rather than one that exists and refuses.
             context.Response.StatusCode = StatusCodes.Status404NotFound;
             return;
         }

--- a/src/API/Nocturne.API/Middleware/PublicDocsMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/PublicDocsMiddleware.cs
@@ -7,16 +7,12 @@ namespace Nocturne.API.Middleware;
 /// resolution and authentication, and gates them on the resolved tenant's opt-in.
 /// </summary>
 /// <remarks>
-/// <para>
 /// Running before <see cref="Multitenancy.TenantResolutionMiddleware"/> is what lets the reference
 /// render on a fresh install: the apex of an instance with no tenants answers 503 setup_required,
 /// and an instance with several answers 404. Neither is a useful first page for an operator who is
-/// standing the instance up, so the request jumps straight to the endpoint instead.
-/// </para>
-/// <para>
-/// The flip side is that everything downstream is skipped, so what a tenant's host exposes here is
-/// decided entirely by <see cref="ScalarAuthProvider"/>.
-/// </para>
+/// standing the instance up, so the request jumps straight to the endpoint instead — which also
+/// skips everything downstream, leaving what a tenant's host exposes to
+/// <see cref="ScalarAuthProvider"/> alone.
 /// </remarks>
 public sealed class PublicDocsMiddleware
 {
@@ -25,9 +21,8 @@ public sealed class PublicDocsMiddleware
     public PublicDocsMiddleware(RequestDelegate next) => _next = next;
 
     /// <summary>
-    /// Documentation paths: the OpenAPI specs and the Scalar UI plus its wwwroot assets.
-    /// These are tenantless and publicly accessible, so they both bypass the tenant/auth
-    /// middleware stack and get the any-origin CORS policy.
+    /// The OpenAPI specs and the Scalar UI plus its wwwroot assets. Also picks out the branch
+    /// that gets the any-origin CORS policy in <c>Program</c>.
     /// </summary>
     public static bool IsPublicDocsPath(HttpContext context)
     {
@@ -38,8 +33,7 @@ public sealed class PublicDocsMiddleware
 
     public async Task InvokeAsync(HttpContext context, ScalarAuthProvider docs)
     {
-        // A docs path with no endpoint is not one of ours (MapOpenApi / MapScalarApiReference);
-        // it continues down the pipeline to whatever else would have handled it.
+        // A docs path with no endpoint is not one of ours (MapOpenApi / MapScalarApiReference).
         if (!IsPublicDocsPath(context) || context.GetEndpoint()?.RequestDelegate is not { } handle)
         {
             await _next(context);
@@ -50,8 +44,8 @@ public sealed class PublicDocsMiddleware
         // (OAuth client, demo bearer token) is resolved here and stashed on Items.
         if (!await docs.TryPrepareAsync(context))
         {
-            // The answer an unknown slug gets elsewhere in the app: a tenant that has not opted
-            // in has no documentation surface, rather than one that exists and refuses.
+            // 404 rather than 403: a tenant that has not opted in has no documentation surface,
+            // as an unknown slug has none.
             context.Response.StatusCode = StatusCodes.Status404NotFound;
             return;
         }

--- a/src/API/Nocturne.API/Middleware/PublicDocsMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/PublicDocsMiddleware.cs
@@ -1,0 +1,61 @@
+using Nocturne.API.Services.Docs;
+
+namespace Nocturne.API.Middleware;
+
+/// <summary>
+/// Serves the documentation paths — the OpenAPI specs and the Scalar reference — ahead of tenant
+/// resolution and authentication, and gates them on the resolved tenant's opt-in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Running before <see cref="Multitenancy.TenantResolutionMiddleware"/> is what lets the reference
+/// render on a fresh install: the apex of an instance with no tenants answers 503 setup_required,
+/// and an instance with several answers 404. Neither is a useful first page for an operator who is
+/// standing the instance up, so the request jumps straight to the endpoint instead.
+/// </para>
+/// <para>
+/// The flip side is that everything downstream is skipped, so what a tenant's host exposes here is
+/// decided entirely by <see cref="ScalarAuthProvider"/>.
+/// </para>
+/// </remarks>
+public sealed class PublicDocsMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public PublicDocsMiddleware(RequestDelegate next) => _next = next;
+
+    /// <summary>
+    /// Documentation paths: the OpenAPI specs and the Scalar UI plus its wwwroot assets.
+    /// These are tenantless and publicly accessible, so they both bypass the tenant/auth
+    /// middleware stack and get the any-origin CORS policy.
+    /// </summary>
+    public static bool IsPublicDocsPath(HttpContext context)
+    {
+        var path = context.Request.Path.Value ?? "";
+        return path.StartsWith("/scalar", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith("/openapi", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async Task InvokeAsync(HttpContext context, ScalarAuthProvider docs)
+    {
+        // A docs path with no endpoint is not one of ours (MapOpenApi / MapScalarApiReference);
+        // it continues down the pipeline to whatever else would have handled it.
+        if (!IsPublicDocsPath(context) || context.GetEndpoint()?.RequestDelegate is not { } handle)
+        {
+            await _next(context);
+            return;
+        }
+
+        // Scalar's options delegate is synchronous, so the per-tenant auth context
+        // (OAuth client, demo bearer token) is resolved here and stashed on Items.
+        if (!await docs.TryPrepareAsync(context))
+        {
+            // Same answer an unknown tenant slug gets: a tenant that has not opted in has no
+            // documentation surface, rather than one that exists and refuses.
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        await handle(context);
+    }
+}

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -368,8 +368,8 @@ app.UseStatusCodePages();
 // chaining both would emit conflicting Access-Control-Allow-Origin headers. Both sit ahead of
 // UseStaticFiles so the Scalar assets under wwwroot/scalar are covered, and ahead of
 // UseRouting so preflights short-circuit.
-app.UseWhen(IsPublicDocsPath, branch => branch.UseCors(PublicDocsCorsPolicy));
-app.UseWhen(context => !IsPublicDocsPath(context), branch => branch.UseCors());
+app.UseWhen(PublicDocsMiddleware.IsPublicDocsPath, branch => branch.UseCors(PublicDocsCorsPolicy));
+app.UseWhen(context => !PublicDocsMiddleware.IsPublicDocsPath(context), branch => branch.UseCors());
 app.UseStaticFiles();
 app.UseForwardedHeaders();
 
@@ -391,27 +391,7 @@ app.UseRouting();
 
 // Documentation paths (/scalar, /openapi) bypass the entire tenant/auth
 // middleware stack — they're tenantless and publicly accessible.
-app.Use(async (context, next) =>
-{
-    if (IsPublicDocsPath(context))
-    {
-        // Jump straight to the endpoint (MapOpenApi / MapScalarApiReference)
-        var endpoint = context.GetEndpoint();
-        if (endpoint != null)
-        {
-            // Scalar's options delegate is synchronous, so the per-tenant auth context
-            // (OAuth client, demo bearer token) is resolved here and stashed on Items.
-            if (context.Request.Path.StartsWithSegments("/scalar", StringComparison.OrdinalIgnoreCase))
-            {
-                await context.RequestServices.GetRequiredService<ScalarAuthProvider>().PrepareAsync(context);
-            }
-
-            await endpoint.RequestDelegate!(context);
-            return;
-        }
-    }
-    await next();
-});
+app.UseMiddleware<PublicDocsMiddleware>();
 
 // Redirect OIDC callbacks from apex to the originating tenant subdomain
 app.UseMiddleware<OidcCallbackRedirectMiddleware>();
@@ -653,16 +633,6 @@ if (app.Environment.IsDevelopment() && !isNSwagGeneration)
 }
 
 await app.RunAsync();
-
-// Documentation paths: the OpenAPI specs and the Scalar UI plus its wwwroot assets.
-// These are tenantless and publicly accessible, so they both bypass the tenant/auth
-// middleware stack and get the any-origin CORS policy.
-static bool IsPublicDocsPath(HttpContext context)
-{
-    var path = context.Request.Path.Value ?? "";
-    return path.StartsWith("/scalar", StringComparison.OrdinalIgnoreCase)
-        || path.StartsWith("/openapi", StringComparison.OrdinalIgnoreCase);
-}
 
 // Detects if the application is being run by NSwag for OpenAPI document generation.
 // NSwag uses its AspNetCore.Launcher to load and introspect the app without actually running it.

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -389,15 +389,13 @@ app.UseMiddleware<JsonExtensionMiddleware>();
 // but we make it explicit for clarity.
 app.UseRouting();
 
-// Rate limiting. Ahead of the documentation branch below, which jumps straight to its
-// endpoint and would otherwise skip the limiter entirely; the policies are attached to
-// endpoints, so this needs UseRouting to have run. Everything without a policy passes
-// through untouched, and every policy that exists partitions on the remote address alone,
-// so none of their accounting depends on running after UseAuthorization.
+// Ahead of the documentation branch below, which jumps straight to its endpoint and would
+// otherwise skip the limiter entirely; the policies are attached to endpoints, so this needs
+// UseRouting to have run. Everything without a policy passes through untouched, and every
+// policy that exists partitions on the remote address alone, so none of their accounting
+// depends on running after UseAuthorization.
 app.UseRateLimiter();
 
-// Documentation paths (/scalar, /openapi) bypass the entire tenant/auth
-// middleware stack — they're tenantless and publicly accessible.
 app.UseMiddleware<PublicDocsMiddleware>();
 
 // Redirect OIDC callbacks from apex to the originating tenant subdomain

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -389,6 +389,13 @@ app.UseMiddleware<JsonExtensionMiddleware>();
 // but we make it explicit for clarity.
 app.UseRouting();
 
+// Rate limiting. Ahead of the documentation branch below, which jumps straight to its
+// endpoint and would otherwise skip the limiter entirely; the policies are attached to
+// endpoints, so this needs UseRouting to have run. Everything without a policy passes
+// through untouched, and every policy that exists partitions on the remote address alone,
+// so none of their accounting depends on running after UseAuthorization.
+app.UseRateLimiter();
+
 // Documentation paths (/scalar, /openapi) bypass the entire tenant/auth
 // middleware stack — they're tenantless and publicly accessible.
 app.UseMiddleware<PublicDocsMiddleware>();
@@ -433,9 +440,6 @@ app.UseMiddleware<SiteSecurityMiddleware>();
 // directly.
 app.UseAuthorization();
 
-// Add rate limiting
-app.UseRateLimiter();
-
 // Add compatibility proxy middleware (background comparison against Nightscout for v1/v2/v3 GET requests)
 app.UseMiddleware<CompatibilityProxyMiddleware>();
 
@@ -450,7 +454,7 @@ app.MapHub<ConfigHub>("/hubs/config");
 app.MapHub<HomeAssistantHub>("/hubs/home-assistant");
 
 // Serve OpenAPI specs at /openapi/{documentName}.json
-app.MapOpenApi();
+app.MapOpenApi().RequireRateLimiting(ServiceRegistrationExtensions.DocsRateLimitPolicy);
 
 var scalarCss = app.Configuration["SCALAR_CUSTOM_CSS"];
 
@@ -500,7 +504,7 @@ app.MapScalarApiReference((options, httpContext) =>
             .AddPreferredSecuritySchemes("bearer", "oauth2", "apiSecret")
             .WithHttpBearerAuthentication(bearer => bearer.Token = demoToken);
     }
-});
+}).RequireRateLimiting(ServiceRegistrationExtensions.DocsRateLimitPolicy);
 
 // Add root endpoint to serve a basic info page
 app.MapGet(

--- a/src/API/Nocturne.API/Services/Demo/DemoTenantService.cs
+++ b/src/API/Nocturne.API/Services/Demo/DemoTenantService.cs
@@ -378,8 +378,8 @@ public sealed class DemoTenantService
         tenant.OnboardingCompletedAt ??= DateTime.UtcNow;
         // A demo tenant has no owner to review access requests.
         tenant.AllowAccessRequests = false;
-        // The demo exists to be poked at: its Scalar page prefills a working token, which
-        // needs the docs surface served on the demo's own host.
+        // The demo's Scalar page prefills a working token, which needs the docs served on the
+        // demo's own host.
         tenant.AllowPublicDocs = true;
     }
 

--- a/src/API/Nocturne.API/Services/Demo/DemoTenantService.cs
+++ b/src/API/Nocturne.API/Services/Demo/DemoTenantService.cs
@@ -367,13 +367,20 @@ public sealed class DemoTenantService
         };
     }
 
-    private static void ApplyTenantDefaults(TenantEntity tenant)
+    /// <summary>
+    /// The tenant-row state a demo tenant is expected to hold. Applied at provisioning and
+    /// re-applied by every reset, so a demo that predates one of these defaults picks it up.
+    /// </summary>
+    internal static void ApplyTenantDefaults(TenantEntity tenant)
     {
         // The web app's authenticated layout bounces a tenant whose onboarding is
         // incomplete to /setup, which would strand a signed-in demo visitor.
         tenant.OnboardingCompletedAt ??= DateTime.UtcNow;
         // A demo tenant has no owner to review access requests.
         tenant.AllowAccessRequests = false;
+        // The demo exists to be poked at: its Scalar page prefills a working token, which
+        // needs the docs surface served on the demo's own host.
+        tenant.AllowPublicDocs = true;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
+++ b/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
@@ -32,9 +32,10 @@ public sealed record ScalarAuthContext(string ClientId, string RedirectUri, stri
 }
 
 /// <summary>
-/// Prepares the Scalar reference UI's authentication for the tenant whose host the docs
-/// were opened on: registers that tenant's Scalar OAuth client on demand and, for a demo
-/// tenant, hands Scalar a bearer token so requests work without any sign-in step.
+/// Decides whether the documentation paths may be served for a request, and prepares the
+/// Scalar reference UI's authentication for the tenant whose host they were opened on:
+/// registers that tenant's Scalar OAuth client on demand and, for a demo tenant, hands
+/// Scalar a bearer token so requests work without any sign-in step.
 /// </summary>
 /// <remarks>
 /// The docs paths deliberately bypass tenant resolution and authentication (they must
@@ -109,54 +110,43 @@ public sealed class ScalarAuthProvider
     }
 
     /// <summary>
-    /// Resolves the request's tenant and stashes a <see cref="ScalarAuthContext"/> on
-    /// <see cref="HttpContext.Items"/> for the Scalar options delegate to read. Does
-    /// nothing when the host resolves to no tenant, so the docs still render.
+    /// Decides whether the documentation paths may be served for this request and, on the
+    /// Scalar page, stashes a <see cref="ScalarAuthContext"/> on
+    /// <see cref="HttpContext.Items"/> for the Scalar options delegate to read.
     /// </summary>
-    public async Task PrepareAsync(HttpContext context)
+    /// <returns>
+    /// <see langword="false"/> when the host resolves to a tenant that has not opted in, which
+    /// the caller answers with 404. <see langword="true"/> when the host resolves to no tenant
+    /// at all, so a bare instance still renders the reference.
+    /// </returns>
+    public async Task<bool> TryPrepareAsync(HttpContext context)
     {
+        ResolvedDocsTenant? resolved;
         try
         {
-            var scheme = ParseScheme(context);
-            if (scheme is null)
-                return;
+            resolved = await ResolveAsync(context.Request.Host, context.RequestAborted);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // The opt-in could not be read, and an unreadable opt-in is not an opt-in: a
+            // failed lookup must not serve the docs on a tenant that never turned them on.
+            _logger.LogWarning(ex, "Failed to resolve the tenant for a documentation request");
+            return false;
+        }
 
-            var resolved = await ResolveAsync(context.Request.Host, scheme, context.RequestAborted);
-            if (resolved is null)
-                return;
+        if (resolved is null)
+            return true;
 
-            var redirectUri = resolved.RedirectUri;
+        if (!resolved.AllowPublicDocs)
+            return false;
 
-            // Belt and braces: the URI is assembled from configuration and the tenant's
-            // own slug, so this should never fail. It is the same gate a redirect URI
-            // submitted through client registration passes, and it is what stops a
-            // cleartext http URI being registered for a public host.
-            if (!_redirectUriValidator.IsValidForRegistration(redirectUri))
-            {
-                _logger.LogWarning("Rejected Scalar redirect URI for tenant {TenantId}", resolved.TenantId);
-                return;
-            }
+        // Only the reference UI needs an authentication context; the specs are static.
+        if (!context.Request.Path.StartsWithSegments("/scalar", StringComparison.OrdinalIgnoreCase))
+            return true;
 
-            var clientId = await EnsureScalarClientAsync(
-                resolved.TenantId, redirectUri, context.RequestAborted);
-            if (clientId is null)
-                return;
-
-            var bearerToken = resolved.IsDemo
-                ? await GetDemoBearerTokenAsync(resolved.TenantId, context)
-                : null;
-
-            if (bearerToken is not null)
-            {
-                // The token is embedded in the page, so this response is per-credential
-                // even though the URL is not. Keep it out of shared caches: a CDN with a
-                // blanket "cache everything" rule would otherwise serve it on past the
-                // reset that revokes it.
-                context.Response.Headers.CacheControl = "no-store, private";
-            }
-
-            context.Items[ScalarAuthContext.HttpContextItemKey] =
-                new ScalarAuthContext(clientId, redirectUri, bearerToken);
+        try
+        {
+            await PrepareScalarAuthAsync(resolved, context);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -164,53 +154,110 @@ public sealed class ScalarAuthProvider
             // static configuration rather than failing the page.
             _logger.LogWarning(ex, "Failed to prepare Scalar authentication context");
         }
+
+        return true;
+    }
+
+    private async Task PrepareScalarAuthAsync(ResolvedDocsTenant resolved, HttpContext context)
+    {
+        var redirectUri = BuildRedirectUri(resolved, context);
+        if (redirectUri is null)
+            return;
+
+        // Belt and braces: the URI is assembled from configuration and the tenant's
+        // own slug, so this should never fail. It is the same gate a redirect URI
+        // submitted through client registration passes, and it is what stops a
+        // cleartext http URI being registered for a public host.
+        if (!_redirectUriValidator.IsValidForRegistration(redirectUri))
+        {
+            _logger.LogWarning("Rejected Scalar redirect URI for tenant {TenantId}", resolved.TenantId);
+            return;
+        }
+
+        var clientId = await EnsureScalarClientAsync(
+            resolved.TenantId, redirectUri, context.RequestAborted);
+        if (clientId is null)
+            return;
+
+        var bearerToken = resolved.IsDemo
+            ? await GetDemoBearerTokenAsync(resolved.TenantId, context)
+            : null;
+
+        if (bearerToken is not null)
+        {
+            // The token is embedded in the page, so this response is per-credential
+            // even though the URL is not. Keep it out of shared caches: a CDN with a
+            // blanket "cache everything" rule would otherwise serve it on past the
+            // reset that revokes it.
+            context.Response.Headers.CacheControl = "no-store, private";
+        }
+
+        context.Items[ScalarAuthContext.HttpContextItemKey] =
+            new ScalarAuthContext(clientId, redirectUri, bearerToken);
     }
 
     /// <summary>
-    /// Returns the request's scheme, or <see langword="null"/> when it is not http(s).
+    /// The redirect URI to register for <paramref name="resolved"/>, or
+    /// <see langword="null"/> when this request's origin is not one the deployment serves.
     /// </summary>
     /// <remarks>
-    /// Read from <see cref="HttpRequest.Scheme"/>, which <c>UseForwardedHeaders</c> has
-    /// already set from <c>X-Forwarded-Proto</c> — reading the header again here would
-    /// pick a different entry from the one the rest of the pipeline used.
+    /// Assembled from the configured base domain and the tenant's own slug as stored, so the
+    /// only byte of it a caller influences is the scheme, which
+    /// <see cref="RedirectUriValidator"/> then gates. The scheme and the port are read from
+    /// the request and are both caller-controlled (see <see cref="ResolveAsync"/>), so they
+    /// decide only whether a client is registered — never which tenant is resolved, and never
+    /// whether the docs are served.
     /// </remarks>
-    private static string? ParseScheme(HttpContext context)
+    private string? BuildRedirectUri(ResolvedDocsTenant resolved, HttpContext context)
     {
+        // Read from HttpRequest.Scheme, which UseForwardedHeaders has already set from
+        // X-Forwarded-Proto — reading the header again here would pick a different entry
+        // from the one the rest of the pipeline used.
         var scheme = context.Request.Scheme?.ToLowerInvariant();
-        return scheme is "http" or "https" ? scheme : null;
+        if (scheme is not ("http" or "https"))
+            return null;
+
+        var (_, basePort) = _baseDomain.SplitHostPort();
+
+        // The port has to be the one the deployment is served on, so a caller cannot
+        // register extra origins that differ only by port.
+        if (context.Request.Host.Port != basePort)
+            return null;
+
+        var authority = basePort is null
+            ? resolved.CanonicalHost
+            : $"{resolved.CanonicalHost}:{basePort}";
+
+        return $"{scheme}://{authority}/scalar";
     }
 
     /// <summary>
-    /// Resolves the tenant the docs were opened on and the redirect URI to register for
-    /// it, or <see langword="null"/> when <paramref name="requestHost"/> is not an origin
-    /// this deployment serves.
+    /// Resolves the tenant whose host the docs were opened on, or <see langword="null"/>
+    /// when <paramref name="requestHost"/> is not a host this deployment serves a tenant on.
     /// </summary>
     /// <remarks>
     /// The request host is client-controllable: the gateway forwards
     /// <c>X-Forwarded-Host</c> untouched and <c>UseForwardedHeaders</c> runs with no
     /// trusted-proxy list, so it decides <see cref="HttpRequest.Host"/>. It is therefore
-    /// used only to <em>select</em> a tenant, never to build the redirect URI — that is
-    /// assembled from the configured base domain and the tenant's own slug as stored, so
-    /// the only byte of it a caller influences is the scheme, which
-    /// <see cref="RedirectUriValidator"/> then gates. Without this, a host belonging to
-    /// nobody (<c>attacker.example</c>) fell through to the sole-tenant branch below and
-    /// registered an attacker-controlled OAuth redirect URI on that tenant.
+    /// used only to <em>select</em> a tenant, never to build the redirect URI. Without this,
+    /// a host belonging to nobody (<c>attacker.example</c>) fell through to the sole-tenant
+    /// branch below and registered an attacker-controlled OAuth redirect URI on that tenant.
+    /// <para>
+    /// Selection deliberately ignores the port and the scheme, which are caller-controlled
+    /// for the same reason: a tenant that has not opted into the docs must not get them back
+    /// by being asked for on a made-up port. Both are checked in
+    /// <see cref="BuildRedirectUri"/>, where getting them wrong costs only the OAuth client.
+    /// </para>
     /// <para>
     /// Returns <see langword="null"/> for the apex with more than one tenant, an unknown
     /// slug, an inactive tenant, and for a public share host — a share grants read-only
     /// anonymous access and must not be handed a client or a token.
     /// </para>
     /// </remarks>
-    private async Task<ResolvedDocsTenant?> ResolveAsync(
-        HostString requestHost, string scheme, CancellationToken ct)
+    private async Task<ResolvedDocsTenant?> ResolveAsync(HostString requestHost, CancellationToken ct)
     {
-        var (baseHost, basePort) = _baseDomain.SplitHostPort();
+        var (baseHost, _) = _baseDomain.SplitHostPort();
         if (baseHost is null || string.IsNullOrEmpty(requestHost.Host))
-            return null;
-
-        // The port has to be the one the deployment is served on, so a caller cannot
-        // register extra origins that differ only by port.
-        if (requestHost.Port != basePort)
             return null;
 
         var slug = SubdomainParser.Extract(requestHost.Host, baseHost);
@@ -220,12 +267,16 @@ public sealed class ScalarAuthProvider
         if (slug is not null && SubdomainParser.TryExtractShareToken(slug, out _))
             return null;
 
-        // Only resolutions that found a tenant are cached. The docs paths run before the rate
-        // limiter, so the host on an unauthenticated request decides this key — caching misses
-        // would let arbitrary hostnames each pin an entry. A miss costs one indexed lookup on
-        // tenants.slug; a hit is what repeated views of a real tenant's docs page would otherwise
-        // pay for on every request.
-        var cacheKey = $"scalar-tenant:{scheme}:{requestHost.Value}";
+        // Apex. Single-tenant installs serve everything from it; anything that is not the
+        // configured apex is not ours to resolve a tenant for. Checked before the cache so a
+        // foreign host never reaches the database or pins an entry.
+        if (slug is null && !requestHost.Host.Equals(baseHost, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        // Keyed on the slug rather than the request host so the entry is evictable when the
+        // opt-in is toggled, and so ports and schemes — both caller-supplied — collapse onto
+        // one entry instead of pinning one each.
+        var cacheKey = TenantCacheKey(slug);
         if (_cache.TryGetValue(cacheKey, out ResolvedDocsTenant? cached) && cached is not null)
             return cached;
 
@@ -234,11 +285,6 @@ public sealed class ScalarAuthProvider
         TenantEntity? tenant;
         if (slug is null)
         {
-            // Apex. Single-tenant installs serve everything from it; anything that is not
-            // the configured apex is not ours to register a redirect URI for.
-            if (!requestHost.Host.Equals(baseHost, StringComparison.OrdinalIgnoreCase))
-                return null;
-
             var soleTenants = await db.Set<TenantEntity>()
                 .AsNoTracking()
                 .Where(t => t.IsActive)
@@ -261,11 +307,11 @@ public sealed class ScalarAuthProvider
                 return null;
         }
 
-        var canonicalHost = slug is null ? baseHost : $"{tenant.Slug}.{baseHost}";
-        var authority = basePort is null ? canonicalHost : $"{canonicalHost}:{basePort}";
-
         var resolved = new ResolvedDocsTenant(
-            tenant.Id, tenant.IsDemo, $"{scheme}://{authority}/scalar");
+            tenant.Id,
+            tenant.IsDemo,
+            tenant.AllowPublicDocs,
+            slug is null ? baseHost : $"{tenant.Slug}.{baseHost}");
 
         // Same TTL as the client cache, so a demo reset — which clears the tenant's OAuth clients —
         // heals both within the same couple of minutes.
@@ -274,11 +320,38 @@ public sealed class ScalarAuthProvider
         return resolved;
     }
 
+    /// <summary>Cache key holding the resolved docs tenant for a slug, or for the apex.</summary>
+    private static string TenantCacheKey(string? slug) => $"scalar-tenant:{slug ?? "__apex__"}";
+
     /// <summary>
-    /// The parts of the resolved tenant the docs page needs. A record rather than the entity so
+    /// Drops the cached docs resolution for a tenant, so the next documentation request reads
+    /// the opt-in from the row instead of serving the previous answer for up to
+    /// <see cref="ClientCacheTtl"/>.
+    /// </summary>
+    /// <remarks>
+    /// Both keys go, for the reason <see cref="Multitenancy.TenantResolutionMiddleware.EvictTenant"/>
+    /// drops both of its own: a single-tenant install resolves the apex to the sole tenant, which
+    /// is cached under the apex key.
+    /// </remarks>
+    public static void EvictTenant(IMemoryCache cache, string slug)
+    {
+        cache.Remove(TenantCacheKey(slug));
+        cache.Remove(TenantCacheKey(null));
+    }
+
+    /// <summary>
+    /// The parts of the resolved tenant the docs paths need. A record rather than the entity so
     /// nothing tracked by a disposed context is held in the cache.
     /// </summary>
-    private sealed record ResolvedDocsTenant(Guid TenantId, bool IsDemo, string RedirectUri);
+    /// <param name="TenantId">The resolved tenant.</param>
+    /// <param name="IsDemo">Whether the tenant is the demo, whose Scalar page prefills a token.</param>
+    /// <param name="AllowPublicDocs">Whether the tenant serves the documentation paths at all.</param>
+    /// <param name="CanonicalHost">
+    /// The host this deployment serves the tenant on, assembled from the configured base domain
+    /// and the stored slug — never from the request.
+    /// </param>
+    private sealed record ResolvedDocsTenant(
+        Guid TenantId, bool IsDemo, bool AllowPublicDocs, string CanonicalHost);
 
     /// <summary>
     /// Registers the tenant's Scalar OAuth client if absent, and adds

--- a/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
+++ b/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
@@ -67,13 +67,8 @@ public sealed class ScalarAuthProvider
     /// domain and the tenant's stored slug, and the only part a caller influences is the scheme,
     /// which <see cref="RedirectUriValidator"/> narrows to https on a public host and http on
     /// loopback. So one tenant can accumulate at most one entry per deployment origin, and a
-    /// deployment has one.
-    /// <para>
-    /// Kept rather than deleted because the row is written by an unauthenticated request, so the
-    /// bound should not depend on the URI-construction argument staying true. An earlier commit
-    /// message on this branch claimed a test covered this cap; none did. <see
-    /// cref="Docs.ScalarAuthProviderTests"/> now exercises it directly.
-    /// </para>
+    /// deployment has one. Kept rather than deleted because the row is written by an
+    /// unauthenticated request, so the bound must not rest on that argument staying true.
     /// </remarks>
     internal const int MaxRedirectUris = 5;
 
@@ -109,11 +104,6 @@ public sealed class ScalarAuthProvider
         _logger = logger;
     }
 
-    /// <summary>
-    /// Decides whether the documentation paths may be served for this request and, on the
-    /// Scalar page, stashes a <see cref="ScalarAuthContext"/> on
-    /// <see cref="HttpContext.Items"/> for the Scalar options delegate to read.
-    /// </summary>
     /// <returns>
     /// <see langword="false"/> when the host resolves to a tenant that has not opted in, which
     /// the caller answers with 404. <see langword="true"/> when the host resolves to no tenant
@@ -128,8 +118,8 @@ public sealed class ScalarAuthProvider
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            // The opt-in could not be read, and an unreadable opt-in is not an opt-in: a
-            // failed lookup must not serve the docs on a tenant that never turned them on.
+            // An unreadable opt-in is not an opt-in: a failed lookup must not serve the docs
+            // on a tenant that never turned them on.
             _logger.LogWarning(ex, "Failed to resolve the tenant for a documentation request");
             return false;
         }
@@ -201,12 +191,9 @@ public sealed class ScalarAuthProvider
     /// <see langword="null"/> when this request's origin is not one the deployment serves.
     /// </summary>
     /// <remarks>
-    /// Assembled from the configured base domain and the tenant's own slug as stored, so the
-    /// only byte of it a caller influences is the scheme, which
-    /// <see cref="RedirectUriValidator"/> then gates. The scheme and the port are read from
-    /// the request and are both caller-controlled (see <see cref="ResolveAsync"/>), so they
-    /// decide only whether a client is registered — never which tenant is resolved, and never
-    /// whether the docs are served.
+    /// Assembled from the configured base domain and the tenant's own slug as stored. The scheme
+    /// and the port are the only parts a caller influences, and they decide nothing beyond whether
+    /// a client is registered — see <see cref="ResolveAsync"/>.
     /// </remarks>
     private string? BuildRedirectUri(ResolvedDocsTenant resolved, HttpContext context)
     {
@@ -320,19 +307,13 @@ public sealed class ScalarAuthProvider
         return resolved;
     }
 
-    /// <summary>Cache key holding the resolved docs tenant for a slug, or for the apex.</summary>
     private static string TenantCacheKey(string? slug) => $"scalar-tenant:{slug ?? "__apex__"}";
 
     /// <summary>
-    /// Drops the cached docs resolution for a tenant, so the next documentation request reads
-    /// the opt-in from the row instead of serving the previous answer for up to
-    /// <see cref="ClientCacheTtl"/>.
-    /// </summary>
-    /// <remarks>
     /// Both keys go, for the reason <see cref="Multitenancy.TenantResolutionMiddleware.EvictTenant"/>
     /// drops both of its own: a single-tenant install resolves the apex to the sole tenant, which
     /// is cached under the apex key.
-    /// </remarks>
+    /// </summary>
     public static void EvictTenant(IMemoryCache cache, string slug)
     {
         cache.Remove(TenantCacheKey(slug));
@@ -341,15 +322,10 @@ public sealed class ScalarAuthProvider
 
     /// <summary>
     /// The parts of the resolved tenant the docs paths need. A record rather than the entity so
-    /// nothing tracked by a disposed context is held in the cache.
+    /// nothing tracked by a disposed context is held in the cache. <c>CanonicalHost</c> is the host
+    /// this deployment serves the tenant on, assembled from the configured base domain and the
+    /// stored slug — never from the request.
     /// </summary>
-    /// <param name="TenantId">The resolved tenant.</param>
-    /// <param name="IsDemo">Whether the tenant is the demo, whose Scalar page prefills a token.</param>
-    /// <param name="AllowPublicDocs">Whether the tenant serves the documentation paths at all.</param>
-    /// <param name="CanonicalHost">
-    /// The host this deployment serves the tenant on, assembled from the configured base domain
-    /// and the stored slug — never from the request.
-    /// </param>
     private sealed record ResolvedDocsTenant(
         Guid TenantId, bool IsDemo, bool AllowPublicDocs, string CanonicalHost);
 

--- a/src/API/Nocturne.API/Services/Identity/TenantService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Configuration;
 using Nocturne.API.Services.Auth;
+using Nocturne.API.Services.Docs;
 using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
@@ -236,6 +237,35 @@ public partial class TenantService : ITenantService
         TenantResolutionMiddleware.EvictTenant(_cache, tenant.Slug);
 
         return ToDto(tenant);
+    }
+
+    public async Task<TenantSettingsDto> GetSettingsAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var context = await _factory.CreateDbContextAsync(ct);
+        var settings = await context.Tenants
+            .AsNoTracking()
+            .Where(t => t.Id == id)
+            .Select(t => new TenantSettingsDto(t.AllowPublicDocs))
+            .FirstOrDefaultAsync(ct);
+
+        return settings ?? throw new KeyNotFoundException($"Tenant {id} not found");
+    }
+
+    public async Task<TenantSettingsDto> SetAllowPublicDocsAsync(
+        Guid id, bool allowPublicDocs, CancellationToken ct = default)
+    {
+        await using var context = await _factory.CreateDbContextAsync(ct);
+        var tenant = await context.Tenants.FindAsync([id], ct)
+            ?? throw new KeyNotFoundException($"Tenant {id} not found");
+
+        tenant.AllowPublicDocs = allowPublicDocs;
+        await context.SaveChangesAsync(ct);
+
+        // The documentation paths resolve the tenant through their own cache, which holds the
+        // opt-in; without this the previous answer stands for the cache lifetime.
+        ScalarAuthProvider.EvictTenant(_cache, tenant.Slug);
+
+        return new TenantSettingsDto(tenant.AllowPublicDocs);
     }
 
     public async Task DeleteAsync(Guid id, CancellationToken ct = default)

--- a/src/API/Nocturne.API/Services/Identity/TenantService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantService.cs
@@ -261,8 +261,8 @@ public partial class TenantService : ITenantService
         tenant.AllowPublicDocs = allowPublicDocs;
         await context.SaveChangesAsync(ct);
 
-        // The documentation paths resolve the tenant through their own cache, which holds the
-        // opt-in; without this the previous answer stands for the cache lifetime.
+        // The documentation paths resolve the tenant through a cache of their own, which holds
+        // the opt-in.
         ScalarAuthProvider.EvictTenant(_cache, tenant.Slug);
 
         return new TenantSettingsDto(tenant.AllowPublicDocs);

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantService.cs
@@ -29,10 +29,8 @@ public interface ITenantService
     /// <summary>Updates a tenant's display name, active state, and access-request policy.</summary>
     Task<TenantDto> UpdateAsync(Guid id, string displayName, bool isActive, bool? allowAccessRequests = null, CancellationToken ct = default);
 
-    /// <summary>Returns the tenant-level settings a tenant's own administrators control.</summary>
     Task<TenantSettingsDto> GetSettingsAsync(Guid id, CancellationToken ct = default);
 
-    /// <summary>Turns the tenant's public API documentation on or off.</summary>
     Task<TenantSettingsDto> SetAllowPublicDocsAsync(Guid id, bool allowPublicDocs, CancellationToken ct = default);
 
     /// <summary>Permanently deletes a tenant and all associated data.</summary>
@@ -63,13 +61,6 @@ public interface ITenantService
 
 public record TenantDto(Guid Id, string Slug, string DisplayName, bool IsActive, DateTime SysCreatedAt);
 
-/// <summary>
-/// Tenant-level settings a tenant's own administrators control, as opposed to the platform-admin
-/// fields on <see cref="TenantDto"/>.
-/// </summary>
-/// <param name="AllowPublicDocs">
-/// Whether this tenant's hosts serve the API reference and the OpenAPI specs behind it.
-/// </param>
 public record TenantSettingsDto(bool AllowPublicDocs);
 
 public record TenantCreatedDto(Guid Id, string Slug, string DisplayName, bool IsActive, DateTime SysCreatedAt);

--- a/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Multitenancy/ITenantService.cs
@@ -29,6 +29,12 @@ public interface ITenantService
     /// <summary>Updates a tenant's display name, active state, and access-request policy.</summary>
     Task<TenantDto> UpdateAsync(Guid id, string displayName, bool isActive, bool? allowAccessRequests = null, CancellationToken ct = default);
 
+    /// <summary>Returns the tenant-level settings a tenant's own administrators control.</summary>
+    Task<TenantSettingsDto> GetSettingsAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>Turns the tenant's public API documentation on or off.</summary>
+    Task<TenantSettingsDto> SetAllowPublicDocsAsync(Guid id, bool allowPublicDocs, CancellationToken ct = default);
+
     /// <summary>Permanently deletes a tenant and all associated data.</summary>
     Task DeleteAsync(Guid id, CancellationToken ct = default);
 
@@ -56,6 +62,15 @@ public interface ITenantService
 }
 
 public record TenantDto(Guid Id, string Slug, string DisplayName, bool IsActive, DateTime SysCreatedAt);
+
+/// <summary>
+/// Tenant-level settings a tenant's own administrators control, as opposed to the platform-admin
+/// fields on <see cref="TenantDto"/>.
+/// </summary>
+/// <param name="AllowPublicDocs">
+/// Whether this tenant's hosts serve the API reference and the OpenAPI specs behind it.
+/// </param>
+public record TenantSettingsDto(bool AllowPublicDocs);
 
 public record TenantCreatedDto(Guid Id, string Slug, string DisplayName, bool IsActive, DateTime SysCreatedAt);
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TenantEntity.cs
@@ -60,6 +60,14 @@ public class TenantEntity : ISystemTimestamped
     public bool IsDemo { get; set; }
 
     /// <summary>
+    /// Whether this tenant's hosts serve the public API documentation (the Scalar reference and
+    /// the OpenAPI specs behind it). Off unless the tenant opts in: the reference registers an
+    /// OAuth client on the tenant from an unauthenticated request, and most tenants never open it.
+    /// </summary>
+    [Column("allow_public_docs")]
+    public bool AllowPublicDocs { get; set; }
+
+    /// <summary>
     /// SHA-256 hex digest (<see cref="Security.CredentialHash.ShareToken"/>) of the unguessable
     /// token for the tenant's public read-only dashboard, served at {token}.share.{baseDomain}.
     /// Null when public sharing is disabled. The token itself is never stored: it is returned once

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811023446_AddTenantAllowPublicDocs.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811023446_AddTenantAllowPublicDocs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811023446_AddTenantAllowPublicDocs")]
+    partial class AddTenantAllowPublicDocs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811023446_AddTenantAllowPublicDocs.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811023446_AddTenantAllowPublicDocs.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantAllowPublicDocs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "allow_public_docs",
+                table: "tenants",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "allow_public_docs",
+                table: "tenants");
+        }
+    }
+}

--- a/src/Web/packages/app/src/lib/components/settings/ApiReference.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ApiReference.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import * as Card from "$lib/components/ui/card";
+  import { Switch } from "$lib/components/ui/switch";
+  import { BookOpen, ExternalLink } from "lucide-svelte";
+  import {
+    getTenantSettings,
+    setPublicDocs,
+  } from "$api/generated/tenantSettings.generated.remote";
+
+  const effectivePermissions: string[] = $derived(
+    (page.data as any).effectivePermissions ?? [],
+  );
+  const canManageSettings = $derived(
+    effectivePermissions.includes("*") ||
+      effectivePermissions.includes("tenant.settings"),
+  );
+
+  const settingsQuery = $derived(canManageSettings ? getTenantSettings() : null);
+
+  // Held only while a write is in flight; null = use server truth.
+  let pending = $state<boolean | null>(null);
+  let busy = $state(false);
+  let errorMessage = $state<string | null>(null);
+
+  const enabled = $derived(
+    pending ?? settingsQuery?.current?.allowPublicDocs ?? false,
+  );
+
+  async function setEnabled(on: boolean) {
+    busy = true;
+    errorMessage = null;
+    pending = on;
+    try {
+      await setPublicDocs({ enabled: on });
+    } catch {
+      errorMessage = on
+        ? "Couldn't publish the API reference. Please try again."
+        : "Couldn't hide the API reference. Please try again.";
+    } finally {
+      busy = false;
+      pending = null;
+    }
+  }
+</script>
+
+{#if canManageSettings}
+  <Card.Root>
+    <div class="flex items-start gap-4 p-5 @md:p-6">
+      <div
+        class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl {enabled
+          ? 'bg-primary/10 text-primary'
+          : 'bg-muted text-muted-foreground'}"
+      >
+        <BookOpen class="h-5 w-5" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <h2 class="text-lg font-semibold">API reference</h2>
+        <p class="mt-0.5 max-w-prose text-sm text-muted-foreground">
+          Publishes the interactive API reference and its OpenAPI specification
+          on this address, for anyone who visits — no sign-in required. Turn it
+          on if you're building against the API; leave it off otherwise. Your
+          data stays behind the same sign-in either way.
+        </p>
+      </div>
+      <Switch
+        checked={enabled}
+        disabled={busy}
+        onCheckedChange={(v: boolean) => setEnabled(v)}
+        aria-label="API reference"
+      />
+    </div>
+
+    {#if errorMessage}
+      <div
+        class="mx-5 mb-5 rounded-md border border-destructive/20 bg-destructive/5 p-3 @md:mx-6"
+      >
+        <p class="text-sm text-destructive">{errorMessage}</p>
+      </div>
+    {:else if enabled}
+      <div class="border-t border-border px-5 py-4 @md:px-6">
+        <a
+          href="/scalar"
+          class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+        >
+          Open the API reference
+          <ExternalLink class="h-3.5 w-3.5" />
+        </a>
+      </div>
+    {/if}
+  </Card.Root>
+{/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/access/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/access/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { KeyRound } from "lucide-svelte";
   import ActiveSessions from "$lib/components/settings/ActiveSessions.svelte";
+  import ApiReference from "$lib/components/settings/ApiReference.svelte";
   import ConnectedApps from "$lib/components/settings/ConnectedApps.svelte";
   import GuestLinksSection from "$lib/components/members/GuestLinksSection.svelte";
 </script>
@@ -28,5 +29,6 @@
     <ActiveSessions />
     <GuestLinksSection />
     <ConnectedApps />
+    <ApiReference />
   </div>
 </div>

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -205,6 +205,7 @@ public class V4WriteScopeGatingTests
             ["AuditController"] = NotDataCategory.TenantOperationalConfig,
             ["GlucoseProcessingSettingsController"] = NotDataCategory.TenantOperationalConfig,
             ["SystemEventsController"] = NotDataCategory.TenantOperationalConfig,
+            ["TenantSettingsController"] = NotDataCategory.TenantOperationalConfig,
 
             ["SupportController"] = NotDataCategory.OutboundOnly,
             ["SystemController"] = NotDataCategory.OutboundOnly,

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/TenantSettingsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/TenantSettingsControllerTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4;
+
+/// <summary>
+/// The documentation opt-in is a tenant-administration setting, so it is gated on the same
+/// <c>tenant.settings</c> atom the rest of that surface uses — a member who can read the tenant
+/// must not be able to publish its API reference.
+/// </summary>
+public class TenantSettingsControllerTests
+{
+    private static readonly Guid TenantId = Guid.CreateVersion7();
+
+    [Fact]
+    public async Task SetPublicDocs_RefusesAMemberWithoutTenantSettings()
+    {
+        var (controller, tenants) = Build(TenantPermissions.IdentityRead);
+
+        var result = await controller.SetPublicDocs(new SetPublicDocsRequest(true), CancellationToken.None);
+
+        result.Result.Should().BeOfType<ForbidResult>();
+        tenants.Verify(
+            t => t.SetAllowPublicDocsAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SetPublicDocs_WritesTheTenantsOwnFlag()
+    {
+        var (controller, tenants) = Build(TenantPermissions.TenantSettings);
+        tenants.Setup(t => t.SetAllowPublicDocsAsync(TenantId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TenantSettingsDto(true));
+
+        var result = await controller.SetPublicDocs(new SetPublicDocsRequest(true), CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeEquivalentTo(new TenantSettingsDto(true));
+        tenants.Verify(t => t.SetAllowPublicDocsAsync(TenantId, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SetPublicDocs_TurnsTheDocumentationSurfaceOffAgain()
+    {
+        var (controller, tenants) = Build(TenantPermissions.TenantSettings);
+        tenants.Setup(t => t.SetAllowPublicDocsAsync(TenantId, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TenantSettingsDto(false));
+
+        await controller.SetPublicDocs(new SetPublicDocsRequest(false), CancellationToken.None);
+
+        tenants.Verify(t => t.SetAllowPublicDocsAsync(TenantId, false, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetTenantSettings_RefusesAMemberWithoutTenantSettings()
+    {
+        var (controller, tenants) = Build(TenantPermissions.IdentityRead);
+
+        var result = await controller.GetTenantSettings(CancellationToken.None);
+
+        result.Result.Should().BeOfType<ForbidResult>();
+        tenants.Verify(
+            t => t.GetSettingsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetTenantSettings_ReadsTheResolvedTenant()
+    {
+        var (controller, tenants) = Build(TenantPermissions.TenantSettings);
+        tenants.Setup(t => t.GetSettingsAsync(TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TenantSettingsDto(true));
+
+        var result = await controller.GetTenantSettings(CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeEquivalentTo(new TenantSettingsDto(true));
+    }
+
+    private static (TenantSettingsController Controller, Mock<ITenantService> Tenants) Build(
+        params string[] grantedScopes)
+    {
+        var tenants = new Mock<ITenantService>(MockBehavior.Strict);
+
+        var accessor = new Mock<ITenantAccessor>();
+        accessor.SetupGet(a => a.TenantId).Returns(TenantId);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(grantedScopes);
+
+        var controller = new TenantSettingsController(tenants.Object, accessor.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+
+        return (controller, tenants);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Middleware/PublicDocsMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/PublicDocsMiddlewareTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Nocturne.API.Middleware;
+using Nocturne.API.Tests.Services.Docs;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware;
+
+/// <summary>
+/// The documentation branch answers before tenant resolution and authentication, so it is the
+/// only thing standing between an anonymous request and the reference. Both paths it covers —
+/// the Scalar UI and the OpenAPI specs behind it — hang off the same tenant opt-in.
+/// </summary>
+public class PublicDocsMiddlewareTests : IDisposable
+{
+    private readonly DocsTenantFixture _fixture = new();
+
+    [Theory]
+    [InlineData("/scalar")]
+    [InlineData("/openapi/nocturne.json")]
+    public async Task InvokeAsync_ServesTheEndpoint_ForATenantThatOptedIn(string path)
+    {
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+
+        var (context, served) = await InvokeAsync(path, "rhys.nocturne.run");
+
+        served.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    /// <summary>
+    /// Gating only the reference would leave the specs it renders from public, which is most of
+    /// the same exposure — so both hang off the flag.
+    /// </summary>
+    [Theory]
+    [InlineData("/scalar")]
+    [InlineData("/openapi/nocturne.json")]
+    public async Task InvokeAsync_Answers404_ForATenantThatHasNotOptedIn(string path)
+    {
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false, allowPublicDocs: false);
+
+        var (context, served) = await InvokeAsync(path, "rhys.nocturne.run");
+
+        served.Should().BeFalse();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
+    /// The reason this branch runs ahead of tenant resolution at all: a fresh install has no
+    /// tenants, and its apex would otherwise answer 503 setup_required.
+    /// </summary>
+    [Theory]
+    [InlineData("/scalar")]
+    [InlineData("/openapi/nocturne.json")]
+    public async Task InvokeAsync_ServesTheEndpoint_OnABareInstance(string path)
+    {
+        var (context, served) = await InvokeAsync(path, DocsTenantFixture.BaseDomain);
+
+        served.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PassesNonDocumentationPathsDownThePipeline()
+    {
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false, allowPublicDocs: false);
+
+        var context = DocsTenantFixture.BuildContext("rhys.nocturne.run", path: "/api/v4/status");
+        SetEndpoint(context, _ => Task.CompletedTask);
+
+        var continued = false;
+        await new PublicDocsMiddleware(_ => { continued = true; return Task.CompletedTask; })
+            .InvokeAsync(context, _fixture.BuildProvider());
+
+        continued.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    /// <summary>
+    /// A documentation path with no endpoint is not one of ours; it keeps going rather than
+    /// being answered here.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_PassesADocumentationPathWithNoEndpointDownThePipeline()
+    {
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false, allowPublicDocs: false);
+
+        var context = DocsTenantFixture.BuildContext("rhys.nocturne.run", path: "/scalar");
+
+        var continued = false;
+        await new PublicDocsMiddleware(_ => { continued = true; return Task.CompletedTask; })
+            .InvokeAsync(context, _fixture.BuildProvider());
+
+        continued.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Runs the middleware over a request that has an endpoint mapped, reporting whether that
+    /// endpoint was reached.
+    /// </summary>
+    private async Task<(HttpContext Context, bool Served)> InvokeAsync(string path, string host)
+    {
+        var context = DocsTenantFixture.BuildContext(host, path: path);
+
+        var served = false;
+        SetEndpoint(context, _ => { served = true; return Task.CompletedTask; });
+
+        await new PublicDocsMiddleware(_ => Task.FromException(new InvalidOperationException(
+                "a documentation path with an endpoint is answered by the branch, not passed on")))
+            .InvokeAsync(context, _fixture.BuildProvider());
+
+        return (context, served);
+    }
+
+    private static void SetEndpoint(HttpContext context, RequestDelegate handler) =>
+        context.SetEndpoint(new Endpoint(handler, EndpointMetadataCollection.Empty, "docs"));
+
+    public void Dispose()
+    {
+        _fixture.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Middleware/PublicDocsMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/PublicDocsMiddlewareTests.cs
@@ -8,8 +8,7 @@ namespace Nocturne.API.Tests.Middleware;
 
 /// <summary>
 /// The documentation branch answers before tenant resolution and authentication, so it is the
-/// only thing standing between an anonymous request and the reference. Both paths it covers —
-/// the Scalar UI and the OpenAPI specs behind it — hang off the same tenant opt-in.
+/// only thing standing between an anonymous request and the reference.
 /// </summary>
 public class PublicDocsMiddlewareTests : IDisposable
 {
@@ -46,8 +45,8 @@ public class PublicDocsMiddlewareTests : IDisposable
     }
 
     /// <summary>
-    /// The reason this branch runs ahead of tenant resolution at all: a fresh install has no
-    /// tenants, and its apex would otherwise answer 503 setup_required.
+    /// A fresh install has no tenants, and its apex answers 503 setup_required — so the reference
+    /// has to be served without one.
     /// </summary>
     [Theory]
     [InlineData("/scalar")]
@@ -76,10 +75,6 @@ public class PublicDocsMiddlewareTests : IDisposable
         context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
     }
 
-    /// <summary>
-    /// A documentation path with no endpoint is not one of ours; it keeps going rather than
-    /// being answered here.
-    /// </summary>
     [Fact]
     public async Task InvokeAsync_PassesADocumentationPathWithNoEndpointDownThePipeline()
     {
@@ -94,10 +89,6 @@ public class PublicDocsMiddlewareTests : IDisposable
         continued.Should().BeTrue();
     }
 
-    /// <summary>
-    /// Runs the middleware over a request that has an endpoint mapped, reporting whether that
-    /// endpoint was reached.
-    /// </summary>
     private async Task<(HttpContext Context, bool Served)> InvokeAsync(string path, string host)
     {
         var context = DocsTenantFixture.BuildContext(host, path: path);

--- a/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoTenantServiceResetTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoTenantServiceResetTests.cs
@@ -78,6 +78,22 @@ public class DemoTenantServiceResetTests : IDisposable
         tenant.OnboardingCompletedAt.Should().NotBeNull("a demo visitor must not be sent to /setup");
     }
 
+    /// <summary>
+    /// The demo's Scalar page prefills a working token, which needs the documentation surface
+    /// served on the demo's own host — and the column defaults to off for everyone else.
+    /// </summary>
+    [Fact]
+    public async Task ResetAsync_LeavesTheDocumentationSurfaceOn()
+    {
+        var tenantId = SeedDemoTenant();
+
+        await _service.ResetAsync();
+
+        await using var db = new NocturneDbContext(_dbOptions);
+        var tenant = await db.Tenants.SingleAsync(t => t.Id == tenantId);
+        tenant.AllowPublicDocs.Should().BeTrue();
+    }
+
     [Fact]
     public async Task ResetAsync_CarriesDemoScheduleAcross()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoTenantServiceResetTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoTenantServiceResetTests.cs
@@ -79,8 +79,7 @@ public class DemoTenantServiceResetTests : IDisposable
     }
 
     /// <summary>
-    /// The demo's Scalar page prefills a working token, which needs the documentation surface
-    /// served on the demo's own host — and the column defaults to off for everyone else.
+    /// The column defaults to off, so the demo's own reference depends on the reset re-applying it.
     /// </summary>
     [Fact]
     public async Task ResetAsync_LeavesTheDocumentationSurfaceOn()

--- a/tests/Unit/Nocturne.API.Tests/Services/Docs/DocsTenantFixture.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Docs/DocsTenantFixture.cs
@@ -55,8 +55,8 @@ internal sealed class DocsTenantFixture : IDisposable
     public NocturneDbContext Db() => new(_dbOptions);
 
     /// <summary>
-    /// Seeds a tenant. <paramref name="allowPublicDocs"/> defaults to on so a test that is not
-    /// about the opt-in reaches the behaviour it is testing; the column itself defaults to off.
+    /// <paramref name="allowPublicDocs"/> defaults to on so a test that is not about the opt-in
+    /// reaches the behaviour it is testing; the column itself defaults to off.
     /// </summary>
     public Guid SeedTenant(
         string slug,
@@ -103,7 +103,7 @@ internal sealed class DocsTenantFixture : IDisposable
         return tenant.Id;
     }
 
-    /// <summary>Flips a seeded tenant's documentation opt-in, leaving every cache untouched.</summary>
+    /// <summary>Flips the opt-in in the database only, leaving every cache untouched.</summary>
     public void SetAllowPublicDocs(Guid tenantId, bool allow)
     {
         using var db = Db();

--- a/tests/Unit/Nocturne.API.Tests/Services/Docs/DocsTenantFixture.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Docs/DocsTenantFixture.cs
@@ -1,0 +1,153 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Multitenancy;
+using Nocturne.API.Services.Auth;
+using Nocturne.API.Services.Demo;
+using Nocturne.API.Services.Docs;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Cache.Abstractions;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.API.Tests.Services.Docs;
+
+/// <summary>
+/// A database with tenants in it and a <see cref="ScalarAuthProvider"/> over it, as the
+/// documentation paths see them: no tenant resolution, no authentication, nothing but the
+/// request host to go on.
+/// </summary>
+internal sealed class DocsTenantFixture : IDisposable
+{
+    public const string BaseDomain = "nocturne.run";
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+
+    public DocsTenantFixture()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var seed = new NocturneDbContext(_dbOptions);
+        seed.Database.EnsureCreated();
+
+        SessionService
+            .Setup(s => s.IssueSessionAsync(
+                It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionTokenPair("demo-access-token", "refresh", 3600));
+    }
+
+    public Mock<ISessionService> SessionService { get; } = new();
+
+    public NocturneDbContext Db() => new(_dbOptions);
+
+    /// <summary>
+    /// Seeds a tenant. <paramref name="allowPublicDocs"/> defaults to on so a test that is not
+    /// about the opt-in reaches the behaviour it is testing; the column itself defaults to off.
+    /// </summary>
+    public Guid SeedTenant(
+        string slug,
+        bool isDemo,
+        bool withDemoMember,
+        bool isActive = true,
+        bool allowPublicDocs = true)
+    {
+        using var db = Db();
+
+        var tenant = new TenantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Slug = slug,
+            DisplayName = slug,
+            IsActive = isActive,
+            IsDemo = isDemo,
+            AllowPublicDocs = allowPublicDocs,
+        };
+        db.Add(tenant);
+
+        if (withDemoMember)
+        {
+            var subject = new SubjectEntity
+            {
+                Id = Guid.CreateVersion7(),
+                Name = DemoTenantService.DemoMemberName,
+                IsActive = true,
+                // As provisioning creates it. The lookup requires the flag, not just the
+                // membership, so seeding it false would model a state the provider refuses.
+                IsDemoSubject = true,
+            };
+            db.Subjects.Add(subject);
+            db.TenantMembers.Add(new TenantMemberEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = tenant.Id,
+                SubjectId = subject.Id,
+                Username = DemoTenantService.DemoMemberUsername,
+            });
+        }
+
+        db.SaveChanges();
+        return tenant.Id;
+    }
+
+    /// <summary>Flips a seeded tenant's documentation opt-in, leaving every cache untouched.</summary>
+    public void SetAllowPublicDocs(Guid tenantId, bool allow)
+    {
+        using var db = Db();
+        var tenant = db.Tenants.Single(t => t.Id == tenantId);
+        tenant.AllowPublicDocs = allow;
+        db.SaveChanges();
+    }
+
+    /// <summary>
+    /// Builds a request as the pipeline presents it to the provider: UseForwardedHeaders
+    /// has already applied X-Forwarded-Host/-Proto onto Request.Host and Request.Scheme,
+    /// so the provider reads those rather than the headers.
+    /// </summary>
+    public static HttpContext BuildContext(string host, string proto = "https", string path = "/scalar")
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Request.Host = new HostString(host);
+        context.Request.Scheme = proto;
+        return context;
+    }
+
+    public ScalarAuthProvider BuildProvider(IMemoryCache? cache = null)
+    {
+        var dbFactory = new Mock<IDbContextFactory<NocturneDbContext>>();
+        dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Db);
+
+        var demoTenantService = new DemoTenantService(
+            dbFactory.Object,
+            new Mock<ITenantService>().Object,
+            TestPublicAccessCache.Create(),
+            new Mock<ICacheService>().Object,
+            new Mock<ILogger<DemoTenantService>>().Object);
+
+        return new ScalarAuthProvider(
+            dbFactory.Object,
+            demoTenantService,
+            SessionService.Object,
+            new RedirectUriValidator(),
+            cache ?? new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new BaseDomainOptions { BaseDomain = BaseDomain }),
+            new Mock<ILogger<ScalarAuthProvider>>().Object);
+    }
+
+    public void Dispose() => _connection.Dispose();
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Docs/ScalarAuthProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Docs/ScalarAuthProviderTests.cs
@@ -1,66 +1,34 @@
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
-using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Auth;
-using Nocturne.API.Services.Demo;
 using Nocturne.API.Services.Docs;
-using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Contracts.Auth;
-using Nocturne.Core.Contracts.Multitenancy;
-using Nocturne.Infrastructure.Cache.Abstractions;
-using Nocturne.Infrastructure.Data;
-using Nocturne.Infrastructure.Data.Entities;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.Docs;
 
 /// <summary>
-/// The Scalar reference is served on every host without tenant resolution or
-/// authentication, so what it hands the browser is decided entirely here: an OAuth client
-/// for the host's tenant, and a bearer token only when that tenant is a demo.
+/// The documentation paths are served on every host without tenant resolution or
+/// authentication, so what they expose is decided entirely here: whether the host's tenant
+/// opted in at all, an OAuth client for that tenant, and a bearer token only when it is a demo.
 /// </summary>
 public class ScalarAuthProviderTests : IDisposable
 {
-    private const string BaseDomain = "nocturne.run";
+    private const string BaseDomain = DocsTenantFixture.BaseDomain;
 
-    private readonly SqliteConnection _connection;
-    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
-    private readonly Mock<ISessionService> _sessionService = new();
-
-    public ScalarAuthProviderTests()
-    {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
-
-        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseSqlite(_connection)
-            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
-            .Options;
-
-        using var seed = new NocturneDbContext(_dbOptions);
-        seed.Database.EnsureCreated();
-
-        _sessionService
-            .Setup(s => s.IssueSessionAsync(
-                It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new SessionTokenPair("demo-access-token", "refresh", 3600));
-    }
+    private readonly DocsTenantFixture _fixture = new();
 
     [Fact]
-    public async Task PrepareAsync_RegistersClientAndPrefillsToken_OnADemoHost()
+    public async Task TryPrepareAsync_RegistersClientAndPrefillsToken_OnADemoHost()
     {
-        var tenantId = SeedTenant("demo", isDemo: true, withDemoMember: true);
-        var context = BuildContext("demo.nocturne.run");
+        var tenantId = _fixture.SeedTenant("demo", isDemo: true, withDemoMember: true);
+        var context = DocsTenantFixture.BuildContext("demo.nocturne.run");
 
-        await BuildProvider().PrepareAsync(context);
+        (await _fixture.BuildProvider().TryPrepareAsync(context)).Should().BeTrue();
 
         var auth = Auth(context);
         auth.Should().NotBeNull();
@@ -68,7 +36,7 @@ public class ScalarAuthProviderTests : IDisposable
         auth.RedirectUri.Should().Be("https://demo.nocturne.run/scalar");
         auth.BearerToken.Should().Be("demo-access-token");
 
-        await using var db = new NocturneDbContext(_dbOptions);
+        await using var db = _fixture.Db();
         var client = await db.OAuthClients.IgnoreQueryFilters()
             .SingleAsync(c => c.TenantId == tenantId && c.SoftwareId == ScalarAuthProvider.ScalarSoftwareId);
         JsonSerializer.Deserialize<List<string>>(client.RedirectUris)
@@ -76,91 +44,205 @@ public class ScalarAuthProviderTests : IDisposable
     }
 
     [Fact]
-    public async Task PrepareAsync_RegistersClientWithoutAToken_OnARealTenantHost()
+    public async Task TryPrepareAsync_RegistersClientWithoutAToken_OnARealTenantHost()
     {
-        SeedTenant("rhys", isDemo: false, withDemoMember: false);
-        var context = BuildContext("rhys.nocturne.run");
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext("rhys.nocturne.run");
 
-        await BuildProvider().PrepareAsync(context);
+        (await _fixture.BuildProvider().TryPrepareAsync(context)).Should().BeTrue();
 
         var auth = Auth(context);
         auth.Should().NotBeNull();
         auth!.RedirectUri.Should().Be("https://rhys.nocturne.run/scalar");
         auth.BearerToken.Should().BeNull("only a demo tenant's account may be handed out");
-        _sessionService.Verify(
+        _fixture.SessionService.Verify(
             s => s.IssueSessionAsync(It.IsAny<Guid>(), It.IsAny<SessionContext>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
-    [Fact]
-    public async Task PrepareAsync_DoesNothing_OnAShareHost()
+    /// <summary>
+    /// The opt-in is the whole point of the flag: a tenant that never asked for the reference
+    /// must not have one, and must not have an OAuth client written on it by the request that
+    /// asked for it.
+    /// </summary>
+    [Theory]
+    [InlineData("/scalar")]
+    [InlineData("/openapi/nocturne.json")]
+    public async Task TryPrepareAsync_RefusesATenantThatHasNotOptedIn(string path)
     {
-        SeedTenant("demo", isDemo: true, withDemoMember: true);
-        var context = BuildContext("sometoken.share.nocturne.run");
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false, allowPublicDocs: false);
+        var context = DocsTenantFixture.BuildContext("rhys.nocturne.run", path: path);
 
-        await BuildProvider().PrepareAsync(context);
+        (await _fixture.BuildProvider().TryPrepareAsync(context)).Should().BeFalse();
+
+        Auth(context).Should().BeNull();
+        await using var db = _fixture.Db();
+        (await db.OAuthClients.IgnoreQueryFilters().AnyAsync())
+            .Should().BeFalse("nothing may be registered on a tenant with no documentation surface");
+    }
+
+    /// <summary>
+    /// The scheme and the port both come from headers the caller controls, so neither may decide
+    /// whether the docs are served — only whether an OAuth client is registered.
+    /// </summary>
+    [Theory]
+    [InlineData("https", "rhys.nocturne.run:8443")]
+    [InlineData("javascript", "rhys.nocturne.run")]
+    [InlineData("http", "rhys.nocturne.run")]
+    public async Task TryPrepareAsync_RefusesAnOptedOutTenant_WhateverTheSchemeOrPort(
+        string proto, string host)
+    {
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false, allowPublicDocs: false);
+        var context = DocsTenantFixture.BuildContext(host, proto);
+
+        (await _fixture.BuildProvider().TryPrepareAsync(context)).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Positive control for the theory above: the same odd origins on a tenant that <em>has</em>
+    /// opted in are still served, so the refusals there come from the opt-in and not from the
+    /// origin being rejected outright.
+    /// </summary>
+    [Theory]
+    [InlineData("https", "rhys.nocturne.run:8443")]
+    [InlineData("javascript", "rhys.nocturne.run")]
+    [InlineData("http", "rhys.nocturne.run")]
+    public async Task TryPrepareAsync_ServesAnOptedInTenant_ButRegistersNoClient_OnAnOddOrigin(
+        string proto, string host)
+    {
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext(host, proto);
+
+        (await _fixture.BuildProvider().TryPrepareAsync(context)).Should().BeTrue();
+
+        Auth(context).Should().BeNull("a caller must not register origins of its own choosing");
+        await using var db = _fixture.Db();
+        (await db.OAuthClients.IgnoreQueryFilters().AnyAsync()).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The reference has to render on a fresh install, which is the whole reason these paths
+    /// run ahead of tenant resolution. Also the positive control for the gate: it can only be
+    /// trusted to refuse if it is shown letting something through.
+    /// </summary>
+    [Theory]
+    [InlineData(BaseDomain)]              // apex of an instance with no tenants
+    [InlineData("nope.nocturne.run")]     // a slug nobody has
+    public async Task TryPrepareAsync_ServesTheDocs_WhenNoTenantResolves(string host)
+    {
+        var context = DocsTenantFixture.BuildContext(host);
+
+        (await _fixture.BuildProvider().TryPrepareAsync(context)).Should().BeTrue();
+
+        Auth(context).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryPrepareAsync_ServesTheSpecs_WithoutRegisteringAClient()
+    {
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext("rhys.nocturne.run", path: "/openapi/nocturne.json");
+
+        (await _fixture.BuildProvider().TryPrepareAsync(context)).Should().BeTrue();
+
+        Auth(context).Should().BeNull("the specs are static — only the reference UI signs in");
+        await using var db = _fixture.Db();
+        (await db.OAuthClients.IgnoreQueryFilters().AnyAsync()).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The resolution is cached, so a toggle that did not evict it would leave the previous
+    /// answer standing for the cache lifetime.
+    /// </summary>
+    [Fact]
+    public async Task EvictTenant_LetsAToggleTakeEffectBeforeTheCacheExpires()
+    {
+        var tenantId = _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        (await _fixture.BuildProvider(cache).TryPrepareAsync(DocsTenantFixture.BuildContext("rhys.nocturne.run")))
+            .Should().BeTrue();
+
+        _fixture.SetAllowPublicDocs(tenantId, false);
+
+        (await _fixture.BuildProvider(cache).TryPrepareAsync(DocsTenantFixture.BuildContext("rhys.nocturne.run")))
+            .Should().BeTrue("the cached resolution still says the tenant opted in");
+
+        ScalarAuthProvider.EvictTenant(cache, "rhys");
+
+        (await _fixture.BuildProvider(cache).TryPrepareAsync(DocsTenantFixture.BuildContext("rhys.nocturne.run")))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryPrepareAsync_DoesNothing_OnAShareHost()
+    {
+        _fixture.SeedTenant("demo", isDemo: true, withDemoMember: true);
+        var context = DocsTenantFixture.BuildContext("sometoken.share.nocturne.run");
+
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         Auth(context).Should().BeNull("a share link grants read-only anonymous access only");
-        await using var db = new NocturneDbContext(_dbOptions);
+        await using var db = _fixture.Db();
         (await db.OAuthClients.IgnoreQueryFilters().AnyAsync()).Should().BeFalse();
     }
 
     [Fact]
-    public async Task PrepareAsync_DoesNothing_ForAnUnknownSlug()
+    public async Task TryPrepareAsync_DoesNothing_ForAnUnknownSlug()
     {
-        SeedTenant("demo", isDemo: true, withDemoMember: true);
-        var context = BuildContext("nope.nocturne.run");
+        _fixture.SeedTenant("demo", isDemo: true, withDemoMember: true);
+        var context = DocsTenantFixture.BuildContext("nope.nocturne.run");
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         Auth(context).Should().BeNull();
     }
 
     [Fact]
-    public async Task PrepareAsync_DoesNothing_ForAnInactiveTenant()
+    public async Task TryPrepareAsync_DoesNothing_ForAnInactiveTenant()
     {
-        SeedTenant("demo", isDemo: true, withDemoMember: true, isActive: false);
-        var context = BuildContext("demo.nocturne.run");
+        _fixture.SeedTenant("demo", isDemo: true, withDemoMember: true, isActive: false);
+        var context = DocsTenantFixture.BuildContext("demo.nocturne.run");
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         Auth(context).Should().BeNull();
     }
 
     [Fact]
-    public async Task PrepareAsync_MarksTheDemoResponseUncacheable()
+    public async Task TryPrepareAsync_MarksTheDemoResponseUncacheable()
     {
-        SeedTenant("demo", isDemo: true, withDemoMember: true);
-        var context = BuildContext("demo.nocturne.run");
+        _fixture.SeedTenant("demo", isDemo: true, withDemoMember: true);
+        var context = DocsTenantFixture.BuildContext("demo.nocturne.run");
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         context.Response.Headers.CacheControl.ToString()
             .Should().Contain("no-store", "the page carries a bearer token");
     }
 
     [Fact]
-    public async Task PrepareAsync_LeavesARealTenantResponseCacheable()
+    public async Task TryPrepareAsync_LeavesARealTenantResponseCacheable()
     {
-        SeedTenant("rhys", isDemo: false, withDemoMember: false);
-        var context = BuildContext("rhys.nocturne.run");
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext("rhys.nocturne.run");
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         context.Response.Headers.CacheControl.ToString().Should().BeEmpty();
     }
 
     [Fact]
-    public async Task PrepareAsync_DoesNotDuplicateARedirectUri()
+    public async Task TryPrepareAsync_DoesNotDuplicateARedirectUri()
     {
-        var tenantId = SeedTenant("demo", isDemo: true, withDemoMember: true);
+        var tenantId = _fixture.SeedTenant("demo", isDemo: true, withDemoMember: true);
 
         // A fresh provider per call so the in-memory client cache does not mask a
         // repeated registration.
-        await BuildProvider().PrepareAsync(BuildContext("demo.nocturne.run"));
-        await BuildProvider().PrepareAsync(BuildContext("demo.nocturne.run"));
+        await _fixture.BuildProvider().TryPrepareAsync(DocsTenantFixture.BuildContext("demo.nocturne.run"));
+        await _fixture.BuildProvider().TryPrepareAsync(DocsTenantFixture.BuildContext("demo.nocturne.run"));
 
-        await using var db = new NocturneDbContext(_dbOptions);
+        await using var db = _fixture.Db();
         var client = await db.OAuthClients.IgnoreQueryFilters()
             .SingleAsync(c => c.TenantId == tenantId);
         JsonSerializer.Deserialize<List<string>>(client.RedirectUris)
@@ -168,17 +250,17 @@ public class ScalarAuthProviderTests : IDisposable
     }
 
     [Fact]
-    public async Task PrepareAsync_StopsAddingRedirectUrisAtTheCap()
+    public async Task TryPrepareAsync_StopsAddingRedirectUrisAtTheCap()
     {
         // Unreachable by construction — the URI comes from configuration plus the stored slug,
         // and only https survives on a public host — but the row is written by an unauthenticated
         // request, so the bound must not rest on that argument staying true. Exercised directly
         // because nothing else can reach it.
-        var tenantId = SeedTenant("demo", isDemo: true, withDemoMember: true);
+        var tenantId = _fixture.SeedTenant("demo", isDemo: true, withDemoMember: true);
 
-        await BuildProvider().PrepareAsync(BuildContext("demo.nocturne.run"));
+        await _fixture.BuildProvider().TryPrepareAsync(DocsTenantFixture.BuildContext("demo.nocturne.run"));
 
-        await using (var seed = new NocturneDbContext(_dbOptions))
+        await using (var seed = _fixture.Db())
         {
             var client = await seed.OAuthClients.IgnoreQueryFilters()
                 .SingleAsync(c => c.TenantId == tenantId);
@@ -189,13 +271,13 @@ public class ScalarAuthProviderTests : IDisposable
             await seed.SaveChangesAsync();
         }
 
-        var context = BuildContext("demo.nocturne.run");
-        await BuildProvider().PrepareAsync(context);
+        var context = DocsTenantFixture.BuildContext("demo.nocturne.run");
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         context.Items.Should().NotContainKey(ScalarAuthContext.HttpContextItemKey,
             "at the cap the provider declines rather than growing the row");
 
-        await using var db = new NocturneDbContext(_dbOptions);
+        await using var db = _fixture.Db();
         var after = await db.OAuthClients.IgnoreQueryFilters()
             .SingleAsync(c => c.TenantId == tenantId);
         JsonSerializer.Deserialize<List<string>>(after.RedirectUris)
@@ -218,53 +300,66 @@ public class ScalarAuthProviderTests : IDisposable
     [InlineData("127.0.0.1")]
     [InlineData("0x7f.1")]                                  // parses as loopback
     [InlineData("[::1]")]
-    public async Task PrepareAsync_RejectsAHostThisDeploymentDoesNotServe(string host)
+    public async Task TryPrepareAsync_RejectsAHostThisDeploymentDoesNotServe(string host)
     {
-        SeedTenant("rhys", isDemo: false, withDemoMember: false);
-        var context = BuildContext(host);
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext(host);
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         Auth(context).Should().BeNull();
 
-        await using var db = new NocturneDbContext(_dbOptions);
+        await using var db = _fixture.Db();
         (await db.OAuthClients.IgnoreQueryFilters().AnyAsync())
             .Should().BeFalse("a foreign host must not register a redirect URI on any tenant");
     }
 
     [Fact]
-    public async Task PrepareAsync_RejectsAForeignHost_EvenOnASingleTenantInstall()
+    public async Task TryPrepareAsync_RejectsAForeignHost_EvenOnASingleTenantInstall()
     {
         // The apex branch serves single-tenant installs. It must not treat a host that is
         // not the configured apex as the apex, or the sole tenant absorbs any origin.
-        SeedTenant("rhys", isDemo: false, withDemoMember: false);
-        var context = BuildContext("attacker.example");
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext("attacker.example");
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         Auth(context).Should().BeNull();
     }
 
     [Fact]
-    public async Task PrepareAsync_ResolvesTheSoleTenant_OnTheConfiguredApex()
+    public async Task TryPrepareAsync_ResolvesTheSoleTenant_OnTheConfiguredApex()
     {
-        SeedTenant("rhys", isDemo: false, withDemoMember: false);
-        var context = BuildContext(BaseDomain);
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext(BaseDomain);
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         Auth(context)!.RedirectUri.Should().Be($"https://{BaseDomain}/scalar");
+    }
+
+    /// <summary>
+    /// The apex of a single-tenant install resolves to that tenant, so its opt-in governs the
+    /// apex too — otherwise turning the docs off would leave them served from the front door.
+    /// </summary>
+    [Fact]
+    public async Task TryPrepareAsync_RefusesTheApex_WhenTheSoleTenantHasNotOptedIn()
+    {
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false, allowPublicDocs: false);
+        var context = DocsTenantFixture.BuildContext(BaseDomain);
+
+        (await _fixture.BuildProvider().TryPrepareAsync(context)).Should().BeFalse();
     }
 
     [Theory]
     [InlineData("rhys.nocturne.run:8443")]
     [InlineData("rhys.nocturne.run:80")]
-    public async Task PrepareAsync_RejectsAPortTheDeploymentIsNotServedOn(string host)
+    public async Task TryPrepareAsync_RejectsAPortTheDeploymentIsNotServedOn(string host)
     {
-        SeedTenant("rhys", isDemo: false, withDemoMember: false);
-        var context = BuildContext(host);
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext(host);
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         Auth(context).Should().BeNull("a caller must not register origins differing by port");
     }
@@ -273,41 +368,41 @@ public class ScalarAuthProviderTests : IDisposable
     [InlineData("javascript")]
     [InlineData("file")]
     [InlineData("HTTPS evil")]
-    public async Task PrepareAsync_RejectsANonHttpForwardedProto(string proto)
+    public async Task TryPrepareAsync_RejectsANonHttpForwardedProto(string proto)
     {
-        SeedTenant("rhys", isDemo: false, withDemoMember: false);
-        var context = BuildContext("rhys.nocturne.run", proto);
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext("rhys.nocturne.run", proto);
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         Auth(context).Should().BeNull();
     }
 
     [Fact]
-    public async Task PrepareAsync_RejectsCleartextHttpOnAPublicHost()
+    public async Task TryPrepareAsync_RejectsCleartextHttpOnAPublicHost()
     {
         // RedirectUriValidator treats http on a non-loopback host as invalid for
         // registration; authorization codes must not be issued over plaintext.
-        SeedTenant("rhys", isDemo: false, withDemoMember: false);
-        var context = BuildContext("rhys.nocturne.run", proto: "http");
+        _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var context = DocsTenantFixture.BuildContext("rhys.nocturne.run", proto: "http");
 
-        await BuildProvider().PrepareAsync(context);
+        await _fixture.BuildProvider().TryPrepareAsync(context);
 
         Auth(context).Should().BeNull();
-        await using var db = new NocturneDbContext(_dbOptions);
+        await using var db = _fixture.Db();
         (await db.OAuthClients.IgnoreQueryFilters().AnyAsync()).Should().BeFalse();
     }
 
     [Fact]
-    public async Task PrepareAsync_DoesNotBadgeTheClientAsKnown()
+    public async Task TryPrepareAsync_DoesNotBadgeTheClientAsKnown()
     {
         // The consent screen suppresses its "app not recognized" warning for known
         // clients. This row is created by an unauthenticated request.
-        var tenantId = SeedTenant("rhys", isDemo: false, withDemoMember: false);
+        var tenantId = _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
 
-        await BuildProvider().PrepareAsync(BuildContext("rhys.nocturne.run"));
+        await _fixture.BuildProvider().TryPrepareAsync(DocsTenantFixture.BuildContext("rhys.nocturne.run"));
 
-        await using var db = new NocturneDbContext(_dbOptions);
+        await using var db = _fixture.Db();
         var client = await db.OAuthClients.IgnoreQueryFilters()
             .SingleAsync(c => c.TenantId == tenantId);
         client.IsKnown.Should().BeFalse();
@@ -317,85 +412,9 @@ public class ScalarAuthProviderTests : IDisposable
     private static ScalarAuthContext? Auth(HttpContext context) =>
         context.Items[ScalarAuthContext.HttpContextItemKey] as ScalarAuthContext;
 
-    private Guid SeedTenant(string slug, bool isDemo, bool withDemoMember, bool isActive = true)
-    {
-        using var db = new NocturneDbContext(_dbOptions);
-
-        var tenant = new TenantEntity
-        {
-            Id = Guid.CreateVersion7(),
-            Slug = slug,
-            DisplayName = slug,
-            IsActive = isActive,
-            IsDemo = isDemo,
-        };
-        db.Add(tenant);
-
-        if (withDemoMember)
-        {
-            var subject = new SubjectEntity
-            {
-                Id = Guid.CreateVersion7(),
-                Name = DemoTenantService.DemoMemberName,
-                IsActive = true,
-                // As provisioning creates it. The lookup requires the flag, not just the
-                // membership, so seeding it false would model a state the provider refuses.
-                IsDemoSubject = true,
-            };
-            db.Subjects.Add(subject);
-            db.TenantMembers.Add(new TenantMemberEntity
-            {
-                Id = Guid.CreateVersion7(),
-                TenantId = tenant.Id,
-                SubjectId = subject.Id,
-                Username = DemoTenantService.DemoMemberUsername,
-            });
-        }
-
-        db.SaveChanges();
-        return tenant.Id;
-    }
-
-    /// <summary>
-    /// Builds a request as the pipeline presents it to the provider: UseForwardedHeaders
-    /// has already applied X-Forwarded-Host/-Proto onto Request.Host and Request.Scheme,
-    /// so the provider reads those rather than the headers.
-    /// </summary>
-    private static HttpContext BuildContext(string host, string proto = "https")
-    {
-        var context = new DefaultHttpContext();
-        context.Request.Path = "/scalar";
-        context.Request.Host = new HostString(host);
-        context.Request.Scheme = proto;
-        return context;
-    }
-
-    private ScalarAuthProvider BuildProvider(IMemoryCache? cache = null)
-    {
-        var dbFactory = new Mock<IDbContextFactory<NocturneDbContext>>();
-        dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() => new NocturneDbContext(_dbOptions));
-
-        var demoTenantService = new DemoTenantService(
-            dbFactory.Object,
-            new Mock<ITenantService>().Object,
-            TestPublicAccessCache.Create(),
-            new Mock<ICacheService>().Object,
-            new Mock<ILogger<DemoTenantService>>().Object);
-
-        return new ScalarAuthProvider(
-            dbFactory.Object,
-            demoTenantService,
-            _sessionService.Object,
-            new RedirectUriValidator(),
-            cache ?? new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new BaseDomainOptions { BaseDomain = BaseDomain }),
-            new Mock<ILogger<ScalarAuthProvider>>().Object);
-    }
-
     public void Dispose()
     {
-        _connection.Dispose();
+        _fixture.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Docs/ScalarAuthProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Docs/ScalarAuthProviderTests.cs
@@ -61,9 +61,8 @@ public class ScalarAuthProviderTests : IDisposable
     }
 
     /// <summary>
-    /// The opt-in is the whole point of the flag: a tenant that never asked for the reference
-    /// must not have one, and must not have an OAuth client written on it by the request that
-    /// asked for it.
+    /// A tenant that never asked for the reference must not have one — and must not have an
+    /// OAuth client written on it by the request that asked.
     /// </summary>
     [Theory]
     [InlineData("/scalar")]
@@ -121,9 +120,8 @@ public class ScalarAuthProviderTests : IDisposable
     }
 
     /// <summary>
-    /// The reference has to render on a fresh install, which is the whole reason these paths
-    /// run ahead of tenant resolution. Also the positive control for the gate: it can only be
-    /// trusted to refuse if it is shown letting something through.
+    /// Positive control for the gate: it can only be trusted to refuse if it is shown letting
+    /// something through.
     /// </summary>
     [Theory]
     [InlineData(BaseDomain)]              // apex of an instance with no tenants


### PR DESCRIPTION
Follow-up to #644. `ScalarAuthProvider` registered an `oauth_clients` row on the resolved tenant from an **unauthenticated** request — no header spoofing needed, browsing to `https://<tenant>.<basedomain>/scalar` was enough, and it happened for every tenant, not just the demo. Most tenants will never use Scalar and do not need their API surface served interactively, so it is now opt-in.

## The flag

`tenants.allow_public_docs`, `NOT NULL DEFAULT false`. Both `/scalar` and `/openapi` are gated on it — gating only the UI would leave the raw spec public, which is most of the same exposure. A tenant that has not opted in gets 404.

Demo tenants default it on, so the demo's Scalar prefill from #644 keeps working. Provisioning now applies the demo defaults on the create path as well as on reset, so an already-provisioned demo self-heals rather than waiting for its next reset.

**Bare-instance rendering is preserved**: with no tenant resolved the docs still render, because the reference has to be readable on a fresh install. A tenant lookup that *throws* answers 404 — an opt-in that cannot be read is not an opt-in.

## A bypass closed on the way

`ResolveAsync` used to return early when the scheme was not http(s) or the port did not match the configured one. Both derive from `X-Forwarded-Proto`/`-Host`, which are caller-controlled here (`KnownProxies` and `KnownIPNetworks` are cleared), so `tenant.example.run:8443/scalar` resolved *no* tenant — which under the new gating would have rendered an opted-out tenant's docs anyway. Tenant selection now uses the host alone; scheme and port moved into redirect-URI construction, where getting them wrong costs only the OAuth client. The registered URI is still built from configuration and the tenant's stored slug, so no caller-controlled byte reaches it beyond the scheme, which `RedirectUriValidator` narrows.

## Rate limiting

The docs paths short-circuit to the endpoint before `UseRateLimiter`, and there is no `GlobalLimiter` — only named policies — so nothing limited them even in principle. `UseRateLimiter` moved above the docs branch and the endpoints carry a `docs` policy.

The cost, stated plainly: the limiter now runs before `UseAuthorization`, so a request that later fails authorization consumes a permit. Only `support-issues` is genuinely affected — every policy partitions on the remote address alone, and that address comes from `X-Forwarded-For`, so a caller rotating it gets a fresh partition. The comment says so rather than implying a ceiling.

## Settings

`GET /api/v4/tenant-settings` and `PUT /api/v4/tenant-settings/public-docs`, gated on `TenantPermissions.TenantSettings` — this is that atom's first enforcement site. The write also carries `[DenyDemoSubject]`, because `DemoVisitorPermissions` includes `tenant.settings` and a permission gate alone would let any anonymous demo visitor take the demo's own reference down.

## Known, accepted

A public-share host and an inactive tenant's host both fall to the no-tenant branch and render the generic reference — no OAuth client, no token, no tenant data. Reaching them with the flag means resolving a share token in the docs path, which is wider than this change.

## Verification

Every behavioural change mutation-proofed: reverted, confirmed the named test fails, restored. `Nocturne.API.Tests` 5132 passed with one known-unrelated pre-existing failure (`CacheIntegrationTests.CreateEntriesAsync_DecomposesToV4AndFiresEvents`). Frontend `pnpm run check` unchanged at 64 pre-existing errors, none in the new files.

https://claude.ai/code/session_018VEAjkfp8WDb8fogHCzkrN