### PR TITLE
fix(connect): bound the connector dry-run fetch to the sync window

### DIFF
--- a/nocturne.sln
+++ b/nocturne.sln
@@ -178,6 +178,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Services.Demo.Gene
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Connectors.MyFitnessPal.Tests", "tests\Unit\Nocturne.Connectors.MyFitnessPal.Tests\Nocturne.Connectors.MyFitnessPal.Tests.csproj", "{52A7C3FF-98DE-42E7-881F-24CEA5791CB8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Tools.Connect.Tests", "tests\Unit\Nocturne.Tools.Connect.Tests\Nocturne.Tools.Connect.Tests.csproj", "{F8F11145-C385-45CC-96B7-5C44889EEE04}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -920,6 +922,18 @@ Global
 		{52A7C3FF-98DE-42E7-881F-24CEA5791CB8}.Release|x64.Build.0 = Release|Any CPU
 		{52A7C3FF-98DE-42E7-881F-24CEA5791CB8}.Release|x86.ActiveCfg = Release|Any CPU
 		{52A7C3FF-98DE-42E7-881F-24CEA5791CB8}.Release|x86.Build.0 = Release|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Debug|x64.Build.0 = Debug|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Debug|x86.Build.0 = Debug|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Release|x64.ActiveCfg = Release|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Release|x64.Build.0 = Release|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Release|x86.ActiveCfg = Release|Any CPU
+		{F8F11145-C385-45CC-96B7-5C44889EEE04}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -998,5 +1012,6 @@ Global
 		{E34250B8-0520-4A11-B55E-272681FAB007} = {F25A9213-C080-46DC-93A8-09D96E2C55A1}
 		{9C974379-4C52-46C8-8281-E574C5142B48} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
 		{52A7C3FF-98DE-42E7-881F-24CEA5791CB8} = {F25A9213-C080-46DC-93A8-09D96E2C55A1}
+		{F8F11145-C385-45CC-96B7-5C44889EEE04} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/Tools/Nocturne.Tools.Connect/Commands/RunCommand.cs
+++ b/src/Tools/Nocturne.Tools.Connect/Commands/RunCommand.cs
@@ -32,6 +32,10 @@ public sealed class RunSettings : CommandSettings
     [Description("Test run without uploading data to Nightscout")]
     public bool DryRun { get; init; }
 
+    [CommandOption("-s|--since <TIMESTAMP>")]
+    [Description("Start of the sync window; defaults to a rolling three-hour lookback")]
+    public DateTime? Since { get; init; }
+
     [CommandOption("-v|--verbose")]
     [Description("Enable verbose logging")]
     public bool Verbose { get; init; }
@@ -109,6 +113,7 @@ public class RunCommand : AsyncCommand<RunSettings>
                 once: settings.Once,
                 interval: settings.Interval,
                 dryRun: settings.DryRun,
+                since: settings.Since?.ToUniversalTime(),
                 cancellationToken: CancellationToken.None
             );
 

--- a/src/Tools/Nocturne.Tools.Connect/Services/ConnectorExecutionService.cs
+++ b/src/Tools/Nocturne.Tools.Connect/Services/ConnectorExecutionService.cs
@@ -34,6 +34,11 @@ public class ConnectorExecutionService(
     // Optional dependency
 
     /// <summary>
+    /// Lower bound of a sync window when the caller supplies no explicit start.
+    /// </summary>
+    private static readonly TimeSpan DefaultSyncWindow = TimeSpan.FromHours(3);
+
+    /// <summary>
     /// Executes the connector synchronization operation
     /// </summary>
     /// <param name="config">Connect configuration</param>
@@ -41,6 +46,7 @@ public class ConnectorExecutionService(
     /// <param name="once">Whether to run only once</param>
     /// <param name="interval">Sync interval in minutes for daemon mode</param>
     /// <param name="dryRun">Whether this is a dry run</param>
+    /// <param name="since">Start of the sync window; defaults to a rolling three-hour lookback</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>True if successful, false otherwise</returns>
     public async Task<bool> ExecuteConnectorAsync(
@@ -49,6 +55,7 @@ public class ConnectorExecutionService(
         bool once = false,
         int interval = 5,
         bool dryRun = false,
+        DateTime? since = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -111,6 +118,7 @@ public class ConnectorExecutionService(
                     connectorConfig,
                     interval,
                     dryRun,
+                    since,
                     cancellationToken
                 );
             }
@@ -120,6 +128,7 @@ public class ConnectorExecutionService(
                     connector,
                     connectorConfig,
                     dryRun,
+                    since,
                     cancellationToken
                 );
             }
@@ -143,6 +152,7 @@ public class ConnectorExecutionService(
         IConnectorConfiguration config,
         int intervalMinutes,
         bool dryRun,
+        DateTime? since,
         CancellationToken cancellationToken
     )
     {
@@ -163,23 +173,10 @@ public class ConnectorExecutionService(
                 _logger.LogInformation("Starting sync operation #{SyncCount}", syncCount);
 
                 var syncStartTime = DateTime.UtcNow;
-                bool syncResult;
 
-                if (dryRun)
-                {
-                    _logger.LogInformation("Dry run mode - fetching data without uploading");
-                    var entries = await connector.FetchGlucoseDataAsync();
-                    var entryCount = System.Linq.Enumerable.Count(entries);
-                    _logger.LogInformation(
-                        "Dry run: Would have uploaded {Count} entries",
-                        entryCount
-                    );
-                    syncResult = true;
-                }
-                else
-                {
-                    syncResult = await PerformSyncAsync(connector, config);
-                }
+                var syncResult = dryRun
+                    ? await RunDryRunAsync(connector, since)
+                    : await PerformSyncAsync(connector, config, since);
 
                 var syncDuration = DateTime.UtcNow - syncStartTime;
                 lastSyncTime = DateTime.UtcNow;
@@ -283,6 +280,7 @@ public class ConnectorExecutionService(
         IConnectorService<IConnectorConfiguration> connector,
         IConnectorConfiguration config,
         bool dryRun,
+        DateTime? since,
         CancellationToken cancellationToken
     )
     {
@@ -290,18 +288,9 @@ public class ConnectorExecutionService(
 
         try
         {
-            if (dryRun)
-            {
-                _logger.LogInformation("Dry run mode - fetching data without uploading");
-                var entries = await connector.FetchGlucoseDataAsync();
-                var entryCount = System.Linq.Enumerable.Count(entries);
-                _logger.LogInformation("Dry run: Would have uploaded {Count} entries", entryCount);
-                return true;
-            }
-            else
-            {
-                return await PerformSyncAsync(connector, config);
-            }
+            return dryRun
+                ? await RunDryRunAsync(connector, since)
+                : await PerformSyncAsync(connector, config, since);
         }
         catch (Exception ex)
         {
@@ -311,11 +300,42 @@ public class ConnectorExecutionService(
     }
 
     /// <summary>
+    /// Fetches over the sync window and reports what a real sync would have uploaded.
+    /// </summary>
+    private async Task<bool> RunDryRunAsync(
+        IConnectorService<IConnectorConfiguration> connector,
+        DateTime? since
+    )
+    {
+        var windowStart = ResolveWindowStart(since);
+        _logger.LogInformation(
+            "Dry run mode - fetching data since {Since:o} without uploading",
+            windowStart
+        );
+
+        var entries = await connector.FetchGlucoseDataAsync(windowStart);
+        _logger.LogInformation(
+            "Dry run: Would have uploaded {Count} entries since {Since:o}",
+            entries.Count(),
+            windowStart
+        );
+        return true;
+    }
+
+    /// <summary>
+    /// Resolved per cycle so that, absent an explicit start, daemon mode keeps a rolling
+    /// window rather than one that grows for the lifetime of the process.
+    /// </summary>
+    private static DateTime ResolveWindowStart(DateTime? since) =>
+        since ?? DateTime.UtcNow - DefaultSyncWindow;
+
+    /// <summary>
     /// Performs the actual sync operation using the connector's SyncDataAsync method
     /// </summary>
     private async Task<bool> PerformSyncAsync(
         IConnectorService<IConnectorConfiguration> connector,
-        IConnectorConfiguration config
+        IConnectorConfiguration config,
+        DateTime? since
     )
     {
         try
@@ -327,7 +347,7 @@ public class ConnectorExecutionService(
             var request = new SyncRequest
             {
                 DataTypes = connector.SupportedDataTypes,
-                From = DateTime.UtcNow.AddHours(-3), // Default 3-hour lookback
+                From = ResolveWindowStart(since),
                 To = DateTime.UtcNow,
             };
 
@@ -404,7 +424,7 @@ public class ConnectorExecutionService(
     /// <summary>
     /// Creates the appropriate connector service based on the configuration
     /// </summary>
-    private IConnectorService<IConnectorConfiguration>? CreateConnectorService(
+    protected virtual IConnectorService<IConnectorConfiguration>? CreateConnectorService(
         IConnectorConfiguration config
     )
     {

--- a/tests/Unit/Nocturne.Tools.Connect.Tests/Nocturne.Tools.Connect.Tests.csproj
+++ b/tests/Unit/Nocturne.Tools.Connect.Tests/Nocturne.Tools.Connect.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Moq"/>
+        <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../../../src/Tools/Nocturne.Tools.Connect/Nocturne.Tools.Connect.csproj"/>
+    </ItemGroup>
+</Project>

--- a/tests/Unit/Nocturne.Tools.Connect.Tests/Services/ConnectorExecutionServiceDryRunTests.cs
+++ b/tests/Unit/Nocturne.Tools.Connect.Tests/Services/ConnectorExecutionServiceDryRunTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Core.Models;
+using Nocturne.Tools.Connect.Configuration;
+using Nocturne.Tools.Connect.Services;
+using Xunit;
+
+namespace Nocturne.Tools.Connect.Tests.Services;
+
+public class ConnectorExecutionServiceDryRunTests
+{
+    private static readonly TimeSpan DefaultWindow = TimeSpan.FromHours(3);
+
+    private static ConnectConfiguration DexcomConfig() =>
+        new()
+        {
+            NightscoutUrl = "https://example.com",
+            NightscoutApiSecret = "supersecretvalue",
+            ConnectSource = "dexcom",
+            DexcomUsername = "user",
+            DexcomPassword = "pass",
+        };
+
+    private static Mock<IConnectorService<IConnectorConfiguration>> AuthenticatedConnector(
+        Action? onFetch = null
+    )
+    {
+        var connector = new Mock<IConnectorService<IConnectorConfiguration>>();
+        connector.Setup(c => c.AuthenticateAsync()).ReturnsAsync(true);
+        connector
+            .Setup(c => c.FetchGlucoseDataAsync(It.IsAny<DateTime?>()))
+            .ReturnsAsync(new Entry[] { new(), new() })
+            .Callback(() => onFetch?.Invoke());
+        return connector;
+    }
+
+    [Fact]
+    public async Task RunOnceDryRun_FetchesOnlyTheDefaultSyncWindow()
+    {
+        var connector = AuthenticatedConnector();
+        var service = new StubbedConnectorExecutionService(connector.Object);
+        var before = DateTime.UtcNow;
+
+        var result = await service.ExecuteConnectorAsync(
+            DexcomConfig(),
+            once: true,
+            dryRun: true
+        );
+
+        result.Should().BeTrue();
+        AssertWithinDefaultWindow(CapturedSince(connector), before);
+    }
+
+    [Fact]
+    public async Task RunOnceDryRun_HonoursAnExplicitSince()
+    {
+        var connector = AuthenticatedConnector();
+        var service = new StubbedConnectorExecutionService(connector.Object);
+        var since = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
+        await service.ExecuteConnectorAsync(DexcomConfig(), once: true, dryRun: true, since: since);
+
+        CapturedSince(connector).Should().Be(since);
+    }
+
+    [Fact]
+    public async Task DaemonDryRun_FetchesOnlyTheDefaultSyncWindow()
+    {
+        using var cts = new CancellationTokenSource();
+        // The daemon loop exits only on cancellation, so end it once the first cycle has fetched.
+        var connector = AuthenticatedConnector(cts.Cancel);
+        var service = new StubbedConnectorExecutionService(connector.Object);
+        var before = DateTime.UtcNow;
+
+        await service.ExecuteConnectorAsync(
+            DexcomConfig(),
+            daemon: true,
+            dryRun: true,
+            cancellationToken: cts.Token
+        );
+
+        AssertWithinDefaultWindow(CapturedSince(connector), before);
+    }
+
+    private static void AssertWithinDefaultWindow(DateTime? since, DateTime before)
+    {
+        since.Should().NotBeNull();
+        since!.Value.Should().BeOnOrAfter(before - DefaultWindow);
+        since.Value.Should().BeOnOrBefore(DateTime.UtcNow - DefaultWindow);
+    }
+
+    private static DateTime? CapturedSince(
+        Mock<IConnectorService<IConnectorConfiguration>> connector
+    )
+    {
+        var fetches = connector
+            .Invocations.Where(i => i.Method.Name == "FetchGlucoseDataAsync")
+            .ToList();
+        fetches.Should().ContainSingle();
+        return (DateTime?)fetches[0].Arguments[0];
+    }
+
+    private sealed class StubbedConnectorExecutionService(
+        IConnectorService<IConnectorConfiguration> connector
+    )
+        : ConnectorExecutionService(
+            NullLogger<ConnectorExecutionService>.Instance,
+            NullLoggerFactory.Instance
+        )
+    {
+        protected override IConnectorService<IConnectorConfiguration>? CreateConnectorService(
+            IConnectorConfiguration config
+        ) => connector;
+    }
+}


### PR DESCRIPTION
## Problem

The Connect CLI's dry-run paths (daemon and run-once) called `FetchGlucoseDataAsync()` with no `since`, which every connector treats as "everything available". Since full-history backfill works, a daemon-mode dry run re-crawled and re-materialised the entire source history on every interval.

(One correction to the follow-up as filed: the CLI can't currently construct a Nightscout connector config, so the worst case — the paginated full-history crawl — isn't reachable from this tool today. The unbounded fetch is in the tool's shared contract call and applies to every connector it can run.)

## Fix

- Dry runs fetch from a resolved window start and log both the count and the window: `since ?? UtcNow − 3h`, resolved per cycle so daemon mode keeps a rolling window rather than one pinned at process start.
- The two duplicated dry-run blocks collapse into one `RunDryRunAsync`; `PerformSyncAsync`'s inline `AddHours(-3)` now uses the same `ResolveWindowStart`, so real and dry runs share one definition of the sync window. Real-sync default behaviour is unchanged.
- `run` gains `-s|--since <TIMESTAMP>` to override the window start.

## Tests

New `tests/Unit/Nocturne.Tools.Connect.Tests` (the Tools tree had none; CI's `tests/Unit/*/` loop picks it up, and it's registered in the solution). Three tests pin the bounded fetch for run-once default, run-once with explicit `--since`, and daemon mode; assertions bracket the window on both sides, so `DateTime.MinValue` fails as well as null. All three fail with the bound reverted; 3/3 green with it.

Follow-up from #625.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
