### PR TITLE
feat(desktop): per-capability opt-in toggles for Companion alert actions

### DIFF
--- a/src/Web/packages/desktop/src-tauri/src/alert_actuation.rs
+++ b/src/Web/packages/desktop/src-tauri/src/alert_actuation.rs
@@ -7,8 +7,10 @@
 //! live event overlapping the periodic poll cannot double-actuate) and self-healing (an alert closed
 //! while the companion was offline simply never appears, producing nothing). Acknowledged intents are
 //! skipped. Each active intent actuates the subset of capabilities the server narrowed it to
-//! (`notify` → toast, `tray_flash` → flash), so an intent can drive both. Reconcile runs on connect,
-//! on every `device_action`, and on a ~30s interval.
+//! (`notify` → toast, `tray_flash` → flash), so an intent can drive both, further narrowed by the
+//! user's local opt-in (`device_capabilities`) so a capability switched off stops actuating before
+//! the re-registration that withdraws it server-side lands. Reconcile runs on connect, on every
+//! `device_action`, and on a ~30s interval.
 //!
 //! Registration happens once per process and the device id is reused across sessions; it is
 //! re-resolved only when the server invalidates it (401/404 on the snapshot, 409 on register) or the
@@ -26,6 +28,7 @@
 
 use crate::auth::{self, TokenError};
 use crate::client_devices::{self, DeviceActionIntent};
+use crate::device_capabilities::{self, DeviceCapabilitySettings};
 use crate::signalr::DeviceNotificationMirror;
 use crate::toast::{self, AckContext};
 use crate::tray;
@@ -135,8 +138,20 @@ pub fn on_link(app: &tauri::AppHandle) {
     reset_registration(app);
 }
 
+/// Called when the user changes which capabilities are enabled. Dropping the registration makes the
+/// next pass re-register with the new advertised set; the state reset withdraws what is actuating
+/// now, so a capability switched off stops immediately rather than at the next excursion. Leaves
+/// `NEEDS_RELINK` alone — a capability choice says nothing about the grant's scopes.
+pub fn on_capabilities_changed(app: &tauri::AppHandle) {
+    restart(app);
+}
+
 fn reset_registration(app: &tauri::AppHandle) {
     NEEDS_RELINK.store(false, Ordering::SeqCst);
+    restart(app);
+}
+
+fn restart(app: &tauri::AppHandle) {
     RESET_STATE.store(true, Ordering::SeqCst);
     tray::stop_all_flashes(app);
     wake().notify_one();
@@ -262,9 +277,10 @@ async fn register_install(
     install_id: &mut String,
     label: &str,
 ) -> Result<String, u64> {
+    let capabilities = device_capabilities::current().advertised();
     let mut regenerated = false;
     loop {
-        match client_devices::register(client, server, token, install_id, label).await {
+        match client_devices::register(client, server, token, install_id, label, &capabilities).await {
             Ok(id) => return Ok(id),
             Err(e) => {
                 eprintln!("alert actuation: register: {e}");
@@ -536,7 +552,7 @@ async fn reconcile_with(
         }
     };
 
-    let effects = reconcile_effects(state, &intents);
+    let effects = reconcile_effects(state, &intents, device_capabilities::current());
     for intent in &effects.toast {
         show_toast(intent, &server, runtime);
     }
@@ -562,37 +578,61 @@ struct ReconcileEffects {
     flash_stop: Vec<String>,
 }
 
-fn reconcile_effects(state: &mut ActuationState, intents: &[DeviceActionIntent]) -> ReconcileEffects {
-    let active: HashSet<String> = intents
-        .iter()
-        .filter(|i| i.is_active())
-        .map(|i| i.excursion_id.clone())
-        .collect();
+fn reconcile_effects(
+    state: &mut ActuationState,
+    intents: &[DeviceActionIntent],
+    enabled: DeviceCapabilitySettings,
+) -> ReconcileEffects {
+    let wanted_notify = wanted(intents, enabled.notify, DeviceActionIntent::wants_notify);
+    let wanted_flash = wanted(intents, enabled.tray_flash, DeviceActionIntent::wants_tray_flash);
 
     let mut effects = ReconcileEffects::default();
 
     // New actuations per capability: fire once per excursion (HashSet::insert is the dedup gate).
     for intent in intents.iter().filter(|i| i.is_active()) {
-        if intent.wants_notify() && state.notified.insert(intent.excursion_id.clone()) {
+        if wanted_notify.contains(&intent.excursion_id)
+            && state.notified.insert(intent.excursion_id.clone())
+        {
             effects.toast.push(intent.clone());
         }
-        if intent.wants_tray_flash() && state.flashing.insert(intent.excursion_id.clone()) {
+        if wanted_flash.contains(&intent.excursion_id)
+            && state.flashing.insert(intent.excursion_id.clone())
+        {
             effects.flash_start.push(intent.excursion_id.clone());
         }
     }
 
-    // Withdrawn excursions: actuating locally but no longer active server-side → clear. Windows owns
-    // the toast lifecycle (the alarm scenario persists until dismissed), so notify only drops its
-    // dedup record; tray_flash is companion-owned, so each stopped excursion is reported for an
+    // Withdrawn excursions: actuating locally but no longer wanted — the excursion left the active
+    // set, the server narrowed the capability away, or the user disabled it here → clear. Windows
+    // owns the toast lifecycle (the alarm scenario persists until dismissed), so notify only drops
+    // its dedup record; tray_flash is companion-owned, so each stopped excursion is reported for an
     // explicit stop. Dropping the dedup record lets a later re-open of the same excursion id actuate
     // again.
-    state.notified.retain(|id| active.contains(id));
-    effects.flash_stop = state.flashing.difference(&active).cloned().collect();
+    state.notified.retain(|id| wanted_notify.contains(id));
+    effects.flash_stop = state.flashing.difference(&wanted_flash).cloned().collect();
     for id in &effects.flash_stop {
         state.flashing.remove(id);
     }
 
     effects
+}
+
+/// The excursions one capability should currently be actuating: active intents the server narrowed
+/// that capability to, and only while the user has it enabled here. A disabled capability yields an
+/// empty set, which both suppresses new actuations and withdraws any already running.
+fn wanted(
+    intents: &[DeviceActionIntent],
+    enabled: bool,
+    requests: fn(&DeviceActionIntent) -> bool,
+) -> HashSet<String> {
+    if !enabled {
+        return HashSet::new();
+    }
+    intents
+        .iter()
+        .filter(|i| i.is_active() && requests(i))
+        .map(|i| i.excursion_id.clone())
+        .collect()
 }
 
 /// Withdraws every active actuation: clears the per-excursion state and stops all tray flashes
@@ -649,6 +689,12 @@ mod tests {
         }
     }
 
+    /// The default opt-in: every capability enabled, i.e. actuation driven purely by the server's
+    /// narrowed set.
+    fn all_enabled() -> DeviceCapabilitySettings {
+        DeviceCapabilitySettings::default()
+    }
+
     impl ReconcileEffects {
         fn toasted_ids(&self) -> Vec<&str> {
             self.toast.iter().map(|i| i.excursion_id.as_str()).collect()
@@ -659,21 +705,21 @@ mod tests {
     fn new_excursion_toasts_once_then_is_deduped() {
         let mut state = ActuationState::default();
         let intents = vec![intent("a", true, false, &[NOTIFY_CAPABILITY])];
-        assert_eq!(reconcile_effects(&mut state, &intents).toasted_ids(), vec!["a"]);
+        assert_eq!(reconcile_effects(&mut state, &intents, all_enabled()).toasted_ids(), vec!["a"]);
         // Same active state on the next reconcile → no new toast.
-        assert!(reconcile_effects(&mut state, &intents).toast.is_empty());
+        assert!(reconcile_effects(&mut state, &intents, all_enabled()).toast.is_empty());
     }
 
     #[test]
     fn resolved_excursion_clears_and_can_reopen() {
         let mut state = ActuationState::default();
-        reconcile_effects(&mut state, &[intent("a", true, false, &[NOTIFY_CAPABILITY])]);
+        reconcile_effects(&mut state, &[intent("a", true, false, &[NOTIFY_CAPABILITY])], all_enabled());
         // Resolved → removed from the notified set.
-        assert!(reconcile_effects(&mut state, &[intent("a", false, false, &[NOTIFY_CAPABILITY])]).toast.is_empty());
+        assert!(reconcile_effects(&mut state, &[intent("a", false, false, &[NOTIFY_CAPABILITY])], all_enabled()).toast.is_empty());
         assert!(!state.notified.contains("a"));
         // Re-open of the same id toasts again.
         assert_eq!(
-            reconcile_effects(&mut state, &[intent("a", true, false, &[NOTIFY_CAPABILITY])]).toasted_ids(),
+            reconcile_effects(&mut state, &[intent("a", true, false, &[NOTIFY_CAPABILITY])], all_enabled()).toasted_ids(),
             vec!["a"]
         );
     }
@@ -681,7 +727,7 @@ mod tests {
     #[test]
     fn acknowledged_excursion_is_not_actuated() {
         let mut state = ActuationState::default();
-        let fx = reconcile_effects(&mut state, &[intent("a", true, true, &[NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY])]);
+        let fx = reconcile_effects(&mut state, &[intent("a", true, true, &[NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY])], all_enabled());
         assert!(fx.toast.is_empty());
         assert!(fx.flash_start.is_empty());
         assert!(!state.notified.contains("a"));
@@ -692,16 +738,16 @@ mod tests {
     fn closed_while_offline_produces_nothing() {
         // The companion was offline for the whole excursion; the snapshot is empty on reconnect.
         let mut state = ActuationState::default();
-        assert_eq!(reconcile_effects(&mut state, &[]), ReconcileEffects::default());
+        assert_eq!(reconcile_effects(&mut state, &[], all_enabled()), ReconcileEffects::default());
     }
 
     #[test]
     fn tray_flash_starts_once_then_is_deduped() {
         let mut state = ActuationState::default();
         let intents = vec![intent("a", true, false, &[TRAY_FLASH_CAPABILITY])];
-        assert_eq!(reconcile_effects(&mut state, &intents).flash_start, vec!["a".to_string()]);
+        assert_eq!(reconcile_effects(&mut state, &intents, all_enabled()).flash_start, vec!["a".to_string()]);
         // Same active state next reconcile → no restart (don't re-flash every 30s poll).
-        let fx = reconcile_effects(&mut state, &intents);
+        let fx = reconcile_effects(&mut state, &intents, all_enabled());
         assert!(fx.flash_start.is_empty());
         assert!(fx.flash_stop.is_empty());
     }
@@ -709,14 +755,14 @@ mod tests {
     #[test]
     fn tray_flash_stops_when_excursion_leaves_active_set() {
         let mut state = ActuationState::default();
-        reconcile_effects(&mut state, &[intent("a", true, false, &[TRAY_FLASH_CAPABILITY])]);
+        reconcile_effects(&mut state, &[intent("a", true, false, &[TRAY_FLASH_CAPABILITY])], all_enabled());
         // Resolved → flash stops and the dedup record clears.
-        let fx = reconcile_effects(&mut state, &[intent("a", false, false, &[TRAY_FLASH_CAPABILITY])]);
+        let fx = reconcile_effects(&mut state, &[intent("a", false, false, &[TRAY_FLASH_CAPABILITY])], all_enabled());
         assert_eq!(fx.flash_stop, vec!["a".to_string()]);
         assert!(!state.flashing.contains("a"));
         // Re-open flashes again.
         assert_eq!(
-            reconcile_effects(&mut state, &[intent("a", true, false, &[TRAY_FLASH_CAPABILITY])]).flash_start,
+            reconcile_effects(&mut state, &[intent("a", true, false, &[TRAY_FLASH_CAPABILITY])], all_enabled()).flash_start,
             vec!["a".to_string()]
         );
     }
@@ -727,6 +773,7 @@ mod tests {
         let fx = reconcile_effects(
             &mut state,
             &[intent("a", true, false, &[NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY])],
+            all_enabled(),
         );
         assert_eq!(fx.toasted_ids(), vec!["a"]);
         assert_eq!(fx.flash_start, vec!["a".to_string()]);
@@ -735,17 +782,80 @@ mod tests {
     #[test]
     fn notify_only_intent_does_not_flash() {
         let mut state = ActuationState::default();
-        let fx = reconcile_effects(&mut state, &[intent("a", true, false, &[NOTIFY_CAPABILITY])]);
+        let fx = reconcile_effects(&mut state, &[intent("a", true, false, &[NOTIFY_CAPABILITY])], all_enabled());
         assert_eq!(fx.toasted_ids(), vec!["a"]);
         assert!(fx.flash_start.is_empty());
         assert!(!state.flashing.contains("a"));
+    }
+
+    // ── local capability opt-in ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn disabled_capability_does_not_actuate() {
+        // The server still narrows the intent to both capabilities (the re-registration that drops
+        // notify may not have landed yet); the local opt-in is what suppresses the toast.
+        let mut state = ActuationState::default();
+        let fx = reconcile_effects(
+            &mut state,
+            &[intent("a", true, false, &[NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY])],
+            DeviceCapabilitySettings { notify: false, tray_flash: true },
+        );
+        assert!(fx.toast.is_empty());
+        assert!(!state.notified.contains("a"));
+        // The capability left enabled is untouched.
+        assert_eq!(fx.flash_start, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn disabling_a_capability_withdraws_what_it_is_already_actuating() {
+        let mut state = ActuationState::default();
+        let intents = vec![intent("a", true, false, &[NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY])];
+        reconcile_effects(&mut state, &intents, all_enabled());
+        assert!(state.flashing.contains("a"));
+
+        // Same still-active excursion, tray_flash switched off here: the flash stops without the
+        // rule or the server's narrowed set changing.
+        let fx = reconcile_effects(
+            &mut state,
+            &intents,
+            DeviceCapabilitySettings { notify: true, tray_flash: false },
+        );
+        assert_eq!(fx.flash_stop, vec!["a".to_string()]);
+        assert!(!state.flashing.contains("a"));
+        assert!(fx.flash_start.is_empty());
+    }
+
+    #[test]
+    fn disabling_every_capability_actuates_nothing() {
+        let mut state = ActuationState::default();
+        let fx = reconcile_effects(
+            &mut state,
+            &[intent("a", true, false, &[NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY])],
+            DeviceCapabilitySettings { notify: false, tray_flash: false },
+        );
+        assert_eq!(fx, ReconcileEffects::default());
+        assert!(state.notified.is_empty());
+        assert!(state.flashing.is_empty());
+    }
+
+    #[test]
+    fn re_enabling_a_capability_actuates_a_still_active_excursion() {
+        let mut state = ActuationState::default();
+        let intents = vec![intent("a", true, false, &[NOTIFY_CAPABILITY])];
+        reconcile_effects(
+            &mut state,
+            &intents,
+            DeviceCapabilitySettings { notify: false, tray_flash: true },
+        );
+        let fx = reconcile_effects(&mut state, &intents, all_enabled());
+        assert_eq!(fx.toasted_ids(), vec!["a"]);
     }
 
     #[test]
     fn withdraw_all_clears_state_and_next_reconcile_reactuates() {
         let mut state = ActuationState::default();
         let intents = vec![intent("a", true, false, &[NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY])];
-        reconcile_effects(&mut state, &intents);
+        reconcile_effects(&mut state, &intents, all_enabled());
         assert!(state.notified.contains("a"));
         assert!(state.flashing.contains("a"));
 
@@ -755,7 +865,7 @@ mod tests {
         assert!(state.flashing.is_empty());
 
         // …and a later relink with the excursion still active re-actuates both capabilities.
-        let fx = reconcile_effects(&mut state, &intents);
+        let fx = reconcile_effects(&mut state, &intents, all_enabled());
         assert_eq!(fx.toasted_ids(), vec!["a"]);
         assert_eq!(fx.flash_start, vec!["a".to_string()]);
     }

--- a/src/Web/packages/desktop/src-tauri/src/app_dir.rs
+++ b/src/Web/packages/desktop/src-tauri/src/app_dir.rs
@@ -1,0 +1,30 @@
+//! The companion's per-user data directory, shared by every plain file it persists (glucose.json,
+//! install_id.txt, capabilities.json). Secrets live in the credential store instead (`auth.rs`).
+
+use std::path::PathBuf;
+
+/// Returns `%LOCALAPPDATA%\Nocturne`, falling back to `%USERPROFILE%\AppData\Local\Nocturne` when
+/// `LOCALAPPDATA` is unset.
+pub fn nocturne_dir() -> PathBuf {
+    let base = std::env::var("LOCALAPPDATA")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let mut p = std::env::var("USERPROFILE").map(PathBuf::from).unwrap_or_default();
+            p.push("AppData");
+            p.push("Local");
+            p
+        });
+    base.join("Nocturne")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dir_is_named_nocturne() {
+        assert_eq!(nocturne_dir().file_name().unwrap(), "Nocturne");
+    }
+}

--- a/src/Web/packages/desktop/src-tauri/src/client_devices.rs
+++ b/src/Web/packages/desktop/src-tauri/src/client_devices.rs
@@ -39,9 +39,10 @@ pub const NOTIFY_CAPABILITY: &str = "notify";
 /// Flash the system tray icon (`DeviceCapabilities.TrayFlash`; requires the `device.actuate` scope).
 pub const TRAY_FLASH_CAPABILITY: &str = "tray_flash";
 
-/// Capabilities this device advertises on registration. The server narrows each intent's
-/// `capabilities` to the intersection of what the rule requested and what this set advertises, so
-/// advertising a capability is what enables actuating it. No local opt-in filtering yet (later phase).
+/// Capabilities this device can actuate. The server narrows each intent's `capabilities` to the
+/// intersection of what the rule requested and what the device advertises, so advertising a
+/// capability is what enables actuating it — which is why registration sends only the subset the
+/// user has left enabled (`device_capabilities`), not this whole set.
 pub const ADVERTISED_CAPABILITIES: [&str; 2] = [NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY];
 
 /// Registration request body (camelCase to match `RegisterDeviceRequest`).
@@ -51,7 +52,7 @@ struct RegisterRequest<'a> {
     install_id: &'a str,
     kind: &'a str,
     label: &'a str,
-    capabilities: Vec<&'a str>,
+    capabilities: &'a [&'a str],
 }
 
 /// Subset of `ClientDeviceDto` we need back: the server-assigned id keys the snapshot endpoint.
@@ -111,20 +112,22 @@ impl DeviceActionIntent {
 
 /// Registers (or refreshes) this install with the server and returns its server-assigned device id.
 /// Idempotent — called on every startup. The label is the machine name when resolvable, else a
-/// generic fallback.
+/// generic fallback. `capabilities` replaces whatever the server has stored for this install, so a
+/// re-registration with a narrower set is how a capability is withdrawn.
 pub async fn register(
     client: &reqwest::Client,
     server: &str,
     token: &str,
     install_id: &str,
     label: &str,
+    capabilities: &[&str],
 ) -> Result<String, ApiError> {
     let server = server.trim_end_matches('/');
     let body = RegisterRequest {
         install_id,
         kind: DEVICE_KIND,
         label,
-        capabilities: ADVERTISED_CAPABILITIES.to_vec(),
+        capabilities,
     };
 
     let resp = client

--- a/src/Web/packages/desktop/src-tauri/src/device_capabilities.rs
+++ b/src/Web/packages/desktop/src-tauri/src/device_capabilities.rs
@@ -1,0 +1,154 @@
+//! The user's local opt-in for each device actuation capability.
+//!
+//! Two things read this: registration, which advertises only the enabled capabilities (the server
+//! narrows every intent to rule-requested ∩ advertised, so a capability that isn't advertised is
+//! never asked for again), and the reconcile pass, which drops a disabled capability's actuation
+//! before the re-registration lands.
+//!
+//! Persisted as a plain file next to install_id.txt rather than in the webview's localStorage: the
+//! actuation loop runs with no window open, so Rust has to read the choice without the frontend. A
+//! missing, unreadable, or partial file means enabled — an existing install keeps advertising both.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use crate::client_devices::{ADVERTISED_CAPABILITIES, NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY};
+
+const FILE_NAME: &str = "capabilities.json";
+
+/// Which capabilities this install may advertise and actuate. Serialized camelCase, matching the
+/// frontend's shape; `#[serde(default)]` is what makes an absent field mean enabled.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct DeviceCapabilitySettings {
+    pub notify: bool,
+    pub tray_flash: bool,
+}
+
+impl Default for DeviceCapabilitySettings {
+    fn default() -> Self {
+        Self { notify: true, tray_flash: true }
+    }
+}
+
+impl DeviceCapabilitySettings {
+    /// Whether `capability` may actuate on this install. An unrecognised capability never can.
+    pub fn allows(&self, capability: &str) -> bool {
+        match capability {
+            NOTIFY_CAPABILITY => self.notify,
+            TRAY_FLASH_CAPABILITY => self.tray_flash,
+            _ => false,
+        }
+    }
+
+    /// The capabilities to send on the next (re-)registration.
+    pub fn advertised(&self) -> Vec<&'static str> {
+        ADVERTISED_CAPABILITIES.into_iter().filter(|c| self.allows(c)).collect()
+    }
+}
+
+fn settings_path() -> PathBuf {
+    crate::app_dir::nocturne_dir().join(FILE_NAME)
+}
+
+/// In-memory copy of the persisted settings, so the reconcile pass doesn't read the file every 30s.
+/// `None` until first read.
+fn cache() -> &'static Mutex<Option<DeviceCapabilitySettings>> {
+    static CACHE: OnceLock<Mutex<Option<DeviceCapabilitySettings>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+/// The current opt-in set, loading it from disk on first call.
+pub fn current() -> DeviceCapabilitySettings {
+    let mut cached = match cache().lock() {
+        Ok(c) => c,
+        Err(_) => return DeviceCapabilitySettings::default(),
+    };
+    *cached.get_or_insert_with(load)
+}
+
+fn load() -> DeviceCapabilitySettings {
+    std::fs::read_to_string(settings_path())
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+/// Persists `settings` and makes them current. Written atomically (temp file + same-volume rename),
+/// like the install id, so a crash mid-write can't leave a truncated file behind. A write failure
+/// leaves the previous settings in force so the caller can surface it rather than the app running on
+/// a choice that won't survive a restart.
+pub fn store(settings: DeviceCapabilitySettings) -> Result<(), String> {
+    let path = settings_path();
+    let body = serde_json::to_vec(&settings).map_err(|e| e.to_string())?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp, &body).and_then(|()| std::fs::rename(&tmp, &path)) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.to_string());
+    }
+
+    if let Ok(mut cached) = cache().lock() {
+        *cached = Some(settings);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_is_nocturne_capabilities_json() {
+        let p = settings_path();
+        assert_eq!(p.file_name().unwrap(), "capabilities.json");
+        assert_eq!(p.parent().unwrap().file_name().unwrap(), "Nocturne");
+    }
+
+    #[test]
+    fn default_advertises_every_capability() {
+        let s = DeviceCapabilitySettings::default();
+        assert_eq!(s.advertised(), vec![NOTIFY_CAPABILITY, TRAY_FLASH_CAPABILITY]);
+        assert!(s.allows(NOTIFY_CAPABILITY));
+        assert!(s.allows(TRAY_FLASH_CAPABILITY));
+    }
+
+    #[test]
+    fn disabled_capability_is_neither_advertised_nor_allowed() {
+        let s = DeviceCapabilitySettings { notify: false, tray_flash: true };
+        assert_eq!(s.advertised(), vec![TRAY_FLASH_CAPABILITY]);
+        assert!(!s.allows(NOTIFY_CAPABILITY));
+    }
+
+    #[test]
+    fn both_disabled_advertises_nothing() {
+        let s = DeviceCapabilitySettings { notify: false, tray_flash: false };
+        assert!(s.advertised().is_empty());
+    }
+
+    #[test]
+    fn unknown_capability_is_never_allowed() {
+        assert!(!DeviceCapabilitySettings::default().allows("torch"));
+    }
+
+    #[test]
+    fn absent_settings_mean_advertised() {
+        // An install that predates the toggles has no file; a partial file leaves the rest enabled.
+        let empty: DeviceCapabilitySettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(empty, DeviceCapabilitySettings::default());
+        let partial: DeviceCapabilitySettings = serde_json::from_str(r#"{"notify":false}"#).unwrap();
+        assert!(!partial.notify);
+        assert!(partial.tray_flash);
+    }
+
+    #[test]
+    fn settings_round_trip_as_camel_case() {
+        let s = DeviceCapabilitySettings { notify: true, tray_flash: false };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("trayFlash"));
+        assert_eq!(serde_json::from_str::<DeviceCapabilitySettings>(&json).unwrap(), s);
+    }
+}

--- a/src/Web/packages/desktop/src-tauri/src/glucose_file.rs
+++ b/src/Web/packages/desktop/src-tauri/src/glucose_file.rs
@@ -6,20 +6,9 @@
 
 use std::path::PathBuf;
 
-/// Returns `%LOCALAPPDATA%\Nocturne\glucose.json`, falling back to
-/// `%USERPROFILE%\AppData\Local\Nocturne\glucose.json` when `LOCALAPPDATA` is unset.
+/// Returns `%LOCALAPPDATA%\Nocturne\glucose.json`.
 pub fn glucose_file_path() -> PathBuf {
-    let base = std::env::var("LOCALAPPDATA")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            let mut p = std::env::var("USERPROFILE").map(PathBuf::from).unwrap_or_default();
-            p.push("AppData");
-            p.push("Local");
-            p
-        });
-    base.join("Nocturne").join("glucose.json")
+    crate::app_dir::nocturne_dir().join("glucose.json")
 }
 
 /// Writes `bytes` to the glucose file via a temp-file + atomic rename, so a reader never observes

--- a/src/Web/packages/desktop/src-tauri/src/install_id.rs
+++ b/src/Web/packages/desktop/src-tauri/src/install_id.rs
@@ -9,19 +9,9 @@ use std::path::PathBuf;
 
 const FILE_NAME: &str = "install_id.txt";
 
-/// Returns `%LOCALAPPDATA%\Nocturne\install_id.txt`, mirroring `glucose_file`'s base-dir fallback.
+/// Returns `%LOCALAPPDATA%\Nocturne\install_id.txt`.
 fn install_id_path() -> PathBuf {
-    let base = std::env::var("LOCALAPPDATA")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            let mut p = std::env::var("USERPROFILE").map(PathBuf::from).unwrap_or_default();
-            p.push("AppData");
-            p.push("Local");
-            p
-        });
-    base.join("Nocturne").join(FILE_NAME)
+    crate::app_dir::nocturne_dir().join(FILE_NAME)
 }
 
 /// Returns the persisted install id, generating and writing a fresh UUID on first launch. A

--- a/src/Web/packages/desktop/src-tauri/src/main.rs
+++ b/src/Web/packages/desktop/src-tauri/src/main.rs
@@ -13,8 +13,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod alert_actuation;
+mod app_dir;
 mod auth;
 mod client_devices;
+mod device_capabilities;
 mod glucose_file;
 mod glucose_poll;
 mod http;
@@ -470,6 +472,24 @@ fn set_run_on_startup(enabled: bool, app: tauri::AppHandle) -> CommandResult<()>
     result.map_err(|e| CommandError::new(e.to_string()))
 }
 
+/// Which alert actuations this install may perform.
+#[tauri::command]
+fn get_device_capabilities() -> device_capabilities::DeviceCapabilitySettings {
+    device_capabilities::current()
+}
+
+/// Persists the capability opt-in and applies it: the actuation loop re-registers with the narrowed
+/// advertised set and withdraws anything a now-disabled capability is actuating.
+#[tauri::command]
+fn set_device_capabilities(
+    settings: device_capabilities::DeviceCapabilitySettings,
+    app: tauri::AppHandle,
+) -> CommandResult<()> {
+    device_capabilities::store(settings).map_err(CommandError::new)?;
+    alert_actuation::on_capabilities_changed(&app);
+    Ok(())
+}
+
 /// One poll cycle: refresh the token, write glucose.json, emit `glucose-updated`. Best-effort —
 /// a token-refresh or fetch failure is logged and skipped, never fatal.
 async fn poll_glucose(client: &reqwest::Client, app: &tauri::AppHandle) {
@@ -618,7 +638,9 @@ fn main() {
             companion_server_url,
             list_clock_faces,
             get_run_on_startup,
-            set_run_on_startup
+            set_run_on_startup,
+            get_device_capabilities,
+            set_device_capabilities
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/Web/packages/desktop/src/routes/settings/+page.svelte
+++ b/src/Web/packages/desktop/src/routes/settings/+page.svelte
@@ -25,6 +25,9 @@
 
   type CommandError = { message: string };
 
+  // Matches the camelCase DeviceCapabilitySettings the `*_device_capabilities` Rust commands carry.
+  type DeviceCapabilities = { notify: boolean; trayFlash: boolean };
+
   const UNIT_OPTIONS: { value: GlucoseUnits; label: string }[] = [
     { value: "mmol", label: "mmol/L" },
     { value: "mg/dl", label: "mg/dL" },
@@ -32,6 +35,8 @@
 
   let runOnStartup = $state(false);
   let savingStartup = $state(false);
+  let capabilities = $state<DeviceCapabilities>({ notify: true, trayFlash: true });
+  let savingCapabilities = $state(false);
   let version = $state<string | null>(null);
   let error = $state<string | null>(null);
 
@@ -98,9 +103,31 @@
     }
   }
 
+  async function toggleCapability(key: keyof DeviceCapabilities, next: boolean) {
+    // Optimistic flip; revert if the choice can't be persisted so the switch reflects what the
+    // Companion will actually do.
+    const previous = capabilities;
+    capabilities = { ...capabilities, [key]: next };
+    savingCapabilities = true;
+    error = null;
+    try {
+      await invoke("set_device_capabilities", { settings: capabilities });
+    } catch (e) {
+      capabilities = previous;
+      error = describeError(e);
+    } finally {
+      savingCapabilities = false;
+    }
+  }
+
   onMount(async () => {
     try {
       runOnStartup = await invoke<boolean>("get_run_on_startup");
+    } catch (e) {
+      error = describeError(e);
+    }
+    try {
+      capabilities = await invoke<DeviceCapabilities>("get_device_capabilities");
     } catch (e) {
       error = describeError(e);
     }
@@ -195,6 +222,46 @@
             {option.label}
           </Button>
         {/each}
+      </div>
+    </CardContent>
+  </Card>
+
+  <Card>
+    <CardHeader>
+      <CardTitle>Alert actions</CardTitle>
+      <CardDescription>
+        What the Companion may do when an alert rule targets this device. Turning one off stops it
+        now and removes it from what this device advertises to your Nocturne site.
+      </CardDescription>
+    </CardHeader>
+    <CardContent class="space-y-4">
+      <div class="flex items-start justify-between gap-4">
+        <div class="space-y-1">
+          <Label for="capability-notify">Show a notification</Label>
+          <p class="text-muted-foreground text-xs">
+            Show a Windows notification when an alert starts, with a button to acknowledge it.
+          </p>
+        </div>
+        <Switch
+          id="capability-notify"
+          checked={capabilities.notify}
+          disabled={savingCapabilities}
+          onCheckedChange={(next) => toggleCapability("notify", next)}
+        />
+      </div>
+      <div class="flex items-start justify-between gap-4">
+        <div class="space-y-1">
+          <Label for="capability-tray-flash">Flash the tray icon</Label>
+          <p class="text-muted-foreground text-xs">
+            Pulse the tray icon for as long as the alert stays active.
+          </p>
+        </div>
+        <Switch
+          id="capability-tray-flash"
+          checked={capabilities.trayFlash}
+          disabled={savingCapabilities}
+          onCheckedChange={(next) => toggleCapability("trayFlash", next)}
+        />
       </div>
     </CardContent>
   </Card>


### PR DESCRIPTION
## Problem

The Companion advertised a hardcoded capability set (`notify`, `tray_flash`) on registration. The server narrows each intent to rule-requested ∩ advertised, so advertising is what enables actuation — both actuators were default-on with no way to decline, and the settings page had no controls. A user who wanted glucose sync but not toasts had no local lever.

## Design

- **Persistence**: `%LOCALAPPDATA%\Nocturne\capabilities.json` (new `device_capabilities.rs`) — deliberately not webview localStorage, because the actuation loop runs tray-only with no window and Rust must read the choice unaided. Atomic temp+rename write, process-lifetime cache, and `#[serde(default)]` with both-on defaults so a missing/partial/corrupt file reads as enabled — existing installs unchanged. A failed write reverts the optimistic switch instead of lying.
- **Re-registration**: `register()` takes the capability slice; a toggle wakes the actuation loop, which drops the device id and re-registers with the narrowed set. Server-side this is a replacement (`Apply()` sets `Capabilities = accepted`), verified — so re-registering with fewer capabilities genuinely withdraws one. The relink flag is deliberately untouched: a capability choice says nothing about grant scopes.
- **Local guard, effective immediately**: `reconcile_effects` computes per-capability *wanted* sets that are empty when disabled — one change that both suppresses new actuations and makes withdrawal of an already-running toast/flash fall out of the existing set-difference logic. (The live SignalR push only nudges a reconcile; the snapshot is authoritative, so the guard sits at the right layer.)
- **UI**: an "Alert actions" card with two switches, following the existing optimistic-flip-and-revert idiom.
- Incidental DRY: the `%LOCALAPPDATA%` fallback existed in two files already; extracted `app_dir::nocturne_dir()` and pointed all three at it.

## Tests

`cargo test` 77/0 (+12 over baseline); desktop `pnpm run check` 0/0. Mutation-proven: neutering the wanted-set guard fails four actuation tests (including withdraw-while-active and re-enable-while-active); neutering the advertised filter fails both advertising tests.

Proven by tests: advertised filtering, wire shape, persistence round-trip, and the full reconcile diff under every on/off combination. Needs the manual live pass (tracked as the D5 verification item, alongside the existing device-action end-to-end): the Tauri command boundary from the switches, visible re-registration against a live server, file persistence across restart, and toggle-off during a live excursion.

Follow-up from #442.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
