### PR TITLE
fix(security): scope-gate the actogram and year-overview reports

### DIFF
--- a/src/API/Nocturne.API/Authorization/ActogramReadScopeGuard.cs
+++ b/src/API/Nocturne.API/Authorization/ActogramReadScopeGuard.cs
@@ -1,0 +1,57 @@
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Enforces per-category OAuth read scopes on the actogram report, the read-side sibling of
+/// <see cref="ActivityReadScopeGuard"/>. <c>IActogramReportService</c> merges four storages into
+/// one payload — glucose, heart rates, step counts and sleep sessions — and each dedicated storage
+/// has its own read scope, so a single <c>RequireScope</c> attribute on the action can only decide
+/// admission, not what the response may contain. The attribute therefore lists
+/// <see cref="AdmissionScopes"/> as an OR and this guard empties every category the caller does not
+/// hold.
+/// </summary>
+internal static class ActogramReadScopeGuard
+{
+    /// <summary>
+    /// The read scopes that admit a caller to the actogram: holding any one of them means at least
+    /// one category in the response is visible. Attribute arguments must be compile-time constants,
+    /// so the admission attribute repeats these constants inline.
+    /// </summary>
+    public static readonly IReadOnlyList<string> AdmissionScopes =
+    [
+        OAuthScopes.GlucoseRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead,
+    ];
+
+    /// <summary>
+    /// Empties every category of <paramref name="data"/> whose read scope the caller does not hold.
+    /// </summary>
+    /// <param name="data">The report about to be returned.</param>
+    /// <param name="grantedScopes">The caller's normalized granted scopes.</param>
+    public static ActogramReportData Redact(
+        ActogramReportData data,
+        IReadOnlySet<string> grantedScopes)
+    {
+        // Thresholds are the band edges of the glucose series, so they leave with it.
+        if (!OAuthScopes.SatisfiesScope(grantedScopes, OAuthScopes.GlucoseRead))
+        {
+            data.Glucose = [];
+            data.Thresholds = new ChartThresholdsDto();
+        }
+
+        if (!OAuthScopes.SatisfiesScope(grantedScopes, OAuthScopes.HeartRateRead))
+            data.HeartRates = [];
+
+        if (!OAuthScopes.SatisfiesScope(grantedScopes, OAuthScopes.StepCountRead))
+            data.StepCounts = [];
+
+        if (!OAuthScopes.SatisfiesScope(grantedScopes, OAuthScopes.SleepRead))
+            data.SleepSpans = [];
+
+        return data;
+    }
+}

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/ActogramController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/ActogramController.cs
@@ -1,6 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Analytics;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using OpenApi.Remote.Attributes;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
@@ -16,6 +20,7 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 /// </remarks>
 /// <seealso cref="IActogramReportService"/>
 /// <seealso cref="ActogramReportData"/>
+/// <seealso cref="ActogramReadScopeGuard"/>
 [ApiController]
 [Tags("Analytics")]
 [Route("api/v4/[controller]")]
@@ -43,6 +48,11 @@ public class ActogramController : ControllerBase
     /// <param name="cancellationToken">Cancellation token.</param>
     [HttpGet]
     [RemoteQuery]
+    [RequireScope(
+        OAuthScopes.GlucoseRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead)]
     [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
     [ProducesResponseType(typeof(ActogramReportData), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -59,7 +69,7 @@ public class ActogramController : ControllerBase
         try
         {
             var result = await _service.GetAsync(startTime, endTime, cancellationToken);
-            return Ok(result);
+            return Ok(ActogramReadScopeGuard.Redact(result, HttpContext.GetGrantedScopes()));
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/DataOverviewController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/DataOverviewController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Services;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
@@ -12,6 +14,12 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 /// <remarks>
 /// Responses are cached (300s for years and GRI timeline; 180s for daily summary)
 /// to reduce database load when the heatmap re-renders.
+/// <para>
+/// Every response is an aggregate — record counts, daily averages, monthly GRI — so the whole
+/// controller sits behind <see cref="OAuthScopes.ReportsRead"/> rather than the read scope of each
+/// category it counts, matching <c>StatisticsController</c>. Public shares are narrowed further by
+/// per-category share RLS.
+/// </para>
 /// </remarks>
 /// <seealso cref="IDataOverviewService"/>
 /// <seealso cref="DataOverviewYearsResponse"/>
@@ -21,6 +29,7 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 [Tags("Analytics")]
 [Route("api/v4/year-overview")]
 [Produces("application/json")]
+[RequireScope(OAuthScopes.ReportsRead)]
 [ClientPropertyName("dataOverview")]
 public class DataOverviewController : ControllerBase
 {

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ActogramReadScopeGuardTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ActogramReadScopeGuardTests.cs
@@ -1,0 +1,179 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+[Trait("Category", "Unit")]
+public class ActogramReadScopeGuardTests
+{
+    private static ActogramReportData OneRecordPerCategory() => new()
+    {
+        Glucose = [new GlucosePointDto { Time = 1700000000000, Sgv = 120 }],
+        Thresholds = new ChartThresholdsDto { Low = 70, High = 180 },
+        HeartRates = [new HeartRatePointDto { Time = 1700000000000, Bpm = 64 }],
+        StepCounts = [new StepBubbleDto { Time = 1700000000000, Steps = 900 }],
+        SleepSpans = [new ActogramSleepSpan { StartMills = 1, EndMills = 2, State = "deep" }],
+    };
+
+    private static IReadOnlySet<string> Granted(params string[] scopes) =>
+        new HashSet<string>(scopes);
+
+    [Fact]
+    public void Redact_GlucoseOnlyGrant_KeepsGlucoseAndItsThresholds()
+    {
+        var data = ActogramReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.GlucoseRead));
+
+        data.Glucose.Should().HaveCount(1);
+        data.Thresholds.Low.Should().Be(70);
+        data.HeartRates.Should().BeEmpty();
+        data.StepCounts.Should().BeEmpty();
+        data.SleepSpans.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Redact_StepCountOnlyGrant_KeepsOnlyStepCounts()
+    {
+        var data = ActogramReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.StepCountRead));
+
+        data.StepCounts.Should().HaveCount(1);
+        data.Glucose.Should().BeEmpty();
+        data.HeartRates.Should().BeEmpty();
+        data.SleepSpans.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Redact_HeartRateOnlyGrant_KeepsOnlyHeartRates()
+    {
+        var data = ActogramReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.HeartRateRead));
+
+        data.HeartRates.Should().HaveCount(1);
+        data.Glucose.Should().BeEmpty();
+        data.StepCounts.Should().BeEmpty();
+        data.SleepSpans.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The thresholds are read off the active therapy profile, so a caller with no glucose grant
+    /// must not learn the personal target band from them either.
+    /// </summary>
+    [Fact]
+    public void Redact_WithoutGlucose_ClearsTheThresholds()
+    {
+        var data = ActogramReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.SleepRead));
+
+        data.Thresholds.Should().BeEquivalentTo(new ChartThresholdsDto());
+    }
+
+    [Fact]
+    public void Redact_NoScopes_EmptiesEveryCategory()
+    {
+        var data = ActogramReadScopeGuard.Redact(OneRecordPerCategory(), Granted());
+
+        data.Glucose.Should().BeEmpty();
+        data.HeartRates.Should().BeEmpty();
+        data.StepCounts.Should().BeEmpty();
+        data.SleepSpans.Should().BeEmpty();
+        data.Thresholds.Should().BeEquivalentTo(new ChartThresholdsDto());
+    }
+
+    [Fact]
+    public void Redact_FullAccess_KeepsEveryCategory()
+    {
+        var data = ActogramReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.FullAccess));
+
+        data.Glucose.Should().HaveCount(1);
+        data.HeartRates.Should().HaveCount(1);
+        data.StepCounts.Should().HaveCount(1);
+        data.SleepSpans.Should().HaveCount(1);
+        data.Thresholds.Low.Should().Be(70);
+    }
+
+    /// <summary>
+    /// A readwrite grant implies its read counterpart, so a sleep-writing client keeps reading back
+    /// what it wrote.
+    /// </summary>
+    [Fact]
+    public void Redact_ReadWriteGrant_SatisfiesTheReadCategory()
+    {
+        var data = ActogramReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.SleepReadWrite));
+
+        data.SleepSpans.Should().HaveCount(1);
+        data.Glucose.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The admission list must cover exactly the categories the merged report can return, or a
+    /// caller holding one of them is refused the endpoint that serves its own data.
+    /// </summary>
+    [Fact]
+    public void AdmissionScopes_CoverEveryMergedCategory()
+    {
+        ActogramReadScopeGuard.AdmissionScopes.Should().BeEquivalentTo(new[]
+        {
+            OAuthScopes.GlucoseRead,
+            OAuthScopes.HeartRateRead,
+            OAuthScopes.StepCountRead,
+            OAuthScopes.SleepRead,
+        });
+    }
+
+    /// <summary>
+    /// The action attribute is what the pipeline actually enforces, and the guard only runs on a
+    /// request the attribute admitted. Requiring all four instead would 403 every public share,
+    /// because <see cref="OAuthScopes.SleepRead"/> is outside
+    /// <see cref="TenantPermissions.PublicShareScopes"/>.
+    /// </summary>
+    [Fact]
+    public void GetActogram_AdmitsAnyMergedCategory()
+    {
+        var attribute = typeof(ActogramController)
+            .GetMethod(nameof(ActogramController.GetActogram))!
+            .GetCustomAttribute<RequireScopeAttribute>();
+
+        attribute.Should().NotBeNull();
+        attribute!.RequiresAll.Should().BeFalse("holding one category must admit the caller");
+        attribute.RequiredScopes.Should().BeEquivalentTo(ActogramReadScopeGuard.AdmissionScopes);
+    }
+
+    /// <summary>
+    /// Asserts that the handler actually calls the guard: the attribute sweep above and the guard
+    /// tests would both stay green with the call removed, leaving the response unfiltered.
+    /// </summary>
+    [Fact]
+    public async Task GetActogram_RedactsTheCategoriesTheCallerLacks()
+    {
+        var service = new Mock<IActogramReportService>();
+        service
+            .Setup(s => s.GetAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OneRecordPerCategory());
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = Granted(OAuthScopes.StepCountRead);
+
+        var controller = new ActogramController(
+            service.Object, NullLogger<ActogramController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+
+        var result = await controller.GetActogram(startTime: 0, endTime: 1);
+
+        var data = result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<ActogramReportData>().Subject;
+        data.StepCounts.Should().HaveCount(1);
+        data.Glucose.Should().BeEmpty();
+        data.HeartRates.Should().BeEmpty();
+        data.SleepSpans.Should().BeEmpty();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
@@ -58,9 +58,7 @@ public class ControllerAuthorizationCoverageTests
             // underlying rows to the categories the share was granted. Adding [Authorize] here
             // would 401 the anonymous share dashboard. All actions are GET, so there is no write
             // surface to expose.
-            ["Nocturne.API.Controllers.V4.Analytics.ActogramController"] = "public-share read analytics (fallback + share RLS)",
             ["Nocturne.API.Controllers.V4.Analytics.ChartDataController"] = "public-share read analytics (fallback + share RLS)",
-            ["Nocturne.API.Controllers.V4.Analytics.DataOverviewController"] = "public-share read analytics (fallback + share RLS)",
             ["Nocturne.API.Controllers.V4.Analytics.RetrospectiveController"] = "public-share read analytics (fallback + share RLS)",
             ["Nocturne.API.Controllers.V4.Analytics.PredictionController"] = "public-share read analytics (fallback + share RLS)",
 

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ShareReadSurfaceReachabilityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ShareReadSurfaceReachabilityTests.cs
@@ -59,6 +59,12 @@ public class ShareReadSurfaceReachabilityTests
             ["Nocturne.API.Controllers.V4.Health.StepCountController"] = OAuthScopes.StepCountRead,
             ["Nocturne.API.Controllers.V4.Analytics.SensorIntegrityController"] = OAuthScopes.ReportsRead,
             ["Nocturne.API.Controllers.V4.Analytics.StatisticsController"] = OAuthScopes.ReportsRead,
+            ["Nocturne.API.Controllers.V4.Analytics.DataOverviewController"] = OAuthScopes.ReportsRead,
+            // Backs the steps and heart-rate reports, which are not member-only, so its gate must
+            // admit a share holding any one of its categories;
+            // ActogramReadScopeGuard empties the rest. Listed against glucose because the default
+            // share grant is glucose-only and the report still renders its glucose overlay.
+            ["Nocturne.API.Controllers.V4.Analytics.ActogramController"] = OAuthScopes.GlucoseRead,
             // Feeds the data quality report. Its rows are hidden from shares by RLS
             // (compression_low_suggestions has no ShareDataCategories entry), so the gate decides
             // error-vs-empty-list, not what a share can see.


### PR DESCRIPTION
## What

`ActogramController` and `DataOverviewController` were gated only by the default-deny fallback (`HasPermissionsRequirement` = any non-empty permission trie), so a member holding a single permission of any kind — a Viewer with `glucose.read` — could read every category they serve. Member requests are not category-filtered by RLS; only shares are.

- **Actogram** (merges glucose + thresholds, heart rates, step counts, sleep spans): `[RequireScope]` listing the four category read scopes as an **OR** for admission, plus a new `ActogramReadScopeGuard.Redact` that empties each category the caller's scopes don't cover — the read-side sibling of the existing `ActivityReadScopeGuard` concept. Thresholds travel with glucose: they're the caller's personal target band read off the active therapy profile, and the frontend's `resolveGlucoseThresholds` treats zeros as absent, so a redacted payload degrades cleanly.
- **Year-overview**: class-level `[RequireScope(reports.read)]`, matching `StatisticsController` — every response is an aggregate (record counts, daily averages, monthly GRI). This closes the fallback hole (an app grant with only e.g. `alerts.read` could previously read it). Honest residual: a Viewer still sees it, because `reports.read` is by design the cross-category aggregate scope and Viewer holds it; per-category gating of aggregates would diverge from `StatisticsController` and is a policy question beyond this controller.

## Why not `requireAll` on the actogram

`sleep.read` is not in `PublicShareScopes`, so an AND gate would 403 every public share forever — the exact #635 failure class. The steps/heart-rate report pages are deliberately not `memberOnly`, so the endpoint must stay share-reachable; shares are additionally narrowed by per-category share RLS at the DB.

## Premise corrections from the backlog item

- `DataOverviewController` does **not** serve heart-rate/step-count/sleep data — its three actions aggregate glucose, boluses, carbs, notes, device events, state spans and APS snapshots only.
- The claim that #708's report-nav declares heartrate/stepcount/sleep scopes for these pages is wrong — `report-navigation.ts` has no scope field, only `memberOnly` (set on Sleep and IDP alone).

## Tests

New `ActogramReadScopeGuardTests` (modelled on `ActivityReadScopeGuardTests`): redaction per grant shape, admission-list completeness, attribute pinned to `ActogramReadScopeGuard.AdmissionScopes` with `RequiresAll` false, and a handler-level test that the controller actually calls the guard. Both controllers moved out of `FallbackGatedControllers` and into `ShareReadableControllers`; the full share-reachability guard suite is green (483/483 in the Authorization namespace).

Mutation-proven four ways (each applied → failed → restored → green): attribute removed from both controllers (3 failures), from year-overview alone (2), `Redact` call removed with the attribute kept (1), and one category branch dropped from `Redact` (3). Full API unit suite: 5251 passed, 0 failed (one pre-existing wall-clock benchmark flaked under concurrent builds on a re-run; passed on the identical earlier run).

## Flagged for the backlog

Other V4 analytics controllers still lack scope gates — `ChartDataController` (merges glucose + treatments + basal), `AnalyticsController`, `CorrelationController`, `CurrentTherapyStateController`, `PredictionController`, `RetrospectiveController`, `SummaryController`. Also pre-existing and untouched: legacy `api-secret`-header callers aren't in the response-cache Vary set (shared with `ChartDataController`).

https://claude.ai/code/session_01FC5TxNBf54o4kvhAWxPGB7
