### PR TITLE
fix(web): resolve display preferences during SSR so first paint stops flashing mg/dL

### DIFF
--- a/src/Web/packages/app/src/lib/stores/appearance-ssr-harness.svelte
+++ b/src/Web/packages/app/src/lib/stores/appearance-ssr-harness.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  // Test-only harness: stands in for the root layout, publishing one request's
+  // preference layers so a descendant can be rendered server-side.
+  import { setPreferencesContext } from "./appearance-store.svelte";
+  import Reader from "./appearance-ssr-reader.svelte";
+  import type { UserDisplayPreferences } from "$lib/api";
+
+  let { layers }: { layers: UserDisplayPreferences[] } = $props();
+
+  setPreferencesContext(() => layers);
+</script>
+
+<Reader />

--- a/src/Web/packages/app/src/lib/stores/appearance-ssr-reader.svelte
+++ b/src/Web/packages/app/src/lib/stores/appearance-ssr-reader.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  // Test-only: reads preferences the way real components do — through the shared
+  // formatting helpers, from a descendant of the component that set the context.
+  import { bg, bgLabel, bgRange } from "$lib/utils/formatting";
+  import { timeFormat } from "./appearance-store.svelte";
+
+  const derivedValue = $derived(bg(100));
+</script>
+
+<span id="value">{bg(100)}</span>
+<span id="derived">{derivedValue}</span>
+<span id="label">{bgLabel()}</span>
+<span id="range">{bgRange(70, 180)}</span>
+<span id="time-format">{timeFormat.current}</span>

--- a/src/Web/packages/app/src/lib/stores/appearance-store.ssr.test.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.ssr.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { render } from "svelte/server";
+import type { UserDisplayPreferences } from "$lib/api";
+import Harness from "./appearance-ssr-harness.svelte";
+import { glucoseUnits } from "./appearance-store.svelte";
+
+const mmol: UserDisplayPreferences = { glucoseUnits: "mmol", timeFormat: "24" };
+
+async function ssr(layers: UserDisplayPreferences[]): Promise<string> {
+  return (await render(Harness, { props: { layers } })).body;
+}
+
+describe("appearance-store SSR resolution", () => {
+  it("renders the request's units, not the module default", async () => {
+    const body = await ssr([mmol]);
+
+    expect(body).toContain("5.6");
+    expect(body).toContain("mmol/L");
+    expect(body).toContain("3.9-10 mmol/L");
+    expect(body).not.toContain("mg/dL");
+  });
+
+  it("falls back to defaults when the request carries no preferences", async () => {
+    const body = await ssr([]);
+
+    expect(body).toContain("100");
+    expect(body).toContain("mg/dL");
+    expect(body).toContain("70-180 mg/dL");
+    expect(body).not.toContain("mmol");
+  });
+
+  it("keeps concurrent requests isolated", async () => {
+    const [mmolBody, defaultBody] = await Promise.all([ssr([mmol]), ssr([])]);
+
+    expect(mmolBody).toContain("mmol/L");
+    expect(defaultBody).toContain("mg/dL");
+    expect(defaultBody).not.toContain("mmol");
+    // The shared module state is never written to by a server render.
+    expect(glucoseUnits.current).toBe("mg/dl");
+  });
+
+  it("resolves each field from the highest-precedence layer that defines it", async () => {
+    const body = await ssr([{ timeFormat: "24" }, { glucoseUnits: "mmol", timeFormat: "12" }]);
+
+    expect(body).toContain("mmol/L");
+    expect(body).toContain(">24<");
+  });
+
+  it("applies every preference layer's own fields, not just the first layer's", async () => {
+    const body = await ssr([{ glucoseUnits: "mmol" }, { timeFormat: "24" }]);
+
+    expect(body).toContain("mmol/L");
+    expect(body).toContain(">24<");
+  });
+});

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -13,15 +13,16 @@
  *
  * SSR note: this module's `$state` is shared across requests on the server, so it
  * is NEVER mutated server-side — the cookie is read and applied only in the browser
- * (`if (browser)` at module load). SSR therefore renders defaults and the client
- * corrects on hydration; server-side rendering of preference-dependent text is a
- * known limitation of the synchronous `bg()`-style accessors.
+ * (`if (browser)` at module load). Server-side reads instead resolve from the
+ * per-request preference context the root layout provides (see
+ * `setPreferencesContext`), so SSR emits the same units/formats hydration will.
  *
  * Language keeps its own dedicated cookie + backend path (used by SSR locale
  * resolution).
  */
 
 import { browser } from "$app/environment";
+import { getContext, setContext } from "svelte";
 import { PersistedState } from "runed";
 import { setMode, mode, userPrefersMode } from "mode-watcher";
 import supportedLocales from "../../../../../supportedLocales.json";
@@ -77,6 +78,31 @@ const PREFS_COOKIE_MAX_AGE = 31536000; // 1 year
 /** Registry of synced prefs by their localStorage key — powers cross-tab sync. */
 const syncedRegistry = new Map<string, SyncedPref<unknown>>();
 
+const PREFERENCES_CONTEXT_KEY = Symbol("nocturne-display-preferences");
+
+/**
+ * Publish this request's preference payloads, highest precedence first, for the
+ * duration of one server render. The store's `$state` is module-scoped and so
+ * shared by every concurrent SSR request; reading preferences from component
+ * context instead is what keeps one user's units out of another's HTML.
+ * Layers mirror the browser's own resolution order (backend blob over cookie),
+ * each contributing only the fields it defines.
+ */
+export function setPreferencesContext(layers: () => UserDisplayPreferences[]): void {
+  setContext(PREFERENCES_CONTEXT_KEY, layers);
+}
+
+function requestPreferences(): UserDisplayPreferences[] {
+  try {
+    return getContext<(() => UserDisplayPreferences[]) | undefined>(
+      PREFERENCES_CONTEXT_KEY
+    )?.() ?? [];
+  } catch {
+    // getContext throws outside a component — server loads and module scope have no request.
+    return [];
+  }
+}
+
 /**
  * Backend write-through callback, injected by the app (kept out of this module so
  * the store never imports a server remote directly — mirrors setLanguage's design).
@@ -129,18 +155,32 @@ function persistLocal<T>(key: string, value: T): void {
  * PersistedState, so no consumer changes. Writes propagate to localStorage (cache),
  * the shared cookie, and the backend. `hydrate` sets the value without a
  * backend/cookie echo (used when applying server- or cross-tab-sourced values).
+ * `read` locates this preference inside a `UserDisplayPreferences` payload, and is
+ * the single mapping used for both hydration and server-side resolution.
  */
 class SyncedPref<T> {
   private _value = $state<T>(undefined as T);
   private _key: string;
+  private _read: (prefs: UserDisplayPreferences) => T | undefined;
 
-  constructor(key: string, initial: T) {
+  constructor(
+    key: string,
+    initial: T,
+    read: (prefs: UserDisplayPreferences) => T | undefined
+  ) {
     this._key = key;
+    this._read = read;
     this._value = readInitial(key, initial);
     syncedRegistry.set(key, this as SyncedPref<unknown>);
   }
 
   get current(): T {
+    if (!browser) {
+      for (const prefs of requestPreferences()) {
+        const value = this._read(prefs);
+        if (value !== undefined && value !== null) return value;
+      }
+    }
     return this._value;
   }
 
@@ -160,6 +200,12 @@ class SyncedPref<T> {
     this._value = value;
     persistLocal(this._key, value);
   }
+
+  /** Hydrate from a preference payload, leaving the current value alone when unset. */
+  hydrateFrom(prefs: UserDisplayPreferences): void {
+    const value = this._read(prefs);
+    if (value !== undefined && value !== null) this.hydrate(value);
+  }
 }
 
 // ==========================================
@@ -170,17 +216,29 @@ class SyncedPref<T> {
  * Color theme preference (Nocturne vs Trio)
  * Controls the CSS class applied to the document root
  */
-export const colorTheme = new SyncedPref<ColorTheme>("nocturne-color-theme", "nocturne");
+export const colorTheme = new SyncedPref<ColorTheme>(
+  "nocturne-color-theme",
+  "nocturne",
+  (p) => p.colorTheme as ColorTheme | undefined
+);
 
 /**
  * Blood glucose units preference. Per-user: syncs across devices/tenants.
  */
-export const glucoseUnits = new SyncedPref<GlucoseUnits>("nocturne-glucose-units", "mg/dl");
+export const glucoseUnits = new SyncedPref<GlucoseUnits>(
+  "nocturne-glucose-units",
+  "mg/dl",
+  (p) => p.glucoseUnits as GlucoseUnits | undefined
+);
 
 /**
  * Time format preference (12-hour or 24-hour)
  */
-export const timeFormat = new SyncedPref<TimeFormat>("nocturne-time-format", "12");
+export const timeFormat = new SyncedPref<TimeFormat>(
+  "nocturne-time-format",
+  "12",
+  (p) => p.timeFormat as TimeFormat | undefined
+);
 
 /**
  * Regional format preference. Empty (the default) means "follow the display language",
@@ -188,23 +246,31 @@ export const timeFormat = new SyncedPref<TimeFormat>("nocturne-time-format", "12
  * "de-DE" for European date ordering and Monday-first calendars while keeping the
  * interface in another language.
  */
-export const regionFormat = new SyncedPref<RegionFormat>("nocturne-region-format", "");
+export const regionFormat = new SyncedPref<RegionFormat>(
+  "nocturne-region-format",
+  "",
+  (p) => p.regionFormat as RegionFormat | undefined
+);
 
 /**
  * Night mode schedule toggle
  * When enabled, automatically switches to dark mode at night
  */
-export const nightModeSchedule = new SyncedPref<boolean>("nocturne-night-mode-schedule", false);
+export const nightModeSchedule = new SyncedPref<boolean>(
+  "nocturne-night-mode-schedule",
+  false,
+  (p) => p.nightModeSchedule
+);
 
 /**
  * Dashboard top widgets configuration
  * Stores the ordered list of widget IDs displayed in the top widget grid
  */
-export const dashboardTopWidgets = new SyncedPref<WidgetId[]>("nocturne-dashboard-top-widgets", [
-  WidgetId.BgDelta,
-  WidgetId.TirChart,
-  WidgetId.Tdd,
-]);
+export const dashboardTopWidgets = new SyncedPref<WidgetId[]>(
+  "nocturne-dashboard-top-widgets",
+  [WidgetId.BgDelta, WidgetId.TirChart, WidgetId.Tdd],
+  (p) => p.dashboardTopWidgets
+);
 
 // ==========================================
 // Color Theme Management (Nocturne/Trio)
@@ -319,13 +385,21 @@ export function setGlucoseUnits(units: GlucoseUnits): void {
  * Prediction time horizon in minutes
  * Controls how far into the future predictions are shown
  */
-export const predictionMinutes = new SyncedPref<number>("nocturne-prediction-minutes", 30);
+export const predictionMinutes = new SyncedPref<number>(
+  "nocturne-prediction-minutes",
+  30,
+  (p) => p.prediction?.minutes
+);
 
 /**
  * Prediction enabled state
  * Controls whether prediction lines are shown on charts
  */
-export const predictionEnabled = new SyncedPref<boolean>("nocturne-prediction-enabled", true);
+export const predictionEnabled = new SyncedPref<boolean>(
+  "nocturne-prediction-enabled",
+  true,
+  (p) => p.prediction?.enabled
+);
 
 /**
  * Get current prediction minutes
@@ -376,7 +450,8 @@ export type AreaMode = "off" | "baseline" | "deviation";
  */
 export const predictionDisplayMode = new SyncedPref<PredictionDisplayMode>(
   "nocturne-prediction-display-mode",
-  "cone"
+  "cone",
+  (p) => p.prediction?.displayMode as PredictionDisplayMode | undefined
 );
 
 // ==========================================
@@ -390,7 +465,11 @@ export type TimeRangeOption = "2" | "4" | "6" | "12" | "24" | "48";
  * This controls the span of time shown, always ending at "now"
  * Can be a preset value or a custom number from brush selection
  */
-export const glucoseChartLookback = new SyncedPref<number>("nocturne-glucose-chart-lookback", 12);
+export const glucoseChartLookback = new SyncedPref<number>(
+  "nocturne-glucose-chart-lookback",
+  12,
+  (p) => p.chart?.lookback
+);
 
 /**
  * Default fetch range in hours for glucose chart data
@@ -404,23 +483,45 @@ export const GLUCOSE_CHART_FETCH_HOURS = 48;
 
 export const chartLineColorMode = new SyncedPref<LineColorMode>(
   "nocturne-chart-line-color-mode",
-  "threshold"
+  "threshold",
+  (p) => p.chart?.lineColorMode as LineColorMode | undefined
 );
 
-export const chartLineColor = new SyncedPref<string>("nocturne-chart-line-color", "#22c55e");
+export const chartLineColor = new SyncedPref<string>(
+  "nocturne-chart-line-color",
+  "#22c55e",
+  (p) => p.chart?.lineColor
+);
 
 export const chartPointColorMode = new SyncedPref<LineColorMode>(
   "nocturne-chart-point-color-mode",
-  "threshold"
+  "threshold",
+  (p) => p.chart?.pointColorMode as LineColorMode | undefined
 );
 
-export const chartPointColor = new SyncedPref<string>("nocturne-chart-point-color", "#22c55e");
+export const chartPointColor = new SyncedPref<string>(
+  "nocturne-chart-point-color",
+  "#22c55e",
+  (p) => p.chart?.pointColor
+);
 
-export const chartShowPoints = new SyncedPref<boolean>("nocturne-chart-show-points", true);
+export const chartShowPoints = new SyncedPref<boolean>(
+  "nocturne-chart-show-points",
+  true,
+  (p) => p.chart?.showPoints
+);
 
-export const chartAreaMode = new SyncedPref<AreaMode>("nocturne-chart-area-mode", "off");
+export const chartAreaMode = new SyncedPref<AreaMode>(
+  "nocturne-chart-area-mode",
+  "off",
+  (p) => p.chart?.areaMode as AreaMode | undefined
+);
 
-export const chartAreaOpacity = new SyncedPref<number>("nocturne-chart-area-opacity", 0.5);
+export const chartAreaOpacity = new SyncedPref<number>(
+  "nocturne-chart-area-opacity",
+  0.5,
+  (p) => p.chart?.areaOpacity
+);
 
 /**
  * Always render chart range/category patterns on screen, not just in print.
@@ -429,7 +530,8 @@ export const chartAreaOpacity = new SyncedPref<number>("nocturne-chart-area-opac
  */
 export const chartAlwaysShowPatterns = new SyncedPref<boolean>(
   "nocturne-chart-always-show-patterns",
-  false
+  false,
+  (p) => p.chart?.alwaysShowPatterns
 );
 
 // ==========================================
@@ -478,40 +580,10 @@ export function applyPreferences(
 ): void {
   if (!prefs) return;
 
-  hydrateIfPresent(glucoseUnits, prefs.glucoseUnits as GlucoseUnits | undefined);
-  hydrateIfPresent(timeFormat, prefs.timeFormat as TimeFormat | undefined);
-  hydrateIfPresent(regionFormat, prefs.regionFormat as RegionFormat | undefined);
-  hydrateIfPresent(colorTheme, prefs.colorTheme as ColorTheme | undefined);
-  hydrateIfPresent(nightModeSchedule, prefs.nightModeSchedule ?? undefined);
-  hydrateIfPresent(dashboardTopWidgets, prefs.dashboardTopWidgets ?? undefined);
-
-  if (prefs.prediction) {
-    hydrateIfPresent(predictionEnabled, prefs.prediction.enabled ?? undefined);
-    hydrateIfPresent(predictionMinutes, prefs.prediction.minutes ?? undefined);
-    hydrateIfPresent(
-      predictionDisplayMode,
-      prefs.prediction.displayMode as PredictionDisplayMode | undefined
-    );
-  }
-
-  if (prefs.chart) {
-    hydrateIfPresent(chartLineColorMode, prefs.chart.lineColorMode as LineColorMode | undefined);
-    hydrateIfPresent(chartLineColor, prefs.chart.lineColor ?? undefined);
-    hydrateIfPresent(chartPointColorMode, prefs.chart.pointColorMode as LineColorMode | undefined);
-    hydrateIfPresent(chartPointColor, prefs.chart.pointColor ?? undefined);
-    hydrateIfPresent(chartShowPoints, prefs.chart.showPoints ?? undefined);
-    hydrateIfPresent(chartAreaMode, prefs.chart.areaMode as AreaMode | undefined);
-    hydrateIfPresent(chartAreaOpacity, prefs.chart.areaOpacity ?? undefined);
-    hydrateIfPresent(chartAlwaysShowPatterns, prefs.chart.alwaysShowPatterns ?? undefined);
-    hydrateIfPresent(glucoseChartLookback, prefs.chart.lookback ?? undefined);
-  }
+  for (const pref of syncedRegistry.values()) pref.hydrateFrom(prefs);
 
   if (browser) applyColorTheme(colorTheme.current);
   if (options.refreshCookie) writePrefsCookie(collectPreferences());
-}
-
-function hydrateIfPresent<T>(pref: SyncedPref<T>, value: T | undefined): void {
-  if (value !== undefined && value !== null) pref.hydrate(value);
 }
 
 /** True when a server preference payload carries at least one saved value. */
@@ -569,17 +641,26 @@ function writePrefsCookie(prefs: UserDisplayPreferences): void {
   document.cookie = `${PREFS_COOKIE_NAME}=${value};path=/;max-age=${PREFS_COOKIE_MAX_AGE};SameSite=Lax`;
 }
 
+/** Decode a raw `nocturne-prefs` cookie value; also used server-side by the root layout load. */
+export function parsePrefsCookie(
+  value: string | null | undefined
+): UserDisplayPreferences | null {
+  if (!value) return null;
+  try {
+    const parsed: unknown = JSON.parse(decodeURIComponent(value));
+    return parsed && typeof parsed === "object" ? (parsed as UserDisplayPreferences) : null;
+  } catch {
+    return null;
+  }
+}
+
 function readPrefsCookie(): UserDisplayPreferences | null {
   if (!browser) return null;
   const match = document.cookie
     .split("; ")
     .find((row) => row.startsWith(`${PREFS_COOKIE_NAME}=`));
   if (!match) return null;
-  try {
-    return JSON.parse(decodeURIComponent(match.slice(PREFS_COOKIE_NAME.length + 1)));
-  } catch {
-    return null;
-  }
+  return parsePrefsCookie(match.slice(PREFS_COOKIE_NAME.length + 1));
 }
 
 // Hydrate synchronously from the cookie on load (before first paint) so a known

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -1,5 +1,10 @@
 import type { LayoutServerLoad } from "./$types";
 import { extractTenantSlug, getOriginalHost, isShareHost } from "$lib/server/request-host";
+import {
+  PREFS_COOKIE_NAME,
+  hasStoredPreferences,
+  parsePrefsCookie,
+} from "$lib/stores/appearance-store.svelte";
 
 /**
  * Root layout server load function.
@@ -7,7 +12,7 @@ import { extractTenantSlug, getOriginalHost, isShareHost } from "$lib/server/req
  * Auth gating is handled by route group layouts.
  * Setup/recovery mode detection is in hooks.server.ts.
  */
-export const load: LayoutServerLoad = async ({ locals, request }) => {
+export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
   // Tenant identity is resolved here, from the request host against BASE_DOMAIN,
   // so the browser never has to guess it by counting hostname labels. A share
   // host carries a token rather than a slug, so it has no tenant to name.
@@ -15,7 +20,17 @@ export const load: LayoutServerLoad = async ({ locals, request }) => {
   const baseDomain = process.env.BASE_DOMAIN ?? null;
   const tenantSlug = isShareHost(host) ? null : extractTenantSlug(host, baseDomain);
 
+  // Display preferences for SSR, in the same precedence the browser applies them
+  // (backend blob over the mirrored cookie) so the markup matches hydration.
+  const serverPrefs = locals.isAuthenticated ? locals.user?.preferences : null;
+  const cookiePrefs = parsePrefsCookie(cookies.get(PREFS_COOKIE_NAME));
+  const displayPreferences = [
+    hasStoredPreferences(serverPrefs) ? serverPrefs : null,
+    cookiePrefs,
+  ].filter((prefs) => prefs !== null && prefs !== undefined);
+
   return {
+    displayPreferences,
     user: locals.user,
     isAuthenticated: locals.isAuthenticated,
     effectivePermissions: locals.effectivePermissions ?? [],

--- a/src/Web/packages/app/src/routes/+layout.svelte
+++ b/src/Web/packages/app/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import NavigationProgress from "$lib/components/ui/NavigationProgress.svelte";
   import { Toaster } from "$lib/components/ui/sonner";
   import * as alarmState from "$lib/stores/alarm-state.svelte";
+  import { setPreferencesContext } from "$lib/stores/appearance-store.svelte";
   import AlarmActiveView from "$lib/components/settings/alarm-preview/AlarmActiveView.svelte";
   import EmergencyOverlay from "$lib/components/settings/alarm-preview/EmergencyOverlay.svelte";
 
@@ -30,7 +31,9 @@
     isEmergencyView = true;
   }
 
-  let { children } = $props();
+  let { children, data } = $props();
+
+  setPreferencesContext(() => data.displayPreferences ?? []);
 </script>
 
 <ModeWatcher />


### PR DESCRIPTION
## Problem

The preference store is module-scoped and never populated server-side; `readPrefsCookie` and its one caller are `browser`-gated. With SSR enabled, every full page load shipped mg/dL markup and hydration rewrote it — including for devices that had the cookie. Reproduced end to end: with SSR resolution disabled, curl with an mmol cookie returned `100 mg/dL` while the hydrated DOM read `5.6 mmol/L`. A misread risk on glucose values.

The trap is that module-scoped mutable state on the server leaks between concurrent requests, so the fix has to be request-scoped, not a server-side write to the store.

## Fix

- Root `+layout.server.ts` parses `nocturne-prefs` (new `parsePrefsCookie`) and returns `displayPreferences` as ordered layers: the authenticated user's saved blob, then the cookie.
- The root layout provides them via Svelte context; `SyncedPref.current` consults the context layers when `!browser` (first defined field wins), else the module value. Layer ordering mirrors the browser's own hydration order exactly, so SSR output equals the first client render. (A probe confirmed `getContext` reaches nested helpers during Svelte 5 SSR from `$derived`/template expressions and stays per-render across interleaved renders.)
- All synced prefs are covered, not just units — each `SyncedPref` now carries its payload reader, which also collapsed `applyPreferences`' 20-line hand-written mapping into one loop. Time format, region format, prediction and chart settings stop flashing too.
- Share/anonymous paths inherit the root layout and take the cookie-only layer; a missing cookie yields today's exact defaults. The browser-only write invariant is untouched.

## Evidence

Real HTTP against the dev server: no cookie → `100 mg/dL`; mmol cookie → `5.6 mmol/L`; Chrome's hydrated DOM matches the SSR HTML. (Svelte 5 emits no hydration-mismatch warning for text content — verified by mutating the fix off — so the SSR-HTML-vs-DOM comparison is the evidence, not a clean console.)

New SSR test file rendering through `svelte/server` with the real provider/reader topology (5 tests); mutation-proven — flipping the `!browser` branch off fails 4 of 5. Full node suite 643 passed / 0 failed. `pnpm check`: 64 → 63 errors (one pre-existing error disappeared with deleted casts), none in touched files.

## Noted for follow-up (same bug class, different plumbing)

`formatting.ts` reads `preferredLanguage.current` for date/number formatting — SSR gets `"en"` regardless — but language rides its own cookie, not `nocturne-prefs`.

Follow-up from #524.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
