### PR TITLE
feat(web): link each tracker threshold to its managed alert rule's channel editor

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
@@ -858,6 +858,12 @@ public class NotificationThresholdDto
     public int MaxRepeats { get; set; }
     public bool RespectQuietHours { get; set; }
 
+    /// <summary>
+    /// The managed alert rule that delivers this threshold. Null until the sync service
+    /// has run, so callers must treat it as optional.
+    /// </summary>
+    public Guid? AlertRuleId { get; set; }
+
     public static NotificationThresholdDto FromEntity(TrackerNotificationThresholdEntity entity) =>
         new()
         {
@@ -874,6 +880,7 @@ public class NotificationThresholdDto
             RepeatIntervalMins = entity.RepeatIntervalMins,
             MaxRepeats = entity.MaxRepeats,
             RespectQuietHours = entity.RespectQuietHours,
+            AlertRuleId = entity.AlertRuleId,
         };
 }
 

--- a/src/Web/packages/app/src/lib/components/trackers/tracker-notification-editor.svelte
+++ b/src/Web/packages/app/src/lib/components/trackers/tracker-notification-editor.svelte
@@ -4,7 +4,7 @@
   import { Label } from "$lib/components/ui/label";
   import * as Select from "$lib/components/ui/select";
   import { DurationInput } from "$lib/components/ui/duration-input";
-  import { Plus, Trash2 } from "lucide-svelte";
+  import { Plus, Trash2, Bell } from "lucide-svelte";
   import { cn } from "$lib/utils";
   import { NotificationUrgency } from "$api";
   import type { TrackerNotification } from "./types";
@@ -154,7 +154,23 @@
             />
           </div>
 
-          <div class="flex-shrink-0 pt-5">
+          <div class="flex-shrink-0 pt-5 flex items-center gap-1">
+            <!-- New tab: this editor lives in a dialog, so in-place navigation
+                 would discard the tracker edits made so far. -->
+            {#if notification.alertRuleId}
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-9 text-muted-foreground"
+                href="/alerts/{notification.alertRuleId}"
+                target="_blank"
+                rel="noopener"
+                title="Configure delivery channels for this threshold"
+              >
+                <Bell class="h-4 w-4" />
+                Channels
+              </Button>
+            {/if}
             <Button
               variant="ghost"
               size="icon"
@@ -182,7 +198,7 @@
   {/if}
 
   <p class="text-xs text-muted-foreground">
-    Each threshold is delivered through a managed alert rule. Channels can be
-    configured on the Alerts page.
+    Each threshold is delivered through a managed alert rule. Use Channels to
+    open that rule; a new threshold gets its rule after the tracker is saved.
   </p>
 </div>

--- a/src/Web/packages/app/src/lib/components/trackers/tracker-notification-editor.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/trackers/tracker-notification-editor.svelte.test.ts
@@ -102,6 +102,47 @@ describe("TrackerNotificationEditor", () => {
 			.toBeVisible();
 	});
 
+	it("links each threshold to its own managed alert rule", async () => {
+		render(TrackerNotificationEditor, {
+			notifications: [
+				{
+					urgency: NotificationUrgency.Info,
+					hours: 24,
+					description: "First",
+					alertRuleId: "11111111-1111-1111-1111-111111111111",
+				},
+				{
+					urgency: NotificationUrgency.Warn,
+					hours: 48,
+					description: "Second",
+					alertRuleId: "22222222-2222-2222-2222-222222222222",
+				},
+			],
+		});
+
+		const links = page.getByRole("link", { name: /Channels/i });
+		await expect.element(links.first()).toHaveAttribute(
+			"href",
+			"/alerts/11111111-1111-1111-1111-111111111111",
+		);
+		await expect.element(links.nth(1)).toHaveAttribute(
+			"href",
+			"/alerts/22222222-2222-2222-2222-222222222222",
+		);
+	});
+
+	it("omits the channels link for a threshold with no managed rule yet", async () => {
+		render(TrackerNotificationEditor, {
+			notifications: [
+				{ urgency: NotificationUrgency.Info, hours: 24, description: "Unsaved" },
+			],
+		});
+
+		await expect
+			.element(page.getByRole("link", { name: /Channels/i }))
+			.not.toBeInTheDocument();
+	});
+
 	it("renders remove buttons for each notification", async () => {
 		render(TrackerNotificationEditor, {
 			notifications: [

--- a/src/Web/packages/app/src/lib/components/trackers/types.ts
+++ b/src/Web/packages/app/src/lib/components/trackers/types.ts
@@ -6,4 +6,6 @@ export interface TrackerNotification {
   hours: number | undefined;
   description?: string;
   displayOrder?: number;
+  /** Managed alert rule delivering this threshold; absent until the server has synced one. */
+  alertRuleId?: string;
 }

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
@@ -132,6 +132,7 @@
         hours: t.hours,
         description: t.description ?? "",
         displayOrder: t.displayOrder ?? i,
+        alertRuleId: t.alertRuleId ?? undefined,
       }));
     }
 


### PR DESCRIPTION
## Problem

The tracker notification editor told users "Channels can be configured on the Alerts page" as plain text — no link, no rule reference. Configuring a threshold's delivery meant leaving the editor and hunting for the synthesised managed rule by name among all alert rules, even though each threshold owns exactly one (`AlertRuleId`).

## Change

- `NotificationThresholdDto` now exposes `alertRuleId` (property + mapping; the entity always had it).
- Each threshold row links to `/alerts/{alertRuleId}` — the existing per-rule editor, which already mounts the channel picker and already badges managed rules. One click instead of a hunt. It opens in a new tab because the tracker editor lives in a dialog and in-place navigation would silently discard unsaved tracker edits.
- The link renders only once the threshold has a managed rule (a brand-new threshold has none until the tracker is saved and synced); the footer copy states that.

An embedded per-row picker was considered and rejected: `ChannelsSection` itself is reusable, but writing through requires the `[id]` page's full rule round-trip (parse → build body → update with condition/severity/clientConfig), which would mean N per-row rule loads in a dialog and a second save path racing the tracker form's own save. Channel edits made via the link survive later tracker edits — the sync service seeds channels at create only and never rewrites them.

## Tests

2 new component tests (11/11 in the file): the link targets the row's own rule id, and is omitted for a threshold with no rule yet. Mutation-proven individually (hardcoding the href fails the first; forcing the link on fails the second). `pnpm check` identical to baseline. On an older API image `alertRuleId` is simply absent and the link doesn't render — today's behaviour, not a break. No overlap with #701's files.

Follow-up from #446.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
