### PR TITLE
fix(web): hide write controls the member lacks scope for, and surface refusals that reach the server

### DIFF
--- a/src/Web/packages/app/src/lib/api/remote-error.ts
+++ b/src/Web/packages/app/src/lib/api/remote-error.ts
@@ -1,0 +1,16 @@
+/**
+ * Message to show for a rejected remote function call.
+ *
+ * SvelteKit rethrows the generated remote function's `error(status, message)` as
+ * an `HttpError` — a plain `{ status, body: { message } }` object, not an
+ * `Error`. A scope refusal is a bare `ForbidResult` with no body, so the 403
+ * message is the HTTP client's own boilerplate; the caller's fallback names the
+ * permission instead.
+ */
+export function remoteErrorMessage(err: unknown, fallback: string): string {
+  const e = err as { status?: number; body?: { message?: unknown } } | null;
+  if (e?.status === 403) return fallback;
+
+  const message = e?.body?.message;
+  return typeof message === "string" && message.trim() ? message : fallback;
+}

--- a/src/Web/packages/app/src/lib/components/alerts/AlertRuleRow.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/AlertRuleRow.svelte
@@ -22,6 +22,8 @@
 
   interface Props {
     rule: AlertRuleResponse;
+    /** Whether the viewer holds alerts.readwrite; gates the mutating actions. */
+    canManage: boolean;
     isToggling: boolean;
     isDeleting: boolean;
     isTesting: boolean;
@@ -35,6 +37,7 @@
 
   let {
     rule,
+    canManage,
     isToggling,
     isDeleting,
     isTesting,
@@ -120,12 +123,14 @@
 
   <!-- Per-row actions -->
   <div class="flex items-center gap-1 shrink-0">
-    <Switch
-      checked={rule.isEnabled ?? false}
-      onCheckedChange={onToggleEnabled}
-      disabled={isToggling}
-      aria-label="Enable rule"
-    />
+    {#if canManage}
+      <Switch
+        checked={rule.isEnabled ?? false}
+        onCheckedChange={onToggleEnabled}
+        disabled={isToggling}
+        aria-label="Enable rule"
+      />
+    {/if}
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>
         {#snippet child({ props }: { props: Record<string, unknown> })}
@@ -145,21 +150,23 @@
         <DropdownMenu.Item onclick={onEdit}>
           <Pencil class="h-4 w-4 mr-2" /> Edit
         </DropdownMenu.Item>
-        <DropdownMenu.Item
-          onclick={onTestFire}
-          disabled={isTesting || !rule.isEnabled}
-        >
-          {#if isTesting}
-            <Loader2 class="h-4 w-4 mr-2 animate-spin" />
-          {:else}
-            <Zap class="h-4 w-4 mr-2" />
-          {/if}
-          Test fire
-        </DropdownMenu.Item>
+        {#if canManage}
+          <DropdownMenu.Item
+            onclick={onTestFire}
+            disabled={isTesting || !rule.isEnabled}
+          >
+            {#if isTesting}
+              <Loader2 class="h-4 w-4 mr-2 animate-spin" />
+            {:else}
+              <Zap class="h-4 w-4 mr-2" />
+            {/if}
+            Test fire
+          </DropdownMenu.Item>
+        {/if}
         <!-- Managed rules live and die with their tracker threshold (the server
              returns 409 on DELETE) — hide the delete action; editing channels
              etc. stays available. -->
-        {#if !rule.managedBy}
+        {#if canManage && !rule.managedBy}
           <DropdownMenu.Separator />
           <AlertDialog.Root>
             <AlertDialog.Trigger>

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
+  import { page } from "$app/state";
+  import { toast } from "svelte-sonner";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import {
     getRules,
     deleteRule,
@@ -36,6 +39,18 @@
   import { isDndActiveNow } from "$lib/components/alerts/dnd";
   import { severity, severityLabel } from "$lib/components/alerts/severity";
 
+  const effectivePermissions: string[] = $derived(
+    (page.data as any).effectivePermissions ?? [],
+  );
+  // Every write on this page — rule toggle/delete/test-fire, acknowledge, and
+  // clearing the manual mute — is gated on alerts.readwrite server-side.
+  const canManageAlerts = $derived(
+    effectivePermissions.includes("*") ||
+      effectivePermissions.includes("alerts.readwrite"),
+  );
+  const NEEDS_ALERTS_READWRITE =
+    "Changing alerts requires the alerts.readwrite permission.";
+
   // ---- Queries ----
   const rulesQuery = getRules();
   const activeAlertsQuery = getActiveAlerts();
@@ -55,6 +70,8 @@
     try {
       await toggleRule(ruleId);
       await rulesQuery.refresh();
+    } catch (err) {
+      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
     } finally {
       togglingRuleId = null;
     }
@@ -65,6 +82,8 @@
     try {
       await deleteRule(ruleId);
       await rulesQuery.refresh();
+    } catch (err) {
+      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
     } finally {
       deletingRuleId = null;
     }
@@ -74,6 +93,8 @@
     testingRuleId = ruleId;
     try {
       await testFire(ruleId);
+    } catch (err) {
+      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
     } finally {
       testingRuleId = null;
     }
@@ -94,6 +115,8 @@
         dndScheduleEnd: current.dndScheduleEnd,
       });
       await dndQuery.refresh();
+    } catch (err) {
+      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
     } finally {
       disablingDnd = false;
     }
@@ -112,6 +135,8 @@
           ),
         ),
       );
+    } catch (err) {
+      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
     } finally {
       acknowledging = false;
     }
@@ -142,11 +167,13 @@
         <p class="text-sm text-muted-foreground">Rules that decide when, how, and where you're notified.</p>
       </div>
     </div>
-    <div class="flex items-center gap-2">
-      <Button onclick={newRule}>
-        <Plus class="h-4 w-4 mr-2" /> New rule
-      </Button>
-    </div>
+    {#if canManageAlerts}
+      <div class="flex items-center gap-2">
+        <Button onclick={newRule}>
+          <Plus class="h-4 w-4 mr-2" /> New rule
+        </Button>
+      </div>
+    {/if}
   </div>
 
   <svelte:boundary>
@@ -193,7 +220,7 @@
     <!-- Do Not Disturb notice, shown only while a manual mute is in effect. -->
     {#if dnd && isDndActiveNow(dnd)}
       <DndNoticeStrip
-        onDisableDnd={() => handleDisableDnd(dnd)}
+        onDisableDnd={canManageAlerts ? () => handleDisableDnd(dnd) : undefined}
         {disablingDnd}
       />
     {/if}
@@ -239,20 +266,22 @@
               <AlertTriangle class="h-5 w-5 shrink-0" />
               <span class="truncate">Active alerts ({activeAlerts.length})</span>
             </CardTitle>
-            <Button
-              class="@sm:shrink-0"
-              variant="outline"
-              size="sm"
-              onclick={handleAcknowledge}
-              disabled={acknowledging || activeAlerts.every((a) => a.acknowledgedAt)}
-            >
-              {#if acknowledging}
-                <Loader2 class="h-4 w-4 mr-2 animate-spin" />
-              {:else}
-                <Check class="h-4 w-4 mr-2" />
-              {/if}
-              Acknowledge all
-            </Button>
+            {#if canManageAlerts}
+              <Button
+                class="@sm:shrink-0"
+                variant="outline"
+                size="sm"
+                onclick={handleAcknowledge}
+                disabled={acknowledging || activeAlerts.every((a) => a.acknowledgedAt)}
+              >
+                {#if acknowledging}
+                  <Loader2 class="h-4 w-4 mr-2 animate-spin" />
+                {:else}
+                  <Check class="h-4 w-4 mr-2" />
+                {/if}
+                Acknowledge all
+              </Button>
+            {/if}
           </div>
         </CardHeader>
         <CardContent class="space-y-2">
@@ -293,15 +322,18 @@
             <Bell class="mx-auto h-8 w-8 opacity-50" />
             <p class="mt-2 text-sm font-medium">No alert rules yet</p>
             <p class="mt-1 text-xs">Add a rule so Nocturne can notify you when glucose goes out of range.</p>
-            <Button class="mt-3" size="sm" onclick={newRule}>
-              <Plus class="h-4 w-4 mr-2" /> New rule
-            </Button>
+            {#if canManageAlerts}
+              <Button class="mt-3" size="sm" onclick={newRule}>
+                <Plus class="h-4 w-4 mr-2" /> New rule
+              </Button>
+            {/if}
           </div>
         {:else}
           <div class="space-y-2">
             {#each rules as rule (rule.id)}
               <AlertRuleRow
                 {rule}
+                canManage={canManageAlerts}
                 isToggling={togglingRuleId === rule.id}
                 isDeleting={deletingRuleId === rule.id}
                 isTesting={testingRuleId === rule.id}

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/alerts-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/alerts-page.svelte.test.ts
@@ -1,0 +1,108 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { page as pageState } from "$app/state";
+import type { AlertRuleResponse } from "$api-clients";
+
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+
+const rules = [
+  {
+    id: "11111111-1111-1111-1111-111111111111",
+    name: "Nighttime low",
+    isEnabled: true,
+    severity: "warning",
+    conditionType: "glucose_below",
+    conditionParams: {},
+    channels: [],
+  },
+] as unknown as AlertRuleResponse[];
+
+/** Stands in for a remote query: awaitable in the template, plus its methods. */
+function remoteQuery<T>(value: T, extra: Record<string, unknown> = {}) {
+  return Object.assign(Promise.resolve(value), {
+    refresh: () => Promise.resolve(),
+    ...extra,
+  });
+}
+
+// `toggleRule` is the shortest write path on the page (one click, no dialog), so
+// it stands in for the server's refusal.
+let toggleImpl: () => Promise<unknown>;
+
+vi.mock("$api/generated/alertRules.generated.remote", () => ({
+  getRules: () => remoteQuery(rules),
+  deleteRule: () => Promise.resolve(),
+  toggleRule: () => toggleImpl(),
+  testFire: () => Promise.resolve(),
+}));
+
+vi.mock("$api/generated/alerts.generated.remote", () => ({
+  getActiveAlerts: () => remoteQuery([], { withOverride: () => undefined }),
+  getAlertHistory: () => remoteQuery({ items: [], totalCount: 0 }),
+  acknowledge: () => ({ updates: () => Promise.resolve() }),
+}));
+
+vi.mock("$api/generated/tenantAlertSettings.generated.remote", () => ({
+  get: () => remoteQuery(null),
+  update: () => Promise.resolve(),
+}));
+
+vi.mock("svelte-sonner", () => ({ toast: { error: toastError } }));
+
+import AlertsPage from "./+page.svelte";
+
+const ruleName = () => page.getByText("Nighttime low");
+const newRuleButton = () => page.getByRole("button", { name: "New rule" });
+const enableSwitch = () => page.getByRole("switch", { name: "Enable rule" });
+const rowActions = () => page.getByRole("button", { name: "Row actions" });
+
+describe("alerts page", () => {
+  beforeEach(() => {
+    toggleImpl = () => Promise.resolve();
+    toastError.mockClear();
+    pageState.data = {};
+  });
+
+  it("hides the write controls from a member without alerts.readwrite", async () => {
+    pageState.data = { effectivePermissions: ["alerts.read"] };
+
+    render(AlertsPage, {});
+
+    // Anchor on the loaded list first: the boundary's pending snippet would
+    // otherwise satisfy every absence assertion below.
+    await expect.element(ruleName()).toBeVisible();
+    await expect.element(newRuleButton()).not.toBeInTheDocument();
+    await expect.element(enableSwitch()).not.toBeInTheDocument();
+
+    await rowActions().click();
+    await expect
+      .element(page.getByRole("menuitem", { name: /Test fire/i }))
+      .not.toBeInTheDocument();
+    await expect
+      .element(page.getByRole("menuitem", { name: /Delete/i }))
+      .not.toBeInTheDocument();
+  });
+
+  it("shows the write controls to a member holding alerts.readwrite", async () => {
+    pageState.data = { effectivePermissions: ["alerts.readwrite"] };
+
+    render(AlertsPage, {});
+
+    await expect.element(ruleName()).toBeVisible();
+    await expect.element(newRuleButton()).toBeVisible();
+    await expect.element(enableSwitch()).toBeVisible();
+  });
+
+  it("surfaces a refused toggle instead of discarding it", async () => {
+    pageState.data = { effectivePermissions: ["alerts.readwrite"] };
+    toggleImpl = () => Promise.reject({ status: 403, body: { message: "Forbidden" } });
+
+    render(AlertsPage, {});
+
+    await expect.element(enableSwitch()).toBeVisible();
+    await enableSwitch().click();
+
+    await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
+  });
+});

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { page } from '$app/state';
+	import { toast } from 'svelte-sonner';
+	import { remoteErrorMessage } from '$lib/api/remote-error';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
@@ -34,6 +37,18 @@
 	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
 	import { time, bg, bgLabel } from '$lib/utils/formatting';
 	import type { CompressionLowSuggestion } from '$lib/api';
+
+	const effectivePermissions: string[] = $derived(
+		(page.data as any).effectivePermissions ?? []
+	);
+	// Accepting, dismissing, deleting and re-running detection all write state
+	// spans and suggestion rows, so the server gates them on glucose.readwrite.
+	const canReviewSuggestions = $derived(
+		effectivePermissions.includes('*') ||
+			effectivePermissions.includes('glucose.readwrite')
+	);
+	const NEEDS_GLUCOSE_READWRITE =
+		'Reviewing compression lows requires the glucose.readwrite permission.';
 
 	// Create resource with automatic layout registration - load ALL suggestions
 	const suggestionsResource = contextResource(
@@ -145,6 +160,8 @@
 			suggestionsResource.refresh();
 			selectedSuggestions = new Set();
 			selectNextSuggestion(firstSelectedIndex);
+		} catch (err) {
+			toast.error(remoteErrorMessage(err, NEEDS_GLUCOSE_READWRITE));
 		} finally {
 			isLoading = false;
 		}
@@ -162,6 +179,8 @@
 			suggestionsResource.refresh();
 			selectedSuggestions = new Set();
 			selectNextSuggestion(firstSelectedIndex);
+		} catch (err) {
+			toast.error(remoteErrorMessage(err, NEEDS_GLUCOSE_READWRITE));
 		} finally {
 			isLoading = false;
 		}
@@ -179,6 +198,8 @@
 			suggestionsResource.refresh();
 			selectedSuggestions = new Set();
 			selectNextSuggestion(firstSelectedIndex);
+		} catch (err) {
+			toast.error(remoteErrorMessage(err, NEEDS_GLUCOSE_READWRITE));
 		} finally {
 			isLoading = false;
 		}
@@ -212,6 +233,8 @@
 			});
 			detectionResult = result;
 			suggestionsResource.refresh();
+		} catch (err) {
+			toast.error(remoteErrorMessage(err, NEEDS_GLUCOSE_READWRITE));
 		} finally {
 			isLoading = false;
 		}
@@ -327,6 +350,7 @@
 					<p class="mb-4 text-muted-foreground">
 						When compression lows are detected during your sleep, they will appear here.
 					</p>
+					{#if canReviewSuggestions}
 					<div class="flex flex-col items-center gap-4 print:hidden">
 						<div class="flex flex-col items-center gap-2 @sm:flex-row @sm:items-end">
 							<div class="flex flex-col gap-1">
@@ -366,6 +390,7 @@
 							</p>
 						{/if}
 					</div>
+					{/if}
 				</CardContent>
 			</Card>
 		{:else if filteredSuggestions.length === 0}
@@ -456,7 +481,9 @@
 												engine={chartEngine}
 												heightClass="h-64"
 												selectionDomain={brushDomain}
-												onSelectionChange={isPending ? handleSelectionChange : undefined}
+												onSelectionChange={isPending && canReviewSuggestions
+													? handleSelectionChange
+													: undefined}
 											>
 												{#snippet tracks(_ctx)}
 													<ThresholdRules />
@@ -505,7 +532,7 @@
 										<p class="font-medium">
 											{time(brushDomain[0])} - {time(brushDomain[1])}
 										</p>
-										{#if isPending}
+										{#if isPending && canReviewSuggestions}
 											<p class="text-sm text-muted-foreground print:hidden">
 												Drag the handles on the chart to adjust
 											</p>
@@ -514,7 +541,7 @@
 								{/if}
 
 								<!-- Bulk Selection Bar -->
-								{#if isBulkMode}
+								{#if isBulkMode && canReviewSuggestions}
 									<div
 									class="mb-4 flex items-center justify-between rounded-lg bg-primary/10 p-3 print:hidden"
 								>
@@ -551,7 +578,7 @@
 								{/if}
 
 								<!-- Actions -->
-								{#if !isBulkMode}
+								{#if !isBulkMode && canReviewSuggestions}
 									{#if isPending}
 										<div class="flex gap-4 print:hidden">
 											<Button

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/compression-lows-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/compression-lows-page.svelte.test.ts
@@ -1,0 +1,93 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { page as pageState } from "$app/state";
+
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+
+const nightStart = Date.UTC(2026, 2, 3, 2, 0);
+const suggestion = {
+  id: "22222222-2222-2222-2222-222222222222",
+  nightOf: "2026-03-03",
+  startMills: nightStart,
+  endMills: nightStart + 45 * 60_000,
+  confidence: 0.8,
+  status: "Pending",
+  lowestGlucose: 52,
+  dropRate: 3,
+  recoveryMinutes: 20,
+};
+
+// No entries, so the page skips the glucose chart and renders just the stats and
+// the review actions this test is about.
+const detail = { suggestion, entries: [] };
+const suggestions = [suggestion];
+
+let acceptImpl: () => Promise<unknown>;
+
+vi.mock("$api/generated/compressionLows.generated.remote", () => ({
+  getSuggestions: () => ({
+    current: suggestions,
+    loading: false,
+    error: undefined,
+    refresh: () => {},
+  }),
+  getSuggestion: () => ({ run: () => Promise.resolve(detail) }),
+  acceptSuggestion: () => acceptImpl(),
+  dismissSuggestion: () => Promise.resolve(),
+  deleteSuggestion: () => Promise.resolve(),
+  triggerDetection: () => Promise.resolve({}),
+}));
+
+vi.mock("svelte-sonner", () => ({ toast: { error: toastError } }));
+
+import CompressionLowsPage from "./+page.svelte";
+
+const detailLoaded = () => page.getByText("Recovery (min)");
+const acceptButton = () => page.getByRole("button", { name: "Accept" });
+const dismissButton = () => page.getByRole("button", { name: "Dismiss" });
+const deleteButton = () => page.getByRole("button", { name: "Delete" });
+
+describe("compression-lows page", () => {
+  beforeEach(() => {
+    acceptImpl = () => Promise.resolve({});
+    toastError.mockClear();
+    pageState.data = {};
+  });
+
+  it("hides the review controls from a member without glucose.readwrite", async () => {
+    pageState.data = { effectivePermissions: ["glucose.read"] };
+
+    render(CompressionLowsPage, {});
+
+    // Anchor on the detail card first: it loads asynchronously, so an absence
+    // assertion would otherwise pass before the actions could ever render.
+    await expect.element(detailLoaded()).toBeVisible();
+    await expect.element(acceptButton()).not.toBeInTheDocument();
+    await expect.element(dismissButton()).not.toBeInTheDocument();
+    await expect.element(deleteButton()).not.toBeInTheDocument();
+  });
+
+  it("shows the review controls to a member holding glucose.readwrite", async () => {
+    pageState.data = { effectivePermissions: ["glucose.readwrite"] };
+
+    render(CompressionLowsPage, {});
+
+    await expect.element(detailLoaded()).toBeVisible();
+    await expect.element(acceptButton()).toBeVisible();
+    await expect.element(dismissButton()).toBeVisible();
+    await expect.element(deleteButton()).toBeVisible();
+  });
+
+  it("surfaces a refused accept instead of discarding it", async () => {
+    pageState.data = { effectivePermissions: ["glucose.readwrite"] };
+    acceptImpl = () => Promise.reject({ status: 403, body: { message: "Forbidden" } });
+
+    render(CompressionLowsPage, {});
+
+    await expect.element(acceptButton()).toBeVisible();
+    await acceptButton().click();
+
+    await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
## Problem

The alert-rules page and the compression-low review page rendered their write controls for every member and swallowed refusals: all handlers were `try { … } finally { … }` with no catch. A member without `alerts.readwrite` clicked Delete, the spinner stopped, and the rule was still there. Compression-low actions require `glucose.readwrite` (Owner/Admin only) with the same silent shape. Verification found a fifth unguarded write beyond the brief — Acknowledge All, which also requires `alerts.readwrite`.

## Change

- **Hide, per the app's unambiguous convention** (`{#if canX}` on every permission-gated surface; `settings/audit` is the precedent for a read-visible page with individually gated writes): New rule, the row enable switch, Test fire, Delete, Acknowledge All, the DND turn-off, the compression-low Run Detection form, bulk bar, per-item Accept/Dismiss/Delete, and the chart brush handles + hint. Navigation-only controls stay. The scope check is the existing inline `$derived` off `effectivePermissions` idiom — no new helper minted for it.
- **Refusals that still reach the server surface as toasts** via one shared `remoteErrorMessage(err, fallback)`. The non-obvious part it documents: SvelteKit rethrows a remote refusal as an `HttpError` (`{status, body:{message}}`), not an `Error`, so the existing `instanceof Error` idiom silently misses it — and `RequireScopeAttribute` returns a body-less `ForbidResult`, so the 403 branch uses a caller-supplied message naming the permission rather than the HTTP client's boilerplate; other statuses show the server's message.

## Tests

Six new browser component tests (permitted role sees controls; refused role doesn't; a rejected call surfaces the refusal — asserting the toast fired, not its wording), anchored on a positive locator first so absence assertions can't pass against the loading boundary. Mutation-proven: forcing the gates open and removing the catches fails 4 of 6, with vitest additionally reporting the two swallowed rejections the catches exist to surface. 12/12 with the fix; `pnpm check` identical to baseline.

Note for CI: the browser suite is flaky when vite's dep optimizer re-optimizes mid-run; `--fileParallelism=false` with cached deps is reliable.

Follow-up from #634.

https://claude.ai/code/session_01NwnN3ND2eSXKAxJteNWSXb
