### PR TITLE
fix(connectors): supervise realtime listeners so a dead socket falls back to polling loudly and recovers

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -100,11 +100,82 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     protected abstract string ConnectorName { get; }
 
     /// <summary>
-    /// Called once after the initial startup delay, before the poll loop begins.
+    /// Called after the initial startup delay and again every <see cref="RealtimeSupervisionInterval"/>.
     /// Override to start real-time listeners (e.g. webhooks, SSE, WebSocket connections).
+    /// Implementations must be idempotent — a tenant that already has a live listener must be left
+    /// untouched — and should use <see cref="ListenerNeedsStartAsync{TClient}"/> to enforce that.
     /// The default implementation is a no-op.
     /// </summary>
     protected virtual Task StartRealtimeListenersAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// How often the poll loop re-runs <see cref="StartRealtimeListenersAsync"/> to replace listeners
+    /// that have died. Deliberately coarser than the poll tick so a permanently unreachable upstream is
+    /// not reconnected every minute. Overridable for tests.
+    /// </summary>
+    protected virtual TimeSpan RealtimeSupervisionInterval => TimeSpan.FromMinutes(5);
+
+    private DateTime _lastRealtimeSupervision = DateTime.MinValue;
+
+    private async Task SuperviseRealtimeListenersAsync(CancellationToken stoppingToken)
+    {
+        var now = DateTime.UtcNow;
+        if (now - _lastRealtimeSupervision < RealtimeSupervisionInterval)
+            return;
+
+        _lastRealtimeSupervision = now;
+
+        try
+        {
+            await StartRealtimeListenersAsync(stoppingToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Logger.LogWarning(
+                ex,
+                "Failed to start real-time listeners for {ConnectorName}, falling back to polling",
+                ConnectorName);
+        }
+    }
+
+    /// <summary>
+    /// Reports whether a real-time listener must be started for a tenant, evicting and disposing a
+    /// tracked client that <paramref name="isAlive"/> rejects so the caller can replace it. The loss of
+    /// real-time delivery is logged at the point of eviction.
+    /// </summary>
+    protected async Task<bool> ListenerNeedsStartAsync<TClient>(
+        ConcurrentDictionary<Guid, TClient> clients,
+        Guid tenantId,
+        string tenantSlug,
+        Func<TClient, bool> isAlive,
+        Func<TClient, Task> disposeAsync)
+    {
+        if (!clients.TryGetValue(tenantId, out var existing))
+            return true;
+
+        if (isAlive(existing))
+            return false;
+
+        clients.TryRemove(tenantId, out _);
+
+        Logger.LogWarning(
+            "{ConnectorName} real-time listener for tenant {TenantSlug} is no longer connected; polling only until it is re-established",
+            ConnectorName, tenantSlug);
+
+        try
+        {
+            await disposeAsync(existing);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(
+                ex,
+                "Error disposing dead {ConnectorName} real-time listener for tenant {TenantSlug}",
+                ConnectorName, tenantSlug);
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Called when the service is shutting down, after the poll loop exits.
@@ -178,18 +249,6 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
         try
         {
-            try
-            {
-                await StartRealtimeListenersAsync(stoppingToken);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                Logger.LogWarning(
-                    ex,
-                    "Failed to start real-time listeners for {ConnectorName}, falling back to polling",
-                    ConnectorName);
-            }
-
             // Poll every minute; each tenant is only synced when its own
             // SyncIntervalMinutes has elapsed since its last sync.
             using var timer = new PeriodicTimer(TimeSpan.FromMinutes(1));
@@ -198,6 +257,7 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
             {
                 try
                 {
+                    await SuperviseRealtimeListenersAsync(stoppingToken);
                     await SyncAllTenantsAsync(stoppingToken);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -115,6 +115,17 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
     /// </summary>
     protected virtual TimeSpan RealtimeSupervisionInterval => TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// Delay before the first poll tick, letting the application fully start. Overridable for tests.
+    /// </summary>
+    protected virtual TimeSpan StartupDelay => TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Interval between poll ticks. Each tenant is still only synced when its own
+    /// SyncIntervalMinutes has elapsed since its last sync. Overridable for tests.
+    /// </summary>
+    protected virtual TimeSpan PollInterval => TimeSpan.FromMinutes(1);
+
     private DateTime _lastRealtimeSupervision = DateTime.MinValue;
 
     private async Task SuperviseRealtimeListenersAsync(CancellationToken stoppingToken)
@@ -240,8 +251,8 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Wait briefly to let the application fully start
-        await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        if (StartupDelay > TimeSpan.Zero)
+            await Task.Delay(StartupDelay, stoppingToken);
 
         Logger.LogInformation(
             "{ConnectorName} connector background service started",
@@ -249,9 +260,7 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
 
         try
         {
-            // Poll every minute; each tenant is only synced when its own
-            // SyncIntervalMinutes has elapsed since its last sync.
-            using var timer = new PeriodicTimer(TimeSpan.FromMinutes(1));
+            using var timer = new PeriodicTimer(PollInterval);
 
             do
             {

--- a/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
@@ -69,8 +69,8 @@ public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<N
             .Select(t => new { t.Id, t.Slug, t.DisplayName })
             .ToListAsync(cancellationToken);
 
-        // Connect tenants concurrently: each tenant waits up to ConnectTimeout, and the poll loop
-        // does not start until this returns, so connecting them in sequence would delay the first
+        // Connect tenants concurrently: each tenant waits up to ConnectTimeout, and the poll cycle
+        // does not continue until this returns, so connecting them in sequence would delay the first
         // sync of every tenant by the sum of all unreachable instances' timeouts.
         await Parallel.ForEachAsync(
             tenants,
@@ -101,6 +101,10 @@ public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<N
         string displayName,
         CancellationToken cancellationToken)
     {
+        if (!await ListenerNeedsStartAsync(
+                _socketClients, tenantId, tenantSlug, c => c.Connected, DisconnectAndDisposeAsync))
+            return;
+
         using var tenantScope = ServiceProvider.CreateScope();
 
         var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
@@ -171,11 +175,21 @@ public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<N
             return;
         }
 
-        _socketClients.TryAdd(tenantId, client);
+        if (!_socketClients.TryAdd(tenantId, client))
+        {
+            await DisconnectAndDisposeAsync(client);
+            return;
+        }
 
         Logger.LogInformation(
             "Started real-time listener for Nightscout tenant {TenantSlug}",
             tenantSlug);
+    }
+
+    private static async Task DisconnectAndDisposeAsync(SocketIO client)
+    {
+        await client.DisconnectAsync();
+        client.Dispose();
     }
 
     /// <inheritdoc />
@@ -185,8 +199,7 @@ public class NightscoutConnectorBackgroundService : ConnectorBackgroundService<N
         {
             try
             {
-                await client.DisconnectAsync();
-                client.Dispose();
+                await DisconnectAndDisposeAsync(client);
             }
             catch (Exception ex)
             {

--- a/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
@@ -53,6 +53,12 @@ public class NocturneRemoteConnectorBackgroundService : ConnectorBackgroundServi
         {
             try
             {
+                // Reconnection is infinite, so anything short of Disconnected is still a live listener.
+                if (!await ListenerNeedsStartAsync(
+                        _hubConnections, tenant.Id, tenant.Slug,
+                        c => c.State != HubConnectionState.Disconnected, StopAndDisposeAsync))
+                    continue;
+
                 using var tenantScope = ServiceProvider.CreateScope();
 
                 var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
@@ -107,7 +113,11 @@ public class NocturneRemoteConnectorBackgroundService : ConnectorBackgroundServi
                     continue;
                 }
 
-                _hubConnections.TryAdd(tenantId, connection);
+                if (!_hubConnections.TryAdd(tenantId, connection))
+                {
+                    await StopAndDisposeAsync(connection);
+                    continue;
+                }
 
                 Logger.LogInformation(
                     "Started real-time listener for NocturneRemote tenant {TenantSlug}",
@@ -123,6 +133,12 @@ public class NocturneRemoteConnectorBackgroundService : ConnectorBackgroundServi
         }
     }
 
+    private static async Task StopAndDisposeAsync(HubConnection connection)
+    {
+        await connection.StopAsync();
+        await connection.DisposeAsync();
+    }
+
     /// <inheritdoc />
     protected override async Task StopRealtimeListenersAsync()
     {
@@ -130,8 +146,7 @@ public class NocturneRemoteConnectorBackgroundService : ConnectorBackgroundServi
         {
             try
             {
-                await connection.StopAsync();
-                await connection.DisposeAsync();
+                await StopAndDisposeAsync(connection);
             }
             catch (Exception ex)
             {

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -889,6 +889,81 @@ public class ConnectorBackgroundServiceTests
     }
 
     /// <summary>
+    /// The poll loop itself must run listener supervision: before the first sync cycle at startup,
+    /// and again on later ticks — that repeat is what replaces a listener that dies mid-lifetime.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_RunsListenerSupervisionFromThePollLoop()
+    {
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+
+        var serviceProvider = BuildServiceProvider(
+            connStr,
+            BuildEnabledConfigMock(),
+            new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 });
+
+        var sut = new PollLoopWiringService(serviceProvider);
+        await sut.StartAsync(CancellationToken.None);
+        try
+        {
+            var winner = await Task.WhenAny(sut.SecondSupervisionPass, Task.Delay(TimeSpan.FromSeconds(10)));
+            winner.Should().Be(sut.SecondSupervisionPass,
+                "the poll loop must re-run listener supervision on later ticks, not just once before the loop");
+        }
+        finally
+        {
+            await sut.StopAsync(CancellationToken.None);
+        }
+
+        sut.Events.TryPeek(out var first);
+        first.Should().Be("listeners", "listener startup must precede the first sync cycle");
+    }
+
+    /// <summary>
+    /// Runs the real ExecuteAsync poll loop with test-fast intervals, recording listener-startup
+    /// passes and sync cycles in order.
+    /// </summary>
+    private sealed class PollLoopWiringService(IServiceProvider serviceProvider)
+        : ConnectorBackgroundService<TestConnectorConfig>(serviceProvider, NullLogger.Instance)
+    {
+        private readonly TaskCompletionSource _secondSupervisionPass =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private int _listenerStartCount;
+
+        public ConcurrentQueue<string> Events { get; } = new();
+
+        public Task SecondSupervisionPass => _secondSupervisionPass.Task;
+
+        protected override string ConnectorName => "TestConnector";
+
+        protected override TimeSpan StartupDelay => TimeSpan.Zero;
+
+        protected override TimeSpan PollInterval => TimeSpan.FromMilliseconds(20);
+
+        protected override TimeSpan RealtimeSupervisionInterval => TimeSpan.Zero;
+
+        protected override Task StartRealtimeListenersAsync(CancellationToken cancellationToken)
+        {
+            Events.Enqueue("listeners");
+            if (Interlocked.Increment(ref _listenerStartCount) >= 2)
+                _secondSupervisionPass.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        protected override Task<SyncResult> PerformSyncAsync(
+            IServiceProvider scopeProvider,
+            TestConnectorConfig config,
+            CancellationToken cancellationToken,
+            ISyncProgressReporter? progressReporter = null)
+        {
+            Events.Enqueue("sync");
+            return Task.FromResult(new SyncResult { Success = true });
+        }
+    }
+
+    /// <summary>
     /// Stand-in for a real-time client whose liveness the test controls.
     /// </summary>
     private sealed class FakeListenerClient

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -802,6 +803,176 @@ public class ConnectorBackgroundServiceTests
         // Sync count should remain at 2 because the nudge was debounced
         // and the 60-minute interval hasn't elapsed
         Assert.Equal(2, syncCount);
+    }
+
+    /// <summary>
+    /// A listener that has died must be evicted from the tracking dictionary and disposed so the next
+    /// supervision pass can replace it, and the loss of real-time delivery must be visible in the log.
+    /// </summary>
+    [Fact]
+    public async Task ListenerNeedsStart_DeadClient_EvictsDisposesAndLogs()
+    {
+        var logger = new MessageRecordingLogger();
+        var sut = new SupervisedListenerService(logger, TimeSpan.Zero);
+        var tenantId = Guid.NewGuid();
+        var client = new FakeListenerClient { IsAlive = false };
+        sut.Clients[tenantId] = client;
+
+        var needsStart = await sut.ListenerNeedsStartAsync(tenantId);
+
+        Assert.True(needsStart);
+        Assert.False(sut.Clients.ContainsKey(tenantId));
+        Assert.Equal(1, client.DisposeCount);
+        Assert.Contains(logger.Messages, m => m.Contains("no longer connected"));
+    }
+
+    /// <summary>
+    /// A tenant whose listener is still connected must be left exactly as it is — no eviction, no
+    /// dispose, and no second client registered on top of it.
+    /// </summary>
+    [Fact]
+    public async Task ListenerNeedsStart_LiveClient_LeavesItRegistered()
+    {
+        var logger = new MessageRecordingLogger();
+        var sut = new SupervisedListenerService(logger, TimeSpan.Zero);
+        var tenantId = Guid.NewGuid();
+        var client = new FakeListenerClient { IsAlive = true };
+        sut.Clients[tenantId] = client;
+
+        var needsStart = await sut.ListenerNeedsStartAsync(tenantId);
+
+        Assert.False(needsStart);
+        Assert.Same(client, sut.Clients[tenantId]);
+        Assert.Equal(0, client.DisposeCount);
+        Assert.Empty(logger.Messages);
+    }
+
+    /// <summary>
+    /// A tenant with no tracked listener at all — never started, or evicted by an earlier pass — needs one.
+    /// </summary>
+    [Fact]
+    public async Task ListenerNeedsStart_NoTrackedClient_RequestsStart()
+    {
+        var sut = new SupervisedListenerService(NullLogger.Instance, TimeSpan.Zero);
+
+        Assert.True(await sut.ListenerNeedsStartAsync(Guid.NewGuid()));
+    }
+
+    /// <summary>
+    /// Once the supervision interval has elapsed the poll loop re-runs listener startup, which is what
+    /// replaces a socket that exhausted its reconnection budget.
+    /// </summary>
+    [Fact]
+    public async Task SuperviseRealtimeListeners_AfterInterval_RunsListenerStartupAgain()
+    {
+        var sut = new SupervisedListenerService(NullLogger.Instance, TimeSpan.Zero);
+
+        await sut.SuperviseOnceAsync(CancellationToken.None);
+        await sut.SuperviseOnceAsync(CancellationToken.None);
+
+        Assert.Equal(2, sut.StartCount);
+    }
+
+    /// <summary>
+    /// Supervision is coarser than the one-minute poll tick, so a permanently unreachable upstream is
+    /// not reconnected on every cycle.
+    /// </summary>
+    [Fact]
+    public async Task SuperviseRealtimeListeners_WithinInterval_DoesNotRunListenerStartupAgain()
+    {
+        var sut = new SupervisedListenerService(NullLogger.Instance, TimeSpan.FromMinutes(5));
+
+        await sut.SuperviseOnceAsync(CancellationToken.None);
+        await sut.SuperviseOnceAsync(CancellationToken.None);
+
+        Assert.Equal(1, sut.StartCount);
+    }
+
+    /// <summary>
+    /// Stand-in for a real-time client whose liveness the test controls.
+    /// </summary>
+    private sealed class FakeListenerClient
+    {
+        public bool IsAlive { get; init; }
+
+        public int DisposeCount { get; private set; }
+
+        public Task DisposeAsync()
+        {
+            DisposeCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Exposes the base class's real-time supervision hooks and counts listener-startup passes.
+    /// </summary>
+    private sealed class SupervisedListenerService(ILogger logger, TimeSpan supervisionInterval)
+        : ConnectorBackgroundService<TestConnectorConfig>(new ServiceCollection().BuildServiceProvider(), logger)
+    {
+        private int _startCount;
+
+        public ConcurrentDictionary<Guid, FakeListenerClient> Clients { get; } = new();
+
+        public int StartCount => _startCount;
+
+        protected override string ConnectorName => "TestConnector";
+
+        protected override TimeSpan RealtimeSupervisionInterval => supervisionInterval;
+
+        protected override Task StartRealtimeListenersAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _startCount);
+            return Task.CompletedTask;
+        }
+
+        protected override Task<SyncResult> PerformSyncAsync(
+            IServiceProvider scopeProvider,
+            TestConnectorConfig config,
+            CancellationToken cancellationToken,
+            ISyncProgressReporter? progressReporter = null)
+            => throw new NotSupportedException();
+
+        public Task<bool> ListenerNeedsStartAsync(Guid tenantId)
+            => ListenerNeedsStartAsync(Clients, tenantId, "test-tenant", c => c.IsAlive, c => c.DisposeAsync());
+
+        /// <summary>
+        /// Invokes the private supervision pass the poll loop runs each tick, via reflection.
+        /// </summary>
+        public async Task SuperviseOnceAsync(CancellationToken ct)
+        {
+            var method = typeof(ConnectorBackgroundService<TestConnectorConfig>)
+                .GetMethod("SuperviseRealtimeListenersAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            await (Task)method.Invoke(this, [ct])!;
+        }
+    }
+
+    /// <summary>
+    /// Records formatted log messages so tests can assert on what was reported.
+    /// </summary>
+    private sealed class MessageRecordingLogger : ILogger
+    {
+        private readonly List<string> _messages = [];
+
+        public IReadOnlyList<string> Messages
+        {
+            get { lock (_messages) return _messages.ToList(); }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (_messages)
+                _messages.Add(formatter(state, exception));
+        }
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -11,6 +12,7 @@ using Nocturne.Connectors.Nightscout.Services;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
+using SocketIOClient;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.BackgroundServices;
@@ -204,7 +206,48 @@ public class NightscoutRealtimeListenerTests
         Assert.DoesNotContain(logger.Exceptions, ex => ex is UriFormatException);
     }
 
+    /// <summary>
+    /// A socket that exhausts its reconnection budget stops trying and reports Connected == false, but
+    /// stays in the tracking dictionary. A repeat listener-startup pass must evict and dispose it so a
+    /// fresh client can take its place, rather than treating the tenant as already covered.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_TrackedClientDisconnected_EvictsDeadClient()
+    {
+        // Arrange — one tenant with an already-tracked client that is not connected
+        var (cleanup, connectionString, tenantId) = CreateSqliteDbWithTenantId(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "http://127.0.0.1:9",
+        };
+
+        var serviceProvider = BuildServiceProvider(connectionString, config);
+        var sut = new NightscoutConnectorBackgroundService(
+            serviceProvider,
+            NullLogger<NightscoutConnectorBackgroundService>.Instance);
+
+        var dead = new SocketIO(new Uri("http://127.0.0.1:9"));
+        SocketClients(sut)[tenantId] = dead;
+
+        // Act
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+
+        // Assert — the dead client is gone (the replacement connect fails; the tenant polls meanwhile)
+        Assert.DoesNotContain(dead, SocketClients(sut).Values);
+    }
+
     #region Helpers
+
+    /// <summary>
+    /// Reaches the private per-tenant Socket.IO client dictionary.
+    /// </summary>
+    private static ConcurrentDictionary<Guid, SocketIO> SocketClients(NightscoutConnectorBackgroundService sut)
+        => (ConcurrentDictionary<Guid, SocketIO>)typeof(NightscoutConnectorBackgroundService)
+            .GetField("_socketClients", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(sut)!;
 
     /// <summary>
     /// Captures exceptions passed to the logger so tests can assert on how a failure surfaced.
@@ -267,9 +310,17 @@ public class NightscoutRealtimeListenerTests
     /// </summary>
     private static (IDisposable cleanup, string connectionString) CreateSqliteDb(bool addTenant)
     {
+        var (cleanup, connectionString, _) = CreateSqliteDbWithTenantId(addTenant);
+        return (cleanup, connectionString);
+    }
+
+    /// <inheritdoc cref="CreateSqliteDb"/>
+    private static (IDisposable cleanup, string connectionString, Guid tenantId) CreateSqliteDbWithTenantId(bool addTenant)
+    {
         var dbPath = Path.Combine(Path.GetTempPath(), $"NsRealtimeTest_{Guid.NewGuid():N}.db");
         var connectionString = $"Data Source={dbPath}";
         var cleanup = new TempFileCleanup(dbPath);
+        var tenantId = Guid.Empty;
 
         var options = new DbContextOptionsBuilder<NocturneDbContext>()
             .UseSqlite(connectionString)
@@ -291,14 +342,14 @@ public class NightscoutRealtimeListenerTests
 
         if (addTenant)
         {
-            var tenantId = Guid.NewGuid();
+            tenantId = Guid.NewGuid();
             context.Database.ExecuteSqlRaw(
                 "INSERT INTO tenants (Id, slug, display_name, is_active, allow_access_requests, sys_created_at, sys_updated_at) VALUES ({0}, {1}, {2}, 1, 1, {3}, {4})",
                 tenantId.ToString(), "test-tenant", "Test Tenant",
                 DateTime.UtcNow.ToString("O"), DateTime.UtcNow.ToString("O"));
         }
 
-        return (cleanup, connectionString);
+        return (cleanup, connectionString, tenantId);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

The tenant Socket.IO client is created with `ReconnectionAttempts = 3`, and that budget also governs reconnects after an established connection drops — a socket that loses its upstream three times stops trying. Listeners were started exactly once, before the poll loop, and the dead client stayed in `_socketClients` unexamined: the tenant silently fell back to interval polling until the process restarted, with no log at the moment realtime stopped.

The budget can't simply be raised: the client library evaluates `attempts * ReconnectionDelayMax` in int arithmetic, so a large value overflows and `ConnectAsync` throws — the bug #589 fixed.

`NocturneRemoteConnectorBackgroundService` had the same once-only shape, plus a latent leak: its `TryAdd` return was discarded, so a re-run would have leaked a duplicate `HubConnection` per tenant per pass.

## Fix

- The pre-loop listener startup moves into a supervision pass at the top of every poll tick, gated by `RealtimeSupervisionInterval` (5 min, virtual for tests) so a permanently unreachable upstream isn't redialled — and warned about — every 60s. The `do/while` runs immediately, so startup ordering is unchanged.
- A shared `ListenerNeedsStartAsync` on the base leaves a live tracked client untouched, and for a dead one evicts it, logs the loss of real-time delivery, disposes it, and asks the caller to replace it. Nightscout probes `c.Connected`; NocturneRemote probes `State != Disconnected` (its retry policy is infinite, so `Reconnecting` is still alive).
- Both connectors now dispose the new client when `TryAdd` loses, and teardown reuses the same dispose helpers.
- Bonus: tenants created after process start now gain listeners on a later supervision pass instead of never.

## Tests

Five new base-class tests (eviction+dispose+log for dead, no-touch for live, start-requested for untracked, interval gating both ways) plus a Nightscout-level test seeding a disconnected `SocketIO` and asserting eviction. Mutation-proven: reverting the three behaviours fails exactly the three corresponding tests. Suite: 31/31; full project green apart from the two known load-flaky benchmarks.

Follow-up from #589.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
