### PR TITLE
perf(devices): index device_events on (tenant_id, event_type, timestamp DESC)

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811185512_AddDeviceEventsTenantEventTypeTimestampIndex.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811185512_AddDeviceEventsTenantEventTypeTimestampIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811185512_AddDeviceEventsTenantEventTypeTimestampIndex")]
+    partial class AddDeviceEventsTenantEventTypeTimestampIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811185512_AddDeviceEventsTenantEventTypeTimestampIndex.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260811185512_AddDeviceEventsTenantEventTypeTimestampIndex.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceEventsTenantEventTypeTimestampIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_device_events_tenant_event_type_timestamp",
+                table: "device_events",
+                columns: new[] { "tenant_id", "event_type", "timestamp" },
+                descending: new[] { false, false, true });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_device_events_tenant_event_type_timestamp",
+                table: "device_events");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1824,6 +1824,15 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasIndex(e => e.CorrelationId)
             .HasDatabaseName("ix_device_events_correlation_id");
 
+        // Latest-of-a-kind lookups (device age, alert enrichment) filter on tenant + event type
+        // and take the newest row. Without the event_type column the plan walks the whole
+        // tenant's history backwards and never terminates early for a type that was never logged.
+        modelBuilder
+            .Entity<DeviceEventEntity>()
+            .HasIndex(e => new { e.TenantId, e.EventType, e.Timestamp })
+            .HasDatabaseName("ix_device_events_tenant_event_type_timestamp")
+            .IsDescending(false, false, true);
+
         // BolusCalculations indexes
         modelBuilder
             .Entity<BolusCalculationEntity>()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/DeviceEventIndexTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/DeviceEventIndexTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// Pins the index backing <c>GetLatestByEventTypeAsync</c>/<c>GetLatestByEventTypesAsync</c>.
+/// Those lookups run once per device-age slot on every properties request, and the tenant/event-type
+/// prefix is what lets Postgres return immediately for an event type the tenant has never logged
+/// instead of walking its whole history backwards.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DeviceEventIndexTests
+{
+    [Fact]
+    public void LatestByEventTypeLookup_IsBackedByATenantEventTypeTimestampIndex()
+    {
+        using var ctx = new NocturneDbContext(
+            new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
+                .Options)
+        { TenantId = Guid.NewGuid() };
+
+        // Column sort direction only survives on the design-time model; the runtime model drops it.
+        var index = ctx.GetService<IDesignTimeModel>().Model
+            .FindEntityType(typeof(DeviceEventEntity))!
+            .GetIndexes()
+            .SingleOrDefault(i => i.GetDatabaseName() == "ix_device_events_tenant_event_type_timestamp");
+
+        index.Should().NotBeNull();
+        index!.Properties.Select(p => p.Name).Should().Equal(
+            nameof(DeviceEventEntity.TenantId),
+            nameof(DeviceEventEntity.EventType),
+            nameof(DeviceEventEntity.Timestamp));
+        index.IsDescending.Should().Equal(false, false, true);
+    }
+}


### PR DESCRIPTION
## Problem

`DeviceEventRepository.GetLatestByEventTypeAsync`/`GetLatestByEventTypesAsync` issue `WHERE tenant_id = … AND deleted_at IS NULL AND event_type IN (…) ORDER BY timestamp DESC LIMIT 1`, and `device_events` has no index covering that predicate (only `correlation_id`, `device_id`, `patient_device_id`, a tenant-less `timestamp DESC`, and the filtered unique `(tenant_id, legacy_id)`). For a tenant that has never logged a given event type — common for `bage` — the plan degenerates into a backward scan of the whole timestamp index with no matching row to stop on. `DeviceAgeService` issues five of these per request (from `/api/v2/properties` and the v4 device-age endpoint); the alert enricher a sixth.

## Change

`ix_device_events_tenant_event_type_timestamp` on `(tenant_id, event_type, timestamp DESC)`, declared beside the entity's other indexes in the `ix_boluses_tenant_timestamp` style; migration generated with `dotnet ef migrations add` — exactly one `CreateIndex`/`DropIndex`, snapshot churn is 4 lines.

No `deleted_at IS NULL` filter, deliberately: the never-logged case is already collapsed to an empty range by the `(tenant_id, event_type)` equality prefix; soft-deleted events are a negligible share of the table; a partial index is unusable on every `IgnoreQueryFilters` path (dedup reconcile, purge/restore); and the codebase reserves `HasFilter` for unique keys where it lets a re-add coexist with a deleted row — none of the read-path composites carry one.

Plan shape: two leading equality columns (tenant from the global filter, event_type from the predicate — an `IN` list is a per-value scan merged in order), third column matches `ORDER BY timestamp DESC`, so Postgres returns the first tuple and stops at `LIMIT 1`; a never-logged type returns zero tuples immediately. `deleted_at` is a cheap heap recheck on the few tuples fetched.

## Tests

New model-metadata test asserting the index's columns in order and per-column sort direction, read from the design-time model (the runtime model discards sort direction). Mutation-proven: dropping `IsDescending` fails it. `Nocturne.Infrastructure.Data.Tests`: 570/570.

## Deploy notes

- Plain (non-`CONCURRENTLY`) `CREATE INDEX`, like every migration here — brief write lock on `device_events` during build; the table is small relative to entries/sensor_glucose.
- #690 also adds a migration; whichever merges second regenerates its snapshot (the migration files themselves don't conflict).

Follow-up from #543.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
