### PR TITLE
fix(notifications): archive the oldest active notification at the per-source cap instead of dropping the newest

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/NotificationsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/NotificationsController.cs
@@ -71,7 +71,6 @@ public class NotificationsController : ControllerBase
     [ProducesResponseType(typeof(InAppNotificationDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
     public async Task<IActionResult> CreateNotification(
         [FromBody] CreateNotificationRequest request,
         CancellationToken cancellationToken)
@@ -101,10 +100,6 @@ public class NotificationsController : ControllerBase
                 cancellationToken: cancellationToken);
 
             return Created($"/api/v4/notifications/{notification.Id}", notification);
-        }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("Rate limit"))
-        {
-            return StatusCode(429, new { error = ex.Message });
         }
         catch (ArgumentException ex)
         {

--- a/src/API/Nocturne.API/Services/Notifications/InAppNotificationService.cs
+++ b/src/API/Nocturne.API/Services/Notifications/InAppNotificationService.cs
@@ -26,6 +26,13 @@ public class InAppNotificationService : IInAppNotificationService
     private readonly ILogger<InAppNotificationService> _logger;
 
     /// <summary>
+    /// Most active notifications one source may hold for a user at once. A create that would
+    /// exceed it archives the source's oldest active notifications as
+    /// <see cref="NotificationArchiveReason.Superseded"/>.
+    /// </summary>
+    public const int MaxActiveNotificationsPerSource = 10;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="InAppNotificationService"/> class.
     /// </summary>
     /// <param name="repository">The notification repository</param>
@@ -87,16 +94,9 @@ public class InAppNotificationService : IInAppNotificationService
         var resolvedActions = actions ?? template?.DefaultActions;
         var resolvedConditions = resolutionConditions ?? template?.DefaultResolutionConditions;
 
-        var resolvedSourceForRateLimit = source ?? template?.Source;
-        if (resolvedSourceForRateLimit != null)
+        if (resolvedSource != null)
         {
-            var activeCount = await _repository.GetActiveCountBySourceAsync(
-                userId, resolvedSourceForRateLimit, cancellationToken);
-            if (activeCount >= 10)
-            {
-                throw new InvalidOperationException(
-                    $"Rate limit exceeded: source '{resolvedSourceForRateLimit}' has {activeCount} active notifications for user");
-            }
+            await SupersedeOldestOverCapAsync(userId, resolvedSource, cancellationToken);
         }
 
         var entity = new InAppNotificationEntity
@@ -155,6 +155,30 @@ public class InAppNotificationService : IInAppNotificationService
         }
 
         return dto;
+    }
+
+    /// <summary>
+    /// Archives a source's oldest active notifications so that one more create leaves the source
+    /// at <see cref="MaxActiveNotificationsPerSource"/>.
+    /// </summary>
+    private async Task SupersedeOldestOverCapAsync(
+        string userId,
+        string source,
+        CancellationToken cancellationToken
+    )
+    {
+        var active = await _repository.GetActiveBySourceAsync(userId, source, cancellationToken);
+        var overflow = active.Count - (MaxActiveNotificationsPerSource - 1);
+
+        for (var i = 0; i < overflow; i++)
+        {
+            await ArchiveNotificationAsync(
+                active[i].Id,
+                NotificationArchiveReason.Superseded,
+                userId,
+                cancellationToken
+            );
+        }
     }
 
     /// <inheritdoc />

--- a/src/API/Nocturne.API/Services/Treatments/MealMatchingService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/MealMatchingService.cs
@@ -71,8 +71,7 @@ public class MealMatchingService : IMealMatchingService
 
         foreach (var entry in pendingEntries)
         {
-            // One entry that cannot be processed — most often the notification source hitting its
-            // active-notification cap — must not abandon the rest of the batch.
+            // One entry that cannot be processed must not abandon the rest of the batch.
             try
             {
                 await ProcessFoodEntryAsync(userId, entry, settings, ct);

--- a/src/Core/Nocturne.Core.Models/TrackerEnums.cs
+++ b/src/Core/Nocturne.Core.Models/TrackerEnums.cs
@@ -255,7 +255,12 @@ public enum NotificationArchiveReason
     /// <summary>
     /// Notification expired based on its configured expiration time
     /// </summary>
-    Expired
+    Expired,
+
+    /// <summary>
+    /// Displaced by a newer notification once its source reached the per-source active cap
+    /// </summary>
+    Superseded
 }
 
 /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Abstractions/IInAppNotificationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Abstractions/IInAppNotificationRepository.cs
@@ -60,9 +60,9 @@ public interface IInAppNotificationRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets the count of active (non-archived) notifications for a user from a specific source
+    /// Gets a user's active (non-archived) notifications from a specific source, oldest first
     /// </summary>
-    Task<int> GetActiveCountBySourceAsync(
+    Task<List<InAppNotificationEntity>> GetActiveBySourceAsync(
         string userId,
         string source,
         CancellationToken cancellationToken = default);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/InAppNotificationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/InAppNotificationRepository.cs
@@ -183,18 +183,20 @@ public class InAppNotificationRepository : IInAppNotificationRepository
     }
 
     /// <summary>
-    /// Get the count of active notifications for a user from a specific source
+    /// Get the active notifications for a user from a specific source, oldest first
     /// </summary>
     /// <param name="userId">The user ID</param>
     /// <param name="source">The notification source</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Count of active notifications from the source</returns>
-    public async Task<int> GetActiveCountBySourceAsync(
+    /// <returns>Active notifications from the source, ordered by creation time ascending</returns>
+    public virtual async Task<List<InAppNotificationEntity>> GetActiveBySourceAsync(
         string userId, string source, CancellationToken cancellationToken = default)
     {
         return await _context.InAppNotifications
             .Where(n => n.UserId == userId && n.Source == source && !n.IsArchived)
-            .CountAsync(cancellationToken);
+            .OrderBy(n => n.CreatedAt)
+            .ThenBy(n => n.Id)
+            .ToListAsync(cancellationToken);
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/Notifications/InAppNotificationServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Notifications/InAppNotificationServiceTests.cs
@@ -13,7 +13,8 @@ namespace Nocturne.API.Tests.Services.Notifications;
 /// Unit tests for the per-subject bookkeeping on <see cref="InAppNotificationService"/>: the
 /// single mark-read ownership/no-op guards, bulk mark-all-read broadcasting, the archive
 /// ownership guard that confines <c>DELETE /api/v4/notifications/{id}</c> to the caller's own rows,
-/// and the type accessor that <c>NotificationsController.ExecuteAction</c> authorizes on.
+/// the type accessor that <c>NotificationsController.ExecuteAction</c> authorizes on, and the
+/// per-source active cap that supersedes a source's oldest notifications.
 /// </summary>
 public class InAppNotificationServiceTests
 {
@@ -32,9 +33,13 @@ public class InAppNotificationServiceTests
         );
     }
 
+    private const string Source = "meal_matching";
+
     private static InAppNotificationEntity Notification(
         string userId,
-        DateTime? readAt = null
+        DateTime? readAt = null,
+        string? source = null,
+        DateTime createdAt = default
     ) => new()
     {
         Id = Guid.CreateVersion7(),
@@ -44,7 +49,118 @@ public class InAppNotificationServiceTests
         Urgency = NotificationUrgency.Info,
         Title = "compression_low_detected",
         ReadAt = readAt,
+        Source = source,
+        CreatedAt = createdAt,
     };
+
+    /// <summary>
+    /// Gives <see cref="Source"/> the requested number of active notifications, oldest first, and
+    /// has create and archive echo back the row they were handed.
+    /// </summary>
+    private List<InAppNotificationEntity> SeedActiveSource(int activeCount)
+    {
+        var active = Enumerable
+            .Range(0, activeCount)
+            .Select(i => Notification(
+                "user-1",
+                source: Source,
+                createdAt: new DateTime(2026, 1, 1, 0, i, 0, DateTimeKind.Utc)))
+            .ToList();
+
+        _repository
+            .Setup(r => r.GetActiveBySourceAsync("user-1", Source, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(active);
+        _repository
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid id, CancellationToken _) => active.FirstOrDefault(n => n.Id == id));
+        _repository
+            .Setup(r => r.ArchiveAsync(
+                It.IsAny<Guid>(), It.IsAny<NotificationArchiveReason>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid id, NotificationArchiveReason _, CancellationToken __) =>
+                active.First(n => n.Id == id));
+        _repository
+            .Setup(r => r.CreateAsync(
+                It.IsAny<InAppNotificationEntity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InAppNotificationEntity entity, CancellationToken _) => entity);
+
+        return active;
+    }
+
+    private Task<InAppNotificationDto> CreateFromSourceAsync(string title) =>
+        _service.CreateNotificationAsync(
+            "user-1",
+            "meal_matching.suggested_match",
+            title,
+            category: NotificationCategory.ActionRequired,
+            source: Source);
+
+    /// <summary>
+    /// A source at its cap used to reject the create outright, so the newest notification was the
+    /// one lost and callers that swallow the failure never surfaced it.
+    /// </summary>
+    [Fact]
+    public async Task CreateNotificationAsync_WhenSourceIsAtCap_SupersedesTheOldestAndKeepsTheNewest()
+    {
+        var active = SeedActiveSource(InAppNotificationService.MaxActiveNotificationsPerSource);
+
+        var created = await CreateFromSourceAsync("eleventh");
+
+        Assert.Equal("eleventh", created.Title);
+        _repository.Verify(
+            r => r.CreateAsync(
+                It.Is<InAppNotificationEntity>(e => e.Title == "eleventh" && e.Source == Source),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repository.Verify(
+            r => r.ArchiveAsync(
+                active[0].Id, NotificationArchiveReason.Superseded, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repository.Verify(
+            r => r.ArchiveAsync(
+                It.IsAny<Guid>(), It.IsAny<NotificationArchiveReason>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _broadcast.Verify(
+            b => b.BroadcastNotificationArchivedAsync(
+                "user-1",
+                It.Is<InAppNotificationDto>(d => d.Id == active[0].Id),
+                NotificationArchiveReason.Superseded),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateNotificationAsync_WhenSourceIsOneBelowCap_SupersedesNothing()
+    {
+        SeedActiveSource(InAppNotificationService.MaxActiveNotificationsPerSource - 1);
+
+        var created = await CreateFromSourceAsync("tenth");
+
+        Assert.Equal("tenth", created.Title);
+        _repository.Verify(
+            r => r.ArchiveAsync(
+                It.IsAny<Guid>(), It.IsAny<NotificationArchiveReason>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateNotificationAsync_WhenSourceIsOverCap_SupersedesEnoughToLandOnTheCap()
+    {
+        var active = SeedActiveSource(InAppNotificationService.MaxActiveNotificationsPerSource + 2);
+
+        await CreateFromSourceAsync("newest");
+
+        foreach (var superseded in active.Take(3))
+        {
+            _repository.Verify(
+                r => r.ArchiveAsync(
+                    superseded.Id, NotificationArchiveReason.Superseded, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        _repository.Verify(
+            r => r.ArchiveAsync(
+                It.IsAny<Guid>(), It.IsAny<NotificationArchiveReason>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
 
     [Fact]
     public async Task MarkAsReadAsync_WhenNotFound_ReturnsFalseAndDoesNotBroadcast()

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/MealMatchingServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/MealMatchingServiceTests.cs
@@ -80,8 +80,8 @@ public class MealMatchingServiceTests
             .Setup(r => r.GetByIdsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ids.Select(Entry).ToList());
 
-        // The notification source's active cap throws; before this was guarded it abandoned the
-        // rest of the batch, so matching silently stopped partway through.
+        // Before this was guarded, one failed notification abandoned the rest of the batch, so
+        // matching silently stopped partway through.
         _notificationService
             .Setup(n => n.CreateNotificationAsync(
                 UserId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<NotificationCategory?>(),
@@ -89,7 +89,7 @@ public class MealMatchingServiceTests
                 It.IsAny<string?>(), ids[0].ToString(), It.IsAny<List<NotificationActionDto>?>(),
                 It.IsAny<ResolutionConditions?>(), It.IsAny<Dictionary<string, object>?>(),
                 It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("Rate limit exceeded"));
+            .ThrowsAsync(new InvalidOperationException("notification write failed"));
 
         await NewService().ProcessNewFoodEntriesAsync(UserId, ids);
 


### PR DESCRIPTION
## Problem

`InAppNotificationService.CreateNotificationAsync` threw once a `(userId, source)` pair held 10 active notifications (inline literal). The cap is per source, not per subject, so a user with 11+ simultaneously pending items from one source lost everything past the tenth — and since `MealMatchingService` catches per entry, the drop was invisible outside an error log. `NotificationsController` additionally caught the throw by message substring (`Contains("Rate limit")`) to return 429.

## Fix

- The limit is a named public constant, `MaxActiveNotificationsPerSource = 10`.
- A create that would exceed it archives the source's oldest active notifications (new `NotificationArchiveReason.Superseded`; the column is string-converted, so no migration) through the existing `ArchiveNotificationAsync` path — archive broadcast and ownership guard included — and then always succeeds. The newest item is kept; the stalest is displaced.
- `GetActiveCountBySourceAsync` (single caller, now useless) is replaced by `GetActiveBySourceAsync`, ordered `CreatedAt` then `Id` for a deterministic oldest.
- The controller's message-sniffing 429 catch and its `ProducesResponseType(429)` are removed; nothing throws for the cap any more.

The constant is a `public const` rather than an options binding: no notification options surface exists today (`NotificationCleanupService` hardcodes its intervals the same way). Happy to bind it to configuration if preferred.

## Tests

Three new tests: the eleventh create supersedes exactly the oldest and keeps the newest; one-below-cap supersedes nothing; over-cap (12 active) archives three to land on the cap. Mutation-proven: off-by-one flips in the overflow arithmetic fail 2–3 of them. `~Notifications` suite: 103 passed / 0 failed.

Follow-up from #571.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
