### PR TITLE
fix(sdk): carry security schemes and per-operation security in the SDK spec

### DIFF
--- a/sdk/filter-v4-spec.js
+++ b/sdk/filter-v4-spec.js
@@ -143,15 +143,28 @@ const output = {
   },
 };
 
-// Remove security schemes not relevant to SDK consumers (keep Bearer)
+// Keep only the schemes SDK consumers can present — an OAuth access token or a
+// pasted bearer token — and drop the requirements that name a removed scheme so
+// no operation references a scheme the spec no longer defines.
+const sdkSchemes = new Set();
 if (output.components.securitySchemes) {
   const kept = {};
   for (const [name, scheme] of Object.entries(output.components.securitySchemes)) {
-    if (scheme.type === 'http' && scheme.scheme === 'bearer') {
+    if (scheme.type === 'oauth2' || (scheme.type === 'http' && scheme.scheme === 'bearer')) {
       kept[name] = scheme;
+      sdkSchemes.add(name);
     }
   }
   output.components.securitySchemes = kept;
+}
+
+for (const operations of Object.values(filteredPaths)) {
+  for (const operation of Object.values(operations)) {
+    if (!Array.isArray(operation?.security)) continue;
+    operation.security = operation.security.filter(
+      requirement => Object.keys(requirement).every(name => sdkSchemes.has(name)));
+    if (operation.security.length === 0) delete operation.security;
+  }
 }
 
 writeFileSync(outputPath, JSON.stringify(output, null, 2));

--- a/src/API/Nocturne.API/Configuration/SecuritySchemeDocumentTransformer.cs
+++ b/src/API/Nocturne.API/Configuration/SecuritySchemeDocumentTransformer.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi;
+using Nocturne.API.OpenApi;
 
 namespace Nocturne.API.Configuration;
 
@@ -20,71 +21,45 @@ public sealed class SecuritySchemeDocumentTransformer : IOpenApiDocumentTransfor
 
         if (context.DocumentName == "nocturne")
         {
-            document.Components.SecuritySchemes["oauth2"] = new OpenApiSecurityScheme
+            document.Components.SecuritySchemes[SecuritySchemeDefinitions.OAuth2] = new OpenApiSecurityScheme
             {
                 Type = SecuritySchemeType.OAuth2,
-                Description =
-                    "OAuth 2.0 Authorization Code with PKCE. "
-                    + "All clients are public — PKCE is mandatory, no client secrets.",
+                Description = SecuritySchemeDefinitions.OAuth2Description,
                 Flows = new OpenApiOAuthFlows
                 {
                     AuthorizationCode = new OpenApiOAuthFlow
                     {
-                        AuthorizationUrl = new Uri("/api/oauth/authorize", UriKind.Relative),
-                        TokenUrl = new Uri("/api/oauth/token", UriKind.Relative),
-                        Scopes = new Dictionary<string, string>
-                        {
-                            ["*"] = "Full access (read, write, delete)",
-                            ["health.read"] =
-                                "Read all health data (glucose, treatments, devices, therapy settings)",
-                            ["glucose.read"] = "Read glucose data",
-                            ["glucose.readwrite"] = "Read and write glucose data",
-                            ["treatments.read"] = "Read treatments",
-                            ["treatments.readwrite"] = "Read and write treatments",
-                            ["devices.read"] = "Read device status data",
-                            ["devices.readwrite"] = "Read and write device status data",
-                            ["therapy.read"] = "Read therapy settings",
-                            ["therapy.readwrite"] = "Read and write therapy settings",
-                            ["alerts.read"] = "Read alert configuration",
-                            ["alerts.readwrite"] = "Read and write alert configuration",
-                            ["reports.read"] = "Read reports",
-                            ["identity.read"] = "Read identity information",
-                            ["sharing.readwrite"] = "Manage sharing settings",
-                        },
+                        AuthorizationUrl = new Uri(SecuritySchemeDefinitions.AuthorizationUrl, UriKind.Relative),
+                        TokenUrl = new Uri(SecuritySchemeDefinitions.TokenUrl, UriKind.Relative),
+                        Scopes = new Dictionary<string, string>(SecuritySchemeDefinitions.OAuth2Scopes),
                     },
                 },
             };
 
-            document.Components.SecuritySchemes["bearer"] = new OpenApiSecurityScheme
+            document.Components.SecuritySchemes[SecuritySchemeDefinitions.Bearer] = new OpenApiSecurityScheme
             {
                 Type = SecuritySchemeType.Http,
                 Scheme = "bearer",
-                BearerFormat = "JWT or noc_* direct grant token",
-                Description =
-                    "Paste an existing token: an OAuth access token (JWT), "
-                    + "OIDC token, or a direct grant token (prefixed `noc_`).",
+                BearerFormat = SecuritySchemeDefinitions.BearerFormat,
+                Description = SecuritySchemeDefinitions.BearerDescription,
             };
 
-            document.Components.SecuritySchemes["instanceKey"] = new OpenApiSecurityScheme
+            document.Components.SecuritySchemes[SecuritySchemeDefinitions.InstanceKey] = new OpenApiSecurityScheme
             {
                 Type = SecuritySchemeType.ApiKey,
-                Name = "X-Instance-Key",
+                Name = SecuritySchemeDefinitions.InstanceKeyHeader,
                 In = ParameterLocation.Header,
-                Description =
-                    "Platform-internal instance key. Grants full admin permissions "
-                    + "— intended for infrastructure services, not end users.",
+                Description = SecuritySchemeDefinitions.InstanceKeyDescription,
             };
         }
         else if (context.DocumentName == "nightscout")
         {
-            document.Components.SecuritySchemes["apiSecret"] = new OpenApiSecurityScheme
+            document.Components.SecuritySchemes[SecuritySchemeDefinitions.ApiSecret] = new OpenApiSecurityScheme
             {
                 Type = SecuritySchemeType.ApiKey,
-                Name = "api-secret",
+                Name = SecuritySchemeDefinitions.ApiSecretHeader,
                 In = ParameterLocation.Header,
-                Description =
-                    "Nightscout API secret (SHA-1 hash). "
-                    + "Grants full read/write access to the tenant.",
+                Description = SecuritySchemeDefinitions.ApiSecretDescription,
             };
         }
 

--- a/src/API/Nocturne.API/OpenApi/NSwagSecurityRegistration.cs
+++ b/src/API/Nocturne.API/OpenApi/NSwagSecurityRegistration.cs
@@ -1,0 +1,17 @@
+using NSwag.Generation;
+
+namespace Nocturne.API.OpenApi;
+
+/// <summary>
+/// Adds the security scheme and requirement processors to an NSwag document. The build-time
+/// document is configured at two sites — the application host and <c>NSwagStartup</c> — so both
+/// register through here.
+/// </summary>
+public static class NSwagSecurityRegistration
+{
+    public static void AddNocturneSecurity(this OpenApiDocumentGeneratorSettings settings)
+    {
+        settings.DocumentProcessors.Add(new SecuritySchemeDocumentProcessor());
+        settings.OperationProcessors.Add(new SecurityRequirementOperationProcessor());
+    }
+}

--- a/src/API/Nocturne.API/OpenApi/SecurityRequirementOperationProcessor.cs
+++ b/src/API/Nocturne.API/OpenApi/SecurityRequirementOperationProcessor.cs
@@ -1,0 +1,38 @@
+using Nocturne.Core.Models.Authorization;
+using NSwag;
+using NSwag.Generation.Processors;
+using NSwag.Generation.Processors.Contexts;
+
+namespace Nocturne.API.OpenApi;
+
+/// <summary>
+/// Attaches per-operation security requirements to the NSwag document, mirroring
+/// <see cref="SecurityRequirementOperationTransformer"/> on the runtime documents.
+/// </summary>
+public sealed class SecurityRequirementOperationProcessor : IOperationProcessor
+{
+    public bool Process(OperationProcessorContext context)
+    {
+        if (!SecuritySchemeDefinitions.RequiresAuthorization(context.MethodInfo, context.ControllerType))
+            return true;
+
+        var operation = context.OperationDescription.Operation;
+        operation.Security ??= [];
+
+        // Each scheme is its own requirement entry → OR logic (any one suffices).
+        operation.Security.Add(new OpenApiSecurityRequirement
+        {
+            [SecuritySchemeDefinitions.OAuth2] = new[] { OAuthScopes.FullAccess },
+        });
+        operation.Security.Add(new OpenApiSecurityRequirement
+        {
+            [SecuritySchemeDefinitions.Bearer] = [],
+        });
+        operation.Security.Add(new OpenApiSecurityRequirement
+        {
+            [SecuritySchemeDefinitions.InstanceKey] = [],
+        });
+
+        return true;
+    }
+}

--- a/src/API/Nocturne.API/OpenApi/SecurityRequirementOperationTransformer.cs
+++ b/src/API/Nocturne.API/OpenApi/SecurityRequirementOperationTransformer.cs
@@ -1,12 +1,12 @@
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.OpenApi;
 
 /// <summary>
-/// Attaches per-operation security requirements based on [Authorize] / [AllowAnonymous] attributes.
+/// Attaches per-operation security requirements to the runtime documents.
 /// Nocturne endpoints get oauth2|bearer|instanceKey; Nightscout endpoints get apiSecret.
 /// </summary>
 public sealed class SecurityRequirementOperationTransformer : IOpenApiOperationTransformer
@@ -20,21 +20,8 @@ public sealed class SecurityRequirementOperationTransformer : IOpenApiOperationT
         if (actionDescriptor is null)
             return Task.CompletedTask;
 
-        var methodInfo = actionDescriptor.MethodInfo;
-        var controllerType = actionDescriptor.ControllerTypeInfo;
-
-        var allowAnonymous =
-            methodInfo.GetCustomAttributes(typeof(AllowAnonymousAttribute), inherit: true).Length > 0
-            || controllerType.GetCustomAttributes(typeof(AllowAnonymousAttribute), inherit: true).Length > 0;
-
-        if (allowAnonymous)
-            return Task.CompletedTask;
-
-        var hasAuthorize =
-            methodInfo.GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true).Length > 0
-            || controllerType.GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true).Length > 0;
-
-        if (!hasAuthorize)
+        if (!SecuritySchemeDefinitions.RequiresAuthorization(
+                actionDescriptor.MethodInfo, actionDescriptor.ControllerTypeInfo))
             return Task.CompletedTask;
 
         var document = context.Document;
@@ -45,15 +32,16 @@ public sealed class SecurityRequirementOperationTransformer : IOpenApiOperationT
             operation.Security ??= [];
             operation.Security.Add(new OpenApiSecurityRequirement
             {
-                [new OpenApiSecuritySchemeReference("oauth2", document)] = ["*"],
+                [new OpenApiSecuritySchemeReference(SecuritySchemeDefinitions.OAuth2, document)] =
+                    [OAuthScopes.FullAccess],
             });
             operation.Security.Add(new OpenApiSecurityRequirement
             {
-                [new OpenApiSecuritySchemeReference("bearer", document)] = [],
+                [new OpenApiSecuritySchemeReference(SecuritySchemeDefinitions.Bearer, document)] = [],
             });
             operation.Security.Add(new OpenApiSecurityRequirement
             {
-                [new OpenApiSecuritySchemeReference("instanceKey", document)] = [],
+                [new OpenApiSecuritySchemeReference(SecuritySchemeDefinitions.InstanceKey, document)] = [],
             });
         }
         else if (context.DocumentName == "nightscout")
@@ -61,7 +49,7 @@ public sealed class SecurityRequirementOperationTransformer : IOpenApiOperationT
             operation.Security ??= [];
             operation.Security.Add(new OpenApiSecurityRequirement
             {
-                [new OpenApiSecuritySchemeReference("apiSecret", document)] = [],
+                [new OpenApiSecuritySchemeReference(SecuritySchemeDefinitions.ApiSecret, document)] = [],
             });
         }
 

--- a/src/API/Nocturne.API/OpenApi/SecuritySchemeDefinitions.cs
+++ b/src/API/Nocturne.API/OpenApi/SecuritySchemeDefinitions.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.OpenApi;
+
+/// <summary>
+/// The security schemes the API publishes, and the rule for which operations require one.
+/// </summary>
+/// <remarks>
+/// Two OpenAPI pipelines emit these: Microsoft.OpenApi serves the runtime documents for Scalar,
+/// NSwag emits the build-time document that feeds the TypeScript client and the published SDK
+/// specs. The two have separate object models, so each pipeline builds its own scheme objects
+/// from the values here.
+/// </remarks>
+public static class SecuritySchemeDefinitions
+{
+    public const string OAuth2 = "oauth2";
+    public const string Bearer = "bearer";
+    public const string InstanceKey = "instanceKey";
+    public const string ApiSecret = "apiSecret";
+
+    public const string AuthorizationUrl = "/api/oauth/authorize";
+    public const string TokenUrl = "/api/oauth/token";
+
+    public const string InstanceKeyHeader = "X-Instance-Key";
+    public const string ApiSecretHeader = "api-secret";
+
+    public const string BearerFormat = "JWT or noc_* direct grant token";
+
+    public const string OAuth2Description =
+        "OAuth 2.0 Authorization Code with PKCE. "
+        + "All clients are public — PKCE is mandatory, no client secrets.";
+
+    public const string BearerDescription =
+        "Paste an existing token: an OAuth access token (JWT), "
+        + "OIDC token, or a direct grant token (prefixed `noc_`).";
+
+    public const string InstanceKeyDescription =
+        "Platform-internal instance key. Grants full admin permissions "
+        + "— intended for infrastructure services, not end users.";
+
+    public const string ApiSecretDescription =
+        "Nightscout API secret (SHA-1 hash). "
+        + "Grants full read/write access to the tenant.";
+
+    public static readonly IReadOnlyDictionary<string, string> OAuth2Scopes =
+        new Dictionary<string, string>
+        {
+            [OAuthScopes.FullAccess] = "Full access (read, write, delete)",
+            [OAuthScopes.HealthRead] =
+                "Read all health data (glucose, treatments, devices, therapy settings)",
+            [OAuthScopes.GlucoseRead] = "Read glucose data",
+            [OAuthScopes.GlucoseReadWrite] = "Read and write glucose data",
+            [OAuthScopes.TreatmentsRead] = "Read treatments",
+            [OAuthScopes.TreatmentsReadWrite] = "Read and write treatments",
+            [OAuthScopes.DevicesRead] = "Read device status data",
+            [OAuthScopes.DevicesReadWrite] = "Read and write device status data",
+            [OAuthScopes.TherapyRead] = "Read therapy settings",
+            [OAuthScopes.TherapyReadWrite] = "Read and write therapy settings",
+            [OAuthScopes.AlertsRead] = "Read alert configuration",
+            [OAuthScopes.AlertsReadWrite] = "Read and write alert configuration",
+            [OAuthScopes.ReportsRead] = "Read reports",
+            [OAuthScopes.IdentityRead] = "Read identity information",
+            [OAuthScopes.SharingReadWrite] = "Manage sharing settings",
+        };
+
+    /// <summary>
+    /// Whether an operation needs credentials. Authorization is default-deny — the
+    /// <see cref="Microsoft.AspNetCore.Authorization.AuthorizationOptions.FallbackPolicy"/> covers
+    /// every endpoint that carries no authorization attribute — so an operation is callable
+    /// anonymously only where it opts out with <c>[AllowAnonymous]</c>.
+    /// </summary>
+    public static bool RequiresAuthorization(MethodInfo method, Type controllerType) =>
+        method.GetCustomAttributes(typeof(AllowAnonymousAttribute), inherit: true).Length == 0
+        && controllerType.GetCustomAttributes(typeof(AllowAnonymousAttribute), inherit: true).Length == 0;
+}

--- a/src/API/Nocturne.API/OpenApi/SecuritySchemeDocumentProcessor.cs
+++ b/src/API/Nocturne.API/OpenApi/SecuritySchemeDocumentProcessor.cs
@@ -1,0 +1,48 @@
+using NSwag;
+using NSwag.Generation.Processors;
+using NSwag.Generation.Processors.Contexts;
+
+namespace Nocturne.API.OpenApi;
+
+/// <summary>
+/// Registers <see cref="SecuritySchemeDefinitions"/> in <c>components/securitySchemes</c> of the
+/// NSwag document. Without them the published SDKs generate no authentication plumbing.
+/// </summary>
+public sealed class SecuritySchemeDocumentProcessor : IDocumentProcessor
+{
+    public void Process(DocumentProcessorContext context)
+    {
+        var schemes = context.Document.Components.SecuritySchemes;
+
+        schemes[SecuritySchemeDefinitions.OAuth2] = new OpenApiSecurityScheme
+        {
+            Type = OpenApiSecuritySchemeType.OAuth2,
+            Description = SecuritySchemeDefinitions.OAuth2Description,
+            Flows = new OpenApiOAuthFlows
+            {
+                AuthorizationCode = new OpenApiOAuthFlow
+                {
+                    AuthorizationUrl = SecuritySchemeDefinitions.AuthorizationUrl,
+                    TokenUrl = SecuritySchemeDefinitions.TokenUrl,
+                    Scopes = new Dictionary<string, string>(SecuritySchemeDefinitions.OAuth2Scopes),
+                },
+            },
+        };
+
+        schemes[SecuritySchemeDefinitions.Bearer] = new OpenApiSecurityScheme
+        {
+            Type = OpenApiSecuritySchemeType.Http,
+            Scheme = "bearer",
+            BearerFormat = SecuritySchemeDefinitions.BearerFormat,
+            Description = SecuritySchemeDefinitions.BearerDescription,
+        };
+
+        schemes[SecuritySchemeDefinitions.InstanceKey] = new OpenApiSecurityScheme
+        {
+            Type = OpenApiSecuritySchemeType.ApiKey,
+            Name = SecuritySchemeDefinitions.InstanceKeyHeader,
+            In = OpenApiSecurityApiKeyLocation.Header,
+            Description = SecuritySchemeDefinitions.InstanceKeyDescription,
+        };
+    }
+}

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -193,6 +193,7 @@ builder.Services.AddOpenApiDocument(config =>
     config.OperationProcessors.Add(new ConsumesContentTypeOperationProcessor());
     config.OperationProcessors.Add(new ControllerNameTagOperationProcessor());
     config.OperationProcessors.Add(new SummaryToDescriptionOperationProcessor());
+    config.AddNocturneSecurity();
 
     config.PostProcess = document =>
     {
@@ -707,6 +708,7 @@ internal class NSwagStartup
             config.OperationProcessors.Add(new RemoteFunctionOperationProcessor());
             config.OperationProcessors.Add(new ConsumesContentTypeOperationProcessor());
             config.OperationProcessors.Add(new ControllerNameTagOperationProcessor());
+            config.AddNocturneSecurity();
         });
     }
 

--- a/tests/Unit/Nocturne.API.Tests/OpenApi/NSwagSecurityProcessorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/OpenApi/NSwagSecurityProcessorTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.API.Configuration;
+using Nocturne.API.Controllers;
+using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.API.OpenApi;
+using NSwag;
+using NSwag.Generation.Processors.Contexts;
+
+namespace Nocturne.API.Tests.OpenApi;
+
+/// <summary>
+/// The NSwag document feeds the published SDK specs, so a scheme or requirement missing here
+/// leaves every generated SDK without authentication plumbing.
+/// </summary>
+public class NSwagSecurityProcessorTests
+{
+    private static OpenApiDocument DocumentWithSchemes()
+    {
+        var document = new OpenApiDocument();
+        new SecuritySchemeDocumentProcessor().Process(
+            new DocumentProcessorContext(document, [], [], null!, null!, null!));
+        return document;
+    }
+
+    private static OpenApiOperation ProcessOperation(Type controllerType, string methodName)
+    {
+        var description = new OpenApiOperationDescription { Operation = new OpenApiOperation() };
+        var context = new OperationProcessorContext(
+            new OpenApiDocument(),
+            description,
+            controllerType,
+            controllerType.GetMethod(methodName)!,
+            null!,
+            null!,
+            null!,
+            []);
+
+        new SecurityRequirementOperationProcessor().Process(context);
+        return description.Operation;
+    }
+
+    [Fact]
+    public void DocumentProcessor_RegistersBearerScheme()
+    {
+        var bearer = DocumentWithSchemes().Components.SecuritySchemes["bearer"];
+
+        bearer.Type.Should().Be(OpenApiSecuritySchemeType.Http);
+        bearer.Scheme.Should().Be("bearer");
+    }
+
+    [Fact]
+    public void DocumentProcessor_RegistersOAuth2SchemeWithAuthorizationCodeFlow()
+    {
+        var oauth2 = DocumentWithSchemes().Components.SecuritySchemes["oauth2"];
+
+        oauth2.Type.Should().Be(OpenApiSecuritySchemeType.OAuth2);
+        oauth2.Flows!.AuthorizationCode!.AuthorizationUrl.Should().Be("/api/oauth/authorize");
+        oauth2.Flows.AuthorizationCode.TokenUrl.Should().Be("/api/oauth/token");
+        oauth2.Flows.AuthorizationCode.Scopes.Should().ContainKey("*");
+    }
+
+    [Fact]
+    public void DocumentProcessor_RegistersInstanceKeyHeaderScheme()
+    {
+        var instanceKey = DocumentWithSchemes().Components.SecuritySchemes["instanceKey"];
+
+        instanceKey.Type.Should().Be(OpenApiSecuritySchemeType.ApiKey);
+        instanceKey.Name.Should().Be("X-Instance-Key");
+        instanceKey.In.Should().Be(OpenApiSecurityApiKeyLocation.Header);
+    }
+
+    [Fact]
+    public void OperationProcessor_ActionCoveredByTheFallbackPolicy_DeclaresEverySchemeAsAnAlternative()
+    {
+        var operation = ProcessOperation(typeof(GuestLinkController), nameof(GuestLinkController.CreateGuestLink));
+
+        operation.Security.Should().HaveCount(3);
+        operation.Security.SelectMany(requirement => requirement.Keys)
+            .Should().BeEquivalentTo(["oauth2", "bearer", "instanceKey"]);
+        operation.Security.First()["oauth2"].Should().BeEquivalentTo(["*"]);
+    }
+
+    [Fact]
+    public void OperationProcessor_AnonymousAction_DeclaresNoSecurity()
+    {
+        var operation = ProcessOperation(typeof(GuestLinkController), nameof(GuestLinkController.ActivateGuestLink));
+
+        operation.Security.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public void OperationProcessor_AnonymousController_DeclaresNoSecurity()
+    {
+        var operation = ProcessOperation(typeof(WellKnownController), nameof(WellKnownController.GetJwks));
+
+        operation.Security.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task BuildTimeAndRuntimeDocuments_PublishTheSameSchemes()
+    {
+        var runtimeDocument = new Microsoft.OpenApi.OpenApiDocument();
+        await new SecuritySchemeDocumentTransformer().TransformAsync(
+            runtimeDocument,
+            new OpenApiDocumentTransformerContext
+            {
+                DocumentName = "nocturne",
+                DescriptionGroups = [],
+                ApplicationServices = new ServiceCollection().BuildServiceProvider(),
+            },
+            CancellationToken.None);
+
+        runtimeDocument.Components!.SecuritySchemes!.Keys
+            .Should().BeEquivalentTo(DocumentWithSchemes().Components.SecuritySchemes.Keys);
+    }
+}


### PR DESCRIPTION
## Problem

The NSwag spec feeding sdk-publish carried no `components.securitySchemes` and no per-operation `security` — the schemes were registered only on the runtime Microsoft.OpenApi documents, which NSwag doesn't read. Consequences: the bearer keep-filter in `sdk/filter-v4-spec.js` could never match, and nocturne-java's `setAccessToken()` compiled to an unconditional `throw new RuntimeException("No OAuth2 authentication configured!")` — every SDK consumer had to inject the Authorization header by hand, while the seven published SDKs are the supported surface for native apps driving the OAuth device flow.

Two things surfaced during verification:

- The live NSwag path is `NSwagStartup`, not the `AddOpenApiDocument` block in `Program.cs` — proven by the generated spec's `info.title = "My Title"` and raw XML summaries (the dead block owns the `PostProcess` humanization). Left in place; flagged below.
- The runtime `SecurityRequirementOperationTransformer` required an explicit `[Authorize]`, but authorization is default-deny via `FallbackPolicy` and only ~69 of ~100 V4 controllers carry the attribute — mirroring that rule would have shipped SDK methods that send no credentials. The rule is now "authed unless `[AllowAnonymous]`".

## Fix

- `SecuritySchemeDefinitions` — one source of truth for scheme names, URLs, header names, the OAuth scope map (keyed on `OAuthScopes` constants), and `RequiresAuthorization`. Both pipelines consume it; only the object-model mapping is per-pipeline.
- NSwag document + operation processors registered at both NSwag config sites; the Microsoft transformers rewritten onto the shared definitions.
- `sdk/filter-v4-spec.js` keeps `oauth2` alongside `bearer` and strips requirements naming removed schemes so `instanceKey` references don't dangle.

## Verified end to end (nothing inferred)

Regenerated spec: oauth2 + bearer + instanceKey schemes; 550/620 operations declare security; `jwks.json` declares none. Post-filter: 532/577; a sampled authed op carries `[{"oauth2":["*"]},{"bearer":[]}]`; the anonymous OAuth endpoints carry none while the consent endpoints do. A real `openapi-generator-cli:v7.21.0` java run against the filtered spec renders `setAccessToken()` setting the token, wires `OAuth` + `HttpBearerAuth`, and emits `localVarAuthNames = { "bearer", "oauth2" }`.

## Tests

7 new tests: scheme shapes, an authed fallback-policy-only endpoint the old rule missed, method- and controller-level `[AllowAnonymous]`, and NSwag↔Microsoft scheme-name parity. Mutation-proven (forcing `RequiresAuthorization => true` fails exactly the two anonymous tests). Full suite green apart from the known load-flaky benchmark.

## Flagged, not fixed

- The `Program.cs` `AddOpenApiDocument` block is dead for spec generation and has drifted from `NSwagStartup` (title/humanization only on the dead one — the SDK spec ships `info.title = "My Title"`).
- The document-membership predicate is triplicated across the two NSwag sites and the Microsoft `ShouldInclude`.

Follow-up from #530.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
