### PR TITLE
fix(oidc): emit the spec-mandated snake_case member names in discovery

### DIFF
--- a/src/API/Nocturne.API/Controllers/WellKnownController.cs
+++ b/src/API/Nocturne.API/Controllers/WellKnownController.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -184,24 +185,63 @@ public class WellKnownController : ControllerBase
 /// OpenID Connect Discovery Document
 /// See: https://openid.net/specs/openid-connect-discovery-1_0.html
 /// </summary>
+/// <remarks>
+/// Discovery metadata member names are fixed by the specifications, so every member is pinned
+/// with <see cref="JsonPropertyNameAttribute"/> rather than left to the camelCase policy MVC
+/// applies by default. Pinning them on the model also keeps the generated OpenAPI schema — and
+/// therefore the generated clients — describing the names that actually go on the wire.
+/// </remarks>
 public class OpenIdConfiguration
 {
+    [JsonPropertyName("issuer")]
     public string Issuer { get; set; } = string.Empty;
+
+    [JsonPropertyName("authorization_endpoint")]
     public string AuthorizationEndpoint { get; set; } = string.Empty;
+
+    [JsonPropertyName("token_endpoint")]
     public string TokenEndpoint { get; set; } = string.Empty;
+
+    [JsonPropertyName("userinfo_endpoint")]
     public string? UserinfoEndpoint { get; set; }
+
+    [JsonPropertyName("jwks_uri")]
     public string JwksUri { get; set; } = string.Empty;
+
+    [JsonPropertyName("registration_endpoint")]
     public string? RegistrationEndpoint { get; set; }
+
+    [JsonPropertyName("end_session_endpoint")]
     public string? EndSessionEndpoint { get; set; }
+
+    [JsonPropertyName("scopes_supported")]
     public string[] ScopesSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("response_types_supported")]
     public string[] ResponseTypesSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("response_modes_supported")]
     public string[] ResponseModesSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("grant_types_supported")]
     public string[] GrantTypesSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("subject_types_supported")]
     public string[] SubjectTypesSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("id_token_signing_alg_values_supported")]
     public string[] IdTokenSigningAlgValuesSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("token_endpoint_auth_methods_supported")]
     public string[] TokenEndpointAuthMethodsSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("claims_supported")]
     public string[] ClaimsSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("code_challenge_methods_supported")]
     public string[] CodeChallengeMethodsSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("service_documentation")]
     public string? ServiceDocumentation { get; set; }
 }
 
@@ -232,19 +272,46 @@ public class JsonWebKey
 /// </summary>
 public class OAuthAuthorizationServerMetadata
 {
+    [JsonPropertyName("issuer")]
     public string Issuer { get; set; } = string.Empty;
+
+    [JsonPropertyName("authorization_endpoint")]
     public string AuthorizationEndpoint { get; set; } = string.Empty;
+
+    [JsonPropertyName("token_endpoint")]
     public string TokenEndpoint { get; set; } = string.Empty;
+
+    [JsonPropertyName("device_authorization_endpoint")]
     public string? DeviceAuthorizationEndpoint { get; set; }
+
+    [JsonPropertyName("revocation_endpoint")]
     public string? RevocationEndpoint { get; set; }
+
+    [JsonPropertyName("introspection_endpoint")]
     public string? IntrospectionEndpoint { get; set; }
+
+    [JsonPropertyName("registration_endpoint")]
     public string? RegistrationEndpoint { get; set; }
+
+    [JsonPropertyName("jwks_uri")]
     public string JwksUri { get; set; } = string.Empty;
+
+    [JsonPropertyName("response_types_supported")]
     public string[] ResponseTypesSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("grant_types_supported")]
     public string[] GrantTypesSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("token_endpoint_auth_methods_supported")]
     public string[] TokenEndpointAuthMethodsSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("scopes_supported")]
     public OAuthScope[] ScopesSupported { get; set; } = Array.Empty<OAuthScope>();
+
+    [JsonPropertyName("code_challenge_methods_supported")]
     public string[] CodeChallengeMethodsSupported { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("service_documentation")]
     public string? ServiceDocumentation { get; set; }
 }
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/WellKnownControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/WellKnownControllerTests.cs
@@ -16,6 +16,24 @@ public sealed class WellKnownControllerTests : IClassFixture<AuthenticationTestF
     private static readonly JsonSerializerOptions CaseInsensitive =
         new() { PropertyNameCaseInsensitive = true };
 
+    /// <summary>
+    /// Member names every relying party looks for, spelled as OpenID Connect Discovery 1.0 and
+    /// RFC 8414 spell them. Both documents carry all of these.
+    /// </summary>
+    private static readonly string[] SpecifiedMemberNames =
+    [
+        "issuer",
+        "authorization_endpoint",
+        "token_endpoint",
+        "jwks_uri",
+        "scopes_supported",
+        "response_types_supported",
+        "grant_types_supported",
+        "token_endpoint_auth_methods_supported",
+        "code_challenge_methods_supported",
+        "service_documentation",
+    ];
+
     private readonly HttpClient _client;
 
     public WellKnownControllerTests(AuthenticationTestFactory factory)
@@ -28,7 +46,10 @@ public sealed class WellKnownControllerTests : IClassFixture<AuthenticationTestF
     [InlineData("/.well-known/oauth-authorization-server")]
     public async Task Advertised_jwks_uri_serves_the_key_set(string discoveryPath)
     {
-        var jwksUri = await GetAdvertisedJwksUriAsync(discoveryPath);
+        using var discovery = await GetDiscoveryDocumentAsync(discoveryPath);
+
+        discovery.RootElement.TryGetProperty("jwks_uri", out var advertised).Should().BeTrue();
+        var jwksUri = advertised.GetString()!;
         jwksUri.Should().EndWith("/.well-known/jwks.json");
 
         var response = await _client.GetAsync(new Uri(jwksUri).PathAndQuery);
@@ -38,18 +59,34 @@ public sealed class WellKnownControllerTests : IClassFixture<AuthenticationTestF
         keySet!.Keys.Should().ContainSingle().Which.Alg.Should().Be("HS256");
     }
 
-    private async Task<string> GetAdvertisedJwksUriAsync(string discoveryPath)
+    [Theory]
+    [InlineData("/.well-known/openid-configuration")]
+    [InlineData("/.well-known/oauth-authorization-server")]
+    public async Task Discovery_document_spells_its_members_the_way_the_specs_do(
+        string discoveryPath
+    )
+    {
+        using var discovery = await GetDiscoveryDocumentAsync(discoveryPath);
+
+        var memberNames = discovery
+            .RootElement.EnumerateObject()
+            .Select(property => property.Name)
+            .ToArray();
+
+        memberNames.Should().Contain(SpecifiedMemberNames);
+        memberNames
+            .Should()
+            .OnlyContain(
+                name => name == name.ToLowerInvariant(),
+                "discovery members are lower snake_case, so no camelCase name is recognisable"
+            );
+    }
+
+    private async Task<JsonDocument> GetDiscoveryDocumentAsync(string discoveryPath)
     {
         var response = await _client.GetAsync(discoveryPath);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-        return document
-            .RootElement.EnumerateObject()
-            .Single(property =>
-                property.Name.Replace("_", string.Empty)
-                    .Equals("jwksuri", StringComparison.OrdinalIgnoreCase)
-            )
-            .Value.GetString()!;
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
     }
 }


### PR DESCRIPTION
## What

Both discovery documents (`/.well-known/openid-configuration`, `/.well-known/oauth-authorization-server`) serialized with MVC's default camelCase policy — the actual wire output was `authorizationEndpoint`, `tokenEndpoint`, `jwksUri`, `scopesSupported`, … with only `issuer` spec-correct. A strict OIDC relying party parsing the document finds no recognizable fields at all. (The #684 test deliberately read property names agnostically so it wouldn't pin the wrong casing; this was flagged in that PR's body.)

Fix: `[JsonPropertyName]` on every member of both DTOs, following the established RFC 7591 idiom in `ClientRegistrationResponse`. A per-action snake_case serializer was rejected deliberately: `[ProducesResponseType]` drives the NSwag schema, so custom `JsonResult` options would fix the wire while leaving the published spec — and every generated client — documenting camelCase. Attributes fix both at once.

**No consumer depended on the old names** — searched the whole tree; everything that parses a discovery document (`OidcProviderService`, `OidcProviderAdminController`) already reads snake_case because those parse *external* providers' documents, and nothing in the frontend touches the `oidcDiscovery` client.

## Tests

Run against the real `Program.cs` pipeline via `WebApplicationFactory`, so they exercise genuine MVC serialization. The #684 jwks test tightened to `TryGetProperty("jwks_uri")` exactly; a new test pins 10 members by exact name (including `authorization_endpoint`/`token_endpoint`) plus an `OnlyContain` invariant rejecting any camelCase leak across all members of both documents.

Mutation-proven: reverting the controller fails all 4 tests (dumping the real camelCase wire output); un-pinning exactly one property per document fails exactly the two exact-name tests with precise attribution while the jwks tests stay green. Cherry-picked onto main after #684 merged; 4/4 green on the current tip.

## Scoped out, flagged

- `JsonWebKeySet`/`JsonWebKey` left unattributed: RFC 7517's names (`keys`, `kty`, `kid`, `n`, `e`, …) are single lowercase words, so camelCase already emits byte-identical output.
- `registration_endpoint`/`end_session_endpoint` still serialize as explicit `null` — spec-untidy but pre-existing and orthogonal to naming.

https://claude.ai/code/session_01FC5TxNBf54o4kvhAWxPGB7
