### PR TITLE
fix(web): stop demo tenants 500ing on the authenticated layout

### DIFF
--- a/src/Web/packages/app/src/lib/utils/api-date.test.ts
+++ b/src/Web/packages/app/src/lib/utils/api-date.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { toIsoString } from "./api-date";
+
+describe("toIsoString", () => {
+	it("normalises the ISO string the client actually returns for a `Date` field", () => {
+		expect(toIsoString("2026-08-14T03:00:00Z")).toBe("2026-08-14T03:00:00.000Z");
+	});
+
+	it("accepts a real Date, in case a field is ever hydrated", () => {
+		expect(toIsoString(new Date(Date.UTC(2026, 7, 14, 3)))).toBe("2026-08-14T03:00:00.000Z");
+	});
+
+	it("returns null for absent or unparseable values", () => {
+		expect(toIsoString(null)).toBeNull();
+		expect(toIsoString(undefined)).toBeNull();
+		expect(toIsoString("")).toBeNull();
+		expect(toIsoString("not a date")).toBeNull();
+	});
+});

--- a/src/Web/packages/app/src/lib/utils/api-date.ts
+++ b/src/Web/packages/app/src/lib/utils/api-date.ts
@@ -1,0 +1,10 @@
+/**
+ * The generated API client types date fields as `Date`, but it parses responses with a
+ * plain `JSON.parse` and no reviver — the values arrive as ISO strings. Calling a `Date`
+ * method straight off a client field throws, so normalise through here first.
+ */
+export function toIsoString(value: Date | string | null | undefined): string | null {
+  if (value == null || value === "") return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -2,6 +2,7 @@ import { redirect } from "@sveltejs/kit";
 import type { LayoutServerLoad } from "./$types";
 import { checkOnboarding } from "$lib/server/onboarding-check";
 import { getOriginalHost, isShareHost } from "$lib/server/request-host";
+import { toIsoString } from "$lib/utils/api-date";
 
 /** Permissions that grant read access to glucose data (mirrors API's CanRead + OAuth scopes). */
 const GLUCOSE_READ_PERMISSIONS = [
@@ -80,7 +81,7 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, request }) 
     : publicViewAllowed;
 
   const isDemo = status?.isDemo ?? false;
-  const nextResetAt = status?.nextResetAt ? status.nextResetAt.toISOString() : null;
+  const nextResetAt = toIsoString(status?.nextResetAt);
 
   return {
     user: locals.user ?? null,


### PR DESCRIPTION
## Problem

The demo instance returns `An error occurred while processing your request.` on every authenticated route, with:

```
status.nextResetAt.toISOString is not a function
```

The generated NSwag client types date fields as `Date`, but `processGetStatus` parses the response with a bare `JSON.parse(_responseText, this.jsonParseReviver)` and the reviver is `undefined` — so `nextResetAt` is an ISO **string** at runtime while the type says `Date`. `(authenticated)/+layout.server.ts` called `.toISOString()` on it directly, throwing inside the layout load, i.e. a 500 for the whole shell.

Only demo tenants hit it: `nextResetAt` is null everywhere else, so the ternary short-circuits. Introduced in #364 (Jun 7), so demo tenants have been broken since the field landed.

## Fix

A shared `toIsoString` helper that takes either shape, plus a NaN guard so an unparseable timestamp costs the demo banner rather than the entire authenticated layout. Covered by `api-date.test.ts` — the string case is the exact regression.

https://claude.ai/code/session_011VsmdVEXvQ6GaegVwedj8H
