### PR TITLE
test(api): fix the stale EntryService cache assertions and un-hide two cache test files from CI

### DIFF
--- a/tests/Unit/Nocturne.API.Tests/Services/CalculationCacheTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/CalculationCacheTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Nocturne.API.Tests.Services;
 
 /// <summary>
-/// Integration tests for Phase 3 calculation caching features
+/// Tests for Phase 3 calculation caching features
 /// Tests expensive IOB and profile calculations with in-memory caching
 /// </summary>
 public class Phase3CalculationCacheTests
@@ -62,7 +62,7 @@ public class Phase3CalculationCacheTests
     #region IOB Calculation Caching Tests
 
     [Fact]
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     [Trait("Category", "Cache")]
     [Trait("Category", "IOB")]
     public async Task CachedIobService_CalculateTotalAsync_CacheHit_ReturnsCachedResult()
@@ -135,7 +135,7 @@ public class Phase3CalculationCacheTests
     }
 
     [Fact]
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     [Trait("Category", "Cache")]
     [Trait("Category", "IOB")]
     public async Task CachedIobService_InvalidateIobCache_RemovesCorrectPattern()
@@ -167,7 +167,7 @@ public class Phase3CalculationCacheTests
     #region Profile Calculation Caching Tests
 
     [Fact]
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     [Trait("Category", "Cache")]
     [Trait("Category", "Profile")]
     public async Task CachedProfileService_GetProfileCalculationsAsync_CacheHit_ReturnsCachedResult()
@@ -243,7 +243,7 @@ public class Phase3CalculationCacheTests
     #region Cache Invalidation Tests
 
     [Fact]
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     [Trait("Category", "Cache")]
     [Trait("Category", "Invalidation")]
     public async Task CacheInvalidationService_InvalidateForNewInsulinTreatment_InvalidatesCorrectPatterns()
@@ -289,7 +289,7 @@ public class Phase3CalculationCacheTests
     }
 
     [Fact]
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     [Trait("Category", "Cache")]
     [Trait("Category", "Invalidation")]
     public async Task CacheInvalidationService_InvalidateForNewGlucoseEntry_InvalidatesCorrectPatterns()

--- a/tests/Unit/Nocturne.API.Tests/Services/ServiceCacheTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ServiceCacheTests.cs
@@ -23,9 +23,9 @@ using Xunit;
 namespace Nocturne.API.Tests.Services;
 
 /// <summary>
-/// Integration tests for cache behavior in domain services
+/// Tests for cache behavior in domain services
 /// </summary>
-public class CacheIntegrationTests
+public class ServiceCacheTests
 {
     private readonly Mock<IEntryStore> _mockEntryStore;
     private readonly Mock<IEntryDecomposer> _mockEntryDecomposer;
@@ -37,7 +37,7 @@ public class CacheIntegrationTests
     private readonly Mock<ILogger<StatusService>> _mockStatusLogger;
     private readonly Mock<ITenantAccessor> _mockTenantAccessor;
 
-    public CacheIntegrationTests()
+    public ServiceCacheTests()
     {
         _mockEntryStore = new Mock<IEntryStore>();
         _mockEntryDecomposer = new Mock<IEntryDecomposer>();
@@ -53,7 +53,7 @@ public class CacheIntegrationTests
     }
 
     [Fact]
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     [Trait("Category", "Cache")]
     public async Task GetCurrentEntryAsync_CacheHit_ReturnsCachedEntry()
     {
@@ -103,7 +103,7 @@ public class CacheIntegrationTests
     }
 
     [Fact]
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     [Trait("Category", "Cache")]
     public async Task GetCurrentEntryAsync_CacheMiss_FetchesFromStoreViaCacheCompute()
     {
@@ -152,57 +152,7 @@ public class CacheIntegrationTests
     }
 
     [Fact]
-    [Trait("Category", "Integration")]
-    [Trait("Category", "Cache")]
-    public async Task CreateEntriesAsync_DecomposesToV4AndFiresEvents()
-    {
-        // Arrange
-        var newEntries = new List<Entry>
-        {
-            new Entry
-            {
-                Id = "new-1",
-                Type = "sgv",
-                Sgv = 140,
-                Mills = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            },
-        };
-
-        _mockEntryDecomposer
-            .Setup(x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Core.Models.V4.DecompositionResult());
-
-        var entryService = new EntryService(
-            _mockEntryStore.Object,
-            _mockEntryDecomposer.Object,
-            _mockEntryCache.Object,
-            _mockEntryEvents.Object,
-            _mockEntryLogger.Object
-        );
-
-        // Act
-        var result = await entryService.CreateEntriesAsync(newEntries, cancellationToken: CancellationToken.None);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Single(result);
-
-        // Verify decomposition happened and events fired (cache invalidation is handled by the event sink)
-        _mockEntryDecomposer.Verify(
-            x => x.DecomposeAsync(It.IsAny<Entry>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
-            Times.Once
-        );
-        _mockEntryEvents.Verify(
-            x => x.OnCreatedAsync(
-                It.IsAny<IReadOnlyList<Entry>>(),
-                It.IsAny<CancellationToken>()
-            ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     [Trait("Category", "Cache")]
     public async Task GetSystemStatusAsync_CacheHit_ReturnsCachedStatus()
     {
@@ -268,7 +218,7 @@ public class CacheIntegrationTests
     }
 
     [Fact]
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     [Trait("Category", "Cache")]
     public async Task GetSystemStatusAsync_CacheMiss_GeneratesAndCachesStatus()
     {


### PR DESCRIPTION
## Problem

`CacheIntegrationTests.CreateEntriesAsync_DecomposesToV4AndFiresEvents` still asserted the pre-refactor shape — `IEntryDecomposer.DecomposeAsync` (the service now calls `DecomposeBatchAsync`) and `IDataEventSink<Entry>.OnCreatedAsync` (events moved to the repository chokepoint) — so it failed on every local run. The file was tagged `Category=Integration`, which CI's filter excludes, so CI stayed green while local runs were red: a standing invitation to ignore red runs.

## Changes

- The stale test is deleted rather than rewritten: `EntryServiceTests.CreateEntriesAsync_DecomposesBatchToV4` already pins exactly the current shape (batch call once, `OnCreatedAsync` never, `InvalidateAsync` never), and the chokepoint side is covered by the `SignalRV4RecordBroadcaster`/`V4BroadcastMap` tests. A rewrite would have been a third copy.
- The remaining four tests are pure Moq + in-memory context, so they're retagged `Unit` and the file/class renamed `ServiceCacheTests` (git rename) to stop the name lying.
- Same sweep applied to `CalculationCacheTests.cs`: five tests carried an unearned Integration tag (all mock-only — no factory, container, DbContext or real cache). All five were green before the retag; the tag was the only thing wrong.

Net effect: 9 tests CI previously skipped now run under its `Category!=Integration&Category!=Performance&Category!=E2E` filter.

## Results

- `ServiceCacheTests` under the CI filter: 4/4 (was 0 selected).
- `Phase3CalculationCacheTests` under the CI filter: 11/11 (was 6 selected).
- Whole `Nocturne.API.Tests` under the CI filter: 5150 passed / 0 failed.

Not done here: an audit of the rest of `tests/Unit/**` for other unearned Integration tags. A guard test asserting nothing under `tests/Unit/` carries `Category=Integration` without declaring a fixture would close the class of bug; flagged as a follow-up.

Follow-up from #648.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
