### PR TITLE
fix(auth): serve /.well-known/jwks.json past the .json rewrite; drop dead v1 .json routes

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/DeviceStatusController.cs
@@ -435,27 +435,4 @@ public class DeviceStatusController : ControllerBase
             return StatusCode(500);
         }
     }
-
-    /// <summary>
-    /// Alternative endpoint for device status - supports .json extension
-    /// </summary>
-    /// <param name="count">Maximum number of device status entries to return (default: 10)</param>
-    /// <param name="skip">Number of device status entries to skip for pagination (default: 0)</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Array of device status entries ordered by most recent first</returns>
-    [HttpGet("~/api/v1/devicestatus.json")]
-    [NightscoutEndpoint("/api/v1/devicestatus.json")]
-    [ProducesResponseType(typeof(DeviceStatus[]), 200)]
-    [ProducesResponseType(400)]
-    [ProducesResponseType(500)]
-    [RequireScope(OAuthScopes.DevicesRead)]
-    public async Task<ActionResult<DeviceStatus[]>> GetDeviceStatusJson(
-        [FromQuery] int count = 10,
-        [FromQuery] int skip = 0,
-        CancellationToken cancellationToken = default
-    )
-    {
-        // Delegate to the main endpoint
-        return await GetDeviceStatus(count, skip, "json", cancellationToken);
-    }
 }

--- a/src/API/Nocturne.API/Controllers/V1/FoodController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/FoodController.cs
@@ -79,23 +79,6 @@ public class FoodController : ControllerBase
     }
 
     /// <summary>
-    /// Alternative endpoint with .json extension for compatibility
-    /// </summary>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Array of food records</returns>
-    [HttpGet("~/api/v1/food.json")]
-    [NightscoutEndpoint("/api/v1/food.json")]
-    [ProducesResponseType(typeof(Food[]), 200)]
-    [ProducesResponseType(500)]
-    [RequireScope(OAuthScopes.FoodRead)]
-    public async Task<ActionResult<Food[]>> GetFoodJson(
-        CancellationToken cancellationToken = default
-    )
-    {
-        return await GetFood(cancellationToken);
-    }
-
-    /// <summary>
     /// Get regular food records only (type="food")
     /// </summary>
     /// <param name="cancellationToken">Cancellation token</param>

--- a/src/API/Nocturne.API/Controllers/V1/StatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/StatusController.cs
@@ -47,41 +47,6 @@ public class StatusController : ControllerBase
     }
 
     /// <summary>
-    /// Get the current system status as JSON.
-    /// This is the .json suffix variant that always returns JSON (Nightscout compatibility).
-    /// </summary>
-    /// <returns>Status response in JSON format</returns>
-    [HttpGet("~/api/v1/status.json")]
-    [NightscoutEndpoint("/api/v1/status.json")]
-    [Produces("application/json")]
-    public async Task<IActionResult> GetStatusJson()
-    {
-        _logger.LogDebug(
-            "Status.json endpoint requested from {RemoteIpAddress}",
-            HttpContext.Connection.RemoteIpAddress
-        );
-
-        try
-        {
-            var status = await _statusService.GetSystemStatusAsync();
-            return Ok(status);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error generating status.json response");
-            return Ok(
-                new StatusResponse
-                {
-                    Status = "error",
-                    Name = "Nocturne",
-                    Version = "unknown",
-                    ServerTime = DateTime.UtcNow,
-                }
-            );
-        }
-    }
-
-    /// <summary>
     /// Get the current system status.
     /// Returns JSON when Accept header includes application/json (Nightscout client behavior),
     /// otherwise returns HTML for browser access.

--- a/src/API/Nocturne.API/Middleware/JsonExtensionMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/JsonExtensionMiddleware.cs
@@ -25,6 +25,13 @@ namespace Nocturne.API.Middleware;
 /// <seealso cref="Attributes.NightscoutEndpointAttribute"/>
 public class JsonExtensionMiddleware
 {
+    /// <summary>
+    /// Prefixes whose <c>.json</c> suffix is part of the real route rather than a legacy
+    /// Nightscout content-negotiation hint: the OpenAPI documents served by <c>MapOpenApi</c>,
+    /// and the OIDC key set that both discovery documents advertise as <c>jwks_uri</c>.
+    /// </summary>
+    private static readonly string[] LiteralJsonPrefixes = ["/openapi", "/.well-known"];
+
     private readonly RequestDelegate _next;
     private readonly ILogger<JsonExtensionMiddleware> _logger;
 
@@ -49,11 +56,12 @@ public class JsonExtensionMiddleware
     {
         var path = context.Request.Path.Value;
 
-        // Check if the path ends with .json (skip /openapi paths — MapOpenApi expects .json)
         if (
             !string.IsNullOrEmpty(path)
             && path.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
-            && !path.StartsWith("/openapi", StringComparison.OrdinalIgnoreCase)
+            && !LiteralJsonPrefixes.Any(prefix =>
+                path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            )
         )
         {
             // Remove the .json extension

--- a/tests/Unit/Nocturne.API.Tests/Controllers/FoodControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/FoodControllerTests.cs
@@ -119,35 +119,6 @@ public class FoodControllerTests
     }
 
     [Fact]
-    public async Task GetFoodJson_WhenFoodExists_ShouldReturnFood()
-    {
-        // Arrange
-        var expectedFood = new List<Food>
-        {
-            new Food
-            {
-                Id = "507f1f77bcf86cd799439011",
-                Type = "food",
-                Name = "Test Food",
-            },
-        };
-
-        _mockFoodRepository
-            .Setup(x => x.GetFoodAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expectedFood);
-
-        // Act
-        var result = await _controller.GetFoodJson(CancellationToken.None);
-
-        // Assert
-        result.Should().NotBeNull();
-        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
-        var food = okResult.Value.Should().BeOfType<Food[]>().Subject;
-        food.Should().HaveCount(1);
-        food[0].Name.Should().Be("Test Food");
-    }
-
-    [Fact]
     public async Task GetFoodByType_WithRegularType_ShouldReturnRegularFoodOnly()
     {
         // Arrange

--- a/tests/Unit/Nocturne.API.Tests/Controllers/WellKnownControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/WellKnownControllerTests.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.API.Controllers;
+using Nocturne.API.Tests.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// Covers the OIDC discovery documents and the key set they point relying parties at.
+/// </summary>
+public sealed class WellKnownControllerTests : IClassFixture<AuthenticationTestFactory>
+{
+    private static readonly JsonSerializerOptions CaseInsensitive =
+        new() { PropertyNameCaseInsensitive = true };
+
+    private readonly HttpClient _client;
+
+    public WellKnownControllerTests(AuthenticationTestFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Theory]
+    [InlineData("/.well-known/openid-configuration")]
+    [InlineData("/.well-known/oauth-authorization-server")]
+    public async Task Advertised_jwks_uri_serves_the_key_set(string discoveryPath)
+    {
+        var jwksUri = await GetAdvertisedJwksUriAsync(discoveryPath);
+        jwksUri.Should().EndWith("/.well-known/jwks.json");
+
+        var response = await _client.GetAsync(new Uri(jwksUri).PathAndQuery);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var keySet = await response.Content.ReadFromJsonAsync<JsonWebKeySet>(CaseInsensitive);
+        keySet!.Keys.Should().ContainSingle().Which.Alg.Should().Be("HS256");
+    }
+
+    private async Task<string> GetAdvertisedJwksUriAsync(string discoveryPath)
+    {
+        var response = await _client.GetAsync(discoveryPath);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return document
+            .RootElement.EnumerateObject()
+            .Single(property =>
+                property.Name.Replace("_", string.Empty)
+                    .Equals("jwksuri", StringComparison.OrdinalIgnoreCase)
+            )
+            .Value.GetString()!;
+    }
+}


### PR DESCRIPTION
## Problem

`JsonExtensionMiddleware` strips any `.json` suffix before routing (legacy Nightscout content-negotiation), exempting only `/openapi`. `/.well-known/jwks.json` — the exact URL both discovery documents advertise as `jwks_uri` — was therefore rewritten to `/.well-known/jwks`, which matches no endpoint. A relying party fetching our JWKS got a 401 (no endpoint metadata, so `[AllowAnonymous]` never applied).

The same rewrite made three v1 `.json` route templates unreachable dead code that also published duplicate OpenAPI operations: `DeviceStatusController.GetDeviceStatusJson`, `FoodController.GetFoodJson`, `StatusController.GetStatusJson`. All three were pure delegations to their stripped siblings, so removing them changes no behaviour (`status.json` responses still go through `GetStatus`, which returns JSON when the middleware forces the Accept header).

## Fix

- The `/openapi` special case becomes a `LiteralJsonPrefixes` exemption list covering `/openapi` and `/.well-known`.
- The three vestigial v1 actions are deleted, along with a test that invoked one of them directly (a line-for-line duplicate of the sibling's test).

## Tests

New `WellKnownControllerTests`: a theory over both discovery documents that reads the advertised `jwks_uri` out of the served document, GETs that exact URL, and asserts the key set comes back. Both cases fail (401) without the middleware exemption — verified by reverting once.

Full unit suite: 5142 passed / 0 failed. The v1 parity/golden tests covering `status.json` et al. request the URLs, not the actions, and stay green.

## Noted while here (not in this PR)

The discovery documents serialize with MVC's default camelCase policy, emitting `jwksUri`/`authorizationEndpoint` instead of the spec-mandated `jwks_uri`/`authorization_endpoint`. A strict OIDC relying party won't find the fields. The new test reads the property name-agnostically so it doesn't pin that as correct.

Follow-up from #651.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
