### PR TITLE
feat(devices): optionally scope deviceage endpoints to a patient device

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceAgeController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceAgeController.cs
@@ -13,7 +13,8 @@ namespace Nocturne.API.Controllers.V4.Devices;
 /// Each endpoint accepts optional threshold parameters (<c>info</c>, <c>warn</c>, <c>urgent</c>
 /// in hours) and a <c>display</c> unit (<c>hours</c> or <c>days</c>) that are forwarded as a
 /// <see cref="DeviceAgePreferences"/> object to the service. Defaults are used when parameters
-/// are not supplied.
+/// are not supplied. An optional <c>patientDeviceId</c> scopes the underlying device events to a
+/// single registered patient device; omitting it uses the latest matching event tenant-wide.
 ///
 /// <b>CAGE</b> — cannula/site age from <c>Site Change</c> events.<br/>
 /// <b>SAGE</b> — sensor age from <c>Sensor Start</c> and <c>Sensor Change</c> events.<br/>
@@ -52,10 +53,11 @@ public class DeviceAgeController : ControllerBase
         [FromQuery] int? warn = null,
         [FromQuery] int? urgent = null,
         [FromQuery] string? display = null,
-        [FromQuery] bool? enableAlerts = null)
+        [FromQuery] bool? enableAlerts = null,
+        [FromQuery] Guid? patientDeviceId = null)
     {
         var prefs = BuildPreferences(info, warn, urgent, display, enableAlerts);
-        var result = await _deviceAgeService.GetCannulaAgeAsync(prefs, HttpContext.RequestAborted);
+        var result = await _deviceAgeService.GetCannulaAgeAsync(prefs, patientDeviceId, HttpContext.RequestAborted);
         return Ok(result);
     }
 
@@ -70,10 +72,11 @@ public class DeviceAgeController : ControllerBase
         [FromQuery] int? warn = null,
         [FromQuery] int? urgent = null,
         [FromQuery] string? display = null,
-        [FromQuery] bool? enableAlerts = null)
+        [FromQuery] bool? enableAlerts = null,
+        [FromQuery] Guid? patientDeviceId = null)
     {
         var prefs = BuildPreferences(info, warn, urgent, display, enableAlerts);
-        var result = await _deviceAgeService.GetSensorAgeAsync(prefs, HttpContext.RequestAborted);
+        var result = await _deviceAgeService.GetSensorAgeAsync(prefs, patientDeviceId, HttpContext.RequestAborted);
         return Ok(result);
     }
 
@@ -87,10 +90,11 @@ public class DeviceAgeController : ControllerBase
         [FromQuery] int? warn = null,
         [FromQuery] int? urgent = null,
         [FromQuery] string? display = null,
-        [FromQuery] bool? enableAlerts = null)
+        [FromQuery] bool? enableAlerts = null,
+        [FromQuery] Guid? patientDeviceId = null)
     {
         var prefs = BuildPreferences(info, warn, urgent, display, enableAlerts);
-        var result = await _deviceAgeService.GetInsulinAgeAsync(prefs, HttpContext.RequestAborted);
+        var result = await _deviceAgeService.GetInsulinAgeAsync(prefs, patientDeviceId, HttpContext.RequestAborted);
         return Ok(result);
     }
 
@@ -104,10 +108,11 @@ public class DeviceAgeController : ControllerBase
         [FromQuery] int? warn = null,
         [FromQuery] int? urgent = null,
         [FromQuery] string? display = null,
-        [FromQuery] bool? enableAlerts = null)
+        [FromQuery] bool? enableAlerts = null,
+        [FromQuery] Guid? patientDeviceId = null)
     {
         var prefs = BuildPreferences(info, warn, urgent, display, enableAlerts);
-        var result = await _deviceAgeService.GetBatteryAgeAsync(prefs, HttpContext.RequestAborted);
+        var result = await _deviceAgeService.GetBatteryAgeAsync(prefs, patientDeviceId, HttpContext.RequestAborted);
         return Ok(result);
     }
 
@@ -116,14 +121,14 @@ public class DeviceAgeController : ControllerBase
     /// </summary>
     [HttpGet("all")]
     [ProducesResponseType(200)]
-    public async Task<ActionResult> GetAllDeviceAges()
+    public async Task<ActionResult> GetAllDeviceAges([FromQuery] Guid? patientDeviceId = null)
     {
         var defaultPrefs = new DeviceAgePreferences();
 
-        var cannula = await _deviceAgeService.GetCannulaAgeAsync(defaultPrefs, HttpContext.RequestAborted);
-        var sensor = await _deviceAgeService.GetSensorAgeAsync(defaultPrefs, HttpContext.RequestAborted);
-        var insulin = await _deviceAgeService.GetInsulinAgeAsync(defaultPrefs, HttpContext.RequestAborted);
-        var battery = await _deviceAgeService.GetBatteryAgeAsync(defaultPrefs, HttpContext.RequestAborted);
+        var cannula = await _deviceAgeService.GetCannulaAgeAsync(defaultPrefs, patientDeviceId, HttpContext.RequestAborted);
+        var sensor = await _deviceAgeService.GetSensorAgeAsync(defaultPrefs, patientDeviceId, HttpContext.RequestAborted);
+        var insulin = await _deviceAgeService.GetInsulinAgeAsync(defaultPrefs, patientDeviceId, HttpContext.RequestAborted);
+        var battery = await _deviceAgeService.GetBatteryAgeAsync(defaultPrefs, patientDeviceId, HttpContext.RequestAborted);
 
         return Ok(new
         {

--- a/src/API/Nocturne.API/Services/Devices/DeviceAgeService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceAgeService.cs
@@ -34,19 +34,19 @@ public class DeviceAgeService : IDeviceAgeService
         _logger = logger;
     }
 
-    public async Task<DeviceAgeInfo> GetCannulaAgeAsync(DeviceAgePreferences prefs, CancellationToken ct = default)
+    public async Task<DeviceAgeInfo> GetCannulaAgeAsync(DeviceAgePreferences prefs, Guid? patientDeviceId = null, CancellationToken ct = default)
     {
         var effectivePrefs = MergePreferences(prefs, DefaultCannulaPrefs);
-        var latestEvent = await _repository.GetLatestByEventTypesAsync(CannulaEventTypes, ct);
+        var latestEvent = await _repository.GetLatestByEventTypesAsync(CannulaEventTypes, patientDeviceId, ct);
         return CreateDeviceAgeInfo(latestEvent, effectivePrefs, "CAGE", "Cannula");
     }
 
-    public async Task<SensorAgeInfo> GetSensorAgeAsync(DeviceAgePreferences prefs, CancellationToken ct = default)
+    public async Task<SensorAgeInfo> GetSensorAgeAsync(DeviceAgePreferences prefs, Guid? patientDeviceId = null, CancellationToken ct = default)
     {
         var effectivePrefs = MergePreferences(prefs, DefaultSensorPrefs);
 
-        var sensorStartEvent = await _repository.GetLatestByEventTypesAsync(SensorStartEventTypes, ct);
-        var sensorChangeEvent = await _repository.GetLatestByEventTypesAsync(SensorChangeEventTypes, ct);
+        var sensorStartEvent = await _repository.GetLatestByEventTypesAsync(SensorStartEventTypes, patientDeviceId, ct);
+        var sensorChangeEvent = await _repository.GetLatestByEventTypesAsync(SensorChangeEventTypes, patientDeviceId, ct);
 
         var sensorStart = CreateDeviceAgeInfo(sensorStartEvent, effectivePrefs, "SAGE", "Sensor");
         var sensorChange = CreateDeviceAgeInfo(sensorChangeEvent, effectivePrefs, "SAGE", "Sensor");
@@ -75,17 +75,17 @@ public class DeviceAgeService : IDeviceAgeService
         };
     }
 
-    public async Task<DeviceAgeInfo> GetInsulinAgeAsync(DeviceAgePreferences prefs, CancellationToken ct = default)
+    public async Task<DeviceAgeInfo> GetInsulinAgeAsync(DeviceAgePreferences prefs, Guid? patientDeviceId = null, CancellationToken ct = default)
     {
         var effectivePrefs = MergePreferences(prefs, DefaultInsulinPrefs);
-        var latestEvent = await _repository.GetLatestByEventTypesAsync(InsulinEventTypes, ct);
+        var latestEvent = await _repository.GetLatestByEventTypesAsync(InsulinEventTypes, patientDeviceId, ct);
         return CreateDeviceAgeInfo(latestEvent, effectivePrefs, "IAGE", "Insulin reservoir");
     }
 
-    public async Task<DeviceAgeInfo> GetBatteryAgeAsync(DeviceAgePreferences prefs, CancellationToken ct = default)
+    public async Task<DeviceAgeInfo> GetBatteryAgeAsync(DeviceAgePreferences prefs, Guid? patientDeviceId = null, CancellationToken ct = default)
     {
         var effectivePrefs = MergePreferences(prefs, DefaultBatteryPrefs);
-        var latestEvent = await _repository.GetLatestByEventTypesAsync(BatteryEventTypes, ct);
+        var latestEvent = await _repository.GetLatestByEventTypesAsync(BatteryEventTypes, patientDeviceId, ct);
         return CreateDeviceAgeInfo(latestEvent, effectivePrefs, "BAGE", "Pump battery");
     }
 

--- a/src/API/Nocturne.API/Services/Profiles/PropertiesService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/PropertiesService.cs
@@ -586,10 +586,10 @@ public class PropertiesService : IPropertiesService
             // properties endpoint reports the service defaults.
             var prefs = new DeviceAgePreferences();
 
-            var sensor = await _deviceAgeService.GetSensorAgeAsync(prefs, cancellationToken);
+            var sensor = await _deviceAgeService.GetSensorAgeAsync(prefs, ct: cancellationToken);
 
             properties["cage"] = ToAgeDictionary(
-                await _deviceAgeService.GetCannulaAgeAsync(prefs, cancellationToken));
+                await _deviceAgeService.GetCannulaAgeAsync(prefs, ct: cancellationToken));
             properties["sage"] = new Dictionary<string, object?>
             {
                 ["Sensor Start"] = ToAgeDictionary(sensor.SensorStart),
@@ -597,9 +597,9 @@ public class PropertiesService : IPropertiesService
                 ["min"] = sensor.Min,
             };
             properties["iage"] = ToAgeDictionary(
-                await _deviceAgeService.GetInsulinAgeAsync(prefs, cancellationToken));
+                await _deviceAgeService.GetInsulinAgeAsync(prefs, ct: cancellationToken));
             properties["bage"] = ToAgeDictionary(
-                await _deviceAgeService.GetBatteryAgeAsync(prefs, cancellationToken));
+                await _deviceAgeService.GetBatteryAgeAsync(prefs, ct: cancellationToken));
         }
         catch (Exception ex)
         {

--- a/src/Core/Nocturne.Core.Contracts/Devices/IDeviceAgeService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Devices/IDeviceAgeService.cs
@@ -11,31 +11,39 @@ public interface IDeviceAgeService
     /// Get cannula/site age (CAGE).
     /// </summary>
     /// <param name="prefs">User preferences controlling warning and alert thresholds.</param>
+    /// <param name="patientDeviceId">Optional registered patient device to scope the underlying device
+    /// events to. <c>null</c> uses the most recent matching event tenant-wide.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Age information for the cannula/infusion site.</returns>
-    Task<DeviceAgeInfo> GetCannulaAgeAsync(DeviceAgePreferences prefs, CancellationToken ct = default);
+    Task<DeviceAgeInfo> GetCannulaAgeAsync(DeviceAgePreferences prefs, Guid? patientDeviceId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get sensor age (SAGE). Returns a composite with both start and change events.
     /// </summary>
     /// <param name="prefs">User preferences controlling warning and alert thresholds.</param>
+    /// <param name="patientDeviceId">Optional registered patient device to scope the underlying device
+    /// events to. <c>null</c> uses the most recent matching event tenant-wide.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Sensor age information including both the session start and the most recent warm-up.</returns>
-    Task<SensorAgeInfo> GetSensorAgeAsync(DeviceAgePreferences prefs, CancellationToken ct = default);
+    Task<SensorAgeInfo> GetSensorAgeAsync(DeviceAgePreferences prefs, Guid? patientDeviceId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get insulin reservoir age (IAGE).
     /// </summary>
     /// <param name="prefs">User preferences controlling warning and alert thresholds.</param>
+    /// <param name="patientDeviceId">Optional registered patient device to scope the underlying device
+    /// events to. <c>null</c> uses the most recent matching event tenant-wide.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Age information for the insulin reservoir.</returns>
-    Task<DeviceAgeInfo> GetInsulinAgeAsync(DeviceAgePreferences prefs, CancellationToken ct = default);
+    Task<DeviceAgeInfo> GetInsulinAgeAsync(DeviceAgePreferences prefs, Guid? patientDeviceId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get pump battery age (BAGE).
     /// </summary>
     /// <param name="prefs">User preferences controlling warning and alert thresholds.</param>
+    /// <param name="patientDeviceId">Optional registered patient device to scope the underlying device
+    /// events to. <c>null</c> uses the most recent matching event tenant-wide.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Age information for the pump battery.</returns>
-    Task<DeviceAgeInfo> GetBatteryAgeAsync(DeviceAgePreferences prefs, CancellationToken ct = default);
+    Task<DeviceAgeInfo> GetBatteryAgeAsync(DeviceAgePreferences prefs, Guid? patientDeviceId = null, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
@@ -142,7 +142,13 @@ public interface IDeviceEventRepository : IV4Repository<DeviceEvent>
     /// Retrieve the most recent <see cref="DeviceEvent"/> matching any of the specified <see cref="DeviceEventType"/> values.
     /// </summary>
     /// <param name="eventTypes">Array of <see cref="DeviceEventType"/> values to search for.</param>
+    /// <param name="patientDeviceId">Optional filter restricting the search to events linked to a single
+    /// registered patient device. Pass <c>null</c> to search tenant-wide.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The most recent matching event, or <c>null</c> if none exists.</returns>
-    Task<DeviceEvent?> GetLatestByEventTypesAsync(DeviceEventType[] eventTypes, CancellationToken ct = default);
+    Task<DeviceEvent?> GetLatestByEventTypesAsync(
+        DeviceEventType[] eventTypes,
+        Guid? patientDeviceId = null,
+        CancellationToken ct = default
+    );
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -211,15 +211,24 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
     /// Gets the latest device event from a set of event types.
     /// </summary>
     /// <param name="eventTypes">The types of device events to search for.</param>
+    /// <param name="patientDeviceId">Optional filter restricting the search to a single registered patient device.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The latest device event, or null if none found.</returns>
-    public async Task<DeviceEvent?> GetLatestByEventTypesAsync(DeviceEventType[] eventTypes, CancellationToken ct = default)
+    public async Task<DeviceEvent?> GetLatestByEventTypesAsync(
+        DeviceEventType[] eventTypes,
+        Guid? patientDeviceId = null,
+        CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         var eventTypeStrings = eventTypes.Select(t => t.ToString()).ToList();
-        var entity = await ctx.DeviceEvents
+        var query = ctx.DeviceEvents
             .AsNoTracking()
-            .Where(e => eventTypeStrings.Contains(e.EventType))
+            .Where(e => eventTypeStrings.Contains(e.EventType));
+
+        if (patientDeviceId.HasValue)
+            query = query.Where(e => e.PatientDeviceId == patientDeviceId.Value);
+
+        var entity = await query
             .OrderByDescending(e => e.Timestamp)
             .FirstOrDefaultAsync(ct);
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/DeviceAgeControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/DeviceAgeControllerTests.cs
@@ -45,6 +45,7 @@ public class DeviceAgeControllerTests
             .Setup(x =>
                 x.GetCannulaAgeAsync(
                     It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -65,6 +66,7 @@ public class DeviceAgeControllerTests
             .Setup(x =>
                 x.GetSensorAgeAsync(
                     It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -88,6 +90,7 @@ public class DeviceAgeControllerTests
                         && p.Display == "days"
                         && p.EnableAlerts
                     ),
+                    It.IsAny<Guid?>(),
                     It.IsAny<CancellationToken>()
                 ),
             Times.Once
@@ -103,6 +106,7 @@ public class DeviceAgeControllerTests
             .Setup(x =>
                 x.GetBatteryAgeAsync(
                     It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -128,6 +132,7 @@ public class DeviceAgeControllerTests
             .Setup(x =>
                 x.GetCannulaAgeAsync(
                     It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -137,6 +142,7 @@ public class DeviceAgeControllerTests
             .Setup(x =>
                 x.GetSensorAgeAsync(
                     It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -146,6 +152,7 @@ public class DeviceAgeControllerTests
             .Setup(x =>
                 x.GetInsulinAgeAsync(
                     It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -155,6 +162,7 @@ public class DeviceAgeControllerTests
             .Setup(x =>
                 x.GetBatteryAgeAsync(
                     It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -171,5 +179,83 @@ public class DeviceAgeControllerTests
         Assert.Same(sensorAge, valueType.GetProperty("sage")?.GetValue(value));
         Assert.Same(insulinAge, valueType.GetProperty("iage")?.GetValue(value));
         Assert.Same(batteryAge, valueType.GetProperty("bage")?.GetValue(value));
+    }
+
+    [Fact]
+    public async Task GetCannulaAge_WithPatientDeviceId_ForwardsItToTheService()
+    {
+        var pumpId = Guid.NewGuid();
+
+        _deviceAgeServiceMock
+            .Setup(x =>
+                x.GetCannulaAgeAsync(
+                    It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(new DeviceAgeInfo());
+
+        await _controller.GetCannulaAge(patientDeviceId: pumpId);
+
+        _deviceAgeServiceMock.Verify(
+            x =>
+                x.GetCannulaAgeAsync(
+                    It.IsAny<DeviceAgePreferences>(),
+                    pumpId,
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GetAllDeviceAges_WithPatientDeviceId_ScopesEveryAge()
+    {
+        var deviceId = Guid.NewGuid();
+
+        _deviceAgeServiceMock
+            .Setup(x =>
+                x.GetCannulaAgeAsync(
+                    It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(new DeviceAgeInfo());
+        _deviceAgeServiceMock
+            .Setup(x =>
+                x.GetSensorAgeAsync(
+                    It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(new SensorAgeInfo());
+        _deviceAgeServiceMock
+            .Setup(x =>
+                x.GetInsulinAgeAsync(
+                    It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(new DeviceAgeInfo());
+        _deviceAgeServiceMock
+            .Setup(x =>
+                x.GetBatteryAgeAsync(
+                    It.IsAny<DeviceAgePreferences>(),
+                    It.IsAny<Guid?>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(new DeviceAgeInfo());
+
+        await _controller.GetAllDeviceAges(deviceId);
+
+        _deviceAgeServiceMock.Verify(x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), deviceId, It.IsAny<CancellationToken>()), Times.Once);
+        _deviceAgeServiceMock.Verify(x => x.GetSensorAgeAsync(It.IsAny<DeviceAgePreferences>(), deviceId, It.IsAny<CancellationToken>()), Times.Once);
+        _deviceAgeServiceMock.Verify(x => x.GetInsulinAgeAsync(It.IsAny<DeviceAgePreferences>(), deviceId, It.IsAny<CancellationToken>()), Times.Once);
+        _deviceAgeServiceMock.Verify(x => x.GetBatteryAgeAsync(It.IsAny<DeviceAgePreferences>(), deviceId, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceAgeServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceAgeServiceTests.cs
@@ -40,6 +40,7 @@ public class DeviceAgeServiceTests
                 It.Is<DeviceEventType[]>(types =>
                     types.Contains(DeviceEventType.SiteChange) &&
                     types.Contains(DeviceEventType.CannulaChange)),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(deviceEvent);
 
@@ -65,6 +66,7 @@ public class DeviceAgeServiceTests
         _repositoryMock
             .Setup(r => r.GetLatestByEventTypesAsync(
                 It.IsAny<DeviceEventType[]>(),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((DeviceEvent?)null);
 
@@ -107,12 +109,14 @@ public class DeviceAgeServiceTests
         _repositoryMock
             .Setup(r => r.GetLatestByEventTypesAsync(
                 It.Is<DeviceEventType[]>(types => types.Contains(DeviceEventType.SensorStart)),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(sensorStartEvent);
 
         _repositoryMock
             .Setup(r => r.GetLatestByEventTypesAsync(
                 It.Is<DeviceEventType[]>(types => types.Contains(DeviceEventType.SensorChange)),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(sensorChangeEvent);
 
@@ -147,6 +151,7 @@ public class DeviceAgeServiceTests
                 It.Is<DeviceEventType[]>(types =>
                     types.Contains(DeviceEventType.InsulinChange) &&
                     types.Contains(DeviceEventType.ReservoirChange)),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(deviceEvent);
 
@@ -181,6 +186,7 @@ public class DeviceAgeServiceTests
             .Setup(r => r.GetLatestByEventTypesAsync(
                 It.Is<DeviceEventType[]>(types =>
                     types.Contains(DeviceEventType.PumpBatteryChange)),
+                It.IsAny<Guid?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(deviceEvent);
 
@@ -195,5 +201,121 @@ public class DeviceAgeServiceTests
         result.Days.Should().Be(14);
         result.Hours.Should().Be(4);
         result.Level.Should().Be(1); // 340h is above warn (336) but below urgent (360)
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetCannulaAgeAsync_WithPatientDeviceId_UsesThatDevicesEvent()
+    {
+        // Arrange
+        var pumpId = Guid.NewGuid();
+        var scopedEvent = new DeviceEvent
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow.AddHours(-30),
+            EventType = DeviceEventType.SiteChange,
+            PatientDeviceId = pumpId
+        };
+        var otherPumpEvent = new DeviceEvent
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow.AddHours(-2),
+            EventType = DeviceEventType.SiteChange,
+            PatientDeviceId = Guid.NewGuid()
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetLatestByEventTypesAsync(
+                It.IsAny<DeviceEventType[]>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(otherPumpEvent);
+
+        _repositoryMock
+            .Setup(r => r.GetLatestByEventTypesAsync(
+                It.IsAny<DeviceEventType[]>(),
+                pumpId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(scopedEvent);
+
+        // Act
+        var result = await _service.GetCannulaAgeAsync(new DeviceAgePreferences(), pumpId);
+
+        // Assert
+        result.Age.Should().Be(30);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetSensorAgeAsync_WithPatientDeviceId_ScopesBothEventTypeLookups()
+    {
+        // Arrange
+        var sensorId = Guid.NewGuid();
+
+        _repositoryMock
+            .Setup(r => r.GetLatestByEventTypesAsync(
+                It.IsAny<DeviceEventType[]>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceEvent
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.UtcNow.AddHours(-2),
+                EventType = DeviceEventType.SensorChange,
+                PatientDeviceId = Guid.NewGuid()
+            });
+
+        _repositoryMock
+            .Setup(r => r.GetLatestByEventTypesAsync(
+                It.Is<DeviceEventType[]>(types => types.Contains(DeviceEventType.SensorStart)),
+                sensorId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeviceEvent
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = DateTime.UtcNow.AddHours(-100),
+                EventType = DeviceEventType.SensorStart,
+                PatientDeviceId = sensorId
+            });
+
+        _repositoryMock
+            .Setup(r => r.GetLatestByEventTypesAsync(
+                It.Is<DeviceEventType[]>(types => types.Contains(DeviceEventType.SensorChange)),
+                sensorId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DeviceEvent?)null);
+
+        // Act
+        var result = await _service.GetSensorAgeAsync(new DeviceAgePreferences(), sensorId);
+
+        // Assert
+        result.Min.Should().Be("Sensor Start");
+        result.SensorStart.Found.Should().BeTrue();
+        result.SensorStart.Age.Should().Be(100);
+        result.SensorChange.Found.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetBatteryAgeAsync_WithNoPatientDeviceId_QueriesTenantWide()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetLatestByEventTypesAsync(
+                It.IsAny<DeviceEventType[]>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DeviceEvent?)null);
+
+        // Act
+        await _service.GetBatteryAgeAsync(new DeviceAgePreferences());
+
+        // Assert
+        _repositoryMock.Verify(
+            r => r.GetLatestByEventTypesAsync(
+                It.IsAny<DeviceEventType[]>(),
+                null,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/PropertiesServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/PropertiesServiceTests.cs
@@ -39,16 +39,16 @@ public class PropertiesServiceTests
 
         _mockDeviceAgeService = new Mock<IDeviceAgeService>();
         _mockDeviceAgeService
-            .Setup(x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DeviceAgeInfo { Found = true, Age = 10, Days = 0, Hours = 10 });
         _mockDeviceAgeService
-            .Setup(x => x.GetSensorAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetSensorAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SensorAgeInfo());
         _mockDeviceAgeService
-            .Setup(x => x.GetInsulinAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetInsulinAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DeviceAgeInfo { Found = true, Age = 30, Days = 1, Hours = 6 });
         _mockDeviceAgeService
-            .Setup(x => x.GetBatteryAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetBatteryAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DeviceAgeInfo());
 
         _service = new PropertiesService(
@@ -161,7 +161,7 @@ public class PropertiesServiceTests
         // zero/false members from typed objects. Age fields are legitimately zero right
         // after a site change, so they must be projected as dictionaries to reach clients.
         _mockDeviceAgeService
-            .Setup(x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DeviceAgeInfo { Found = false, Age = 0, Days = 0, Hours = 0, Level = 0 });
         _mockDDataService
             .Setup(x => x.GetDDataAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
@@ -191,13 +191,13 @@ public class PropertiesServiceTests
         await _service.GetPropertiesAsync(new[] { "iob" }, CancellationToken.None);
 
         _mockDeviceAgeService.Verify(
-            x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()),
+            x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
         await _service.GetPropertiesAsync(new[] { "cage" }, CancellationToken.None);
 
         _mockDeviceAgeService.Verify(
-            x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<CancellationToken>()),
+            x => x.GetCannulaAgeAsync(It.IsAny<DeviceAgePreferences>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceEventRepositoryPatientDeviceScopeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceEventRepositoryPatientDeviceScopeTests.cs
@@ -1,0 +1,161 @@
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Covers the optional patient-device scope on
+/// <see cref="DeviceEventRepository.GetLatestByEventTypesAsync"/>, which backs the CAGE/SAGE/IAGE/BAGE
+/// ages. A wearer with two CGMs or two pumps otherwise gets a blended age: a change on one device
+/// resets the age reported for the other.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+[Trait("Category", "DeviceEvent")]
+public class DeviceEventRepositoryPatientDeviceScopeTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000003");
+    private readonly DbConnection _connection;
+    private readonly NocturneDbContext _context;
+    private readonly DeviceEventRepository _repo;
+
+    public DeviceEventRepositoryPatientDeviceScopeTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seedContext = new NocturneDbContext(options))
+        {
+            seedContext.TenantId = TestTenantId;
+            seedContext.Database.EnsureCreated();
+            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seedContext.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(options) { TenantId = TestTenantId };
+
+        _repo = new DeviceEventRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<DeviceEventRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private Guid SeedDevice(string category, string model)
+    {
+        var id = Guid.NewGuid();
+        _context.PatientDevices.Add(new PatientDeviceEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            DeviceCategory = category,
+            Manufacturer = "Test",
+            Model = model,
+            IsCurrent = true,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    private void SeedEvent(DeviceEventType eventType, DateTime timestamp, Guid? patientDeviceId)
+    {
+        _context.DeviceEvents.Add(new DeviceEventEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            EventType = eventType.ToString(),
+            PatientDeviceId = patientDeviceId,
+        });
+        _context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetLatestByEventTypesAsync_ScopedToAPatientDevice_IgnoresANewerEventOnAnotherDevice()
+    {
+        var firstSensor = SeedDevice("CGM", "G7");
+        var secondSensor = SeedDevice("CGM", "Libre 3");
+
+        var firstChange = new DateTime(2026, 8, 1, 6, 0, 0, DateTimeKind.Utc);
+        var secondChange = new DateTime(2026, 8, 5, 6, 0, 0, DateTimeKind.Utc);
+        SeedEvent(DeviceEventType.SensorChange, firstChange, firstSensor);
+        SeedEvent(DeviceEventType.SensorChange, secondChange, secondSensor);
+
+        var latest = await _repo.GetLatestByEventTypesAsync([DeviceEventType.SensorChange], firstSensor);
+
+        latest.Should().NotBeNull();
+        latest!.Timestamp.Should().Be(firstChange);
+        latest.PatientDeviceId.Should().Be(firstSensor);
+    }
+
+    [Fact]
+    public async Task GetLatestByEventTypesAsync_ScopedToAPatientDevice_ExcludesUnlinkedEvents()
+    {
+        var pump = SeedDevice("InsulinPump", "t:slim");
+
+        var linked = new DateTime(2026, 8, 1, 6, 0, 0, DateTimeKind.Utc);
+        SeedEvent(DeviceEventType.SiteChange, linked, pump);
+        SeedEvent(DeviceEventType.SiteChange, new DateTime(2026, 8, 5, 6, 0, 0, DateTimeKind.Utc), null);
+
+        var latest = await _repo.GetLatestByEventTypesAsync([DeviceEventType.SiteChange], pump);
+
+        latest.Should().NotBeNull();
+        latest!.Timestamp.Should().Be(linked);
+    }
+
+    [Fact]
+    public async Task GetLatestByEventTypesAsync_WithNoPatientDevice_ReturnsTheTenantWideLatest()
+    {
+        var firstSensor = SeedDevice("CGM", "G7");
+        var secondSensor = SeedDevice("CGM", "Libre 3");
+
+        var secondChange = new DateTime(2026, 8, 5, 6, 0, 0, DateTimeKind.Utc);
+        SeedEvent(DeviceEventType.SensorChange, new DateTime(2026, 8, 1, 6, 0, 0, DateTimeKind.Utc), firstSensor);
+        SeedEvent(DeviceEventType.SensorChange, secondChange, secondSensor);
+        SeedEvent(DeviceEventType.SensorChange, new DateTime(2026, 7, 1, 6, 0, 0, DateTimeKind.Utc), null);
+
+        var latest = await _repo.GetLatestByEventTypesAsync([DeviceEventType.SensorChange]);
+
+        latest.Should().NotBeNull();
+        latest!.Timestamp.Should().Be(secondChange);
+        latest.PatientDeviceId.Should().Be(secondSensor);
+    }
+
+    [Fact]
+    public async Task GetLatestByEventTypesAsync_ScopedToADeviceWithNoEvents_ReturnsNull()
+    {
+        var pump = SeedDevice("InsulinPump", "t:slim");
+        var otherPump = SeedDevice("InsulinPump", "Omnipod");
+
+        SeedEvent(DeviceEventType.PumpBatteryChange, new DateTime(2026, 8, 5, 6, 0, 0, DateTimeKind.Utc), otherPump);
+
+        var latest = await _repo.GetLatestByEventTypesAsync([DeviceEventType.PumpBatteryChange], pump);
+
+        latest.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem

CAGE/SAGE/IAGE/BAGE are computed from the single most recent device event of a given type, tenant-wide, with no device dimension. Device events carry a first-class PatientDevice link and the list endpoint already filters on it, so a user wearing two CGMs or two pumps gets one blended age: a sensor change on the second CGM resets the age shown for the first.

## Change

Optional `patientDeviceId` query parameter on the deviceage endpoints, threaded through `IDeviceAgeService` to `IDeviceEventRepository.GetLatestByEventTypesAsync`. Extension rather than parallel overloads: each interface has exactly one implementor, `IDeviceEventRepository.GetAsync` already names this parameter in exactly this shape, and placing it before `ct` made every positional call site a compile error rather than a silent behaviour change — which is how `/api/v2/properties` and the alert enricher were forced to declare themselves explicitly unfiltered (both unchanged; the enricher uses the singular method and is untouched).

Unfiltered behaviour is byte-for-byte today's. No spec hand-edits; the parameter surfaces from the controller signature.

## Tests

Nine new tests across repository (SQLite, two seeded patient devices), service, and controller layers. Mutation-proven twice: dropping the repository predicate fails the three scoped repo tests and leaves the tenant-wide one green; nulling the service threading fails both service scoping tests. `Nocturne.Infrastructure.Data.Tests`: 573/573; DeviceAge/Properties subset: 30/30; full suite green apart from the known load-flaky GC benchmark.

Follow-up from #539.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
