### PR TITLE
fix(web): resolve the display language per request during SSR

### DIFF
--- a/src/Web/packages/app/src/lib/stores/appearance-ssr-harness.svelte
+++ b/src/Web/packages/app/src/lib/stores/appearance-ssr-harness.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   // Test-only harness: stands in for the root layout, publishing one request's
-  // preference layers so a descendant can be rendered server-side.
-  import { setPreferencesContext } from "./appearance-store.svelte";
+  // preference sources so a descendant can be rendered server-side.
+  import { setPreferencesContext, type RequestPreferences } from "./appearance-store.svelte";
   import Reader from "./appearance-ssr-reader.svelte";
-  import type { UserDisplayPreferences } from "$lib/api";
 
-  let { layers }: { layers: UserDisplayPreferences[] } = $props();
+  let { layers, language }: RequestPreferences = $props();
 
-  setPreferencesContext(() => layers);
+  setPreferencesContext(() => ({ layers, language }));
 </script>
 
 <Reader />

--- a/src/Web/packages/app/src/lib/stores/appearance-ssr-reader.svelte
+++ b/src/Web/packages/app/src/lib/stores/appearance-ssr-reader.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
   // Test-only: reads preferences the way real components do — through the shared
   // formatting helpers, from a descendant of the component that set the context.
-  import { bg, bgLabel, bgRange } from "$lib/utils/formatting";
-  import { timeFormat } from "./appearance-store.svelte";
+  import {
+    bg,
+    bgLabel,
+    bgRange,
+    formatLocale,
+    formatWeekdayDate,
+    minutesAgo,
+  } from "$lib/utils/formatting";
+  import { preferredLanguage, timeFormat } from "./appearance-store.svelte";
 
   const derivedValue = $derived(bg(100));
+
+  const SAMPLE_DATE = new Date(2026, 11, 31, 15, 30);
 </script>
 
 <span id="value">{bg(100)}</span>
@@ -12,3 +21,7 @@
 <span id="label">{bgLabel()}</span>
 <span id="range">{bgRange(70, 180)}</span>
 <span id="time-format">{timeFormat.current}</span>
+<span id="language">{preferredLanguage.current}</span>
+<span id="format-locale">{formatLocale()}</span>
+<span id="weekday-date">{formatWeekdayDate(SAMPLE_DATE)}</span>
+<span id="minutes-ago">{minutesAgo(SAMPLE_DATE.getTime() - 300000, SAMPLE_DATE.getTime())}</span>

--- a/src/Web/packages/app/src/lib/stores/appearance-store.ssr.test.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.ssr.test.ts
@@ -2,12 +2,20 @@ import { describe, it, expect } from "vitest";
 import { render } from "svelte/server";
 import type { UserDisplayPreferences } from "$lib/api";
 import Harness from "./appearance-ssr-harness.svelte";
-import { glucoseUnits } from "./appearance-store.svelte";
+import {
+  glucoseUnits,
+  preferredLanguage,
+  resolveLanguage,
+  type SupportedLocale,
+} from "./appearance-store.svelte";
 
 const mmol: UserDisplayPreferences = { glucoseUnits: "mmol", timeFormat: "24" };
 
-async function ssr(layers: UserDisplayPreferences[]): Promise<string> {
-  return (await render(Harness, { props: { layers } })).body;
+async function ssr(
+  layers: UserDisplayPreferences[],
+  language?: SupportedLocale
+): Promise<string> {
+  return (await render(Harness, { props: { layers, language } })).body;
 }
 
 describe("appearance-store SSR resolution", () => {
@@ -51,5 +59,54 @@ describe("appearance-store SSR resolution", () => {
 
     expect(body).toContain("mmol/L");
     expect(body).toContain(">24<");
+  });
+});
+
+describe("language SSR resolution", () => {
+  it("formats dates and numbers in the request's language, not the module default", async () => {
+    const body = await ssr([], "de");
+
+    expect(body).toContain("Do., 31. Dez.");
+    expect(body).toContain("vor 5 Min.");
+    expect(body).not.toContain("Thu, Dec 31");
+  });
+
+  it("falls back to English when the request carries no language", async () => {
+    const body = await ssr([]);
+
+    expect(body).toContain("Thu, Dec 31");
+    expect(body).toContain("5 min. ago");
+  });
+
+  it("keeps concurrent requests isolated", async () => {
+    const [german, fallback] = await Promise.all([ssr([], "de"), ssr([])]);
+
+    expect(german).toContain("Do., 31. Dez.");
+    expect(fallback).toContain("Thu, Dec 31");
+    // The shared module state is never written to by a server render.
+    expect(preferredLanguage.current).toBe("en");
+  });
+
+  it("lets a regional format outrank the language for date ordering", async () => {
+    const body = await ssr([{ regionFormat: "en-GB" }], "de");
+
+    expect(body).toContain(">en-GB<");
+    expect(body).toContain("Thu 31 Dec");
+    // The language still shows through as the user's own choice.
+    expect(body).toContain(">de<");
+  });
+});
+
+describe("resolveLanguage", () => {
+  it("prefers a saved subject preference over the mirrored cookie", () => {
+    expect(resolveLanguage("fr", "de")).toBe("fr");
+  });
+
+  it("skips unset and unsupported candidates", () => {
+    expect(resolveLanguage(null, "klingon", undefined, "de")).toBe("de");
+  });
+
+  it("falls back to English when nothing usable is offered", () => {
+    expect(resolveLanguage(null, undefined, "")).toBe("en");
   });
 });

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -18,7 +18,8 @@
  * `setPreferencesContext`), so SSR emits the same units/formats hydration will.
  *
  * Language keeps its own dedicated cookie + backend path (used by SSR locale
- * resolution).
+ * resolution), so it travels in the request context's own slot rather than as a
+ * field of the preferences blob.
  */
 
 import { browser } from "$app/environment";
@@ -81,25 +82,35 @@ const syncedRegistry = new Map<string, SyncedPref<unknown>>();
 const PREFERENCES_CONTEXT_KEY = Symbol("nocturne-display-preferences");
 
 /**
- * Publish this request's preference payloads, highest precedence first, for the
- * duration of one server render. The store's `$state` is module-scoped and so
- * shared by every concurrent SSR request; reading preferences from component
- * context instead is what keeps one user's units out of another's HTML.
- * Layers mirror the browser's own resolution order (backend blob over cookie),
- * each contributing only the fields it defines.
+ * One request's preference sources: the display-preference payloads, highest
+ * precedence first and each contributing only the fields it defines, plus the
+ * display language, which is stored apart from the blob and so gets its own slot.
  */
-export function setPreferencesContext(layers: () => UserDisplayPreferences[]): void {
-  setContext(PREFERENCES_CONTEXT_KEY, layers);
+export interface RequestPreferences {
+  layers: UserDisplayPreferences[];
+  language?: SupportedLocale;
 }
 
-function requestPreferences(): UserDisplayPreferences[] {
+/**
+ * Publish this request's preference sources for the duration of one server render.
+ * The store's `$state` is module-scoped and so shared by every concurrent SSR
+ * request; reading preferences from component context instead is what keeps one
+ * user's units out of another's HTML. Every source mirrors the browser's own
+ * resolution order, so SSR output equals the first client render.
+ */
+export function setPreferencesContext(preferences: () => RequestPreferences): void {
+  setContext(PREFERENCES_CONTEXT_KEY, preferences);
+}
+
+function requestPreferences(): RequestPreferences | null {
   try {
-    return getContext<(() => UserDisplayPreferences[]) | undefined>(
-      PREFERENCES_CONTEXT_KEY
-    )?.() ?? [];
+    return (
+      getContext<(() => RequestPreferences) | undefined>(PREFERENCES_CONTEXT_KEY)?.() ??
+      null
+    );
   } catch {
     // getContext throws outside a component — server loads and module scope have no request.
-    return [];
+    return null;
   }
 }
 
@@ -176,7 +187,7 @@ class SyncedPref<T> {
 
   get current(): T {
     if (!browser) {
-      for (const prefs of requestPreferences()) {
+      for (const prefs of requestPreferences()?.layers ?? []) {
         const value = this._read(prefs);
         if (value !== undefined && value !== null) return value;
       }
@@ -690,18 +701,48 @@ if (browser) {
 /** Re-export supported locales for external use */
 export { supportedLocales };
 
+const DEFAULT_LANGUAGE: SupportedLocale = "en";
+
 /**
  * Language preference - stored in localStorage and synced to cookie for SSR.
- * Kept as a dedicated PersistedState (not part of the display-preferences blob)
- * because server-side locale resolution reads its own cookie + subject column.
+ * Kept out of the display-preferences blob because server-side locale resolution
+ * reads its own cookie + subject column; server-side reads therefore take the
+ * request context's language slot rather than a `UserDisplayPreferences` field.
  */
-export const preferredLanguage = new PersistedState<SupportedLocale>(
-  "nocturne-language",
-  "en"
-);
+class LanguagePref {
+  private _persisted = new PersistedState<SupportedLocale>(
+    "nocturne-language",
+    DEFAULT_LANGUAGE
+  );
+
+  get current(): SupportedLocale {
+    if (!browser) return requestPreferences()?.language ?? DEFAULT_LANGUAGE;
+    return this._persisted.current;
+  }
+
+  set current(locale: SupportedLocale) {
+    this._persisted.current = locale;
+  }
+}
+
+export const preferredLanguage = new LanguagePref();
 
 /** Cookie name for language preference - used by SSR */
 export const LANGUAGE_COOKIE_NAME = "nocturne-language";
+
+/**
+ * The language the browser will settle on, from the same sources in the same order:
+ * a saved subject preference outranks the cookie that mirrors localStorage. SSR
+ * output only matches hydration while this order matches the client's.
+ */
+export function resolveLanguage(
+  ...candidates: (string | null | undefined)[]
+): SupportedLocale {
+  for (const candidate of candidates) {
+    if (candidate && isSupportedLocale(candidate)) return candidate;
+  }
+  return DEFAULT_LANGUAGE;
+}
 
 /**
  * Check if user has explicitly set a language preference

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -1,9 +1,11 @@
 import type { LayoutServerLoad } from "./$types";
 import { extractTenantSlug, getOriginalHost, isShareHost } from "$lib/server/request-host";
 import {
+  LANGUAGE_COOKIE_NAME,
   PREFS_COOKIE_NAME,
   hasStoredPreferences,
   parsePrefsCookie,
+  resolveLanguage,
 } from "$lib/stores/appearance-store.svelte";
 
 /**
@@ -28,9 +30,14 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
     hasStoredPreferences(serverPrefs) ? serverPrefs : null,
     cookiePrefs,
   ].filter((prefs) => prefs !== null && prefs !== undefined);
+  const displayLanguage = resolveLanguage(
+    locals.isAuthenticated ? locals.user?.preferredLanguage : null,
+    cookies.get(LANGUAGE_COOKIE_NAME)
+  );
 
   return {
     displayPreferences,
+    displayLanguage,
     user: locals.user,
     isAuthenticated: locals.isAuthenticated,
     effectivePermissions: locals.effectivePermissions ?? [],

--- a/src/Web/packages/app/src/routes/+layout.svelte
+++ b/src/Web/packages/app/src/routes/+layout.svelte
@@ -33,7 +33,10 @@
 
   let { children, data } = $props();
 
-  setPreferencesContext(() => data.displayPreferences ?? []);
+  setPreferencesContext(() => ({
+    layers: data.displayPreferences ?? [],
+    language: data.displayLanguage,
+  }));
 </script>
 
 <ModeWatcher />


### PR DESCRIPTION
**Stacked on #704** (`fix/ssr-unit-preference`) — extends its layout-context mechanism to the language cookie. Retarget to `main` after #704 merges.

## The bug

`formatLocale()` (which every `toLocaleDateString`/`Intl` call routes through) reads `preferredLanguage.current`, a runed `PersistedState` whose constructor returns early when `window === undefined` — so SSR always resolved `"en"` regardless of the `nocturne-language` cookie, and every full page load first painted en-formatted dates/numbers before hydrating to the right locale. Language rides its own cookie, not `nocturne-prefs`, so it didn't fall out of #704's fix (#704's own body flags this as the follow-up).

## What changed

One plumbing path, #704's, widened: the layout context payload becomes `RequestPreferences { layers, language? }`; `+layout.server.ts` resolves `displayLanguage` from the subject's saved preference then the cookie; `preferredLanguage` becomes a thin wrapper whose server-side reads take the context's language slot. New `resolveLanguage()` picks the first supported candidate.

**Judgement call:** `hooks.server.ts`'s existing `resolveLocale` was deliberately *not* reused — its cascade (query param → cookie → backend → env → Accept-Language) doesn't match what the browser settles on, so reusing it would trade one hydration mismatch for another (e.g. a first-visit `Accept-Language: fr` user would get fr SSR and en hydration). `resolveLanguage` mirrors the client's order exactly: backend preference over cookie, same as #704's layer order. `resolveLocale` remains untouched (still dead-ended pending wuchale).

## Evidence

curl against the dev server with `Cookie: nocturne-language=de`: SSR now emits `Do., 31. Dez.` / `vor 5 Min.` where the base branch emits `Thu, Dec 31` / `5 min. ago`; `ja` renders `12月31日(木)`. Precedence preserved: `de` language + `en-GB` region format still resolves `en-GB` dates and #704's mmol units. Playwright SSR-vs-hydrated comparison: all five probed values identical with the fix, and the en→de flash reproduced with the fix mutated off.

## Tests

`appearance-store.ssr.test.ts` 12 passed (7 new); full node suite 650 passed / 0 failed. Mutation-proven three ways: server branch hardcoded to the default (3 failures), candidate order reversed (fails the subject-over-cookie test), supported-locale guard dropped (fails on an unsupported value). `pnpm check` 26 errors before and after, none in touched files.

https://claude.ai/code/session_01FC5TxNBf54o4kvhAWxPGB7
