### PR TITLE
feat(desktop): register nocturne-connect:// so the web connect button launches the Companion

### DIFF
--- a/src/Web/packages/app/src/lib/components/connectors/CareLinkConnectPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/CareLinkConnectPanel.svelte
@@ -197,7 +197,7 @@
         </p>
         <p class="text-xs text-muted-foreground">
           The desktop app opens the CareLink sign-in in its own window and captures the code
-          automatically — no developer tools needed. Generate a link code and paste it into the app.
+          automatically — no developer tools needed. Generate a link code and open it in the app.
         </p>
         <a
           href={DESKTOP_DOWNLOAD_URL}
@@ -214,7 +214,11 @@
           </Button>
         {:else}
           <div class="rounded bg-muted px-2 py-1 font-mono text-xs break-all">{desktopLinkCode}</div>
-          <div class="flex items-center gap-2">
+          <div class="flex flex-wrap items-center gap-2">
+            <Button size="sm" href={desktopLinkCode}>
+              <Monitor class="h-3.5 w-3.5 mr-1" />
+              Open in the desktop app
+            </Button>
             <Button variant="outline" size="sm" onclick={copyDesktopLinkCode}>
               <Copy class="h-3.5 w-3.5 mr-1" />
               {desktopCopied ? "Copied" : "Copy"}
@@ -223,6 +227,10 @@
               Expires in {desktopExpiresMinutes} minutes.
             </span>
           </div>
+          <p class="text-xs text-muted-foreground">
+            If nothing opens, the app isn't installed yet — copy the code and paste it into the app
+            instead.
+          </p>
         {/if}
       </div>
     {/if}

--- a/src/Web/packages/desktop/src-tauri/Cargo.lock
+++ b/src/Web/packages/desktop/src-tauri/Cargo.lock
@@ -63,6 +63,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +297,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -364,6 +508,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +618,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -686,6 +865,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +960,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +1011,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -944,6 +1179,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1289,6 +1537,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1315,6 +1569,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1997,7 +2257,9 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-deep-link",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-winrt-notification",
  "tokio",
@@ -2270,6 +2532,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,6 +2589,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2397,6 +2685,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2738,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2842,6 +3155,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -3284,6 +3607,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,6 +3782,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3700,6 +4044,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-process"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,6 +4072,23 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -3946,6 +4328,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4210,7 +4601,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4285,6 +4688,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -4866,6 +5280,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,6 +5817,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5488,3 +5983,44 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.3",
+]

--- a/src/Web/packages/desktop/src-tauri/Cargo.toml
+++ b/src/Web/packages/desktop/src-tauri/Cargo.toml
@@ -12,6 +12,10 @@ tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-autostart = "2"
+tauri-plugin-deep-link = "2"
+# The "deep-link" feature makes the second instance's argv reach the deep-link plugin's
+# on_open_url handler in the first instance instead of dying with the process.
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = "2"

--- a/src/Web/packages/desktop/src-tauri/src/link_code.rs
+++ b/src/Web/packages/desktop/src-tauri/src/link_code.rs
@@ -1,0 +1,131 @@
+//! Parsing and validation for `nocturne-connect://link?server=…&token=…` link codes.
+//!
+//! The same untrusted string arrives two ways — pasted by the user, or handed over by the OS when
+//! a `nocturne-connect://` link is opened in a browser — so both paths land here.
+
+use url::Url;
+
+pub const SCHEME: &str = "nocturne-connect";
+
+const NOT_A_LINK_CODE: &str =
+    "That doesn't look like a link code. Copy the whole nocturne-connect:// line from Nocturne.";
+const MISSING_PARTS: &str =
+    "The link code is missing its server or token part. Generate a fresh one in Nocturne.";
+const BAD_SERVER: &str = "The link code's server address is not a valid URL.";
+
+/// A validated link code: an http(s) server origin with no trailing slash, plus the bearer it
+/// minted.
+#[derive(Debug, PartialEq)]
+pub struct LinkCredentials {
+    pub server_url: String,
+    pub token: String,
+}
+
+pub fn parse(raw: &str) -> Result<LinkCredentials, &'static str> {
+    let parsed = Url::parse(raw.trim()).map_err(|_| NOT_A_LINK_CODE)?;
+
+    if parsed.scheme() != SCHEME {
+        return Err(NOT_A_LINK_CODE);
+    }
+
+    let mut server = None;
+    let mut token = None;
+    for (key, value) in parsed.query_pairs() {
+        match key.as_ref() {
+            "server" => server = Some(value.to_string()),
+            "token" => token = Some(value.to_string()),
+            _ => {}
+        }
+    }
+
+    let (server, token) = match (server, token) {
+        (Some(s), Some(t)) if !s.is_empty() && !t.is_empty() => (s, t),
+        _ => return Err(MISSING_PARTS),
+    };
+
+    let server_url = Url::parse(&server)
+        .ok()
+        .filter(|u| matches!(u.scheme(), "http" | "https"))
+        .ok_or(BAD_SERVER)?;
+
+    Ok(LinkCredentials {
+        server_url: server_url.as_str().trim_end_matches('/').to_string(),
+        token,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn code(server: &str) -> String {
+        format!("nocturne-connect://link?server={server}&token=abc123")
+    }
+
+    #[test]
+    fn accepts_a_well_formed_code() {
+        let parsed = parse(&code("https%3A%2F%2Fdemo.nocturne.run")).unwrap();
+        assert_eq!(parsed.server_url, "https://demo.nocturne.run");
+        assert_eq!(parsed.token, "abc123");
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace() {
+        let raw = format!("  {}\n", code("https%3A%2F%2Fdemo.nocturne.run"));
+        assert_eq!(parse(&raw).unwrap().server_url, "https://demo.nocturne.run");
+    }
+
+    #[test]
+    fn strips_the_trailing_slash_from_the_server() {
+        let parsed = parse(&code("https%3A%2F%2Fdemo.nocturne.run%2F")).unwrap();
+        assert_eq!(parsed.server_url, "https://demo.nocturne.run");
+    }
+
+    #[test]
+    fn rejects_another_scheme() {
+        assert_eq!(
+            parse("https://demo.nocturne.run/link?server=https://x&token=abc"),
+            Err(NOT_A_LINK_CODE)
+        );
+    }
+
+    #[test]
+    fn rejects_a_non_url() {
+        assert_eq!(parse("abc123"), Err(NOT_A_LINK_CODE));
+    }
+
+    #[test]
+    fn rejects_a_missing_or_empty_part() {
+        assert_eq!(
+            parse("nocturne-connect://link?server=https%3A%2F%2Fdemo.nocturne.run"),
+            Err(MISSING_PARTS)
+        );
+        assert_eq!(parse("nocturne-connect://link?token=abc123"), Err(MISSING_PARTS));
+        assert_eq!(
+            parse("nocturne-connect://link?server=https%3A%2F%2Fdemo.nocturne.run&token="),
+            Err(MISSING_PARTS)
+        );
+    }
+
+    #[test]
+    fn rejects_a_non_http_server_scheme() {
+        assert_eq!(parse(&code("file%3A%2F%2F%2FC%3A%2Fwindows")), Err(BAD_SERVER));
+        assert_eq!(parse(&code("javascript%3Aalert(1)")), Err(BAD_SERVER));
+        assert_eq!(parse(&code("data%3Atext%2Fhtml%2Chi")), Err(BAD_SERVER));
+    }
+
+    #[test]
+    fn rejects_a_hostless_server() {
+        assert_eq!(parse(&code("http%3A%2F%2F")), Err(BAD_SERVER));
+    }
+
+    #[test]
+    fn last_duplicated_parameter_wins() {
+        let parsed = parse(
+            "nocturne-connect://link?server=https%3A%2F%2Fa.example&token=one&token=two",
+        )
+        .unwrap();
+        assert_eq!(parsed.token, "two");
+        assert_eq!(parsed.server_url, "https://a.example");
+    }
+}

--- a/src/Web/packages/desktop/src-tauri/src/main.rs
+++ b/src/Web/packages/desktop/src-tauri/src/main.rs
@@ -7,8 +7,9 @@
 // to the Nocturne server, which owns the PKCE exchange and stores the connector secrets.
 //
 // The app authenticates to Nocturne with a short-lived link code minted by the web UI
-// (nocturne-connect://link?server=…&token=…); the token is a tenant-pinned bearer accepted
-// only by the CareLink connect endpoints.
+// (nocturne-connect://link?server=…&token=…), either pasted in or opened from the browser through
+// the registered URL scheme; the token is a tenant-pinned bearer accepted only by the CareLink
+// connect endpoints.
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
@@ -19,6 +20,7 @@ mod glucose_file;
 mod glucose_poll;
 mod http;
 mod install_id;
+mod link_code;
 mod signalr;
 mod toast;
 mod tray;
@@ -38,6 +40,9 @@ struct Session {
     server_url: Option<String>,
     token: Option<String>,
     flow_state: Option<String>,
+    /// A link code that arrived over the `nocturne-connect://` scheme. Held aside until the user
+    /// confirms the server, so opening a link never links the app on its own.
+    pending: Option<link_code::LinkCredentials>,
 }
 
 type SessionState = Mutex<Session>;
@@ -103,46 +108,66 @@ pub(crate) fn error_chain(err: &dyn std::error::Error) -> String {
     msg
 }
 
-/// Parses and stores a `nocturne-connect://link?server=…&token=…` link code.
-#[tauri::command]
-fn link(link_code: String, session: State<'_, SessionState>) -> CommandResult<LinkInfo> {
-    let parsed = Url::parse(link_code.trim())
-        .map_err(|_| CommandError::new("That doesn't look like a link code. Copy the whole nocturne-connect:// line from Nocturne."))?;
-
-    if parsed.scheme() != "nocturne-connect" {
-        return Err(CommandError::new(
-            "That doesn't look like a link code. Copy the whole nocturne-connect:// line from Nocturne.",
-        ));
-    }
-
-    let mut server = None;
-    let mut token = None;
-    for (key, value) in parsed.query_pairs() {
-        match key.as_ref() {
-            "server" => server = Some(value.to_string()),
-            "token" => token = Some(value.to_string()),
-            _ => {}
-        }
-    }
-
-    let (server, token) = match (server, token) {
-        (Some(s), Some(t)) if !s.is_empty() && !t.is_empty() => (s, t),
-        _ => return Err(CommandError::new("The link code is missing its server or token part. Generate a fresh one in Nocturne.")),
-    };
-
-    let server_url = Url::parse(&server)
-        .ok()
-        .filter(|u| matches!(u.scheme(), "http" | "https"))
-        .ok_or_else(|| CommandError::new("The link code's server address is not a valid URL."))?;
-
-    let server_url = server_url.as_str().trim_end_matches('/').to_string();
-
+fn apply_link(credentials: link_code::LinkCredentials, session: &SessionState) -> LinkInfo {
+    let server_url = credentials.server_url;
     let mut session = session.lock().unwrap();
     session.server_url = Some(server_url.clone());
-    session.token = Some(token);
+    session.token = Some(credentials.token);
     session.flow_state = None;
+    session.pending = None;
+    LinkInfo { server_url }
+}
 
-    Ok(LinkInfo { server_url })
+/// Parses and stores a `nocturne-connect://link?server=…&token=…` link code the user pasted in.
+#[tauri::command]
+fn link(link_code: String, session: State<'_, SessionState>) -> CommandResult<LinkInfo> {
+    let credentials = link_code::parse(&link_code).map_err(CommandError::new)?;
+    Ok(apply_link(credentials, &session))
+}
+
+/// The server address of a link code that arrived over the URL scheme and is awaiting confirmation.
+/// Lets the UI recover a deep link that landed before it was listening.
+#[tauri::command]
+fn pending_link_server(session: State<'_, SessionState>) -> Option<String> {
+    session.lock().unwrap().pending.as_ref().map(|p| p.server_url.clone())
+}
+
+/// Accepts the pending deep link. Only the user, having seen the server address, gets to call this
+/// — the token is never handed to the frontend.
+#[tauri::command]
+fn confirm_pending_link(session: State<'_, SessionState>) -> CommandResult<LinkInfo> {
+    let pending = session.lock().unwrap().pending.take();
+    match pending {
+        Some(credentials) => Ok(apply_link(credentials, &session)),
+        None => Err(CommandError::new("That link is no longer available. Open it again from Nocturne.")),
+    }
+}
+
+#[tauri::command]
+fn discard_pending_link(session: State<'_, SessionState>) {
+    session.lock().unwrap().pending = None;
+}
+
+/// Handles `nocturne-connect://` URLs opened elsewhere on the machine. The URL is attacker-supplied
+/// — any web page can navigate to one — so it is validated exactly like a pasted code and then
+/// parked for confirmation rather than applied.
+fn on_deep_link(app: &tauri::AppHandle, urls: Vec<Url>) {
+    let Some(url) = urls.into_iter().find(|u| u.scheme() == link_code::SCHEME) else {
+        return;
+    };
+
+    tray::show_main_window(app);
+
+    match link_code::parse(url.as_str()) {
+        Ok(credentials) => {
+            let server_url = credentials.server_url.clone();
+            app.state::<SessionState>().lock().unwrap().pending = Some(credentials);
+            let _ = app.emit("link-code-received", server_url);
+        }
+        Err(message) => {
+            let _ = app.emit("link-code-rejected", message);
+        }
+    }
 }
 
 /// Starts the connect flow: asks the server for the Auth0 authorize URL (PKCE verifier stays
@@ -520,6 +545,13 @@ fn spawn_glucose_poller(app: tauri::AppHandle, mut refresh_rx: tokio::sync::mpsc
 
 fn main() {
     tauri::Builder::default()
+        // Must be registered first: it decides whether this process is the one that keeps running.
+        // A second launch (including one the OS starts to open a nocturne-connect:// URL) hands its
+        // arguments to the live instance and exits.
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            tray::show_main_window(app);
+        }))
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_autostart::init(
@@ -529,6 +561,25 @@ fn main() {
         .manage(SessionState::default())
         .setup(|app| {
             let handle = app.handle();
+
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+                // In a packaged build the NSIS installer owns the registry association; a dev or
+                // portable run has none, so point it at the running executable.
+                #[cfg(debug_assertions)]
+                let _ = app.deep_link().register_all();
+
+                // A cold start opened by a link has already consumed its argv by the time this hook
+                // runs, so the launch URL is read back rather than awaited.
+                if let Ok(Some(urls)) = app.deep_link().get_current() {
+                    on_deep_link(handle, urls);
+                }
+
+                let handle = handle.clone();
+                app.deep_link().on_open_url(move |event| {
+                    on_deep_link(&handle, event.urls());
+                });
+            }
 
             // Render `--` until the first poll lands a reading.
             tray::build_tray(handle)?;
@@ -604,6 +655,9 @@ fn main() {
         })
         .invoke_handler(tauri::generate_handler![
             link,
+            pending_link_server,
+            confirm_pending_link,
+            discard_pending_link,
             start_connect,
             complete_connect,
             cancel_login,

--- a/src/Web/packages/desktop/src-tauri/src/tray.rs
+++ b/src/Web/packages/desktop/src-tauri/src/tray.rs
@@ -301,7 +301,7 @@ fn font() -> Option<&'static fontdue::Font> {
     .as_ref()
 }
 
-fn show_main_window(app: &AppHandle) {
+pub(crate) fn show_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
         let _ = window.show();
         let _ = window.unminimize();

--- a/src/Web/packages/desktop/src-tauri/tauri.conf.json
+++ b/src/Web/packages/desktop/src-tauri/tauri.conf.json
@@ -36,6 +36,11 @@
     ]
   },
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["nocturne-connect"]
+      }
+    },
     "updater": {
       "endpoints": [
         "https://github.com/nightscout/nocturne/releases/download/companion-latest/latest.json"

--- a/src/Web/packages/desktop/src/lib/CareLinkConnect.svelte
+++ b/src/Web/packages/desktop/src/lib/CareLinkConnect.svelte
@@ -32,6 +32,8 @@
   let busy = $state(false);
   let error = $state<string | null>(null);
   let connectedUsername = $state<string | null>(null);
+  /** Server address of a link opened from the browser, held until the user confirms it. */
+  let pendingServer = $state<string | null>(null);
 
   function describeError(e: unknown): string {
     const err = e as CommandError;
@@ -58,11 +60,32 @@
       serverUrl = info.serverUrl;
       phase = "ready";
       linkCodeInput = "";
+      pendingServer = null;
     } catch (e) {
       error = describeError(e);
     } finally {
       busy = false;
     }
+  }
+
+  async function acceptPendingLink() {
+    busy = true;
+    error = null;
+    try {
+      const info = await invoke<LinkInfo>("confirm_pending_link");
+      serverUrl = info.serverUrl;
+      phase = "ready";
+    } catch (e) {
+      error = describeError(e);
+    } finally {
+      pendingServer = null;
+      busy = false;
+    }
+  }
+
+  async function rejectPendingLink() {
+    pendingServer = null;
+    await invoke("discard_pending_link");
   }
 
   async function startConnect() {
@@ -110,6 +133,19 @@
   }
 
   onMount(() => {
+    // A link opened while the app was closed is already waiting by the time this mounts.
+    invoke<string | null>("pending_link_server")
+      .then((server) => {
+        if (server) pendingServer = server;
+      })
+      .catch(() => {});
+    const unlistenPending = listen<string>("link-code-received", (event) => {
+      pendingServer = event.payload;
+      error = null;
+    });
+    const unlistenRejected = listen<string>("link-code-rejected", (event) => {
+      error = event.payload;
+    });
     const unlistenCode = listen<string>("carelink-code", (event) => {
       completeConnect(event.payload);
     });
@@ -121,6 +157,8 @@
       }
     });
     return () => {
+      unlistenPending.then((fn) => fn());
+      unlistenRejected.then((fn) => fn());
       unlistenCode.then((fn) => fn());
       unlistenClosed.then((fn) => fn());
     };
@@ -131,6 +169,29 @@
   <Alert variant="destructive">
     <AlertDescription>{error}</AlertDescription>
   </Alert>
+{/if}
+
+{#if pendingServer}
+  <Card>
+    <CardHeader>
+      <CardTitle class="flex items-center gap-2">
+        <Link2 class="h-4 w-4" /> Link this app?
+      </CardTitle>
+      <CardDescription>
+        A link code was opened from your browser. Check the address below — only continue if it is
+        your own Nocturne site.
+      </CardDescription>
+    </CardHeader>
+    <CardContent class="space-y-3">
+      <div class="bg-muted rounded px-2 py-1 font-mono text-xs break-all">{pendingServer}</div>
+      <div class="flex items-center gap-2">
+        <Button onclick={acceptPendingLink} disabled={busy}>
+          {busy ? "Linking…" : "Link this site"}
+        </Button>
+        <Button variant="ghost" size="sm" onclick={rejectPendingLink} disabled={busy}>Cancel</Button>
+      </div>
+    </CardContent>
+  </Card>
 {/if}
 
 {#if phase === "link"}

--- a/src/Web/packages/desktop/src/routes/+layout.svelte
+++ b/src/Web/packages/desktop/src/routes/+layout.svelte
@@ -2,6 +2,9 @@
   import "../app.css";
   import { onMount } from "svelte";
   import { page } from "$app/state";
+  import { goto } from "$app/navigation";
+  import { invoke } from "@tauri-apps/api/core";
+  import { listen } from "@tauri-apps/api/event";
   import { check, type Update } from "@tauri-apps/plugin-updater";
   import { relaunch } from "@tauri-apps/plugin-process";
   import { Button } from "@nocturne/ui/ui/button";
@@ -14,6 +17,21 @@
 
   // The floating clock is a chromeless overlay window — keep the update banner off it.
   const isOverlay = $derived(page.url.pathname.startsWith("/float"));
+
+  // The connect surface lives in Settings, so a link opened from the browser has to take the user
+  // there before it can be confirmed.
+  onMount(() => {
+    if (isOverlay) return;
+    invoke<string | null>("pending_link_server")
+      .then((server) => {
+        if (server) goto("/settings");
+      })
+      .catch(() => {});
+    const unlisten = listen("link-code-received", () => goto("/settings"));
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  });
 
   onMount(async () => {
     if (isOverlay) return;


### PR DESCRIPTION
## Problem

The Companion's connect flow was paste-based: the web app mints a `nocturne-connect://link?server=…&token=…` code that the user shuttles through the clipboard into a text field. The token is a tenant-pinned bearer, so the clipboard hop is both friction and the step most likely to be truncated or pasted into the wrong window. Nothing registered the scheme — no deep-link plugin, no protocol association.

## What was built

- **Plugin wiring**: `tauri-plugin-deep-link` + `tauri-plugin-single-instance` (with the `deep-link` feature), scheme declared under `plugins."deep-link".desktop.schemes`. Verified against the Tauri CLI source that the NSIS bundler reads exactly that key and writes the registry association — no `bundle` section change needed. `register_all()` runs only under `debug_assertions` (dev/portable runs have no installer).
- **Single instance**: a second launch forwards its argv to the running instance and the callback shows/unminimizes/focuses the window (it otherwise hides to tray). Cold start reads `get_current()` once in setup — the plugin consumes argv during its own setup, before our listener exists — so no double-fire.
- **Untrusted input**: any web page can invoke the scheme, so a received URL is never applied. `link_code::parse` — one code path shared by paste and deep link — enforces the scheme, non-empty server+token, and an http(s) server URL; the result is parked and the UI shows the server address, linking only when the user presses "Link this site". The token is never sent to the webview. The paste flow and its confirmation card are untouched as the fallback.
- **Web side**: the CareLink connect panel gains a plain "Open in the desktop app" anchor beside Copy — no JS protocol probing.
- Merge-safe with #706: the only shared-file change is making `show_main_window` `pub(crate)` for reuse.

## Proven vs manual

`cargo test` 74/0 (+9 `link_code` tests; mutation-proven — widening the allowed server schemes fails the scheme-rejection test). Desktop check 0/0; app check identical to baseline; desktop build green. Manual (needs a live Windows install; SAC blocks release builds here): the NSIS registry association, and browser-click launch/focus for cold and warm starts — deep links only fire for installed apps on desktop.

Follow-up from #387.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
