### PR TITLE
fix(portal): point the translate lane at the translation files and surface the support tiers on Get Involved

### DIFF
--- a/src/Web/packages/portal/src/lib/data/links.ts
+++ b/src/Web/packages/portal/src/lib/data/links.ts
@@ -4,6 +4,8 @@ export const LINKS = {
   donate: "https://www.nightscoutfoundation.org/donate",
   githubLabel: "https://github.com/nightscout/nocturne/labels/get-involved",
   github: "https://github.com/nightscout/nocturne",
+  translationFiles:
+    "https://github.com/nightscout/nocturne/tree/main/src/Web/locales",
   facebook: "https://www.facebook.com/groups/cgminthecloud",
   hackDiabetes: "https://hackdiabetes.io",
   testimonials: "mailto:testimonials@nocturne.run",

--- a/src/Web/packages/portal/src/routes/get-involved/+page.svelte
+++ b/src/Web/packages/portal/src/routes/get-involved/+page.svelte
@@ -16,6 +16,7 @@
   } from "@lucide/svelte";
   import { onMount } from "svelte";
   import { LINKS } from "$lib/data/links";
+  import SupportNocturne from "$lib/components/docs/SupportNocturne.svelte";
 
   const ACCENT = "oklch(0.6 0.118 184.704)";
 
@@ -44,9 +45,10 @@
       icon: Globe,
       accent: "oklch(0.65 0.16 250)",
       title: "Translate Nocturne",
-      desc: "Help people read Nocturne in their own language. Pick a locale, translate the interface strings — no code, no build tools, just words.",
-      cta: "Start translating",
-      href: "#tasks",
+      desc: "Every interface string lives in a gettext .po file, one per language, and most languages are barely started. Edit one on GitHub and open a pull request — no build tools, just words.",
+      cta: "Open the translation files",
+      href: LINKS.translationFiles,
+      external: true,
     },
     {
       id: "support",
@@ -63,10 +65,9 @@
       icon: Heart,
       accent: "oklch(0.62 0.2 18)",
       title: "Donate",
-      desc: "Nocturne is free and always will be. Donations to the Nightscout Foundation cover servers, testing devices, and keep the project independent.",
-      cta: "Donate via the Foundation",
-      href: LINKS.donate,
-      external: true,
+      desc: "Nocturne is free and always will be. One-off gifts to the Nightscout Foundation and monthly subscriptions from US$10 both cover servers, testing devices, and keep the project independent.",
+      cta: "See the ways to give",
+      href: "#donate",
       highlight: true,
     },
     {
@@ -125,7 +126,7 @@
       fg: "oklch(0.62 0.118 184.7)",
       bg: "oklch(0.62 0.118 184.7 / 0.16)",
     },
-    translation: {
+    i18n: {
       fg: "oklch(0.65 0.16 250)",
       bg: "oklch(0.65 0.16 250 / 0.16)",
     },
@@ -494,7 +495,8 @@
         <p class="text-muted-foreground m-0 max-w-[52ch]">
           There is no company behind Nocturne — just volunteers and the
           Nightscout Foundation, a registered non-profit. Donations cover
-          servers, test devices, and the work that keeps your data yours.
+          servers, test devices, and the work that keeps your data yours. Give
+          once, or subscribe monthly.
         </p>
       </div>
       <div class="flex flex-col gap-2.5">
@@ -512,6 +514,8 @@
         >
       </div>
     </div>
+
+    <SupportNocturne />
   </section>
 </div>
 


### PR DESCRIPTION
## Problem

Get Involved's "Start translating" lane linked to `#tasks` — the same-page GitHub issue feed — because no translation destination existed. And while the page's donate lane and band both link the Foundation donate page, neither mentioned the monthly tiers rendered by `SupportNocturne` on `/docs` and the installation guides; the reverse link already existed.

## Change

- The translate lane now points at the real contribution path: the gettext `.po` tree (`src/Web/locales/` — 11 locales, ~5,240 strings each, nearly all untranslated), with copy saying exactly that: edit a locale's `.po` and open a PR, which `sync-translations.yml` reconciles. No docs page was invented.
- Adjacent bug in the same file: `LABEL_COLORS` was keyed on `translation`, but the repo's label is `i18n` — the entry was dead and real i18n issues rendered grey in the feed. Renamed.
- The tiers surface by reusing `<SupportNocturne />` inside the existing `#donate` section — no duplicated tier data. The donate lane now deep-links `#donate` and names the monthly option; the band gained "Give once, or subscribe monthly."

## Verification

Portal `pnpm run check`: 0 errors / 0 warnings, matching baseline. Full static build green; prerendered `get-involved.html` contains the locales link, no "Start translating", all three Stripe tier links and the resolving `#donate` anchor; `docs.html` tiers unchanged.

Follow-up from #572.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
