### PR TITLE
fix(web): refresh the dashboard reservoir after page load

### DIFF
--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -115,6 +115,10 @@ export class RealtimeStore {
   private static readonly FOREGROUND_POLL_MS = 60_000; // re-check staleness every 60s while visible
   private static readonly FOREGROUND_STALE_MS = 5 * 60_000; // refetch if no data for 5 min while visible
 
+  /** Pending refetch of the records the backend derives from devicestatus. */
+  private decompositionRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly DECOMPOSITION_REFRESH_MS = 3_000;
+
   /** Reactive state using Svelte 5 runes - using $state.raw for arrays to avoid deep proxy issues */
   entries = $state.raw<Entry[]>([]);
   deviceStatuses = $state.raw<DeviceStatus[]>([]);
@@ -131,7 +135,7 @@ export class RealtimeStore {
   deviceEvents = $state.raw<DeviceEvent[]>([]);
   apsSnapshots = $state.raw<ApsSnapshot[]>([]);
 
-  /** Latest pump reservoir (units). Fetched once at init; not yet pushed via the realtime channel. */
+  /** Latest pump reservoir (units), null when the pump reports no numeric level. */
   currentReservoir = $state<number | null>(null);
 
   /** Connection state (with safe initialization) */
@@ -581,9 +585,7 @@ export class RealtimeStore {
           .slice(0, 100);
       }
 
-      // The backend decomposes devicestatus into an ApsSnapshot asynchronously.
-      // Wait briefly then fetch the latest snapshot so pills update in real time.
-      setTimeout(() => this.refreshLatestApsSnapshot(), 3000);
+      this.scheduleDecompositionRefresh();
     }
   }
 
@@ -868,6 +870,10 @@ export class RealtimeStore {
   /** Cleanup */
   destroy(): void {
     this.clearDisconnectNotice();
+    if (this.decompositionRefreshTimer) {
+      clearTimeout(this.decompositionRefreshTimer);
+      this.decompositionRefreshTimer = null;
+    }
     if (this.timeInterval) {
       clearInterval(this.timeInterval);
     }
@@ -912,6 +918,32 @@ export class RealtimeStore {
     if (this.backgroundPollInterval) {
       clearInterval(this.backgroundPollInterval);
       this.backgroundPollInterval = null;
+    }
+  }
+
+  /**
+   * Queue a refetch of the records the backend derives from a devicestatus write
+   * (APS snapshots, pump snapshots), which it decomposes asynchronously. Uploaders
+   * post devicestatus in bursts, so an already-pending refresh absorbs the burst
+   * rather than firing once per document.
+   */
+  private scheduleDecompositionRefresh(): void {
+    if (this.decompositionRefreshTimer) return;
+
+    this.decompositionRefreshTimer = setTimeout(() => {
+      this.decompositionRefreshTimer = null;
+      void this.refreshLatestApsSnapshot();
+      void this.refreshCurrentReservoir();
+    }, RealtimeStore.DECOMPOSITION_REFRESH_MS);
+  }
+
+  /** Re-read the pump reservoir from the current therapy state. */
+  private async refreshCurrentReservoir(): Promise<void> {
+    try {
+      const therapyState = await getApiClient().currentTherapyState.getCurrentTherapyState();
+      this.currentReservoir = therapyState?.reservoir ?? null;
+    } catch {
+      // Non-critical — the reservoir pill keeps its last value until the next refresh.
     }
   }
 
@@ -970,6 +1002,7 @@ export class RealtimeStore {
       // Fetch all data types since last received using existing API methods
       const backfillFromDate = new Date(backfillFrom);
       const nowDate = new Date();
+      const reservoirRefresh = this.refreshCurrentReservoir();
       const [entries, deviceStatuses, boluses, carbIntakes, bgChecks, notes, devEvents, newApsSnapshots] = await Promise.all([
         apiClient.sensorGlucose.getAll(backfillFromDate, nowDate, 1000).then((r) => (r.data ?? []).map(sensorGlucoseToEntry)).catch(() => [] as Entry[]),
         Promise.resolve([] as DeviceStatus[]),
@@ -980,6 +1013,7 @@ export class RealtimeStore {
         apiClient.deviceEvent.getAll(backfillFromDate, nowDate, 500).then((r) => r.data ?? []).catch(() => []),
         apiClient.apsSnapshot.getAll(backfillFromDate, nowDate, 20).then((r) => r.data ?? []).catch(() => []),
       ]);
+      await reservoirRefresh;
 
       let backfilledCount = 0;
 

--- a/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const api = vi.hoisted(() => ({
+  getCurrentTherapyState: vi.fn(),
+  apsGetAll: vi.fn(),
+  emptyPage: vi.fn(),
+}));
+
+vi.mock("$lib/api/client", () => ({
+  getApiClient: () => ({
+    currentTherapyState: { getCurrentTherapyState: api.getCurrentTherapyState },
+    apsSnapshot: { getAll: api.apsGetAll },
+    sensorGlucose: { getAll: api.emptyPage },
+    bolus: { getAll: api.emptyPage },
+    nutrition: { getCarbIntakes: api.emptyPage },
+    bGCheck: { getAll: api.emptyPage },
+    note: { getAll: api.emptyPage },
+    deviceEvent: { getAll: api.emptyPage },
+  }),
+}));
+
+vi.mock("svelte-sonner", () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+import { RealtimeStore } from "./realtime-store.svelte";
+import type { StorageEvent } from "$lib/websocket/types";
+
+/** The realtime/backfill entry points, which the class keeps private. */
+interface StoreInternals {
+  handleCreate(event: StorageEvent): void;
+  performBackfillIfNeeded(force?: boolean): Promise<void>;
+}
+
+type TestStore = StoreInternals &
+  Pick<RealtimeStore, "currentReservoir" | "destroy">;
+
+/** Store instance with an empty socket URL, so nothing connects. */
+function makeStore(): TestStore {
+  const store = new RealtimeStore({
+    url: "",
+    reconnectAttempts: 0,
+    reconnectDelay: 0,
+    maxReconnectDelay: 0,
+    pingTimeout: 0,
+    pingInterval: 0,
+  });
+  return store as unknown as TestStore;
+}
+
+function deviceStatus(id: string): StorageEvent {
+  return {
+    colName: "devicestatus",
+    doc: { _id: id, mills: Date.now(), pump: {} },
+  };
+}
+
+describe("RealtimeStore reservoir freshness", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    api.getCurrentTherapyState.mockResolvedValue({ reservoir: 42 });
+    api.apsGetAll.mockResolvedValue({ data: [] });
+    api.emptyPage.mockResolvedValue({ data: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("refreshes the reservoir after a devicestatus arrives on the realtime channel", async () => {
+    const store = makeStore();
+    expect(store.currentReservoir).toBeNull();
+
+    store.handleCreate(deviceStatus("ds-1"));
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(api.getCurrentTherapyState).toHaveBeenCalledTimes(1);
+    expect(store.currentReservoir).toBe(42);
+
+    store.destroy();
+  });
+
+  it("clears the reservoir when the pump stops reporting a numeric level", async () => {
+    const store = makeStore();
+    api.getCurrentTherapyState.mockResolvedValue({ reservoir: undefined });
+
+    store.currentReservoir = 12;
+    store.handleCreate(deviceStatus("ds-1"));
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(store.currentReservoir).toBeNull();
+
+    store.destroy();
+  });
+
+  it("absorbs a devicestatus burst into a single refresh", async () => {
+    const store = makeStore();
+
+    store.handleCreate(deviceStatus("ds-1"));
+    store.handleCreate(deviceStatus("ds-2"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    store.handleCreate(deviceStatus("ds-3"));
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(api.getCurrentTherapyState).toHaveBeenCalledTimes(1);
+    expect(api.apsGetAll).toHaveBeenCalledTimes(1);
+
+    // A devicestatus after the pending refresh has fired schedules a fresh one.
+    store.handleCreate(deviceStatus("ds-4"));
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(api.getCurrentTherapyState).toHaveBeenCalledTimes(2);
+
+    store.destroy();
+  });
+
+  it("refreshes the reservoir as part of a backfill", async () => {
+    const store = makeStore();
+
+    await store.performBackfillIfNeeded(true);
+
+    expect(api.getCurrentTherapyState).toHaveBeenCalledTimes(1);
+    expect(store.currentReservoir).toBe(42);
+
+    store.destroy();
+  });
+
+  it("keeps the last reservoir value when the refresh fails", async () => {
+    const store = makeStore();
+    store.currentReservoir = 30;
+    api.getCurrentTherapyState.mockRejectedValue(new Error("offline"));
+
+    await store.performBackfillIfNeeded(true);
+
+    expect(store.currentReservoir).toBe(30);
+
+    store.destroy();
+  });
+});


### PR DESCRIPTION
## Problem

`currentReservoir` was assigned exactly once, inside `initialize()` — the realtime channel carries no pump-snapshot broadcast (only devicestatus/food/profiles have collection effect descriptors), and `performBackfillIfNeeded` refetched seven record types but not `current-therapy-state`. The reservoir pill showed the page-load value for the whole session; on a dashboard left open all day it could be many units stale while the pump kept uploading.

## Fix

Reservoir reaches the client only via `GET /api/v4/current-therapy-state`, which reads the `PumpSnapshot` the decomposer produces from a devicestatus write — so the trigger is the `devicestatus` create event, the same one the store already used for its deferred APS-snapshot refetch. Both fold into one `scheduleDecompositionRefresh()`:

- Guarded so a devicestatus burst yields one pair of requests, not one per document — this also fixes the pre-existing unguarded per-document APS refetch.
- Leading-scheduled/trailing-fire, so a sustained stream can't starve the refresh; timer cleared in `destroy()`.
- `refreshCurrentReservoir()` is the single writer (`therapyState?.reservoir ?? null`), so a value that disappears server-side clears the pill; fetch failures keep the last value.
- Backfill (reconnect, wake-from-sleep, background poll) refreshes it alongside the record fetches with no added serial round trip.

## Tests

New `realtime-store.test.ts` (5 tests) driving `handleCreate`/`performBackfillIfNeeded`. Mutation-proven twice: removing both refresh call sites fails 4 of 5; removing only the burst guard fails exactly the debounce test (3 calls where 1 expected). Full app node suite: 643 passed, no regressions; `pnpm check` identical to baseline (64/10).

Follow-up from #542.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
