### PR TITLE
feat(v4): explicit clear semantic for a record's patient-device link; stop bolus/meter PUTs dropping attribution

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
+using Nocturne.API.Services.Devices;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -28,6 +29,7 @@ namespace Nocturne.API.Controllers.V4.Devices;
 /// as are <see cref="DeviceEvent.DeviceId"/> and <see cref="DeviceEvent.PatientDeviceId"/>
 /// when the request carries no explicit <c>patientDeviceId</c>.
 /// </remarks>
+/// <seealso cref="PatientDeviceAttribution"/>
 /// <seealso cref="IDeviceEventRepository"/>
 /// <seealso cref="DeviceEvent"/>
 /// <seealso cref="UpsertDeviceEventRequest"/>
@@ -87,12 +89,10 @@ public class DeviceEventController(
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
-        if (await ResolveExplicitPatientDeviceAsync(request, ct) is { } error)
-            return error;
-
         // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
-        // direct API records stay unstamped. No-op when the request carried an explicit patientDeviceId.
-        await deviceStamper.StampAsync([model], DeviceAttributionCategories.DeviceEvent(model.EventType), model.DataSource, ct);
+        // direct API records stay unstamped.
+        if (await ApplyAttributionAsync(model, request, existing: null, ct) is { } error)
+            return error;
 
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
@@ -110,11 +110,8 @@ public class DeviceEventController(
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
-        if (await ResolveExplicitPatientDeviceAsync(request, ct) is { } error)
+        if (await ApplyAttributionAsync(model, request, existing.PatientDeviceId, ct) is { } error)
             return error;
-
-        // No-op when attribution was preserved or explicitly set above; re-attributes only records still unstamped.
-        await deviceStamper.StampAsync([model], DeviceAttributionCategories.DeviceEvent(model.EventType), model.DataSource, ct);
 
         try
         {
@@ -132,7 +129,6 @@ public class DeviceEventController(
         Timestamp = request.Timestamp.UtcDateTime,
         UtcOffset = request.UtcOffset,
         Device = request.Device,
-        PatientDeviceId = request.PatientDeviceId,
         App = request.App,
         DataSource = request.DataSource,
         EventType = request.EventType,
@@ -146,10 +142,9 @@ public class DeviceEventController(
         Timestamp = request.Timestamp.UtcDateTime,
         UtcOffset = request.UtcOffset,
         Device = request.Device,
-        // Preserve attribution across edits unless the request explicitly re-links the event; rebuilding
-        // the model without this would silently drop the stamped device link.
+        // Preserve the legacy device link across edits; rebuilding the model without this would
+        // silently drop it. PatientDeviceId is settled by ApplyAttributionAsync.
         DeviceId = existing.DeviceId,
-        PatientDeviceId = request.PatientDeviceId ?? existing.PatientDeviceId,
         App = request.App,
         DataSource = request.DataSource,
         EventType = request.EventType,
@@ -162,19 +157,16 @@ public class DeviceEventController(
     };
 
     /// <summary>
-    /// Validates an explicit <see cref="UpsertDeviceEventRequest.PatientDeviceId"/> against the caller's
-    /// registered devices. Returns a 400 result when the id doesn't resolve (tenant scoping makes a
-    /// cross-tenant id indistinguishable from a nonexistent one), or <c>null</c> when valid or absent.
+    /// Settles the event's device attribution from the request. Returns a 400 result when an explicit
+    /// id doesn't resolve (tenant scoping makes a cross-tenant id indistinguishable from a nonexistent
+    /// one), or <c>null</c> on success.
     /// </summary>
-    private async Task<ObjectResult?> ResolveExplicitPatientDeviceAsync(UpsertDeviceEventRequest request, CancellationToken ct)
+    private async Task<ObjectResult?> ApplyAttributionAsync(DeviceEvent model, UpsertDeviceEventRequest request, Guid? existing, CancellationToken ct)
     {
-        if (request.PatientDeviceId is not { } patientDeviceId)
-            return null;
+        var error = await PatientDeviceAttribution.ApplyAsync(
+            model, request.PatientDeviceId, existing, patientDevices, deviceStamper, DeviceAttributionCategories.DeviceEvent(model.EventType), ct);
 
-        var device = await patientDevices.GetByIdAsync(patientDeviceId, ct);
-        return device is null
-            ? Problem(detail: $"patientDeviceId '{patientDeviceId}' does not resolve to a registered patient device", statusCode: 400, title: "Bad Request")
-            : null;
+        return error is null ? null : Problem(detail: error, statusCode: 400, title: "Bad Request");
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
@@ -62,8 +62,8 @@ public class MeterGlucoseController(IMeterGlucoseRepository repo)
 
     /// <summary>
     /// Maps a <see cref="UpsertMeterGlucoseRequest"/> to an updated <see cref="MeterGlucose"/>, preserving
-    /// immutable fields (<c>CorrelationId</c>, <c>LegacyId</c>, <c>CreatedAt</c>, and <c>AdditionalProperties</c>)
-    /// from the <paramref name="existing"/> record.
+    /// immutable fields (<c>CorrelationId</c>, <c>LegacyId</c>, <c>CreatedAt</c>, <c>PatientDeviceId</c>, and
+    /// <c>AdditionalProperties</c>) from the <paramref name="existing"/> record.
     /// </summary>
     /// <param name="id">The record ID being updated.</param>
     /// <param name="request">The update request.</param>
@@ -81,6 +81,7 @@ public class MeterGlucoseController(IMeterGlucoseRepository repo)
         CorrelationId = existing.CorrelationId,
         LegacyId = existing.LegacyId,
         CreatedAt = existing.CreatedAt,
+        PatientDeviceId = existing.PatientDeviceId,
         AdditionalProperties = existing.AdditionalProperties,
     };
 }

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
+using Nocturne.API.Services.Devices;
 using Nocturne.API.Services.Glucose;
 using Nocturne.API.Services.V4;
 using Nocturne.Core.Contracts.Alerts;
@@ -24,6 +25,7 @@ namespace Nocturne.API.Controllers.V4.Glucose;
 /// <seealso cref="SensorGlucose"/>
 /// <seealso cref="UpsertSensorGlucoseRequest"/>
 /// <seealso cref="ICanonicalAlertEvaluator"/>
+/// <seealso cref="PatientDeviceAttribution"/>
 /// <seealso cref="V4CrudControllerBase{TModel, TCreateRequest, TUpdateRequest, TRepository}"/>
 [ApiController]
 [Tags("Glucose")]
@@ -34,6 +36,7 @@ public class SensorGlucoseController(
     ISensorGlucoseRepository repo,
     IGlucoseProcessingResolver glucoseResolver,
     ICanonicalAlertEvaluator alertEvaluator,
+    IPatientDeviceRepository patientDevices,
     IPatientDeviceStamper deviceStamper,
     ILogger<SensorGlucoseController> logger)
     : V4CrudControllerBase<SensorGlucose, UpsertSensorGlucoseRequest, UpsertSensorGlucoseRequest, ISensorGlucoseRepository>(repo)
@@ -84,9 +87,10 @@ public class SensorGlucoseController(
         await glucoseResolver.ResolveAsync(model, request.GlucoseProcessing, request.SmoothedMgdl, request.UnsmoothedMgdl, ct);
 
         // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
-        // direct API records stay unstamped and only ever surface as pseudo-devices. Fills only when
-        // the record is unattributed; the canonical stream still governs reads.
-        await deviceStamper.StampAsync([model], DeviceAttributionCategories.SensorGlucose, model.DataSource, ct);
+        // direct API records stay unstamped and only ever surface as pseudo-devices. The canonical
+        // stream still governs reads.
+        if (await ApplyAttributionAsync(model, request, existing: null, ct) is { } error)
+            return error;
 
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
@@ -128,9 +132,6 @@ public class SensorGlucoseController(
         LegacyId = existing.LegacyId,
         CreatedAt = existing.CreatedAt,
         AdditionalProperties = existing.AdditionalProperties,
-        // Preserve attribution across edits; the update DTO carries no device identity, so rebuilding
-        // the model without this would silently drop the record to a pseudo-device.
-        PatientDeviceId = existing.PatientDeviceId,
     };
 
     public override async Task<ActionResult<SensorGlucose>> Update(Guid id, [FromBody] UpsertSensorGlucoseRequest request, CancellationToken ct = default)
@@ -146,8 +147,8 @@ public class SensorGlucoseController(
 
         await glucoseResolver.ResolveAsync(model, request.GlucoseProcessing, request.SmoothedMgdl, request.UnsmoothedMgdl, ct);
 
-        // No-op when attribution was preserved above; re-attributes only records still unstamped.
-        await deviceStamper.StampAsync([model], DeviceAttributionCategories.SensorGlucose, model.DataSource, ct);
+        if (await ApplyAttributionAsync(model, request, existing.PatientDeviceId, ct) is { } error)
+            return error;
 
         try
         {
@@ -186,7 +187,11 @@ public class SensorGlucoseController(
 
         // Attribute the batch before persisting (see Create). Per-record DataSource drives matching,
         // so no batch-level source is needed for a mixed-source bulk upload.
-        await deviceStamper.StampAsync(models, DeviceAttributionCategories.SensorGlucose, batchSource: null, ct);
+        var attributionError = await PatientDeviceAttribution.ApplyManyAsync(
+            [.. models.Select((m, i) => ((IDeviceAttributed)m, requests[i].PatientDeviceId))],
+            patientDevices, deviceStamper, DeviceAttributionCategories.SensorGlucose, batchSource: null, ct);
+        if (attributionError is not null)
+            return Problem(detail: attributionError, statusCode: 400, title: "Bad Request");
 
         var created = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         var createdArray = created.ToArray();
@@ -196,6 +201,19 @@ public class SensorGlucoseController(
             await alertEvaluator.EvaluateAsync(ct);
 
         return StatusCode(201, createdArray);
+    }
+
+    /// <summary>
+    /// Settles the reading's device attribution from the request. Returns a 400 result when an explicit
+    /// id doesn't resolve (tenant scoping makes a cross-tenant id indistinguishable from a nonexistent
+    /// one), or <c>null</c> on success.
+    /// </summary>
+    private async Task<ObjectResult?> ApplyAttributionAsync(SensorGlucose model, UpsertSensorGlucoseRequest request, Guid? existing, CancellationToken ct)
+    {
+        var error = await PatientDeviceAttribution.ApplyAsync(
+            model, request.PatientDeviceId, existing, patientDevices, deviceStamper, DeviceAttributionCategories.SensorGlucose, ct);
+
+        return error is null ? null : Problem(detail: error, statusCode: 400, title: "Bad Request");
     }
 
     protected override async Task<SensorGlucose> OnAfterCreateAsync(SensorGlucose created, CancellationToken ct)

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -18,8 +18,8 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 ///
 /// On update, immutable fields (<see cref="Bolus.BolusType"/>, <see cref="Bolus.Kind"/>,
 /// <see cref="Bolus.LegacyId"/>, <see cref="Bolus.CreatedAt"/>, <see cref="Bolus.PumpRecordId"/>,
-/// <see cref="Bolus.DeviceId"/>, and <see cref="Bolus.AdditionalProperties"/>) are preserved from the
-/// existing record. <see cref="Bolus.CorrelationId"/> falls back to the existing value if the request
+/// <see cref="Bolus.DeviceId"/>, <see cref="Bolus.PatientDeviceId"/>, and
+/// <see cref="Bolus.AdditionalProperties"/>) are preserved from the existing record. <see cref="Bolus.CorrelationId"/> falls back to the existing value if the request
 /// does not supply one.
 /// </remarks>
 /// <seealso cref="IBolusRepository"/>
@@ -117,7 +117,7 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
     /// <summary>Maps an <see cref="UpdateBolusRequest"/> onto a <see cref="Bolus"/> domain model, preserving immutable fields from the existing record.</summary>
     /// <param name="id">The bolus ID to carry forward.</param>
     /// <param name="request">The inbound update request.</param>
-    /// <param name="existing">The existing <see cref="Bolus"/> record; immutable fields (<c>BolusType</c>, <c>Kind</c>, <c>LegacyId</c>, <c>CreatedAt</c>, <c>PumpRecordId</c>, <c>DeviceId</c>, <c>AdditionalProperties</c>) are copied from here.</param>
+    /// <param name="existing">The existing <see cref="Bolus"/> record; immutable fields (<c>BolusType</c>, <c>Kind</c>, <c>LegacyId</c>, <c>CreatedAt</c>, <c>PumpRecordId</c>, <c>DeviceId</c>, <c>PatientDeviceId</c>, <c>AdditionalProperties</c>) are copied from here.</param>
     /// <returns>A fully-populated <see cref="Bolus"/> ready for persistence.</returns>
     protected override Bolus MapUpdateToModel(Guid id, UpdateBolusRequest request, Bolus existing) => new()
     {
@@ -144,6 +144,7 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
         CreatedAt = existing.CreatedAt,
         PumpRecordId = existing.PumpRecordId,
         DeviceId = existing.DeviceId,
+        PatientDeviceId = existing.PatientDeviceId,
         AdditionalProperties = existing.AdditionalProperties,
     };
 

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertDeviceEventRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertDeviceEventRequest.cs
@@ -28,7 +28,9 @@ public class UpsertDeviceEventRequest
     /// Optional reference to the registered <see cref="Nocturne.Core.Models.V4.PatientDevice"/> the event
     /// occurred on. Must resolve to one of the caller's registered devices. When omitted on create, the
     /// server attempts attribution from <see cref="Device"/> and <see cref="DataSource"/>; when omitted on
-    /// update, the existing link is preserved.
+    /// update, the existing link is preserved. Send the empty GUID
+    /// (<c>00000000-0000-0000-0000-000000000000</c>) to state that the event belongs to no registered
+    /// device: the link is cleared and server-side attribution is skipped for this request.
     /// </summary>
     public Guid? PatientDeviceId { get; set; }
 

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertSensorGlucoseRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertSensorGlucoseRequest.cs
@@ -25,6 +25,16 @@ public class UpsertSensorGlucoseRequest
     public string? Device { get; set; }
 
     /// <summary>
+    /// Optional reference to the registered <see cref="PatientDevice"/> that produced the reading.
+    /// Must resolve to one of the caller's registered devices. When omitted on create, the server
+    /// attempts attribution from <see cref="Device"/> and <see cref="DataSource"/>; when omitted on
+    /// update, the existing link is preserved. Send the empty GUID
+    /// (<c>00000000-0000-0000-0000-000000000000</c>) to state that the reading came from no registered
+    /// device: the link is cleared and server-side attribution is skipped for this request.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Name of the application that submitted this record.
     /// </summary>
     public string? App { get; set; }

--- a/src/API/Nocturne.API/Services/Devices/PatientDeviceAttribution.cs
+++ b/src/API/Nocturne.API/Services/Devices/PatientDeviceAttribution.cs
@@ -1,0 +1,80 @@
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Services.Devices;
+
+/// <summary>
+/// Applies the <c>patientDeviceId</c> field of a V4 upsert request to the record being written,
+/// and stamps whatever the caller left to the server.
+/// </summary>
+/// <seealso cref="IPatientDeviceStamper"/>
+internal static class PatientDeviceAttribution
+{
+    /// <summary>
+    /// The <c>patientDeviceId</c> value meaning "this record belongs to no registered device".
+    /// Omitting the field cannot express that — omission means "leave attribution to the server" —
+    /// and neither the generated SDK clients nor the form bindings preserve absent-versus-null,
+    /// so the clear travels as an in-band value rather than as a JSON null.
+    /// </summary>
+    public static readonly Guid Clear = Guid.Empty;
+
+    /// <summary>
+    /// Applies <paramref name="requested"/> to <paramref name="model"/>: an explicit id is validated
+    /// against the caller's registered devices, <see cref="Clear"/> unattributes the record, and an
+    /// absent value falls back to <paramref name="existing"/> (null on create).
+    /// </summary>
+    /// <returns>A problem detail when the requested id doesn't resolve, otherwise <c>null</c>.</returns>
+    public static Task<string?> ApplyAsync(
+        IDeviceAttributed model,
+        Guid? requested,
+        Guid? existing,
+        IPatientDeviceRepository devices,
+        IPatientDeviceStamper stamper,
+        IReadOnlyList<DeviceCategory> categories,
+        CancellationToken ct)
+    {
+        model.PatientDeviceId = existing;
+        return ApplyManyAsync([(model, requested)], devices, stamper, categories, model.DataSource, ct);
+    }
+
+    /// <summary>
+    /// Batch form of <see cref="ApplyAsync"/> for bulk creates: cleared records are excluded from the
+    /// single stamper pass so the server cannot immediately re-attribute what the caller unattributed.
+    /// </summary>
+    /// <returns>A problem detail for the first requested id that doesn't resolve, otherwise <c>null</c>.</returns>
+    public static async Task<string?> ApplyManyAsync(
+        IReadOnlyList<(IDeviceAttributed Model, Guid? Requested)> items,
+        IPatientDeviceRepository devices,
+        IPatientDeviceStamper stamper,
+        IReadOnlyList<DeviceCategory> categories,
+        string? batchSource,
+        CancellationToken ct)
+    {
+        var stampable = new List<IDeviceAttributed>(items.Count);
+
+        foreach (var (model, requested) in items)
+        {
+            if (requested == Clear)
+            {
+                model.PatientDeviceId = null;
+                continue;
+            }
+
+            if (requested is { } id)
+            {
+                if (await devices.GetByIdAsync(id, ct) is null)
+                    return $"patientDeviceId '{id}' does not resolve to a registered patient device";
+
+                model.PatientDeviceId = id;
+            }
+
+            stampable.Add(model);
+        }
+
+        if (stampable.Count > 0)
+            await stamper.StampAsync(stampable, categories, batchSource, ct);
+
+        return null;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
@@ -150,6 +150,27 @@ public class BolusControllerTests
     }
 
     [Fact]
+    public async Task Update_PreservesExistingPatientDeviceId()
+    {
+        var patientDeviceId = Guid.NewGuid();
+        var id = Guid.NewGuid();
+        Bolus? captured = null;
+
+        _repoMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Bolus { Id = id, Timestamp = DateTime.UtcNow, Insulin = 2.0, PatientDeviceId = patientDeviceId });
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, Bolus, WriteOrigin, CancellationToken>((_, b, _, _) => captured = b)
+            .ReturnsAsync((Guid _, Bolus b, WriteOrigin origin, CancellationToken _) => b);
+
+        await CreateController().Update(id, new UpdateBolusRequest { Timestamp = DateTimeOffset.UtcNow, Insulin = 3.0 });
+
+        captured.Should().NotBeNull();
+        captured!.PatientDeviceId.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
     public async Task Create_WithPatientInsulinId_EnrichesInsulinContext()
     {
         var insulinId = Guid.NewGuid();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/DeviceEventControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/DeviceEventControllerTests.cs
@@ -193,6 +193,53 @@ public class DeviceEventControllerTests
     }
 
     [Fact]
+    public async Task Create_ClearsAttribution_AndSkipsStamping_WhenRequestSendsTheClearSentinel()
+    {
+        DeviceEvent? persisted = null;
+        SetupCreatePassthrough(m => persisted = m);
+
+        var result = await CreateController().Create(ValidRequest(Guid.Empty));
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        persisted.Should().NotBeNull();
+        persisted!.PatientDeviceId.Should().BeNull();
+        VerifyStamperNeverRan();
+    }
+
+    [Fact]
+    public async Task Update_ClearsAttribution_AndSkipsStamping_WhenRequestSendsTheClearSentinel()
+    {
+        var id = Guid.NewGuid();
+        var existing = new DeviceEvent
+        {
+            Id = id,
+            Timestamp = DateTime.UtcNow,
+            EventType = DeviceEventType.SiteChange,
+            PatientDeviceId = Guid.NewGuid(),
+        };
+        _repoMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        DeviceEvent? updated = null;
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<DeviceEvent>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, DeviceEvent, WriteOrigin, CancellationToken>((_, m, _, _) => updated = m)
+            .ReturnsAsync((Guid _, DeviceEvent m, WriteOrigin _, CancellationToken _) => m);
+
+        var result = await CreateController().Update(id, ValidRequest(Guid.Empty));
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        updated.Should().NotBeNull();
+        updated!.PatientDeviceId.Should().BeNull();
+        VerifyStamperNeverRan();
+    }
+
+    private void VerifyStamperNeverRan() =>
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+
+    [Fact]
     public async Task GetAll_PassesPatientDeviceIdFilter_ToRepository()
     {
         var patientDeviceId = Guid.NewGuid();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/MeterGlucoseControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/MeterGlucoseControllerTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Controllers.V4.Glucose;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+using Xunit;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.API.Tests.Controllers.V4;
+
+[Trait("Category", "Unit")]
+public class MeterGlucoseControllerTests
+{
+    private readonly Mock<IMeterGlucoseRepository> _repoMock = new();
+
+    private MeterGlucoseController CreateController()
+    {
+        var controller = new MeterGlucoseController(_repoMock.Object);
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+        return controller;
+    }
+
+    [Fact]
+    public async Task Update_PreservesExistingPatientDeviceId()
+    {
+        var patientDeviceId = Guid.NewGuid();
+        var id = Guid.NewGuid();
+        MeterGlucose? captured = null;
+
+        // IMeterGlucoseRepository shadows GetByIdAsync with `new`, and the base controller reaches the
+        // repository through the IV4Repository<T> constraint, so the setup has to target that interface.
+        var baseRepo = _repoMock.As<IV4Repository<MeterGlucose>>();
+        baseRepo
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MeterGlucose { Id = id, Timestamp = DateTime.UtcNow, Mgdl = 120, PatientDeviceId = patientDeviceId });
+        baseRepo
+            .Setup(r => r.UpdateAsync(id, It.IsAny<MeterGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, MeterGlucose, WriteOrigin, CancellationToken>((_, m, _, _) => captured = m)
+            .ReturnsAsync((Guid _, MeterGlucose m, WriteOrigin _, CancellationToken _) => m);
+
+        await CreateController().Update(id, new UpsertMeterGlucoseRequest { Timestamp = DateTimeOffset.UtcNow, Mgdl = 95 });
+
+        captured.Should().NotBeNull();
+        captured!.PatientDeviceId.Should().Be(patientDeviceId);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
@@ -21,6 +21,7 @@ public class SensorGlucoseControllerTests
     private readonly Mock<ISensorGlucoseRepository> _repoMock = new();
     private readonly Mock<IGlucoseProcessingResolver> _glucoseResolverMock = new();
     private readonly Mock<ICanonicalAlertEvaluator> _alertEvaluatorMock = new();
+    private readonly Mock<IPatientDeviceRepository> _patientDevicesMock = new();
     private readonly Mock<IPatientDeviceStamper> _deviceStamperMock = new();
     private readonly Mock<ILogger<SensorGlucoseController>> _loggerMock = new();
 
@@ -30,6 +31,7 @@ public class SensorGlucoseControllerTests
             _repoMock.Object,
             _glucoseResolverMock.Object,
             _alertEvaluatorMock.Object,
+            _patientDevicesMock.Object,
             _deviceStamperMock.Object,
             _loggerMock.Object);
 
@@ -205,5 +207,196 @@ public class SensorGlucoseControllerTests
             It.IsAny<CancellationToken>()), Times.Once);
         persisted.Should().NotBeNull();
         persisted!.Single().PatientDeviceId.Should().Be(deviceId);
+    }
+
+    private void SetupRegisteredDevice(Guid patientDeviceId) =>
+        _patientDevicesMock
+            .Setup(p => p.GetByIdAsync(patientDeviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PatientDevice { Id = patientDeviceId, DeviceCategory = DeviceCategory.CGM });
+
+    private void VerifyStamperNeverRan() =>
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+
+    [Fact]
+    public async Task Create_PersistsExplicitPatientDeviceId_WithoutStamping()
+    {
+        var patientDeviceId = Guid.NewGuid();
+        SetupRegisteredDevice(patientDeviceId);
+        SensorGlucose? persisted = null;
+        _repoMock
+            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<SensorGlucose, WriteOrigin, CancellationToken>((m, _, _) => persisted = m)
+            .ReturnsAsync((SensorGlucose m, WriteOrigin _, CancellationToken _) => m);
+
+        var result = await CreateController().Create(new UpsertSensorGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 120,
+            PatientDeviceId = patientDeviceId,
+        });
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        persisted.Should().NotBeNull();
+        persisted!.PatientDeviceId.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
+    public async Task Create_Returns400_WhenPatientDeviceIdDoesNotResolve()
+    {
+        _patientDevicesMock
+            .Setup(p => p.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PatientDevice?)null);
+
+        var result = await CreateController().Create(new UpsertSensorGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 120,
+            PatientDeviceId = Guid.NewGuid(),
+        });
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_ClearsAttribution_AndSkipsStamping_WhenRequestSendsTheClearSentinel()
+    {
+        SensorGlucose? persisted = null;
+        _repoMock
+            .Setup(r => r.CreateAsync(It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<SensorGlucose, WriteOrigin, CancellationToken>((m, _, _) => persisted = m)
+            .ReturnsAsync((SensorGlucose m, WriteOrigin _, CancellationToken _) => m);
+
+        var result = await CreateController().Create(new UpsertSensorGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 120,
+            PatientDeviceId = Guid.Empty,
+        });
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        persisted.Should().NotBeNull();
+        persisted!.PatientDeviceId.Should().BeNull();
+        VerifyStamperNeverRan();
+    }
+
+    [Fact]
+    public async Task Update_PreservesAttribution_AndStamps_WhenRequestOmitsPatientDeviceId()
+    {
+        var id = Guid.NewGuid();
+        var existingDeviceId = Guid.NewGuid();
+        SensorGlucose? updated = null;
+        _repoMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SensorGlucose { Id = id, Timestamp = DateTime.UtcNow, Mgdl = 120, PatientDeviceId = existingDeviceId });
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, SensorGlucose, WriteOrigin, CancellationToken>((_, m, _, _) => updated = m)
+            .ReturnsAsync((Guid _, SensorGlucose m, WriteOrigin _, CancellationToken _) => m);
+
+        await CreateController().Update(id, new UpsertSensorGlucoseRequest { Timestamp = DateTimeOffset.UtcNow, Mgdl = 95 });
+
+        updated.Should().NotBeNull();
+        updated!.PatientDeviceId.Should().Be(existingDeviceId);
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Update_RelinksAttribution_WhenRequestCarriesPatientDeviceId()
+    {
+        var id = Guid.NewGuid();
+        var newPatientDeviceId = Guid.NewGuid();
+        SetupRegisteredDevice(newPatientDeviceId);
+        SensorGlucose? updated = null;
+        _repoMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SensorGlucose { Id = id, Timestamp = DateTime.UtcNow, Mgdl = 120, PatientDeviceId = Guid.NewGuid() });
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, SensorGlucose, WriteOrigin, CancellationToken>((_, m, _, _) => updated = m)
+            .ReturnsAsync((Guid _, SensorGlucose m, WriteOrigin _, CancellationToken _) => m);
+
+        await CreateController().Update(id, new UpsertSensorGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 95,
+            PatientDeviceId = newPatientDeviceId,
+        });
+
+        updated.Should().NotBeNull();
+        updated!.PatientDeviceId.Should().Be(newPatientDeviceId);
+    }
+
+    [Fact]
+    public async Task Update_ClearsAttribution_AndSkipsStamping_WhenRequestSendsTheClearSentinel()
+    {
+        var id = Guid.NewGuid();
+        SensorGlucose? updated = null;
+        _repoMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SensorGlucose { Id = id, Timestamp = DateTime.UtcNow, Mgdl = 120, PatientDeviceId = Guid.NewGuid() });
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<SensorGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, SensorGlucose, WriteOrigin, CancellationToken>((_, m, _, _) => updated = m)
+            .ReturnsAsync((Guid _, SensorGlucose m, WriteOrigin _, CancellationToken _) => m);
+
+        var result = await CreateController().Update(id, new UpsertSensorGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 95,
+            PatientDeviceId = Guid.Empty,
+        });
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        updated.Should().NotBeNull();
+        updated!.PatientDeviceId.Should().BeNull();
+        VerifyStamperNeverRan();
+    }
+
+    [Fact]
+    public async Task CreateBulk_StampsOnlyTheReadingsThatDidNotClearAttribution()
+    {
+        var stamped = Guid.NewGuid();
+        var requests = new[]
+        {
+            new UpsertSensorGlucoseRequest { Timestamp = DateTimeOffset.UtcNow, Mgdl = 120, PatientDeviceId = Guid.Empty },
+            new UpsertSensorGlucoseRequest { Timestamp = DateTimeOffset.UtcNow.AddMinutes(-5), Mgdl = 115 },
+        };
+
+        _deviceStamperMock
+            .Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+                It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
+                (records, _, _, _) =>
+                {
+                    foreach (var record in records)
+                        record.PatientDeviceId = stamped;
+                })
+            .Returns(Task.CompletedTask);
+
+        IEnumerable<SensorGlucose>? persisted = null;
+        _repoMock
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((m, _, _) => persisted = m.ToList())
+            .ReturnsAsync((IEnumerable<SensorGlucose> m, WriteOrigin _, CancellationToken _) => m);
+
+        await CreateController().CreateSensorGlucoseBulk(requests);
+
+        persisted.Should().NotBeNull();
+        persisted!.Should().SatisfyRespectively(
+            cleared => cleared.PatientDeviceId.Should().BeNull(),
+            attributed => attributed.PatientDeviceId.Should().Be(stamped));
     }
 }


### PR DESCRIPTION
## Problem

A record's PatientDevice link was write-once-then-sticky: `DeviceEventController` preserved the existing id when the request omitted `patientDeviceId` and re-ran the stamper on update, so no PUT body could express "this event belongs to no registered device". Sensor glucose was worse — the upsert request had no `patientDeviceId` field at all, so a mis-attributed reading could only be re-linked by deleting the PatientDevice (FK SET NULL) and re-registering. Attribution is now a read-time selector input (canonical stream, per-device stats), so a wrong link changes what users see and couldn't be corrected in place.

Verification also surfaced the opposite bug on two other types: `BolusController` and `MeterGlucoseController`'s `MapUpdateToModel` never carried `PatientDeviceId` from `existing`, and both mappers assign it unconditionally — so every PUT to a bolus or meter-glucose record silently nulled its attribution.

## Design

**`Guid.Empty` as the in-band explicit-clear** on the nullable `patientDeviceId`. The tri-state (absent vs null) alternative was rejected on codegen grounds: these endpoints are also `[RemoteForm]`-reachable, where "absent" isn't reliably expressible, and the generated Zod validators come from `z.fromJSONSchema()` where OpenAPI 3.0 `nullable` isn't a JSON-Schema keyword. `Guid.Empty` is a schema-valid uuid that passes every generated validator and can't collide with a real id (UUID v7). No `Optional<T>`/`*Specified` precedent exists in the codebase; sentinel precedent does.

One shared `PatientDeviceAttribution` class owns the three request shapes (omitted → preserve + stamper runs; `Guid.Empty` → clear + stamper suppressed for that record; a real id → validated in-tenant and set) and the sole suppression site.

## Coverage

- **DeviceEvent**: create + update.
- **SensorGlucose**: create + update + bulk create (per-record; cleared readings excluded from the batched stamper pass), plus the `patientDeviceId` request field and in-tenant validation it previously lacked entirely.
- **Bolus / MeterGlucose**: updates now preserve the existing link (the silent-null fix). The full clear/set semantic for these two (and TempBasal, create-only today) is a noted follow-up.

## Tests

11 new tests across the three request shapes and both preserve fixes; V4 controller filter 440/440. Mutation-proven: suppression mutated → 4 clear tests fail; either preserve line removed → its test fails. One test initially failed for the wrong reason (interface `new`-shadowing meant the mock never matched; fixed with the `.As<IV4Repository<T>>()` pattern the SensorGlucose tests already use, with a comment at the site since it isn't surmisable).

Follow-up from #539.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
