### PR TITLE
fix(audit): system-attribute manually triggered connector syncs

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/ConnectorSyncService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorSyncService.cs
@@ -1,5 +1,7 @@
+using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 
 namespace Nocturne.API.Services.Connectors;
@@ -80,6 +82,14 @@ public class ConnectorSyncService : IConnectorSyncService
                     scope.ServiceProvider.GetRequiredService<ITenantAccessor>();
                 scopedTenantAccessor.SetTenant(tenantContext);
             }
+
+            // A manual trigger ingests the same connector data as the scheduled sync and must be
+            // attributed the same way. TenantDbContextFactory stamps this scope's IAuditContext
+            // onto every context it creates for the V4 repositories, and a child scope's is a
+            // blank user context (IsSystem = false) — without this push the imports are audited
+            // as null-attributed user mutations. Mirrors ConnectorBackgroundService.
+            using var systemScope = SystemAuditScope.Push(
+                scope.ServiceProvider.GetRequiredService<IAuditContext>());
 
             var executors = scope.ServiceProvider.GetServices<IConnectorSyncExecutor>();
             var executor = executors.FirstOrDefault(e =>

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorSyncServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorSyncServiceTests.cs
@@ -2,9 +2,11 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.Connectors;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 using Xunit;
 
@@ -41,6 +43,10 @@ public class ConnectorSyncServiceTests
             return mock.Object;
         });
 
+        // Mirrors the production registration (Program.cs) — the sync scope resolves
+        // the mutable scoped AuditContext to mark it system for the sync's duration.
+        services.AddScoped<IAuditContext, AuditContext>();
+
         foreach (var executor in executors)
         {
             services.AddSingleton<IConnectorSyncExecutor>(executor);
@@ -51,8 +57,10 @@ public class ConnectorSyncServiceTests
 
     private static IConnectorSyncExecutor CreateMockExecutor(
         string connectorId,
-        SyncResult? result = null)
+        SyncResult? result = null,
+        Action<IServiceProvider>? onSyncScope = null)
     {
+        var syncResult = result ?? new SyncResult { Success = true, Message = "OK" };
         var mock = new Mock<IConnectorSyncExecutor>();
         mock.Setup(x => x.ConnectorId).Returns(connectorId);
         mock.Setup(x => x.ExecuteSyncAsync(
@@ -60,7 +68,11 @@ public class ConnectorSyncServiceTests
                 It.IsAny<SyncRequest>(),
                 It.IsAny<CancellationToken>(),
                 It.IsAny<ISyncProgressReporter?>()))
-            .ReturnsAsync(result ?? new SyncResult { Success = true, Message = "OK" });
+            .ReturnsAsync((IServiceProvider sp, SyncRequest _, CancellationToken _, ISyncProgressReporter? _) =>
+            {
+                onSyncScope?.Invoke(sp);
+                return syncResult;
+            });
         return mock.Object;
     }
 
@@ -105,6 +117,28 @@ public class ConnectorSyncServiceTests
         // Assert
         result.Success.Should().BeFalse();
         result.Message.Should().Contain("Unknown connector");
+    }
+
+    [Fact]
+    public async Task TriggerSyncAsync_MarksScopedAuditContextAsSystem()
+    {
+        // Regression test for the mutation_audit_log firehose: V4 repositories stamp their
+        // factory-created DbContexts from the scoped IAuditContext, and the child scope this
+        // service creates starts with a blank user context (IsSystem = false), so every record
+        // a manually triggered sync imported was audited with null attribution instead of being
+        // skipped as a system mutation.
+        bool? capturedIsSystemMutation = null;
+        var executor = CreateMockExecutor(
+            "test",
+            onSyncScope: sp =>
+                capturedIsSystemMutation = sp.GetRequiredService<IAuditContext>().IsSystemMutation());
+        var sut = CreateService(BuildProvider(executor));
+
+        // Act
+        await sut.TriggerSyncAsync("test", new SyncRequest(), CancellationToken.None);
+
+        // Assert
+        capturedIsSystemMutation.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## What

`ConnectorSyncService.TriggerSyncAsync` runs the sync in a child DI scope that copied only the tenant, leaving the scope's `IAuditContext` blank (`IsSystem=false`, all-null actor). `TenantDbContextFactory` stamps that context onto every DbContext it creates for the V4 repositories, and since #637 the context-level property beats the request scope's — so the writes a triggered sync makes through the factory without a publisher-level `SystemAuditScope` (profiles via `ProfileDecomposer`, notes, sleep sessions) were audited as **null-attributed user mutations**: the exact actorless-row shape #637 eliminated.

Fix: push `SystemAuditScope` over the child scope's context right after the tenant copy, mirroring `ConnectorBackgroundService` — a sync is now attributed identically whether the schedule or a person triggered it.

## Premise correction from the backlog item

The suspected `DevicePublisher.PublishDeviceStatusAsync` sibling asymmetry is a red herring: the writes it triggers happen in `DeviceStatusDecomposer`, which already pushes `SystemAuditScope` itself. A push there would have been a no-op for this hole while profiles/notes/sleep sessions kept writing actorless rows. Untouched.

## Test

`TriggerSyncAsync_MarksScopedAuditContextAsSystem`, structured like the sibling `ConnectorBackgroundServiceTests` test, capturing the audit context **inside** the executor (asserting after the sync returns reads the value `SystemAuditScope` restores on dispose — the commit message records why). Mutation-proven: with the push commented out, the test fails (`Expected capturedIsSystemMutation to be True, but found False`); restored, green. Full `Nocturne.API.Tests` suite: 5242 passed, 0 failed.

## Adjacent findings (filed to the round-2 backlog, not fixed here)

- Manual syncs still write **user**-attributed rows on the injected-scoped-context path (`StateSpanRepository` via `MetadataPublisher.PublishStateSpansAsync`/`ActivityService`; `AlertExcursionEntity` via `ICanonicalAlertEvaluator` outside `GlucosePublisher`'s scope). Consequence: the interceptor sets `DeletedByUser = !IsSystemMutation()`, so a manual sync's soft-deletes there get flagged user-deleted, which blocks a later resync from re-creating those rows. Closing it means also setting `dbContext.AuditContext = SystemAuditContext.ForService(...)` the way the background path does.
- `ConnectorCursorResetJobService` creates four child scopes with no audit attribution at all — same class of hole, unexamined.

https://claude.ai/code/session_01FC5TxNBf54o4kvhAWxPGB7
