### PR TITLE
fix(alerts): make discord destinations match what the bot consumes, and validate them

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Extensions;
 using Nocturne.API.Services.Alerts;
 using Nocturne.API.Services.Alerts.Evaluators;
 using Nocturne.Core.Contracts.Alerts;
@@ -46,6 +47,9 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 [Route("api/v4/alert-rules")]
 public class AlertRulesController : ControllerBase
 {
+    /// <summary>Chat-identity-directory key for Discord links.</summary>
+    private const string DiscordPlatform = "discord";
+
     private readonly ITenantDbContextFactory _contextFactory;
     private readonly IAlertReferenceService _referenceService;
     private readonly IAlertDeliveryService _deliveryService;
@@ -124,12 +128,12 @@ public class AlertRulesController : ControllerBase
         if (RejectPumpModeOnGenericStateSpan(request.ConditionType, request.ConditionParams) is { } badRequest)
             return badRequest;
 
-        if (RejectInvalidDeviceActionChannels(request.Channels) is { } badChannel)
-            return badChannel;
-
         // No cycle detection on create: the new id is server-generated, so the proposed tree
         // cannot reference an id it doesn't yet know. Cycles can only be introduced via PUT.
         await using var db = await _contextFactory.CreateAsync(ct);
+
+        if (await ResolveAndValidateChannelsAsync(request.Channels, db, ct) is { } badChannel)
+            return badChannel;
 
         if (await RejectInvalidTrackerAgeAsync(db, request.ConditionType, request.ConditionParams, ct) is { } badTracker)
             return badTracker;
@@ -199,10 +203,10 @@ public class AlertRulesController : ControllerBase
         if (RejectPumpModeOnGenericStateSpan(request.ConditionType, request.ConditionParams) is { } badRequest)
             return badRequest;
 
-        if (RejectInvalidDeviceActionChannels(request.Channels) is { } badChannel)
-            return badChannel;
-
         await using var db = await _contextFactory.CreateAsync(ct);
+
+        if (await ResolveAndValidateChannelsAsync(request.Channels, db, ct) is { } badChannel)
+            return badChannel;
 
         if (await RejectInvalidTrackerAgeAsync(db, request.ConditionType, request.ConditionParams, ct) is { } badTracker)
             return badTracker;
@@ -438,13 +442,16 @@ public class AlertRulesController : ControllerBase
     #region Helpers
 
     /// <summary>
-    /// Rejects a channel list that contains a <c>device_action</c> channel whose destination is not
-    /// a valid device kind, or whose metadata requests a capability that is unknown or not allowed
-    /// for that kind — otherwise a typo'd kind/capability would silently never actuate. Returns a
-    /// 400 <see cref="BadRequestObjectResult"/> on the first offender, or null when all channels
-    /// are valid.
+    /// Fills in a Discord DM channel's destination from the caller's linked Discord identity and
+    /// rejects a channel list whose destinations cannot deliver: a <c>device_action</c> channel
+    /// naming an unknown kind or capability, a channel type that needs a destination and was given
+    /// none, or a Discord channel/DM destination that is not a snowflake ID. Nothing downstream
+    /// inspects a destination, so an unrejected one becomes a channel that stores fine and never
+    /// delivers. Returns a 400 <see cref="BadRequestObjectResult"/> on the first offender, or null
+    /// when all channels are valid.
     /// </summary>
-    private ActionResult? RejectInvalidDeviceActionChannels(List<CreateAlertRuleChannelRequest>? channels)
+    private async Task<ActionResult?> ResolveAndValidateChannelsAsync(
+        List<CreateAlertRuleChannelRequest>? channels, NocturneDbContext db, CancellationToken ct)
     {
         if (channels is null)
         {
@@ -453,45 +460,116 @@ public class AlertRulesController : ControllerBase
 
         foreach (var ch in channels)
         {
-            if (ch.ChannelType != ChannelType.DeviceAction)
+            if (ch.ChannelType == ChannelType.DeviceAction)
             {
+                if (RejectInvalidDeviceActionChannel(ch) is { } badDevice)
+                {
+                    return badDevice;
+                }
+
                 continue;
             }
 
-            if (string.IsNullOrWhiteSpace(ch.Destination) || !DeviceKinds.IsValid(ch.Destination))
+            if (ch.ChannelType == ChannelType.DiscordDm && string.IsNullOrWhiteSpace(ch.Destination))
+            {
+                ch.Destination = await ResolveLinkedDiscordUserIdAsync(db, ct);
+                if (ch.Destination is null)
+                {
+                    return BadRequest(new
+                    {
+                        message = "No linked Discord account for this user. Link Discord under "
+                            + "Connectors & Apps, or enter a Discord user ID as the destination.",
+                    });
+                }
+            }
+
+            if (ChannelDestinations.RequiresDestination(ch.ChannelType)
+                && string.IsNullOrWhiteSpace(ch.Destination))
             {
                 return BadRequest(new
                 {
-                    message = $"A device_action channel's destination must be a device kind "
-                        + $"({string.Join(", ", DeviceKinds.All)}); got '{ch.Destination}'.",
+                    message = $"A {WireName(ch.ChannelType)} channel requires a destination.",
                 });
             }
 
-            var requested = DeviceCapabilities.ParseRequestedCapabilities(
-                ch.Metadata is not null ? JsonSerializer.Serialize(ch.Metadata) : null);
-            foreach (var capability in requested)
+            if (ChannelDestinations.RequiresSnowflake(ch.ChannelType)
+                && !ChannelDestinations.IsSnowflake(ch.Destination))
             {
-                if (!DeviceCapabilities.IsKnown(capability))
+                return BadRequest(new
                 {
-                    return BadRequest(new
-                    {
-                        message = $"Unknown device capability '{capability}'.",
-                    });
-                }
-
-                if (!DeviceCapabilities.Registry[capability].Kinds.Contains(ch.Destination))
-                {
-                    return BadRequest(new
-                    {
-                        message = $"Capability '{capability}' is not available on "
-                            + $"device kind '{ch.Destination}'.",
-                    });
-                }
+                    message = $"A {WireName(ch.ChannelType)} channel's destination must be a Discord "
+                        + $"ID (17-20 digits); got '{ch.Destination}'.",
+                });
             }
         }
 
         return null;
     }
+
+    private ActionResult? RejectInvalidDeviceActionChannel(CreateAlertRuleChannelRequest ch)
+    {
+        if (string.IsNullOrWhiteSpace(ch.Destination) || !DeviceKinds.IsValid(ch.Destination))
+        {
+            return BadRequest(new
+            {
+                message = $"A device_action channel's destination must be a device kind "
+                    + $"({string.Join(", ", DeviceKinds.All)}); got '{ch.Destination}'.",
+            });
+        }
+
+        var requested = DeviceCapabilities.ParseRequestedCapabilities(
+            ch.Metadata is not null ? JsonSerializer.Serialize(ch.Metadata) : null);
+        foreach (var capability in requested)
+        {
+            if (!DeviceCapabilities.IsKnown(capability))
+            {
+                return BadRequest(new
+                {
+                    message = $"Unknown device capability '{capability}'.",
+                });
+            }
+
+            if (!DeviceCapabilities.Registry[capability].Kinds.Contains(ch.Destination))
+            {
+                return BadRequest(new
+                {
+                    message = $"Capability '{capability}' is not available on "
+                        + $"device kind '{ch.Destination}'.",
+                });
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the Discord user ID linked to the calling subject within this tenant, or null when
+    /// the subject has no active Discord link. Resolution happens here rather than at delivery
+    /// because a dispatch runs from the background orchestrator, where there is no caller to
+    /// attribute a DM to — and a rule carries no owner of its own.
+    /// </summary>
+    private async Task<string?> ResolveLinkedDiscordUserIdAsync(NocturneDbContext db, CancellationToken ct)
+    {
+        var subjectId = HttpContext?.GetSubjectId();
+        if (subjectId is null)
+        {
+            return null;
+        }
+
+        var tenantId = db.TenantId;
+        return await db.ChatIdentityDirectory
+            .Where(d => d.TenantId == tenantId
+                        && d.NocturneUserId == subjectId.Value
+                        && d.Platform == DiscordPlatform
+                        && d.IsActive)
+            .OrderBy(d => d.CreatedAt)
+            .Select(d => d.PlatformUserId)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    /// <summary>Serialised name of a channel type, so error text matches the request wire format.</summary>
+    private static string WireName(ChannelType channelType) =>
+        JsonSerializer.Serialize(channelType).Trim('"');
 
     private static AlertRuleChannelEntity BuildChannel(
         CreateAlertRuleChannelRequest req, Guid ruleId, Guid tenantId, int sortOrder) => new()

--- a/src/Core/Nocturne.Core.Models/Alerts/ChannelDestinations.cs
+++ b/src/Core/Nocturne.Core.Models/Alerts/ChannelDestinations.cs
@@ -1,0 +1,53 @@
+using System.Text.RegularExpressions;
+
+namespace Nocturne.Core.Models.Alerts;
+
+/// <summary>
+/// Shape rules for an alert channel's destination string, applied when a rule is saved.
+/// </summary>
+/// <remarks>
+/// The delivery path never inspects a destination: the bot service passes it straight to the
+/// platform adapter (a Discord channel destination reaches <c>bot.channel(destination)</c>, a DM
+/// destination reaches <c>bot.openDM(destination)</c>). A destination in the wrong shape therefore
+/// produces a channel that is accepted, stored, and silently never delivers.
+/// </remarks>
+public static partial class ChannelDestinations
+{
+    /// <summary>
+    /// Channel types whose destination the user supplies and that cannot deliver without one.
+    /// DM channels are absent: their destination is resolved from the sender's linked chat
+    /// identity rather than typed in.
+    /// </summary>
+    private static readonly HashSet<ChannelType> RequiredDestinationTypes =
+    [
+        ChannelType.Webhook,
+        ChannelType.DiscordChannel,
+        ChannelType.WhatsAppDm,
+        ChannelType.ResendEmail,
+    ];
+
+    /// <summary>Channel types the Discord adapter addresses by snowflake ID.</summary>
+    private static readonly HashSet<ChannelType> SnowflakeDestinationTypes =
+    [
+        ChannelType.DiscordChannel,
+        ChannelType.DiscordDm,
+    ];
+
+    /// <summary>Whether a channel of this type is undeliverable without a destination.</summary>
+    public static bool RequiresDestination(ChannelType channelType) =>
+        RequiredDestinationTypes.Contains(channelType);
+
+    /// <summary>Whether a channel of this type must carry a Discord snowflake ID.</summary>
+    public static bool RequiresSnowflake(ChannelType channelType) =>
+        SnowflakeDestinationTypes.Contains(channelType);
+
+    /// <summary>
+    /// Whether the value is a Discord snowflake — the 17-20 digit ID a channel, guild, or user is
+    /// addressed by.
+    /// </summary>
+    public static bool IsSnowflake(string? value) =>
+        value is not null && SnowflakePattern().IsMatch(value);
+
+    [GeneratedRegex(@"^\d{17,20}$")]
+    private static partial Regex SnowflakePattern();
+}

--- a/src/Web/packages/app/src/lib/components/alerts/ChannelsSection.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/ChannelsSection.svelte
@@ -12,6 +12,7 @@
   import type { ChannelDef } from "./types";
   import {
     CHANNEL_META,
+    destinationError,
     findChannelMeta,
     type ChannelMetaEntry,
   } from "./channelMeta";
@@ -129,6 +130,7 @@
           />
         {:else}
           {#if opt?.destinationRequired}
+            {@const error = destinationError(opt, ch.destination)}
             <div class="space-y-1.5">
               <Label class="text-xs" for="channel-dest-{i}">{opt.destinationLabel}</Label>
               <Input
@@ -136,12 +138,29 @@
                 type="text"
                 class="h-8 text-sm"
                 placeholder={opt.destinationPlaceholder}
+                aria-invalid={error != null}
+                aria-describedby={error != null
+                  ? `channel-dest-error-${i}`
+                  : opt.destinationHelper
+                    ? `channel-dest-helper-${i}`
+                    : undefined}
                 value={ch.destination}
                 oninput={(e: Event & { currentTarget: HTMLInputElement }) => {
                   channels[i].destination = e.currentTarget.value;
                 }}
               />
+              {#if error}
+                <p id="channel-dest-error-{i}" class="text-xs text-status-warning">
+                  {error}
+                </p>
+              {:else if opt.destinationHelper}
+                <p id="channel-dest-helper-{i}" class="text-xs text-muted-foreground">
+                  {opt.destinationHelper}
+                </p>
+              {/if}
             </div>
+          {:else if opt?.destinationHelper}
+            <p class="text-xs text-muted-foreground">{opt.destinationHelper}</p>
           {/if}
           <div class="space-y-1.5">
             <Label class="text-xs" for="channel-label-{i}">Label (optional)</Label>

--- a/src/Web/packages/app/src/lib/components/alerts/ChannelsSection.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/ChannelsSection.svelte.test.ts
@@ -2,7 +2,7 @@ import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { flushSync } from "svelte";
-import { AlertRuleSeverity } from "$api-clients";
+import { AlertRuleSeverity, ChannelType } from "$api-clients";
 import type { DeviceCapabilityCatalog } from "$api-clients";
 import type { ChannelDef } from "./types";
 
@@ -84,6 +84,41 @@ describe("ChannelsSection", () => {
 			page.getByText("Loading", { exact: true }).elements(),
 		).toHaveLength(0);
 		expect(channels).toHaveLength(0);
+	});
+
+	it("flags a Discord channel destination that is not a channel ID", async () => {
+		const channels = $state<ChannelDef[]>([
+			{
+				_uid: "discord",
+				channelType: ChannelType.DiscordChannel,
+				destination: "https://discord.com/api/webhooks/1/abc",
+				destinationLabel: "",
+			},
+		]);
+		render(ChannelsSection, { channels, severity: AlertRuleSeverity.Warning });
+
+		await expect
+			.element(page.getByText("A channel ID is 17-20 digits."))
+			.toBeVisible();
+	});
+
+	it("shows the channel-ID hint once the Discord destination is a snowflake", async () => {
+		const channels = $state<ChannelDef[]>([
+			{
+				_uid: "discord",
+				channelType: ChannelType.DiscordChannel,
+				destination: "1234567890123456789",
+				destinationLabel: "",
+			},
+		]);
+		render(ChannelsSection, { channels, severity: AlertRuleSeverity.Warning });
+
+		await expect
+			.element(page.getByText(/Copy Channel ID/))
+			.toBeVisible();
+		expect(
+			page.getByText("A channel ID is 17-20 digits.").elements(),
+		).toHaveLength(0);
 	});
 
 	it("adds a device channel seeded from the catalog once it has loaded", async () => {

--- a/src/Web/packages/app/src/lib/components/alerts/channelMeta.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/channelMeta.ts
@@ -28,6 +28,10 @@ export interface ChannelMetaEntry {
   destinationPlaceholder?: string;
   destinationHelper?: string;
   destinationRequired?: boolean;
+  /** Shape the destination must match. Mirrors the server-side check. */
+  destinationPattern?: RegExp;
+  /** Shown when the destination does not match `destinationPattern`. */
+  destinationPatternMessage?: string;
   /**
    * When true, this channel is authored by the dedicated device-action editor
    * (kind selector + capability checkboxes) rather than the generic
@@ -74,6 +78,7 @@ export const CHANNEL_META: ChannelMetaEntry[] = [
     description: "Direct message via the linked Discord identity",
     logo: "/logos/discord.png",
     platform: "discord",
+    destinationHelper: "Sent to the Discord account you linked.",
     destinationLabel: "",
     destinationPlaceholder: "",
     destinationRequired: false,
@@ -81,12 +86,16 @@ export const CHANNEL_META: ChannelMetaEntry[] = [
   {
     type: ChannelType.DiscordChannel,
     label: "Discord channel",
-    description: "Post to a Discord channel via webhook",
+    description: "Post to a Discord channel the Nocturne bot has joined",
     logo: "/logos/discord.png",
-    destinationInput: "url",
-    destinationLabel: "Webhook URL",
-    destinationPlaceholder: "https://discord.com/api/webhooks/…",
+    destinationInput: "text",
+    destinationLabel: "Channel ID",
+    destinationPlaceholder: "1234567890123456789",
+    destinationHelper:
+      "In Discord, turn on Settings → Advanced → Developer Mode, then right-click the channel and choose Copy Channel ID.",
     destinationRequired: true,
+    destinationPattern: /^\d{17,20}$/,
+    destinationPatternMessage: "A channel ID is 17-20 digits.",
   },
   {
     type: ChannelType.SlackDm,
@@ -180,6 +189,23 @@ export const CHANNEL_META: ChannelMetaEntry[] = [
 const CHANNEL_META_BY_TYPE: Map<string, ChannelMetaEntry> = new Map(
   CHANNEL_META.map((m) => [m.type as string, m]),
 );
+
+/**
+ * Validation message for a channel's destination, or null when it is acceptable. The API
+ * runs the same checks and is authoritative; this only shortens the feedback loop.
+ */
+export function destinationError(
+  meta: ChannelMetaEntry | undefined,
+  destination: string | undefined,
+): string | null {
+  if (!meta?.destinationRequired) return null;
+  const value = (destination ?? "").trim();
+  if (value === "") return `${meta.destinationLabel} is required.`;
+  if (meta.destinationPattern && !meta.destinationPattern.test(value)) {
+    return meta.destinationPatternMessage ?? null;
+  }
+  return null;
+}
 
 /** Fast lookup by ChannelType. Returns undefined for unknown values. */
 export function findChannelMeta(

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/AlertRulesControllerChannelDestinationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/AlertRulesControllerChannelDestinationTests.cs
@@ -1,0 +1,226 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.API.Services.Alerts;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Monitoring;
+
+/// <summary>
+/// Covers destination validation on <see cref="AlertRulesController"/>. Nothing downstream
+/// inspects a channel destination — the bot service hands it straight to the platform adapter —
+/// so a destination in the wrong shape saves cleanly and then never delivers.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AlertRulesControllerChannelDestinationTests
+{
+    private static readonly Guid Tenant = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static readonly Guid Subject = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private const string ChannelSnowflake = "1234567890123456789";
+    private const string DiscordUserSnowflake = "9876543210987654321";
+
+    private static (AlertRulesController Controller, NocturneDbContext Db) CreateController()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var ctx = new NocturneDbContext(options) { TenantId = Tenant };
+
+        var controller = new AlertRulesController(
+            new TestTenantDbContextFactory(ctx),
+            Mock.Of<IAlertReferenceService>(),
+            Mock.Of<IAlertDeliveryService>(),
+            Mock.Of<IRuleScopeClassifier>(),
+            Mock.Of<ILogger<AlertRulesController>>());
+
+        var http = new DefaultHttpContext();
+        http.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            SubjectId = Subject,
+            TenantId = Tenant,
+        };
+        controller.ControllerContext = new ControllerContext { HttpContext = http };
+
+        return (controller, ctx);
+    }
+
+    private static CreateAlertRuleRequest RuleWith(ChannelType type, string? destination) => new()
+    {
+        Name = "Low",
+        ConditionType = AlertConditionType.Threshold,
+        Channels = [new CreateAlertRuleChannelRequest { ChannelType = type, Destination = destination }],
+    };
+
+    [Fact]
+    public async Task CreateRule_rejects_discord_channel_destination_that_is_a_webhook_url()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.DiscordChannel, "https://discord.com/api/webhooks/123/abc"),
+            CancellationToken.None);
+
+        var bad = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        JsonSerializer.Serialize(bad.Value).Should().Contain("\"message\"").And.Contain("discord_channel");
+    }
+
+    [Fact]
+    public async Task CreateRule_accepts_discord_channel_snowflake_destination()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.DiscordChannel, ChannelSnowflake),
+            CancellationToken.None);
+
+        var created = result.Result.Should().BeOfType<CreatedAtActionResult>()
+            .Subject.Value.Should().BeOfType<AlertRuleResponse>().Subject;
+        created.Channels.Should().ContainSingle()
+            .Which.Destination.Should().Be(ChannelSnowflake);
+    }
+
+    [Theory]
+    [InlineData("1234567890123456")]      // 16 digits — one short
+    [InlineData("123456789012345678901")] // 21 digits — one long
+    public async Task CreateRule_rejects_discord_channel_destination_outside_snowflake_length(string destination)
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.DiscordChannel, destination),
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateRule_rejects_webhook_channel_with_empty_destination()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.Webhook, "   "),
+            CancellationToken.None);
+
+        var bad = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        JsonSerializer.Serialize(bad.Value).Should().Contain("\"message\"").And.Contain("webhook");
+    }
+
+    [Fact]
+    public async Task CreateRule_rejects_discord_dm_when_the_caller_has_no_linked_discord_account()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.DiscordDm, null),
+            CancellationToken.None);
+
+        var bad = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        JsonSerializer.Serialize(bad.Value).Should().Contain("\"message\"").And.Contain("Discord");
+    }
+
+    [Fact]
+    public async Task CreateRule_resolves_discord_dm_destination_from_the_linked_identity()
+    {
+        var (controller, db) = CreateController();
+        db.ChatIdentityDirectory.Add(new ChatIdentityDirectoryEntry
+        {
+            Id = Guid.CreateVersion7(),
+            Platform = "discord",
+            PlatformUserId = DiscordUserSnowflake,
+            TenantId = Tenant,
+            NocturneUserId = Subject,
+            IsActive = true,
+        });
+        await db.SaveChangesAsync();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.DiscordDm, null),
+            CancellationToken.None);
+
+        var created = result.Result.Should().BeOfType<CreatedAtActionResult>()
+            .Subject.Value.Should().BeOfType<AlertRuleResponse>().Subject;
+        created.Channels.Should().ContainSingle()
+            .Which.Destination.Should().Be(DiscordUserSnowflake);
+    }
+
+    [Fact]
+    public async Task CreateRule_ignores_a_discord_link_belonging_to_another_subject()
+    {
+        var (controller, db) = CreateController();
+        db.ChatIdentityDirectory.Add(new ChatIdentityDirectoryEntry
+        {
+            Id = Guid.CreateVersion7(),
+            Platform = "discord",
+            PlatformUserId = DiscordUserSnowflake,
+            TenantId = Tenant,
+            NocturneUserId = Guid.CreateVersion7(),
+            IsActive = true,
+        });
+        await db.SaveChangesAsync();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.DiscordDm, null),
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateRule_keeps_saving_channels_that_need_no_destination()
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.InApp, null),
+            CancellationToken.None);
+
+        var created = result.Result.Should().BeOfType<CreatedAtActionResult>()
+            .Subject.Value.Should().BeOfType<AlertRuleResponse>().Subject;
+        created.Channels.Should().ContainSingle()
+            .Which.ChannelType.Should().Be(ChannelType.InApp);
+    }
+
+    [Fact]
+    public async Task UpdateRule_rejects_discord_channel_destination_that_is_a_webhook_url()
+    {
+        var (controller, db) = CreateController();
+        var rule = new AlertRuleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = Tenant,
+            Name = "Low",
+            ConditionType = AlertConditionType.Threshold,
+        };
+        db.AlertRules.Add(rule);
+        await db.SaveChangesAsync();
+
+        var result = await controller.UpdateRule(rule.Id, new UpdateAlertRuleRequest
+        {
+            Name = "Low",
+            ConditionType = AlertConditionType.Threshold,
+            Channels =
+            [
+                new CreateAlertRuleChannelRequest
+                {
+                    ChannelType = ChannelType.DiscordChannel,
+                    Destination = "https://discord.com/api/webhooks/123/abc",
+                },
+            ],
+        }, CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}


### PR DESCRIPTION
## Problem

The alert-channel editor presented `discord_channel` as a "Webhook URL" with a `discord.com/api/webhooks/…` placeholder, but the bot excludes `discord_channel` from its direct set and calls `bot.channel(destination)` — a channel ID. Following the UI guaranteed a silently dead alert channel on a safety-critical path (observed on a production tenant). Nothing validated any of it: only `device_action` destinations were checked, everything else persisted unchanged, and an empty `discord_dm` reached `openDM("")` — nothing resolved it from the linked identity, so every `discord_dm` channel was dead (the UI never even rendered an input for it).

## Fix

- **UI**: `discord_channel` is a "Channel ID" text input (snowflake placeholder, Developer-Mode Copy-Channel-ID helper), with a client-side pattern error surfaced accessibly; `discord_dm` gained a helper line. The API check is authoritative.
- **API validation** (in `AlertRulesController`, where the `device_action` validation already lives, same error shape): destination-requiring channel types reject empty; `discord_channel`/`discord_dm` destinations must be a 17–20 digit snowflake. Shape rules live in `ChannelDestinations` (Core).
- **`discord_dm` resolves at save time** from the caller's active Discord link in `chat_identity_directory`, scoped `(tenant_id, nocturne_user_id)` — no new plumbing. Save-time rather than delivery-time because a rule carries no owner and dispatch runs from the background orchestrator: at delivery there is no caller to attribute a DM to. With no linked account, the save is rejected with a message naming Connectors & Apps.
- **No data migration**: validation applies to writes; existing webhook-URL rows keep failing delivery exactly as today until edited, at which point they must be fixed.

## Tests

10 new controller tests (33/33 on the AlertRules filter; short-circuiting the new checks fails 8, with the two positive controls green). 2 new browser component tests for the pattern error and helper (5/5). svelte-check identical to baseline (64/10), measured by reverting only the touched files.

## Follow-ups (not this PR)

- The same bug class covers `slack_channel`, `telegram`, `telegram_group`, `whatsapp`, `slack_dm`, `telegram_dm` — all fall through to `bot.channel()`/`openDM()` yet render no destination input, so each is stored empty and undeliverable. Needs UI inputs or per-platform identity resolution.
- `destinationRequired` now exists in the UI table and `ChannelDestinations`; exposing destination metadata on the channel-status endpoint would deduplicate it.
- `TestFireDryRun` skips channel validation, so a preview of a blank DM still lies.
- `ChannelPicker.svelte` has no importers and carries a parallel destination renderer — dead code.

Follow-up from nocturne-cloud#49.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
