### PR TITLE
fix(glucose): archive compression-low notifications under the tenant owner

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/CompressionLowDetectionService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/CompressionLowDetectionService.cs
@@ -35,6 +35,10 @@ public class CompressionLowDetectionService : BackgroundService, ICompressionLow
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<CompressionLowDetectionService> _logger;
 
+    public const string NotificationType = "glucose.compression_low_review";
+
+    public static string NotificationSourceId(DateOnly nightOf) => nightOf.ToString("yyyy-MM-dd");
+
     // Detection configuration - sleep hours are now read from settings
     private const int DetectionDelayMinutes = 15;
     internal const double MinDropRateMgDlPerMin = 2.0;
@@ -575,10 +579,10 @@ public class CompressionLowDetectionService : BackgroundService, ICompressionLow
         // The metadata contains the count and nightOf for interpolation.
         await notificationService.CreateNotificationAsync(
             userId: userId,
-            type: "glucose.compression_low_review",
+            type: NotificationType,
             title: "compression_low_detected",
             subtitle: "compression_low_detected_subtitle",
-            sourceId: nightOf.ToString("yyyy-MM-dd"),
+            sourceId: NotificationSourceId(nightOf),
             actions: new List<NotificationActionDto>
             {
                 new()

--- a/src/API/Nocturne.API/Services/Glucose/CompressionLowService.cs
+++ b/src/API/Nocturne.API/Services/Glucose/CompressionLowService.cs
@@ -1,4 +1,7 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.API.Services.BackgroundServices;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
@@ -24,6 +27,8 @@ public class CompressionLowService : ICompressionLowService
     private readonly IInAppNotificationService _notificationService;
     private readonly ITherapySettingsResolver _therapySettingsResolver;
     private readonly IUISettingsService _uiSettingsService;
+    private readonly ITenantOwnerResolver _tenantOwnerResolver;
+    private readonly ITenantAccessor _tenantAccessor;
     private readonly ILogger<CompressionLowService> _logger;
 
     public CompressionLowService(
@@ -34,6 +39,8 @@ public class CompressionLowService : ICompressionLowService
         IInAppNotificationService notificationService,
         ITherapySettingsResolver therapySettingsResolver,
         IUISettingsService uiSettingsService,
+        ITenantOwnerResolver tenantOwnerResolver,
+        ITenantAccessor tenantAccessor,
         ILogger<CompressionLowService> logger)
     {
         _repository = repository;
@@ -43,6 +50,8 @@ public class CompressionLowService : ICompressionLowService
         _notificationService = notificationService;
         _therapySettingsResolver = therapySettingsResolver;
         _uiSettingsService = uiSettingsService;
+        _tenantOwnerResolver = tenantOwnerResolver;
+        _tenantAccessor = tenantAccessor;
         _logger = logger;
     }
 
@@ -206,21 +215,32 @@ public class CompressionLowService : ICompressionLowService
         CancellationToken cancellationToken)
     {
         var pendingCount = await _repository.CountPendingForNightAsync(nightOf, cancellationToken);
-        if (pendingCount == 0)
+        if (pendingCount != 0)
+            return;
+
+        try
         {
-            try
+            var ownerId = await _tenantOwnerResolver.GetOwnerSubjectIdAsync(
+                _tenantAccessor.TenantId, cancellationToken);
+
+            if (ownerId == null)
             {
-                await _notificationService.ArchiveBySourceAsync(
-                    userId: "default",
-                    type: "glucose.compression_low_review",
-                    sourceId: nightOf.ToString("yyyy-MM-dd"),
-                    reason: NotificationArchiveReason.Completed,
-                    cancellationToken: cancellationToken);
+                _logger.LogWarning(
+                    "No owner found for tenant {TenantId}; leaving the compression low notification for {NightOf} active",
+                    _tenantAccessor.TenantId, nightOf);
+                return;
             }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to archive compression low notification for {NightOf}", nightOf);
-            }
+
+            await _notificationService.ArchiveBySourceAsync(
+                userId: ownerId,
+                type: CompressionLowDetectionService.NotificationType,
+                sourceId: CompressionLowDetectionService.NotificationSourceId(nightOf),
+                reason: NotificationArchiveReason.Completed,
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to archive compression low notification for {NightOf}", nightOf);
         }
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Glucose/CompressionLowServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Glucose/CompressionLowServiceTests.cs
@@ -1,0 +1,144 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.BackgroundServices;
+using Nocturne.API.Services.Glucose;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Notifications;
+using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Glucose;
+
+[Trait("Category", "Unit")]
+public class CompressionLowServiceTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+    private const string OwnerSubjectId = "8f0f3d4e-6f2a-4a0b-9d1e-2b3c4d5e6f70";
+    private static readonly DateOnly NightOf = new(2026, 4, 17);
+
+    private readonly Mock<ICompressionLowRepository> _repository = new();
+    private readonly Mock<IStateSpanService> _stateSpanService = new();
+    private readonly Mock<IInAppNotificationService> _notificationService = new();
+    private readonly Mock<ITenantOwnerResolver> _tenantOwnerResolver = new();
+    private readonly CompressionLowService _sut;
+
+    public CompressionLowServiceTests()
+    {
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.SetupGet(a => a.TenantId).Returns(TenantId);
+
+        _tenantOwnerResolver
+            .Setup(r => r.GetOwnerSubjectIdAsync(TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OwnerSubjectId);
+
+        _stateSpanService
+            .Setup(s => s.UpsertStateSpanAsync(It.IsAny<StateSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StateSpan span, CancellationToken _) =>
+            {
+                span.Id = Guid.NewGuid().ToString();
+                return span;
+            });
+
+        _sut = new CompressionLowService(
+            _repository.Object,
+            _stateSpanService.Object,
+            Mock.Of<IEntryService>(),
+            Mock.Of<ITreatmentService>(),
+            _notificationService.Object,
+            Mock.Of<ITherapySettingsResolver>(),
+            Mock.Of<IUISettingsService>(),
+            _tenantOwnerResolver.Object,
+            tenantAccessor.Object,
+            NullLogger<CompressionLowService>.Instance);
+    }
+
+    private CompressionLowSuggestion PendingSuggestion(int stillPendingAfterReview)
+    {
+        var suggestion = new CompressionLowSuggestion
+        {
+            Id = Guid.NewGuid(),
+            NightOf = NightOf,
+            Status = CompressionLowStatus.Pending,
+            StartMills = 1_760_000_000_000,
+            EndMills = 1_760_000_900_000
+        };
+
+        _repository
+            .Setup(r => r.GetByIdAsync(suggestion.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(suggestion);
+        _repository
+            .Setup(r => r.CountPendingForNightAsync(NightOf, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stillPendingAfterReview);
+
+        return suggestion;
+    }
+
+    private void VerifyArchivedUnder(string userId) =>
+        _notificationService.Verify(n => n.ArchiveBySourceAsync(
+            userId,
+            CompressionLowDetectionService.NotificationType,
+            "2026-04-17",
+            NotificationArchiveReason.Completed,
+            It.IsAny<CancellationToken>()), Times.Once);
+
+    [Fact]
+    public async Task AcceptSuggestionAsync_WhenNightFullyReviewed_ArchivesNotificationUnderTenantOwner()
+    {
+        var suggestion = PendingSuggestion(stillPendingAfterReview: 0);
+
+        await _sut.AcceptSuggestionAsync(suggestion.Id, suggestion.StartMills, suggestion.EndMills);
+
+        VerifyArchivedUnder(OwnerSubjectId);
+    }
+
+    [Fact]
+    public async Task DismissSuggestionAsync_WhenNightFullyReviewed_ArchivesNotificationUnderTenantOwner()
+    {
+        var suggestion = PendingSuggestion(stillPendingAfterReview: 0);
+
+        await _sut.DismissSuggestionAsync(suggestion.Id);
+
+        suggestion.Status.Should().Be(CompressionLowStatus.Dismissed);
+        VerifyArchivedUnder(OwnerSubjectId);
+    }
+
+    [Fact]
+    public async Task DismissSuggestionAsync_WhenSuggestionsStillPending_LeavesNotificationActive()
+    {
+        var suggestion = PendingSuggestion(stillPendingAfterReview: 1);
+
+        await _sut.DismissSuggestionAsync(suggestion.Id);
+
+        _notificationService.Verify(n => n.ArchiveBySourceAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<NotificationArchiveReason>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DismissSuggestionAsync_WhenTenantHasNoOwner_LeavesNotificationActive()
+    {
+        _tenantOwnerResolver
+            .Setup(r => r.GetOwnerSubjectIdAsync(TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        var suggestion = PendingSuggestion(stillPendingAfterReview: 0);
+
+        await _sut.DismissSuggestionAsync(suggestion.Id);
+
+        suggestion.Status.Should().Be(CompressionLowStatus.Dismissed);
+        _notificationService.Verify(n => n.ArchiveBySourceAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<NotificationArchiveReason>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+}


### PR DESCRIPTION
## Problem

`CompressionLowDetectionService` creates the `glucose.compression_low_review` notification under the tenant owner's subject id, but `CompressionLowService` archived it with the literal `userId: "default"`. `FindBySourceAsync` filters on `UserId`, so the archive matched zero rows: the notification stayed active after every suggestion for the night had been accepted or dismissed, and each stale row counted against the per-source active-notification cap.

## Fix

- `CompressionLowService.TryArchiveNotificationAsync` resolves the owner through the same `ITenantOwnerResolver` path the create side uses. If the tenant has no owner it logs a warning and leaves the notification active, mirroring the detection side.
- The notification type and source-id key components are now shared constants on `CompressionLowDetectionService` (`NotificationType`, `NotificationSourceId`), so the three-part lookup key can no longer drift between the create and archive sides.

## Tests

New `CompressionLowServiceTests`: accept-last-pending and dismiss-last-pending archive under the owner subject id, still-pending leaves the notification active, no-owner leaves it active. Both archive tests fail against the previous `"default"` behaviour (verified by reverting the fix once).

Follow-up from #650.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
