### PR TITLE
fix(nightscout): stop the created_at crawl skipping offset-formatted records

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -601,12 +601,14 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     /// <param name="buildUrl">Builds the request URL for the given bounds.</param>
     /// <param name="oldestOf">Extracts the oldest record time from a page, or null when the page has no usable times.</param>
     /// <param name="operationName">Operation label for fetch logging.</param>
+    /// <param name="keep">Optional page filter; pagination still steps on the unfiltered page.</param>
     private async IAsyncEnumerable<T[]> FetchPagesAsync<T>(
         DateTime? from,
         DateTime? to,
         Func<DateTime?, DateTime?, string> buildUrl,
         Func<T[], DateTime?> oldestOf,
-        string operationName)
+        string operationName,
+        Func<T[], T[]>? keep = null)
     {
         var currentTo = AnchorUnboundedFetch(from, to);
 
@@ -624,7 +626,9 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             if (page.Length == 0)
                 yield break;
 
-            yield return page;
+            var kept = keep is null ? page : keep(page);
+            if (kept.Length > 0)
+                yield return kept;
 
             // Fewer than MaxCount means we've fetched everything in this range
             if (page.Length < _currentConfig.MaxCount)
@@ -660,25 +664,74 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             : null;
     }
 
+    private static DateTimeOffset? ParseCreatedAt(string? createdAt) =>
+        DateTimeOffset.TryParse(createdAt, out var parsed) ? parsed : null;
+
     /// <summary>
     ///     Oldest created_at on a page. Uses DateTimeOffset for consistent UTC comparison
     ///     regardless of system timezone.
     /// </summary>
-    private static DateTime? OldestCreatedAt<T>(T[] page, Func<T, string?> createdAtOf)
-    {
-        return page
-            .Select(item => DateTimeOffset.TryParse(createdAtOf(item), out var dto) ? dto.UtcDateTime : (DateTime?)null)
-            .Where(dt => dt.HasValue)
-            .Min();
-    }
+    private static DateTime? OldestCreatedAt<T>(T[] page, Func<T, string?> createdAtOf) =>
+        page.Select(item => ParseCreatedAt(createdAtOf(item))?.UtcDateTime).Min();
 
     /// <summary>Newest created_at on a page; the counterpart of <see cref="OldestCreatedAt{T}"/>.</summary>
-    private static DateTime? NewestCreatedAt<T>(T[] page, Func<T, string?> createdAtOf)
+    private static DateTime? NewestCreatedAt<T>(T[] page, Func<T, string?> createdAtOf) =>
+        page.Select(item => ParseCreatedAt(createdAtOf(item))?.UtcDateTime).Max();
+
+    /// <summary>
+    ///     Oldest created_at on a page as the source wrote it — the key the source orders and
+    ///     filters by. Labelled UTC so formatting it back into a bound reproduces that wall clock
+    ///     verbatim rather than shifting it by the host's timezone.
+    /// </summary>
+    private static DateTime? OldestWrittenCreatedAt<T>(T[] page, Func<T, string?> createdAtOf) =>
+        page.Select(item => ParseCreatedAt(createdAtOf(item)) is { } parsed
+                ? DateTime.SpecifyKind(parsed.DateTime, DateTimeKind.Utc)
+                : (DateTime?)null)
+            .Min();
+
+    /// <summary>
+    ///     Whether a created_at falls inside the caller's window. A value that will not parse is
+    ///     kept: the crawl has never dropped records it cannot date.
+    /// </summary>
+    private static bool WithinWindow(string? createdAt, DateTime? from, DateTime? to)
     {
-        return page
-            .Select(item => DateTimeOffset.TryParse(createdAtOf(item), out var dto) ? dto.UtcDateTime : (DateTime?)null)
-            .Where(dt => dt.HasValue)
-            .Max();
+        if (ParseCreatedAt(createdAt) is not { } parsed)
+            return true;
+
+        return (from is null || parsed.UtcDateTime >= from.Value)
+            && (to is null || parsed.UtcDateTime <= to.Value);
+    }
+
+    // Real-world UTC offsets span -12:00 to +14:00.
+    private static readonly TimeSpan MaxUtcOffset = TimeSpan.FromHours(14);
+
+    /// <summary>
+    ///     Pages a created_at collection. Legacy Nightscout stores created_at as a string and
+    ///     compares it as one, so a record an old uploader wrote with a local offset
+    ///     ("2020-06-15T20:00:00+10:00") orders by its wall clock rather than its instant — up to
+    ///     <see cref="MaxUtcOffset"/> away. The requested window is widened by that envelope so such
+    ///     records are returned at all, and each page is filtered back to the true window here.
+    ///     Only the opening bounds are widened: the page cursor is already a wall clock the source
+    ///     returned, so widening it again would step over records the source has yet to serve.
+    ///     The filter's ceiling is the anchor the fetch bound was widened from, so an unbounded
+    ///     backfill still stops at "now" rather than importing a future-dated device clock.
+    /// </summary>
+    private IAsyncEnumerable<T[]> FetchCreatedAtPagesAsync<T>(
+        DateTime? from,
+        DateTime? to,
+        string collection,
+        Func<T, string?> createdAtOf,
+        string operationName)
+    {
+        var anchoredTo = AnchorUnboundedFetch(from, to);
+
+        return FetchPagesAsync<T>(
+            from - MaxUtcOffset,
+            anchoredTo + MaxUtcOffset,
+            (pageFrom, pageTo) => BuildCreatedAtUrl(collection, pageFrom, pageTo),
+            page => OldestWrittenCreatedAt(page, createdAtOf),
+            operationName,
+            page => page.Where(item => WithinWindow(createdAtOf(item), from, anchoredTo)).ToArray());
     }
 
     private async IAsyncEnumerable<Entry[]> FetchGlucosePagesAsync(DateTime? from, DateTime? to)
@@ -694,8 +747,8 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
     private async IAsyncEnumerable<Treatment[]> FetchTreatmentPagesAsync(DateTime? from, DateTime? to)
     {
-        await foreach (var page in FetchPagesAsync<Treatment>(
-            from, to, BuildTreatmentsUrl, p => OldestCreatedAt(p, t => t.CreatedAt), "FetchTreatments"))
+        await foreach (var page in FetchCreatedAtPagesAsync<Treatment>(
+            from, to, "treatments", t => t.CreatedAt, "FetchTreatments"))
         {
             foreach (var treatment in page)
                 treatment.DataSource = ConnectorSource;
@@ -756,8 +809,8 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     }
 
     private IAsyncEnumerable<DeviceStatus[]> FetchDeviceStatusPagesAsync(DateTime? from, DateTime? to) =>
-        FetchPagesAsync<DeviceStatus>(
-            from, to, BuildDeviceStatusUrl, p => OldestCreatedAt(p, d => d.CreatedAt), "FetchDeviceStatus");
+        FetchCreatedAtPagesAsync<DeviceStatus>(
+            from, to, "devicestatus", d => d.CreatedAt, "FetchDeviceStatus");
 
     private async Task<IEnumerable<Food>> FetchFoodAsync()
     {
@@ -782,8 +835,8 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     }
 
     private IAsyncEnumerable<Activity[]> FetchActivityPagesAsync(DateTime? from, DateTime? to) =>
-        FetchPagesAsync<Activity>(
-            from, to, BuildActivityUrl, p => OldestCreatedAt(p, a => a.CreatedAt), "FetchActivity");
+        FetchCreatedAtPagesAsync<Activity>(
+            from, to, "activity", a => a.CreatedAt, "FetchActivity");
 
     private async Task<T?> FetchDataAsync<T>(string url, string operationName) where T : class
     {
@@ -833,35 +886,9 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         return url;
     }
 
-    private string BuildTreatmentsUrl(DateTime? from, DateTime? to)
+    private string BuildCreatedAtUrl(string collection, DateTime? from, DateTime? to)
     {
-        var url = $"/api/v1/treatments.json?count={_currentConfig.MaxCount}";
-
-        if (from.HasValue)
-            url += $"&find[created_at][$gte]={from.Value.ToUniversalTime():o}";
-
-        if (to.HasValue)
-            url += $"&find[created_at][$lte]={to.Value.ToUniversalTime():o}";
-
-        return url;
-    }
-
-    private string BuildDeviceStatusUrl(DateTime? from, DateTime? to)
-    {
-        var url = $"/api/v1/devicestatus.json?count={_currentConfig.MaxCount}";
-
-        if (from.HasValue)
-            url += $"&find[created_at][$gte]={from.Value.ToUniversalTime():o}";
-
-        if (to.HasValue)
-            url += $"&find[created_at][$lte]={to.Value.ToUniversalTime():o}";
-
-        return url;
-    }
-
-    private string BuildActivityUrl(DateTime? from, DateTime? to)
-    {
-        var url = $"/api/v1/activity.json?count={_currentConfig.MaxCount}";
+        var url = $"/api/v1/{collection}.json?count={_currentConfig.MaxCount}";
 
         if (from.HasValue)
             url += $"&find[created_at][$gte]={from.Value.ToUniversalTime():o}";

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
@@ -23,7 +24,8 @@ public class NightscoutConnectorPaginationTests
     private static NightscoutConnectorService CreateService(
         HttpMessageHandler handler,
         NightscoutConnectorConfiguration? config = null,
-        bool withPublisher = false)
+        bool withPublisher = false,
+        List<Treatment>? publishedTreatments = null)
     {
         config ??= new NightscoutConnectorConfiguration
         {
@@ -48,6 +50,8 @@ public class NightscoutConnectorPaginationTests
             var treatmentMock = new Mock<ITreatmentPublisher>();
             treatmentMock.Setup(p => p.PublishTreatmentsAsync(
                     It.IsAny<IEnumerable<Treatment>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+                .Callback<IEnumerable<Treatment>, string, WriteOrigin, CancellationToken>(
+                    (batch, _, _, _) => publishedTreatments?.AddRange(batch))
                 .ReturnsAsync(true);
 
             var mock = new Mock<IConnectorPublisher>();
@@ -335,10 +339,9 @@ public class NightscoutConnectorPaginationTests
     public async Task FetchTreatments_MultiplePages_ReturnsAll()
     {
         var page1 = CreateTreatments(MaxCount, BaseTime);
-        var oldestDate = page1
-            .Select(t => DateTime.Parse(t.CreatedAt!))
-            .Min();
-        var page2Start = new DateTimeOffset(DateTime.SpecifyKind(oldestDate, DateTimeKind.Utc))
+        var page2Start = page1
+            .Select(t => DateTimeOffset.Parse(t.CreatedAt!, CultureInfo.InvariantCulture))
+            .Min()
             .AddMilliseconds(-1);
         var page2 = CreateTreatments(4, page2Start);
 
@@ -473,4 +476,158 @@ public class NightscoutConnectorPaginationTests
 
     #endregion
 
+    #region Offset-formatted created_at
+
+    private const string InWindowOffset = "2025-06-15T21:30:00+10:00";      // 11:30Z
+    private const string AfterWindowOffset = "2025-06-15T23:00:00+10:00";   // 13:00Z
+    private const string InWindowUtc = "2025-06-15T11:00:00.000Z";
+
+    private static Treatment OffsetTreatment(string createdAt) =>
+        new() { Created_at = createdAt, EventType = "Correction Bolus", Insulin = 1.0 };
+
+    private static async Task<(Nocturne.Connectors.Core.Models.SyncResult Result, List<Treatment> Published)> SyncTreatmentsAsync(
+        LegacyTreatmentsHandler handler,
+        DateTimeOffset? from,
+        DateTimeOffset? to)
+    {
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "https://nightscout.example.com",
+            ApiSecret = "test-secret",
+            MaxCount = MaxCount,
+        };
+
+        var published = new List<Treatment>();
+        var service = CreateService(handler, config, withPublisher: true, publishedTreatments: published);
+
+        var request = new Nocturne.Connectors.Core.Models.SyncRequest
+        {
+            From = from?.UtcDateTime,
+            To = to?.UtcDateTime,
+            DataTypes = [Nocturne.Connectors.Core.Models.SyncDataType.Boluses],
+        };
+
+        return (await service.SyncDataAsync(request, config, CancellationToken.None), published);
+    }
+
+    [Fact]
+    public async Task Treatments_OffsetFormattedCreatedAtInsideWindow_IsImported()
+    {
+        // Legacy Nightscout compares created_at as a string, so a record an old uploader wrote
+        // with a local offset sorts by its wall clock: "2025-06-15T21:30:00+10:00" is the same
+        // instant as 11:30Z but sorts ABOVE a 12:00Z upper bound, and used to fall outside every
+        // page of the crawl.
+        var handler = new LegacyTreatmentsHandler(
+            OffsetTreatment(InWindowOffset),
+            OffsetTreatment(InWindowUtc));
+
+        var (result, published) = await SyncTreatmentsAsync(handler, BaseTime.AddHours(-2), BaseTime);
+
+        result.Success.Should().BeTrue();
+        handler.ServedCreatedAt.Should().Contain(InWindowOffset,
+            "the requested window must be wide enough for the source's string comparison to return it");
+        published.Select(t => t.CreatedAt).Should().BeEquivalentTo([InWindowOffset, InWindowUtc]);
+    }
+
+    [Fact]
+    public async Task Treatments_OffsetFormattedCreatedAtOutsideWindow_IsFetchedButDropped()
+    {
+        // The widened request pulls in records either side of the true window; the client-side
+        // filter on the parsed instant is what keeps the window honest.
+        var handler = new LegacyTreatmentsHandler(
+            OffsetTreatment(AfterWindowOffset),
+            OffsetTreatment(InWindowUtc));
+
+        var (result, published) = await SyncTreatmentsAsync(handler, BaseTime.AddHours(-2), BaseTime);
+
+        result.Success.Should().BeTrue();
+        handler.ServedCreatedAt.Should().Contain(AfterWindowOffset,
+            "the widening must actually return the out-of-window record, or the filter is untested");
+        published.Select(t => t.CreatedAt).Should().Equal(InWindowUtc);
+    }
+
+    [Fact]
+    public async Task Treatments_OffsetFormattedCreatedAtAcrossPages_PaginatesToTheEnd()
+    {
+        // The page cursor has to step in the source's wall-clock space: a cursor in instant space
+        // steps the next bound past records the source has not served yet, and the crawl ends
+        // after the first page.
+        var stored = Enumerable.Range(0, MaxCount + 4)
+            .Select(i => OffsetTreatment(
+                BaseTime.AddMinutes(-5 * i).AddHours(10).UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fff") + "+10:00"))
+            .ToArray();
+
+        var handler = new LegacyTreatmentsHandler(stored);
+
+        var (result, published) = await SyncTreatmentsAsync(handler, BaseTime.AddHours(-6), BaseTime);
+
+        result.Success.Should().BeTrue();
+        published.Select(t => t.CreatedAt)
+            .Should().BeEquivalentTo(stored.Select(t => t.CreatedAt),
+                "every offset-formatted record in the window must be crawled, not just the first page");
+        handler.RequestUrls.Count(u => u.Contains("treatments.json")).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Treatments_UnboundedBackfill_DoesNotImportFutureDatedRecords()
+    {
+        // An unbounded backfill anchors its upper bound to "now", and the widening lifts the
+        // fetch bound 14h past that. The client-side filter has to keep the original anchor as
+        // its ceiling, or a device with a fast clock starts landing in "latest" displays.
+        var future = DateTimeOffset.UtcNow.AddHours(3).UtcDateTime.ToString("o");
+        var past = DateTimeOffset.UtcNow.AddHours(-1).UtcDateTime.ToString("o");
+
+        var handler = new LegacyTreatmentsHandler(
+            OffsetTreatment(future),
+            OffsetTreatment(past));
+
+        var (result, published) = await SyncTreatmentsAsync(handler, from: null, to: null);
+
+        result.Success.Should().BeTrue();
+        handler.ServedCreatedAt.Should().Contain(future,
+            "the widened fetch bound reaches 14h past the anchor, so the source does return it");
+        published.Select(t => t.CreatedAt).Should().Equal(past);
+    }
+
+    /// <summary>
+    /// Stands in for legacy Nightscout's treatments collection, where created_at is a plain
+    /// string: the find bounds and the newest-first sort are ordinal string comparisons.
+    /// </summary>
+    private sealed class LegacyTreatmentsHandler(params Treatment[] stored) : HttpMessageHandler
+    {
+        public List<string> RequestUrls { get; } = [];
+        public List<string> ServedCreatedAt { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = Uri.UnescapeDataString(request.RequestUri?.PathAndQuery ?? "");
+            RequestUrls.Add(url);
+
+            if (!url.Contains("treatments.json"))
+                return Task.FromResult(JsonResponse(Array.Empty<Treatment>()));
+
+            var gte = Bound(url, "gte");
+            var lte = Bound(url, "lte");
+            var count = int.Parse(System.Text.RegularExpressions.Regex.Match(url, @"count=(\d+)").Groups[1].Value);
+
+            var page = stored
+                .Where(t => (gte is null || string.CompareOrdinal(t.CreatedAt, gte) >= 0)
+                            && (lte is null || string.CompareOrdinal(t.CreatedAt, lte) <= 0))
+                .OrderByDescending(t => t.CreatedAt, StringComparer.Ordinal)
+                .Take(count)
+                .ToArray();
+
+            ServedCreatedAt.AddRange(page.Select(t => t.CreatedAt!));
+            return Task.FromResult(JsonResponse(page));
+        }
+
+        private static string? Bound(string url, string op)
+        {
+            var match = System.Text.RegularExpressions.Regex.Match(url, $@"\[\${op}\]=([^&]+)");
+            return match.Success ? match.Groups[1].Value : null;
+        }
+    }
+
+    #endregion
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutPerTypeCursorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutPerTypeCursorTests.cs
@@ -83,14 +83,20 @@ public class NightscoutPerTypeCursorTests
         MaxCount = MaxCount,
     };
 
-    /// <summary>Extracts the <c>find[created_at][$gte]</c> lower bound from a recorded request URL.</summary>
-    private static DateTime ExtractGte(string url)
+    /// <summary>
+    /// Recovers the cursor a request's <c>find[created_at][$gte]</c> bound was derived from. The
+    /// wire bound is widened by the max-UTC-offset envelope so offset-formatted created_at values
+    /// still fall inside it; these tests are about which cursor each data type picks, not the
+    /// envelope.
+    /// </summary>
+    private static DateTime ExtractCursor(string url)
     {
         var decoded = Uri.UnescapeDataString(url);
         var match = Regex.Match(decoded, @"\$gte\]=([^&]+)");
         match.Success.Should().BeTrue($"request URL should carry a created_at lower bound: {decoded}");
         return DateTime.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)
-            .ToUniversalTime();
+            .ToUniversalTime()
+            .Add(TimeSpan.FromHours(14));
     }
 
     private static string TreatmentsUrl(SequentialMockHandler handler) =>
@@ -165,9 +171,9 @@ public class NightscoutPerTypeCursorTests
 
         await service.SyncDataAsync(request, config, CancellationToken.None);
 
-        var gte = ExtractGte(TreatmentsUrl(handler));
+        var cursor = ExtractCursor(TreatmentsUrl(handler));
         // Catch-up resumes from the latest treatment minus a small overlap, independent of glucose.
-        gte.Should().BeCloseTo(treatmentLatest.AddMinutes(-5), TimeSpan.FromMinutes(1));
+        cursor.Should().BeCloseTo(treatmentLatest.AddMinutes(-5), TimeSpan.FromMinutes(1));
     }
 
     [Fact]
@@ -191,8 +197,8 @@ public class NightscoutPerTypeCursorTests
 
         await service.SyncDataAsync(request, config, CancellationToken.None);
 
-        var gte = ExtractGte(TreatmentsUrl(handler));
-        gte.Should().BeCloseTo(from, TimeSpan.FromSeconds(1));
+        var cursor = ExtractCursor(TreatmentsUrl(handler));
+        cursor.Should().BeCloseTo(from, TimeSpan.FromSeconds(1));
     }
 
     [Fact]
@@ -212,8 +218,8 @@ public class NightscoutPerTypeCursorTests
 
         await service.SyncDataAsync(request, config, CancellationToken.None);
 
-        var gte = ExtractGte(DeviceStatusUrl(handler));
-        gte.Should().BeCloseTo(from, TimeSpan.FromSeconds(1));
+        var cursor = ExtractCursor(DeviceStatusUrl(handler));
+        cursor.Should().BeCloseTo(from, TimeSpan.FromSeconds(1));
     }
 
     private static HttpResponseMessage JsonResponse<T>(T data) =>


### PR DESCRIPTION
## Problem

Legacy Nightscout stores `created_at` as a string and compares it lexicographically. Our treatment/device-status/activity bounds are Z-suffixed round-trip strings, so a document an old uploader wrote with a local UTC offset (`"2020-06-15T20:00:00+10:00"`) sorts by its wall clock — up to 14h above the Z anchor for the same instant. The paginated crawl always carries an upper bound and steps it down per page, so such a record fell outside every page and was never imported. Entries are unaffected (numeric `find[date]`).

## Fix

One entry point for the three created_at collections, `FetchCreatedAtPagesAsync`:

- The requested window is widened by the real-world offset envelope (−12:00…+14:00 → 14h both ways) so the server returns offset-written candidates at all; each page is filtered back to the true window client-side by parsed instant.
- The filter's ceiling is the resolved anchor (not the raw `to`), so the unbounded-backfill path keeps its old "nothing past now" behaviour instead of importing up to 14h of future-dated records the widened fetch would admit. Catch-up crawls (`to = null`) are unchanged — they never had an upper bound.
- The crux is the page cursor: it now descends in the server's comparison space (the created_at as the source wrote it, `OldestWrittenCreatedAt`) rather than instant space. An instant-space cursor silently truncates the crawl — proven by mutation: flipping it back loses page 2 (10 of 14 records).
- Unparseable `created_at` is kept, as the crawl has always done.
- The three identical URL builders collapse into `BuildCreatedAtUrl(collection, from, to)`.

## Tests

New `LegacyTreatmentsHandler` test double reproduces legacy Nightscout faithfully: ordinal string comparison for the find bounds and newest-first ordinal sort. Four scenarios: an in-window `+10:00` record imports; an out-of-window offset record is served by the widened fetch but dropped (asserted served, so non-vacuous); 14 offset records across 2 pages all arrive; a future-dated record on an unbounded backfill is served but not published. Mutation-proven three ways (zeroed envelope → 3 fail; instant-space cursor → pagination truncates; raw-`to` filter ceiling → future-record test fails). `~Nightscout` suite: 88/88.

## Accepted cost

A catch-up crawl re-requests up to 14h of already-imported history per cycle for these three collections (device status being the high-volume one). Rows are dropped client-side before publish; dedup is unaffected — fetch bandwidth only.

Follow-up from #625/#626.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
