### PR TITLE
feat(v4): let bolus and meter-glucose upserts set or clear their patient device

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
@@ -2,6 +2,9 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
+using Nocturne.API.Services.Devices;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
@@ -21,13 +24,17 @@ namespace Nocturne.API.Controllers.V4.Glucose;
 /// <seealso cref="IMeterGlucoseRepository"/>
 /// <seealso cref="MeterGlucose"/>
 /// <seealso cref="UpsertMeterGlucoseRequest"/>
+/// <seealso cref="PatientDeviceAttribution"/>
 /// <seealso cref="V4CrudControllerBase{TModel,TCreateRequest,TUpdateRequest,TRepository}"/>
 [ApiController]
 [Tags("Glucose")]
 [Route("api/v4/glucose/meter")]
 [RequireScope(OAuthScopes.GlucoseRead)]
 [Produces("application/json")]
-public class MeterGlucoseController(IMeterGlucoseRepository repo)
+public class MeterGlucoseController(
+    IMeterGlucoseRepository repo,
+    IPatientDeviceRepository patientDevices,
+    IPatientDeviceStamper deviceStamper)
     : V4CrudControllerBase<MeterGlucose, UpsertMeterGlucoseRequest, UpsertMeterGlucoseRequest, IMeterGlucoseRepository>(repo)
 {
     /// <inheritdoc/>
@@ -44,6 +51,50 @@ public class MeterGlucoseController(IMeterGlucoseRepository repo)
         [FromQuery] string? device = null, [FromQuery] string? source = null,
         CancellationToken ct = default)
         => base.GetAll(from, to, limit, offset, sort, device, source, ct);
+
+    /// <inheritdoc/>
+    public override async Task<ActionResult<MeterGlucose>> Create([FromBody] UpsertMeterGlucoseRequest request, CancellationToken ct = default)
+    {
+        var model = MapCreateToModel(request);
+
+        if (model.Timestamp == default)
+            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
+
+        // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
+        // direct API records stay unstamped and only ever surface as pseudo-devices.
+        if (await ApplyAttributionAsync(model, request, existing: null, ct) is { } error)
+            return error;
+
+        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
+        created = await OnAfterCreateAsync(created, ct);
+        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<ActionResult<MeterGlucose>> Update(Guid id, [FromBody] UpsertMeterGlucoseRequest request, CancellationToken ct = default)
+    {
+        var existing = await Repository.GetByIdAsync(id, ct);
+        if (existing is null)
+            return NotFound();
+
+        var model = MapUpdateToModel(id, request, existing);
+
+        if (model.Timestamp == default)
+            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
+
+        if (await ApplyAttributionAsync(model, request, existing.PatientDeviceId, ct) is { } error)
+            return error;
+
+        try
+        {
+            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
+            return Ok(updated);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+    }
 
     /// <summary>
     /// Maps a <see cref="UpsertMeterGlucoseRequest"/> to a new <see cref="MeterGlucose"/> domain model for creation.
@@ -62,7 +113,7 @@ public class MeterGlucoseController(IMeterGlucoseRepository repo)
 
     /// <summary>
     /// Maps a <see cref="UpsertMeterGlucoseRequest"/> to an updated <see cref="MeterGlucose"/>, preserving
-    /// immutable fields (<c>CorrelationId</c>, <c>LegacyId</c>, <c>CreatedAt</c>, <c>PatientDeviceId</c>, and
+    /// immutable fields (<c>CorrelationId</c>, <c>LegacyId</c>, <c>CreatedAt</c>, and
     /// <c>AdditionalProperties</c>) from the <paramref name="existing"/> record.
     /// </summary>
     /// <param name="id">The record ID being updated.</param>
@@ -81,7 +132,20 @@ public class MeterGlucoseController(IMeterGlucoseRepository repo)
         CorrelationId = existing.CorrelationId,
         LegacyId = existing.LegacyId,
         CreatedAt = existing.CreatedAt,
-        PatientDeviceId = existing.PatientDeviceId,
         AdditionalProperties = existing.AdditionalProperties,
     };
+
+    /// <summary>
+    /// Settles the reading's device attribution from the request. Returns a 400 result when an explicit
+    /// id doesn't resolve (tenant scoping makes a cross-tenant id indistinguishable from a nonexistent
+    /// one), or <c>null</c> on success.
+    /// </summary>
+    private async Task<ObjectResult?> ApplyAttributionAsync(MeterGlucose model, UpsertMeterGlucoseRequest request, Guid? existing, CancellationToken ct)
+    {
+        var error = await PatientDeviceAttribution.ApplyAsync(
+            model, request.PatientDeviceId, existing, patientDevices, deviceStamper,
+            DeviceAttributionCategories.MeterGlucose, ct);
+
+        return error is null ? null : Problem(detail: error, statusCode: 400, title: "Bad Request");
+    }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Models.Requests.V4;
+using Nocturne.API.Services.Devices;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
@@ -18,20 +20,25 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 ///
 /// On update, immutable fields (<see cref="Bolus.BolusType"/>, <see cref="Bolus.Kind"/>,
 /// <see cref="Bolus.LegacyId"/>, <see cref="Bolus.CreatedAt"/>, <see cref="Bolus.PumpRecordId"/>,
-/// <see cref="Bolus.DeviceId"/>, <see cref="Bolus.PatientDeviceId"/>, and
-/// <see cref="Bolus.AdditionalProperties"/>) are preserved from the existing record. <see cref="Bolus.CorrelationId"/> falls back to the existing value if the request
+/// <see cref="Bolus.DeviceId"/>, and <see cref="Bolus.AdditionalProperties"/>) are preserved from the
+/// existing record. <see cref="Bolus.CorrelationId"/> falls back to the existing value if the request
 /// does not supply one.
 /// </remarks>
 /// <seealso cref="IBolusRepository"/>
 /// <seealso cref="Bolus"/>
 /// <seealso cref="CreateBolusRequest"/>
 /// <seealso cref="UpdateBolusRequest"/>
+/// <seealso cref="PatientDeviceAttribution"/>
 [ApiController]
 [Tags("Treatments")]
 [Route("api/v4/insulin/boluses")]
 [RequireScope(OAuthScopes.TreatmentsRead)]
 [Produces("application/json")]
-public class BolusController(IBolusRepository repo, IPatientInsulinRepository insulinRepo)
+public class BolusController(
+    IBolusRepository repo,
+    IPatientInsulinRepository insulinRepo,
+    IPatientDeviceRepository patientDevices,
+    IPatientDeviceStamper deviceStamper)
     : V4CrudControllerBase<Bolus, CreateBolusRequest, UpdateBolusRequest, IBolusRepository>(repo)
 {
     /// <inheritdoc/>
@@ -59,6 +66,11 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
 
         await EnrichInsulinContextAsync(model, request.PatientInsulinId, ct);
 
+        // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
+        // direct API records stay unstamped and only ever surface as pseudo-devices.
+        if (await ApplyAttributionAsync(model, request.PatientDeviceId, existing: null, ct) is { } error)
+            return error;
+
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
@@ -77,6 +89,9 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
         await EnrichInsulinContextAsync(model, request.PatientInsulinId, ct);
+
+        if (await ApplyAttributionAsync(model, request.PatientDeviceId, existing.PatientDeviceId, ct) is { } error)
+            return error;
 
         try
         {
@@ -117,7 +132,7 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
     /// <summary>Maps an <see cref="UpdateBolusRequest"/> onto a <see cref="Bolus"/> domain model, preserving immutable fields from the existing record.</summary>
     /// <param name="id">The bolus ID to carry forward.</param>
     /// <param name="request">The inbound update request.</param>
-    /// <param name="existing">The existing <see cref="Bolus"/> record; immutable fields (<c>BolusType</c>, <c>Kind</c>, <c>LegacyId</c>, <c>CreatedAt</c>, <c>PumpRecordId</c>, <c>DeviceId</c>, <c>PatientDeviceId</c>, <c>AdditionalProperties</c>) are copied from here.</param>
+    /// <param name="existing">The existing <see cref="Bolus"/> record; immutable fields (<c>BolusType</c>, <c>Kind</c>, <c>LegacyId</c>, <c>CreatedAt</c>, <c>PumpRecordId</c>, <c>DeviceId</c>, <c>AdditionalProperties</c>) are copied from here.</param>
     /// <returns>A fully-populated <see cref="Bolus"/> ready for persistence.</returns>
     protected override Bolus MapUpdateToModel(Guid id, UpdateBolusRequest request, Bolus existing) => new()
     {
@@ -144,7 +159,6 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
         CreatedAt = existing.CreatedAt,
         PumpRecordId = existing.PumpRecordId,
         DeviceId = existing.DeviceId,
-        PatientDeviceId = existing.PatientDeviceId,
         AdditionalProperties = existing.AdditionalProperties,
     };
 
@@ -186,6 +200,14 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
             models.Add(model);
         }
 
+        // Attribute the batch before persisting (see Create). Per-record DataSource drives matching,
+        // so no batch-level source is needed for a mixed-source bulk upload.
+        var attributionError = await PatientDeviceAttribution.ApplyManyAsync(
+            [.. models.Select((m, i) => ((IDeviceAttributed)m, requests[i].PatientDeviceId))],
+            patientDevices, deviceStamper, DeviceAttributionCategories.Bolus, batchSource: null, ct);
+        if (attributionError is not null)
+            return Problem(detail: attributionError, statusCode: 400, title: "Bad Request");
+
         var persisted = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         return StatusCode(201, persisted.ToArray());
     }
@@ -209,6 +231,20 @@ public class BolusController(IBolusRepository repo, IPatientInsulinRepository in
 
         var deleted = await ((IBolusRepository)Repository).DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, WriteOrigin.Live, ct);
         return deleted > 0 ? NoContent() : NotFound();
+    }
+
+    /// <summary>
+    /// Settles the bolus's device attribution from the request. Returns a 400 result when an explicit
+    /// id doesn't resolve (tenant scoping makes a cross-tenant id indistinguishable from a nonexistent
+    /// one), or <c>null</c> on success.
+    /// </summary>
+    private async Task<ObjectResult?> ApplyAttributionAsync(Bolus model, Guid? requested, Guid? existing, CancellationToken ct)
+    {
+        var error = await PatientDeviceAttribution.ApplyAsync(
+            model, requested, existing, patientDevices, deviceStamper,
+            DeviceAttributionCategories.Bolus, ct);
+
+        return error is null ? null : Problem(detail: error, statusCode: 400, title: "Bad Request");
     }
 
     private async Task EnrichInsulinContextAsync(Bolus model, Guid? patientInsulinId, CancellationToken ct)

--- a/src/API/Nocturne.API/Models/Requests/V4/CreateBolusRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/CreateBolusRequest.cs
@@ -25,6 +25,15 @@ public class CreateBolusRequest
     public string? Device { get; set; }
 
     /// <summary>
+    /// Optional reference to the registered <see cref="PatientDevice"/> that delivered the bolus.
+    /// Must resolve to one of the caller's registered devices. When omitted, the server attempts
+    /// attribution from <see cref="Device"/> and <see cref="DataSource"/>. Send the empty GUID
+    /// (<c>00000000-0000-0000-0000-000000000000</c>) to state that the bolus came from no registered
+    /// device: the link is cleared and server-side attribution is skipped for this request.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Name of the application that submitted this record.
     /// </summary>
     public string? App { get; set; }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpdateBolusRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpdateBolusRequest.cs
@@ -26,6 +26,15 @@ public class UpdateBolusRequest
     public string? Device { get; set; }
 
     /// <summary>
+    /// Optional reference to the registered <see cref="PatientDevice"/> that delivered the bolus.
+    /// Must resolve to one of the caller's registered devices. When omitted, the existing link is
+    /// preserved. Send the empty GUID (<c>00000000-0000-0000-0000-000000000000</c>) to state that the
+    /// bolus came from no registered device: the link is cleared and server-side attribution is
+    /// skipped for this request.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Name of the application that submitted this record.
     /// </summary>
     public string? App { get; set; }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertMeterGlucoseRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertMeterGlucoseRequest.cs
@@ -23,6 +23,16 @@ public class UpsertMeterGlucoseRequest
     public string? Device { get; set; }
 
     /// <summary>
+    /// Optional reference to the registered <see cref="Nocturne.Core.Models.V4.PatientDevice"/> that
+    /// produced the reading. Must resolve to one of the caller's registered devices. When omitted on
+    /// create, the server attempts attribution from <see cref="Device"/> and <see cref="DataSource"/>;
+    /// when omitted on update, the existing link is preserved. Send the empty GUID
+    /// (<c>00000000-0000-0000-0000-000000000000</c>) to state that the reading came from no registered
+    /// device: the link is cleared and server-side attribution is skipped for this request.
+    /// </summary>
+    public Guid? PatientDeviceId { get; set; }
+
+    /// <summary>
     /// Name of the application that submitted this record.
     /// </summary>
     public string? App { get; set; }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Nocturne.API.Controllers.V4.Treatments;
 using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Xunit;
@@ -16,10 +17,16 @@ public class BolusControllerTests
 {
     private readonly Mock<IBolusRepository> _repoMock = new();
     private readonly Mock<IPatientInsulinRepository> _insulinRepoMock = new();
+    private readonly Mock<IPatientDeviceRepository> _patientDevicesMock = new();
+    private readonly Mock<IPatientDeviceStamper> _deviceStamperMock = new();
 
     private BolusController CreateController()
     {
-        var controller = new BolusController(_repoMock.Object, _insulinRepoMock.Object);
+        var controller = new BolusController(
+            _repoMock.Object,
+            _insulinRepoMock.Object,
+            _patientDevicesMock.Object,
+            _deviceStamperMock.Object);
         controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
@@ -156,19 +163,198 @@ public class BolusControllerTests
         var id = Guid.NewGuid();
         Bolus? captured = null;
 
-        _repoMock
-            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Bolus { Id = id, Timestamp = DateTime.UtcNow, Insulin = 2.0, PatientDeviceId = patientDeviceId });
-        _repoMock
-            .Setup(r => r.UpdateAsync(id, It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, Bolus, WriteOrigin, CancellationToken>((_, b, _, _) => captured = b)
-            .ReturnsAsync((Guid _, Bolus b, WriteOrigin origin, CancellationToken _) => b);
+        SetupExisting(id, patientDeviceId);
+        CaptureUpdate(id, b => captured = b);
 
         await CreateController().Update(id, new UpdateBolusRequest { Timestamp = DateTimeOffset.UtcNow, Insulin = 3.0 });
 
         captured.Should().NotBeNull();
         captured!.PatientDeviceId.Should().Be(patientDeviceId);
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task Create_StampsWithInsulinDeliveryCategories_WhenRequestOmitsPatientDeviceId()
+    {
+        Bolus? captured = null;
+        SetupCreatePassthrough(b => captured = b);
+
+        await CreateController().Create(new CreateBolusRequest { Timestamp = DateTimeOffset.UtcNow, Insulin = 5.0 });
+
+        captured.Should().NotBeNull();
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.Is<IReadOnlyList<DeviceCategory>>(c => c.Contains(DeviceCategory.InsulinPump) && c.Contains(DeviceCategory.SmartPen)),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_PersistsExplicitPatientDeviceId_WithoutStamping()
+    {
+        var patientDeviceId = Guid.NewGuid();
+        SetupRegisteredDevice(patientDeviceId);
+        Bolus? captured = null;
+        SetupCreatePassthrough(b => captured = b);
+
+        var result = await CreateController().Create(new CreateBolusRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Insulin = 5.0,
+            PatientDeviceId = patientDeviceId,
+        });
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        captured.Should().NotBeNull();
+        captured!.PatientDeviceId.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
+    public async Task Create_Returns400_WhenPatientDeviceIdDoesNotResolve()
+    {
+        _patientDevicesMock
+            .Setup(p => p.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PatientDevice?)null);
+
+        var result = await CreateController().Create(new CreateBolusRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Insulin = 5.0,
+            PatientDeviceId = Guid.NewGuid(),
+        });
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_ClearsAttribution_AndSkipsStamping_WhenRequestSendsTheClearSentinel()
+    {
+        Bolus? captured = null;
+        SetupCreatePassthrough(b => captured = b);
+
+        var result = await CreateController().Create(new CreateBolusRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Insulin = 5.0,
+            PatientDeviceId = Guid.Empty,
+        });
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        captured.Should().NotBeNull();
+        captured!.PatientDeviceId.Should().BeNull();
+        VerifyStamperNeverRan();
+    }
+
+    [Fact]
+    public async Task Update_RelinksAttribution_WhenRequestCarriesPatientDeviceId()
+    {
+        var id = Guid.NewGuid();
+        var newPatientDeviceId = Guid.NewGuid();
+        SetupRegisteredDevice(newPatientDeviceId);
+        Bolus? captured = null;
+
+        SetupExisting(id, Guid.NewGuid());
+        CaptureUpdate(id, b => captured = b);
+
+        await CreateController().Update(id, new UpdateBolusRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Insulin = 3.0,
+            PatientDeviceId = newPatientDeviceId,
+        });
+
+        captured.Should().NotBeNull();
+        captured!.PatientDeviceId.Should().Be(newPatientDeviceId);
+    }
+
+    [Fact]
+    public async Task Update_ClearsAttribution_AndSkipsStamping_WhenRequestSendsTheClearSentinel()
+    {
+        var id = Guid.NewGuid();
+        Bolus? captured = null;
+
+        SetupExisting(id, Guid.NewGuid());
+        CaptureUpdate(id, b => captured = b);
+
+        var result = await CreateController().Update(id, new UpdateBolusRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Insulin = 3.0,
+            PatientDeviceId = Guid.Empty,
+        });
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        captured.Should().NotBeNull();
+        captured!.PatientDeviceId.Should().BeNull();
+        VerifyStamperNeverRan();
+    }
+
+    [Fact]
+    public async Task CreateBulk_StampsOnlyTheBolusesThatDidNotClearAttribution()
+    {
+        var stamped = Guid.NewGuid();
+        var requests = new[]
+        {
+            new CreateBolusRequest { Timestamp = DateTimeOffset.UtcNow, Insulin = 5.0, PatientDeviceId = Guid.Empty },
+            new CreateBolusRequest { Timestamp = DateTimeOffset.UtcNow.AddMinutes(-5), Insulin = 2.0 },
+        };
+
+        _deviceStamperMock
+            .Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+                It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
+                (records, _, _, _) =>
+                {
+                    foreach (var record in records)
+                        record.PatientDeviceId = stamped;
+                })
+            .Returns(Task.CompletedTask);
+
+        IEnumerable<Bolus>? persisted = null;
+        _repoMock
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<Bolus>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<Bolus>, WriteOrigin, CancellationToken>((b, _, _) => persisted = b.ToList())
+            .ReturnsAsync((IEnumerable<Bolus> b, WriteOrigin _, CancellationToken _) => b);
+
+        await CreateController().CreateBolusesBulk(requests);
+
+        persisted.Should().NotBeNull();
+        persisted!.Should().SatisfyRespectively(
+            cleared => cleared.PatientDeviceId.Should().BeNull(),
+            attributed => attributed.PatientDeviceId.Should().Be(stamped));
+    }
+
+    private void SetupExisting(Guid id, Guid? patientDeviceId) =>
+        _repoMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Bolus { Id = id, Timestamp = DateTime.UtcNow, Insulin = 2.0, PatientDeviceId = patientDeviceId });
+
+    private void CaptureUpdate(Guid id, Action<Bolus> onUpdate) =>
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<Bolus>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, Bolus, WriteOrigin, CancellationToken>((_, b, _, _) => onUpdate(b))
+            .ReturnsAsync((Guid _, Bolus b, WriteOrigin _, CancellationToken _) => b);
+
+    private void SetupRegisteredDevice(Guid patientDeviceId) =>
+        _patientDevicesMock
+            .Setup(p => p.GetByIdAsync(patientDeviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PatientDevice { Id = patientDeviceId, DeviceCategory = DeviceCategory.InsulinPump });
+
+    private void VerifyStamperNeverRan() =>
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
 
     [Fact]
     public async Task Create_WithPatientInsulinId_EnrichesInsulinContext()

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/MeterGlucoseControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/MeterGlucoseControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Nocturne.API.Controllers.V4.Glucose;
 using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Xunit;
@@ -15,10 +16,15 @@ namespace Nocturne.API.Tests.Controllers.V4;
 public class MeterGlucoseControllerTests
 {
     private readonly Mock<IMeterGlucoseRepository> _repoMock = new();
+    private readonly Mock<IPatientDeviceRepository> _patientDevicesMock = new();
+    private readonly Mock<IPatientDeviceStamper> _deviceStamperMock = new();
 
     private MeterGlucoseController CreateController()
     {
-        var controller = new MeterGlucoseController(_repoMock.Object);
+        var controller = new MeterGlucoseController(
+            _repoMock.Object,
+            _patientDevicesMock.Object,
+            _deviceStamperMock.Object);
         controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
         return controller;
     }
@@ -30,20 +36,164 @@ public class MeterGlucoseControllerTests
         var id = Guid.NewGuid();
         MeterGlucose? captured = null;
 
-        // IMeterGlucoseRepository shadows GetByIdAsync with `new`, and the base controller reaches the
-        // repository through the IV4Repository<T> constraint, so the setup has to target that interface.
-        var baseRepo = _repoMock.As<IV4Repository<MeterGlucose>>();
-        baseRepo
-            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MeterGlucose { Id = id, Timestamp = DateTime.UtcNow, Mgdl = 120, PatientDeviceId = patientDeviceId });
-        baseRepo
-            .Setup(r => r.UpdateAsync(id, It.IsAny<MeterGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, MeterGlucose, WriteOrigin, CancellationToken>((_, m, _, _) => captured = m)
-            .ReturnsAsync((Guid _, MeterGlucose m, WriteOrigin _, CancellationToken _) => m);
+        SetupExisting(id, patientDeviceId);
+        CaptureUpdate(id, m => captured = m);
 
         await CreateController().Update(id, new UpsertMeterGlucoseRequest { Timestamp = DateTimeOffset.UtcNow, Mgdl = 95 });
 
         captured.Should().NotBeNull();
         captured!.PatientDeviceId.Should().Be(patientDeviceId);
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task Create_StampsWithGlucoseMeterCategory_WhenRequestOmitsPatientDeviceId()
+    {
+        MeterGlucose? persisted = null;
+        CaptureCreate(m => persisted = m);
+
+        await CreateController().Create(new UpsertMeterGlucoseRequest { Timestamp = DateTimeOffset.UtcNow, Mgdl = 120 });
+
+        persisted.Should().NotBeNull();
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.Is<IReadOnlyList<DeviceCategory>>(c => c.Contains(DeviceCategory.GlucoseMeter)),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_PersistsExplicitPatientDeviceId_WithoutStamping()
+    {
+        var patientDeviceId = Guid.NewGuid();
+        SetupRegisteredDevice(patientDeviceId);
+        MeterGlucose? persisted = null;
+        CaptureCreate(m => persisted = m);
+
+        var result = await CreateController().Create(new UpsertMeterGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 120,
+            PatientDeviceId = patientDeviceId,
+        });
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        persisted.Should().NotBeNull();
+        persisted!.PatientDeviceId.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
+    public async Task Create_Returns400_WhenPatientDeviceIdDoesNotResolve()
+    {
+        _patientDevicesMock
+            .Setup(p => p.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PatientDevice?)null);
+
+        var result = await CreateController().Create(new UpsertMeterGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 120,
+            PatientDeviceId = Guid.NewGuid(),
+        });
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<MeterGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_ClearsAttribution_AndSkipsStamping_WhenRequestSendsTheClearSentinel()
+    {
+        MeterGlucose? persisted = null;
+        CaptureCreate(m => persisted = m);
+
+        var result = await CreateController().Create(new UpsertMeterGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 120,
+            PatientDeviceId = Guid.Empty,
+        });
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        persisted.Should().NotBeNull();
+        persisted!.PatientDeviceId.Should().BeNull();
+        VerifyStamperNeverRan();
+    }
+
+    [Fact]
+    public async Task Update_RelinksAttribution_WhenRequestCarriesPatientDeviceId()
+    {
+        var id = Guid.NewGuid();
+        var newPatientDeviceId = Guid.NewGuid();
+        SetupRegisteredDevice(newPatientDeviceId);
+        MeterGlucose? updated = null;
+
+        SetupExisting(id, Guid.NewGuid());
+        CaptureUpdate(id, m => updated = m);
+
+        await CreateController().Update(id, new UpsertMeterGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 95,
+            PatientDeviceId = newPatientDeviceId,
+        });
+
+        updated.Should().NotBeNull();
+        updated!.PatientDeviceId.Should().Be(newPatientDeviceId);
+    }
+
+    [Fact]
+    public async Task Update_ClearsAttribution_AndSkipsStamping_WhenRequestSendsTheClearSentinel()
+    {
+        var id = Guid.NewGuid();
+        MeterGlucose? updated = null;
+
+        SetupExisting(id, Guid.NewGuid());
+        CaptureUpdate(id, m => updated = m);
+
+        var result = await CreateController().Update(id, new UpsertMeterGlucoseRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Mgdl = 95,
+            PatientDeviceId = Guid.Empty,
+        });
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        updated.Should().NotBeNull();
+        updated!.PatientDeviceId.Should().BeNull();
+        VerifyStamperNeverRan();
+    }
+
+    private void SetupExisting(Guid id, Guid? patientDeviceId) =>
+        _repoMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MeterGlucose { Id = id, Timestamp = DateTime.UtcNow, Mgdl = 120, PatientDeviceId = patientDeviceId });
+
+    private void CaptureCreate(Action<MeterGlucose> onCreate) =>
+        _repoMock
+            .Setup(r => r.CreateAsync(It.IsAny<MeterGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<MeterGlucose, WriteOrigin, CancellationToken>((m, _, _) => onCreate(m))
+            .ReturnsAsync((MeterGlucose m, WriteOrigin _, CancellationToken _) => m);
+
+    private void CaptureUpdate(Guid id, Action<MeterGlucose> onUpdate) =>
+        _repoMock
+            .Setup(r => r.UpdateAsync(id, It.IsAny<MeterGlucose>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, MeterGlucose, WriteOrigin, CancellationToken>((_, m, _, _) => onUpdate(m))
+            .ReturnsAsync((Guid _, MeterGlucose m, WriteOrigin _, CancellationToken _) => m);
+
+    private void SetupRegisteredDevice(Guid patientDeviceId) =>
+        _patientDevicesMock
+            .Setup(p => p.GetByIdAsync(patientDeviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PatientDevice { Id = patientDeviceId, DeviceCategory = DeviceCategory.GlucoseMeter });
+
+    private void VerifyStamperNeverRan() =>
+        _deviceStamperMock.Verify(s => s.StampAsync(
+            It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+            It.IsAny<IReadOnlyList<DeviceCategory>>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
 }


### PR DESCRIPTION
## What

#703 gave DeviceEvent and SensorGlucose the explicit `Guid.Empty` clear semantic; Bolus and MeterGlucose could still only preserve their `PatientDevice` link — neither controller ran the stamper on create (so direct V4 REST writes stayed unattributed and surfaced as pseudo-devices), and no PUT body could re-link or unlink one. Mis-attributed insulin records couldn't be corrected in place.

Both controllers now route create, update, and — for boluses — the bulk write through the same `PatientDeviceAttribution` mechanism, answering the identical three request shapes: **omitted** leaves attribution to the server (stamp on create, preserve on update), **`Guid.Empty`** unattributes and suppresses the stamper, an **explicit id** is validated against the caller's registered devices in-tenant. The `PatientDeviceId = existing.PatientDeviceId` copies in `MapUpdateToModel` are gone — preserve now flows through the helper's `existing` argument, so preserve/clear/set share one path. Bolus bulk is included because `CreateBolusRequest` is the bulk body type; adding `patientDeviceId` there and ignoring it would be a silent hole (mirrors #703's SensorGlucose bulk).

## TempBasal verdict (assessed, not changed)

No by-id update endpoint exists — only `GET`s and one bulk `POST` whose upsert happens inside the repository on `(DataSource, SyncIdentifier)`. Two findings filed for the backlog rather than bolted on here:
- That upsert path is reachable as an in-place update, but can't express a clear.
- It **silently overwrites** attribution: `TempBasalMapper.UpdateEntity` assigns `PatientDeviceId` unconditionally from a freshly stamped model, so an uploader retry after a device-usage-window edit nulls an existing link — the same shape as the bolus/meter PUT bug #703 fixed, on a create endpoint. Giving it a clear semantic is a design question (what does "omitted" mean when the existing row is never loaded?).

## Note on the base

Written against a faithful local rebase of #703 (range-diff-verified; the conflicts were #709's `DeviceAttributionCategories` centralization replacing #703's inline category lists). #703 then merged independently with a semantically identical resolution (delta: pure line wrapping), so this cherry-picked cleanly onto main; the 47 attribution-related controller tests pass on the current tip.

## Tests

14 new (7 per type): preserve, stamp-with-category on create, explicit set, 400 on unresolvable id, clear on create, relink on update, clear on update, plus the bulk partial-clear case. Mutation-proven three ways: un-suppressing the stamper in the shared clear branch fails 10 tests (the 5 new per-type clears *plus* #703's 5, confirming the branch is genuinely shared); dropping the request's `patientDeviceId` in both helpers fails 10; nulling the bulk per-record pass-through fails the partial-clear test. Full API unit suite on the pre-merge base: 5260 passed, 0 failed.

https://claude.ai/code/session_01FC5TxNBf54o4kvhAWxPGB7
