### PR TITLE
fix(v4): enforce page-size and date-span limits on V4 read endpoints

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -166,6 +166,9 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
         [FromQuery] int limit = 100, [FromQuery] int offset = 0,
         CancellationToken ct = default)
     {
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+
         var data = await Repository.GetDeletedAsync(limit, offset, ct);
         var total = await Repository.CountDeletedAsync(ct);
         return Ok(new PaginatedResponse<TModel> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4ReadLimits.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4ReadLimits.cs
@@ -1,0 +1,68 @@
+namespace Nocturne.API.Controllers.V4.Base;
+
+/// <summary>
+/// Server-side ceilings on how much a V4 read may ask for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The v1 equivalents live in <c>LegacyReadLimits</c> and are deliberately not shared: those
+/// ceilings are shaped by Nightscout compatibility, and either set may move without the other.
+/// </para>
+/// <para>
+/// Over-large values are clamped rather than rejected, matching the existing V4 paging behaviour
+/// in <c>ProfileController.GetProfileRecords</c>. An over-long date range is rejected instead,
+/// matching <c>SleepReportController.GetTrends</c>: silently narrowing a range would answer a
+/// different question than the caller asked.
+/// </para>
+/// </remarks>
+public static class V4ReadLimits
+{
+    /// <summary>
+    /// Maximum records a V4 list read may return.
+    /// </summary>
+    /// <remarks>
+    /// An order of magnitude above the largest first-party caller: the report and chart pages ask
+    /// for 10,000 per list route, and nothing in the SDKs or connectors asks for more.
+    /// </remarks>
+    public const int MaxPageSize = 100_000;
+
+    /// <summary>
+    /// Maximum records reachable across a V4 read that merges several sources in memory before it
+    /// paginates, counting both the page and everything skipped to reach it.
+    /// </summary>
+    /// <remarks>
+    /// Bounds the window rather than the page because such a read over-fetches
+    /// <c>limit + offset</c> records from every source it merges, so clamping <c>limit</c> alone
+    /// would leave the cost proportional to <c>offset</c>. Deeper pages come back empty.
+    /// </remarks>
+    public const int MaxMergedPageWindow = 10_000;
+
+    /// <summary>
+    /// Maximum span, in days, between the <c>from</c> and <c>to</c> bounds of a V4 range read.
+    /// </summary>
+    /// <remarks>
+    /// The widest range the report pages offer is 90 days, but their date picker also takes an
+    /// arbitrary custom range, so the ceiling sits far enough above the presets to leave the picker
+    /// usable. A range with only one bound set is not spanned and is left alone.
+    /// </remarks>
+    public const int MaxDateSpanDays = 366;
+
+    /// <summary>Clamp a caller-supplied page size to <see cref="MaxPageSize"/>.</summary>
+    public static int ClampLimit(int limit) => Math.Clamp(limit, 0, MaxPageSize);
+
+    /// <summary>Normalize a caller-supplied offset to be non-negative.</summary>
+    public static int ClampOffset(int offset) => Math.Max(0, offset);
+
+    /// <summary>
+    /// The records a merged read may return for a page starting at <paramref name="offset"/>, so
+    /// that <paramref name="offset"/> cannot walk past <see cref="MaxMergedPageWindow"/>.
+    /// </summary>
+    public static int ClampMergedPage(int limit, int offset) =>
+        Math.Clamp(limit, 0, MaxMergedPageWindow - Math.Min(ClampOffset(offset), MaxMergedPageWindow));
+
+    /// <summary>
+    /// Whether a range read's bounds are further apart than <see cref="MaxDateSpanDays"/>.
+    /// </summary>
+    public static bool ExceedsMaxDateSpan(DateTime? from, DateTime? to) =>
+        from is { } start && to is { } end && (end - start).TotalDays > MaxDateSpanDays;
+}

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4ReadOnlyControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4ReadOnlyControllerBase.cs
@@ -36,7 +36,9 @@ public abstract class V4ReadOnlyControllerBase<TModel, TRepository>(TRepository 
     /// - `timestamp_asc` — oldest records first
     /// - `timestamp_desc` — newest records first (default)
     ///
-    /// Use `limit` and `offset` together for paginated access to large result sets.
+    /// Use `limit` and `offset` together for paginated access to large result sets. `limit` is
+    /// capped at <see cref="V4ReadLimits.MaxPageSize"/>, and a `from`/`to` range wider than
+    /// <see cref="V4ReadLimits.MaxDateSpanDays"/> days is rejected with `400 Bad Request`.
     /// </remarks>
     [HttpGet]
     [RemoteQuery]
@@ -49,13 +51,38 @@ public abstract class V4ReadOnlyControllerBase<TModel, TRepository>(TRepository 
         [FromQuery] string? device = null, [FromQuery] string? source = null,
         CancellationToken ct = default)
     {
-        if (sort is not "timestamp_desc" and not "timestamp_asc")
-            return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+        if (PrepareListQuery(from, to, sort, ref limit, ref offset, out var descending) is { } error)
+            return error;
 
-        var descending = sort == "timestamp_desc";
         var data = await Repository.GetAsync(from, to, device, source, limit, offset, descending, ct);
         var total = await Repository.CountAsync(from, to, ct);
         return Ok(new PaginatedResponse<TModel> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });
+    }
+
+    /// <summary>
+    /// Validates the shared list-query parameters and clamps the paging window to
+    /// <see cref="V4ReadLimits"/>.
+    /// </summary>
+    /// <remarks>
+    /// Overrides of <see cref="GetAll"/> that add their own filters must route through this rather
+    /// than re-deriving <paramref name="descending"/>, which is the only way to obtain it.
+    /// </remarks>
+    /// <returns>The error response to return, or <c>null</c> when the query is usable.</returns>
+    protected ActionResult? PrepareListQuery(
+        DateTime? from, DateTime? to, string sort, ref int limit, ref int offset, out bool descending)
+    {
+        descending = true;
+
+        if (sort is not "timestamp_desc" and not "timestamp_asc")
+            return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        if (V4ReadLimits.ExceedsMaxDateSpan(from, to))
+            return Problem(detail: $"Date range must not exceed {V4ReadLimits.MaxDateSpanDays} days.", statusCode: 400, title: "Bad Request");
+
+        descending = sort == "timestamp_desc";
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+        return null;
     }
 
     /// <summary>Retrieves a single record by its unique identifier.</summary>

--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
@@ -67,14 +67,13 @@ public class DeviceEventController(
         [FromQuery] string? device = null, [FromQuery] string? source = null,
         CancellationToken ct = default)
     {
-        if (sort is not "timestamp_desc" and not "timestamp_asc")
-            return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+        if (PrepareListQuery(from, to, sort, ref limit, ref offset, out var descending) is { } error)
+            return error;
 
         Guid? patientDeviceId = null;
         if (Request.Query.TryGetValue("patientDeviceId", out var raw) && Guid.TryParse(raw, out var parsed))
             patientDeviceId = parsed;
 
-        var descending = sort == "timestamp_desc";
         var data = await Repository.GetAsync(from, to, device, source, limit, offset, descending,
             nativeOnly: false, patientDeviceId: patientDeviceId, ct: ct);
         var total = await Repository.CountAsync(from, to, ct);

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -61,14 +61,13 @@ public class SensorGlucoseController(
         [FromQuery] string? device = null, [FromQuery] string? source = null,
         CancellationToken ct = default)
     {
-        if (sort is not "timestamp_desc" and not "timestamp_asc")
-            return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+        if (PrepareListQuery(from, to, sort, ref limit, ref offset, out var descending) is { } error)
+            return error;
 
         Guid? patientDeviceId = null;
         if (Request.Query.TryGetValue("patientDeviceId", out var raw) && Guid.TryParse(raw, out var parsed))
             patientDeviceId = parsed;
 
-        var descending = sort == "timestamp_desc";
         var data = await Repository.GetAsync(from, to, device, source, limit, offset, descending,
             nativeOnly: false, afterTimestamp: null, afterId: null, patientDeviceId: patientDeviceId, ct: ct);
         var total = await Repository.CountAsync(from, to, ct);

--- a/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Extensions;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Health;
@@ -39,6 +40,10 @@ public class ActivityController : ControllerBase
     /// <summary>
     /// Get activity records with pagination
     /// </summary>
+    /// <remarks>
+    /// This read merges four sources in memory, so the page is bounded by
+    /// <see cref="V4ReadLimits.ClampMergedPage"/> rather than the plain page-size ceiling.
+    /// </remarks>
     [HttpGet]
     [RemoteQuery]
     [ProducesResponseType(typeof(PaginatedResponse<Activity>), StatusCodes.Status200OK)]
@@ -47,6 +52,9 @@ public class ActivityController : ControllerBase
         [FromQuery] int offset = 0,
         CancellationToken cancellationToken = default)
     {
+        offset = V4ReadLimits.ClampOffset(offset);
+        limit = V4ReadLimits.ClampMergedPage(limit, offset);
+
         var records = await _activityService.GetActivitiesAsync(
             count: limit, skip: offset, cancellationToken: cancellationToken);
         var total = (int)await _activityService.CountActivitiesAsync(cancellationToken: cancellationToken);

--- a/src/API/Nocturne.API/Helpers/LegacyReadLimits.cs
+++ b/src/API/Nocturne.API/Helpers/LegacyReadLimits.cs
@@ -67,7 +67,7 @@ public static class LegacyReadLimits
     /// </remarks>
     /// <remarks>
     /// Governs the v1 routes only. <c>/api/v4/activity</c> reaches the same four-source fan-out
-    /// with no ceiling of its own; capping it is queued separately, because v4 should not import a
+    /// under its own ceiling in <c>V4ReadLimits</c>, which v4 owns so that it need not import a
     /// legacy-compat helper.
     /// </remarks>
     public const int MaxMergedCount = 10_000;

--- a/src/Core/Nocturne.Core.Models/Configuration/NocturneOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/NocturneOptions.cs
@@ -134,11 +134,6 @@ public class ApiSettingsOptions
     public int DefaultPageSize { get; set; } = 50;
 
     /// <summary>
-    /// Maximum allowed page size.
-    /// </summary>
-    public int MaxPageSize { get; set; } = 1000;
-
-    /// <summary>
     /// Enable Swagger/OpenAPI documentation.
     /// </summary>
     public bool EnableSwagger { get; set; } = true;

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
@@ -106,6 +106,28 @@ public class V4CrudControllerBaseTests
     }
 
     [Fact]
+    public async Task ListDeleted_LimitAtCeiling_ReachesRepositoryUnchanged()
+    {
+        _repo.Setup(r => r.GetDeletedAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await _controller.ListDeleted(V4ReadLimits.MaxPageSize, 0);
+
+        _repo.Verify(r => r.GetDeletedAsync(V4ReadLimits.MaxPageSize, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ListDeleted_LimitAboveCeiling_IsClamped()
+    {
+        _repo.Setup(r => r.GetDeletedAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await _controller.ListDeleted(V4ReadLimits.MaxPageSize + 1, -1);
+
+        _repo.Verify(r => r.GetDeletedAsync(V4ReadLimits.MaxPageSize, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task GetAll_InvalidSort_ReturnsBadRequest()
     {
         var result = await _controller.GetAll(null, null, 100, 0, "invalid", null, null);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4ReadOnlyControllerBaseTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4ReadOnlyControllerBaseTests.cs
@@ -93,6 +93,88 @@ public class V4ReadOnlyControllerBaseTests
     }
 
     [Fact]
+    public async Task GetAll_LimitAtCeiling_ReachesRepositoryUnchanged()
+    {
+        StubRepository();
+
+        await _controller.GetAll(null, null, V4ReadLimits.MaxPageSize, 0, "timestamp_desc", null, null);
+
+        _repo.Verify(r => r.GetAsync(null, null, null, null, V4ReadLimits.MaxPageSize, 0, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAll_LimitAboveCeiling_IsClampedInBothQueryAndPagination()
+    {
+        StubRepository();
+
+        var result = await _controller.GetAll(null, null, V4ReadLimits.MaxPageSize + 1, 0, "timestamp_desc", null, null);
+
+        _repo.Verify(r => r.GetAsync(null, null, null, null, V4ReadLimits.MaxPageSize, 0, true, It.IsAny<CancellationToken>()), Times.Once);
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<PaginatedResponse<ReadOnlyTestRecord>>().Subject;
+        response.Pagination.Limit.Should().Be(V4ReadLimits.MaxPageSize);
+    }
+
+    [Fact]
+    public async Task GetAll_NegativeOffset_IsNormalizedToZero()
+    {
+        StubRepository();
+
+        await _controller.GetAll(null, null, 100, -1, "timestamp_desc", null, null);
+
+        _repo.Verify(r => r.GetAsync(null, null, null, null, 100, 0, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAll_DateSpanAtMaximum_IsAccepted()
+    {
+        var to = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var from = to.AddDays(-V4ReadLimits.MaxDateSpanDays);
+        _repo.Setup(r => r.GetAsync(from, to, null, null, 100, 0, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _repo.Setup(r => r.CountAsync(from, to, It.IsAny<CancellationToken>())).ReturnsAsync(0);
+
+        var result = await _controller.GetAll(from, to, 100, 0, "timestamp_desc", null, null);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetAll_DateSpanOneMillisecondOverMaximum_ReturnsBadRequest()
+    {
+        var to = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var from = to.AddDays(-V4ReadLimits.MaxDateSpanDays).AddMilliseconds(-1);
+
+        var result = await _controller.GetAll(from, to, 100, 0, "timestamp_desc", null, null);
+
+        result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(400);
+        _repo.Verify(r => r.GetAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAll_OpenEndedRange_IsNotSpanChecked()
+    {
+        var from = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        _repo.Setup(r => r.GetAsync(from, null, null, null, 100, 0, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _repo.Setup(r => r.CountAsync(from, null, It.IsAny<CancellationToken>())).ReturnsAsync(0);
+
+        var result = await _controller.GetAll(from, null, 100, 0, "timestamp_desc", null, null);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    private void StubRepository()
+    {
+        _repo.Setup(r => r.GetAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _repo.Setup(r => r.CountAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+    }
+
+    [Fact]
     public async Task GetById_Found_ReturnsOk()
     {
         var id = Guid.NewGuid();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/ActivityControllerV4Tests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/ActivityControllerV4Tests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Controllers.V4.Health;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Health;
@@ -32,6 +33,59 @@ public class ActivityControllerV4Tests
 
     private void GrantScopes(params string[] scopes) =>
         _controller.HttpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(scopes);
+
+    [Fact]
+    public async Task GetActivities_LimitAtWindow_ReachesServiceUnchanged()
+    {
+        await _controller.GetActivities(V4ReadLimits.MaxMergedPageWindow, 0, CancellationToken.None);
+
+        VerifyFetched(count: V4ReadLimits.MaxMergedPageWindow, skip: 0);
+    }
+
+    [Fact]
+    public async Task GetActivities_LimitAboveWindow_IsClampedToWindow()
+    {
+        await _controller.GetActivities(V4ReadLimits.MaxMergedPageWindow + 1, 0, CancellationToken.None);
+
+        VerifyFetched(count: V4ReadLimits.MaxMergedPageWindow, skip: 0);
+    }
+
+    [Fact]
+    public async Task GetActivities_OffsetInsideWindow_LeavesOnlyTheRemainder()
+    {
+        await _controller.GetActivities(V4ReadLimits.MaxMergedPageWindow, 1, CancellationToken.None);
+
+        VerifyFetched(count: V4ReadLimits.MaxMergedPageWindow - 1, skip: 1);
+    }
+
+    [Fact]
+    public async Task GetActivities_OffsetAtWindow_LeavesNothing()
+    {
+        await _controller.GetActivities(V4ReadLimits.MaxMergedPageWindow, V4ReadLimits.MaxMergedPageWindow, CancellationToken.None);
+
+        VerifyFetched(count: 0, skip: V4ReadLimits.MaxMergedPageWindow);
+    }
+
+    [Fact]
+    public async Task GetActivities_OffsetPastWindow_LeavesNothingRatherThanReopeningIt()
+    {
+        const int past = V4ReadLimits.MaxMergedPageWindow * 10;
+
+        await _controller.GetActivities(V4ReadLimits.MaxMergedPageWindow, past, CancellationToken.None);
+
+        VerifyFetched(count: 0, skip: past);
+    }
+
+    [Fact]
+    public async Task GetActivities_NegativeOffset_IsNormalizedToZero()
+    {
+        await _controller.GetActivities(100, -1, CancellationToken.None);
+
+        VerifyFetched(count: 100, skip: 0);
+    }
+
+    private void VerifyFetched(int count, int skip) =>
+        _service.Verify(x => x.GetActivitiesAsync(null, count, skip, It.IsAny<CancellationToken>()), Times.Once);
 
     [Fact]
     public async Task CreateActivities_SleepRecordWithoutSleepScope_ReturnsForbidden()


### PR DESCRIPTION
## Problem

The shared V4 list routes passed caller-supplied `limit`/`offset` straight to the repository with no ceiling, and `from`/`to` were unbounded — the 30s `statement_timeout` was the only backstop. `ApiSettingsOptions.MaxPageSize` existed but had exactly one occurrence in the repo: its own declaration, on an options tree that is never bound or injected. `/api/v4/activity` was the worst case: it over-fetches `limit + offset` from each of four sources before merging in memory, so one request could materialise ~400k rows.

Two controllers (`SensorGlucoseController`, `DeviceEventController`) re-implement `GetAll` rather than delegating, so a clamp placed only in the base body would have missed the two highest-traffic list routes.

## Fix

New `V4ReadLimits` (mirroring `LegacyReadLimits`' shape, not its code — v4 doesn't import legacy compat):

- `MaxPageSize = 100_000`, clamped (precedent: `ProfileController`'s existing `Math.Clamp`). Largest first-party caller asks for 10,000; nothing anywhere asks for more.
- `MaxMergedPageWindow = 10_000` bounds the activity merge's `limit + offset` — its cost is proportional to both.
- `MaxDateSpanDays = 366`, rejected with 400 (precedent: the sleep-report 90-day guard). Rejecting rather than clamping is deliberate: silently narrowing a range answers a different question than the caller asked. Open-ended ranges are not span-checked — they're still bounded by `limit`, and the year-overview page uses `DataOverviewController`, which has no `from`/`to` list surface, so nothing first-party breaks.

The shared pre-flight is extracted into `PrepareListQuery(...)`, which validates sort, enforces the span, clamps paging, and is now the only way to obtain `descending` — a future `GetAll` override can't skip the guard without also losing sort handling. Both bypassing overrides now go through it. The dead `MaxPageSize` property is deleted so there aren't two things by that name with one doing nothing.

## Tests

+14 tests, all boundary-pinned from both sides: at-ceiling accepted, above-ceiling clamped; span at 366d accepted, 366d + 1ms rejected; activity offset inside/at/past the merged window. Mutation-proven with predicted failures: three simultaneous comparison flips produced exactly the six predicted failures and nothing else. Full suite: 5172 passed / 2 failed — both failures byte-identical on the untouched baseline (the stale cache test fixed in #687, and the known load-flaky GC benchmark).

## Not covered (follow-up)

~24 non-base V4 routes declare their own `limit`/`count` and remain unclamped (StateSpans, Audit, Sleep, Nutrition, Battery, Health trio, Compatibility, SystemEvents, Discrepancy, Trackers, Foods, TherapySettings). Each is now a mechanical two-line `V4ReadLimits` call; listed for a follow-up rather than ballooning this PR.

Follow-up from #478 and #651.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
