### PR TITLE
chore(trackers): drop the dead repeat_interval_mins and max_repeats threshold columns

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
@@ -305,8 +305,6 @@ public class TrackersController : ControllerBase, IWriteScopedController
                         AudioEnabled = threshold.AudioEnabled,
                         AudioSound = threshold.AudioSound,
                         VibrateEnabled = threshold.VibrateEnabled,
-                        RepeatIntervalMins = threshold.RepeatIntervalMins,
-                        MaxRepeats = threshold.MaxRepeats,
                         RespectQuietHours = threshold.RespectQuietHours,
                     }
                 );
@@ -415,8 +413,6 @@ public class TrackersController : ControllerBase, IWriteScopedController
                         AudioEnabled = t.AudioEnabled,
                         AudioSound = t.AudioSound,
                         VibrateEnabled = t.VibrateEnabled,
-                        RepeatIntervalMins = t.RepeatIntervalMins,
-                        MaxRepeats = t.MaxRepeats,
                         RespectQuietHours = t.RespectQuietHours,
                     })
                     .ToList(),
@@ -854,8 +850,6 @@ public class NotificationThresholdDto
     public bool AudioEnabled { get; set; }
     public string? AudioSound { get; set; }
     public bool VibrateEnabled { get; set; }
-    public int RepeatIntervalMins { get; set; }
-    public int MaxRepeats { get; set; }
     public bool RespectQuietHours { get; set; }
 
     public static NotificationThresholdDto FromEntity(TrackerNotificationThresholdEntity entity) =>
@@ -871,8 +865,6 @@ public class NotificationThresholdDto
             AudioEnabled = entity.AudioEnabled,
             AudioSound = entity.AudioSound,
             VibrateEnabled = entity.VibrateEnabled,
-            RepeatIntervalMins = entity.RepeatIntervalMins,
-            MaxRepeats = entity.MaxRepeats,
             RespectQuietHours = entity.RespectQuietHours,
         };
 }
@@ -1146,8 +1138,6 @@ public class CreateNotificationThresholdRequest
     public bool AudioEnabled { get; set; }
     public string? AudioSound { get; set; }
     public bool VibrateEnabled { get; set; }
-    public int RepeatIntervalMins { get; set; }
-    public int MaxRepeats { get; set; } = 3;
     public bool RespectQuietHours { get; set; } = true;
 }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TrackerNotificationThresholdEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/TrackerNotificationThresholdEntity.cs
@@ -83,18 +83,6 @@ public class TrackerNotificationThresholdEntity : ITenantScoped
     public bool VibrateEnabled { get; set; } = false;
 
     /// <summary>
-    /// Repeat interval in minutes (0 = no repeat)
-    /// </summary>
-    [Column("repeat_interval_mins")]
-    public int RepeatIntervalMins { get; set; } = 0;
-
-    /// <summary>
-    /// Maximum number of repeats (0 = unlimited until acknowledged)
-    /// </summary>
-    [Column("max_repeats")]
-    public int MaxRepeats { get; set; } = 3;
-
-    /// <summary>
     /// Whether this notification respects quiet hours
     /// </summary>
     [Column("respect_quiet_hours")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811112649_DropTrackerThresholdRepeatColumns.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811112649_DropTrackerThresholdRepeatColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811112649_DropTrackerThresholdRepeatColumns")]
+    partial class DropTrackerThresholdRepeatColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811112649_DropTrackerThresholdRepeatColumns.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811112649_DropTrackerThresholdRepeatColumns.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropTrackerThresholdRepeatColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "max_repeats",
+                table: "tracker_notification_thresholds");
+
+            migrationBuilder.DropColumn(
+                name: "repeat_interval_mins",
+                table: "tracker_notification_thresholds");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "max_repeats",
+                table: "tracker_notification_thresholds",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "repeat_interval_mins",
+                table: "tracker_notification_thresholds",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/tests/Integration/Nocturne.API.Tests/Monitoring/TrackerIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Monitoring/TrackerIntegrationTests.cs
@@ -61,8 +61,6 @@ public class TrackerIntegrationTests : AspireIntegrationTestBase
                 hours = 648,
                 pushEnabled = true,
                 displayOrder = 0,
-                repeatIntervalMins = 60,
-                maxRepeats = 3,
                 respectQuietHours = true
             }
         }


### PR DESCRIPTION
## What

Re-notification moved to `alert_state` escalation rules when tracker notifications were unified onto the alert engine (#446); `repeat_interval_mins` and `max_repeats` have had no reader since beyond DTO round-trips. A tracked-file grep finds exactly 16 references in 3 files: the entity's two `[Column]` properties, ten pure round-trip lines in `TrackersController` (DTO/request declarations and mapping assignments), and two fields in an integration-test payload. No SQL strings, no service or repository reader, no `TrackerAlertRuleSyncService` reference, no frontend or SDK-spec hit.

The other columns #446 once named as retired are **not** dead (`RespectQuietHours`, `PushEnabled`, `AudioEnabled`/`AudioSound`/`VibrateEnabled` still seed the synthesised rule at create time) and are untouched here.

## Changes

- Entity, DTO/request declarations and mapping lines removed; integration-test payload updated. No test existed that only exercised these fields.
- Migration `DropTrackerThresholdRepeatColumns` generated via `dotnet ef migrations add` (design-time factory): `Up` is exactly two `DropColumn` ops, `Down` restores the two int columns. Snapshot churn is exactly the two property blocks.

## Tests

`--filter FullyQualifiedName~Tracker`: 85/85. Full unit suite green apart from the pre-existing stale cache test (fixed separately in #687) and the known load-flaky memory benchmark.

## Deploy note

Dropping columns is not backward-compatible with a running pre-merge image: don't roll the API back past this migration once it has applied. With no readers, practical risk is confined to the `Down` path.

Follow-up from #446.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
