### PR TITLE
test: guard tests/Unit against unearned Category=Integration tags

### DIFF
--- a/tests/Unit/Nocturne.API.Tests/Nocturne.API.Tests.csproj
+++ b/tests/Unit/Nocturne.API.Tests/Nocturne.API.Tests.csproj
@@ -29,6 +29,10 @@
         <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="Microsoft.Data.Sqlite" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <!-- The central 4.8.0 pin is for the source generators, which must load in Visual Studio's
+             Roslyn. Here the parser only reads test sources, and EF Core's design-time package
+             already pulls 5.0.0 in transitively, so anything older is a version conflict. -->
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="5.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\API\Nocturne.API\Nocturne.API.csproj" />

--- a/tests/Unit/Nocturne.API.Tests/TestSuite/UnitTestIntegrationTraitTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/TestSuite/UnitTestIntegrationTraitTests.cs
@@ -1,0 +1,187 @@
+using FluentAssertions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Nocturne.API.Tests.TestSuite;
+
+/// <summary>
+/// CI runs the unit suite under <c>Category!=Integration</c>, so a test in <c>tests/Unit</c> that
+/// carries the Integration trait runs nowhere on CI and can rot to red locally while CI stays green.
+/// </summary>
+/// <remarks>
+/// The trait is earned by binding to an xUnit fixture — <c>[Collection]</c>,
+/// <c>IClassFixture&lt;&gt;</c> or <c>ICollectionFixture&lt;&gt;</c>, on the class or on a base
+/// class — which is what every Integration-tagged class under <c>tests/Integration</c> has and what
+/// makes the container, host or database it needs a real reason to sit out a CI run.
+/// <para>
+/// A source scan rather than a reflection one: each unit test project builds its own assembly and no
+/// test process loads the others, so reflection can only ever see the project it runs in.
+/// </para>
+/// </remarks>
+public class UnitTestIntegrationTraitTests
+{
+    private static readonly IReadOnlyList<ScannedFile> UnitFiles = Scan("Unit");
+
+    private static readonly ILookup<string, TestType> DeclarationsByName = UnitFiles
+        .Concat(Scan("Shared"))
+        .SelectMany(file => file.Types)
+        .ToLookup(type => type.Name, StringComparer.Ordinal);
+
+    [Fact]
+    public void NoUnitTestCarriesTheIntegrationTraitWithoutAFixture()
+    {
+        var offenders = UnitFiles
+            .SelectMany(file => file.Types)
+            .Where(type => type.CarriesIntegrationTrait && !IsFixtureBound(type))
+            .Select(type => $"{type.Name} ({type.Path})")
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "CI filters the unit suite on Category!=Integration, so tagging a test that binds no " +
+            "fixture drops it from every CI run and leaves it to fail only on developer machines; " +
+            "a test that genuinely needs a fixture belongs under tests/Integration");
+    }
+
+    [Fact]
+    public void TheScanSeesTheUnitTestTree()
+    {
+        // Without this the sweep above passes by parsing nothing at all — a moved directory, a
+        // changed build layout or a syntax the parser rejects would make it a test of nothing.
+        var types = UnitFiles.SelectMany(file => file.Types).ToList();
+
+        types.Should().HaveCountGreaterThan(300,
+            "the unit suite is hundreds of test classes; finding almost none means the scan lost " +
+            "the source tree rather than that the tree shrank");
+
+        foreach (var file in UnitFiles.Where(file => file.MentionsCategoryTrait))
+        {
+            file.Types.Should().NotBeEmpty(
+                "{0} declares category traits, so a scan that finds no type in it has failed to " +
+                "parse the file and would miss any trait inside it",
+                file.Path);
+        }
+    }
+
+    [Fact]
+    public void FixtureBindingIsResolvedThroughBaseClasses()
+    {
+        var inherited = UnitFiles
+            .SelectMany(file => file.Types)
+            .Where(type => !type.DeclaresFixtureBinding && IsFixtureBound(type));
+
+        inherited.Should().NotBeEmpty(
+            "unit tests bind fixtures through shared base classes, so a resolver that only reads " +
+            "the class's own declaration would call those tests unearned");
+    }
+
+    private static bool IsFixtureBound(TestType type) => IsFixtureBound(type, []);
+
+    private static bool IsFixtureBound(TestType type, HashSet<string> visited) =>
+        type.DeclaresFixtureBinding
+        || type.BaseNames.Any(name =>
+            visited.Add(name) && DeclarationsByName[name].Any(@base => IsFixtureBound(@base, visited)));
+
+    private static List<ScannedFile> Scan(string tree)
+    {
+        var root = RepositoryRoot();
+        var files = new List<ScannedFile>();
+
+        foreach (var path in Directory.EnumerateFiles(
+                     Path.Combine(root, "tests", tree), "*.cs", SearchOption.AllDirectories))
+        {
+            if (path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
+                || path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(path);
+            var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
+
+            var types = CSharpSyntaxTree.ParseText(text).GetRoot()
+                .DescendantNodes()
+                .OfType<TypeDeclarationSyntax>()
+                .Select(type => new TestType(
+                    type.Identifier.ValueText,
+                    relative,
+                    BaseNames(type),
+                    DeclaresFixtureBinding(type),
+                    CarriesIntegrationTrait(type)))
+                .ToList();
+
+            files.Add(new ScannedFile(
+                relative, types, text.Contains("Trait(\"Category\"", StringComparison.Ordinal)));
+        }
+
+        return files;
+    }
+
+    private static bool DeclaresFixtureBinding(TypeDeclarationSyntax type) =>
+        Attributes(type.AttributeLists).Any(attribute => AttributeName(attribute) == "Collection")
+        || BaseNames(type).Any(name => name is "IClassFixture" or "ICollectionFixture");
+
+    private static bool CarriesIntegrationTrait(TypeDeclarationSyntax type) =>
+        Attributes(type.AttributeLists.Concat(type.Members.SelectMany(m => m.AttributeLists)))
+            .Any(IsIntegrationTrait);
+
+    private static bool IsIntegrationTrait(AttributeSyntax attribute) =>
+        AttributeName(attribute) == "Trait"
+        && attribute.ArgumentList?.Arguments
+            .Select(argument => (argument.Expression as LiteralExpressionSyntax)?.Token.ValueText)
+            .SequenceEqual(["Category", "Integration"]) == true;
+
+    private static IEnumerable<AttributeSyntax> Attributes(IEnumerable<AttributeListSyntax> lists) =>
+        lists.SelectMany(list => list.Attributes);
+
+    private static string AttributeName(AttributeSyntax attribute)
+    {
+        var name = SimpleName(attribute.Name);
+        return name.EndsWith("Attribute", StringComparison.Ordinal)
+            ? name[..^"Attribute".Length]
+            : name;
+    }
+
+    private static List<string> BaseNames(TypeDeclarationSyntax type) =>
+        type.BaseList is null ? [] : [.. type.BaseList.Types.Select(@base => SimpleName(@base.Type))];
+
+    private static string SimpleName(NameSyntax name) => name switch
+    {
+        GenericNameSyntax generic => generic.Identifier.ValueText,
+        QualifiedNameSyntax qualified => SimpleName(qualified.Right),
+        SimpleNameSyntax simple => simple.Identifier.ValueText,
+        _ => name.ToString(),
+    };
+
+    private static string SimpleName(TypeSyntax type) =>
+        type is NameSyntax name ? SimpleName(name) : type.ToString();
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (Directory.Exists(Path.Combine(directory.FullName, "tests", "Unit")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"No tests/Unit directory above {AppContext.BaseDirectory}.");
+    }
+
+    private sealed record TestType(
+        string Name,
+        string Path,
+        IReadOnlyList<string> BaseNames,
+        bool DeclaresFixtureBinding,
+        bool CarriesIntegrationTrait);
+
+    private sealed record ScannedFile(
+        string Path,
+        IReadOnlyList<TestType> Types,
+        bool MentionsCategoryTrait);
+}


### PR DESCRIPTION
## What

#687 fixed two files where mock-only tests wore `Category=Integration` and were silently excluded from every CI run (the class of bug: tests that only fail off-CI). This closes the class.

**Audit first:** a sweep of all 614 files / 960 trait sites under `tests/Unit` found **zero** Integration carriers remain — #687 got the last two, so this PR is purely the recurrence guard.

**The earn-condition, derived from the code:** every legitimate `Category=Integration` class under `tests/Integration` binds an xUnit fixture — `[Collection]`, `IClassFixture<>`, or `ICollectionFixture<>`, directly or through a base class. So the guard: nothing under `tests/Unit` may carry the Integration trait without such a binding, failing with the offending class names and paths.

**Why a Roslyn source scan, not reflection:** the unit suite is 19 assemblies and no test process loads more than its own — reflection can only ever see a nineteenth of the tree. The scan parses `tests/Unit` + `tests/Shared`, resolves fixture bindings transitively through base classes (cycle-guarded), and sidesteps the self-match trap a regex scan would have. Two guard-the-guard facts: the scan must find 300+ test classes (an empty enumeration fails loudly), and inherited fixture binding must be observed in the wild (so the base-class branch can't silently go dead).

One flagged judgement call: `Microsoft.CodeAnalysis.CSharp` needed `VersionOverride="5.0.0"` in this one test csproj — the central 4.8.0 pin exists for source generators (which must load in VS's Roslyn), and EF Core's design-time package already drags 5.0.0 in transitively here, making 4.8.0 a hard NU1107. Local override keeps the generators' pin untouched.

## Mutation proofs

1. Re-adding an Integration tag to a mock-only test in `ServiceCacheTests` (one of #687's files): guard fails naming `ServiceCacheTests (tests/Unit/.../ServiceCacheTests.cs)`. Reverted.
2. Sabotaging the scan glob to enumerate nothing: both guard-the-guard facts fail (`found 0: {empty}`) — which is exactly the vacuous-pass mode they exist to make loud. Restored.

Full `Nocturne.API.Tests` under the CI filter: 5244 passed, 0 failed.

## Adjacent findings (filed to the round-2 backlog, not fixed here)

- `tests/Integration/Nocturne.API.Tests/LoopServiceParityTests.cs` is the mirror-image bug: Integration-tagged, pure Moq, no fixture — the only one of 48 Integration carriers with no fixture binding. Lives outside `tests/Unit`, so outside this guard's scope.
- 9 methods under `tests/Unit` carry `Category=Performance`, which CI also excludes — deliberate benchmarks, but the same silent-exclusion shape, unguarded.

https://claude.ai/code/session_01FC5TxNBf54o4kvhAWxPGB7
