### PR TITLE
fix(alerts): serialise excursion state transitions per rule

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -819,7 +819,9 @@ public static class ServiceRegistrationExtensions
         // Sustained-condition timer store
         services.AddScoped<IConditionTimerStore, ConditionTimerRepository>();
 
-        // Excursion tracker
+        // Excursion tracker. Its per-rule serialisation gate is a singleton: the sweep and the
+        // per-reading path evaluate the same rule from different scopes.
+        services.AddSingleton<AlertRuleEvaluationGate>();
         services.AddScoped<IExcursionTracker, ExcursionTracker>();
 
         // Alert evaluation engine seam (Alerts:Engine = managed | shadow | rust)

--- a/src/API/Nocturne.API/Services/Alerts/AlertRuleEvaluationGate.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertRuleEvaluationGate.cs
@@ -1,0 +1,95 @@
+namespace Nocturne.API.Services.Alerts;
+
+/// <summary>
+/// Per-rule mutual exclusion for excursion state transitions.
+/// </summary>
+/// <remarks>
+/// Two evaluation paths drive the same rule's state machine in this process: the 30s
+/// <see cref="AlertSweepService"/> and the orchestrator's per-reading pass. Read-modify-write
+/// of tracker state is not atomic, so at a crossing instant both can read <c>idle</c>, both
+/// open an excursion, and the second state write orphans the first excursion row. Locks are
+/// striped per rule id so evaluations of unrelated rules never queue behind each other, and
+/// each stripe is dropped once nobody holds or awaits it.
+/// </remarks>
+public sealed class AlertRuleEvaluationGate
+{
+    private readonly Dictionary<Guid, Stripe> _stripes = new();
+
+    /// <summary>
+    /// Waits for exclusive access to <paramref name="alertRuleId"/>. Dispose the returned
+    /// lease to release it.
+    /// </summary>
+    /// <param name="alertRuleId">The alert rule to serialise on.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<IDisposable> AcquireAsync(Guid alertRuleId, CancellationToken ct)
+    {
+        Stripe stripe;
+        lock (_stripes)
+        {
+            if (!_stripes.TryGetValue(alertRuleId, out stripe!))
+            {
+                stripe = new Stripe();
+                _stripes[alertRuleId] = stripe;
+            }
+
+            stripe.Users++;
+        }
+
+        try
+        {
+            await stripe.Semaphore.WaitAsync(ct);
+        }
+        catch
+        {
+            Release(alertRuleId, stripe, held: false);
+            throw;
+        }
+
+        return new Lease(this, alertRuleId, stripe);
+    }
+
+    /// <summary>Number of rules currently holding or awaiting a stripe.</summary>
+    internal int StripeCount
+    {
+        get
+        {
+            lock (_stripes) return _stripes.Count;
+        }
+    }
+
+    private void Release(Guid alertRuleId, Stripe stripe, bool held)
+    {
+        if (held) stripe.Semaphore.Release();
+
+        lock (_stripes)
+        {
+            if (--stripe.Users > 0) return;
+            if (_stripes.TryGetValue(alertRuleId, out var current) && ReferenceEquals(current, stripe))
+            {
+                _stripes.Remove(alertRuleId);
+            }
+
+            stripe.Semaphore.Dispose();
+        }
+    }
+
+    private sealed class Stripe
+    {
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+
+        /// <summary>Holders plus waiters, mutated only under the dictionary lock.</summary>
+        public int Users { get; set; }
+    }
+
+    private sealed class Lease(AlertRuleEvaluationGate gate, Guid alertRuleId, Stripe stripe) : IDisposable
+    {
+        private bool _released;
+
+        public void Dispose()
+        {
+            if (_released) return;
+            _released = true;
+            gate.Release(alertRuleId, stripe, held: true);
+        }
+    }
+}

--- a/src/API/Nocturne.API/Services/Alerts/Engines/RustBackedAlertEngine.cs
+++ b/src/API/Nocturne.API/Services/Alerts/Engines/RustBackedAlertEngine.cs
@@ -27,6 +27,7 @@ internal sealed class RustBackedAlertEngine(
     IConditionTimerStore timerStore,
     IAlertTrackerRepository trackerRepository,
     IExcursionTracker excursionTracker,
+    AlertRuleEvaluationGate gate,
     TimeProvider timeProvider,
     ILogger<RustBackedAlertEngine> logger)
     : IAlertEvaluationEngine
@@ -38,6 +39,10 @@ internal sealed class RustBackedAlertEngine(
         AlertEngineOptions options,
         CancellationToken ct)
     {
+        // This adapter owns the tracker-state read-modify-write itself (the managed tracker's
+        // own lease never covers it), so it takes the same per-rule lease.
+        using var lease = await gate.AcquireAsync(rule.Id, ct);
+
         // The snapshot doesn't carry ConfirmationReadings/HysteresisMinutes; the managed
         // tracker loads the rule row per evaluation, so mirror that here.
         var ruleRow = await trackerRepository.GetRuleAsync(rule.Id, ct);

--- a/src/API/Nocturne.API/Services/Alerts/ExcursionTracker.cs
+++ b/src/API/Nocturne.API/Services/Alerts/ExcursionTracker.cs
@@ -25,6 +25,7 @@ namespace Nocturne.API.Services.Alerts;
 /// <seealso cref="IAlertTrackerRepository"/>
 public class ExcursionTracker(
     IAlertTrackerRepository repository,
+    AlertRuleEvaluationGate gate,
     TimeProvider timeProvider,
     ILogger<ExcursionTracker> logger)
     : IExcursionTracker
@@ -47,6 +48,11 @@ public class ExcursionTracker(
         bool conditionMet,
         CancellationToken ct)
     {
+        // Load, decide, persist and open/close the excursion under one per-rule lease, so a
+        // concurrent evaluation of the same rule re-reads the committed state instead of
+        // racing it to a second excursion (and a second dispatch off the opened transition).
+        using var lease = await gate.AcquireAsync(alertRuleId, ct);
+
         var rule = await repository.GetRuleAsync(alertRuleId, ct);
         if (rule == null)
         {
@@ -217,6 +223,8 @@ public class ExcursionTracker(
         ExcursionCloseReason reason,
         CancellationToken ct)
     {
+        using var lease = await gate.AcquireAsync(alertRuleId, ct);
+
         var state = await repository.GetTrackerStateAsync(alertRuleId, ct);
         if (state?.ActiveExcursionId is null)
         {

--- a/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioRunner.cs
+++ b/tests/Parity/Nocturne.Alerts.ParityCorpus.Generator/Harness/ScenarioRunner.cs
@@ -30,7 +30,8 @@ public sealed class ScenarioRunner
         var time = new ManualTimeProvider();
         var timerStore = new RecordingTimerStore();
         var trackerRepo = new InMemoryTrackerRepository(rules);
-        var tracker = new ExcursionTracker(trackerRepo, time, NullLogger<ExcursionTracker>.Instance);
+        var tracker = new ExcursionTracker(
+            trackerRepo, new AlertRuleEvaluationGate(), time, NullLogger<ExcursionTracker>.Instance);
 
         // Mirrors AlertReplayService.BuildReplayServices: the evaluator set comes from the
         // single AddAlertEvaluators registration so the corpus can never drift behind the

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertRuleEvaluationGateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertRuleEvaluationGateTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Nocturne.API.Services.Alerts;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Alerts;
+
+[Trait("Category", "Unit")]
+public class AlertRuleEvaluationGateTests
+{
+    [Fact]
+    public async Task Acquire_excludes_a_second_holder_of_the_same_rule()
+    {
+        var gate = new AlertRuleEvaluationGate();
+        var ruleId = Guid.NewGuid();
+
+        var held = await gate.AcquireAsync(ruleId, CancellationToken.None);
+        var contender = gate.AcquireAsync(ruleId, CancellationToken.None);
+
+        contender.IsCompleted.Should().BeFalse();
+
+        held.Dispose();
+        (await contender.WaitAsync(TimeSpan.FromSeconds(5))).Dispose();
+    }
+
+    [Fact]
+    public async Task Acquire_does_not_exclude_a_different_rule()
+    {
+        var gate = new AlertRuleEvaluationGate();
+
+        using var held = await gate.AcquireAsync(Guid.NewGuid(), CancellationToken.None);
+        using var other = await gate.AcquireAsync(Guid.NewGuid(), CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task Stripes_are_dropped_once_nobody_holds_or_awaits_them()
+    {
+        var gate = new AlertRuleEvaluationGate();
+        var ruleId = Guid.NewGuid();
+
+        var held = await gate.AcquireAsync(ruleId, CancellationToken.None);
+        var contender = gate.AcquireAsync(ruleId, CancellationToken.None);
+        gate.StripeCount.Should().Be(1);
+
+        held.Dispose();
+        (await contender.WaitAsync(TimeSpan.FromSeconds(5))).Dispose();
+
+        gate.StripeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task A_cancelled_waiter_releases_its_stripe()
+    {
+        var gate = new AlertRuleEvaluationGate();
+        var ruleId = Guid.NewGuid();
+        using var cts = new CancellationTokenSource();
+
+        var held = await gate.AcquireAsync(ruleId, CancellationToken.None);
+        var contender = gate.AcquireAsync(ruleId, cts.Token);
+        await cts.CancelAsync();
+
+        await FluentActions.Awaiting(() => contender).Should().ThrowAsync<OperationCanceledException>();
+
+        held.Dispose();
+        gate.StripeCount.Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/AlertEngineSelectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/AlertEngineSelectionTests.cs
@@ -108,6 +108,7 @@ public class AlertEngineSelectionTests
         services.AddSingleton(Mock.Of<IConditionTimerStore>());
         services.AddSingleton(Mock.Of<IAlertTrackerRepository>());
         services.AddSingleton(Mock.Of<IExcursionTracker>());
+        services.AddSingleton<AlertRuleEvaluationGate>();
         services.AddAlertEvaluators();
         services.AddScoped<ConditionEvaluatorRegistry>();
         services.AddAlertEvaluationEngine(configuration, nativeProbe);

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/EngineTestHarness.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/EngineTestHarness.cs
@@ -60,7 +60,8 @@ internal static class EngineTestHarness
         services.AddSingleton<ConditionEvaluatorRegistry>();
         var provider = services.BuildServiceProvider();
 
-        var tracker = new ExcursionTracker(trackerRepo, time, NullLogger<ExcursionTracker>.Instance);
+        var tracker = new ExcursionTracker(
+            trackerRepo, new AlertRuleEvaluationGate(), time, NullLogger<ExcursionTracker>.Instance);
         var engine = new ManagedAlertEngine(
             provider.GetRequiredService<ConditionEvaluatorRegistry>(),
             tracker,
@@ -74,11 +75,13 @@ internal static class EngineTestHarness
         IConditionTimerStore timerStore,
         InMemoryTrackerRepository trackerRepo)
     {
-        var tracker = new ExcursionTracker(trackerRepo, time, NullLogger<ExcursionTracker>.Instance);
+        var gate = new AlertRuleEvaluationGate();
+        var tracker = new ExcursionTracker(trackerRepo, gate, time, NullLogger<ExcursionTracker>.Instance);
         return new RustBackedAlertEngine(
             timerStore,
             trackerRepo,
             tracker,
+            gate,
             time,
             NullLogger<RustBackedAlertEngine>.Instance);
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/ExcursionTrackerConcurrencyTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/ExcursionTrackerConcurrencyTests.cs
@@ -1,0 +1,190 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Nocturne.API.Services.Alerts;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Repositories;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Alerts;
+
+/// <summary>
+/// The 30s sweep and the per-reading pass evaluate the same rule from separate scopes, so
+/// two <see cref="ExcursionTracker"/> instances share the singleton
+/// <see cref="AlertRuleEvaluationGate"/> here, exactly as they do in the container.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ExcursionTrackerConcurrencyTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 3, 22, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task Concurrent_evaluations_of_one_rule_open_exactly_one_excursion()
+    {
+        var ruleId = Guid.NewGuid();
+        // Both evaluations rendezvous inside the state read, so unguarded they would each
+        // observe "idle" and open their own excursion.
+        var repository = new RendezvousTrackerRepository(
+            [Rule(ruleId)], participants: 2, rendezvousTimeout: TimeSpan.FromMilliseconds(500));
+        var gate = new AlertRuleEvaluationGate();
+
+        var transitions = await Task.WhenAll(
+            Evaluate(repository, gate, ruleId),
+            Evaluate(repository, gate, ruleId));
+
+        repository.Excursions.Should().ContainSingle();
+        transitions.Count(t => t.Type == ExcursionTransitionType.ExcursionOpened).Should().Be(1);
+        transitions.Count(t => t.Type == ExcursionTransitionType.ExcursionContinues).Should().Be(1);
+
+        var state = await repository.GetTrackerStateAsync(ruleId);
+        state!.ActiveExcursionId.Should().Be(repository.Excursions.Single().Id,
+            "the surviving state must reference the one excursion that was opened");
+    }
+
+    [Fact]
+    public async Task Concurrent_evaluations_of_different_rules_are_not_serialised()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        // The rendezvous only completes if both rules are inside the state read at once — a
+        // gate that isn't striped per rule would hold the second out until the first finished.
+        var repository = new RendezvousTrackerRepository(
+            [Rule(first), Rule(second)], participants: 2, rendezvousTimeout: TimeSpan.FromSeconds(5));
+        var gate = new AlertRuleEvaluationGate();
+
+        var transitions = await Task.WhenAll(
+            Evaluate(repository, gate, first),
+            Evaluate(repository, gate, second))
+            .WaitAsync(TimeSpan.FromSeconds(30));
+
+        repository.Overlapped.Should().BeTrue("evaluations of different rules must run concurrently");
+        transitions.Should().OnlyContain(t => t.Type == ExcursionTransitionType.ExcursionOpened);
+        repository.Excursions.Should().HaveCount(2);
+    }
+
+    private static Task<ExcursionTransition> Evaluate(
+        IAlertTrackerRepository repository, AlertRuleEvaluationGate gate, Guid ruleId) =>
+        Task.Run(() => new ExcursionTracker(
+                repository, gate, new FakeTimeProvider(Now), NullLogger<ExcursionTracker>.Instance)
+            .ProcessEvaluationAsync(ruleId, true, CancellationToken.None));
+
+    private static AlertRule Rule(Guid id) => new()
+    {
+        Id = id,
+        Name = "Test Rule",
+        ConfirmationReadings = 1,
+        HysteresisMinutes = 5,
+    };
+
+    /// <summary>
+    /// In-memory tracker persistence whose state read blocks until every participant has
+    /// entered it (or the rendezvous times out), turning the read-modify-write window into a
+    /// deterministic one instead of one that depends on thread scheduling.
+    /// </summary>
+    private sealed class RendezvousTrackerRepository(
+        IReadOnlyList<AlertRule> rules, int participants, TimeSpan rendezvousTimeout)
+        : IAlertTrackerRepository
+    {
+        private readonly TaskCompletionSource _allInside = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly Lock _sync = new();
+        private readonly Dictionary<Guid, AlertTrackerState> _states = [];
+        private int _inside;
+
+        public List<AlertExcursion> Excursions { get; } = [];
+
+        /// <summary>Whether every participant was inside the state read at the same moment.</summary>
+        public bool Overlapped { get; private set; }
+
+        public async Task<AlertTrackerState?> GetTrackerStateAsync(Guid alertRuleId, CancellationToken ct = default)
+        {
+            if (Interlocked.Increment(ref _inside) >= participants)
+            {
+                Overlapped = true;
+                _allInside.TrySetResult();
+            }
+
+            try
+            {
+                await _allInside.Task.WaitAsync(rendezvousTimeout, ct);
+            }
+            catch (TimeoutException)
+            {
+                // Serialised callers never meet; carry on with whatever state is committed.
+            }
+
+            Interlocked.Decrement(ref _inside);
+
+            lock (_sync)
+            {
+                return _states.TryGetValue(alertRuleId, out var state)
+                    ? new AlertTrackerState
+                    {
+                        AlertRuleId = state.AlertRuleId,
+                        State = state.State,
+                        ConfirmationCount = state.ConfirmationCount,
+                        ActiveExcursionId = state.ActiveExcursionId,
+                        UpdatedAt = state.UpdatedAt,
+                    }
+                    : null;
+            }
+        }
+
+        public Task UpsertTrackerStateAsync(AlertTrackerState state, CancellationToken ct = default)
+        {
+            lock (_sync) _states[state.AlertRuleId] = state;
+            return Task.CompletedTask;
+        }
+
+        public Task<AlertRule?> GetRuleAsync(Guid alertRuleId, CancellationToken ct = default) =>
+            Task.FromResult(rules.FirstOrDefault(r => r.Id == alertRuleId));
+
+        public Task<AlertExcursion> CreateExcursionAsync(
+            Guid alertRuleId, DateTime startedAt, CancellationToken ct = default)
+        {
+            var excursion = new AlertExcursion
+            {
+                Id = Guid.CreateVersion7(),
+                AlertRuleId = alertRuleId,
+                StartedAt = startedAt,
+            };
+
+            lock (_sync) Excursions.Add(excursion);
+            return Task.FromResult(excursion);
+        }
+
+        public Task CloseExcursionAsync(Guid excursionId, DateTime endedAt, CancellationToken ct = default)
+        {
+            lock (_sync)
+            {
+                var excursion = Excursions.FirstOrDefault(e => e.Id == excursionId);
+                if (excursion is not null) excursion.EndedAt = endedAt;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task SetHysteresisStartedAsync(
+            Guid excursionId, DateTime hysteresisStartedAt, CancellationToken ct = default)
+        {
+            lock (_sync)
+            {
+                var excursion = Excursions.FirstOrDefault(e => e.Id == excursionId);
+                if (excursion is not null) excursion.HysteresisStartedAt = hysteresisStartedAt;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task ClearHysteresisAsync(Guid excursionId, CancellationToken ct = default)
+        {
+            lock (_sync)
+            {
+                var excursion = Excursions.FirstOrDefault(e => e.Id == excursionId);
+                if (excursion is not null) excursion.HysteresisStartedAt = null;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/ExcursionTrackerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/ExcursionTrackerTests.cs
@@ -28,7 +28,8 @@ public class ExcursionTrackerTests
         _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 22, 12, 0, 0, TimeSpan.Zero));
 
         var logger = new Mock<ILogger<ExcursionTracker>>();
-        _tracker = new ExcursionTracker(_mockRepo.Object, _timeProvider, logger.Object);
+        _tracker = new ExcursionTracker(
+            _mockRepo.Object, new AlertRuleEvaluationGate(), _timeProvider, logger.Object);
 
         _defaultRule = new AlertRule
         {


### PR DESCRIPTION
## Problem

`ExcursionTracker.ProcessEvaluationAsync` read tracker state, mutated it in memory, and wrote it back with no lock, transaction or concurrency token; `AlertTrackerRepository` is a last-writer-wins upsert that inserts excursions unconditionally. Two evaluation paths run concurrently against the same rule in one process — the 30s sweep (signal_loss direct, tracker_age via the orchestrator) and per-reading evaluation. At the crossing instant both can read "idle" and both open an excursion: two rows, two dispatches, and the second state write orphans the first excursion forever.

The follow-up as filed missed one path: with `Alerts:Engine=rust` (live on main), `RustBackedAlertEngine.EvaluateRuleAsync` performs the same read-modify-write itself via `IAlertTrackerRepository`, bypassing `ExcursionTracker` — a tracker-only lock would have left rust mode unguarded.

## Fix

`AlertRuleEvaluationGate`: a singleton keyed async lock, one `SemaphoreSlim` stripe per rule id, refcounted so a stripe is disposed once nobody holds or awaits it (waiters register under the dictionary lock; cancellation releases). Leases are taken at the three sites that own a tracker-state read-modify-write — `ProcessEvaluationAsync`, `ForceCloseAsync`, and `RustBackedAlertEngine.EvaluateRuleAsync` — and never nested (verified against the call graph). The managed/shadow engines reach state only through the gated tracker, so gating them would deadlock; the pure read stays ungated. Dispatch stays in the orchestrator outside the lease, which is correct: the race loser re-reads committed state under the lease and sees `ExcursionContinues`, so exactly one dispatch.

No partial unique index: its graceful-violation handling rides Postgres-only error codes the SQLite/InMemory suites can never exercise. The in-process gate is sufficient for the single-deployment topology; a second API replica would need the index — noted as the condition for a follow-up.

## Tests

Deterministic rather than timing-hopeful: the fake repository rendezvouses inside the state read and records whether both callers were genuinely inside at once. Two concurrency tests (one rule → exactly one excursion and one dispatch; different rules → not serialised against each other) plus four gate tests including stripe and cancelled-waiter cleanup. Mutation-proven both ways: removing the lease fails the single-rule test; making the gate global fails the cross-rule test — each deterministically, with the other still green. Alerts suite: 655/655.

Follow-up from #446.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
