### PR TITLE
fix(web): resolve the tenant slug on the server, not by counting hostname labels

### DIFF
--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import { browser } from "$app/environment";
 
   import * as Sidebar from "$lib/components/ui/sidebar";
   import * as Collapsible from "$lib/components/ui/collapsible";
@@ -59,9 +58,20 @@
     isPlatformAccessGrant?: boolean;
     /** Whether the current session is a guest link session (read-only) */
     isGuestSession?: boolean;
+    /** Slug of the tenant this host resolves to, or null on the apex (from layout data) */
+    currentSlug?: string | null;
+    /** Public base domain tenant subdomains hang off (from layout data) */
+    baseDomain?: string | null;
   }
 
-  const { user = null, isPlatformAdmin = false, isPlatformAccessGrant = false, isGuestSession = false }: Props = $props();
+  const {
+    user = null,
+    isPlatformAdmin = false,
+    isPlatformAccessGrant = false,
+    isGuestSession = false,
+    currentSlug = null,
+    baseDomain = null,
+  }: Props = $props();
 
   const sidebar = Sidebar.useSidebar();
 
@@ -84,8 +94,6 @@
   let totalTenantCount = $state(0);
   let selectedTenantSlug = $state<string | null>(null);
   let defaultTenantSlug = $state<string | null>(null);
-  let baseDomain = $state<string | null>(null);
-  let currentSlug = $state<string | null>(null);
 
   /**
    * Platform-admin "access" mode: the session is a short-lived platform-access grant on a
@@ -103,16 +111,6 @@
         )
       : null,
   );
-
-  // Derive subdomain info from hostname
-  $effect(() => {
-    if (!browser) return;
-    const parts = window.location.hostname.split(".");
-    if (parts.length > 2 && window.location.hostname !== "localhost") {
-      currentSlug = parts[0];
-      baseDomain = parts.slice(1).join(".");
-    }
-  });
 
   // Available tenants for the subdomain switcher.
   const myTenantsQuery = getMyTenants();
@@ -542,6 +540,7 @@
           {user}
           {isPlatformAdmin}
           {isGuestSession}
+          tenantSlug={currentSlug}
           collapsed={sidebar.state === "collapsed"}
           class="flex-1 min-w-0"
         />

--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -540,7 +540,6 @@
           {user}
           {isPlatformAdmin}
           {isGuestSession}
-          tenantSlug={currentSlug}
           collapsed={sidebar.state === "collapsed"}
           class="flex-1 min-w-0"
         />

--- a/src/Web/packages/app/src/lib/components/layout/UserMenu.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/UserMenu.svelte
@@ -17,11 +17,9 @@
     isPlatformAdmin?: boolean;
     /** Whether the current session is a guest link session */
     isGuestSession?: boolean;
-    /** Slug of the tenant this host resolves to, or null on the apex (from layout data) */
-    tenantSlug?: string | null;
   }
 
-  const { user, collapsed = false, class: className = "", isPlatformAdmin = false, isGuestSession = false, tenantSlug = null }: Props = $props();
+  const { user, collapsed = false, class: className = "", isPlatformAdmin = false, isGuestSession = false }: Props = $props();
 
   let isOpen = $state(false);
   let showRequestDialog = $state(false);
@@ -149,7 +147,7 @@
     </DropdownMenu.Content>
   </DropdownMenu.Root>
   {#if isGuestSession}
-    <RequestMembershipDialog bind:open={showRequestDialog} {tenantSlug} />
+    <RequestMembershipDialog bind:open={showRequestDialog} />
   {/if}
 {:else}
   <!-- Not logged in - show login button -->

--- a/src/Web/packages/app/src/lib/components/layout/UserMenu.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/UserMenu.svelte
@@ -4,7 +4,6 @@
   import { Button } from "$lib/components/ui/button";
   import { User, LogOut, Settings, Shield, ChevronDown, UserPlus } from "lucide-svelte";
   import { goto } from "$app/navigation";
-  import { browser } from "$app/environment";
   import type { AuthUser } from "$lib/stores/auth-store.svelte";
   import RequestMembershipDialog from "$lib/components/members/RequestMembershipDialog.svelte";
 
@@ -18,19 +17,14 @@
     isPlatformAdmin?: boolean;
     /** Whether the current session is a guest link session */
     isGuestSession?: boolean;
+    /** Slug of the tenant this host resolves to, or null on the apex (from layout data) */
+    tenantSlug?: string | null;
   }
 
-  const { user, collapsed = false, class: className = "", isPlatformAdmin = false, isGuestSession = false }: Props = $props();
+  const { user, collapsed = false, class: className = "", isPlatformAdmin = false, isGuestSession = false, tenantSlug = null }: Props = $props();
 
   let isOpen = $state(false);
   let showRequestDialog = $state(false);
-
-  let tenantSlug = $state<string | undefined>(undefined);
-  $effect(() => {
-    if (!browser) return;
-    const parts = window.location.hostname.split(".");
-    if (parts.length > 2) tenantSlug = parts[0];
-  });
 
   /** Get initials from user name */
   function getInitials(name: string): string {

--- a/src/Web/packages/app/src/lib/components/members/MembershipRequestAutoSubmit.svelte
+++ b/src/Web/packages/app/src/lib/components/members/MembershipRequestAutoSubmit.svelte
@@ -2,21 +2,19 @@
   import { browser } from "$app/environment";
   import { onMount } from "svelte";
   import { createRequest } from "$lib/api/generated/membershipRequests.generated.remote";
+  import { membershipRequestStorageKey } from "$lib/membership-request-storage";
 
   interface Props {
     isAuthenticated: boolean;
     isGuestSession: boolean;
-    tenantSlug: string | null;
   }
 
-  const { isAuthenticated, isGuestSession, tenantSlug }: Props = $props();
-
-  const STORAGE_KEY_PREFIX = "nocturne:membership-request:";
+  const { isAuthenticated, isGuestSession }: Props = $props();
 
   onMount(async () => {
-    if (!browser || !tenantSlug || !isAuthenticated || isGuestSession) return;
+    if (!browser || !isAuthenticated || isGuestSession) return;
 
-    const key = `${STORAGE_KEY_PREFIX}${tenantSlug}`;
+    const key = membershipRequestStorageKey(window.location.host);
     const message = localStorage.getItem(key);
     if (message === null) return;
 

--- a/src/Web/packages/app/src/lib/components/members/MembershipRequestAutoSubmit.svelte
+++ b/src/Web/packages/app/src/lib/components/members/MembershipRequestAutoSubmit.svelte
@@ -6,7 +6,7 @@
   interface Props {
     isAuthenticated: boolean;
     isGuestSession: boolean;
-    tenantSlug: string | undefined;
+    tenantSlug: string | null;
   }
 
   const { isAuthenticated, isGuestSession, tenantSlug }: Props = $props();

--- a/src/Web/packages/app/src/lib/components/members/RequestMembershipDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/members/RequestMembershipDialog.svelte
@@ -7,7 +7,7 @@
 
   interface Props {
     open: boolean;
-    tenantSlug?: string;
+    tenantSlug?: string | null;
   }
 
   let { open = $bindable(false), tenantSlug }: Props = $props();

--- a/src/Web/packages/app/src/lib/components/members/RequestMembershipDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/members/RequestMembershipDialog.svelte
@@ -4,23 +4,21 @@
   import { Textarea } from "$lib/components/ui/textarea";
   import { browser } from "$app/environment";
   import { goto } from "$app/navigation";
+  import { membershipRequestStorageKey } from "$lib/membership-request-storage";
 
   interface Props {
     open: boolean;
-    tenantSlug?: string | null;
   }
 
-  let { open = $bindable(false), tenantSlug }: Props = $props();
+  let { open = $bindable(false) }: Props = $props();
 
   let message = $state("");
 
-  const STORAGE_KEY_PREFIX = "nocturne:membership-request:";
-
   function handleSubmit() {
-    if (!browser || !tenantSlug) return;
+    if (!browser) return;
 
     try {
-      localStorage.setItem(`${STORAGE_KEY_PREFIX}${tenantSlug}`, message);
+      localStorage.setItem(membershipRequestStorageKey(window.location.host), message);
     } catch {
       // Storage full or unavailable
     }

--- a/src/Web/packages/app/src/lib/components/support/IssueCreatorDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/support/IssueCreatorDialog.svelte
@@ -22,6 +22,7 @@
     Copy,
   } from "lucide-svelte";
   import { submitIssue, getFallbackUrl } from "$lib/api/support.remote";
+  import { page } from "$app/state";
   import type { CreateIssueResponse } from "$api-clients";
   import { copyToClipboard } from "$lib/utils";
   import { toast } from "svelte-sonner";
@@ -101,10 +102,7 @@
     };
 
     if (includeTenantSlug) {
-      info.tenantSlug =
-        typeof window !== "undefined"
-          ? window.location.hostname.split(".")[0]
-          : "unknown";
+      info.tenantSlug = page.data.tenantSlug ?? "unknown";
     }
     if (includeCgmSource) {
       info.cgmSource = cgmSource || "not specified";

--- a/src/Web/packages/app/src/lib/membership-request-storage.ts
+++ b/src/Web/packages/app/src/lib/membership-request-storage.ts
@@ -1,0 +1,14 @@
+/**
+ * A membership-request message is parked in localStorage while the visitor goes
+ * off to sign up, then submitted once they come back authenticated. Both halves
+ * must agree on the key, so they share this one.
+ *
+ * The key is namespaced by host rather than by tenant slug. The request is
+ * submitted to whichever tenant the host resolves to, so the slug was never
+ * load-bearing — and the apex and share hosts have no slug of their own to name.
+ */
+const STORAGE_KEY_PREFIX = "nocturne:membership-request:";
+
+export function membershipRequestStorageKey(host: string): string {
+  return `${STORAGE_KEY_PREFIX}${host}`;
+}

--- a/src/Web/packages/app/src/lib/server/request-host.test.ts
+++ b/src/Web/packages/app/src/lib/server/request-host.test.ts
@@ -72,8 +72,14 @@ describe("extractTenantSlug", () => {
     );
   });
 
-  it("is case insensitive and normalises to lower case", () => {
-    expect(extractTenantSlug("RHYS.Nocturne.Run", "nocturne.run")).toBe("rhys");
+  // Matches SubdomainParser: the suffix compares case-insensitively, but the
+  // slug keeps the host's casing because the tenant lookup is case-sensitive.
+  it("matches the suffix case-insensitively and preserves the slug's case", () => {
+    expect(extractTenantSlug("RHYS.Nocturne.Run", "nocturne.run")).toBe("RHYS");
+  });
+
+  it("returns the share host's token-and-label rather than a tenant", () => {
+    expect(extractTenantSlug("tok.share.nocturne.run", "nocturne.run")).toBe("tok.share");
   });
 
   it("returns null when the base domain is missing", () => {

--- a/src/Web/packages/app/src/lib/server/request-host.test.ts
+++ b/src/Web/packages/app/src/lib/server/request-host.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isShareHost } from "./request-host";
+import { extractTenantSlug, isShareHost } from "./request-host";
 
 describe("isShareHost", () => {
   it("matches the {token}.share.{baseDomain} form", () => {
@@ -31,5 +31,54 @@ describe("isShareHost", () => {
   it("handles null and undefined", () => {
     expect(isShareHost(null)).toBe(false);
     expect(isShareHost(undefined)).toBe(false);
+  });
+});
+
+describe("extractTenantSlug", () => {
+  it("strips a two-label base domain", () => {
+    expect(extractTenantSlug("rhys.nocturne.run", "nocturne.run")).toBe("rhys");
+  });
+
+  it("returns null on the apex", () => {
+    expect(extractTenantSlug("nocturne.run", "nocturne.run")).toBeNull();
+  });
+
+  // A base domain may have any number of labels. These two cases are what
+  // hostname label-counting got wrong: it read the apex's own first label as a
+  // tenant slug.
+  it("strips a base domain with more than two labels", () => {
+    expect(
+      extractTenantSlug("bob.nocturne.example.com", "nocturne.example.com"),
+    ).toBe("bob");
+  });
+
+  it("returns null on the apex of a base domain with more than two labels", () => {
+    expect(
+      extractTenantSlug("nocturne.example.com", "nocturne.example.com"),
+    ).toBeNull();
+  });
+
+  it("returns null for a host outside the base domain", () => {
+    expect(extractTenantSlug("bob.example.com", "nocturne.example.com")).toBeNull();
+    expect(extractTenantSlug("evil-nocturne.run", "nocturne.run")).toBeNull();
+  });
+
+  it("ignores ports on either side", () => {
+    expect(
+      extractTenantSlug("sleepy.nocturne.localhost:1612", "nocturne.localhost:1612"),
+    ).toBe("sleepy");
+    expect(extractTenantSlug("sleepy.nocturne.localhost", "nocturne.localhost:1612")).toBe(
+      "sleepy",
+    );
+  });
+
+  it("is case insensitive and normalises to lower case", () => {
+    expect(extractTenantSlug("RHYS.Nocturne.Run", "nocturne.run")).toBe("rhys");
+  });
+
+  it("returns null when the base domain is missing", () => {
+    expect(extractTenantSlug("rhys.nocturne.run", null)).toBeNull();
+    expect(extractTenantSlug("rhys.nocturne.run", "")).toBeNull();
+    expect(extractTenantSlug(null, "nocturne.run")).toBeNull();
   });
 });

--- a/src/Web/packages/app/src/lib/server/request-host.ts
+++ b/src/Web/packages/app/src/lib/server/request-host.ts
@@ -29,6 +29,31 @@ export function getOriginalProto(request: Request): string {
 }
 
 /**
+ * Extract the tenant slug from a request host, mirroring the API's
+ * SubdomainParser: strip the base domain suffix, whatever its label count.
+ * `nocturne.example.com` is as valid a base domain as `example.com`, so the
+ * number of labels carries no meaning — only the suffix does.
+ *
+ * Returns null on the apex, on an unrelated host, or when BASE_DOMAIN is unset.
+ * Ports are ignored on both sides.
+ */
+export function extractTenantSlug(
+  host: string | null | undefined,
+  baseDomain: string | null | undefined,
+): string | null {
+  if (!host || !baseDomain) return null;
+
+  const hostname = host.split(":")[0]!.toLowerCase();
+  const baseHostname = baseDomain.split(":")[0]!.toLowerCase();
+  if (!baseHostname) return null;
+
+  const suffix = `.${baseHostname}`;
+  if (!hostname.endsWith(suffix)) return null;
+
+  return hostname.slice(0, -suffix.length) || null;
+}
+
+/**
  * Cookie set during setup to carry the tenant slug while the user is still
  * on the apex domain. httpOnly, 1-hour TTL, cleaned up by markSetupComplete.
  * Read by hooks that create API clients so they can prepend the slug to

--- a/src/Web/packages/app/src/lib/server/request-host.ts
+++ b/src/Web/packages/app/src/lib/server/request-host.ts
@@ -35,7 +35,11 @@ export function getOriginalProto(request: Request): string {
  * number of labels carries no meaning — only the suffix does.
  *
  * Returns null on the apex, on an unrelated host, or when BASE_DOMAIN is unset.
- * Ports are ignored on both sides.
+ * Ports are ignored on both sides, and the slug keeps the host's own casing
+ * because tenant slugs are looked up case-sensitively.
+ *
+ * A share host ({token}.share.{baseDomain}) yields "{token}.share" rather than a
+ * tenant, so callers that can be reached on one must filter it with isShareHost.
  */
 export function extractTenantSlug(
   host: string | null | undefined,
@@ -43,12 +47,12 @@ export function extractTenantSlug(
 ): string | null {
   if (!host || !baseDomain) return null;
 
-  const hostname = host.split(":")[0]!.toLowerCase();
-  const baseHostname = baseDomain.split(":")[0]!.toLowerCase();
+  const hostname = host.split(":")[0]!;
+  const baseHostname = baseDomain.split(":")[0]!;
   if (!baseHostname) return null;
 
   const suffix = `.${baseHostname}`;
-  if (!hostname.endsWith(suffix)) return null;
+  if (!hostname.toLowerCase().endsWith(suffix.toLowerCase())) return null;
 
   return hostname.slice(0, -suffix.length) || null;
 }

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -61,13 +61,6 @@
 
   let commandPaletteOpen = $state(false);
 
-  let tenantSlug = $state<string | undefined>(undefined);
-  $effect(() => {
-    if (!browser) return;
-    const parts = window.location.hostname.split(".");
-    if (parts.length > 2) tenantSlug = parts[0];
-  });
-
   // One poll for the alert surfaces this layout mounts (AlertBanner and
   // FiringToast both read the same query).
   pollActiveAlerts();
@@ -214,7 +207,7 @@
   <CoachParamHandler />
   <ChartPrintPatterns />
   <Sidebar.Provider>
-    <AppSidebar user={data.user} isPlatformAdmin={data.isPlatformAdmin} isPlatformAccessGrant={data.isPlatformAccessGrant} isGuestSession={data.isGuestSession} />
+    <AppSidebar user={data.user} isPlatformAdmin={data.isPlatformAdmin} isPlatformAccessGrant={data.isPlatformAccessGrant} isGuestSession={data.isGuestSession} currentSlug={data.tenantSlug} baseDomain={data.baseDomain} />
     <Sidebar.Inset>
       <MobileHeader />
       {#if data.isDemo}
@@ -226,7 +219,7 @@
       <MembershipRequestAutoSubmit
         isAuthenticated={!!data.user}
         isGuestSession={data.isGuestSession}
-        {tenantSlug}
+        tenantSlug={data.tenantSlug}
       />
       <AlertBanner />
       <FiringToast />

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -219,7 +219,6 @@
       <MembershipRequestAutoSubmit
         isAuthenticated={!!data.user}
         isGuestSession={data.isGuestSession}
-        tenantSlug={data.tenantSlug}
       />
       <AlertBanner />
       <FiringToast />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/discord.remote.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/discord.remote.ts
@@ -8,6 +8,7 @@
 import { getRequestEvent, query, command } from "$app/server";
 import { signOAuthLinkState } from "$lib/server/bot/oauth-state";
 import { getDiscordOAuthConfig } from "$lib/server/bot/platform-credentials";
+import { extractTenantSlug } from "$lib/server/request-host";
 
 /**
  * Get Discord integration configuration. Credentials resolve from the
@@ -41,14 +42,7 @@ export const initiateDiscordLink = command(async () => {
     return { error: "Discord OAuth2 is not configured on this server." };
   }
 
-  // Extract tenant slug from host
-  const baseHost = baseDomain.split(":")[0] ?? baseDomain;
-  const currentHost = url.host.split(":")[0] ?? url.host;
-  let slug: string | null = null;
-  if (currentHost.endsWith(`.${baseHost}`)) {
-    slug = currentHost.slice(0, currentHost.length - baseHost.length - 1) || null;
-  }
-
+  const slug = extractTenantSlug(url.host, baseDomain);
   if (!slug) {
     return { error: "Could not determine tenant slug from current host." };
   }

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.svelte
@@ -6,7 +6,6 @@
   import { getAuthStatus } from "$lib/api/generated";
   import { page } from "$app/state";
   import { goto } from "$app/navigation";
-  import { browser } from "$app/environment";
   import LoginForm from "$lib/components/auth/LoginForm.svelte";
   import RequestMembershipDialog from "$lib/components/members/RequestMembershipDialog.svelte";
 
@@ -19,11 +18,7 @@
 
   let showRequestDialog = $state(false);
 
-  const tenantSlug = $derived.by(() => {
-    if (!browser) return undefined;
-    const parts = window.location.hostname.split(".");
-    return parts.length > 2 ? parts[0] : undefined;
-  });
+  const tenantSlug = $derived(page.data.tenantSlug);
 
   // Get return URL from query params
   const returnUrl = $derived(page.url.searchParams.get("returnUrl") || "/");

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.svelte
@@ -18,8 +18,6 @@
 
   let showRequestDialog = $state(false);
 
-  const tenantSlug = $derived(page.data.tenantSlug);
-
   // Get return URL from query params
   const returnUrl = $derived(page.url.searchParams.get("returnUrl") || "/");
 
@@ -88,4 +86,4 @@
   </Card.Root>
 </div>
 
-<RequestMembershipDialog bind:open={showRequestDialog} {tenantSlug} />
+<RequestMembershipDialog bind:open={showRequestDialog} />

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -1,4 +1,5 @@
 import type { LayoutServerLoad } from "./$types";
+import { extractTenantSlug, getOriginalHost, isShareHost } from "$lib/server/request-host";
 
 /**
  * Root layout server load function.
@@ -6,12 +7,21 @@ import type { LayoutServerLoad } from "./$types";
  * Auth gating is handled by route group layouts.
  * Setup/recovery mode detection is in hooks.server.ts.
  */
-export const load: LayoutServerLoad = async ({ locals }) => {
+export const load: LayoutServerLoad = async ({ locals, request }) => {
+  // Tenant identity is resolved here, from the request host against BASE_DOMAIN,
+  // so the browser never has to guess it by counting hostname labels. A share
+  // host carries a token rather than a slug, so it has no tenant to name.
+  const host = getOriginalHost(request);
+  const baseDomain = process.env.BASE_DOMAIN ?? null;
+  const tenantSlug = isShareHost(host) ? null : extractTenantSlug(host, baseDomain);
+
   return {
     user: locals.user,
     isAuthenticated: locals.isAuthenticated,
     effectivePermissions: locals.effectivePermissions ?? [],
     isPlatformAdmin: locals.isPlatformAdmin,
     isPlatformAccessGrant: locals.isPlatformAccessGrant ?? false,
+    tenantSlug,
+    baseDomain,
   };
 };


### PR DESCRIPTION
## The bug

Five client components derived the tenant slug from the hostname:

```ts
const parts = window.location.hostname.split(".");
if (parts.length > 2) tenantSlug = parts[0];
```

That treats label count as meaningful, which it is not — the base domain may have any number of labels. `SubdomainParser` has never counted labels; it strips the base-domain suffix, and local dev itself runs on a three-label base domain (`nocturne.localhost`).

On a base domain like `nocturne.example.com` the apex's own first label was read as a tenant slug. The sidebar switcher computed the wrong target host, and the membership-request auto-submit carried a slug naming no tenant.

This came out of a self-hoster asking whether they could run Nocturne at `nocturne.theirdomain.com` alongside a professional site at the apex. They can — the parser, the Helm chart's own canonical example, and local dev all agree — but the frontend was quietly wrong about it.

## The fix

The server resolves the slug once, in the root layout load, from the request host against `BASE_DOMAIN`, and passes it down as layout data. This is what "backend is source of truth" asks for, and it removes the guessing rather than making the guess smarter.

`extractTenantSlug` mirrors `SubdomainParser` exactly: the suffix compares case-insensitively, but the slug keeps the host's own casing, because the tenant lookup is case-sensitive. A share host carries a token rather than a slug, so it reports no tenant.

## Two fixes that came along

`discord.remote.ts` had a hand-inlined copy of the same suffix-strip; it now calls the shared helper.

The sidebar's tenant switcher built its target host from the hostname, which **drops the port**. In local dev, where `BASE_DOMAIN` is `nocturne.localhost:1612`, switching tenants navigated to a portless host and could never have worked. It now uses `BASE_DOMAIN`, which carries the port.

## Second commit: a regression the review caught

The first commit broke the "Request membership" flow. That slug was never tenant identity — it only namespaced a localStorage key holding the message while the visitor goes off to sign up. Both halves guarded on it being present, so once the slug became honest about hosts that do not name a tenant, the guard swallowed the `open = false` and the `goto` along with the write. The button went inert with no feedback, and the owner never received the request.

Keying on the host removes the dependency entirely: the store and the auto-submit run on the same host, and neither needs a slug. The key lives in one module now so the two halves cannot drift apart, and the guard is down to a browser check.

## Testing

638 unit tests pass, including 15 for the new helper. Mutation-tested rather than trusting green: reverting the helper to `parts.length > 2` fails exactly the two tests that pin the bug, and leaves the tenant-host case passing — that one was accidentally right before.

`svelte-check` reports zero errors in the twelve files touched. No remaining hostname-derived tenant identity anywhere in the app package.

`pnpm run build` could not be verified locally (JS heap OOM on a machine with 2 GB free); relying on CI for that.

## Left alone deliberately

Three pre-existing issues found while tracing, none introduced here: `discord.remote.ts` reads `url.host` rather than the forwarded host, which breaks Discord linking in local dev; the sidebar's `__self__` option maps to the current slug and is then rejected by its own guard, so "My Data" can never navigate; and the `Root domain only, e.g. example.com` docs strings that prompted the original question are still misleading in four files.
