### PR TITLE
fix(v4): clamp the remaining V4 routes that declare their own page size

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Models;
@@ -77,6 +78,9 @@ public class StateSpansController : ControllerBase
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
 
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+
         var descending = sort == "timestamp_desc";
         var data = await _stateSpanService.GetStateSpansAsync(
             category, state, from, to, source, active, limit, offset, descending, cancellationToken);
@@ -102,6 +106,9 @@ public class StateSpansController : ControllerBase
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
 
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+
         var descending = sort == "timestamp_desc";
         var data = await _stateSpanService.GetStateSpansAsync(StateSpanCategory.PumpMode, from: from, to: to, count: limit, skip: offset, descending: descending, cancellationToken: cancellationToken);
         var total = await _stateSpanService.CountStateSpansAsync(StateSpanCategory.PumpMode, from: from, to: to, cancellationToken: cancellationToken);
@@ -124,6 +131,9 @@ public class StateSpansController : ControllerBase
     {
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
 
         var descending = sort == "timestamp_desc";
         var data = await _stateSpanService.GetStateSpansAsync(StateSpanCategory.PumpConnectivity, from: from, to: to, count: limit, skip: offset, descending: descending, cancellationToken: cancellationToken);
@@ -148,6 +158,9 @@ public class StateSpansController : ControllerBase
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
 
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+
         var descending = sort == "timestamp_desc";
         var data = await _stateSpanService.GetStateSpansAsync(StateSpanCategory.Override, from: from, to: to, count: limit, skip: offset, descending: descending, cancellationToken: cancellationToken);
         var total = await _stateSpanService.CountStateSpansAsync(StateSpanCategory.Override, from: from, to: to, cancellationToken: cancellationToken);
@@ -170,6 +183,9 @@ public class StateSpansController : ControllerBase
     {
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
 
         var descending = sort == "timestamp_desc";
         var data = await _stateSpanService.GetStateSpansAsync(StateSpanCategory.TemporaryTarget, from: from, to: to, count: limit, skip: offset, descending: descending, cancellationToken: cancellationToken);
@@ -194,6 +210,9 @@ public class StateSpansController : ControllerBase
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
 
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+
         var descending = sort == "timestamp_desc";
         var data = await _stateSpanService.GetStateSpansAsync(StateSpanCategory.Profile, from: from, to: to, count: limit, skip: offset, descending: descending, cancellationToken: cancellationToken);
         var total = await _stateSpanService.CountStateSpansAsync(StateSpanCategory.Profile, from: from, to: to, cancellationToken: cancellationToken);
@@ -216,6 +235,9 @@ public class StateSpansController : ControllerBase
     {
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
 
         var descending = sort == "timestamp_desc";
         var data = await _stateSpanService.GetStateSpansAsync(StateSpanCategory.Exercise, from: from, to: to, count: limit, skip: offset, descending: descending, cancellationToken: cancellationToken);
@@ -240,6 +262,9 @@ public class StateSpansController : ControllerBase
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
 
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+
         var descending = sort == "timestamp_desc";
         var data = await _stateSpanService.GetStateSpansAsync(StateSpanCategory.Illness, from: from, to: to, count: limit, skip: offset, descending: descending, cancellationToken: cancellationToken);
         var total = await _stateSpanService.CountStateSpansAsync(StateSpanCategory.Illness, from: from, to: to, cancellationToken: cancellationToken);
@@ -263,6 +288,9 @@ public class StateSpansController : ControllerBase
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
 
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+
         var descending = sort == "timestamp_desc";
         var data = await _stateSpanService.GetStateSpansAsync(StateSpanCategory.Travel, from: from, to: to, count: limit, skip: offset, descending: descending, cancellationToken: cancellationToken);
         var total = await _stateSpanService.CountStateSpansAsync(StateSpanCategory.Travel, from: from, to: to, cancellationToken: cancellationToken);
@@ -285,6 +313,9 @@ public class StateSpansController : ControllerBase
     {
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
 
         var descending = sort == "timestamp_desc";
         var activityCategories = new[] { StateSpanCategory.Exercise, StateSpanCategory.Illness, StateSpanCategory.Travel };

--- a/src/API/Nocturne.API/Controllers/V4/Audit/AuditController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Audit/AuditController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Responses;
 using Nocturne.API.Services.BackgroundServices;
 using Nocturne.Core.Contracts.Audit;
@@ -61,6 +62,9 @@ public class AuditController : ControllerBase
     {
         if (!HasPermission(TenantPermissions.AuditRead))
             return Forbid();
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
 
         await using var db = await _contextFactory.CreateDbContextAsync(ct);
         db.TenantId = _tenantAccessor.TenantId;
@@ -132,6 +136,9 @@ public class AuditController : ControllerBase
     {
         if (!HasPermission(TenantPermissions.AuditRead))
             return Forbid();
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
 
         await using var db = await _contextFactory.CreateDbContextAsync(ct);
         db.TenantId = _tenantAccessor.TenantId;

--- a/src/API/Nocturne.API/Controllers/V4/Devices/BatteryController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/BatteryController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.Core.Models.Authorization;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Devices;
@@ -189,6 +190,8 @@ public class BatteryController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        limit = V4ReadLimits.ClampLimit(limit);
+
         _logger.LogDebug(
             "Charge cycles requested for device: {Device}, from: {From}, to: {To}, limit: {Limit}",
             device,

--- a/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
@@ -58,6 +59,9 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
         CancellationToken cancellationToken = default
     )
     {
+        count = V4ReadLimits.ClampLimit(count);
+        skip = V4ReadLimits.ClampOffset(skip);
+
         try
         {
             var records = await _bodyWeightService.GetBodyWeightsAsync(count, skip, cancellationToken);

--- a/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Models;
@@ -54,6 +55,9 @@ public class HeartRateController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        count = V4ReadLimits.ClampLimit(count);
+        skip = V4ReadLimits.ClampOffset(skip);
+
         try
         {
             IEnumerable<HeartRate> records;

--- a/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Models;
@@ -54,6 +55,9 @@ public class StepCountController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        count = V4ReadLimits.ClampLimit(count);
+        skip = V4ReadLimits.ClampOffset(skip);
+
         try
         {
             IEnumerable<StepCount> records;

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/TrackersController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Extensions;
 using Nocturne.API.Services.Monitoring;
 using Nocturne.Core.Contracts.Alerts;
@@ -501,6 +502,8 @@ public class TrackersController : ControllerBase, IWriteScopedController
         [FromQuery] int limit = 100
     )
     {
+        limit = V4ReadLimits.ClampLimit(limit);
+
         var userId = HttpContext.GetSubjectIdString();
         var instances = await _repository.GetCompletedInstancesAsync(
             userId,

--- a/src/API/Nocturne.API/Controllers/V4/Platform/CompatibilityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/CompatibilityController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Attributes;
 using Nocturne.API.Configuration;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Services.Compatibility;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Models;
@@ -136,6 +137,9 @@ public class CompatibilityController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
+        count = V4ReadLimits.ClampLimit(count);
+        skip = V4ReadLimits.ClampOffset(skip);
+
         try
         {
             var analyses = await _repository.GetAnalysesAsync(

--- a/src/API/Nocturne.API/Controllers/V4/Platform/SystemEventsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/SystemEventsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.Core.Contracts.Repositories;
 using Nocturne.Core.Models;
 
@@ -41,6 +42,9 @@ public class SystemEventsController : ControllerBase
         [FromQuery] int skip = 0,
         CancellationToken cancellationToken = default)
     {
+        count = V4ReadLimits.ClampLimit(count);
+        skip = V4ReadLimits.ClampOffset(skip);
+
         var fromMills = from.HasValue ? new DateTimeOffset(from.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : (long?)null;
         var toMills = to.HasValue ? new DateTimeOffset(to.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : (long?)null;
         var events = await _repository.GetSystemEventsAsync(

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Contracts.V4.Repositories;
@@ -250,6 +251,10 @@ public class ProfileController : ControllerBase, IWriteScopedController
             return BadRequest(
                 new { error = $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'." }
             );
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+
         var descending = sort == "timestamp_desc";
         var data = await _therapyRepo.GetAsync(
             from,

--- a/src/API/Nocturne.API/Controllers/V4/SleepController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SleepController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.Core.Contracts.Sleep;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
@@ -51,6 +52,9 @@ public class SleepController : ControllerBase
     {
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
 
         var descending = sort == "timestamp_desc";
         var data = await _sleepService.GetSessionsAsync(from, to, type, source, limit, offset, descending, cancellationToken: cancellationToken);

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DiscrepancyController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DiscrepancyController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Attributes;
 using Nocturne.API.Configuration;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Services.Compatibility;
 using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Data.Abstractions;
@@ -124,7 +125,7 @@ public class DiscrepancyController : ControllerBase
     /// <param name="overallMatch">Filter by overall match type (optional)</param>
     /// <param name="fromDate">Start date for filter (optional)</param>
     /// <param name="toDate">End date for filter (optional)</param>
-    /// <param name="count">Number of results to return (default: 100, max: 1000)</param>
+    /// <param name="count">Number of results to return (default: 100, capped at <see cref="V4ReadLimits.MaxPageSize"/>)</param>
     /// <param name="skip">Number of results to skip for pagination (default: 0)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>List of detailed discrepancy analyses</returns>
@@ -152,6 +153,8 @@ public class DiscrepancyController : ControllerBase
             {
                 return Problem(detail: "Skip must be non-negative", statusCode: 400, title: "Bad Request");
             }
+
+            count = V4ReadLimits.ClampLimit(count);
 
             _logger.LogDebug(
                 "Retrieving discrepancy analyses: path={RequestPath}, match={OverallMatch}, count={Count}, skip={Skip}",

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/FoodsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/FoodsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Models;
@@ -261,6 +262,9 @@ public class FoodsController : ControllerBase, IWriteScopedController
     [ProducesResponseType(typeof(Food[]), StatusCodes.Status200OK)]
     public async Task<ActionResult<Food[]>> GetRecentFoods([FromQuery] int limit = 20)
     {
+        limit = V4ReadLimits.ClampLimit(limit);
+
+
         // Recents are tenant-wide; the subject only subtracts the caller's own favorites, so a
         // subject-less caller gets the same list with nothing subtracted.
         var foods = await _favoriteService.GetRecentFoodsAsync(

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.API.Services.Platform;
 using Nocturne.API.Services.Treatments;
@@ -94,6 +95,10 @@ public class NutritionController : ControllerBase, IWriteScopedController
     {
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
+
         var descending = sort == "timestamp_desc";
         var data = await _carbIntakeRepo.GetAsync(from, to, device, source, limit, offset, descending, ct: ct);
         var total = await _carbIntakeRepo.CountAsync(from, to, ct);

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4;
@@ -49,6 +50,9 @@ public class TempBasalController(
     {
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
+
+        limit = V4ReadLimits.ClampLimit(limit);
+        offset = V4ReadLimits.ClampOffset(offset);
 
         var descending = sort == "timestamp_desc";
         var data = await repo.GetAsync(from, to, device, source, limit, offset, descending, ct);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/TempBasalControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/TempBasalControllerTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Controllers.V4.Treatments;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Devices;
@@ -151,4 +152,23 @@ public class TempBasalControllerTests
 
         ((ObjectResult)result.Result!).StatusCode.Should().Be(400);
     }
+
+    [Fact]
+    public async Task GetAll_LimitAtCeiling_ReachesRepositoryUnchanged()
+    {
+        await _controller.GetAll(null, null, V4ReadLimits.MaxPageSize, 0);
+
+        VerifyFetched(V4ReadLimits.MaxPageSize, 0);
+    }
+
+    [Fact]
+    public async Task GetAll_LimitAboveCeiling_IsClamped()
+    {
+        await _controller.GetAll(null, null, V4ReadLimits.MaxPageSize + 1, -1);
+
+        VerifyFetched(V4ReadLimits.MaxPageSize, 0);
+    }
+
+    private void VerifyFetched(int limit, int offset) =>
+        _repo.Verify(r => r.GetAsync(null, null, null, null, limit, offset, true, It.IsAny<CancellationToken>()), Times.Once);
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Audit/AuditControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Audit/AuditControllerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using Nocturne.API.Controllers.V4.Audit;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Responses;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -577,4 +578,54 @@ public class AuditControllerTests : IDisposable
 
         result.Should().BeOfType<OkObjectResult>();
     }
+
+    // ── Read limits ─────────────────────────────────────────────────
+    //
+    // Both audit reads page in EF rather than through a repository, so the clamp is observed on
+    // the pagination the response reports, which is the same value the query was given.
+
+    [Fact]
+    public async Task GetMutations_LimitAtCeiling_IsUnchanged()
+    {
+        var result = await CreateController(Scopes(TenantPermissions.AuditRead)).GetMutationAuditLog(
+            DateTime.UtcNow.AddDays(-1), DateTime.UtcNow, V4ReadLimits.MaxPageSize, 0);
+
+        PaginationOf<MutationAuditDto>(result).Should().BeEquivalentTo(
+            new PaginationInfo(V4ReadLimits.MaxPageSize, 0, 0));
+    }
+
+    [Fact]
+    public async Task GetMutations_LimitAboveCeiling_IsClamped()
+    {
+        var result = await CreateController(Scopes(TenantPermissions.AuditRead)).GetMutationAuditLog(
+            DateTime.UtcNow.AddDays(-1), DateTime.UtcNow, V4ReadLimits.MaxPageSize + 1, -1);
+
+        PaginationOf<MutationAuditDto>(result).Should().BeEquivalentTo(
+            new PaginationInfo(V4ReadLimits.MaxPageSize, 0, 0));
+    }
+
+    [Fact]
+    public async Task GetReads_LimitAtCeiling_IsUnchanged()
+    {
+        var result = await CreateController(Scopes(TenantPermissions.AuditRead)).GetReadAccessAuditLog(
+            DateTime.UtcNow.AddDays(-1), DateTime.UtcNow, V4ReadLimits.MaxPageSize, 0);
+
+        PaginationOf<ReadAccessAuditDto>(result).Should().BeEquivalentTo(
+            new PaginationInfo(V4ReadLimits.MaxPageSize, 0, 0));
+    }
+
+    [Fact]
+    public async Task GetReads_LimitAboveCeiling_IsClamped()
+    {
+        var result = await CreateController(Scopes(TenantPermissions.AuditRead)).GetReadAccessAuditLog(
+            DateTime.UtcNow.AddDays(-1), DateTime.UtcNow, V4ReadLimits.MaxPageSize + 1, -1);
+
+        PaginationOf<ReadAccessAuditDto>(result).Should().BeEquivalentTo(
+            new PaginationInfo(V4ReadLimits.MaxPageSize, 0, 0));
+    }
+
+    private static PaginationInfo PaginationOf<T>(IActionResult result) =>
+        result.Should().BeOfType<OkObjectResult>().Subject
+            .Value.Should().BeOfType<PaginatedResponse<T>>().Subject
+            .Pagination;
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4ReadLimitCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4ReadLimitCoverageTests.cs
@@ -1,0 +1,219 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Nocturne.API.Controllers.V4.Base;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Base;
+
+/// <summary>
+/// Guards that every V4 read taking a caller-supplied page size runs it through
+/// <see cref="V4ReadLimits"/> before it reaches a repository or service.
+/// </summary>
+/// <remarks>
+/// The per-route boundary tests pin the behaviour of the routes that exist today; this pins the
+/// rule, so a new V4 list route that declares its own <c>limit</c> or <c>count</c> and forgets the
+/// clamp fails here rather than shipping an unbounded read. It reads IL, so it can tell that an
+/// action reaches <see cref="V4ReadLimits"/> but not which of its parameters it clamped — the
+/// boundary tests are what pin that.
+/// </remarks>
+public class V4ReadLimitCoverageTests
+{
+    private const string V4Namespace = "Nocturne.API.Controllers.V4";
+
+    /// <summary>
+    /// Parameter names that carry a caller-supplied page size on this surface. <c>offset</c> and
+    /// <c>skip</c> are not listed: they are meaningless without a page size, so an action that
+    /// declares one declares the other, and the page-size name is what selects the action.
+    /// </summary>
+    private static readonly string[] PageSizeParameterNames = ["limit", "count"];
+
+    /// <summary>
+    /// Actions exempt from the rule, keyed <c>Controller.Action</c>, with what bounds them instead.
+    /// <see cref="ExemptActions_StillNameACandidate"/> keeps the keys live.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> ExemptActions =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // Clamps to a ceiling of its own, an order of magnitude below V4ReadLimits.MaxPageSize.
+            // A monolithic legacy-shaped profile carries every schedule array inline, so the page
+            // is far heavier per record than the rest of this surface.
+            ["ProfileController.GetProfileRecords"] = "clamps to its own tighter ceiling",
+
+            // count and skip are inert: FoodService.GetFoodAsync ignores them and returns the whole
+            // catalog, so clamping them would bound nothing. Bounding this read means teaching the
+            // food repository to page, not clamping a parameter it never sees.
+            ["FoodsController.GetFoods"] = "parameter never reaches the query",
+        };
+
+    [Fact]
+    public void EveryV4ReadTakingAPageSize_ClampsItThroughV4ReadLimits()
+    {
+        var candidates = FindCandidates();
+        var violations = candidates
+            .Where(c => !ExemptActions.ContainsKey(Key(c)))
+            .Where(c => !ClampsThroughV4ReadLimits(c.Action))
+            .Select(Key)
+            .ToList();
+
+        // A sweep that discovers nothing would pass while guarding nothing.
+        candidates.Should().HaveCountGreaterThan(20,
+            "the scan should discover the V4 routes that declare their own page size");
+
+        violations.Should().BeEmpty(
+            $"a V4 read must clamp its page size through {nameof(V4ReadLimits)} before it reaches a " +
+            "repository or service, or a single request can ask for the whole table. Unclamped: " +
+            string.Join("; ", violations));
+    }
+
+    [Fact]
+    public void ExemptActions_StillNameACandidate()
+    {
+        var candidates = FindCandidates().Select(Key).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var (key, reason) in ExemptActions)
+        {
+            candidates.Should().Contain(key,
+                $"{key} is exempted ({reason}) but the scan no longer finds it — remove the exemption");
+        }
+    }
+
+    private static string Key((Type Controller, MethodInfo Action) candidate) =>
+        $"{candidate.Controller.Name}.{candidate.Action.Name}";
+
+    /// <summary>
+    /// The V4 actions declaring a page-size parameter of their own.
+    /// </summary>
+    private static List<(Type Controller, MethodInfo Action)> FindCandidates() =>
+        typeof(V4ReadLimits).Assembly.GetTypes()
+            .Where(t => t.Namespace is { } ns
+                        && (ns == V4Namespace || ns.StartsWith($"{V4Namespace}.", StringComparison.Ordinal)))
+            .Where(t => typeof(ControllerBase).IsAssignableFrom(t) && t.IsClass)
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => m.GetCustomAttributes().OfType<IActionHttpMethodProvider>().Any())
+                .Where(DeclaresAPageSize)
+                .Select(m => (Controller: t, Action: m)))
+            .ToList();
+
+    private static bool DeclaresAPageSize(MethodInfo action) =>
+        action.GetParameters().Any(p =>
+            (p.ParameterType == typeof(int) || p.ParameterType == typeof(int?))
+            && PageSizeParameterNames.Contains(p.Name, StringComparer.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Whether <paramref name="action"/> reaches <see cref="V4ReadLimits"/>, following calls into
+    /// its own async state machine and into helpers it inherits (the shared base controllers clamp
+    /// in a protected helper rather than in the action body).
+    /// </summary>
+    private static bool ClampsThroughV4ReadLimits(MethodInfo action)
+    {
+        var visited = new HashSet<MethodBase>();
+        var pending = new Queue<MethodBase>();
+        pending.Enqueue(action);
+
+        while (pending.Count > 0)
+        {
+            var current = pending.Dequeue();
+            if (!visited.Add(current))
+                continue;
+
+            foreach (var body in Bodies(current))
+            {
+                foreach (var called in CalledMethods(body))
+                {
+                    if (called.DeclaringType == typeof(V4ReadLimits))
+                        return true;
+
+                    if (DeclaredWithin(called.DeclaringType, action.DeclaringType!))
+                        pending.Enqueue(called);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The method itself plus, for an async method, the <c>MoveNext</c> its body was rewritten
+    /// into — where every call an async action makes actually lives.
+    /// </summary>
+    private static IEnumerable<MethodBase> Bodies(MethodBase method)
+    {
+        yield return method;
+
+        var stateMachine = method.GetCustomAttribute<AsyncStateMachineAttribute>()?.StateMachineType;
+        var moveNext = stateMachine?.GetMethod("MoveNext", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        if (moveNext is not null)
+            yield return moveNext;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="candidate"/> is the controller, one of its base controllers, or a
+    /// type nested in either — the reach within which a clamp still counts as the action's own.
+    /// </summary>
+    private static bool DeclaredWithin(Type? candidate, Type controller)
+    {
+        var outer = candidate;
+        while (outer?.DeclaringType is not null)
+            outer = outer.DeclaringType;
+
+        if (outer is null)
+            return false;
+
+        if (outer.IsGenericType)
+            outer = outer.GetGenericTypeDefinition();
+
+        for (var type = controller; type is not null; type = type.BaseType)
+        {
+            var self = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+            if (self == outer)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The methods called from <paramref name="method"/>'s IL, found by resolving the token after
+    /// every <c>call</c> and <c>callvirt</c> opcode byte.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the same walk in <c>HubAuthorizationFilterTests</c>. A byte that is not an
+    /// instruction boundary yields a token that does not resolve and is skipped, so the result is a
+    /// superset of the real calls.
+    /// </remarks>
+    private static IEnumerable<MethodBase> CalledMethods(MethodBase method)
+    {
+        const byte Call = 0x28;
+        const byte CallVirt = 0x6F;
+
+        var il = method.GetMethodBody()?.GetILAsByteArray();
+        if (il is null)
+            yield break;
+
+        var typeArguments = method.DeclaringType?.IsGenericType == true
+            ? method.DeclaringType.GetGenericArguments()
+            : null;
+
+        for (var i = 0; i + 4 < il.Length; i++)
+        {
+            if (il[i] is not (Call or CallVirt))
+                continue;
+
+            MethodBase? called = null;
+            try
+            {
+                called = method.Module.ResolveMethod(BitConverter.ToInt32(il, i + 1), typeArguments, null);
+            }
+            catch (Exception)
+            {
+                // Not an instruction boundary, or a token needing generic context to resolve.
+            }
+
+            if (called is not null)
+                yield return called;
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/FoodsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/FoodsControllerTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Controllers.V4.Treatments;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Models;
@@ -270,6 +271,32 @@ public class FoodsControllerTests : IDisposable
             .Which.Should().HaveCount(1);
         _favoriteServiceMock.Verify(
             x => x.GetRecentFoodsAsync(null, 5, It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GetRecentFoods_LimitAtCeiling_ReachesServiceUnchanged()
+    {
+        var controller = CreateController(null);
+
+        await controller.GetRecentFoods(V4ReadLimits.MaxPageSize);
+
+        _favoriteServiceMock.Verify(
+            x => x.GetRecentFoodsAsync(null, V4ReadLimits.MaxPageSize, It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task GetRecentFoods_LimitAboveCeiling_IsClamped()
+    {
+        var controller = CreateController(null);
+
+        await controller.GetRecentFoods(V4ReadLimits.MaxPageSize + 1);
+
+        _favoriteServiceMock.Verify(
+            x => x.GetRecentFoodsAsync(null, V4ReadLimits.MaxPageSize, It.IsAny<CancellationToken>()),
             Times.Once
         );
     }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/NutritionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/NutritionControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Moq;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Controllers.V4.Treatments;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.API.Services.Platform;
@@ -210,4 +211,24 @@ public class NutritionControllerTests : IDisposable
 
         result.Result.Should().BeOfType<NotFoundResult>();
     }
+
+    [Fact]
+    public async Task GetCarbIntakes_LimitAtCeiling_ReachesRepositoryUnchanged()
+    {
+        await CreateController().GetCarbIntakes(null, null, V4ReadLimits.MaxPageSize, 0);
+
+        VerifyCarbIntakesFetched(V4ReadLimits.MaxPageSize, 0);
+    }
+
+    [Fact]
+    public async Task GetCarbIntakes_LimitAboveCeiling_IsClamped()
+    {
+        await CreateController().GetCarbIntakes(null, null, V4ReadLimits.MaxPageSize + 1, -1);
+
+        VerifyCarbIntakesFetched(V4ReadLimits.MaxPageSize, 0);
+    }
+
+    private void VerifyCarbIntakesFetched(int limit, int offset) =>
+        _repoMock.Verify(r => r.GetAsync(
+            null, null, null, null, limit, offset, true, false, null, null, It.IsAny<CancellationToken>()), Times.Once);
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/V4ReadLimitClampTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/V4ReadLimitClampTests.cs
@@ -1,0 +1,420 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Configuration;
+using Nocturne.API.Controllers.V4;
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.API.Controllers.V4.Base;
+using Nocturne.API.Controllers.V4.Devices;
+using Nocturne.API.Controllers.V4.Health;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.API.Controllers.V4.Platform;
+using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.API.Controllers.V4.TenantAdmin;
+using Nocturne.API.Services.Compatibility;
+using Nocturne.API.Services.Monitoring;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Core.Contracts.Repositories;
+using Nocturne.Core.Contracts.Sleep;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Abstractions;
+using Nocturne.Infrastructure.Data.Services;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4;
+
+/// <summary>
+/// Boundary tests for the V4 read routes that declare their own <c>limit</c>/<c>count</c> instead
+/// of inheriting one from the shared base controllers, whose own boundaries are covered by
+/// <c>V4ReadOnlyControllerBaseTests</c> and <c>V4CrudControllerBaseTests</c>.
+/// </summary>
+/// <remarks>
+/// Grouped rather than split per controller because only four of these controllers have a test
+/// class of their own; those four are covered in place, next to their existing fixtures
+/// (<c>AuditControllerTests</c>, <c>FoodsControllerTests</c>, <c>NutritionControllerTests</c>,
+/// <c>ActivityControllerV4Tests</c>). <c>V4ReadLimitCoverageTests</c> guards that the whole
+/// surface stays covered.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class V4ReadLimitClampTests
+{
+    private const int Ceiling = V4ReadLimits.MaxPageSize;
+    private const int AboveCeiling = V4ReadLimits.MaxPageSize + 1;
+
+    // ── State spans ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StateSpans_LimitAtCeiling_ReachesServiceUnchanged()
+    {
+        var service = new Mock<IStateSpanService>();
+        var controller = new StateSpansController(service.Object);
+
+        await controller.GetStateSpans(limit: Ceiling, offset: 0);
+
+        VerifySpansFetched(service, Ceiling, 0, Times.Once());
+    }
+
+    [Fact]
+    public async Task StateSpans_LimitAboveCeiling_IsClamped()
+    {
+        var service = new Mock<IStateSpanService>();
+        var controller = new StateSpansController(service.Object);
+
+        await controller.GetStateSpans(limit: AboveCeiling, offset: -1);
+
+        VerifySpansFetched(service, Ceiling, 0, Times.Once());
+    }
+
+    [Fact]
+    public async Task StateSpansCategorySubRoutes_LimitAtCeiling_ReachesServiceUnchanged()
+    {
+        var service = new Mock<IStateSpanService>();
+        var controller = new StateSpansController(service.Object);
+
+        await InvokeCategorySubRoutes(controller, Ceiling, 0);
+
+        VerifySpansFetched(service, Ceiling, 0, Times.Exactly(CategorySubRouteCount));
+    }
+
+    [Fact]
+    public async Task StateSpansCategorySubRoutes_LimitAboveCeiling_IsClamped()
+    {
+        var service = new Mock<IStateSpanService>();
+        var controller = new StateSpansController(service.Object);
+
+        await InvokeCategorySubRoutes(controller, AboveCeiling, -1);
+
+        VerifySpansFetched(service, Ceiling, 0, Times.Exactly(CategorySubRouteCount));
+    }
+
+    [Fact]
+    public async Task StateSpanActivities_LimitAboveCeiling_IsClampedInTheReportedPage()
+    {
+        var service = new Mock<IStateSpanService>();
+        var controller = new StateSpansController(service.Object);
+
+        var result = await controller.GetActivities(limit: AboveCeiling, offset: -1);
+
+        var page = result.Result.Should().BeOfType<OkObjectResult>().Subject
+            .Value.Should().BeOfType<PaginatedResponse<StateSpan>>().Subject;
+        page.Pagination.Limit.Should().Be(Ceiling);
+        page.Pagination.Offset.Should().Be(0);
+    }
+
+    /// <summary>The <c>/state-spans</c> sub-routes that pre-filter by a single category.</summary>
+    private const int CategorySubRouteCount = 8;
+
+    private static async Task InvokeCategorySubRoutes(StateSpansController controller, int limit, int offset)
+    {
+        await controller.GetPumpModes(limit: limit, offset: offset);
+        await controller.GetConnectivity(limit: limit, offset: offset);
+        await controller.GetOverrides(limit: limit, offset: offset);
+        await controller.GetTemporaryTargets(limit: limit, offset: offset);
+        await controller.GetProfiles(limit: limit, offset: offset);
+        await controller.GetExercise(limit: limit, offset: offset);
+        await controller.GetIllness(limit: limit, offset: offset);
+        await controller.GetTravel(limit: limit, offset: offset);
+    }
+
+    private static void VerifySpansFetched(Mock<IStateSpanService> service, int count, int skip, Times times) =>
+        service.Verify(s => s.GetStateSpansAsync(
+            It.IsAny<StateSpanCategory?>(), null, null, null, null, null,
+            count, skip, true, It.IsAny<CancellationToken>()), times);
+
+    // ── Therapy settings ────────────────────────────────────────────
+
+    [Fact]
+    public async Task TherapySettings_LimitAtCeiling_ReachesRepositoryUnchanged()
+    {
+        var repo = new Mock<ITherapySettingsRepository>();
+
+        await CreateProfileController(repo).GetTherapySettings(null, null, Ceiling, 0);
+
+        VerifyTherapySettingsFetched(repo, Ceiling, 0);
+    }
+
+    [Fact]
+    public async Task TherapySettings_LimitAboveCeiling_IsClamped()
+    {
+        var repo = new Mock<ITherapySettingsRepository>();
+
+        await CreateProfileController(repo).GetTherapySettings(null, null, AboveCeiling, -1);
+
+        VerifyTherapySettingsFetched(repo, Ceiling, 0);
+    }
+
+    private static ProfileController CreateProfileController(Mock<ITherapySettingsRepository> repo) =>
+        new(
+            repo.Object,
+            Mock.Of<IBasalScheduleRepository>(),
+            Mock.Of<ICarbRatioScheduleRepository>(),
+            Mock.Of<ISensitivityScheduleRepository>(),
+            Mock.Of<ITargetRangeScheduleRepository>(),
+            Mock.Of<IProfileProjectionService>());
+
+    private static void VerifyTherapySettingsFetched(Mock<ITherapySettingsRepository> repo, int limit, int offset) =>
+        repo.Verify(r => r.GetAsync(null, null, null, null, limit, offset, true, It.IsAny<CancellationToken>()), Times.Once);
+
+    // ── Sleep sessions ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task SleepSessions_LimitAtCeiling_ReachesServiceUnchanged()
+    {
+        var service = new Mock<ISleepService>();
+
+        await new SleepController(service.Object).GetSessions(limit: Ceiling, offset: 0);
+
+        VerifySessionsFetched(service, Ceiling, 0);
+    }
+
+    [Fact]
+    public async Task SleepSessions_LimitAboveCeiling_IsClamped()
+    {
+        var service = new Mock<ISleepService>();
+
+        await new SleepController(service.Object).GetSessions(limit: AboveCeiling, offset: -1);
+
+        VerifySessionsFetched(service, Ceiling, 0);
+    }
+
+    private static void VerifySessionsFetched(Mock<ISleepService> service, int limit, int offset) =>
+        service.Verify(s => s.GetSessionsAsync(
+            null, null, null, null, limit, offset, true, false, It.IsAny<CancellationToken>()), Times.Once);
+
+    // ── Charge cycles ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChargeCycles_LimitAtCeiling_ReachesServiceUnchanged()
+    {
+        var service = new Mock<IBatteryService>();
+        var controller = new BatteryController(service.Object, Mock.Of<ILogger<BatteryController>>());
+
+        var result = await controller.GetChargeCycles(limit: Ceiling);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyChargeCyclesFetched(service, Ceiling);
+    }
+
+    [Fact]
+    public async Task ChargeCycles_LimitAboveCeiling_IsClamped()
+    {
+        var service = new Mock<IBatteryService>();
+        var controller = new BatteryController(service.Object, Mock.Of<ILogger<BatteryController>>());
+
+        var result = await controller.GetChargeCycles(limit: AboveCeiling);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyChargeCyclesFetched(service, Ceiling);
+    }
+
+    private static void VerifyChargeCyclesFetched(Mock<IBatteryService> service, int limit) =>
+        service.Verify(s => s.GetChargeCyclesAsync(null, null, null, limit, It.IsAny<CancellationToken>()), Times.Once);
+
+    // ── Body weight ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BodyWeights_CountAtCeiling_ReachesServiceUnchanged()
+    {
+        var service = new Mock<IBodyWeightService>();
+        var controller = new BodyWeightController(service.Object, Mock.Of<ILogger<BodyWeightController>>());
+
+        var result = await controller.GetBodyWeights(count: Ceiling, skip: 0);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        service.Verify(s => s.GetBodyWeightsAsync(Ceiling, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task BodyWeights_CountAboveCeiling_IsClamped()
+    {
+        var service = new Mock<IBodyWeightService>();
+        var controller = new BodyWeightController(service.Object, Mock.Of<ILogger<BodyWeightController>>());
+
+        var result = await controller.GetBodyWeights(count: AboveCeiling, skip: -1);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        service.Verify(s => s.GetBodyWeightsAsync(Ceiling, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── Heart rate ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HeartRates_CountAtCeiling_ReachesServiceUnchanged()
+    {
+        var service = new Mock<IHeartRateService>();
+        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+
+        var result = await controller.GetHeartRates(count: Ceiling, skip: 0);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        service.Verify(s => s.GetHeartRatesAsync(Ceiling, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HeartRates_CountAboveCeiling_IsClamped()
+    {
+        var service = new Mock<IHeartRateService>();
+        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+
+        var result = await controller.GetHeartRates(count: AboveCeiling, skip: -1);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        service.Verify(s => s.GetHeartRatesAsync(Ceiling, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── Step count ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StepCounts_CountAtCeiling_ReachesServiceUnchanged()
+    {
+        var service = new Mock<IStepCountService>();
+        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+
+        var result = await controller.GetStepCounts(count: Ceiling, skip: 0);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        service.Verify(s => s.GetStepCountsAsync(Ceiling, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StepCounts_CountAboveCeiling_IsClamped()
+    {
+        var service = new Mock<IStepCountService>();
+        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+
+        var result = await controller.GetStepCounts(count: AboveCeiling, skip: -1);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        service.Verify(s => s.GetStepCountsAsync(Ceiling, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── Compatibility analyses ──────────────────────────────────────
+
+    [Fact]
+    public async Task CompatibilityAnalyses_CountAtCeiling_ReachesRepositoryUnchanged()
+    {
+        var repo = new Mock<IDiscrepancyAnalysisRepository>();
+
+        var result = await CreateCompatibilityController(repo).GetAnalyses(count: Ceiling, skip: 0);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyAnalysesFetched(repo, Ceiling, 0);
+    }
+
+    [Fact]
+    public async Task CompatibilityAnalyses_CountAboveCeiling_IsClamped()
+    {
+        var repo = new Mock<IDiscrepancyAnalysisRepository>();
+
+        var result = await CreateCompatibilityController(repo).GetAnalyses(count: AboveCeiling, skip: -1);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyAnalysesFetched(repo, Ceiling, 0);
+    }
+
+    private static CompatibilityController CreateCompatibilityController(Mock<IDiscrepancyAnalysisRepository> repo) =>
+        new(
+            Mock.Of<IDiscrepancyPersistenceService>(),
+            repo.Object,
+            Options.Create(new CompatibilityProxyConfiguration()),
+            Mock.Of<ILogger<CompatibilityController>>());
+
+    // ── Discrepancy analyses ────────────────────────────────────────
+
+    [Fact]
+    public async Task DiscrepancyAnalyses_CountAtCeiling_ReachesRepositoryUnchanged()
+    {
+        var repo = new Mock<IDiscrepancyAnalysisRepository>();
+        var controller = new DiscrepancyController(repo.Object, Mock.Of<ILogger<DiscrepancyController>>());
+
+        var result = await controller.GetDiscrepancyAnalyses(count: Ceiling, skip: 0);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyAnalysesFetched(repo, Ceiling, 0);
+    }
+
+    [Fact]
+    public async Task DiscrepancyAnalyses_CountAboveCeiling_IsClamped()
+    {
+        var repo = new Mock<IDiscrepancyAnalysisRepository>();
+        var controller = new DiscrepancyController(repo.Object, Mock.Of<ILogger<DiscrepancyController>>());
+
+        var result = await controller.GetDiscrepancyAnalyses(count: AboveCeiling, skip: 0);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyAnalysesFetched(repo, Ceiling, 0);
+    }
+
+    private static void VerifyAnalysesFetched(Mock<IDiscrepancyAnalysisRepository> repo, int count, int skip) =>
+        repo.Verify(r => r.GetAnalysesAsync(null, null, null, null, count, skip, It.IsAny<CancellationToken>()), Times.Once);
+
+    // ── System events ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task SystemEvents_CountAtCeiling_ReachesRepositoryUnchanged()
+    {
+        var repo = new Mock<ISystemEventRepository>();
+
+        await new SystemEventsController(repo.Object).GetSystemEvents(count: Ceiling, skip: 0);
+
+        VerifySystemEventsFetched(repo, Ceiling, 0);
+    }
+
+    [Fact]
+    public async Task SystemEvents_CountAboveCeiling_IsClamped()
+    {
+        var repo = new Mock<ISystemEventRepository>();
+
+        await new SystemEventsController(repo.Object).GetSystemEvents(count: AboveCeiling, skip: -1);
+
+        VerifySystemEventsFetched(repo, Ceiling, 0);
+    }
+
+    private static void VerifySystemEventsFetched(Mock<ISystemEventRepository> repo, int count, int skip) =>
+        repo.Verify(r => r.GetSystemEventsAsync(
+            null, null, null, null, null, count, skip, It.IsAny<CancellationToken>()), Times.Once);
+
+    // ── Tracker instance history ────────────────────────────────────
+
+    [Fact]
+    public async Task TrackerHistory_LimitAtCeiling_ReachesRepositoryUnchanged()
+    {
+        var repo = new Mock<ITrackerRepository>();
+
+        await CreateTrackersController(repo).GetInstanceHistory(Ceiling);
+
+        repo.Verify(r => r.GetCompletedInstancesAsync(null, Ceiling, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TrackerHistory_LimitAboveCeiling_IsClamped()
+    {
+        var repo = new Mock<ITrackerRepository>();
+
+        await CreateTrackersController(repo).GetInstanceHistory(AboveCeiling);
+
+        repo.Verify(r => r.GetCompletedInstancesAsync(null, Ceiling, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static TrackersController CreateTrackersController(Mock<ITrackerRepository> repo) =>
+        new(
+            repo.Object,
+            Mock.Of<ISignalRBroadcastService>(),
+            Mock.Of<ITrackerAlertRuleSyncService>(),
+            Mock.Of<ITenantDbContextFactory>(),
+            Mock.Of<IAlertAcknowledgementService>(),
+            Mock.Of<ILogger<TrackersController>>())
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+}


### PR DESCRIPTION
## What

#694 clamped the shared V4 bases, the bypassing overrides, and activity. This clamps the 24 remaining V4 routes that declare their own `limit`/`count` (several actually use `count`/`skip`) — each a mechanical `V4ReadLimits.ClampLimit`/`ClampOffset` in #694's idiom: `StateSpansController` (10 actions), `AuditController` (2), `ProfileController.GetTherapySettings`, `SleepController`, `NutritionController.GetCarbIntakes`, `BatteryController`, `BodyWeight`/`HeartRate`/`StepCount`, `Compatibility`, `SystemEvents`, `DiscrepancyController` (kept its lower-bound 400s, added the ceiling), `TrackersController.GetInstanceHistory` (notable: `[AllowAnonymous]`, so public-share reachable), `FoodsController.GetRecentFoods` — **plus one the backlog missed and the new sweep caught**: `TempBasalController.GetAll`, which derives from plain `ControllerBase` and re-implements the read, so it never got #694's base clamp.

## Deliberate exemptions (recorded in the sweep, kept live by a companion fact)

- `ProfileController.GetProfileRecords` already clamps to its own tighter ceiling (1,000) — converting it to `V4ReadLimits` would have *raised* the ceiling 100×. #694 cites it as the clamp-don't-reject precedent; left alone.
- `FoodsController.GetFoods`: `count`/`skip` never reach the query — `FoodService` returns the whole catalog regardless. Clamping would bound nothing; bounding that read means teaching the food repository to page (follow-up).

## The sweep

`V4ReadLimitCoverageTests` reflects over `Controllers.V4*`, selects actions with an `int`/`int?` named `limit`/`count`, and walks their IL (through async `MoveNext` and inherited helpers, imitating `HubAuthorizationFilterTests`) to prove each reaches `V4ReadLimits`. It fails on an empty discovery (`>20` candidates asserted first), and a companion fact fails if an exemption key stops naming a live action. Documented limitation in its remarks: IL says an action reaches the clamp, not which parameter — the per-route boundary tests pin that.

## Tests

Boundary pairs (at ceiling / one above) for every clamped controller: in existing test classes where one existed (Audit +4, Foods +2, Nutrition +2, TempBasal +2), one shared `V4ReadLimitClampTests` for the 10 controllers that had none. Mutation-proven twice: unclamping `SystemEventsController` fails its boundary test *and* the sweep by name; unclamping 1 of `StateSpansController`'s 10 actions fails its category-sub-route test *and* the sweep by name. Full suite: 5278 passed, 0 failed.

## Flagged for the backlog

- `state-spans/activities` fetches `count: int.MaxValue` per category regardless of caller paging — pre-existing unbounded fan-out behind the now-clamped page.
- `HeartRate`/`StepCount` date-range branches ignore `count`/`skip` entirely and return the full range.
- `AlertsController.GetAlertHistory` clamps inline via a bespoke `page`/`pageSize` variant — bounded, but outside the sweep's name set; widening the sweep to `pageSize` would fold it in.

https://claude.ai/code/session_01FC5TxNBf54o4kvhAWxPGB7
