### PR TITLE
perf(glucose-chart): render per-datum markers and basal spans as native SVG

### DIFF
--- a/src/Web/packages/glucose-chart/src/markers/BolusMarker.svelte
+++ b/src/Web/packages/glucose-chart/src/markers/BolusMarker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { Group, Polygon, Text } from "layerchart";
-
+  // Native SVG rather than layerchart marks: each mark registers with the chart
+  // on mount and the chart's mark deriveds re-run over every mark, so one
+  // component per bolus cost O(N^2).
   interface Props {
     xPos: number;
     yPos: number;
@@ -14,20 +15,17 @@
     $props();
 </script>
 
-<Group
-  x={xPos}
-  y={yPos + 0}
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<g
+  transform="translate({xPos}, {yPos})"
   onclick={() => onMarkerClick(treatmentId)}
   class="cursor-pointer"
 >
   {#if isOverride}
     <!-- Triangle for manual override -->
-    <Polygon
-      points={[
-        { x: 0, y: 12 },
-        { x: -8, y: 0 },
-        { x: 8, y: 0 },
-      ]}
+    <polygon
+      points="0,12 -8,0 8,0"
       class="opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity"
     />
   {:else}
@@ -37,11 +35,12 @@
       class="opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity"
     />
   {/if}
-  <Text
+  <text
     y={-14}
-    textAnchor="middle"
+    dy="-0.355em"
+    text-anchor="middle"
     class="text-[8px] fill-insulin-bolus font-medium"
   >
     {insulin.toFixed(1)}U
-  </Text>
-</Group>
+  </text>
+</g>

--- a/src/Web/packages/glucose-chart/src/markers/CarbMarker.svelte
+++ b/src/Web/packages/glucose-chart/src/markers/CarbMarker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { Group, Text } from "layerchart";
-
+  // Native SVG rather than layerchart marks: each mark registers with the chart
+  // on mount and the chart's mark deriveds re-run over every mark, so one
+  // component per carb entry cost O(N^2).
   interface Props {
     xPos: number;
     yPos: number;
@@ -14,21 +15,23 @@
     $props();
 </script>
 
-<Group
-  x={xPos}
-  y={yPos}
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<g
+  transform="translate({xPos}, {yPos})"
   onclick={() => onMarkerClick(treatmentId)}
   class="cursor-pointer"
 >
   <!-- Food/meal label above the marker -->
   {#if label}
-    <Text
+    <text
       y={-18}
-      textAnchor="middle"
+      dy="-0.355em"
+      text-anchor="middle"
       class="text-[7px] fill-carbs font-medium opacity-80"
     >
       {label}
-    </Text>
+    </text>
   {/if}
   <!-- Hemisphere (bowl shape - curves below baseline) -->
   <path
@@ -36,7 +39,12 @@
     fill="var(--color-carbs)"
     class="opacity-90 hover:opacity-100 transition-opacity"
   />
-  <Text y={18} textAnchor="middle" class="text-[8px] fill-carbs font-medium">
+  <text
+    y={18}
+    dy="-0.355em"
+    text-anchor="middle"
+    class="text-[8px] fill-carbs font-medium"
+  >
     {carbs}g
-  </Text>
-</Group>
+  </text>
+</g>

--- a/src/Web/packages/glucose-chart/src/tracks/BasalTrack.svelte
+++ b/src/Web/packages/glucose-chart/src/tracks/BasalTrack.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
+  // Per-span geometry is native SVG: layerchart marks register with the chart on
+  // mount and its mark deriveds re-run over every mark, so one AnnotationRange
+  // per temp basal / step cost O(N^2). Pattern is not a mark and stays.
   import {
     Area,
     Spline,
     Axis,
     Text,
-    Group,
+    Pattern,
     ChartClipPath,
     Highlight,
-    AnnotationRange,
     AnnotationLine,
     AnnotationPoint,
   } from "layerchart";
@@ -147,31 +149,38 @@
   <ChartClipPath>
     <!-- Temp basal span indicators (shown in basal track when basal is visible) -->
     {#each tempBasalSpans as span (span.id)}
-      <AnnotationRange
-        x={[span.displayStart.getTime(), span.displayEnd.getTime()]}
-        y={[basalScale(maxBasalRate * 0.9), basalScale(maxBasalRate * 0.7)]}
+      {@const spanLeft = context.xScale(span.displayStart)}
+      {@const spanUpper = context.yScale(basalScale(maxBasalRate * 0.9))}
+      {@const spanLower = context.yScale(basalScale(maxBasalRate * 0.7))}
+      {@const labelX = spanLeft + 4}
+      {@const labelY = context.yScale(basalScale(maxBasalRate * 0.8))}
+      <rect
+        x={spanLeft}
+        y={Math.min(spanUpper, spanLower)}
+        width={context.xScale(span.displayEnd) - spanLeft}
+        height={Math.abs(spanLower - spanUpper)}
         fill={span.color}
         class="opacity-40"
       />
       <!-- Show temp basal rate label -->
       {#if span.rate !== null}
-        <Group
-          x={context.xScale(span.displayStart)}
-          y={context.yScale(basalScale(maxBasalRate * 0.8))}
+        <text
+          x={labelX}
+          y={labelY}
+          dy="-0.355em"
+          class="text-[7px] fill-insulin-basal font-medium"
         >
-          <Text x={4} y={0} class="text-[7px] fill-insulin-basal font-medium">
-            {span.rate.toFixed(2)}U/h
-          </Text>
-        </Group>
+          {span.rate.toFixed(2)}U/h
+        </text>
       {:else if span.percent !== null}
-        <Group
-          x={context.xScale(span.displayStart)}
-          y={context.yScale(basalScale(maxBasalRate * 0.8))}
+        <text
+          x={labelX}
+          y={labelY}
+          dy="-0.355em"
+          class="text-[7px] fill-insulin-basal font-medium"
         >
-          <Text x={4} y={0} class="text-[7px] fill-insulin-basal font-medium">
-            {span.percent}%
-          </Text>
-        </Group>
+          {span.percent}%
+        </text>
       {/if}
     {/each}
   </ChartClipPath>
@@ -179,17 +188,21 @@
   <!-- Stale basal data indicator -->
   {#if staleBasalData}
     <ChartClipPath>
-      <AnnotationRange
-        x={[staleBasalData.start.getTime(), staleBasalData.end.getTime()]}
-        y={[basalScale(maxBasalRate), basalZero]}
-        pattern={{
-          size: 8,
-          lines: {
-            rotate: -45,
-            opacity: 0.1,
-          },
-        }}
-      />
+      {@const staleLeft = context.xScale(staleBasalData.start)}
+      {@const staleWidth = context.xScale(staleBasalData.end) - staleLeft}
+      {@const staleTop = context.yScale(basalScale(maxBasalRate))}
+      {@const staleBottom = context.yScale(basalZero)}
+      <Pattern size={8} lines={{ rotate: -45, opacity: 0.1 }}>
+        {#snippet children({ pattern }: { pattern: string })}
+          <rect
+            x={staleLeft}
+            y={Math.min(staleTop, staleBottom)}
+            width={staleWidth}
+            height={Math.abs(staleBottom - staleTop)}
+            fill={pattern}
+          />
+        {/snippet}
+      </Pattern>
     </ChartClipPath>
     <AnnotationLine
       x={staleBasalData.start}
@@ -245,19 +258,25 @@
       {@const fillColor = segment.points[0].fillColor}
       {@const strokeColor = segment.points[0].strokeColor}
       {#if pattern}
-        <!-- Use AnnotationRange for segments with patterns (Inferred) -->
-        {#each segment.points as point, pointIdx}
-          {#if pointIdx < segment.points.length - 1}
-            {@const nextPoint = segment.points[pointIdx + 1]}
-            <AnnotationRange
-              x={[point.timestamp ?? 0, nextPoint.timestamp ?? 0]}
-              y={[basalScale(point.rate ?? 0), basalZero]}
-              fill={fillColor}
-              {pattern}
-              style="opacity: {opacity}"
-            />
-          {/if}
-        {/each}
+        <!-- Hatched step rects for segments with patterns (Inferred) -->
+        <Pattern size={pattern.size} lines={pattern.lines}>
+          {#snippet children({ pattern: patternFill }: { pattern: string })}
+            {#each segment.points.slice(0, -1) as point, pointIdx (pointIdx)}
+              {@const nextPoint = segment.points[pointIdx + 1]}
+              {@const left = context.xScale(new Date(point.timestamp ?? 0))}
+              {@const top = context.yScale(basalScale(point.rate ?? 0))}
+              {@const bottom = context.yScale(basalZero)}
+              {@const step = {
+                x: left,
+                y: Math.min(top, bottom),
+                width: context.xScale(new Date(nextPoint.timestamp ?? 0)) - left,
+                height: Math.abs(bottom - top),
+              }}
+              <rect {...step} fill={fillColor} style="opacity: {opacity}" />
+              <rect {...step} fill={patternFill} style="opacity: {opacity}" />
+            {/each}
+          {/snippet}
+        </Pattern>
       {:else}
         <!-- Use Area for segments without patterns -->
         <Area


### PR DESCRIPTION
## Problem

layerchart 2.0.1 registers a mark per component on mount and its mark-dependent deriveds loop over all marks per registration — N marks cost O(N²). #498/#499 converted the tracks and app-side charts; the `@nightscout/glucose-chart` package still registered per datum (verified against the pinned dist's `registerComponent` sites):

- one `Polygon`/`Text` pair per bolus and per carb marker,
- one `AnnotationRange` per temp-basal span (Rect + label Text = 2 registrations),
- two `Rect`s per adjacent inferred basal-point pair (fill + pattern), plus a `<defs><pattern>` each —

hundreds of registrations on a 48h window.

## Change

`BolusMarker`/`CarbMarker` render native `<g>`/`<polygon>`/`<text>` with the same classes, fills and click handlers; `BasalTrack`'s temp-basal spans, stale-data range and inferred segments render native `<rect>`/`<text>` from the same `xScale`/`yScale` calls, with the hatch kept as one `<Pattern>` per segment (`Pattern` registers nothing) instead of one per step. `AnnotationLine`/`AnnotationPoint`/`Axis`/`Area`/`Spline`/`Highlight` and the track-label `Text` stay — all O(1) per track. `IobCobTrack` needed no change (it passes pre-scaled coordinates).

Two behaviour notes:

- Label baselines use the `dy="-0.355em"` convention from #499; layerchart's own offset is a hard-coded −5.68px, so 7–8px labels sit ~2.8px lower than before — the same approximation already shipped in the app-side conversions.
- One deliberate visual fix: `AnnotationRange` destructures without `...rest`, so the `style="opacity: 0.4"` passed for inferred segments was silently dropped and they drew fully opaque. The native rects honour it.

## Verification

`pnpm --filter @nightscout/glucose-chart run check` (the exact CI gate): 0 errors / 0 warnings, before and after — and proven to cover the changed files (an intermediate revision produced warnings pointing at both markers). No layerchart imports remain in the marker components; the package has no other consumers in the monorepo.

Follow-up from #501.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
