### PR TITLE
feat(devices): back-stamp all device-attributed record types when a patient device is registered

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
@@ -93,7 +93,7 @@ public class DeviceEventController(
 
         // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
         // direct API records stay unstamped. No-op when the request carried an explicit patientDeviceId.
-        await deviceStamper.StampAsync([model], CategoriesFor(model.EventType), model.DataSource, ct);
+        await deviceStamper.StampAsync([model], DeviceAttributionCategories.DeviceEvent(model.EventType), model.DataSource, ct);
 
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
@@ -115,7 +115,7 @@ public class DeviceEventController(
             return error;
 
         // No-op when attribution was preserved or explicitly set above; re-attributes only records still unstamped.
-        await deviceStamper.StampAsync([model], CategoriesFor(model.EventType), model.DataSource, ct);
+        await deviceStamper.StampAsync([model], DeviceAttributionCategories.DeviceEvent(model.EventType), model.DataSource, ct);
 
         try
         {
@@ -177,18 +177,6 @@ public class DeviceEventController(
             ? Problem(detail: $"patientDeviceId '{patientDeviceId}' does not resolve to a registered patient device", statusCode: 400, title: "Bad Request")
             : null;
     }
-
-    /// <summary>
-    /// Device categories eligible to receive an event of the given type: sensor lifecycle events belong
-    /// to CGMs, every other lifecycle event (site, cannula, reservoir, battery, pod, priming, settings)
-    /// to insulin pumps.
-    /// </summary>
-    private static DeviceCategory[] CategoriesFor(DeviceEventType eventType) => eventType switch
-    {
-        DeviceEventType.SensorStart or DeviceEventType.SensorChange or DeviceEventType.SensorStop
-            or DeviceEventType.TransmitterSensorInsert => [DeviceCategory.CGM],
-        _ => [DeviceCategory.InsulinPump],
-    };
 
     /// <summary>
     /// Delete a device event by its external sync identifier (dataSource + syncIdentifier pair).

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -87,7 +87,7 @@ public class SensorGlucoseController(
         // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
         // direct API records stay unstamped and only ever surface as pseudo-devices. Fills only when
         // the record is unattributed; the canonical stream still governs reads.
-        await deviceStamper.StampAsync([model], [DeviceCategory.CGM], model.DataSource, ct);
+        await deviceStamper.StampAsync([model], DeviceAttributionCategories.SensorGlucose, model.DataSource, ct);
 
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
@@ -148,7 +148,7 @@ public class SensorGlucoseController(
         await glucoseResolver.ResolveAsync(model, request.GlucoseProcessing, request.SmoothedMgdl, request.UnsmoothedMgdl, ct);
 
         // No-op when attribution was preserved above; re-attributes only records still unstamped.
-        await deviceStamper.StampAsync([model], [DeviceCategory.CGM], model.DataSource, ct);
+        await deviceStamper.StampAsync([model], DeviceAttributionCategories.SensorGlucose, model.DataSource, ct);
 
         try
         {
@@ -187,7 +187,7 @@ public class SensorGlucoseController(
 
         // Attribute the batch before persisting (see Create). Per-record DataSource drives matching,
         // so no batch-level source is needed for a mixed-source bulk upload.
-        await deviceStamper.StampAsync(models, [DeviceCategory.CGM], batchSource: null, ct);
+        await deviceStamper.StampAsync(models, DeviceAttributionCategories.SensorGlucose, batchSource: null, ct);
 
         var created = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         var createdArray = created.ToArray();

--- a/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/PatientRecordController.cs
@@ -136,7 +136,7 @@ public class PatientRecordController : ControllerBase
     {
         await ResolveDeviceIdAsync(model, cancellationToken);
         var created = await _deviceRepo.CreateAsync(model, WriteOrigin.Live, cancellationToken);
-        // Back-stamp existing unattributed readings this device now explains (glucose stream only).
+        // Back-stamp existing unattributed records this device now explains.
         await _reattribution.ReattributeForDeviceAsync(created, cancellationToken);
         return CreatedAtAction(nameof(GetDevices), created);
     }

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
@@ -121,7 +121,7 @@ public class TempBasalController(
             var model = MapToModel(request);
             // Attribute like the sensor-glucose native path — otherwise direct API records stay
             // unstamped and only ever surface as pseudo-devices.
-            await deviceStamper.StampAsync([model], [DeviceCategory.InsulinPump], model.DataSource, ct);
+            await deviceStamper.StampAsync([model], DeviceAttributionCategories.TempBasal, model.DataSource, ct);
             results.Add(await repo.CreateAsync(model, WriteOrigin.Live, ct));
         }
 

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -78,7 +78,7 @@ internal sealed class GlucosePublisher : IGlucosePublisher
             var recordList = records.ToList();
             if (recordList.Count == 0) return true;
 
-            await _patientDeviceStamper.StampAsync(recordList, [DeviceCategory.CGM], source, cancellationToken);
+            await _patientDeviceStamper.StampAsync(recordList, DeviceAttributionCategories.SensorGlucose, source, cancellationToken);
             using (SystemAuditScope.Push(_auditContext))
                 await _sensorGlucoseRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             await _alertEvaluator.EvaluateAsync(cancellationToken);

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
@@ -104,7 +104,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
 
             await ResolvePatientInsulinsForBolusesAsync(recordList, origin, cancellationToken);
             await _patientDeviceStamper.StampAsync(
-                recordList, [DeviceCategory.InsulinPump, DeviceCategory.SmartPen], source, cancellationToken);
+                recordList, DeviceAttributionCategories.Bolus, source, cancellationToken);
             using (SystemAuditScope.Push(_auditContext))
                 await _bolusRepository.BulkCreateAsync(recordList, origin, cancellationToken);
             _logger.LogDebug("Published {Count} Bolus records for {Source}", recordList.Count, source);
@@ -198,7 +198,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             if (recordList.Count == 0) return true;
 
             await _patientDeviceStamper.StampAsync(
-                recordList, [DeviceCategory.InsulinPump], source, cancellationToken);
+                recordList, DeviceAttributionCategories.TempBasal, source, cancellationToken);
 
             var minTimestamp = recordList.Min(r => r.StartTimestamp);
             var maxTimestamp = recordList.Max(r => r.StartTimestamp);
@@ -302,7 +302,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
 
             await ResolvePatientInsulinsForBasalInjectionsAsync(recordList, origin, cancellationToken);
             await _patientDeviceStamper.StampAsync(
-                recordList, [DeviceCategory.InsulinPen, DeviceCategory.SmartPen], source, cancellationToken);
+                recordList, DeviceAttributionCategories.BasalInjection, source, cancellationToken);
             using (SystemAuditScope.Push(_auditContext))
                 await _basalInjectionRepository.BulkCreateAsync(recordList, origin, cancellationToken);
 

--- a/src/API/Nocturne.API/Services/Devices/DeviceReattributionService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceReattributionService.cs
@@ -1,11 +1,12 @@
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.API.Services.Devices;
 
 /// <summary>
-/// Back-stamps existing unattributed readings to a device the moment it is registered, so a
+/// Back-stamps existing unattributed records to a device the moment it is registered, so a
 /// newly-declared <see cref="PatientDevice"/> immediately owns the history it explains instead of
 /// waiting for new data. Registration-scoped by design — there is deliberately no global migration;
 /// each registration re-runs attribution only over its own usage window.
@@ -13,8 +14,9 @@ namespace Nocturne.API.Services.Devices;
 public interface IDeviceReattributionService
 {
     /// <summary>
-    /// Re-attributes unattributed sensor glucose within the device's usage window, running the same
-    /// matching ladder as ingest. Returns the number of readings whose attribution changed.
+    /// Re-attributes the unattributed records within the device's usage window that its category can
+    /// own, running the same matching ladder as ingest. Returns the number of records whose
+    /// attribution changed.
     /// </summary>
     Task<int> ReattributeForDeviceAsync(PatientDevice device, CancellationToken ct = default);
 }
@@ -23,23 +25,38 @@ public interface IDeviceReattributionService
 internal sealed class DeviceReattributionService : IDeviceReattributionService
 {
     /// <summary>
-    /// Upper bound on readings re-stamped per registration. A multi-year CGM window can hold hundreds
-    /// of thousands of rows; capping keeps the registration request bounded. Newest-first, so the most
-    /// recent history is attributed; readings beyond the cap in the same window stay unattributed
-    /// (consistent with the deliberate no-global-migration design).
+    /// Upper bound on records re-stamped per registration, per record type. A multi-year CGM window
+    /// can hold hundreds of thousands of rows; capping keeps the registration request bounded.
+    /// Newest-first, so the most recent history is attributed; records beyond the cap in the same
+    /// window stay unattributed (consistent with the deliberate no-global-migration design).
     /// </summary>
-    private const int MaxReattributeReadings = 50_000;
+    private const int MaxReattributeRecords = 50_000;
 
     private readonly ISensorGlucoseRepository _sensorGlucose;
+    private readonly IMeterGlucoseRepository _meterGlucose;
+    private readonly IBolusRepository _boluses;
+    private readonly ITempBasalRepository _tempBasals;
+    private readonly IBasalInjectionRepository _basalInjections;
+    private readonly IDeviceEventRepository _deviceEvents;
     private readonly IPatientDeviceStamper _stamper;
     private readonly ILogger<DeviceReattributionService> _logger;
 
     public DeviceReattributionService(
         ISensorGlucoseRepository sensorGlucose,
+        IMeterGlucoseRepository meterGlucose,
+        IBolusRepository boluses,
+        ITempBasalRepository tempBasals,
+        IBasalInjectionRepository basalInjections,
+        IDeviceEventRepository deviceEvents,
         IPatientDeviceStamper stamper,
         ILogger<DeviceReattributionService> logger)
     {
         _sensorGlucose = sensorGlucose;
+        _meterGlucose = meterGlucose;
+        _boluses = boluses;
+        _tempBasals = tempBasals;
+        _basalInjections = basalInjections;
+        _deviceEvents = deviceEvents;
         _stamper = stamper;
         _logger = logger;
     }
@@ -47,33 +64,88 @@ internal sealed class DeviceReattributionService : IDeviceReattributionService
     /// <inheritdoc />
     public async Task<int> ReattributeForDeviceAsync(PatientDevice device, CancellationToken ct = default)
     {
-        // Glucose stream only. Treatment (pump) re-attribution is a separate follow-up; a CGM
-        // registration cannot own bolus/basal history.
-        if (device.DeviceCategory != DeviceCategory.CGM)
-            return 0;
-
         // Device usage dates are local; pad ±1 day for local/UTC skew, matching the ingest stamper's
         // candidate window. Null bounds mean the device has an open-ended window.
         var from = device.StartDate is { } start ? start.ToDateTime(TimeOnly.MinValue).AddDays(-1) : (DateTime?)null;
         var to = device.EndDate is { } end ? end.ToDateTime(TimeOnly.MaxValue).AddDays(1) : (DateTime?)null;
 
-        var unattributed = await _sensorGlucose.GetUnattributedAsync(from, to, MaxReattributeReadings, ct);
+        // A record type is in scope when the registered category is one of the categories ingest
+        // lets own that type — the same map, so back-stamping and live stamping cannot diverge.
+        var category = device.DeviceCategory;
+        var updated = 0;
+
+        if (DeviceAttributionCategories.SensorGlucose.Contains(category))
+            updated += await BackStampAsync(_sensorGlucose, DeviceAttributionCategories.SensorGlucose, from, to, ct);
+
+        if (DeviceAttributionCategories.MeterGlucose.Contains(category))
+            updated += await BackStampAsync(_meterGlucose, DeviceAttributionCategories.MeterGlucose, from, to, ct);
+
+        if (DeviceAttributionCategories.Bolus.Contains(category))
+            updated += await BackStampAsync(_boluses, DeviceAttributionCategories.Bolus, from, to, ct);
+
+        if (DeviceAttributionCategories.TempBasal.Contains(category))
+            updated += await BackStampAsync(_tempBasals, DeviceAttributionCategories.TempBasal, from, to, ct);
+
+        if (DeviceAttributionCategories.BasalInjection.Contains(category))
+            updated += await BackStampAsync(_basalInjections, DeviceAttributionCategories.BasalInjection, from, to, ct);
+
+        if (DeviceAttributionCategories.SensorDeviceEvent.Contains(category))
+            updated += await BackStampDeviceEventsAsync(
+                DeviceAttributionCategories.SensorEventTypes, DeviceAttributionCategories.SensorDeviceEvent, from, to, ct);
+
+        if (DeviceAttributionCategories.PumpDeviceEvent.Contains(category))
+            updated += await BackStampDeviceEventsAsync(
+                DeviceAttributionCategories.PumpEventTypes, DeviceAttributionCategories.PumpDeviceEvent, from, to, ct);
+
+        if (updated > 0)
+            _logger.LogInformation(
+                "Back-stamped {Count} record(s) after registering {Category} device {DeviceId}",
+                updated, category, device.Id);
+
+        return updated;
+    }
+
+    private async Task<int> BackStampAsync<TRecord>(
+        IDeviceAttributedRepository<TRecord> repository,
+        IReadOnlyList<DeviceCategory> categories,
+        DateTime? from,
+        DateTime? to,
+        CancellationToken ct)
+        where TRecord : class, IDeviceAttributed
+        => await StampAndPersistAsync(
+            repository, await repository.GetUnattributedAsync(from, to, MaxReattributeRecords, ct), categories, ct);
+
+    private async Task<int> BackStampDeviceEventsAsync(
+        IReadOnlyCollection<DeviceEventType> eventTypes,
+        IReadOnlyList<DeviceCategory> categories,
+        DateTime? from,
+        DateTime? to,
+        CancellationToken ct)
+        => await StampAndPersistAsync(
+            _deviceEvents,
+            await _deviceEvents.GetUnattributedAsync(from, to, eventTypes, MaxReattributeRecords, ct),
+            categories,
+            ct);
+
+    /// <summary>
+    /// Re-runs the full matching ladder over all active devices of the eligible categories (including
+    /// the just-registered one), then persists only the records that gained an attribution.
+    /// </summary>
+    private async Task<int> StampAndPersistAsync(
+        IDeviceAttributionWriter writer,
+        IReadOnlyList<IDeviceAttributed> unattributed,
+        IReadOnlyList<DeviceCategory> categories,
+        CancellationToken ct)
+    {
         if (unattributed.Count == 0)
             return 0;
 
-        // Re-run the full matching ladder over all active devices (including the just-registered one),
-        // then persist only the readings that gained an attribution.
-        await _stamper.StampAsync(unattributed, [DeviceCategory.CGM], batchSource: null, ct);
+        await _stamper.StampAsync(unattributed, categories, batchSource: null, ct);
 
         var attributed = unattributed
             .Where(r => r.PatientDeviceId.HasValue)
             .ToDictionary(r => r.Id, r => r.PatientDeviceId!.Value);
-        if (attributed.Count == 0)
-            return 0;
 
-        var updated = await _sensorGlucose.SetPatientDeviceIdsAsync(attributed, ct);
-        _logger.LogInformation(
-            "Back-stamped {Count} sensor glucose reading(s) after registering device {DeviceId}", updated, device.Id);
-        return updated;
+        return attributed.Count == 0 ? 0 : await writer.SetPatientDeviceIdsAsync(attributed, ct);
     }
 }

--- a/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
@@ -116,7 +116,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         // Carry an earlier attribution forward on re-upload: the rebuilt model starts null and a
         // later ambiguous stamp (e.g. a second device registered since) must not wipe the stored FK.
         model.PatientDeviceId = existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], [DeviceCategory.CGM], model.DataSource, ct);
+        await _patientDeviceStamper.StampAsync([model], DeviceAttributionCategories.SensorGlucose, model.DataSource, ct);
 
         if (existing != null)
         {
@@ -141,7 +141,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
 
         var model = MapToMeterGlucose(entry, result.CorrelationId);
         model.PatientDeviceId = existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], [DeviceCategory.GlucoseMeter], model.DataSource, ct);
+        await _patientDeviceStamper.StampAsync([model], DeviceAttributionCategories.MeterGlucose, model.DataSource, ct);
 
         if (existing != null)
         {
@@ -234,9 +234,9 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         }
 
         if (sgvList.Count > 0)
-            await _patientDeviceStamper.StampAsync(sgvList, [DeviceCategory.CGM], batchSource: null, ct);
+            await _patientDeviceStamper.StampAsync(sgvList, DeviceAttributionCategories.SensorGlucose, batchSource: null, ct);
         if (mbgList.Count > 0)
-            await _patientDeviceStamper.StampAsync(mbgList, [DeviceCategory.GlucoseMeter], batchSource: null, ct);
+            await _patientDeviceStamper.StampAsync(mbgList, DeviceAttributionCategories.MeterGlucose, batchSource: null, ct);
 
         using (SystemAuditScope.Push(_auditContext))
         {

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -67,34 +67,6 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         "TempBasal"
     ];
 
-    /// <summary>
-    /// Categories eligible for fallback attribution when the upload carries no pump serial
-    /// (serial-based DeviceId → PatientDevice resolution takes precedence).
-    /// </summary>
-    private static readonly V4Models.DeviceCategory[] BolusDeviceCategories =
-        [V4Models.DeviceCategory.InsulinPump, V4Models.DeviceCategory.SmartPen];
-
-    private static readonly V4Models.DeviceCategory[] TempBasalDeviceCategories =
-        [V4Models.DeviceCategory.InsulinPump];
-
-    private static readonly V4Models.DeviceCategory[] PumpEventDeviceCategories =
-        [V4Models.DeviceCategory.InsulinPump];
-
-    private static readonly V4Models.DeviceCategory[] SensorEventDeviceCategories =
-        [V4Models.DeviceCategory.CGM];
-
-    /// <summary>
-    /// Sensor lifecycle events attribute to the CGM; every other device event is pump-originated.
-    /// </summary>
-    private static bool IsSensorEvent(DeviceEventType eventType) => eventType is
-        DeviceEventType.SensorStart or
-        DeviceEventType.SensorChange or
-        DeviceEventType.SensorStop or
-        DeviceEventType.TransmitterSensorInsert;
-
-    private static V4Models.DeviceCategory[] DeviceEventCategories(DeviceEventType eventType) =>
-        IsSensorEvent(eventType) ? SensorEventDeviceCategories : PumpEventDeviceCategories;
-
     /// <param name="dbContext">EF Core context used to look up treatment entity PKs and run bulk deletes.</param>
     /// <param name="bolusRepository">Repository for <see cref="V4Models.Bolus"/> records.</param>
     /// <param name="tempBasalRepository">Repository for <see cref="V4Models.TempBasal"/> records.</param>
@@ -498,7 +470,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
         model.PatientDeviceId ??= existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], BolusDeviceCategories, model.DataSource, ct);
+        await _patientDeviceStamper.StampAsync([model], V4Models.DeviceAttributionCategories.Bolus, model.DataSource, ct);
 
         if (existing != null)
         {
@@ -528,7 +500,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
         model.PatientDeviceId ??= existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], BolusDeviceCategories, model.DataSource, ct);
+        await _patientDeviceStamper.StampAsync([model], V4Models.DeviceAttributionCategories.Bolus, model.DataSource, ct);
 
         if (existing != null)
         {
@@ -641,7 +613,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
         model.PatientDeviceId ??= existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], DeviceEventCategories(model.EventType), model.DataSource, ct);
+        await _patientDeviceStamper.StampAsync([model], V4Models.DeviceAttributionCategories.DeviceEvent(model.EventType), model.DataSource, ct);
 
         if (existing != null)
         {
@@ -751,7 +723,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
         model.PatientDeviceId ??= existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], TempBasalDeviceCategories, model.DataSource, ct);
+        await _patientDeviceStamper.StampAsync([model], V4Models.DeviceAttributionCategories.TempBasal, model.DataSource, ct);
 
         // Resolve insulin context: active profile switch → primary insulin → null
         model.InsulinContext = await _activeProfileResolver.GetActiveInsulinContextAsync(treatment.Mills, ct);
@@ -1380,17 +1352,17 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
         // Fallback attribution for records the serial-based DeviceId resolution left unattributed.
         if (bolusList.Count > 0)
-            await _patientDeviceStamper.StampAsync(bolusList, BolusDeviceCategories, batchSource: null, ct);
+            await _patientDeviceStamper.StampAsync(bolusList, V4Models.DeviceAttributionCategories.Bolus, batchSource: null, ct);
         if (tempBasalList.Count > 0)
-            await _patientDeviceStamper.StampAsync(tempBasalList, TempBasalDeviceCategories, batchSource: null, ct);
+            await _patientDeviceStamper.StampAsync(tempBasalList, V4Models.DeviceAttributionCategories.TempBasal, batchSource: null, ct);
         if (deviceEventList.Count > 0)
         {
-            var sensorEvents = deviceEventList.Where(e => IsSensorEvent(e.EventType)).ToList();
-            var pumpEvents = deviceEventList.Where(e => !IsSensorEvent(e.EventType)).ToList();
+            var sensorEvents = deviceEventList.Where(e => V4Models.DeviceAttributionCategories.IsSensorEvent(e.EventType)).ToList();
+            var pumpEvents = deviceEventList.Where(e => !V4Models.DeviceAttributionCategories.IsSensorEvent(e.EventType)).ToList();
             if (sensorEvents.Count > 0)
-                await _patientDeviceStamper.StampAsync(sensorEvents, SensorEventDeviceCategories, batchSource: null, ct);
+                await _patientDeviceStamper.StampAsync(sensorEvents, V4Models.DeviceAttributionCategories.SensorDeviceEvent, batchSource: null, ct);
             if (pumpEvents.Count > 0)
-                await _patientDeviceStamper.StampAsync(pumpEvents, PumpEventDeviceCategories, batchSource: null, ct);
+                await _patientDeviceStamper.StampAsync(pumpEvents, V4Models.DeviceAttributionCategories.PumpDeviceEvent, batchSource: null, ct);
         }
 
         // Pre-pass: upsert profile switch StateSpans first (temp basals depend on them for insulin context)

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalInjectionRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalInjectionRepository.cs
@@ -12,7 +12,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// </remarks>
 /// <seealso cref="BasalInjection"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IBasalInjectionRepository : IV4Repository<BasalInjection>
+public interface IBasalInjectionRepository : IV4Repository<BasalInjection>, IDeviceAttributedRepository<BasalInjection>
 {
     /// <summary>Delete <see cref="BasalInjection"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusRepository.cs
@@ -15,7 +15,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="BolusKind"/>
 /// <seealso cref="IBolusCalculationRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IBolusRepository : IV4Repository<Bolus>
+public interface IBolusRepository : IV4Repository<Bolus>, IDeviceAttributedRepository<Bolus>
 {
     /// <summary>
     /// Retrieve a page of <see cref="Bolus"/> records filtered by time range, device, source, origin, and kind.

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceAttributedRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceAttributedRepository.cs
@@ -1,0 +1,35 @@
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Core.Contracts.V4.Repositories;
+
+/// <summary>
+/// Persists resolved device attribution for one <see cref="IDeviceAttributed"/> record type.
+/// Split from <see cref="IDeviceAttributedRepository{TRecord}"/> so back-stamping can write through
+/// a repository whose unattributed backlog is read with type-specific filters (device events).
+/// </summary>
+public interface IDeviceAttributionWriter
+{
+    /// <summary>
+    /// Persists <see cref="IDeviceAttributed.PatientDeviceId"/> for the given record ids in one batch.
+    /// Ids absent for this tenant are ignored.
+    /// </summary>
+    /// <returns>The number of rows updated.</returns>
+    Task<int> SetPatientDeviceIdsAsync(
+        IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Reads and writes the unattributed backlog of one <see cref="IDeviceAttributed"/> record type,
+/// so a device registration can back-stamp the history it explains.
+/// </summary>
+/// <typeparam name="TRecord">The device-attributed record type.</typeparam>
+public interface IDeviceAttributedRepository<TRecord> : IDeviceAttributionWriter
+    where TRecord : IDeviceAttributed
+{
+    /// <summary>
+    /// Returns unattributed records (<c>PatientDeviceId == null</c>) within the time window,
+    /// newest first, capped at <paramref name="limit"/>.
+    /// </summary>
+    Task<IReadOnlyList<TRecord>> GetUnattributedAsync(
+        DateTime? from, DateTime? to, int limit, CancellationToken ct = default);
+}

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
@@ -16,8 +16,21 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="DeviceEvent"/>
 /// <seealso cref="DeviceEventType"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IDeviceEventRepository : IV4Repository<DeviceEvent>
+public interface IDeviceEventRepository : IV4Repository<DeviceEvent>, IDeviceAttributionWriter
 {
+    /// <summary>
+    /// Returns unattributed events (<c>PatientDeviceId == null</c>) of the given types within the time
+    /// window, newest first, capped at <paramref name="limit"/>. Unlike the other device-attributed
+    /// types, one table holds both sensor- and pump-originated events, so back-stamping must narrow to
+    /// the types the registering device's category can own.
+    /// </summary>
+    Task<IReadOnlyList<DeviceEvent>> GetUnattributedAsync(
+        DateTime? from,
+        DateTime? to,
+        IReadOnlyCollection<DeviceEventType> eventTypes,
+        int limit,
+        CancellationToken ct = default);
+
     /// <summary>
     /// Retrieve a page of <see cref="DeviceEvent"/> records filtered by time range, device, source, and origin.
     /// </summary>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IMeterGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IMeterGlucoseRepository.cs
@@ -14,7 +14,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="MeterGlucose"/>
 /// <seealso cref="IBGCheckRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IMeterGlucoseRepository : IV4Repository<MeterGlucose>
+public interface IMeterGlucoseRepository : IV4Repository<MeterGlucose>, IDeviceAttributedRepository<MeterGlucose>
 {
     /// <summary>Retrieve a page of <see cref="MeterGlucose"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
@@ -17,7 +17,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="IBGCheckRepository"/>
 /// <seealso cref="ICalibrationRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
+public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>, IDeviceAttributedRepository<SensorGlucose>
 {
     /// <summary>
     /// Retrieve a page of <see cref="SensorGlucose"/> records filtered by time range, device, source, and origin.
@@ -170,19 +170,6 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>
     /// last-seen timestamp per combination. Drives the "discovered sources" device-registration UI.
     /// </summary>
     Task<IReadOnlyList<DiscoveredSource>> GetDiscoveredSourcesAsync(DateTime since, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns unattributed readings (<c>PatientDeviceId == null</c>) within the time window, capped at
-    /// <paramref name="limit"/>. Used to back-stamp attribution when a device is registered from a discovered source.
-    /// </summary>
-    Task<IReadOnlyList<SensorGlucose>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default);
-
-    /// <summary>
-    /// Persists <see cref="SensorGlucose.PatientDeviceId"/> for the given record ids in one batch.
-    /// Ids absent for this tenant are ignored.
-    /// </summary>
-    /// <returns>The number of rows updated.</returns>
-    Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default);
 
     /// <summary>
     /// Delete all records within the given time range.

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
@@ -17,7 +17,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="TempBasal"/>
 /// <seealso cref="Treatments.IIobCalculator"/>
 /// <seealso cref="IStateSpanService"/>
-public interface ITempBasalRepository
+public interface ITempBasalRepository : IDeviceAttributedRepository<TempBasal>
 {
     /// <summary>Retrieve a page of <see cref="TempBasal"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>

--- a/src/Core/Nocturne.Core.Models/V4/DeviceAttributionCategories.cs
+++ b/src/Core/Nocturne.Core.Models/V4/DeviceAttributionCategories.cs
@@ -1,0 +1,57 @@
+namespace Nocturne.Core.Models.V4;
+
+/// <summary>
+/// The <see cref="DeviceCategory"/> values eligible to own each <see cref="IDeviceAttributed"/>
+/// record type. Single source of truth for ingest-time stamping and registration-time
+/// back-stamping alike, so the two can never disagree about which device explains a record.
+/// </summary>
+/// <seealso cref="IDeviceAttributed"/>
+/// <seealso cref="PatientDevice"/>
+public static class DeviceAttributionCategories
+{
+    /// <summary>Categories eligible to own a <see cref="V4.SensorGlucose"/> reading.</summary>
+    public static IReadOnlyList<DeviceCategory> SensorGlucose { get; } = [DeviceCategory.CGM];
+
+    /// <summary>Categories eligible to own a <see cref="V4.MeterGlucose"/> reading.</summary>
+    public static IReadOnlyList<DeviceCategory> MeterGlucose { get; } = [DeviceCategory.GlucoseMeter];
+
+    /// <summary>Categories eligible to own a <see cref="V4.Bolus"/>.</summary>
+    public static IReadOnlyList<DeviceCategory> Bolus { get; } =
+        [DeviceCategory.InsulinPump, DeviceCategory.SmartPen];
+
+    /// <summary>Categories eligible to own a <see cref="V4.TempBasal"/>.</summary>
+    public static IReadOnlyList<DeviceCategory> TempBasal { get; } = [DeviceCategory.InsulinPump];
+
+    /// <summary>Categories eligible to own a <see cref="V4.BasalInjection"/> (MDI long-acting dose).</summary>
+    public static IReadOnlyList<DeviceCategory> BasalInjection { get; } =
+        [DeviceCategory.InsulinPen, DeviceCategory.SmartPen];
+
+    /// <summary>Categories eligible to own a sensor-lifecycle <see cref="V4.DeviceEvent"/>.</summary>
+    public static IReadOnlyList<DeviceCategory> SensorDeviceEvent { get; } = [DeviceCategory.CGM];
+
+    /// <summary>Categories eligible to own a pump-lifecycle <see cref="V4.DeviceEvent"/>.</summary>
+    public static IReadOnlyList<DeviceCategory> PumpDeviceEvent { get; } = [DeviceCategory.InsulinPump];
+
+    /// <summary>
+    /// Sensor lifecycle events attribute to the CGM; every other device event (site, cannula,
+    /// reservoir, battery, pod, priming, settings) is pump-originated.
+    /// </summary>
+    public static IReadOnlyList<DeviceEventType> SensorEventTypes { get; } =
+    [
+        DeviceEventType.SensorStart,
+        DeviceEventType.SensorChange,
+        DeviceEventType.SensorStop,
+        DeviceEventType.TransmitterSensorInsert,
+    ];
+
+    /// <summary>The complement of <see cref="SensorEventTypes"/>, so every event type is classified.</summary>
+    public static IReadOnlyList<DeviceEventType> PumpEventTypes { get; } =
+        Enum.GetValues<DeviceEventType>().Except(SensorEventTypes).ToArray();
+
+    /// <summary>True when the event type describes a CGM sensor's lifecycle rather than a pump's.</summary>
+    public static bool IsSensorEvent(DeviceEventType eventType) => SensorEventTypes.Contains(eventType);
+
+    /// <summary>Categories eligible to own a <see cref="V4.DeviceEvent"/> of the given type.</summary>
+    public static IReadOnlyList<DeviceCategory> DeviceEvent(DeviceEventType eventType) =>
+        IsSensorEvent(eventType) ? SensorDeviceEvent : PumpDeviceEvent;
+}

--- a/src/Core/Nocturne.Core.Models/V4/IDeviceAttributed.cs
+++ b/src/Core/Nocturne.Core.Models/V4/IDeviceAttributed.cs
@@ -14,6 +14,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="PatientDevice"/>
 public interface IDeviceAttributed
 {
+    /// <summary>Primary key of the record, used to persist a resolved attribution back to its row.</summary>
+    Guid Id { get; }
+
     /// <summary>Timestamp used to match the record against a device's usage window.</summary>
     DateTime Timestamp { get; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IDeviceAttributedEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IDeviceAttributedEntity.cs
@@ -1,0 +1,14 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// A V4 record entity carrying the <c>patient_device_id</c> foreign key, so the shared
+/// device-attribution queries can read an unattributed backlog and back-stamp it.
+///
+/// Implementers MUST map <see cref="PatientDeviceId"/> as an ordinary EF column (a plain
+/// auto-property with a <c>[Column]</c> mapping) so generic <c>ctx.Set&lt;TEntity&gt;()</c> queries
+/// translate the interface-member access to SQL.
+/// </summary>
+public interface IDeviceAttributedEntity : IV4Entity
+{
+    Guid? PatientDeviceId { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BasalInjection.
 /// </summary>
 [Table("basal_injections")]
-public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Bolus
 /// </summary>
 [Table("boluses")]
-public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.DeviceEvent
 /// </summary>
 [Table("device_events")]
-public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.MeterGlucose
 /// </summary>
 [Table("meter_glucose")]
-public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensorGlucose
 /// </summary>
 [Table("sensor_glucose")]
-public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TempBasal
 /// </summary>
 [Table("temp_basals")]
-public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISystemTimestamped
+public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DeviceAttributionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DeviceAttributionExtensions.cs
@@ -1,0 +1,69 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// The unattributed-backlog read and the batch back-stamp write, shared by every repository whose
+/// records carry a <c>patient_device_id</c>.
+/// </summary>
+public static class DeviceAttributionExtensions
+{
+    /// <summary>
+    /// Unattributed rows within the time window, newest first, capped at <paramref name="limit"/>.
+    /// Span-shaped types that key on a start timestamp (and so are not
+    /// <see cref="IV4TimeSeriesEntity"/>) window with <see cref="UnattributedNewestFirstAsync{TEntity}"/>.
+    /// </summary>
+    public static Task<List<TEntity>> GetUnattributedAsync<TEntity>(
+        this NocturneDbContext ctx,
+        DateTime? from,
+        DateTime? to,
+        int limit,
+        CancellationToken ct,
+        Expression<Func<TEntity, bool>>? filter = null)
+        where TEntity : class, IV4TimeSeriesEntity, IDeviceAttributedEntity
+    {
+        var query = ctx.Set<TEntity>().AsNoTracking();
+        if (from.HasValue) query = query.Where(e => e.Timestamp >= from.Value);
+        if (to.HasValue) query = query.Where(e => e.Timestamp <= to.Value);
+        if (filter is not null) query = query.Where(filter);
+        return query.UnattributedNewestFirstAsync(e => e.Timestamp, limit, ct);
+    }
+
+    /// <summary>
+    /// Narrows an already-windowed query to its unattributed rows and takes the newest
+    /// <paramref name="limit"/> by <paramref name="orderBy"/>.
+    /// </summary>
+    public static Task<List<TEntity>> UnattributedNewestFirstAsync<TEntity>(
+        this IQueryable<TEntity> windowed,
+        Expression<Func<TEntity, DateTime>> orderBy,
+        int limit,
+        CancellationToken ct)
+        where TEntity : class, IDeviceAttributedEntity
+        => windowed
+            .Where(e => e.PatientDeviceId == null)
+            .OrderByDescending(orderBy)
+            .Take(limit)
+            .ToListAsync(ct);
+
+    /// <summary>
+    /// Sets <c>patient_device_id</c> on the given record ids in one batch, ignoring ids absent for
+    /// this tenant. Returns the number of rows updated.
+    /// </summary>
+    public static async Task<int> SetPatientDeviceIdsAsync<TEntity>(
+        this NocturneDbContext ctx,
+        IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId,
+        CancellationToken ct)
+        where TEntity : class, IDeviceAttributedEntity
+    {
+        if (patientDeviceIdByRecordId.Count == 0) return 0;
+
+        var ids = patientDeviceIdByRecordId.Keys.ToList();
+        var entities = await ctx.Set<TEntity>().Where(e => ids.Contains(e.Id)).ToListAsync(ct);
+        foreach (var entity in entities)
+            entity.PatientDeviceId = patientDeviceIdByRecordId[entity.Id];
+
+        return entities.Count > 0 ? await ctx.SaveChangesAsync(ct) : 0;
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -441,4 +441,15 @@ public class BasalInjectionRepository : IBasalInjectionRepository
             .FirstOrDefaultAsync(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier, ct);
         return entity is null ? null : BasalInjectionMapper.ToDomainModel(entity);
     }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<BasalInjection>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default)
+    {
+        var entities = await _context.GetUnattributedAsync<BasalInjectionEntity>(from, to, limit, ct);
+        return entities.Select(BasalInjectionMapper.ToDomainModel).ToList();
+    }
+
+    /// <inheritdoc />
+    public Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default)
+        => _context.SetPatientDeviceIdsAsync<BasalInjectionEntity>(patientDeviceIdByRecordId, ct);
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -320,4 +320,19 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
             _logger.LogWarning(ex, "Failed to deduplicate {Type} batch of {Count}", "Bolus", inserted.Count);
         }
     }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<Bolus>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entities = await ctx.GetUnattributedAsync<BolusEntity>(from, to, limit, ct);
+        return entities.Select(BolusMapper.ToDomainModel).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        return await ctx.SetPatientDeviceIdsAsync<BolusEntity>(patientDeviceIdByRecordId, ct);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -225,4 +225,28 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
 
         return entity is null ? null : DeviceEventMapper.ToDomainModel(entity);
     }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DeviceEvent>> GetUnattributedAsync(
+        DateTime? from,
+        DateTime? to,
+        IReadOnlyCollection<DeviceEventType> eventTypes,
+        int limit,
+        CancellationToken ct = default)
+    {
+        if (eventTypes.Count == 0) return [];
+
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var eventTypeStrings = eventTypes.Select(t => t.ToString()).ToList();
+        var entities = await ctx.GetUnattributedAsync<DeviceEventEntity>(
+            from, to, limit, ct, filter: e => eventTypeStrings.Contains(e.EventType));
+        return entities.Select(DeviceEventMapper.ToDomainModel).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        return await ctx.SetPatientDeviceIdsAsync<DeviceEventEntity>(patientDeviceIdByRecordId, ct);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -7,6 +7,7 @@ using Nocturne.Core.Models;
 using Nocturne.Core.Models.Projections;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 
@@ -93,5 +94,20 @@ public class MeterGlucoseRepository : V4RepositoryBase<MeterGlucose, MeterGlucos
             query = query.Where(e => e.Timestamp < to.Value);
 
         return await query.ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MeterGlucose>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entities = await ctx.GetUnattributedAsync<MeterGlucoseEntity>(from, to, limit, ct);
+        return entities.Select(MeterGlucoseMapper.ToDomainModel).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        return await ctx.SetPatientDeviceIdsAsync<MeterGlucoseEntity>(patientDeviceIdByRecordId, ct);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -497,31 +497,15 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     public async Task<IReadOnlyList<SensorGlucose>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        var query = ctx.SensorGlucose.AsNoTracking().Where(e => e.PatientDeviceId == null);
-        if (from.HasValue)
-            query = query.Where(e => e.Timestamp >= from.Value);
-        if (to.HasValue)
-            query = query.Where(e => e.Timestamp <= to.Value);
-
-        var entities = await query
-            .OrderByDescending(e => e.Timestamp)
-            .Take(limit)
-            .ToListAsync(ct);
+        var entities = await ctx.GetUnattributedAsync<SensorGlucoseEntity>(from, to, limit, ct);
         return entities.Select(SensorGlucoseMapper.ToDomainModel).ToList();
     }
 
     /// <inheritdoc />
     public async Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default)
     {
-        if (patientDeviceIdByRecordId.Count == 0) return 0;
-
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        var ids = patientDeviceIdByRecordId.Keys.ToList();
-        var entities = await ctx.SensorGlucose.Where(e => ids.Contains(e.Id)).ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.PatientDeviceId = patientDeviceIdByRecordId[entity.Id];
-
-        return entities.Count > 0 ? await ctx.SaveChangesAsync(ct) : 0;
+        return await ctx.SetPatientDeviceIdsAsync<SensorGlucoseEntity>(patientDeviceIdByRecordId, ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -437,4 +437,24 @@ public class TempBasalRepository : ITempBasalRepository
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : TempBasalMapper.ToDomainModel(entity);
     }
+
+    /// <inheritdoc />
+    /// <remarks>Windows on the span start, the timestamp temp basals are attributed by.</remarks>
+    public async Task<IReadOnlyList<TempBasal>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        var query = ctx.TempBasals.AsNoTracking();
+        if (from.HasValue) query = query.Where(e => e.StartTimestamp >= from.Value);
+        if (to.HasValue) query = query.Where(e => e.StartTimestamp <= to.Value);
+
+        var entities = await query.UnattributedNewestFirstAsync(e => e.StartTimestamp, limit, ct);
+        return entities.Select(TempBasalMapper.ToDomainModel).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default)
+    {
+        await using var ctx = await _contextFactory.CreateAsync(ct);
+        return await ctx.SetPatientDeviceIdsAsync<TempBasalEntity>(patientDeviceIdByRecordId, ct);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceReattributionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceReattributionServiceTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using Nocturne.API.Services.Devices;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Xunit;
 
@@ -12,70 +13,262 @@ namespace Nocturne.API.Tests.Services.Devices;
 [Trait("Category", "Unit")]
 public class DeviceReattributionServiceTests
 {
-    private readonly Mock<ISensorGlucoseRepository> _repo = new();
+    private const int ExpectedCap = 50_000;
+
+    private readonly Mock<ISensorGlucoseRepository> _sensorGlucose = new();
+    private readonly Mock<IMeterGlucoseRepository> _meterGlucose = new();
+    private readonly Mock<IBolusRepository> _boluses = new();
+    private readonly Mock<ITempBasalRepository> _tempBasals = new();
+    private readonly Mock<IBasalInjectionRepository> _basalInjections = new();
+    private readonly Mock<IDeviceEventRepository> _deviceEvents = new();
     private readonly Mock<IPatientDeviceStamper> _stamper = new();
     private readonly DeviceReattributionService _service;
+
+    /// <summary>Categories the stamper was asked to match, in call order.</summary>
+    private readonly List<IReadOnlyList<DeviceCategory>> _stampedCategories = [];
+
+    /// <summary>Device the stubbed matching ladder attributes every record it is handed to.</summary>
+    private Guid? _ladderMatches;
 
     public DeviceReattributionServiceTests()
     {
         _service = new DeviceReattributionService(
-            _repo.Object, _stamper.Object, NullLogger<DeviceReattributionService>.Instance);
+            _sensorGlucose.Object, _meterGlucose.Object, _boluses.Object, _tempBasals.Object,
+            _basalInjections.Object, _deviceEvents.Object, _stamper.Object,
+            NullLogger<DeviceReattributionService>.Instance);
+
+        _stamper.Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
+                (records, categories, _, _) =>
+                {
+                    _stampedCategories.Add(categories);
+                    if (_ladderMatches is { } deviceId)
+                        foreach (var record in records)
+                            record.PatientDeviceId = deviceId;
+                })
+            .Returns(Task.CompletedTask);
     }
 
-    private static PatientDevice CgmDevice(DateOnly? start = null, DateOnly? end = null) => new()
+    private static PatientDevice Device(DeviceCategory category, DateOnly? start = null, DateOnly? end = null) => new()
     {
         Id = Guid.NewGuid(),
-        DeviceCategory = DeviceCategory.CGM,
+        DeviceCategory = category,
         Manufacturer = "Dexcom",
         Model = "G7",
         StartDate = start,
         EndDate = end,
     };
 
-    [Fact]
-    public async Task NonCgmDevice_ReturnsZero_AndTouchesNothing()
+    /// <summary>
+    /// Every stream holds one unattributed record, and the matching ladder attributes whatever it is
+    /// handed to <paramref name="deviceId"/> — so each stream the service reads contributes exactly 1.
+    /// </summary>
+    private void SetupAllStreams(Guid deviceId)
     {
-        var pump = new PatientDevice
-        {
-            Id = Guid.NewGuid(),
-            DeviceCategory = DeviceCategory.InsulinPump,
-            Manufacturer = "Tandem",
-            Model = "t:slim X2",
-        };
+        _ladderMatches = deviceId;
 
-        var result = await _service.ReattributeForDeviceAsync(pump);
+        Setup(_sensorGlucose, new SensorGlucose { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Mgdl = 120 });
+        Setup(_meterGlucose, new MeterGlucose { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Mgdl = 120 });
+        Setup(_boluses, new Bolus { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Insulin = 1 });
+        Setup(_tempBasals, new TempBasal { Id = Guid.NewGuid(), StartTimestamp = DateTime.UtcNow, Rate = 1 });
+        Setup(_basalInjections, new BasalInjection { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Units = 20 });
 
-        result.Should().Be(0);
-        _repo.Verify(r => r.GetUnattributedAsync(
+        var deviceEvent = new DeviceEvent { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, EventType = DeviceEventType.SiteChange };
+        _deviceEvents.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<IReadOnlyCollection<DeviceEventType>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([deviceEvent]);
+        _deviceEvents.Setup(r => r.SetPatientDeviceIdsAsync(
+                It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+    }
+
+    private static void Setup<TRepo, TRecord>(Mock<TRepo> repo, TRecord record)
+        where TRepo : class, IDeviceAttributedRepository<TRecord>
+        where TRecord : class, IDeviceAttributed
+    {
+        repo.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([record]);
+        repo.Setup(r => r.SetPatientDeviceIdsAsync(
+                It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+    }
+
+    private void VerifyNotRead<TRepo, TRecord>(Mock<TRepo> repo)
+        where TRepo : class, IDeviceAttributedRepository<TRecord>
+        where TRecord : class, IDeviceAttributed
+    {
+        repo.Verify(r => r.GetUnattributedAsync(
             It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
-        _stamper.Verify(s => s.StampAsync(
-            It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
-            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-        _repo.Verify(r => r.SetPatientDeviceIdsAsync(
+        repo.Verify(r => r.SetPatientDeviceIdsAsync(
             It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    private void VerifyDeviceEventsNotRead() => _deviceEvents.Verify(r => r.GetUnattributedAsync(
+        It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<IReadOnlyCollection<DeviceEventType>>(),
+        It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+
     [Fact]
-    public async Task CgmWithMatches_PersistsOnlyMatchedReadings_AndReturnsCount()
+    public async Task Cgm_BackStampsSensorGlucoseAndSensorEvents_LeavingPumpStreamsUntouched()
     {
-        var device = CgmDevice(start: new DateOnly(2026, 6, 1), end: new DateOnly(2026, 6, 30));
+        var device = Device(DeviceCategory.CGM);
+        SetupAllStreams(device.Id);
+
+        var result = await _service.ReattributeForDeviceAsync(device);
+
+        result.Should().Be(2, "sensor glucose and sensor device events are the CGM's streams");
+        VerifyNotRead<IBolusRepository, Bolus>(_boluses);
+        VerifyNotRead<ITempBasalRepository, TempBasal>(_tempBasals);
+        VerifyNotRead<IBasalInjectionRepository, BasalInjection>(_basalInjections);
+        VerifyNotRead<IMeterGlucoseRepository, MeterGlucose>(_meterGlucose);
+        _deviceEvents.Verify(r => r.GetUnattributedAsync(
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+            It.Is<IReadOnlyCollection<DeviceEventType>>(t => t.SequenceEqual(DeviceAttributionCategories.SensorEventTypes)),
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+        _stampedCategories.Should().AllSatisfy(c => c.Should().Equal(DeviceCategory.CGM));
+    }
+
+    [Fact]
+    public async Task InsulinPump_BackStampsBolusesTempBasalsAndPumpEvents_LeavingGlucoseStreamsUntouched()
+    {
+        var device = Device(DeviceCategory.InsulinPump);
+        SetupAllStreams(device.Id);
+
+        var result = await _service.ReattributeForDeviceAsync(device);
+
+        result.Should().Be(3, "boluses, temp basals and pump device events are the pump's streams");
+        VerifyNotRead<ISensorGlucoseRepository, SensorGlucose>(_sensorGlucose);
+        VerifyNotRead<IMeterGlucoseRepository, MeterGlucose>(_meterGlucose);
+        VerifyNotRead<IBasalInjectionRepository, BasalInjection>(_basalInjections);
+        _deviceEvents.Verify(r => r.GetUnattributedAsync(
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+            It.Is<IReadOnlyCollection<DeviceEventType>>(t =>
+                t.SequenceEqual(DeviceAttributionCategories.PumpEventTypes)
+                && !t.Any(DeviceAttributionCategories.IsSensorEvent)),
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SmartPen_BackStampsBolusesAndBasalInjections()
+    {
+        var device = Device(DeviceCategory.SmartPen);
+        SetupAllStreams(device.Id);
+
+        var result = await _service.ReattributeForDeviceAsync(device);
+
+        result.Should().Be(2);
+        VerifyNotRead<ITempBasalRepository, TempBasal>(_tempBasals);
+        VerifyNotRead<ISensorGlucoseRepository, SensorGlucose>(_sensorGlucose);
+        VerifyDeviceEventsNotRead();
+        // The pen's boluses are matched against every category ingest lets own a bolus, not just pens.
+        _stampedCategories.Should().Contain(c => c.SequenceEqual(DeviceAttributionCategories.Bolus));
+        _stampedCategories.Should().Contain(c => c.SequenceEqual(DeviceAttributionCategories.BasalInjection));
+    }
+
+    [Fact]
+    public async Task InsulinPen_BackStampsBasalInjectionsOnly()
+    {
+        var device = Device(DeviceCategory.InsulinPen);
+        SetupAllStreams(device.Id);
+
+        var result = await _service.ReattributeForDeviceAsync(device);
+
+        result.Should().Be(1);
+        VerifyNotRead<IBolusRepository, Bolus>(_boluses);
+        VerifyDeviceEventsNotRead();
+    }
+
+    [Fact]
+    public async Task GlucoseMeter_BackStampsMeterGlucoseOnly()
+    {
+        var device = Device(DeviceCategory.GlucoseMeter);
+        SetupAllStreams(device.Id);
+
+        var result = await _service.ReattributeForDeviceAsync(device);
+
+        result.Should().Be(1);
+        VerifyNotRead<ISensorGlucoseRepository, SensorGlucose>(_sensorGlucose);
+        VerifyDeviceEventsNotRead();
+        _stampedCategories.Should().ContainSingle()
+            .Which.Should().Equal(DeviceCategory.GlucoseMeter);
+    }
+
+    [Fact]
+    public async Task Uploader_OwnsNoRecordType_AndTouchesNothing()
+    {
+        var device = Device(DeviceCategory.Uploader);
+        SetupAllStreams(device.Id);
+
+        var result = await _service.ReattributeForDeviceAsync(device);
+
+        result.Should().Be(0);
+        VerifyNotRead<ISensorGlucoseRepository, SensorGlucose>(_sensorGlucose);
+        VerifyNotRead<IMeterGlucoseRepository, MeterGlucose>(_meterGlucose);
+        VerifyNotRead<IBolusRepository, Bolus>(_boluses);
+        VerifyNotRead<ITempBasalRepository, TempBasal>(_tempBasals);
+        VerifyNotRead<IBasalInjectionRepository, BasalInjection>(_basalInjections);
+        VerifyDeviceEventsNotRead();
+        _stamper.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EveryStream_IsWindowedToTheUsageDates_AndCapped()
+    {
+        var device = Device(DeviceCategory.InsulinPump, start: new DateOnly(2026, 6, 1), end: new DateOnly(2026, 6, 30));
+        SetupAllStreams(device.Id);
+
+        // Usage window is padded ±1 day around the device's local dates.
+        var expectedFrom = new DateOnly(2026, 6, 1).ToDateTime(TimeOnly.MinValue).AddDays(-1);
+        var expectedTo = new DateOnly(2026, 6, 30).ToDateTime(TimeOnly.MaxValue).AddDays(1);
+
+        await _service.ReattributeForDeviceAsync(device);
+
+        _boluses.Verify(r => r.GetUnattributedAsync(expectedFrom, expectedTo, ExpectedCap, It.IsAny<CancellationToken>()), Times.Once);
+        _tempBasals.Verify(r => r.GetUnattributedAsync(expectedFrom, expectedTo, ExpectedCap, It.IsAny<CancellationToken>()), Times.Once);
+        _deviceEvents.Verify(r => r.GetUnattributedAsync(
+            expectedFrom, expectedTo, It.IsAny<IReadOnlyCollection<DeviceEventType>>(), ExpectedCap,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task OpenEndedUsageWindow_PassesNullBounds()
+    {
+        var device = Device(DeviceCategory.CGM);
+        SetupAllStreams(device.Id);
+
+        await _service.ReattributeForDeviceAsync(device);
+
+        _sensorGlucose.Verify(r => r.GetUnattributedAsync(null, null, ExpectedCap, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PersistsOnlyTheRecordsTheLadderAttributed()
+    {
+        var device = Device(DeviceCategory.CGM, start: new DateOnly(2026, 6, 1));
         var matched = new SensorGlucose { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Mgdl = 120, DataSource = "dexcom" };
         var unmatched = new SensorGlucose { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Mgdl = 118, DataSource = "libre" };
 
-        _repo.Setup(r => r.GetUnattributedAsync(
-                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<SensorGlucose> { matched, unmatched });
-
-        // Simulate the ingest ladder attributing only the matching reading.
+        // The ladder attributes only the reading whose source matches the registered device.
         _stamper.Setup(s => s.StampAsync(
                 It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
                 It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
-                (records, _, _, _) => matched.PatientDeviceId = device.Id)
+            .Callback(() => matched.PatientDeviceId = device.Id)
             .Returns(Task.CompletedTask);
+        _sensorGlucose.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([matched, unmatched]);
+        _deviceEvents.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<IReadOnlyCollection<DeviceEventType>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         IReadOnlyDictionary<Guid, Guid>? persisted = null;
-        _repo.Setup(r => r.SetPatientDeviceIdsAsync(
+        _sensorGlucose.Setup(r => r.SetPatientDeviceIdsAsync(
                 It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()))
             .Callback<IReadOnlyDictionary<Guid, Guid>, CancellationToken>((map, _) => persisted = map)
             .ReturnsAsync(1);
@@ -86,21 +279,19 @@ public class DeviceReattributionServiceTests
         persisted.Should().NotBeNull();
         persisted.Should().ContainKey(matched.Id).WhoseValue.Should().Be(device.Id);
         persisted.Should().NotContainKey(unmatched.Id);
-
-        // Usage window is padded ±1 day around the device's local dates.
-        _repo.Verify(r => r.GetUnattributedAsync(
-            It.Is<DateTime?>(d => d == new DateOnly(2026, 6, 1).ToDateTime(TimeOnly.MinValue).AddDays(-1)),
-            It.Is<DateTime?>(d => d == new DateOnly(2026, 6, 30).ToDateTime(TimeOnly.MaxValue).AddDays(1)),
-            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task CgmWithNoUnattributed_ReturnsZero_WithoutStampingOrPersisting()
+    public async Task NoUnattributedRecords_SkipsStampingAndPersisting()
     {
-        var device = CgmDevice(start: new DateOnly(2026, 6, 1));
-        _repo.Setup(r => r.GetUnattributedAsync(
+        var device = Device(DeviceCategory.CGM, start: new DateOnly(2026, 6, 1));
+        _sensorGlucose.Setup(r => r.GetUnattributedAsync(
                 It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<SensorGlucose>());
+            .ReturnsAsync([]);
+        _deviceEvents.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<IReadOnlyCollection<DeviceEventType>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         var result = await _service.ReattributeForDeviceAsync(device);
 
@@ -108,29 +299,30 @@ public class DeviceReattributionServiceTests
         _stamper.Verify(s => s.StampAsync(
             It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
             It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-        _repo.Verify(r => r.SetPatientDeviceIdsAsync(
+        _sensorGlucose.Verify(r => r.SetPatientDeviceIdsAsync(
             It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task CgmWithUnattributedButNoMatches_ReturnsZero_WithoutPersisting()
+    public async Task UnattributedButUnmatched_DoesNotPersist()
     {
-        var device = CgmDevice(start: new DateOnly(2026, 6, 1));
-        var reading = new SensorGlucose { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Mgdl = 120, DataSource = "libre" };
-        _repo.Setup(r => r.GetUnattributedAsync(
+        var device = Device(DeviceCategory.InsulinPump, start: new DateOnly(2026, 6, 1));
+        // The ladder leaves the record unattributed (no matching device), so nothing is written.
+        _boluses.Setup(r => r.GetUnattributedAsync(
                 It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<SensorGlucose> { reading });
-
-        // Stamper leaves the reading unattributed (no match against this device).
-        _stamper.Setup(s => s.StampAsync(
-                It.IsAny<IReadOnlyList<IDeviceAttributed>>(), It.IsAny<IReadOnlyList<DeviceCategory>>(),
-                It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync([new Bolus { Id = Guid.NewGuid(), Timestamp = DateTime.UtcNow, Insulin = 1 }]);
+        _tempBasals.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _deviceEvents.Setup(r => r.GetUnattributedAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<IReadOnlyCollection<DeviceEventType>>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         var result = await _service.ReattributeForDeviceAsync(device);
 
         result.Should().Be(0);
-        _repo.Verify(r => r.SetPatientDeviceIdsAsync(
+        _boluses.Verify(r => r.SetPatientDeviceIdsAsync(
             It.IsAny<IReadOnlyDictionary<Guid, Guid>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/tests/Unit/Nocturne.Core.Models.Tests/V4/DeviceAttributionCategoriesTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/V4/DeviceAttributionCategoriesTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.V4;
+
+/// <summary>
+/// Characterizes the record-type → device-category map. The device-event half is deliberately
+/// pinned member by member: a new sensor-ish <see cref="DeviceEventType"/> falls into the pump half
+/// by default, which would silently back-stamp CGM history to an insulin pump, so adding one must
+/// break here and force a classification decision.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DeviceAttributionCategoriesTests
+{
+    [Fact]
+    public void SensorEventTypes_AreExactlyTheCgmLifecycleEvents()
+    {
+        DeviceAttributionCategories.SensorEventTypes.Should().BeEquivalentTo(new[]
+        {
+            DeviceEventType.SensorStart,
+            DeviceEventType.SensorChange,
+            DeviceEventType.SensorStop,
+            DeviceEventType.TransmitterSensorInsert,
+        });
+    }
+
+    /// <summary>
+    /// Pins the pump half member by member as well, so a new <see cref="DeviceEventType"/> fails here
+    /// rather than defaulting into the pump half unexamined.
+    /// </summary>
+    [Fact]
+    public void PumpEventTypes_AreExactlyTheRemainingLifecycleEvents()
+    {
+        DeviceAttributionCategories.PumpEventTypes.Should().BeEquivalentTo(new[]
+        {
+            DeviceEventType.SiteChange,
+            DeviceEventType.InsulinChange,
+            DeviceEventType.PumpBatteryChange,
+            DeviceEventType.PodChange,
+            DeviceEventType.ReservoirChange,
+            DeviceEventType.CannulaChange,
+            DeviceEventType.PodActivated,
+            DeviceEventType.PodDeactivated,
+            DeviceEventType.PumpSuspend,
+            DeviceEventType.PumpResume,
+            DeviceEventType.Priming,
+            DeviceEventType.TubePriming,
+            DeviceEventType.NeedlePriming,
+            DeviceEventType.Rewind,
+            DeviceEventType.DateChanged,
+            DeviceEventType.TimeChanged,
+            DeviceEventType.BolusMaxChanged,
+            DeviceEventType.BasalMaxChanged,
+            DeviceEventType.ProfileSwitch,
+        });
+    }
+
+    [Fact]
+    public void SensorAndPumpEventTypes_PartitionTheEnum()
+    {
+        var all = Enum.GetValues<DeviceEventType>();
+
+        DeviceAttributionCategories.SensorEventTypes
+            .Concat(DeviceAttributionCategories.PumpEventTypes)
+            .Should().BeEquivalentTo(all, "every event type must be classified exactly once");
+        DeviceAttributionCategories.PumpEventTypes
+            .Should().NotIntersectWith(DeviceAttributionCategories.SensorEventTypes);
+    }
+
+    [Theory]
+    [InlineData(DeviceEventType.SensorStart, DeviceCategory.CGM)]
+    [InlineData(DeviceEventType.SensorChange, DeviceCategory.CGM)]
+    [InlineData(DeviceEventType.SensorStop, DeviceCategory.CGM)]
+    [InlineData(DeviceEventType.TransmitterSensorInsert, DeviceCategory.CGM)]
+    [InlineData(DeviceEventType.SiteChange, DeviceCategory.InsulinPump)]
+    [InlineData(DeviceEventType.CannulaChange, DeviceCategory.InsulinPump)]
+    [InlineData(DeviceEventType.ReservoirChange, DeviceCategory.InsulinPump)]
+    [InlineData(DeviceEventType.PumpBatteryChange, DeviceCategory.InsulinPump)]
+    [InlineData(DeviceEventType.PodChange, DeviceCategory.InsulinPump)]
+    [InlineData(DeviceEventType.ProfileSwitch, DeviceCategory.InsulinPump)]
+    public void DeviceEvent_MapsEachEventTypeToItsOwningCategory(DeviceEventType eventType, DeviceCategory expected)
+    {
+        DeviceAttributionCategories.DeviceEvent(eventType).Should().Equal(expected);
+        DeviceAttributionCategories.IsSensorEvent(eventType).Should().Be(expected == DeviceCategory.CGM);
+    }
+
+    [Fact]
+    public void RecordTypes_MapToTheCategoriesIngestStampsThemWith()
+    {
+        DeviceAttributionCategories.SensorGlucose.Should().Equal(DeviceCategory.CGM);
+        DeviceAttributionCategories.MeterGlucose.Should().Equal(DeviceCategory.GlucoseMeter);
+        DeviceAttributionCategories.Bolus.Should().Equal(DeviceCategory.InsulinPump, DeviceCategory.SmartPen);
+        DeviceAttributionCategories.TempBasal.Should().Equal(DeviceCategory.InsulinPump);
+        DeviceAttributionCategories.BasalInjection.Should().Equal(DeviceCategory.InsulinPen, DeviceCategory.SmartPen);
+    }
+
+    [Fact]
+    public void NoRecordTypeIsOwnedByAnUploader()
+    {
+        var uploaderOwns = new[]
+        {
+            DeviceAttributionCategories.SensorGlucose,
+            DeviceAttributionCategories.MeterGlucose,
+            DeviceAttributionCategories.Bolus,
+            DeviceAttributionCategories.TempBasal,
+            DeviceAttributionCategories.BasalInjection,
+            DeviceAttributionCategories.SensorDeviceEvent,
+            DeviceAttributionCategories.PumpDeviceEvent,
+        };
+
+        uploaderOwns.Should().AllSatisfy(c => c.Should().NotContain(DeviceCategory.Uploader));
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceAttributionBackstampTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceAttributionBackstampTests.cs
@@ -1,0 +1,367 @@
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Covers the unattributed-backlog read and batch back-stamp on the non-glucose device-attributed
+/// types, which a device registration re-attributes alongside sensor glucose. Uses in-memory SQLite
+/// so the window, ordering, cap, and patient_device_id writes are exercised end-to-end.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class DeviceAttributionBackstampTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly DateTime Base = new(2026, 6, 10, 8, 0, 0, DateTimeKind.Utc);
+
+    private readonly DbConnection _connection;
+    private readonly NocturneDbContext _context;
+    private readonly BolusRepository _boluses;
+    private readonly TempBasalRepository _tempBasals;
+    private readonly BasalInjectionRepository _basalInjections;
+    private readonly MeterGlucoseRepository _meterGlucose;
+    private readonly DeviceEventRepository _deviceEvents;
+
+    public DeviceAttributionBackstampTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seedContext = new NocturneDbContext(options))
+        {
+            seedContext.TenantId = TestTenantId;
+            seedContext.Database.EnsureCreated();
+            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seedContext.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(options) { TenantId = TestTenantId };
+        var factory = new TestTenantDbContextFactory(_context);
+        var dedup = new Mock<IDeduplicationService>().Object;
+        var audit = new Mock<IAuditContext>().Object;
+
+        _boluses = new BolusRepository(factory, dedup, audit, NullLogger<BolusRepository>.Instance);
+        _tempBasals = new TempBasalRepository(factory, dedup, audit, NullLogger<TempBasalRepository>.Instance);
+        _basalInjections = new BasalInjectionRepository(_context, audit, NullLogger<BasalInjectionRepository>.Instance);
+        _meterGlucose = new MeterGlucoseRepository(factory, audit, NullLogger<MeterGlucoseRepository>.Instance);
+        _deviceEvents = new DeviceEventRepository(factory, dedup, audit, NullLogger<DeviceEventRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private Guid SeedDevice()
+    {
+        var id = Guid.NewGuid();
+        _context.PatientDevices.Add(new PatientDeviceEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            DeviceCategory = "InsulinPump",
+            Manufacturer = "Tandem",
+            Model = "t:slim X2",
+            IsCurrent = true,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    private Guid SeedBolus(DateTime timestamp, Guid? patientDeviceId = null)
+    {
+        var id = Guid.NewGuid();
+        _context.Boluses.Add(new BolusEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            Insulin = 1.5,
+            PatientDeviceId = patientDeviceId,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    private Guid SeedTempBasal(DateTime startTimestamp, Guid? patientDeviceId = null)
+    {
+        var id = Guid.NewGuid();
+        _context.TempBasals.Add(new TempBasalEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            StartTimestamp = startTimestamp,
+            Rate = 0.8,
+            Origin = nameof(TempBasalOrigin.Algorithm),
+            PatientDeviceId = patientDeviceId,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    private Guid SeedBasalInjection(DateTime timestamp, Guid? patientDeviceId = null)
+    {
+        var id = Guid.NewGuid();
+        _context.BasalInjections.Add(new BasalInjectionEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            Units = 22,
+            PatientDeviceId = patientDeviceId,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    private Guid SeedMeterGlucose(DateTime timestamp, Guid? patientDeviceId = null)
+    {
+        var id = Guid.NewGuid();
+        _context.MeterGlucose.Add(new MeterGlucoseEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            Mgdl = 130,
+            PatientDeviceId = patientDeviceId,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    private Guid SeedDeviceEvent(DateTime timestamp, DeviceEventType eventType, Guid? patientDeviceId = null)
+    {
+        var id = Guid.NewGuid();
+        _context.DeviceEvents.Add(new DeviceEventEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            Timestamp = timestamp,
+            EventType = eventType.ToString(),
+            PatientDeviceId = patientDeviceId,
+        });
+        _context.SaveChanges();
+        return id;
+    }
+
+    [Fact]
+    public async Task Boluses_ReturnsUnattributedInWindow_ExcludingAttributedAndOutOfWindow()
+    {
+        var deviceId = SeedDevice();
+        var inWindow = SeedBolus(Base);
+        SeedBolus(Base.AddDays(-30));                       // before the window
+        SeedBolus(Base.AddHours(1), patientDeviceId: deviceId); // already attributed
+
+        var result = await _boluses.GetUnattributedAsync(Base.AddDays(-1), Base.AddDays(1), limit: 100);
+
+        result.Should().ContainSingle().Which.Id.Should().Be(inWindow);
+    }
+
+    [Fact]
+    public async Task Boluses_WindowIsInclusiveAtBothBounds()
+    {
+        var from = Base;
+        var to = Base.AddHours(4);
+        var atFrom = SeedBolus(from);
+        var atTo = SeedBolus(to);
+        SeedBolus(from.AddMilliseconds(-1));
+        SeedBolus(to.AddMilliseconds(1));
+
+        var result = await _boluses.GetUnattributedAsync(from, to, limit: 100);
+
+        result.Select(b => b.Id).Should().BeEquivalentTo(new[] { atFrom, atTo });
+    }
+
+    [Fact]
+    public async Task TempBasals_WindowIsInclusiveAtBothBounds()
+    {
+        var from = Base;
+        var to = Base.AddHours(4);
+        var atFrom = SeedTempBasal(from);
+        var atTo = SeedTempBasal(to);
+        SeedTempBasal(from.AddMilliseconds(-1));
+        SeedTempBasal(to.AddMilliseconds(1));
+
+        var result = await _tempBasals.GetUnattributedAsync(from, to, limit: 100);
+
+        result.Select(t => t.Id).Should().BeEquivalentTo(new[] { atFrom, atTo });
+    }
+
+    [Fact]
+    public async Task Boluses_NewestFirst_AtCapReturnsAll_OneOverDropsOldest()
+    {
+        var oldest = SeedBolus(Base);
+        var middle = SeedBolus(Base.AddHours(1));
+        var newest = SeedBolus(Base.AddHours(2));
+
+        var atCap = await _boluses.GetUnattributedAsync(from: null, to: null, limit: 3);
+        atCap.Select(b => b.Id).Should().Equal(newest, middle, oldest);
+
+        var overCap = await _boluses.GetUnattributedAsync(from: null, to: null, limit: 2);
+        overCap.Select(b => b.Id).Should().Equal(newest, middle);
+        overCap.Should().NotContain(b => b.Id == oldest);
+    }
+
+    [Fact]
+    public async Task Boluses_SetPatientDeviceIds_UpdatesOnlyMappedRows()
+    {
+        var deviceId = SeedDevice();
+        var stamped = SeedBolus(Base);
+        var untouched = SeedBolus(Base.AddHours(1));
+
+        var updated = await _boluses.SetPatientDeviceIdsAsync(new Dictionary<Guid, Guid> { [stamped] = deviceId });
+
+        updated.Should().Be(1);
+        (await _context.Boluses.AsNoTracking().FirstAsync(e => e.Id == stamped)).PatientDeviceId.Should().Be(deviceId);
+        (await _context.Boluses.AsNoTracking().FirstAsync(e => e.Id == untouched)).PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TempBasals_WindowAndOrderOnSpanStart_AtCapReturnsAll_OneOverDropsOldest()
+    {
+        var deviceId = SeedDevice();
+        var oldest = SeedTempBasal(Base);
+        var newest = SeedTempBasal(Base.AddHours(2));
+        SeedTempBasal(Base.AddDays(-30));                        // before the window
+        SeedTempBasal(Base.AddHours(1), patientDeviceId: deviceId); // already attributed
+
+        var atCap = await _tempBasals.GetUnattributedAsync(Base.AddDays(-1), Base.AddDays(1), limit: 2);
+        atCap.Select(t => t.Id).Should().Equal(newest, oldest);
+
+        var overCap = await _tempBasals.GetUnattributedAsync(Base.AddDays(-1), Base.AddDays(1), limit: 1);
+        overCap.Select(t => t.Id).Should().Equal(newest);
+    }
+
+    [Fact]
+    public async Task TempBasals_SetPatientDeviceIds_UpdatesOnlyMappedRows()
+    {
+        var deviceId = SeedDevice();
+        var stamped = SeedTempBasal(Base);
+        var untouched = SeedTempBasal(Base.AddHours(1));
+
+        var updated = await _tempBasals.SetPatientDeviceIdsAsync(new Dictionary<Guid, Guid> { [stamped] = deviceId });
+
+        updated.Should().Be(1);
+        (await _context.TempBasals.AsNoTracking().FirstAsync(e => e.Id == stamped)).PatientDeviceId.Should().Be(deviceId);
+        (await _context.TempBasals.AsNoTracking().FirstAsync(e => e.Id == untouched)).PatientDeviceId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BasalInjections_ReturnsUnattributedNewestFirst_AndBackStamps()
+    {
+        var deviceId = SeedDevice();
+        var oldest = SeedBasalInjection(Base);
+        var newest = SeedBasalInjection(Base.AddHours(2));
+        SeedBasalInjection(Base.AddHours(1), patientDeviceId: deviceId);
+
+        var atCap = await _basalInjections.GetUnattributedAsync(from: null, to: null, limit: 2);
+        atCap.Select(b => b.Id).Should().Equal(newest, oldest);
+
+        var overCap = await _basalInjections.GetUnattributedAsync(from: null, to: null, limit: 1);
+        overCap.Select(b => b.Id).Should().Equal(newest);
+
+        var updated = await _basalInjections.SetPatientDeviceIdsAsync(new Dictionary<Guid, Guid> { [oldest] = deviceId });
+        updated.Should().Be(1);
+        (await _context.BasalInjections.AsNoTracking().FirstAsync(e => e.Id == oldest)).PatientDeviceId.Should().Be(deviceId);
+    }
+
+    [Fact]
+    public async Task MeterGlucose_ReturnsUnattributedNewestFirst_AndBackStamps()
+    {
+        var deviceId = SeedDevice();
+        var oldest = SeedMeterGlucose(Base);
+        var newest = SeedMeterGlucose(Base.AddHours(2));
+        SeedMeterGlucose(Base.AddHours(1), patientDeviceId: deviceId);
+
+        var atCap = await _meterGlucose.GetUnattributedAsync(from: null, to: null, limit: 2);
+        atCap.Select(m => m.Id).Should().Equal(newest, oldest);
+
+        var overCap = await _meterGlucose.GetUnattributedAsync(from: null, to: null, limit: 1);
+        overCap.Select(m => m.Id).Should().Equal(newest);
+
+        var updated = await _meterGlucose.SetPatientDeviceIdsAsync(new Dictionary<Guid, Guid> { [newest] = deviceId });
+        updated.Should().Be(1);
+        (await _context.MeterGlucose.AsNoTracking().FirstAsync(e => e.Id == newest)).PatientDeviceId.Should().Be(deviceId);
+    }
+
+    [Fact]
+    public async Task DeviceEvents_ReturnsOnlyRequestedEventTypes()
+    {
+        var sensorStart = SeedDeviceEvent(Base, DeviceEventType.SensorStart);
+        var sensorChange = SeedDeviceEvent(Base.AddHours(1), DeviceEventType.SensorChange);
+        SeedDeviceEvent(Base.AddHours(2), DeviceEventType.SiteChange);
+        SeedDeviceEvent(Base.AddHours(3), DeviceEventType.PodChange);
+
+        var sensorEvents = await _deviceEvents.GetUnattributedAsync(
+            from: null, to: null,
+            eventTypes: [DeviceEventType.SensorStart, DeviceEventType.SensorChange],
+            limit: 100);
+
+        sensorEvents.Select(e => e.Id).Should().BeEquivalentTo([sensorStart, sensorChange]);
+        sensorEvents.Should().OnlyContain(e =>
+            e.EventType == DeviceEventType.SensorStart || e.EventType == DeviceEventType.SensorChange);
+    }
+
+    [Fact]
+    public async Task DeviceEvents_NewestFirst_AtCapReturnsAll_OneOverDropsOldest()
+    {
+        var deviceId = SeedDevice();
+        var oldest = SeedDeviceEvent(Base, DeviceEventType.SiteChange);
+        var newest = SeedDeviceEvent(Base.AddHours(2), DeviceEventType.SiteChange);
+        SeedDeviceEvent(Base.AddHours(1), DeviceEventType.SiteChange, patientDeviceId: deviceId);
+        SeedDeviceEvent(Base.AddDays(-30), DeviceEventType.SiteChange);
+
+        var atCap = await _deviceEvents.GetUnattributedAsync(
+            Base.AddDays(-1), Base.AddDays(1), [DeviceEventType.SiteChange], limit: 2);
+        atCap.Select(e => e.Id).Should().Equal(newest, oldest);
+
+        var overCap = await _deviceEvents.GetUnattributedAsync(
+            Base.AddDays(-1), Base.AddDays(1), [DeviceEventType.SiteChange], limit: 1);
+        overCap.Select(e => e.Id).Should().Equal(newest);
+    }
+
+    [Fact]
+    public async Task DeviceEvents_NoEventTypes_ReturnsEmpty()
+    {
+        SeedDeviceEvent(Base, DeviceEventType.SiteChange);
+
+        var result = await _deviceEvents.GetUnattributedAsync(from: null, to: null, eventTypes: [], limit: 100);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeviceEvents_SetPatientDeviceIds_UpdatesOnlyMappedRows()
+    {
+        var deviceId = SeedDevice();
+        var stamped = SeedDeviceEvent(Base, DeviceEventType.SiteChange);
+        var untouched = SeedDeviceEvent(Base.AddHours(1), DeviceEventType.SiteChange);
+
+        var updated = await _deviceEvents.SetPatientDeviceIdsAsync(new Dictionary<Guid, Guid> { [stamped] = deviceId });
+
+        updated.Should().Be(1);
+        (await _context.DeviceEvents.AsNoTracking().FirstAsync(e => e.Id == stamped)).PatientDeviceId.Should().Be(deviceId);
+        (await _context.DeviceEvents.AsNoTracking().FirstAsync(e => e.Id == untouched)).PatientDeviceId.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem

`DeviceReattributionService` re-attributed only sensor glucose: registering a CGM left its own `SensorStart`/`SensorChange` events unattributed, and registering an insulin pump back-stamped nothing (the code comment said so verbatim). Per-device reads — deviceage scoping, per-device stats, canonical-stream rank — only see data stamped after registration, so a user registering devices today got an empty device history. This is the unfinished half of closed #124.

## Change

Registration-triggered back-stamping now covers all six `IDeviceAttributed` types: sensor glucose, meter glucose, boluses, temp basals, basal injections, and device events (event-type-filtered in the query so a CGM registration never attributes a SiteChange and the cap isn't spent on ineligible rows).

- **`DeviceAttributionCategories` (Core) is the single source of truth** for which device categories each record type belongs to. Every row is copied from what the live ingest path already passes to the stamper — and the seven ingest sites that owned private copies (TreatmentDecomposer's four arrays, DeviceEventController's `CategoriesFor`, EntryDecomposer, publishers/controllers) now read it, verbatim-identical per review. The registration-side inverse is derived from the forward map (`Categories.Bolus.Contains(device.Category)`), never restated, so back-stamping and live stamping cannot diverge. Uploader derives to nothing.
- The stamper receives the full eligible set, so a same-window rival device can still win a record — matching ingest exactly.
- Repository plumbing: `IDeviceAttributionWriter`/`IDeviceAttributedRepository<TRecord>` + shared `DeviceAttributionExtensions` (window, newest-first, cap); each repo is a 3-line delegation, with TempBasal windowing on `StartTimestamp`. The hand-rolled sensor-glucose implementation was replaced by the shared one. No schema change — `patient_device_id` already exists on all six tables (verified; no pending model changes).
- `PumpEventTypes` is the computed complement of the four sensor types over the enum, and a characterization test pins **both halves member-by-member** — a computed complement means a new enum value lands in the pump half silently, so the explicit pin is what forces a classification decision (mutation-proven with a synthetic enum member).

## Review

A dedicated review pass verified all seven refactored ingest sites element-for-element (no widening/narrowing anywhere), the derived inverse, the event-type split's Npgsql/SQLite translation (string column, `IN` list), and that the interface additions cause no EF model change.

## Tests

13 repo tests (unattributed filter, newest-first, cap at-cap/one-over, event-type filter, and both window bounds pinned inclusively — operator flips fail exactly those tests), 11 service tests (each category's streams, Uploader nothing, rival-device semantics, window pass-through), 14 characterization tests. Mutation-proven across four axes. Suites: Core.Models 598/0, Infrastructure.Data 582/0, DeviceReattributionService 11/0.

Follow-up from #460/#539; completes the registration half of #124.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
