### PR TITLE
fix(v4): apply the source filter on snapshot list reads by migrating the three snapshot repositories onto V4RepositoryBase

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.ApsSnapshot
 /// </summary>
 [Table("aps_snapshots")]
-public class ApsSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class ApsSnapshotEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PumpSnapshot
 /// </summary>
 [Table("pump_snapshots")]
-public class PumpSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class PumpSnapshotEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.UploaderSnapshot
 /// </summary>
 [Table("uploader_snapshots")]
-public class UploaderSnapshotEntity : ITenantScoped, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class UploaderSnapshotEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -1,10 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
@@ -12,213 +12,49 @@ using Nocturne.Core.Contracts.V4;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing APS snapshots in the database.
+/// Repository for managing APS snapshots in the database. Inherits the shared CRUD, soft-delete and
+/// LegacyId-deduplicated bulk-insert surface from <see cref="V4RepositoryBase{TModel,TEntity}"/> and
+/// keeps only the APS-specific queries and the (DataSource, SyncIdentifier) upsert below.
 /// </summary>
-public class ApsSnapshotRepository : IApsSnapshotRepository
+public class ApsSnapshotRepository : V4RepositoryBase<ApsSnapshot, ApsSnapshotEntity>, IApsSnapshotRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
-    private readonly ILogger<ApsSnapshotRepository> _logger;
-    private readonly IV4RecordBroadcaster<ApsSnapshot>? _broadcaster;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ApsSnapshotRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
+    // logger is unused but retained for DI + direct test construction.
     public ApsSnapshotRepository(
         ITenantDbContextFactory contextFactory,
+        IAuditContext auditContext,
         ILogger<ApsSnapshotRepository> logger,
         IV4RecordBroadcaster<ApsSnapshot>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
-        _contextFactory = contextFactory;
-        _logger = logger;
-        _broadcaster = broadcaster;
     }
 
-    /// <summary>
-    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
-    /// writes (backfill imports stay silent). Mirrors the gate in <c>V4RepositoryBase.RaiseBroadcastAsync</c>.
-    /// </summary>
-    private Task RaiseBroadcastAsync(
-        IReadOnlyList<ApsSnapshot> created,
-        IReadOnlyList<ApsSnapshot> updated,
-        IReadOnlyList<Guid> deletedIds,
-        WriteOrigin origin,
-        CancellationToken ct)
-        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
+    /// <inheritdoc />
+    protected override ApsSnapshotEntity ToEntity(ApsSnapshot model) => ApsSnapshotMapper.ToEntity(model);
 
-    /// <summary>
-    /// Gets APS snapshots based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of APS snapshots.</returns>
-    public async Task<IEnumerable<ApsSnapshot>> GetAsync(
-        DateTime? from, DateTime? to, string? device, string? source,
-        int limit = 100, int offset = 0, bool descending = true,
-        CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.ApsSnapshots.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null) query = query.Where(e => e.Device == device);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(ApsSnapshotMapper.ToDomainModel);
-    }
+    /// <inheritdoc />
+    protected override ApsSnapshot ToDomain(ApsSnapshotEntity entity) => ApsSnapshotMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(ApsSnapshotEntity target, ApsSnapshot source) =>
+        ApsSnapshotMapper.UpdateEntity(target, source);
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<ApsIobCobPoint>> GetIobCobPointsAsync(
         DateTime from, DateTime to, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.ApsSnapshots.AsNoTracking()
             .Where(e => e.Timestamp >= from && e.Timestamp <= to)
             .OrderBy(e => e.Timestamp)
             .Select(e => new ApsIobCobPoint(e.Timestamp, e.Iob, e.Cob))
             .ToListAsync(ct);
-    }
-
-    /// <summary>
-    /// Gets an APS snapshot by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The APS snapshot, or null if not found.</returns>
-    public async Task<ApsSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.ApsSnapshots.FindAsync([id], ct);
-        return entity is null ? null : ApsSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<ApsSnapshot?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.ApsSnapshots
-            .Where(e => e.Id >= low && e.Id <= high)
-            .OrderBy(e => e.Id)
-            .FirstOrDefaultAsync(ct);
-        return entity is null ? null : ApsSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets an APS snapshot by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The APS snapshot, or null if not found.</returns>
-    public async Task<ApsSnapshot?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.ApsSnapshots.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : ApsSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new APS snapshot record.
-    /// </summary>
-    /// <param name="model">The APS snapshot to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created APS snapshot.</returns>
-    public async Task<ApsSnapshot> CreateAsync(ApsSnapshot model, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = ApsSnapshotMapper.ToEntity(model);
-        ctx.ApsSnapshots.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        var created = ApsSnapshotMapper.ToDomainModel(entity);
-        await RaiseBroadcastAsync([created], [], [], origin, ct);
-        return created;
-    }
-
-    /// <summary>
-    /// Updates an existing APS snapshot record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the snapshot to update.</param>
-    /// <param name="model">The updated snapshot data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated APS snapshot.</returns>
-    public async Task<ApsSnapshot> UpdateAsync(Guid id, ApsSnapshot model, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.ApsSnapshots.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"ApsSnapshot {id} not found");
-        ApsSnapshotMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return ApsSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes an APS snapshot record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.ApsSnapshots.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"ApsSnapshot {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<ApsSnapshot> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.ApsSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted ApsSnapshot {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return ApsSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<ApsSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.ApsSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(ApsSnapshotMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<ApsSnapshot>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.ApsSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(ApsSnapshotMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.ApsSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
     }
 
     /// <summary>
@@ -233,7 +69,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
         var ids = correlationIds.ToList();
         if (ids.Count == 0) return [];
 
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx.ApsSnapshots
             .AsNoTracking()
             .Where(e => e.CorrelationId != null && ids.Contains(e.CorrelationId.Value))
@@ -252,7 +88,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     public async Task<IEnumerable<ApsSnapshot>> GetModifiedSinceAsync(
         long lastModifiedMills, int limit = 1000, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var since = DateTimeOffset.FromUnixTimeMilliseconds(lastModifiedMills).UtcDateTime;
         // Filter and order on the event Timestamp: it is the clock the V3 devicestatus DTO
         // reports as srvModified and the AAPS history cursor advances on, and it is the
@@ -271,40 +107,10 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
         return entities.Select(ApsSnapshotMapper.ToDomainModel);
     }
 
-    /// <summary>
-    /// Counts APS snapshots within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.ApsSnapshots.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Deletes an APS snapshot record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.ApsSnapshots
-            .Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
     /// <inheritdoc />
     public async Task<DateTime?> GetLatestTimestampAsOfAsync(DateTime? asOf, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.ApsSnapshots.AsNoTracking();
         if (asOf.HasValue) query = query.Where(e => e.Timestamp <= asOf.Value);
         return await query
@@ -314,18 +120,9 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     }
 
     /// <inheritdoc />
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.ApsSnapshots.AsNoTracking();
-        if (source != null) query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <inheritdoc />
     public async Task<DateTime?> GetLatestEnactedTimestampAsync(DateTime? asOf, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.ApsSnapshots.AsNoTracking().Where(e => e.Enacted);
         if (asOf.HasValue) query = query.Where(e => e.Timestamp <= asOf.Value);
         return await query
@@ -340,7 +137,7 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     /// </remarks>
     public async Task<decimal?> GetLatestSensitivityRatioAsync(DateTime? asOf, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.ApsSnapshots.AsNoTracking().Where(e => e.SensitivityRatio != null);
         if (asOf.HasValue) query = query.Where(e => e.Timestamp <= asOf.Value);
         var value = await query
@@ -351,78 +148,20 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<ApsSnapshot>> BulkCreateAsync(
+    public Task<IEnumerable<ApsSnapshot>> BulkUpsertAsync(
         IEnumerable<ApsSnapshot> records,
         WriteOrigin origin, CancellationToken ct = default)
+        => BulkWriteAsync(records, SplitBySyncKeyAsync, origin, ct);
+
+    /// <summary>
+    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
+    /// rows in the DB by that key and update them in place. Soft-deleted rows are excluded: the partial
+    /// unique index ignores them, so a re-upload after a delete inserts a fresh row instead of writing
+    /// into the deleted one.
+    /// </summary>
+    private static async Task<UpsertSplit> SplitBySyncKeyAsync(
+        NocturneDbContext ctx, List<ApsSnapshotEntity> entities, CancellationToken ct)
     {
-        var entities = records.Select(ApsSnapshotMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<ApsSnapshotEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.ApsSnapshots.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-
-            var created = entities.Select(ApsSnapshotMapper.ToDomainModel).ToList();
-            await RaiseBroadcastAsync(created, [], [], origin, ct);
-            return created;
-        });
-    }
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// Mirrors the (DataSource, SyncIdentifier) upsert split in <c>SensorGlucoseRepository</c> /
-    /// <c>BolusRepository</c>: intra-batch keep-last per key, DB-matched rows update in place,
-    /// the rest insert through the LegacyId-dedup path.
-    /// </remarks>
-    public async Task<IEnumerable<ApsSnapshot>> BulkUpsertAsync(
-        IEnumerable<ApsSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default)
-    {
-        var entities = records.Select(ApsSnapshotMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Intra-batch dedup: keep the last occurrence per (DataSource, SyncIdentifier).
         // Records without both keys keep a unique grouping key so they're not collapsed.
         entities = entities
             .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
@@ -431,89 +170,52 @@ public class ApsSnapshotRepository : IApsSnapshotRepository
             .Select(g => g.Last())
             .ToList();
 
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        var syncKeyed = entities
+            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+            .ToList();
+
+        var updatedEntities = new List<ApsSnapshotEntity>();
+        var materiallyChanged = new List<ApsSnapshotEntity>();
+        if (syncKeyed.Count == 0)
+            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
+
+        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+        var existingRows = await ctx.ApsSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
+            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+            .ToListAsync(ct);
+
+        var existingByKey = existingRows
+            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var toInsert = new List<ApsSnapshotEntity>();
+        foreach (var entity in entities)
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            // DB-level upsert: rows matched by (DataSource, SyncIdentifier) are updated in place.
-            // Soft-deleted rows are excluded: the partial unique index ignores them, so a
-            // re-upload after a delete inserts a fresh row instead of writing into the deleted one.
-            var updatedEntities = new List<ApsSnapshotEntity>();
-            var materiallyChanged = new List<ApsSnapshotEntity>();
-            var toInsert = entities;
-            var syncKeyed = entities
-                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-                .ToList();
-
-            if (syncKeyed.Count > 0)
+            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                && !string.IsNullOrEmpty(entity.SyncIdentifier);
+            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
             {
-                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-                var existingRows = await ctx.ApsSnapshots.IgnoreQueryFilters()
-                    .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
-                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-                    .ToListAsync(ct);
-
-                var existingByKey = existingRows
-                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-                    .ToDictionary(g => g.Key, g => g.First());
-
-                toInsert = [];
-                foreach (var entity in entities)
-                {
-                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
-                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-                    {
-                        ApsSnapshotMapper.UpdateEntity(existing, ApsSnapshotMapper.ToDomainModel(entity));
-                        updatedEntities.Add(existing);
-                        // Capture material changes now, before SaveChanges clears the modified flags.
-                        if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
-                            materiallyChanged.Add(existing);
-                    }
-                    else
-                    {
-                        toInsert.Add(entity);
-                    }
-                }
-
-                if (updatedEntities.Count > 0)
-                    await ctx.SaveChangesAsync(ct);
+                ApsSnapshotMapper.UpdateEntity(existing, ApsSnapshotMapper.ToDomainModel(entity));
+                updatedEntities.Add(existing);
+                // Capture material changes now, before SaveChanges clears the modified flags.
+                if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
+                    materiallyChanged.Add(existing);
             }
-
-            // Insert path: LegacyId dedup as in BulkCreateAsync.
-            var legacyIds = toInsert
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
-
-            if (legacyIds.Count > 0)
+            else
             {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<ApsSnapshotEntity>(legacyIds, ct);
-                toInsert = toInsert
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
+                toInsert.Add(entity);
             }
+        }
 
-            const int batchSize = 500;
-            foreach (var batch in toInsert.Chunk(batchSize))
-            {
-                ctx.ApsSnapshots.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
+        if (updatedEntities.Count > 0)
+        {
+            // Persist updates before the insert-chunking loop clears the tracker.
+            await ctx.SaveChangesAsync(ct);
+        }
 
-            await tx.CommitAsync(ct);
-
-            var updated = updatedEntities.Select(ApsSnapshotMapper.ToDomainModel).ToList();
-            var created = toInsert.Select(ApsSnapshotMapper.ToDomainModel).ToList();
-            // Broadcast only materially changed updates: a byte-identical retry of the same
-            // batch must not push update events to every client (the #513 broadcast-storm shape).
-            await RaiseBroadcastAsync(created, materiallyChanged.Select(ApsSnapshotMapper.ToDomainModel).ToList(), [], origin, ct);
-            return updated.Concat(created).ToList();
-        });
+        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -1,10 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
@@ -12,110 +12,44 @@ using Nocturne.Core.Contracts.V4;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing pump snapshot records (point-in-time pump state) in the database.
+/// Repository for managing pump snapshot records (point-in-time pump state) in the database. Inherits
+/// the shared CRUD, soft-delete and LegacyId-deduplicated bulk-insert surface from
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the pump-specific queries and the
+/// (DataSource, SyncIdentifier) upsert below.
 /// </summary>
-public class PumpSnapshotRepository : IPumpSnapshotRepository
+public class PumpSnapshotRepository : V4RepositoryBase<PumpSnapshot, PumpSnapshotEntity>, IPumpSnapshotRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
-    private readonly ILogger<PumpSnapshotRepository> _logger;
-    private readonly IV4RecordBroadcaster<PumpSnapshot>? _broadcaster;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="PumpSnapshotRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
+    // logger is unused but retained for DI + direct test construction.
     public PumpSnapshotRepository(
         ITenantDbContextFactory contextFactory,
+        IAuditContext auditContext,
         ILogger<PumpSnapshotRepository> logger,
         IV4RecordBroadcaster<PumpSnapshot>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
-        _contextFactory = contextFactory;
-        _logger = logger;
-        _broadcaster = broadcaster;
-    }
-
-    /// <summary>
-    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
-    /// writes (backfill imports stay silent). Mirrors the gate in <c>V4RepositoryBase.RaiseBroadcastAsync</c>.
-    /// </summary>
-    private Task RaiseBroadcastAsync(
-        IReadOnlyList<PumpSnapshot> created,
-        IReadOnlyList<PumpSnapshot> updated,
-        IReadOnlyList<Guid> deletedIds,
-        WriteOrigin origin,
-        CancellationToken ct)
-        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
-
-    /// <summary>
-    /// Gets pump snapshot records based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of pump snapshots.</returns>
-    public async Task<IEnumerable<PumpSnapshot>> GetAsync(
-        DateTime? from, DateTime? to, string? device, string? source,
-        int limit = 100, int offset = 0, bool descending = true,
-        CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.PumpSnapshots.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null) query = query.Where(e => e.Device == device);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(PumpSnapshotMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Gets a pump snapshot record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The pump snapshot, or null if not found.</returns>
-    public async Task<PumpSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.PumpSnapshots.FindAsync([id], ct);
-        return entity is null ? null : PumpSnapshotMapper.ToDomainModel(entity);
     }
 
     /// <inheritdoc />
-    public async Task<PumpSnapshot?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.PumpSnapshots
-            .Where(e => e.Id >= low && e.Id <= high)
-            .OrderBy(e => e.Id)
-            .FirstOrDefaultAsync(ct);
-        return entity is null ? null : PumpSnapshotMapper.ToDomainModel(entity);
-    }
+    protected override PumpSnapshotEntity ToEntity(PumpSnapshot model) => PumpSnapshotMapper.ToEntity(model);
 
-    /// <summary>
-    /// Gets a pump snapshot record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The pump snapshot, or null if not found.</returns>
-    public async Task<PumpSnapshot?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.PumpSnapshots.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : PumpSnapshotMapper.ToDomainModel(entity);
-    }
+    /// <inheritdoc />
+    protected override PumpSnapshot ToDomain(PumpSnapshotEntity entity) => PumpSnapshotMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(PumpSnapshotEntity target, PumpSnapshot source) =>
+        PumpSnapshotMapper.UpdateEntity(target, source);
 
     /// <inheritdoc />
     public async Task<PumpSnapshot?> GetLatestBeforeAsync(DateTime timestamp, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entity = await ctx.PumpSnapshots
             .AsNoTracking()
             .Where(e => e.Timestamp < timestamp)
@@ -127,110 +61,13 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
     /// <inheritdoc />
     public async Task<PumpSnapshot?> GetLatestAsync(DateTime? asOf, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.PumpSnapshots.AsNoTracking();
         if (asOf.HasValue) query = query.Where(e => e.Timestamp <= asOf.Value);
         var entity = await query
             .OrderByDescending(e => e.Timestamp)
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : PumpSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new pump snapshot record.
-    /// </summary>
-    /// <param name="model">The pump snapshot to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created pump snapshot.</returns>
-    public async Task<PumpSnapshot> CreateAsync(PumpSnapshot model, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = PumpSnapshotMapper.ToEntity(model);
-        ctx.PumpSnapshots.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        var created = PumpSnapshotMapper.ToDomainModel(entity);
-        await RaiseBroadcastAsync([created], [], [], origin, ct);
-        return created;
-    }
-
-    /// <summary>
-    /// Updates an existing pump snapshot record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the snapshot to update.</param>
-    /// <param name="model">The updated snapshot data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated pump snapshot.</returns>
-    public async Task<PumpSnapshot> UpdateAsync(Guid id, PumpSnapshot model, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.PumpSnapshots.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"PumpSnapshot {id} not found");
-        PumpSnapshotMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return PumpSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes a pump snapshot record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.PumpSnapshots.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"PumpSnapshot {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<PumpSnapshot> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.PumpSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted PumpSnapshot {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return PumpSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<PumpSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.PumpSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(PumpSnapshotMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<PumpSnapshot>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.PumpSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(PumpSnapshotMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.PumpSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
     }
 
     /// <summary>
@@ -245,7 +82,7 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
         var ids = correlationIds.ToList();
         if (ids.Count == 0) return [];
 
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx.PumpSnapshots
             .AsNoTracking()
             .Where(e => e.CorrelationId != null && ids.Contains(e.CorrelationId.Value))
@@ -254,118 +91,21 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
         return entities.Select(PumpSnapshotMapper.ToDomainModel);
     }
 
-    /// <summary>
-    /// Counts pump snapshot records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.PumpSnapshots.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Deletes a pump snapshot record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.PumpSnapshots
-            .Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
     /// <inheritdoc />
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.PumpSnapshots.AsNoTracking();
-        if (source != null) query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<PumpSnapshot>> BulkCreateAsync(
+    public Task<IEnumerable<PumpSnapshot>> BulkUpsertAsync(
         IEnumerable<PumpSnapshot> records,
         WriteOrigin origin, CancellationToken ct = default)
+        => BulkWriteAsync(records, SplitBySyncKeyAsync, origin, ct);
+
+    /// <summary>
+    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
+    /// rows in the DB by that key and update them in place. Soft-deleted rows are excluded: the partial
+    /// unique index ignores them, so a re-upload after a delete inserts a fresh row instead of writing
+    /// into the deleted one.
+    /// </summary>
+    private static async Task<UpsertSplit> SplitBySyncKeyAsync(
+        NocturneDbContext ctx, List<PumpSnapshotEntity> entities, CancellationToken ct)
     {
-        var entities = records.Select(PumpSnapshotMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<PumpSnapshotEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.PumpSnapshots.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-
-            var created = entities.Select(PumpSnapshotMapper.ToDomainModel).ToList();
-            await RaiseBroadcastAsync(created, [], [], origin, ct);
-            return created;
-        });
-    }
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// Mirrors the (DataSource, SyncIdentifier) upsert split in <c>SensorGlucoseRepository</c> /
-    /// <c>BolusRepository</c>: intra-batch keep-last per key, DB-matched rows update in place,
-    /// the rest insert through the LegacyId-dedup path.
-    /// </remarks>
-    public async Task<IEnumerable<PumpSnapshot>> BulkUpsertAsync(
-        IEnumerable<PumpSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default)
-    {
-        var entities = records.Select(PumpSnapshotMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Intra-batch dedup: keep the last occurrence per (DataSource, SyncIdentifier).
         // Records without both keys keep a unique grouping key so they're not collapsed.
         entities = entities
             .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
@@ -374,89 +114,52 @@ public class PumpSnapshotRepository : IPumpSnapshotRepository
             .Select(g => g.Last())
             .ToList();
 
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        var syncKeyed = entities
+            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+            .ToList();
+
+        var updatedEntities = new List<PumpSnapshotEntity>();
+        var materiallyChanged = new List<PumpSnapshotEntity>();
+        if (syncKeyed.Count == 0)
+            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
+
+        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+        var existingRows = await ctx.PumpSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
+            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+            .ToListAsync(ct);
+
+        var existingByKey = existingRows
+            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var toInsert = new List<PumpSnapshotEntity>();
+        foreach (var entity in entities)
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            // DB-level upsert: rows matched by (DataSource, SyncIdentifier) are updated in place.
-            // Soft-deleted rows are excluded: the partial unique index ignores them, so a
-            // re-upload after a delete inserts a fresh row instead of writing into the deleted one.
-            var updatedEntities = new List<PumpSnapshotEntity>();
-            var materiallyChanged = new List<PumpSnapshotEntity>();
-            var toInsert = entities;
-            var syncKeyed = entities
-                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-                .ToList();
-
-            if (syncKeyed.Count > 0)
+            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                && !string.IsNullOrEmpty(entity.SyncIdentifier);
+            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
             {
-                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-                var existingRows = await ctx.PumpSnapshots.IgnoreQueryFilters()
-                    .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
-                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-                    .ToListAsync(ct);
-
-                var existingByKey = existingRows
-                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-                    .ToDictionary(g => g.Key, g => g.First());
-
-                toInsert = [];
-                foreach (var entity in entities)
-                {
-                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
-                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-                    {
-                        PumpSnapshotMapper.UpdateEntity(existing, PumpSnapshotMapper.ToDomainModel(entity));
-                        updatedEntities.Add(existing);
-                        // Capture material changes now, before SaveChanges clears the modified flags.
-                        if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
-                            materiallyChanged.Add(existing);
-                    }
-                    else
-                    {
-                        toInsert.Add(entity);
-                    }
-                }
-
-                if (updatedEntities.Count > 0)
-                    await ctx.SaveChangesAsync(ct);
+                PumpSnapshotMapper.UpdateEntity(existing, PumpSnapshotMapper.ToDomainModel(entity));
+                updatedEntities.Add(existing);
+                // Capture material changes now, before SaveChanges clears the modified flags.
+                if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
+                    materiallyChanged.Add(existing);
             }
-
-            // Insert path: LegacyId dedup as in BulkCreateAsync.
-            var legacyIds = toInsert
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
-
-            if (legacyIds.Count > 0)
+            else
             {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<PumpSnapshotEntity>(legacyIds, ct);
-                toInsert = toInsert
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
+                toInsert.Add(entity);
             }
+        }
 
-            const int batchSize = 500;
-            foreach (var batch in toInsert.Chunk(batchSize))
-            {
-                ctx.PumpSnapshots.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
+        if (updatedEntities.Count > 0)
+        {
+            // Persist updates before the insert-chunking loop clears the tracker.
+            await ctx.SaveChangesAsync(ct);
+        }
 
-            await tx.CommitAsync(ct);
-
-            var updated = updatedEntities.Select(PumpSnapshotMapper.ToDomainModel).ToList();
-            var created = toInsert.Select(PumpSnapshotMapper.ToDomainModel).ToList();
-            // Broadcast only materially changed updates: a byte-identical retry of the same
-            // batch must not push update events to every client (the #513 broadcast-storm shape).
-            await RaiseBroadcastAsync(created, materiallyChanged.Select(PumpSnapshotMapper.ToDomainModel).ToList(), [], origin, ct);
-            return updated.Concat(created).ToList();
-        });
+        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -1,10 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
@@ -13,201 +13,38 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
 /// Repository for managing uploader snapshot records (point-in-time uploader state) in the database.
+/// Inherits the shared CRUD, soft-delete and LegacyId-deduplicated bulk-insert surface from
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the uploader-specific queries and the
+/// (DataSource, SyncIdentifier) upsert below.
 /// </summary>
-public class UploaderSnapshotRepository : IUploaderSnapshotRepository
+public class UploaderSnapshotRepository : V4RepositoryBase<UploaderSnapshot, UploaderSnapshotEntity>, IUploaderSnapshotRepository
 {
-    private readonly ITenantDbContextFactory _contextFactory;
-    private readonly ILogger<UploaderSnapshotRepository> _logger;
-    private readonly IV4RecordBroadcaster<UploaderSnapshot>? _broadcaster;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="UploaderSnapshotRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
+    /// <param name="auditContext">The audit context for tracking mutations (used by the base soft-delete path).</param>
     /// <param name="logger">The logger instance.</param>
     /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
+    // logger is unused but retained for DI + direct test construction.
     public UploaderSnapshotRepository(
         ITenantDbContextFactory contextFactory,
+        IAuditContext auditContext,
         ILogger<UploaderSnapshotRepository> logger,
         IV4RecordBroadcaster<UploaderSnapshot>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
-        _contextFactory = contextFactory;
-        _logger = logger;
-        _broadcaster = broadcaster;
-    }
-
-    /// <summary>
-    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
-    /// writes (backfill imports stay silent). Mirrors the gate in <c>V4RepositoryBase.RaiseBroadcastAsync</c>.
-    /// </summary>
-    private Task RaiseBroadcastAsync(
-        IReadOnlyList<UploaderSnapshot> created,
-        IReadOnlyList<UploaderSnapshot> updated,
-        IReadOnlyList<Guid> deletedIds,
-        WriteOrigin origin,
-        CancellationToken ct)
-        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
-
-    /// <summary>
-    /// Gets uploader snapshot records based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of uploader snapshots.</returns>
-    public async Task<IEnumerable<UploaderSnapshot>> GetAsync(
-        DateTime? from, DateTime? to, string? device, string? source,
-        int limit = 100, int offset = 0, bool descending = true,
-        CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.UploaderSnapshots.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        if (device != null) query = query.Where(e => e.Device == device);
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(UploaderSnapshotMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Gets an uploader snapshot record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The uploader snapshot, or null if not found.</returns>
-    public async Task<UploaderSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.UploaderSnapshots.FindAsync([id], ct);
-        return entity is null ? null : UploaderSnapshotMapper.ToDomainModel(entity);
     }
 
     /// <inheritdoc />
-    public async Task<UploaderSnapshot?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.UploaderSnapshots
-            .Where(e => e.Id >= low && e.Id <= high)
-            .OrderBy(e => e.Id)
-            .FirstOrDefaultAsync(ct);
-        return entity is null ? null : UploaderSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Gets an uploader snapshot record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The uploader snapshot, or null if not found.</returns>
-    public async Task<UploaderSnapshot?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.UploaderSnapshots.FirstOrDefaultAsync(e => e.LegacyId == legacyId, ct);
-        return entity is null ? null : UploaderSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Creates a new uploader snapshot record.
-    /// </summary>
-    /// <param name="model">The uploader snapshot to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created uploader snapshot.</returns>
-    public async Task<UploaderSnapshot> CreateAsync(UploaderSnapshot model, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = UploaderSnapshotMapper.ToEntity(model);
-        ctx.UploaderSnapshots.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        var created = UploaderSnapshotMapper.ToDomainModel(entity);
-        await RaiseBroadcastAsync([created], [], [], origin, ct);
-        return created;
-    }
-
-    /// <summary>
-    /// Updates an existing uploader snapshot record.
-    /// </summary>
-    /// <param name="id">The unique identifier of the snapshot to update.</param>
-    /// <param name="model">The updated snapshot data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated uploader snapshot.</returns>
-    public async Task<UploaderSnapshot> UpdateAsync(Guid id, UploaderSnapshot model, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.UploaderSnapshots.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"UploaderSnapshot {id} not found");
-        UploaderSnapshotMapper.UpdateEntity(entity, model);
-        await ctx.SaveChangesAsync(ct);
-        return UploaderSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <summary>
-    /// Deletes an uploader snapshot record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.UploaderSnapshots.FindAsync([id], ct)
-            ?? throw new KeyNotFoundException($"UploaderSnapshot {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await ctx.SaveChangesAsync(ct);
-    }
+    protected override UploaderSnapshotEntity ToEntity(UploaderSnapshot model) => UploaderSnapshotMapper.ToEntity(model);
 
     /// <inheritdoc />
-    public async Task<UploaderSnapshot> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.UploaderSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted UploaderSnapshot {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return UploaderSnapshotMapper.ToDomainModel(entity);
-    }
+    protected override UploaderSnapshot ToDomain(UploaderSnapshotEntity entity) => UploaderSnapshotMapper.ToDomainModel(entity);
 
     /// <inheritdoc />
-    public async Task<IEnumerable<UploaderSnapshot>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.UploaderSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(UploaderSnapshotMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<UploaderSnapshot>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.UploaderSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(UploaderSnapshotMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.UploaderSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
+    protected override void ApplyUpdate(UploaderSnapshotEntity target, UploaderSnapshot source) =>
+        UploaderSnapshotMapper.UpdateEntity(target, source);
 
     /// <summary>
     /// Gets uploader snapshots by correlation IDs.
@@ -221,7 +58,7 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
         var ids = correlationIds.ToList();
         if (ids.Count == 0) return [];
 
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var entities = await ctx.UploaderSnapshots
             .AsNoTracking()
             .Where(e => e.CorrelationId != null && ids.Contains(e.CorrelationId.Value))
@@ -230,49 +67,10 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
         return entities.Select(UploaderSnapshotMapper.ToDomainModel);
     }
 
-    /// <summary>
-    /// Counts uploader snapshot records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.UploaderSnapshots.AsNoTracking().AsQueryable();
-        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Deletes an uploader snapshot record by its legacy identifier.
-    /// </summary>
-    /// <param name="legacyId">The legacy identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.UploaderSnapshots
-            .Where(e => e.LegacyId == legacyId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <inheritdoc />
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var query = ctx.UploaderSnapshots.AsNoTracking();
-        if (source != null) query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
     /// <inheritdoc />
     public async Task<UploaderSnapshot?> GetLatestAsync(DateTime? asOf, CancellationToken ct = default)
     {
-        await using var ctx = await _contextFactory.CreateAsync(ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         var query = ctx.UploaderSnapshots.AsNoTracking();
         if (asOf.HasValue) query = query.Where(e => e.Timestamp <= asOf.Value);
         var entity = await query
@@ -284,78 +82,20 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<UploaderSnapshot>> BulkCreateAsync(
+    public Task<IEnumerable<UploaderSnapshot>> BulkUpsertAsync(
         IEnumerable<UploaderSnapshot> records,
         WriteOrigin origin, CancellationToken ct = default)
+        => BulkWriteAsync(records, SplitBySyncKeyAsync, origin, ct);
+
+    /// <summary>
+    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
+    /// rows in the DB by that key and update them in place. Soft-deleted rows are excluded: the partial
+    /// unique index ignores them, so a re-upload after a delete inserts a fresh row instead of writing
+    /// into the deleted one.
+    /// </summary>
+    private static async Task<UpsertSplit> SplitBySyncKeyAsync(
+        NocturneDbContext ctx, List<UploaderSnapshotEntity> entities, CancellationToken ct)
     {
-        var entities = records.Select(UploaderSnapshotMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Batch-level dedup: keep first occurrence per LegacyId
-        entities = entities
-            .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-            .Select(g => g.First())
-            .ToList();
-
-        // DB-level dedup: filter out records whose LegacyId already exists
-        var legacyIds = entities
-            .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-            .Select(e => e.LegacyId!)
-            .ToHashSet();
-
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<UploaderSnapshotEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count == 0)
-            {
-                await tx.CommitAsync(ct);
-                return [];
-            }
-
-            const int batchSize = 500;
-            foreach (var batch in entities.Chunk(batchSize))
-            {
-                ctx.UploaderSnapshots.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
-
-            await tx.CommitAsync(ct);
-
-            var created = entities.Select(UploaderSnapshotMapper.ToDomainModel).ToList();
-            await RaiseBroadcastAsync(created, [], [], origin, ct);
-            return created;
-        });
-    }
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// Mirrors the (DataSource, SyncIdentifier) upsert split in <c>SensorGlucoseRepository</c> /
-    /// <c>BolusRepository</c>: intra-batch keep-last per key, DB-matched rows update in place,
-    /// the rest insert through the LegacyId-dedup path.
-    /// </remarks>
-    public async Task<IEnumerable<UploaderSnapshot>> BulkUpsertAsync(
-        IEnumerable<UploaderSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default)
-    {
-        var entities = records.Select(UploaderSnapshotMapper.ToEntity).ToList();
-        if (entities.Count == 0)
-            return [];
-
-        // Intra-batch dedup: keep the last occurrence per (DataSource, SyncIdentifier).
         // Records without both keys keep a unique grouping key so they're not collapsed.
         entities = entities
             .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
@@ -364,89 +104,52 @@ public class UploaderSnapshotRepository : IUploaderSnapshotRepository
             .Select(g => g.Last())
             .ToList();
 
-        await using var ctx = await _contextFactory.CreateAsync(ct);
-        var strategy = ctx.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
+        var syncKeyed = entities
+            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+            .ToList();
+
+        var updatedEntities = new List<UploaderSnapshotEntity>();
+        var materiallyChanged = new List<UploaderSnapshotEntity>();
+        if (syncKeyed.Count == 0)
+            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
+
+        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+        var existingRows = await ctx.UploaderSnapshots.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
+            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+            .ToListAsync(ct);
+
+        var existingByKey = existingRows
+            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var toInsert = new List<UploaderSnapshotEntity>();
+        foreach (var entity in entities)
         {
-            await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-
-            // DB-level upsert: rows matched by (DataSource, SyncIdentifier) are updated in place.
-            // Soft-deleted rows are excluded: the partial unique index ignores them, so a
-            // re-upload after a delete inserts a fresh row instead of writing into the deleted one.
-            var updatedEntities = new List<UploaderSnapshotEntity>();
-            var materiallyChanged = new List<UploaderSnapshotEntity>();
-            var toInsert = entities;
-            var syncKeyed = entities
-                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-                .ToList();
-
-            if (syncKeyed.Count > 0)
+            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                && !string.IsNullOrEmpty(entity.SyncIdentifier);
+            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
             {
-                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-                var existingRows = await ctx.UploaderSnapshots.IgnoreQueryFilters()
-                    .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
-                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-                    .ToListAsync(ct);
-
-                var existingByKey = existingRows
-                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-                    .ToDictionary(g => g.Key, g => g.First());
-
-                toInsert = [];
-                foreach (var entity in entities)
-                {
-                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
-                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-                    {
-                        UploaderSnapshotMapper.UpdateEntity(existing, UploaderSnapshotMapper.ToDomainModel(entity));
-                        updatedEntities.Add(existing);
-                        // Capture material changes now, before SaveChanges clears the modified flags.
-                        if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
-                            materiallyChanged.Add(existing);
-                    }
-                    else
-                    {
-                        toInsert.Add(entity);
-                    }
-                }
-
-                if (updatedEntities.Count > 0)
-                    await ctx.SaveChangesAsync(ct);
+                UploaderSnapshotMapper.UpdateEntity(existing, UploaderSnapshotMapper.ToDomainModel(entity));
+                updatedEntities.Add(existing);
+                // Capture material changes now, before SaveChanges clears the modified flags.
+                if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
+                    materiallyChanged.Add(existing);
             }
-
-            // Insert path: LegacyId dedup as in BulkCreateAsync.
-            var legacyIds = toInsert
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
-
-            if (legacyIds.Count > 0)
+            else
             {
-                var blockedLegacyIds = await ctx.GetBlockingLegacyIdsAsync<UploaderSnapshotEntity>(legacyIds, ct);
-                toInsert = toInsert
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
+                toInsert.Add(entity);
             }
+        }
 
-            const int batchSize = 500;
-            foreach (var batch in toInsert.Chunk(batchSize))
-            {
-                ctx.UploaderSnapshots.AddRange(batch);
-                await ctx.SaveChangesAsync(ct);
-                ctx.ChangeTracker.Clear();
-            }
+        if (updatedEntities.Count > 0)
+        {
+            // Persist updates before the insert-chunking loop clears the tracker.
+            await ctx.SaveChangesAsync(ct);
+        }
 
-            await tx.CommitAsync(ct);
-
-            var updated = updatedEntities.Select(UploaderSnapshotMapper.ToDomainModel).ToList();
-            var created = toInsert.Select(UploaderSnapshotMapper.ToDomainModel).ToList();
-            // Broadcast only materially changed updates: a byte-identical retry of the same
-            // batch must not push update events to every client (the #513 broadcast-storm shape).
-            await RaiseBroadcastAsync(created, materiallyChanged.Select(UploaderSnapshotMapper.ToDomainModel).ToList(), [], origin, ct);
-            return updated.Concat(created).ToList();
-        });
+        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -382,8 +382,22 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     /// the <see cref="SplitUpsertsAsync"/> / <see cref="PostCommitDedupAsync"/> hooks rather than the
     /// whole method.
     /// </summary>
-    public virtual async Task<IEnumerable<TModel>> BulkCreateAsync(
+    public virtual Task<IEnumerable<TModel>> BulkCreateAsync(
         IEnumerable<TModel> recordsParam, WriteOrigin origin, CancellationToken ct = default)
+        => BulkWriteAsync(recordsParam, SplitUpsertsAsync, origin, ct);
+
+    /// <summary>
+    /// The transaction every bulk write shares: <paramref name="splitter"/> separates the rows upserted
+    /// in place from the rows still to insert, the insert set is deduplicated by LegacyId (batch- then
+    /// DB-level) and inserted in chunks, and the commit is followed by dedup linking and the broadcast.
+    /// Types that expose a second bulk entry point alongside the insert-only
+    /// <see cref="BulkCreateAsync"/> (an explicit <c>BulkUpsertAsync</c>) pass their own splitter.
+    /// </summary>
+    protected async Task<IEnumerable<TModel>> BulkWriteAsync(
+        IEnumerable<TModel> recordsParam,
+        Func<NocturneDbContext, List<TEntity>, CancellationToken, Task<UpsertSplit>> splitter,
+        WriteOrigin origin,
+        CancellationToken ct)
     {
         var records = recordsParam.ToList();
         if (records.Count == 0) return [];
@@ -394,7 +408,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
             await using var tx = await ctx.Database.BeginTransactionAsync(ct);
             var entities = records.Select(ToEntity).ToList();
 
-            var split = await SplitUpsertsAsync(ctx, entities, ct);
+            var split = await splitter(ctx, entities, ct);
             var toInsert = split.ToInsert;
 
             // Batch-level LegacyId dedup

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
@@ -32,9 +32,9 @@ public class DeviceStatusDecomposerTests : IDisposable
         _context = TestDbContextFactory.CreateInMemoryContext();
         _context.TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
         var ctxFactory = new TestTenantDbContextFactory(_context);
-        var apsRepo = new ApsSnapshotRepository(ctxFactory, NullLogger<ApsSnapshotRepository>.Instance);
-        var pumpRepo = new PumpSnapshotRepository(ctxFactory, NullLogger<PumpSnapshotRepository>.Instance);
-        var uploaderRepo = new UploaderSnapshotRepository(ctxFactory, NullLogger<UploaderSnapshotRepository>.Instance);
+        var apsRepo = new ApsSnapshotRepository(ctxFactory, new SystemAuditContext(), NullLogger<ApsSnapshotRepository>.Instance);
+        var pumpRepo = new PumpSnapshotRepository(ctxFactory, new SystemAuditContext(), NullLogger<PumpSnapshotRepository>.Instance);
+        var uploaderRepo = new UploaderSnapshotRepository(ctxFactory, new SystemAuditContext(), NullLogger<UploaderSnapshotRepository>.Instance);
         _extrasRepo = new DeviceStatusExtrasRepository(ctxFactory);
         _stateSpanServiceMock = new Mock<IStateSpanService>();
         _deviceServiceMock = new Mock<IDeviceService>();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/ApsSnapshotRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/ApsSnapshotRepositoryTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -23,7 +24,7 @@ public class ApsSnapshotRepositoryTests : IDisposable
         var dbName = $"aps_snapshot_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new ApsSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<ApsSnapshotRepository>.Instance);
+        _repository = new ApsSnapshotRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<ApsSnapshotRepository>.Instance);
     }
 
     public void Dispose()
@@ -69,6 +70,24 @@ public class ApsSnapshotRepositoryTests : IDisposable
             });
         }
         await _context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetAsync_FiltersBySource()
+    {
+        // The list read advertises a source filter on GET /api/v4/device-status/aps; dropping the
+        // predicate returned every connector's snapshots under a single connector's name.
+        var t1 = new DateTime(2026, 4, 30, 10, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc);
+        await SeedSourceAsync(TenantA,
+            (t1, "carelink"),
+            (t2, "nightscout"));
+
+        var carelink = await _repository.GetAsync(null, null, device: null, source: "carelink");
+        carelink.Should().ContainSingle().Which.Timestamp.Should().Be(t1);
+
+        var unfiltered = await _repository.GetAsync(null, null, device: null, source: null);
+        unfiltered.Should().HaveCount(2);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/PumpSnapshotRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/PumpSnapshotRepositoryTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -21,7 +22,7 @@ public class PumpSnapshotRepositoryTests : IDisposable
     {
         _context = TestDbContextFactory.CreateInMemoryContext();
         _context.TenantId = TenantA;
-        _repository = new PumpSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<PumpSnapshotRepository>.Instance);
+        _repository = new PumpSnapshotRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<PumpSnapshotRepository>.Instance);
     }
 
     public void Dispose()
@@ -64,6 +65,24 @@ public class PumpSnapshotRepositoryTests : IDisposable
             });
         }
         await _context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetAsync_FiltersBySource()
+    {
+        // The list read advertises a source filter on GET /api/v4/device-status/pump; dropping the
+        // predicate returned every connector's snapshots under a single connector's name.
+        var t1 = new DateTime(2026, 4, 30, 10, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc);
+        await SeedSourceAsync(TenantA,
+            (t1, "carelink"),
+            (t2, "nightscout"));
+
+        var carelink = await _repository.GetAsync(null, null, device: null, source: "carelink");
+        carelink.Should().ContainSingle().Which.Timestamp.Should().Be(t1);
+
+        var unfiltered = await _repository.GetAsync(null, null, device: null, source: null);
+        unfiltered.Should().HaveCount(2);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/UploaderSnapshotRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/UploaderSnapshotRepositoryTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -21,7 +22,7 @@ public class UploaderSnapshotRepositoryTests : IDisposable
     {
         _context = TestDbContextFactory.CreateInMemoryContext();
         _context.TenantId = TenantA;
-        _repository = new UploaderSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<UploaderSnapshotRepository>.Instance);
+        _repository = new UploaderSnapshotRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<UploaderSnapshotRepository>.Instance);
     }
 
     public void Dispose()
@@ -65,6 +66,24 @@ public class UploaderSnapshotRepositoryTests : IDisposable
             });
         }
         await _context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetAsync_FiltersBySource()
+    {
+        // The list read advertises a source filter on GET /api/v4/device-status/uploader; dropping the
+        // predicate returned every connector's snapshots under a single connector's name.
+        var t1 = new DateTime(2026, 4, 30, 10, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc);
+        await SeedSourceAsync(TenantA,
+            (t1, "carelink"),
+            (t2, "nightscout"));
+
+        var carelink = await _repository.GetAsync(null, null, device: null, source: "carelink");
+        carelink.Should().ContainSingle().Which.Timestamp.Should().Be(t1);
+
+        var unfiltered = await _repository.GetAsync(null, null, device: null, source: null);
+        unfiltered.Should().HaveCount(2);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkCreateTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -22,7 +23,7 @@ public class ApsSnapshotRepositoryBulkCreateTests : IDisposable
         var dbName = $"aps_snapshot_bulk_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new ApsSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<ApsSnapshotRepository>.Instance);
+        _repository = new ApsSnapshotRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<ApsSnapshotRepository>.Instance);
     }
 
     public void Dispose()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -22,7 +23,7 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
         var dbName = $"aps_snapshot_upsert_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new ApsSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<ApsSnapshotRepository>.Instance);
+        _repository = new ApsSnapshotRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<ApsSnapshotRepository>.Instance);
     }
 
     public void Dispose()
@@ -173,7 +174,7 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
     {
         var broadcaster = new RecordingBroadcaster();
         var repository = new ApsSnapshotRepository(
-            new TestTenantDbContextFactory(_context), NullLogger<ApsSnapshotRepository>.Instance, broadcaster);
+            new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<ApsSnapshotRepository>.Instance, broadcaster);
 
         await repository.BulkUpsertAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
         broadcaster.Created.Should().HaveCount(1);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkCreateTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -22,7 +23,7 @@ public class PumpSnapshotRepositoryBulkCreateTests : IDisposable
         var dbName = $"pump_snapshot_bulk_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new PumpSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<PumpSnapshotRepository>.Instance);
+        _repository = new PumpSnapshotRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<PumpSnapshotRepository>.Instance);
     }
 
     public void Dispose()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkUpsertTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -22,7 +23,7 @@ public class PumpSnapshotRepositoryBulkUpsertTests : IDisposable
         var dbName = $"pump_snapshot_upsert_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new PumpSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<PumpSnapshotRepository>.Instance);
+        _repository = new PumpSnapshotRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<PumpSnapshotRepository>.Instance);
     }
 
     public void Dispose()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkCreateTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -22,7 +23,7 @@ public class UploaderSnapshotRepositoryBulkCreateTests : IDisposable
         var dbName = $"uploader_snapshot_bulk_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new UploaderSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<UploaderSnapshotRepository>.Instance);
+        _repository = new UploaderSnapshotRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<UploaderSnapshotRepository>.Instance);
     }
 
     public void Dispose()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkUpsertTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -22,7 +23,7 @@ public class UploaderSnapshotRepositoryBulkUpsertTests : IDisposable
         var dbName = $"uploader_snapshot_upsert_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new UploaderSnapshotRepository(new TestTenantDbContextFactory(_context), NullLogger<UploaderSnapshotRepository>.Instance);
+        _repository = new UploaderSnapshotRepository(new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<UploaderSnapshotRepository>.Instance);
     }
 
     public void Dispose()


### PR DESCRIPTION
## Problem

`ApsSnapshotRepository.GetAsync`, `PumpSnapshotRepository.GetAsync` and `UploaderSnapshotRepository.GetAsync` each took a `string? source` parameter and never used it — the only three V4 repositories that drop the predicate `V4RepositoryBase` applies. The parameter is reachable from the public API: `GET /api/v4/device-status/{aps|pump|uploader}?source=x` returned every source's snapshots while advertising a filter. The three were originally left off the base because they had no `data_source` column; that column has existed since #439.

## Fix

All three snapshot repositories now derive from `V4RepositoryBase<TModel,TEntity>`, deleting ~1100 lines of copy-pasted CRUD/soft-delete/bulk plumbing so the divergence cannot recur. Type-specific queries (IOB/COB points, modified-since, latest-as-of, latest-enacted, sensitivity ratio, correlation-id lookups, pump latest-before, the battery-ordered uploader latest) are kept verbatim as members on top of the base. The base's bulk body is extracted into a shared `BulkWriteAsync(records, splitter, …)` so the snapshot repos' sync-key upsert reuses the same transaction/dedup/broadcast plumbing — zero behaviour change for existing `BulkCreateAsync` users.

Base-migration normalizations, verified in review:

- **Deletion resurrection fixed**: `DeleteByLegacyIdAsync` (v1/v3 devicestatus DELETE, v3 PUT) previously used a raw `ExecuteUpdate`, which bypassed the audit interceptor — so `DeletedByUser` was never set for snapshots and a user-deleted snapshot could be silently re-created by connector resync. It now routes through the audited soft-delete helper, which sets the flag resurrection-blocking keys on.
- Snapshot update/delete/restore now broadcast, with updates gated on material change (the #513 storm gate), matching every other V4 type.
- No EF model change: `DeletedByUser` was already conventioned onto all `ISoftDeletable` entities, and the added interfaces map only pre-existing columns. Verified with `dotnet ef migrations has-pending-model-changes` → clean; no migration needed.

Two behaviour deltas worth knowing, both consistent with the platform's existing conventions:

- Inline v1/v3 devicestatus uploads now write user-attributed `mutation_audit_log` create rows (up to 3 per POST), as the other `IAuditable` V4 types already do on the same paths; bounded by the 90-day retention. Scheduled connector syncs stay system-attributed and unaudited.
- The upsert insert path now batch-dedups duplicate LegacyIds (keep-first) where the old hand-rolled path inserted both.

## Tests

New `GetAsync_FiltersBySource` in all three repo test suites (seed two sources, filtered read returns exactly the requested one, unfiltered returns both); all three fail with the base predicate removed. `Nocturne.Infrastructure.Data.Tests`: 575/575. `DeviceStatusDecomposerTests`: 74/74. No tests deleted.

Noted for a separate issue: `ConnectorSyncService.TriggerSyncAsync` creates its child scope with a blank non-system `AuditContext`, so manually triggered connector syncs write null-actor audit rows for every `IAuditable` type (pre-existing for glucose/bolus/extras; snapshots now join). Symmetric fix would be a `SystemAuditScope.Push` in `DevicePublisher.PublishDeviceStatusAsync` matching its device-events sibling.

Follow-up from #434.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
