### PR TITLE
chore(mylife): drop the dead sync-months constants and fix the app-platform docs

### DIFF
--- a/src/Core/Nocturne.Core.Constants/ConnectorConfigurationConstants.cs
+++ b/src/Core/Nocturne.Core.Constants/ConnectorConfigurationConstants.cs
@@ -306,19 +306,16 @@ public static class ConnectorEnvironmentVariables
     public const string MyLifeTempBasalConsolidationWindowMinutes = "CONNECT_MYLIFE_TEMP_BASAL_CONSOLIDATION_WINDOW_MINUTES";
 
     /// <summary>
-    /// Platform identifier sent to the MyLife API (e.g., "android", "ios").
+    /// Numeric platform identifier sent as the appPlatform argument of the MyLife Login
+    /// SOAP request. Defaults to 2.
     /// </summary>
     public const string MyLifeAppPlatform = "CONNECT_MYLIFE_APP_PLATFORM";
 
     /// <summary>
-    /// App version string sent to the MyLife API for compatibility negotiation.
+    /// Numeric app version sent as the appVersion argument of the MyLife Login SOAP request
+    /// for compatibility negotiation. Defaults to 20403.
     /// </summary>
     public const string MyLifeAppVersion = "CONNECT_MYLIFE_APP_VERSION";
-
-    /// <summary>
-    /// Number of months of historical data to sync on the initial MyLife import.
-    /// </summary>
-    public const string MyLifeSyncMonths = "CONNECT_MYLIFE_SYNC_MONTHS";
 
     // ========================================================================
     // Nightscout Source Configuration

--- a/src/Infrastructure/Nocturne.Infrastructure.Shared/Constants/DefaultConstants.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Shared/Constants/DefaultConstants.cs
@@ -63,7 +63,6 @@ public static class DefaultConstants
         {
             public const int AppPlatform = 2;
             public const int AppVersion = 20403;
-            public const int SyncMonths = 6;
         }
     }
 


### PR DESCRIPTION
## What

- Deletes `CONNECT_MYLIFE_SYNC_MONTHS` and `DefaultConstants.Connectors.MyLife.SyncMonths` — both orphaned by the connector refactor that removed `MyLifeConnectorConfiguration.SyncMonths`. Nothing reads either, so setting the env var silently did nothing; the effective bound is `BaseConnectorService.DefaultInitialSyncFloor()` (the same six-month floor every connector uses).
- Corrects the `MyLifeAppPlatform` doc comment: the property is `int AppPlatform = 2`, forwarded verbatim into the `appPlatform` argument of the MyLife Login SOAP request — not the `"android"`/`"ios"` string the comment described. The adjacent `MyLifeAppVersion` comment had the identical defect (`int AppVersion = 20403` sent as a SOAP int, documented as a string) and is fixed in the same pass.

## Why delete rather than wire

No sibling connector exposes a config knob for its initial-sync window — the only per-connector customisation is in code (`NightscoutConnectorService` overrides the floor to null; Tandem uses the default directly). Wiring MyLife would have made it the odd one out for a knob nobody asked for, whose default (6 months) is exactly what the shared floor already provides.

## Noted, not done here

`DefaultConstants.Connectors` is entirely unreferenced (`Glooko.Server`, `CareLink.Region`, `Dexcom.Region`, `LibreLinkUp.Region`, `MyLife.*` are all dead, duplicated by `ConnectorDefaults` and `[ConnectorProperty(DefaultValue = …)]`). That's a larger dedup than this fix and is queued as its own follow-up item.

## Verification

- Repo-wide `git grep` for `SyncMonths`/`SYNC_MONTHS` over all tracked files returns only the two deleted declaration sites.
- `dotnet build nocturne.sln`: 0 errors.

https://claude.ai/code/session_01FC5TxNBf54o4kvhAWxPGB7
