### PR TITLE
fix(demo): discover the tenantless surface, and refuse the shared visitor two more places

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.API.Services.Alerts.Webhooks;
 using Nocturne.Core.Models.Configuration;
@@ -63,7 +64,16 @@ public class WebhookSettingsController(
     }
 
     /// <summary>Tests webhook settings by sending test payloads to configured URLs.</summary>
+    /// <remarks>
+    /// Refused for the demo tenant's shared visitor, which any anonymous caller can obtain a
+    /// session for. The destination is caller-chosen, so this is the server making an outbound
+    /// POST from the deployment's address on the caller's behalf.
+    /// <c>OutboundDestination</c> already keeps it off private networks; what remains is a
+    /// relay to public hosts. The other two actions carry no such capability, so the gate is on
+    /// this one and the demo's notification settings screen still renders.
+    /// </remarks>
     [HttpPost("test")]
+    [DenyDemoSubject]
     [ProducesResponseType(typeof(WebhookTestResult), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]

--- a/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
@@ -65,12 +65,10 @@ public class WebhookSettingsController(
 
     /// <summary>Tests webhook settings by sending test payloads to configured URLs.</summary>
     /// <remarks>
-    /// Refused for the demo tenant's shared visitor, which any anonymous caller can obtain a
-    /// session for. The destination is caller-chosen, so this is the server making an outbound
-    /// POST from the deployment's address on the caller's behalf.
-    /// <c>OutboundDestination</c> already keeps it off private networks; what remains is a
-    /// relay to public hosts. The other two actions carry no such capability, so the gate is on
-    /// this one and the demo's notification settings screen still renders.
+    /// Gated for the demo's shared visitor because the destination is caller-chosen: the server
+    /// makes an outbound POST from its own address. <c>OutboundDestination</c> keeps it off private
+    /// networks, so what remains is a relay to public hosts. The GET and PUT above are a stub and a
+    /// logged no-op, so gating them would only break the demo's notification settings screen.
     /// </remarks>
     [HttpPost("test")]
     [DenyDemoSubject]

--- a/src/API/Nocturne.API/Controllers/V4/Demo/DemoSessionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Demo/DemoSessionController.cs
@@ -75,8 +75,7 @@ public class DemoSessionController : ControllerBase
         if (subjectId is null)
             return NotFound();
 
-        // The endpoint is anonymous and each call writes a refresh_tokens row, so the table needs
-        // a ceiling that does not depend on the per-IP rate limit. It has one, applied where the
+        // Anonymous, and each call writes a refresh_tokens row; the ceiling is applied where the
         // row is created rather than here — see DemoSessionLimits.
         //
         // No IP or user-agent: every visitor shares this subject, and the session list at

--- a/src/API/Nocturne.API/Controllers/V4/Demo/DemoSessionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Demo/DemoSessionController.cs
@@ -75,11 +75,10 @@ public class DemoSessionController : ControllerBase
         if (subjectId is null)
             return NotFound();
 
-        // The endpoint is anonymous and each call writes a refresh_tokens row, so the table
-        // needs a ceiling that does not depend on the per-IP rate limit — whose partition key
-        // is X-Forwarded-For and therefore caller-supplied. See MaxLiveDemoSessions.
-        await _demoTenantService.TrimSessionsAsync(subjectId.Value, ct);
-
+        // The endpoint is anonymous and each call writes a refresh_tokens row, so the table needs
+        // a ceiling that does not depend on the per-IP rate limit. It has one, applied where the
+        // row is created rather than here — see DemoSessionLimits.
+        //
         // No IP or user-agent: every visitor shares this subject, and the session list at
         // /api/v4/account/sessions is readable by any member of it — recording them would
         // show each visitor the addresses of everyone else currently using the demo.

--- a/src/API/Nocturne.API/Controllers/V4/Identity/SessionsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/SessionsController.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Configuration;
@@ -76,8 +77,15 @@ public class SessionsController : ControllerBase
     /// Revoke a login session, logging that device out. Revoking the current
     /// session is allowed and acts as a logout.
     /// </summary>
+    /// <remarks>
+    /// Refused for the demo tenant's shared visitor: every visitor is signed in as that one
+    /// subject, so the sessions here belong to the other people using the demo and revoking one
+    /// logs a stranger out. A visitor ending their own session signs out through
+    /// <c>POST /api/auth/oidc/logout</c>, which is untouched by this.
+    /// </remarks>
     /// <inheritdoc cref="IRefreshTokenService.RevokeSessionForSubjectAsync"/>
     [HttpDelete("{sessionId}")]
+    [DenyDemoSubject]
     [RemoteCommand(Invalidates = ["List"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -109,8 +117,13 @@ public class SessionsController : ControllerBase
     /// <summary>
     /// Revoke every session except the current one (log out everywhere else).
     /// </summary>
+    /// <remarks>
+    /// Refused for the demo tenant's shared visitor: "everything else" on that subject is every
+    /// other visitor currently using the demo.
+    /// </remarks>
     /// <inheritdoc cref="IRefreshTokenService.RevokeOtherSessionsForSubjectAsync"/>
     [HttpPost("revoke-others")]
+    [DenyDemoSubject]
     [RemoteCommand(Invalidates = ["List"])]
     [ProducesResponseType(typeof(RevokeOthersResultDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/API/Nocturne.API/Controllers/V4/Identity/SessionsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/SessionsController.cs
@@ -78,10 +78,9 @@ public class SessionsController : ControllerBase
     /// session is allowed and acts as a logout.
     /// </summary>
     /// <remarks>
-    /// Refused for the demo tenant's shared visitor: every visitor is signed in as that one
-    /// subject, so the sessions here belong to the other people using the demo and revoking one
-    /// logs a stranger out. A visitor ending their own session signs out through
-    /// <c>POST /api/auth/oidc/logout</c>, which is untouched by this.
+    /// The demo's subject is shared, so these sessions belong to other visitors and revoking one
+    /// logs a stranger out. A visitor ending their own session uses
+    /// <c>POST /api/auth/oidc/logout</c>, which stays open.
     /// </remarks>
     /// <inheritdoc cref="IRefreshTokenService.RevokeSessionForSubjectAsync"/>
     [HttpDelete("{sessionId}")]
@@ -118,8 +117,7 @@ public class SessionsController : ControllerBase
     /// Revoke every session except the current one (log out everywhere else).
     /// </summary>
     /// <remarks>
-    /// Refused for the demo tenant's shared visitor: "everything else" on that subject is every
-    /// other visitor currently using the demo.
+    /// On the shared demo subject, "everything else" is every other visitor currently using it.
     /// </remarks>
     /// <inheritdoc cref="IRefreshTokenService.RevokeOtherSessionsForSubjectAsync"/>
     [HttpPost("revoke-others")]

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -368,7 +368,7 @@ public static class ServiceRegistrationExtensions
             // Connection.RemoteIpAddress, which UseForwardedHeaders sets from X-Forwarded-For
             // with no trusted-proxy list, and the gateway does not strip that header, so a
             // caller rotating it gets a fresh partition every request. The real ceiling is
-            // DemoTenantService.MaxLiveDemoSessions, enforced on the subject id.
+            // DemoSessionLimits.MaxLiveSessions, enforced on the subject id.
             options.AddPolicy(
                 "demo-session",
                 context =>

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -91,12 +91,9 @@ public class TenantResolutionMiddleware
     ];
 
     /// <summary>
-    /// Whether a request path is served without a resolved tenant.
+    /// Whether a request path is served without a resolved tenant. Public so the authorization
+    /// guard tests can enumerate the same surface rather than restating these lists.
     /// </summary>
-    /// <remarks>
-    /// Exposed so the authorization guards can enumerate the same surface this middleware admits,
-    /// rather than restating the lists and drifting from them.
-    /// </remarks>
     public static bool IsTenantlessAllowed(string path) =>
         TenantlessAllowedPaths.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)) ||
         TenantlessAllowedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase));

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -90,6 +90,17 @@ public class TenantResolutionMiddleware
         "/api/v4/setup/",
     ];
 
+    /// <summary>
+    /// Whether a request path is served without a resolved tenant.
+    /// </summary>
+    /// <remarks>
+    /// Exposed so the authorization guards can enumerate the same surface this middleware admits,
+    /// rather than restating the lists and drifting from them.
+    /// </remarks>
+    public static bool IsTenantlessAllowed(string path) =>
+        TenantlessAllowedPaths.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)) ||
+        TenantlessAllowedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase));
+
     public async Task InvokeAsync(HttpContext context)
     {
         var tenantAccessor = context.RequestServices.GetRequiredService<ITenantAccessor>();
@@ -132,9 +143,7 @@ public class TenantResolutionMiddleware
         }
 
         var path = context.Request.Path.Value ?? "";
-        var isTenantlessAllowedPath =
-            TenantlessAllowedPaths.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)) ||
-            TenantlessAllowedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase));
+        var isTenantlessAllowedPath = IsTenantlessAllowed(path);
 
         // On the apex (no subdomain), GET /api/v4/status is tenant-scoped yet listed as
         // tenantless-allowed (so a fresh apex doesn't 404). On a single-tenant install,

--- a/src/API/Nocturne.API/Services/Demo/DemoTenantService.cs
+++ b/src/API/Nocturne.API/Services/Demo/DemoTenantService.cs
@@ -4,7 +4,6 @@ using Nocturne.Infrastructure.Cache.Abstractions;
 using Nocturne.Infrastructure.Cache.Keys;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
-using Nocturne.Core.Models.Demo;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 
@@ -48,28 +47,6 @@ public sealed class DemoTenantService
     /// <see cref="EnsureDemoRoleAsync"/>.
     /// </summary>
     public const string DemoRoleSlug = "demo-visitor";
-
-    /// <summary>
-    /// Ceiling on live <c>refresh_tokens</c> rows for the demo subject.
-    /// </summary>
-    /// <remarks>
-    /// The per-IP rate limit on the sign-in endpoint does not bound this. That partition key
-    /// comes from <c>Connection.RemoteIpAddress</c>, which <c>UseForwardedHeaders</c> — running
-    /// before the rate limiter, with <c>KnownProxies</c> and <c>KnownIPNetworks</c> cleared
-    /// because the API is only meant to be reachable through the gateway — takes from
-    /// <c>X-Forwarded-For</c>. The gateway does not strip that header, so a caller rotating it
-    /// gets a fresh partition per request and the limit bounds nothing. The limit is kept for
-    /// the friction it adds to naive abuse; this cap is the actual ceiling, and it is enforced
-    /// on a value no caller supplies.
-    /// <para>
-    /// Rotation is bounded by it too, but not here: <c>POST /api/auth/oidc/refresh</c> is
-    /// anonymous and carries no rate limit of its own, and each call writes a replacement row
-    /// without passing through any demo code. The cap is applied at the row-creating sink in the
-    /// data layer, so <see cref="TrimSessionsAsync"/> is the issue-path convenience rather than
-    /// the only enforcement.
-    /// </para>
-    /// </remarks>
-    public const int MaxLiveDemoSessions = DemoSessionLimits.MaxLiveSessions;
 
     private readonly IDbContextFactory<NocturneDbContext> _factory;
     private readonly ITenantService _tenantService;
@@ -129,71 +106,6 @@ public sealed class DemoTenantService
                 && m.Subject!.IsDemoSubject)
             .Select(m => (Guid?)m.SubjectId)
             .FirstOrDefaultAsync(ct);
-    }
-
-    /// <summary>
-    /// Deletes the demo subject's oldest sessions so that at most
-    /// <see cref="MaxLiveDemoSessions"/> - 1 remain, leaving room for the caller to issue one.
-    /// Call immediately before issuing a demo session.
-    /// </summary>
-    /// <remarks>
-    /// Deletes rather than revokes: a revoked row still occupies the table, and the point of the
-    /// cap is that an endpoint anyone can call cannot grow it without bound. Expired and revoked
-    /// rows are dropped first, so a live session is only ever displaced once there is nothing
-    /// dead left to clear.
-    /// </remarks>
-    /// <param name="subjectId">
-    /// The demo member's subject. Verified to carry <see cref="SubjectEntity.IsDemoSubject"/>
-    /// before anything is deleted — this removes credential rows, so it must never be pointed at
-    /// a real account.
-    /// </param>
-    /// <returns>The number of session rows deleted.</returns>
-    public async Task<int> TrimSessionsAsync(Guid subjectId, CancellationToken ct = default)
-    {
-        await using var db = await _factory.CreateDbContextAsync(ct);
-
-        var isDemoSubject = await db.Subjects
-            .AsNoTracking()
-            .Where(s => s.Id == subjectId)
-            .Select(s => (bool?)s.IsDemoSubject)
-            .FirstOrDefaultAsync(ct);
-
-        if (isDemoSubject is not true)
-        {
-            _logger.LogWarning(
-                "Refusing to trim sessions for subject {SubjectId}: not a demo subject", subjectId);
-            return 0;
-        }
-
-        var now = DateTime.UtcNow;
-
-        // Age out the dead rows first; they are nobody's session.
-        var deleted = await db.RefreshTokens
-            .Where(t => t.SubjectId == subjectId && (t.RevokedAt != null || t.ExpiresAt <= now))
-            .ExecuteDeleteAsync(ct);
-
-        var keep = MaxLiveDemoSessions - 1;
-        var surplus = await db.RefreshTokens
-            .Where(t => t.SubjectId == subjectId)
-            .OrderByDescending(t => t.IssuedAt)
-            .Skip(keep)
-            .Select(t => t.Id)
-            .ToListAsync(ct);
-
-        if (surplus.Count > 0)
-        {
-            deleted += await db.RefreshTokens
-                .Where(t => surplus.Contains(t.Id))
-                .ExecuteDeleteAsync(ct);
-        }
-
-        if (deleted > 0)
-        {
-            _logger.LogInformation(
-                "Trimmed {Count} demo session row(s) for subject {SubjectId}", deleted, subjectId);
-        }
-
-        return deleted;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
+++ b/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
@@ -381,9 +381,8 @@ public sealed class ScalarAuthProvider
         if (_cache.TryGetValue(cacheKey, out string? cached) && cached is not null)
             return cached;
 
-        // Bounded like the sign-in endpoint: /scalar is anonymous too, and the row this issues is
-        // capped where it is written — see DemoSessionLimits. The token cache is keyed on the
-        // subject, so a reset (which changes it) lets the docs mint again.
+        // /scalar is anonymous too; the row this issues is capped where it is written — see
+        // DemoSessionLimits.
         //
         // No IP or user-agent — see DemoSessionController: the demo subject is shared, and its
         // session list is readable by anyone holding a demo session.

--- a/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
+++ b/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
@@ -381,10 +381,10 @@ public sealed class ScalarAuthProvider
         if (_cache.TryGetValue(cacheKey, out string? cached) && cached is not null)
             return cached;
 
-        // Bounded like the sign-in endpoint: /scalar is anonymous too, and the token cache is
-        // keyed on the subject, so a reset (which changes it) lets the docs mint again.
-        await _demoTenantService.TrimSessionsAsync(subjectId.Value, context.RequestAborted);
-
+        // Bounded like the sign-in endpoint: /scalar is anonymous too, and the row this issues is
+        // capped where it is written — see DemoSessionLimits. The token cache is keyed on the
+        // subject, so a reset (which changes it) lets the docs mint again.
+        //
         // No IP or user-agent — see DemoSessionController: the demo subject is shared, and its
         // session list is readable by anyone holding a demo session.
         var session = await _sessionService.IssueSessionAsync(

--- a/src/Core/Nocturne.Core.Models/Demo/DemoSessionLimits.cs
+++ b/src/Core/Nocturne.Core.Models/Demo/DemoSessionLimits.cs
@@ -8,6 +8,15 @@ namespace Nocturne.Core.Models.Demo;
 /// the single place a <c>refresh_tokens</c> row is created — the demo sign-in endpoint is only one
 /// of the paths that reaches it, and the anonymous, unrate-limited refresh endpoint rotates rows
 /// through the same sink without passing through any demo code.
+/// <para>
+/// The per-IP rate limit on the sign-in endpoint is not a substitute. That partition key comes from
+/// <c>Connection.RemoteIpAddress</c>, which <c>UseForwardedHeaders</c> — running before the rate
+/// limiter, with <c>KnownProxies</c> and <c>KnownIPNetworks</c> cleared because the API is only
+/// meant to be reachable through the gateway — takes from <c>X-Forwarded-For</c>. The gateway does
+/// not strip that header, so a caller rotating it gets a fresh partition per request and the limit
+/// bounds nothing. It is kept for the friction it adds to naive abuse; this cap is the actual
+/// ceiling, and it is enforced on a value no caller supplies.
+/// </para>
 /// </remarks>
 public static class DemoSessionLimits
 {

--- a/src/Core/Nocturne.Core.Models/Demo/DemoSessionLimits.cs
+++ b/src/Core/Nocturne.Core.Models/Demo/DemoSessionLimits.cs
@@ -9,13 +9,9 @@ namespace Nocturne.Core.Models.Demo;
 /// of the paths that reaches it, and the anonymous, unrate-limited refresh endpoint rotates rows
 /// through the same sink without passing through any demo code.
 /// <para>
-/// The per-IP rate limit on the sign-in endpoint is not a substitute. That partition key comes from
-/// <c>Connection.RemoteIpAddress</c>, which <c>UseForwardedHeaders</c> — running before the rate
-/// limiter, with <c>KnownProxies</c> and <c>KnownIPNetworks</c> cleared because the API is only
-/// meant to be reachable through the gateway — takes from <c>X-Forwarded-For</c>. The gateway does
-/// not strip that header, so a caller rotating it gets a fresh partition per request and the limit
-/// bounds nothing. It is kept for the friction it adds to naive abuse; this cap is the actual
-/// ceiling, and it is enforced on a value no caller supplies.
+/// The sign-in endpoint's per-IP rate limit is not a substitute: it partitions on a caller-supplied
+/// header (see the <c>demo-session</c> policy in <c>ServiceRegistrationExtensions</c>), while this
+/// cap keys on the subject id.
 /// </para>
 /// </remarks>
 public static class DemoSessionLimits

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerActionReflection.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerActionReflection.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Shared reflection over the API's MVC controllers, used by the authorization guard tests to
+/// enumerate actions, their routes and the gates in front of them.
+/// </summary>
+internal static class ControllerActionReflection
+{
+    /// <summary>The API assembly under audit.</summary>
+    public static Assembly ApiAssembly => typeof(AuthorizationConfiguration).Assembly;
+
+    /// <summary>Every controller MVC would discover in the API assembly.</summary>
+    public static IEnumerable<Type> GetControllers() =>
+        ApiAssembly.GetTypes()
+            .Where(t => typeof(ControllerBase).IsAssignableFrom(t)
+                        && t is { IsClass: true, IsAbstract: false, IsPublic: true }
+                        && t.GetCustomAttribute<NonControllerAttribute>() is null);
+
+    /// <summary>Every action method on a controller.</summary>
+    public static IEnumerable<MethodInfo> GetActionMethods(Type controller) =>
+        controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => !m.IsSpecialName
+                        && m.GetCustomAttributes().OfType<IActionHttpMethodProvider>().Any());
+
+    /// <summary>
+    /// The absolute routes an action answers on, with a leading slash and no trailing one.
+    /// </summary>
+    /// <remarks>
+    /// One action can carry several method attributes and therefore several routes, so this
+    /// returns them all. Attribute routing only; the API declares no conventional routes.
+    /// </remarks>
+    public static IEnumerable<string> GetRoutes(Type controller, MethodInfo action)
+    {
+        var prefix = controller.GetCustomAttributes<RouteAttribute>(inherit: true)
+            .Select(r => r.Template)
+            .FirstOrDefault() ?? string.Empty;
+
+        prefix = prefix.Replace(
+            "[controller]",
+            controller.Name.EndsWith("Controller", StringComparison.Ordinal)
+                ? controller.Name[..^"Controller".Length]
+                : controller.Name,
+            StringComparison.Ordinal);
+
+        var templates = action.GetCustomAttributes()
+            .OfType<IActionHttpMethodProvider>()
+            .OfType<IRouteTemplateProvider>()
+            .Select(t => t.Template)
+            .ToList();
+
+        if (templates.Count == 0)
+        {
+            templates.Add(null);
+        }
+
+        return templates.Select(t => Combine(prefix, t)).Distinct(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Whether the action is explicitly anonymous, itself or through its controller.</summary>
+    public static bool HasAnonymous(MethodInfo action, Type controller) =>
+        action.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any()
+        || controller.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any();
+
+    /// <summary>
+    /// Whether the action declares an authorization gate — <c>[Authorize]</c> and friends, or one
+    /// of the Nocturne <c>[Require*]</c> filters — itself or through its controller.
+    /// </summary>
+    public static bool HasAuthorizationGate(MethodInfo action, Type controller) =>
+        HasGate(action.GetCustomAttributes(inherit: true))
+        || HasGate(controller.GetCustomAttributes(inherit: true));
+
+    /// <summary>
+    /// Whether the action refuses the demo tenant's shared visitor account, itself or through
+    /// its controller.
+    /// </summary>
+    public static bool DeniesTheDemoSubject(MethodInfo action, Type controller) =>
+        action.GetCustomAttribute<DenyDemoSubjectAttribute>() is not null
+        || controller.GetCustomAttribute<DenyDemoSubjectAttribute>() is not null;
+
+    private static bool HasGate(IEnumerable<object> attributes) =>
+        attributes.Any(a => a is IAuthorizeData
+                            or RequirePermissionAttribute // covers [RequireAdmin]/[RequireRead]/[RequireWrite]
+                            or RequireScopeAttribute
+                            or RequireInstanceKeyAuthAttribute
+                            or RequireAuthenticationAttribute);
+
+    private static string Combine(string prefix, string? template)
+    {
+        if (!string.IsNullOrEmpty(template) && (template.StartsWith('/') || template.StartsWith("~/")))
+        {
+            return Normalize(template.TrimStart('~'));
+        }
+
+        var combined = string.IsNullOrEmpty(template)
+            ? prefix
+            : $"{prefix.TrimEnd('/')}/{template.TrimStart('/')}";
+
+        return Normalize(combined);
+    }
+
+    private static string Normalize(string route) => "/" + route.Trim('/');
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerActionReflection.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerActionReflection.cs
@@ -11,22 +11,18 @@ using Nocturne.API.Authorization;
 namespace Nocturne.API.Tests.Authorization;
 
 /// <summary>
-/// Shared reflection over the API's MVC controllers, used by the authorization guard tests to
-/// enumerate actions, their routes and the gates in front of them.
+/// Reflection over the API's MVC controllers, shared by the authorization guard tests.
 /// </summary>
 internal static class ControllerActionReflection
 {
-    /// <summary>The API assembly under audit.</summary>
     public static Assembly ApiAssembly => typeof(AuthorizationConfiguration).Assembly;
 
-    /// <summary>Every controller MVC would discover in the API assembly.</summary>
     public static IEnumerable<Type> GetControllers() =>
         ApiAssembly.GetTypes()
             .Where(t => typeof(ControllerBase).IsAssignableFrom(t)
                         && t is { IsClass: true, IsAbstract: false, IsPublic: true }
                         && t.GetCustomAttribute<NonControllerAttribute>() is null);
 
-    /// <summary>Every action method on a controller.</summary>
     public static IEnumerable<MethodInfo> GetActionMethods(Type controller) =>
         controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)
             .Where(m => !m.IsSpecialName
@@ -35,10 +31,7 @@ internal static class ControllerActionReflection
     /// <summary>
     /// The absolute routes an action answers on, with a leading slash and no trailing one.
     /// </summary>
-    /// <remarks>
-    /// One action can carry several method attributes and therefore several routes, so this
-    /// returns them all. Attribute routing only; the API declares no conventional routes.
-    /// </remarks>
+    /// <remarks>Attribute routing only; the API declares no conventional routes.</remarks>
     public static IEnumerable<string> GetRoutes(Type controller, MethodInfo action)
     {
         var prefix = controller.GetCustomAttributes<RouteAttribute>(inherit: true)
@@ -66,23 +59,14 @@ internal static class ControllerActionReflection
         return templates.Select(t => Combine(prefix, t)).Distinct(StringComparer.OrdinalIgnoreCase);
     }
 
-    /// <summary>Whether the action is explicitly anonymous, itself or through its controller.</summary>
     public static bool HasAnonymous(MethodInfo action, Type controller) =>
         action.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any()
         || controller.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any();
 
-    /// <summary>
-    /// Whether the action declares an authorization gate — <c>[Authorize]</c> and friends, or one
-    /// of the Nocturne <c>[Require*]</c> filters — itself or through its controller.
-    /// </summary>
     public static bool HasAuthorizationGate(MethodInfo action, Type controller) =>
         HasGate(action.GetCustomAttributes(inherit: true))
         || HasGate(controller.GetCustomAttributes(inherit: true));
 
-    /// <summary>
-    /// Whether the action refuses the demo tenant's shared visitor account, itself or through
-    /// its controller.
-    /// </summary>
     public static bool DeniesTheDemoSubject(MethodInfo action, Type controller) =>
         action.GetCustomAttribute<DenyDemoSubjectAttribute>() is not null
         || controller.GetCustomAttribute<DenyDemoSubjectAttribute>() is not null;

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
@@ -40,7 +40,7 @@ namespace Nocturne.API.Tests.Authorization;
 /// </remarks>
 public class ControllerAuthorizationCoverageTests
 {
-    private static Assembly ApiAssembly => typeof(AuthorizationConfiguration).Assembly;
+    private static Assembly ApiAssembly => ControllerActionReflection.ApiAssembly;
 
     /// <summary>
     /// Controllers whose actions are intentionally gated only by the <see cref="HasPermissionsRequirement"/>
@@ -93,11 +93,7 @@ public class ControllerAuthorizationCoverageTests
     [Fact]
     public void EveryControllerAction_HasAnExplicitAuthorizationDecision()
     {
-        var controllers = ApiAssembly.GetTypes()
-            .Where(t => typeof(ControllerBase).IsAssignableFrom(t)
-                        && t is { IsClass: true, IsAbstract: false, IsPublic: true }
-                        && t.GetCustomAttribute<NonControllerAttribute>() is null)
-            .ToList();
+        var controllers = ControllerActionReflection.GetControllers().ToList();
 
         controllers.Should().NotBeEmpty("the API assembly must expose controllers to audit");
 
@@ -156,22 +152,11 @@ public class ControllerAuthorizationCoverageTests
     }
 
     private static IEnumerable<MethodInfo> GetActionMethods(Type controller) =>
-        controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-            .Where(m => !m.IsSpecialName
-                        && m.GetCustomAttributes().OfType<IActionHttpMethodProvider>().Any());
+        ControllerActionReflection.GetActionMethods(controller);
 
     private static bool HasAnonymous(MethodInfo action, Type controller) =>
-        action.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any()
-        || controller.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any();
+        ControllerActionReflection.HasAnonymous(action, controller);
 
     private static bool HasAuthorizationGate(MethodInfo action, Type controller) =>
-        HasGate(action.GetCustomAttributes(inherit: true))
-        || HasGate(controller.GetCustomAttributes(inherit: true));
-
-    private static bool HasGate(IEnumerable<object> attributes) =>
-        attributes.Any(a => a is IAuthorizeData
-                            or RequirePermissionAttribute // covers [RequireAdmin]/[RequireRead]/[RequireWrite]
-                            or RequireScopeAttribute
-                            or RequireInstanceKeyAuthAttribute
-                            or RequireAuthenticationAttribute);
+        ControllerActionReflection.HasAuthorizationGate(action, controller);
 }

--- a/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
@@ -14,11 +14,10 @@ namespace Nocturne.API.Tests.Authorization;
 /// Pins which endpoints refuse the demo tenant's shared visitor account.
 /// </summary>
 /// <remarks>
-/// A demo session is handed to any anonymous caller, so the subject behind it is
-/// authenticated but stands for no one, and every visitor is the <em>same</em> subject.
-/// Two classes of endpoint must refuse it, and neither is protected by a tenant permission
-/// check — one because there is no tenant in the request to check against, the other
-/// because the demo member legitimately holds the permission involved:
+/// The premise is in <see cref="DenyDemoSubjectAttribute"/>. Two classes of endpoint must refuse
+/// that subject, and neither is protected by a tenant permission check — one because there is no
+/// tenant in the request to check against, the other because the demo member legitimately holds
+/// the permission involved:
 /// <list type="bullet">
 /// <item><b>Acting as a platform user</b> — creating a tenant, accepting an invite,
 /// requesting membership, minting a subject. Covered by
@@ -81,15 +80,11 @@ public class DemoSubjectGatedEndpointsTests
         { typeof(CareLinkConnectController), nameof(CareLinkConnectController.Start) },
 
         // The webhook tester posts to a caller-named destination from inside the deployment's
-        // network. OutboundDestination keeps it off private addresses, so what is left is an
-        // outbound POST to a public host sourced from the deployment's own address, available to
-        // anyone who asks for a demo session. The endpoint carries no permission attribute at all,
-        // so [Authorize] is the whole gate.
+        // network. It carries no permission attribute at all, so [Authorize] is the whole gate.
         { typeof(WebhookSettingsController), nameof(WebhookSettingsController.TestWebhookSettings) },
 
         // Session management on a shared subject acts on other visitors' sessions, not the
-        // caller's. List stays open: the rows carry no address (the repository scrubs them) and
-        // name no device beyond "demo-visitor".
+        // caller's. List stays open — see TheSessionListStaysOpenWhileRevocationDoesNot.
         { typeof(SessionsController), nameof(SessionsController.Revoke) },
         { typeof(SessionsController), nameof(SessionsController.RevokeOthers) },
     };
@@ -131,10 +126,9 @@ public class DemoSubjectGatedEndpointsTests
     }
 
     /// <summary>
-    /// Listing sessions stays reachable with a demo session while revoking them does not. The
-    /// rows carry no address — the repository scrubs them for a demo subject — and no device
-    /// beyond <c>demo-visitor</c>, so the list shows a visitor how many people are on the demo
-    /// and nothing about them. Pinned so the split is a recorded decision rather than a gap.
+    /// Listing sessions stays open while revoking them does not: the rows carry no address — the
+    /// repository scrubs them for a demo subject — and no device beyond <c>demo-visitor</c>, so the
+    /// list tells a visitor only how many people are on the demo.
     /// </summary>
     [Fact]
     public void TheSessionListStaysOpenWhileRevocationDoesNot()

--- a/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
@@ -79,6 +79,19 @@ public class DemoSubjectGatedEndpointsTests
         // guards the write, but this flow stores a refresh token as a connector secret on the way
         // and its persist step swallows exceptions, so it has to be refused at the edge too.
         { typeof(CareLinkConnectController), nameof(CareLinkConnectController.Start) },
+
+        // The webhook tester posts to a caller-named destination from inside the deployment's
+        // network. OutboundDestination keeps it off private addresses, so what is left is an
+        // outbound POST to a public host sourced from the deployment's own address, available to
+        // anyone who asks for a demo session. The endpoint carries no permission attribute at all,
+        // so [Authorize] is the whole gate.
+        { typeof(WebhookSettingsController), nameof(WebhookSettingsController.TestWebhookSettings) },
+
+        // Session management on a shared subject acts on other visitors' sessions, not the
+        // caller's. List stays open: the rows carry no address (the repository scrubs them) and
+        // name no device beyond "demo-visitor".
+        { typeof(SessionsController), nameof(SessionsController.Revoke) },
+        { typeof(SessionsController), nameof(SessionsController.RevokeOthers) },
     };
 
     [Theory]
@@ -115,5 +128,23 @@ public class DemoSubjectGatedEndpointsTests
         ungated!.GetCustomAttribute<DenyDemoSubjectAttribute>().Should().BeNull();
         typeof(GuestLinkController).GetCustomAttribute<DenyDemoSubjectAttribute>().Should().BeNull(
             "the gate is per-endpoint here, so the guest-activation path stays open");
+    }
+
+    /// <summary>
+    /// Listing sessions stays reachable with a demo session while revoking them does not. The
+    /// rows carry no address — the repository scrubs them for a demo subject — and no device
+    /// beyond <c>demo-visitor</c>, so the list shows a visitor how many people are on the demo
+    /// and nothing about them. Pinned so the split is a recorded decision rather than a gap.
+    /// </summary>
+    [Fact]
+    public void TheSessionListStaysOpenWhileRevocationDoesNot()
+    {
+        var list = typeof(SessionsController)
+            .GetMethod(nameof(SessionsController.List), BindingFlags.Public | BindingFlags.Instance);
+
+        list.Should().NotBeNull();
+        list!.GetCustomAttribute<DenyDemoSubjectAttribute>().Should().BeNull();
+        typeof(SessionsController).GetCustomAttribute<DenyDemoSubjectAttribute>().Should().BeNull(
+            "gating the controller would take the list with it");
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
@@ -19,40 +19,37 @@ namespace Nocturne.API.Tests.Authorization;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The surface is the tenantless one — the paths
-/// <see cref="TenantResolutionMiddleware.IsTenantlessAllowed"/> admits with no resolved tenant —
-/// intersected with the endpoints whose only gate is authentication. Both halves matter. Off a
-/// tenant, a tenant's permission check has nothing to check against; and the fallback policy
-/// (<see cref="HasPermissionsRequirement"/>) that gates every attribute-less endpoint is not
-/// satisfiable there by the demo subject, whose permissions come from a tenant membership and
-/// whose global role set is empty. A bare <c>[Authorize]</c> drops that to the framework's
-/// "is authenticated", which every demo session is.
+/// The surface is the paths <see cref="TenantResolutionMiddleware.IsTenantlessAllowed"/> admits
+/// with no resolved tenant, intersected with the endpoints whose only gate is <em>bare</em>
+/// <c>[Authorize]</c> — not "endpoints with no attribute". An attribute-less endpoint falls to the
+/// fallback policy (<see cref="HasPermissionsRequirement"/>), which the demo subject fails off a
+/// tenant: its permissions come from a tenant membership while the fallback reads only global
+/// <c>subject_roles</c>, which is empty for it. A bare <c>[Authorize]</c> drops that to the
+/// framework's "is authenticated", which every demo session is. Widening the predicate would
+/// pull in endpoints the demo subject cannot reach anyway.
 /// </para>
 /// <para>
 /// An endpoint gated by roles, a policy, or a Nocturne <c>[Require*]</c> filter asks for more than
-/// authentication and is out of scope; one carrying <c>[AllowAnonymous]</c> was never gated by a
-/// session in the first place. Anything else added to this surface later has to be classified here
-/// before it ships, which is the point — <see cref="DemoSubjectGatedEndpointsTests"/> pins the
-/// endpoints already decided on and cannot see a new one.
+/// authentication; one carrying <c>[AllowAnonymous]</c> was never gated by a session at all. This
+/// discovers, so anything added to the surface later must be classified before it ships —
+/// <see cref="DemoSubjectGatedEndpointsTests"/> pins what is already decided and cannot see a new
+/// endpoint.
 /// </para>
 /// </remarks>
 public class TenantlessDemoSubjectCoverageTests
 {
     /// <summary>
-    /// Tenantless authentication-only endpoints deliberately left reachable by a demo visitor,
-    /// keyed by <c>Controller.Action</c> with the reason.
+    /// Endpoints on this surface deliberately left reachable by a demo visitor, keyed by
+    /// <c>Controller.Action</c> with the reason.
     /// </summary>
     private static readonly IReadOnlyDictionary<string, string> Exempt =
         new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            // Both list the tenants the calling subject belongs to. A demo subject belongs to the
-            // demo tenant and nothing else — the reset deletes any membership it picked up
-            // elsewhere — so each returns the tenant the visitor is already looking at.
+            // A demo subject holds the demo tenant's membership and nothing else — the reset
+            // deletes any it picked up elsewhere — so both return the tenant already on screen.
             ["PlatformController.GetTenants"] = "lists the caller's own memberships, which for the demo subject is the demo tenant",
             ["MyTenantsController.GetOverview"] = "aggregates over the caller's own memberships, which for the demo subject is the demo tenant",
 
-            // Deployment-wide configuration echoed to the login and setup screens: the base domain
-            // and whether multitenancy is on. Carries nothing subject-scoped.
             ["PlatformController.GetTransitionStatus"] = "reports the deployment's multitenancy configuration, not subject state",
         };
 
@@ -74,8 +71,8 @@ public class TenantlessDemoSubjectCoverageTests
     }
 
     /// <summary>
-    /// Positive control on the discovery: a guard that enumerates nothing passes while checking
-    /// nothing, so pin both that the surface is found and that a known member of it is on it.
+    /// Non-vacuity: a discovery that enumerates nothing passes the guard above while checking
+    /// nothing, so pin that the surface is found and that a known member of it is on it.
     /// </summary>
     [Fact]
     public void TheDiscoveryFindsTheTenantlessSurface()
@@ -93,9 +90,9 @@ public class TenantlessDemoSubjectCoverageTests
     }
 
     /// <summary>
-    /// Positive control on the gate check: every exemption must name an endpoint that is both
-    /// discovered and genuinely ungated, so the check cannot be passing because it reports
-    /// everything as gated, and the list cannot go stale.
+    /// Non-vacuity on the gate check, and staleness on the list: an exemption must name an endpoint
+    /// that is still discovered and still ungated, so the guard above cannot be passing because
+    /// everything reads as gated.
     /// </summary>
     [Fact]
     public void EveryExemptionNamesADiscoveredUngatedEndpoint()
@@ -118,10 +115,6 @@ public class TenantlessDemoSubjectCoverageTests
 
     private static string Key(Type controller, MethodInfo action) => $"{controller.Name}.{action.Name}";
 
-    /// <summary>
-    /// Endpoints served without a resolved tenant whose only gate is that the caller is
-    /// authenticated.
-    /// </summary>
     private static IEnumerable<(Type Controller, MethodInfo Action)> Discover()
     {
         foreach (var controller in ControllerActionReflection.GetControllers())
@@ -149,8 +142,7 @@ public class TenantlessDemoSubjectCoverageTests
             .Concat(controller.GetCustomAttributes(inherit: true))
             .ToList();
 
-        // A permission, scope or instance-key filter asks for more than a session, and no demo
-        // grant satisfies one off a tenant.
+        // No demo grant satisfies one of these off a tenant.
         if (attributes.Any(a => a is RequirePermissionAttribute
                                 or RequireScopeAttribute
                                 or RequireInstanceKeyAuthAttribute))
@@ -160,8 +152,8 @@ public class TenantlessDemoSubjectCoverageTests
 
         var authorize = attributes.OfType<IAuthorizeData>().ToList();
 
-        // Roles and policies are evaluated on top of authentication, so an endpoint naming one is
-        // asking for something the demo subject — which holds no global role — does not have.
+        // A named role or policy asks for something the demo subject, which holds no global role,
+        // does not have.
         if (authorize.Any(a => !string.IsNullOrEmpty(a.Roles) || !string.IsNullOrEmpty(a.Policy)))
         {
             return false;

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.V4;
+using Nocturne.API.Multitenancy;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Discovers the endpoints an anonymous visitor holding a demo session can reach off the demo
+/// tenant, and requires each to be gated with <see cref="DenyDemoSubjectAttribute"/> or named in
+/// <see cref="Exempt"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The surface is the tenantless one — the paths
+/// <see cref="TenantResolutionMiddleware.IsTenantlessAllowed"/> admits with no resolved tenant —
+/// intersected with the endpoints whose only gate is authentication. Both halves matter. Off a
+/// tenant, a tenant's permission check has nothing to check against; and the fallback policy
+/// (<see cref="HasPermissionsRequirement"/>) that gates every attribute-less endpoint is not
+/// satisfiable there by the demo subject, whose permissions come from a tenant membership and
+/// whose global role set is empty. A bare <c>[Authorize]</c> drops that to the framework's
+/// "is authenticated", which every demo session is.
+/// </para>
+/// <para>
+/// An endpoint gated by roles, a policy, or a Nocturne <c>[Require*]</c> filter asks for more than
+/// authentication and is out of scope; one carrying <c>[AllowAnonymous]</c> was never gated by a
+/// session in the first place. Anything else added to this surface later has to be classified here
+/// before it ships, which is the point — <see cref="DemoSubjectGatedEndpointsTests"/> pins the
+/// endpoints already decided on and cannot see a new one.
+/// </para>
+/// </remarks>
+public class TenantlessDemoSubjectCoverageTests
+{
+    /// <summary>
+    /// Tenantless authentication-only endpoints deliberately left reachable by a demo visitor,
+    /// keyed by <c>Controller.Action</c> with the reason.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> Exempt =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // Both list the tenants the calling subject belongs to. A demo subject belongs to the
+            // demo tenant and nothing else — the reset deletes any membership it picked up
+            // elsewhere — so each returns the tenant the visitor is already looking at.
+            ["PlatformController.GetTenants"] = "lists the caller's own memberships, which for the demo subject is the demo tenant",
+            ["MyTenantsController.GetOverview"] = "aggregates over the caller's own memberships, which for the demo subject is the demo tenant",
+
+            // Deployment-wide configuration echoed to the login and setup screens: the base domain
+            // and whether multitenancy is on. Carries nothing subject-scoped.
+            ["PlatformController.GetTransitionStatus"] = "reports the deployment's multitenancy configuration, not subject state",
+        };
+
+    [Fact]
+    public void EveryTenantlessAuthenticationOnlyEndpoint_RefusesTheDemoSubjectOrIsExempt()
+    {
+        var ungated = Discover()
+            .Where(e => !ControllerActionReflection.DeniesTheDemoSubject(e.Action, e.Controller))
+            .Select(e => Key(e.Controller, e.Action))
+            .Where(k => !Exempt.ContainsKey(k))
+            .Distinct()
+            .OrderBy(k => k, StringComparer.Ordinal)
+            .ToList();
+
+        ungated.Should().BeEmpty(
+            "an anonymous caller can obtain a demo session, and off a tenant nothing but "
+            + "authentication stands in front of these — gate them with [DenyDemoSubject] or add "
+            + "them to Exempt with a reason. Ungated:\n  " + string.Join("\n  ", ungated));
+    }
+
+    /// <summary>
+    /// Positive control on the discovery: a guard that enumerates nothing passes while checking
+    /// nothing, so pin both that the surface is found and that a known member of it is on it.
+    /// </summary>
+    [Fact]
+    public void TheDiscoveryFindsTheTenantlessSurface()
+    {
+        var discovered = Discover().Select(e => Key(e.Controller, e.Action)).Distinct().ToList();
+
+        discovered.Should().NotBeEmpty(
+            "the tenantless surface has authentication-only endpoints on it, so a discovery that "
+            + "returns nothing has stopped matching routes rather than found the surface clean");
+
+        discovered.Should().Contain(
+            $"{nameof(PlatformController)}.{nameof(PlatformController.CreateTenant)}",
+            "tenant creation is served off the apex under a bare [Authorize] and is the endpoint "
+            + "this surface was gated for");
+    }
+
+    /// <summary>
+    /// Positive control on the gate check: every exemption must name an endpoint that is both
+    /// discovered and genuinely ungated, so the check cannot be passing because it reports
+    /// everything as gated, and the list cannot go stale.
+    /// </summary>
+    [Fact]
+    public void EveryExemptionNamesADiscoveredUngatedEndpoint()
+    {
+        var discovered = Discover().ToDictionary(e => Key(e.Controller, e.Action), e => e);
+
+        foreach (var (key, reason) in Exempt)
+        {
+            discovered.Should().ContainKey(key,
+                "{0} is exempted with the reason \"{1}\" but is no longer on the tenantless "
+                + "authentication-only surface — drop the entry", key, reason);
+
+            var endpoint = discovered[key];
+            ControllerActionReflection.DeniesTheDemoSubject(endpoint.Action, endpoint.Controller)
+                .Should().BeFalse(
+                    "{0} now carries [DenyDemoSubject], so its exemption is dead — drop the entry",
+                    key);
+        }
+    }
+
+    private static string Key(Type controller, MethodInfo action) => $"{controller.Name}.{action.Name}";
+
+    /// <summary>
+    /// Endpoints served without a resolved tenant whose only gate is that the caller is
+    /// authenticated.
+    /// </summary>
+    private static IEnumerable<(Type Controller, MethodInfo Action)> Discover()
+    {
+        foreach (var controller in ControllerActionReflection.GetControllers())
+        {
+            foreach (var action in ControllerActionReflection.GetActionMethods(controller))
+            {
+                if (ControllerActionReflection.HasAnonymous(action, controller))
+                    continue;
+
+                if (!AuthenticationIsTheOnlyGate(action, controller))
+                    continue;
+
+                if (!ControllerActionReflection.GetRoutes(controller, action)
+                        .Any(TenantResolutionMiddleware.IsTenantlessAllowed))
+                    continue;
+
+                yield return (controller, action);
+            }
+        }
+    }
+
+    private static bool AuthenticationIsTheOnlyGate(MethodInfo action, Type controller)
+    {
+        var attributes = action.GetCustomAttributes(inherit: true)
+            .Concat(controller.GetCustomAttributes(inherit: true))
+            .ToList();
+
+        // A permission, scope or instance-key filter asks for more than a session, and no demo
+        // grant satisfies one off a tenant.
+        if (attributes.Any(a => a is RequirePermissionAttribute
+                                or RequireScopeAttribute
+                                or RequireInstanceKeyAuthAttribute))
+        {
+            return false;
+        }
+
+        var authorize = attributes.OfType<IAuthorizeData>().ToList();
+
+        // Roles and policies are evaluated on top of authentication, so an endpoint naming one is
+        // asking for something the demo subject — which holds no global role — does not have.
+        if (authorize.Any(a => !string.IsNullOrEmpty(a.Roles) || !string.IsNullOrEmpty(a.Policy)))
+        {
+            return false;
+        }
+
+        return authorize.Count > 0 || attributes.Any(a => a is RequireAuthenticationAttribute);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Demo/DemoSessionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Demo/DemoSessionControllerTests.cs
@@ -141,9 +141,8 @@ public class DemoSessionControllerTests : IDisposable
     /// not be enough on its own — the subject has to carry the flag too.
     /// </summary>
     /// <remarks>
-    /// The one downstream guard is <c>TrimSessionsAsync</c>, which reports its refusal only through
-    /// a return value this endpoint discards, so without the check on the lookup a real account
-    /// under that username would be issued a session to whoever asked.
+    /// Nothing downstream of the lookup re-examines whose subject it resolved, so without the check
+    /// there a real account under that username would be issued a session to whoever asked.
     /// </remarks>
     [Fact]
     public async Task CreateSession_ReturnsNotFound_WhenTheDemoMemberIsNotADemoSubject()
@@ -165,46 +164,6 @@ public class DemoSessionControllerTests : IDisposable
 
         result.Should().BeOfType<NotFoundResult>();
         VerifyNoSessionIssued();
-    }
-
-    [Fact]
-    public async Task CreateSession_TrimsTheSubjectsSessionsBeforeIssuing()
-    {
-        // The endpoint is anonymous and each call writes a refresh_tokens row, and the per-IP
-        // rate limit partitions on a caller-supplied header, so the cap is the only ceiling.
-        var tenantId = SeedTenant(isDemo: true, withDemoMember: true);
-        var subjectId = await new DemoTenantService(
-            BuildDbFactory(), new Mock<ITenantService>().Object, TestPublicAccessCache.Create(),
-            new Mock<ICacheService>().Object, new Mock<ILogger<DemoTenantService>>().Object)
-            .FindDemoMemberSubjectIdAsync(tenantId);
-
-        subjectId.Should().NotBeNull();
-
-        await using (var db = new NocturneDbContext(_dbOptions))
-        {
-            var subject = await db.Subjects.SingleAsync(s => s.Id == subjectId!.Value);
-            subject.IsDemoSubject = true;
-            for (var i = 0; i < DemoTenantService.MaxLiveDemoSessions + 5; i++)
-            {
-                db.RefreshTokens.Add(new RefreshTokenEntity
-                {
-                    Id = Guid.CreateVersion7(),
-                    SubjectId = subjectId!.Value,
-                    TokenHash = $"h{i}",
-                    IssuedAt = DateTime.UtcNow.AddMinutes(-100 + i),
-                    ExpiresAt = DateTime.UtcNow.AddDays(30),
-                });
-            }
-            await db.SaveChangesAsync();
-        }
-
-        var controller = BuildController(tenantId, isDemo: true);
-        await controller.CreateSession(redirect: null, format: null, CancellationToken.None);
-
-        await using var check = new NocturneDbContext(_dbOptions);
-        (await check.RefreshTokens.CountAsync(t => t.SubjectId == subjectId!.Value))
-            .Should().Be(DemoTenantService.MaxLiveDemoSessions - 1,
-                "the controller trims before issuing; the issue itself is mocked here");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Demo/DemoSessionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Demo/DemoSessionControllerTests.cs
@@ -137,13 +137,10 @@ public class DemoSessionControllerTests : IDisposable
     }
 
     /// <summary>
-    /// The endpoint hands a session to any anonymous caller, so holding the demo membership must
-    /// not be enough on its own — the subject has to carry the flag too.
+    /// Holding the demo membership must not be enough on its own — the subject has to carry the flag
+    /// too. Nothing downstream of the lookup re-examines whose subject it resolved, so without the
+    /// check a real account under that username would be handed a session to whoever asked.
     /// </summary>
-    /// <remarks>
-    /// Nothing downstream of the lookup re-examines whose subject it resolved, so without the check
-    /// there a real account under that username would be issued a session to whoever asked.
-    /// </remarks>
     [Fact]
     public async Task CreateSession_ReturnsNotFound_WhenTheDemoMemberIsNotADemoSubject()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoTenantServiceResetTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoTenantServiceResetTests.cs
@@ -277,9 +277,9 @@ public class DemoTenantServiceResetTests : IDisposable
     /// </summary>
     /// <remarks>
     /// Provisioning adopts a pre-existing membership under that username rather than asserting it
-    /// created the subject behind it. Were the flag not checked here, a real account holding that
-    /// membership would be handed to any anonymous caller as a session — nothing downstream of the
-    /// lookup re-examines whose subject it is.
+    /// created the subject behind it, and nothing downstream of the lookup re-examines whose subject
+    /// it is — so without the flag check here a real account holding that membership would be handed
+    /// out as a session.
     /// </remarks>
     [Fact]
     public async Task FindDemoMemberSubjectIdAsync_IgnoresAMembershipHeldByANonDemoSubject()

--- a/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoTenantServiceResetTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoTenantServiceResetTests.cs
@@ -198,132 +198,6 @@ public class DemoTenantServiceResetTests : IDisposable
     }
 
     [Fact]
-    public async Task TrimSessionsAsync_HoldsTheDemoSubjectUnderTheSessionCap()
-    {
-        // The sign-in endpoint is anonymous and writes a refresh_tokens row per call. Its
-        // per-IP rate limit partitions on X-Forwarded-For, which the caller supplies, so it
-        // bounds nothing; this cap is the ceiling, and it is enforced on the subject id.
-        var tenantId = SeedDemoTenant();
-        var subjectId = (await _service.FindDemoMemberSubjectIdAsync(tenantId))!.Value;
-
-        const int issued = DemoTenantService.MaxLiveDemoSessions + 25;
-        await using (var db = new NocturneDbContext(_dbOptions))
-        {
-            for (var i = 0; i < issued; i++)
-            {
-                db.RefreshTokens.Add(new RefreshTokenEntity
-                {
-                    Id = Guid.CreateVersion7(),
-                    SubjectId = subjectId,
-                    TokenHash = $"hash-{i}",
-                    IssuedAt = DateTime.UtcNow.AddMinutes(-issued + i),
-                    ExpiresAt = DateTime.UtcNow.AddDays(30),
-                });
-            }
-            await db.SaveChangesAsync();
-        }
-
-        await _service.TrimSessionsAsync(subjectId);
-
-        await using var check = new NocturneDbContext(_dbOptions);
-        var remaining = await check.RefreshTokens
-            .Where(t => t.SubjectId == subjectId)
-            .OrderByDescending(t => t.IssuedAt)
-            .ToListAsync();
-
-        remaining.Should().HaveCount(DemoTenantService.MaxLiveDemoSessions - 1,
-            "the trim leaves room for the session about to be issued");
-        remaining.Select(t => t.TokenHash).Should().Contain($"hash-{issued - 1}",
-            "the newest session is kept");
-        remaining.Select(t => t.TokenHash).Should().NotContain("hash-0",
-            "the oldest sessions are the ones displaced");
-    }
-
-    [Fact]
-    public async Task TrimSessionsAsync_ClearsDeadRowsBeforeDisplacingALiveSession()
-    {
-        var tenantId = SeedDemoTenant();
-        var subjectId = (await _service.FindDemoMemberSubjectIdAsync(tenantId))!.Value;
-
-        await using (var db = new NocturneDbContext(_dbOptions))
-        {
-            db.RefreshTokens.Add(new RefreshTokenEntity
-            {
-                Id = Guid.CreateVersion7(),
-                SubjectId = subjectId,
-                TokenHash = "expired",
-                IssuedAt = DateTime.UtcNow.AddDays(-40),
-                ExpiresAt = DateTime.UtcNow.AddDays(-10),
-            });
-            db.RefreshTokens.Add(new RefreshTokenEntity
-            {
-                Id = Guid.CreateVersion7(),
-                SubjectId = subjectId,
-                TokenHash = "revoked",
-                IssuedAt = DateTime.UtcNow.AddDays(-1),
-                ExpiresAt = DateTime.UtcNow.AddDays(29),
-                RevokedAt = DateTime.UtcNow.AddHours(-1),
-            });
-            db.RefreshTokens.Add(new RefreshTokenEntity
-            {
-                Id = Guid.CreateVersion7(),
-                SubjectId = subjectId,
-                TokenHash = "live",
-                IssuedAt = DateTime.UtcNow,
-                ExpiresAt = DateTime.UtcNow.AddDays(30),
-            });
-            await db.SaveChangesAsync();
-        }
-
-        var deleted = await _service.TrimSessionsAsync(subjectId);
-
-        deleted.Should().Be(2, "the expired and revoked rows go; they are nobody's session");
-
-        await using var check = new NocturneDbContext(_dbOptions);
-        var remaining = await check.RefreshTokens
-            .Where(t => t.SubjectId == subjectId)
-            .Select(t => t.TokenHash)
-            .ToListAsync();
-        remaining.Should().BeEquivalentTo(["live"]);
-    }
-
-    [Fact]
-    public async Task TrimSessionsAsync_RefusesASubjectThatIsNotADemoSubject()
-    {
-        // This deletes credential rows, so pointing it at a real account must be impossible.
-        SeedDemoTenant();
-
-        Guid realSubjectId;
-        await using (var db = new NocturneDbContext(_dbOptions))
-        {
-            var real = new SubjectEntity
-            {
-                Id = Guid.CreateVersion7(),
-                Name = "Real Person",
-                IsActive = true,
-            };
-            db.Subjects.Add(real);
-            db.RefreshTokens.Add(new RefreshTokenEntity
-            {
-                Id = Guid.CreateVersion7(),
-                SubjectId = real.Id,
-                TokenHash = "their-session",
-                IssuedAt = DateTime.UtcNow.AddDays(-40),
-                ExpiresAt = DateTime.UtcNow.AddDays(-1),
-            });
-            await db.SaveChangesAsync();
-            realSubjectId = real.Id;
-        }
-
-        var deleted = await _service.TrimSessionsAsync(realSubjectId);
-
-        deleted.Should().Be(0);
-        await using var check = new NocturneDbContext(_dbOptions);
-        (await check.RefreshTokens.CountAsync(t => t.SubjectId == realSubjectId))
-            .Should().Be(1, "an expired session belonging to a real account is not ours to delete");
-    }
-
-    [Fact]
     public async Task ConfigureAccessAsync_DoesNotBindDemoMemberToAnUnrelatedSubjectNamedDemo()
     {
         // subjects.username carries no unique index and any operator or invitee can pick
@@ -404,9 +278,8 @@ public class DemoTenantServiceResetTests : IDisposable
     /// <remarks>
     /// Provisioning adopts a pre-existing membership under that username rather than asserting it
     /// created the subject behind it. Were the flag not checked here, a real account holding that
-    /// membership would be handed to any anonymous caller as a session — the one guard downstream
-    /// (<c>TrimSessionsAsync</c>) reports its refusal only through a return value the endpoint
-    /// discards.
+    /// membership would be handed to any anonymous caller as a session — nothing downstream of the
+    /// lookup re-examines whose subject it is.
     /// </remarks>
     [Fact]
     public async Task FindDemoMemberSubjectIdAsync_IgnoresAMembershipHeldByANonDemoSubject()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/EfFirstPartyTokenRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/EfFirstPartyTokenRepositoryTests.cs
@@ -238,18 +238,16 @@ public class EfFirstPartyTokenRepositoryTests : IDisposable
     }
 
     /// <summary>
-    /// Which rows the cap displaces, not just how many survive it. Reaching the cap has to cost
-    /// the visitors who have already gone, so the oldest rows are the ones that go — the inverse
-    /// evicts whoever just signed in, on every subsequent sign-in, while the oldest rows never
-    /// leave.
+    /// Which rows the cap displaces, not just how many survive it. The inverse ordering evicts
+    /// whoever just signed in, on every subsequent sign-in, while the oldest rows never leave.
     /// </summary>
     [Fact]
     public async Task CreateAsync_displaces_a_demo_subjects_oldest_sessions_and_keeps_the_newest()
     {
         var demoSubjectId = await AddSubjectAsync(isDemoSubject: true);
 
-        // Distinct IssuedAt values, oldest first, so the expected retention is total order rather
-        // than anything the tiebreaker settles.
+        // Distinct IssuedAt values, so the expected retention is a total order and nothing here
+        // rests on the tiebreaker.
         const int seeded = DemoSessionLimits.MaxLiveSessions + 5;
         var issuedAt = DateTime.UtcNow.AddMinutes(-seeded);
         for (var i = 0; i < seeded; i++)
@@ -276,13 +274,13 @@ public class EfFirstPartyTokenRepositoryTests : IDisposable
     }
 
     /// <summary>
-    /// Visitors arriving together are issued rows in the same instant, so the order the cap
-    /// applies must not be left to the provider. The token id settles it.
+    /// Visitors arriving together are issued rows in the same instant, so which of them the cap
+    /// displaces must not be left to the provider. The token id settles it.
     /// </summary>
     /// <remarks>
     /// The two ids differ only in their final byte, which .NET's <see cref="Guid"/> comparison and
-    /// PostgreSQL's bytewise <c>uuid</c> comparison order the same way — so the row this expects to
-    /// survive does not depend on which of them is running the sort.
+    /// PostgreSQL's bytewise <c>uuid</c> comparison order the same way, so the row expected to
+    /// survive does not depend on which of them runs the sort.
     /// </remarks>
     [Fact]
     public async Task CreateAsync_breaks_a_demo_subjects_issued_at_tie_by_token_id()
@@ -293,8 +291,9 @@ public class EfFirstPartyTokenRepositoryTests : IDisposable
         var lowerId = Guid.Parse("11111111-1111-1111-1111-111111111110");
         var higherId = Guid.Parse("11111111-1111-1111-1111-111111111111");
 
-        // Seeded lower id first: without the tiebreaker a stable sort leaves them in this order and
-        // displaces the wrong one of the pair.
+        // Seeded lower id first: without the tiebreaker, the InMemory provider's stable sort leaves
+        // them in this order and displaces the wrong one, so dropping it fails here. Against real
+        // PostgreSQL an untied order is unspecified, so this pins the tiebreaker, not its absence.
         AddToken(demoSubjectId, "tie-low", issuedAt: tied, tokenHash: "tie-low", id: lowerId);
         AddToken(demoSubjectId, "tie-high", issuedAt: tied, tokenHash: "tie-high", id: higherId);
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/EfFirstPartyTokenRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/EfFirstPartyTokenRepositoryTests.cs
@@ -38,12 +38,14 @@ public class EfFirstPartyTokenRepositoryTests : IDisposable
         string? oidcSessionId,
         DateTime? revokedAt = null,
         DateTime? expiresAt = null,
-        DateTime? issuedAt = null)
+        DateTime? issuedAt = null,
+        string? tokenHash = null,
+        Guid? id = null)
     {
         var entity = new RefreshTokenEntity
         {
-            Id = Guid.CreateVersion7(),
-            TokenHash = Guid.NewGuid().ToString("N"),
+            Id = id ?? Guid.CreateVersion7(),
+            TokenHash = tokenHash ?? Guid.NewGuid().ToString("N"),
             SubjectId = subjectId,
             OidcSessionId = oidcSessionId,
             IssuedAt = issuedAt ?? DateTime.UtcNow,
@@ -233,6 +235,85 @@ public class EfFirstPartyTokenRepositoryTests : IDisposable
         _context.RefreshTokens.Count(t => t.SubjectId == demoSubjectId)
             .Should().Be(DemoSessionLimits.MaxLiveSessions,
                 "an anonymous account anyone can obtain must not be able to grow the table without bound");
+    }
+
+    /// <summary>
+    /// Which rows the cap displaces, not just how many survive it. Reaching the cap has to cost
+    /// the visitors who have already gone, so the oldest rows are the ones that go — the inverse
+    /// evicts whoever just signed in, on every subsequent sign-in, while the oldest rows never
+    /// leave.
+    /// </summary>
+    [Fact]
+    public async Task CreateAsync_displaces_a_demo_subjects_oldest_sessions_and_keeps_the_newest()
+    {
+        var demoSubjectId = await AddSubjectAsync(isDemoSubject: true);
+
+        // Distinct IssuedAt values, oldest first, so the expected retention is total order rather
+        // than anything the tiebreaker settles.
+        const int seeded = DemoSessionLimits.MaxLiveSessions + 5;
+        var issuedAt = DateTime.UtcNow.AddMinutes(-seeded);
+        for (var i = 0; i < seeded; i++)
+        {
+            AddToken(demoSubjectId, $"session-{i}", issuedAt: issuedAt.AddMinutes(i), tokenHash: $"seed-{i}");
+        }
+
+        await _repository.CreateAsync(NewRecord(demoSubjectId, ipAddress: null, userAgent: null));
+
+        var surviving = _context.RefreshTokens
+            .Where(t => t.SubjectId == demoSubjectId && t.TokenHash.StartsWith("seed-"))
+            .Select(t => t.TokenHash)
+            .ToList();
+
+        // 5 + 1 seeded rows go: the cap, less the slot the new row takes.
+        var expected = Enumerable
+            .Range(seeded - (DemoSessionLimits.MaxLiveSessions - 1), DemoSessionLimits.MaxLiveSessions - 1)
+            .Select(i => $"seed-{i}");
+
+        surviving.Should().BeEquivalentTo(expected,
+            "the cap displaces the oldest sessions and keeps the newest");
+        surviving.Should().NotContain("seed-0", "the oldest session is the first to go");
+        surviving.Should().Contain($"seed-{seeded - 1}", "the newest session is the last to go");
+    }
+
+    /// <summary>
+    /// Visitors arriving together are issued rows in the same instant, so the order the cap
+    /// applies must not be left to the provider. The token id settles it.
+    /// </summary>
+    /// <remarks>
+    /// The two ids differ only in their final byte, which .NET's <see cref="Guid"/> comparison and
+    /// PostgreSQL's bytewise <c>uuid</c> comparison order the same way — so the row this expects to
+    /// survive does not depend on which of them is running the sort.
+    /// </remarks>
+    [Fact]
+    public async Task CreateAsync_breaks_a_demo_subjects_issued_at_tie_by_token_id()
+    {
+        var demoSubjectId = await AddSubjectAsync(isDemoSubject: true);
+
+        var tied = DateTime.UtcNow.AddHours(-1);
+        var lowerId = Guid.Parse("11111111-1111-1111-1111-111111111110");
+        var higherId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+        // Seeded lower id first: without the tiebreaker a stable sort leaves them in this order and
+        // displaces the wrong one of the pair.
+        AddToken(demoSubjectId, "tie-low", issuedAt: tied, tokenHash: "tie-low", id: lowerId);
+        AddToken(demoSubjectId, "tie-high", issuedAt: tied, tokenHash: "tie-high", id: higherId);
+
+        // Fill the rest of the cap with strictly newer rows, so the tied pair is the boundary and
+        // exactly one of the two has to go.
+        for (var i = 0; i < DemoSessionLimits.MaxLiveSessions - 2; i++)
+        {
+            AddToken(demoSubjectId, $"newer-{i}", issuedAt: tied.AddMinutes(i + 1), tokenHash: $"newer-{i}");
+        }
+
+        await _repository.CreateAsync(NewRecord(demoSubjectId, ipAddress: null, userAgent: null));
+
+        var surviving = _context.RefreshTokens
+            .Where(t => t.SubjectId == demoSubjectId)
+            .Select(t => t.TokenHash)
+            .ToList();
+
+        surviving.Should().Contain("tie-high", "the higher id sorts first and is kept");
+        surviving.Should().NotContain("tie-low", "the lower id is the one the tiebreaker displaces");
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #644. A demo tenant's `GET /api/v4/demo/session` hands any anonymous caller a real session for a shared subject, so "authenticated" does not imply "a person who signed up" and every `[Authorize]`-only endpoint becomes anonymously reachable.

## The coverage test could not see the failure mode it existed for

`DemoSubjectGatedEndpointsTests` enumerated 21 `(controller, action)` pairs by hand. It catches an attribute going *missing*, but a **new** tenantless authorized endpoint added later was invisible to it — which is the case that actually matters.

`TenantlessDemoSubjectCoverageTests` now reflects over every controller action, computes its route, and keeps those that are both tenantless-reachable and gated by authentication alone. Each must carry `[DenyDemoSubject]` or appear in a commented exemption list. `TenantResolutionMiddleware.IsTenantlessAllowed` was made public so the test reads the same source the middleware does rather than restating the path lists.

The predicate is "bare `[Authorize]`", not "no attribute", and that distinction is load-bearing: an attribute-less endpoint falls to `HasPermissionsRequirement`, which a demo subject fails off a tenant because its permissions come from a tenant membership while the fallback reads only global `subject_roles`. A bare `[Authorize]` drops to authenticated-only, which every demo session satisfies.

Three exemptions, each returning only the caller's own memberships or deployment constants: `PlatformController.GetTenants`, `PlatformController.GetTransitionStatus`, `MyTenantsController.GetOverview`.

## Two more gates

- **The webhook tester.** `alerts.readwrite` is in `DemoVisitorPermissions` and the endpoint carried no permission attribute, so the SSRF being closed elsewhere still left an anonymously-obtainable way to make the server POST attacker-chosen bodies to arbitrary public hosts from the deployment's IP. GET and PUT stay open — GET returns a hardcoded disabled stub and PUT is a logged no-op, so gating the class would break the demo's notification screen for nothing.
- **Session revocation.** Any visitor could revoke every other visitor's session. `Revoke` and `RevokeOthers` are gated; `List` stays open because IP and user-agent are already scrubbed for demo subjects and the rows name no device beyond `demo-visitor`. A demo visitor still signs themselves out through the logout endpoint, and real members are unaffected.

## One trim, not two

`DemoTenantService.TrimSessionsAsync` was deleted rather than given a tiebreaker. The cap is already enforced at the single `refresh_tokens` insert sink, which the demo sign-in path reaches anyway and which additionally covers the anonymous rotation path the service-level trim never did. The post-insert ceiling is unchanged — the controller's call was a redundant first pass.

The deleted method's tests were re-established at the sink, including the one property the first pass at this genuinely lost: **which** sessions get displaced. Without it, inverting the sort would have left the whole suite green while the demo evicted its newest visitors on every sign-in and the oldest rows persisted forever.

## Verification

Each change mutation-proofed: reverted, confirmed the named test fails, restored. Adding a *new* ungated tenantless authorized endpoint makes the discovery test fail by name — the case the old hand-list could not catch. Non-vacuity is pinned three ways: the discovered set must be non-empty, must contain a known-gated endpoint, and every exemption must name an endpoint that is both discovered and genuinely ungated.

`Nocturne.API.Tests` 5107 passed with two known-unrelated failures (`CacheIntegrationTests.CreateEntriesAsync_DecomposesToV4AndFiresEvents`, and a wall-clock flake). `Nocturne.Infrastructure.Data.Tests` 569/569.

One caveat worth stating: the tie-break assertion discriminates under the test provider's stable sort, so it pins that the code requests a total order — it would not deterministically catch the tiebreaker's removal against real PostgreSQL, where tied ordering is undefined either way. The retention-order property it sits beside carries no such caveat.

## Not addressed

The larger surface remains: on the demo subdomain a visitor resolves the demo tenant and reaches everything satisfied by `DemoVisitorPermissions` or a bare `[Authorize]`. That is not enumerable as a gate list and needs the per-action scope attributes already flagged in `AuthorizationConfiguration`. This change covers the tenantless slice only.

https://claude.ai/code/session_018VEAjkfp8WDb8fogHCzkrN