### PR TITLE
feat(demo): full data-type coverage — unified timeline, device status, V4 realtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ docs/diagrams/er-*.mmd
 # External projects
 AndroidAPS/
 Trio/
+.claude/worktrees/

--- a/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
@@ -234,13 +234,15 @@ public class DemoAdminController : ControllerBase
     }
 
     /// <summary>
-    /// Seeds the demo tenant with the non-glucose sample set: device changes,
-    /// sleep sessions, heart rate, step counts, consumable trackers, and alert
-    /// rules with alarm history. Called by the demo background service after
-    /// each regenerate; entries/treatments arrive separately via the streaming
-    /// v1 posts. Idempotent — trackers, sleep, activity, and alarm history
-    /// upsert or rebuild rather than duplicate. Trackers are owned by the demo
-    /// tenant's Public subject, which anonymous visitors browse as.
+    /// Seeds the demo tenant with the full sample set — glucose, treatments,
+    /// device status, therapy profile, device changes, sleep, activity,
+    /// trackers, alert rules with alarm history and notifications, foods,
+    /// state spans, patient record, body weight, timezone timeline, clock
+    /// face, and a DND example. Called by the demo background service after
+    /// each reset. Idempotent — every type upserts or rebuilds rather than
+    /// duplicates, except entries/treatments which append (the demo resets
+    /// before seeding). Per-user types are owned by the demo tenant's Public
+    /// subject, which anonymous visitors browse as.
     /// </summary>
     [HttpPost("seed-extras")]
     [ProducesResponseType(typeof(SampleDataSeedResult), StatusCodes.Status200OK)]
@@ -267,54 +269,10 @@ public class DemoAdminController : ControllerBase
             request?.Days ?? 7,
             publicSubjectId,
             DataSources.DemoService,
-            includeGlucose: false,
+            includeGlucose: request?.IncludeGlucose ?? true,
             ct);
 
         return Ok(seeded);
-    }
-
-    /// <summary>
-    /// Ensures a demo PatientInsulin record exists for the demo tenant.
-    /// Creates a default rapid-acting insulin (Humalog) if none exists.
-    /// </summary>
-    [HttpPost("ensure-insulin")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> EnsureInsulin(CancellationToken ct)
-    {
-        await using var db = await _factory.CreateDbContextAsync(ct);
-
-        var tenant = await db.Set<TenantEntity>().FirstOrDefaultAsync(t => t.IsDemo, ct);
-        if (tenant is null)
-            return NotFound();
-
-        db.TenantId = tenant.Id;
-
-        var exists = await db.PatientInsulins.AnyAsync(ct);
-        if (exists)
-            return Ok(new { created = false });
-
-        var insulin = new PatientInsulinEntity
-        {
-            Id = Guid.CreateVersion7(),
-            TenantId = tenant.Id,
-            InsulinCategory = "RapidActing",
-            Name = "Humalog",
-            IsCurrent = true,
-            Dia = 4.0,
-            Peak = 75,
-            Curve = "rapid-acting",
-            Concentration = 100,
-            Role = "Bolus",
-            IsPrimary = true,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
-        };
-
-        db.PatientInsulins.Add(insulin);
-        await db.SaveChangesAsync(ct);
-
-        return Ok(new { created = true });
     }
 
     private static DemoStateDto ToDto(TenantEntity tenant, bool alreadyExisted) => new(
@@ -351,4 +309,4 @@ public record DemoDeleteResultDto(long DeletedCount);
 
 public record DemoResetResultDto(Guid TenantId);
 
-public record DemoSeedExtrasDto(int Days = 7);
+public record DemoSeedExtrasDto(int Days = 7, bool IncludeGlucose = true);

--- a/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
+++ b/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
@@ -5,13 +5,16 @@ using Nocturne.API.Services.Alerts;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Sleep;
 using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Alerts;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Abstractions;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Services.Demo.Configuration;
 using Nocturne.Services.Demo.Services;
 
@@ -28,17 +31,27 @@ public sealed record SampleDataSeedResult(
     int TrackerDefinitions,
     int TrackerInstances,
     int AlertRules,
-    int AlertExcursions);
+    int AlertExcursions,
+    int DeviceStatuses,
+    int Profiles,
+    int Foods,
+    int StateSpans,
+    int Notifications);
 
 /// <summary>
-/// Populates a tenant with realistic sample data using the demo service's oref
-/// pharmacokinetic generator plus the scenario-correlated health generators:
-/// CGM entries, treatments, device-change events, sleep sessions, heart rate,
-/// step counts, consumable trackers, and alert rules with historical alarm
-/// firings derived from the generated glucose itself. Everything is written
-/// through the normal ingestion services and repositories so device
-/// attribution, the v4 canonical glucose stream, and RLS tenant context are
-/// handled exactly like production writes.
+/// Populates a tenant with realistic sample data covering every data type the
+/// platform can hold, driven by the demo service's unified oref simulation
+/// timeline: CGM entries, fingersticks and calibrations, treatments (boluses,
+/// carbs, temp basals, BG checks, notes), Trio-style device status (APS
+/// snapshots with predictions, pump reservoir/battery, phone battery), the
+/// therapy profile, device-change events, sleep, heart rate, steps, consumable
+/// trackers, alert rules with alarm history and their in-app notifications,
+/// state spans (pump mode, overrides, exercise, illness, travel), the food
+/// library with per-meal attribution, patient record and devices, body weight,
+/// the timezone timeline, a clock face, and a DND-window example. Everything
+/// writes through the normal ingestion services and decomposers so device
+/// attribution, the v4 canonical streams, and RLS tenant context are handled
+/// exactly like production writes.
 ///
 /// Two callers: the dev-only admin endpoints (Development, dataSource
 /// "dev-sample") and the demo admin endpoint the demo container invokes after
@@ -55,14 +68,22 @@ public class SampleDataSeeder
     private readonly IStepCountService _stepCountService;
     private readonly ITrackerRepository _trackerRepository;
     private readonly IRuleScopeClassifier _scopeClassifier;
+    private readonly IProfileWriteService _profileWriteService;
+    private readonly IDeviceStatusDecomposer _deviceStatusDecomposer;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<SampleDataSeeder> _logger;
 
     private const int BatchSize = 500;
     private const int MaxDays = 90;
 
+    /// <summary>Device status cadence: one document per 15 minutes of history.</summary>
+    private const int DeviceStatusMinutes = 15;
+
     /// <summary>Most recent alarm episodes to materialize as excursions/instances.</summary>
     private const int MaxAlarmEpisodes = 40;
+
+    /// <summary>Most recent alarm episodes to mirror as in-app notifications.</summary>
+    private const int MaxAlarmNotifications = 6;
 
     /// <summary>
     /// Default source for dev seeding. The generator stamps records with
@@ -82,6 +103,8 @@ public class SampleDataSeeder
         IStepCountService stepCountService,
         ITrackerRepository trackerRepository,
         IRuleScopeClassifier scopeClassifier,
+        IProfileWriteService profileWriteService,
+        IDeviceStatusDecomposer deviceStatusDecomposer,
         ILoggerFactory loggerFactory,
         ILogger<SampleDataSeeder> logger)
     {
@@ -94,16 +117,18 @@ public class SampleDataSeeder
         _stepCountService = stepCountService;
         _trackerRepository = trackerRepository;
         _scopeClassifier = scopeClassifier;
+        _profileWriteService = profileWriteService;
+        _deviceStatusDecomposer = deviceStatusDecomposer;
         _loggerFactory = loggerFactory;
         _logger = logger;
     }
 
     /// <summary>
     /// Generates and persists <paramref name="days"/> days of sample data.
-    /// <paramref name="ownerSubjectId"/> owns the seeded tracker definitions
-    /// and instances; when null, trackers are skipped (they are per-user).
-    /// With <paramref name="includeGlucose"/> false, entries/treatments are
-    /// assumed already present (the demo container streams them itself) and
+    /// <paramref name="ownerSubjectId"/> owns the seeded tracker definitions,
+    /// clock faces, food favorites, and notifications; when null, those
+    /// per-user types are skipped. With <paramref name="includeGlucose"/>
+    /// false, entries/treatments/device status are assumed already present and
     /// alarm history derives from the stored glucose instead of the generated
     /// stream. Re-seeding is idempotent for every type except
     /// entries/treatments, which append.
@@ -126,53 +151,110 @@ public class SampleDataSeeder
         _tenantAccessor.SetTenant(tenant);
         _db.TenantId = tenant.TenantId;
 
+        var config = new DemoModeConfiguration { BackfillDays = days };
+
         // The episode tracker rides along with the glucose stream so alarm
         // history matches the lows/highs actually visible on the chart.
         var episodeTracker = new DemoAlertSeeds.GlucoseEpisodeTracker(DemoAlertSeeds.Defaults);
 
+        // Seed the therapy profile before glucose so scheduled-basal context
+        // exists from the first record.
+        var profilesCreated = await SeedProfileAsync(config, ct);
+
         var entryCount = 0;
         var treatmentCount = 0;
+        var deviceStatusCount = 0;
+        var mealCarbLinks = new List<(DateTime Time, string MealName)>();
+
         if (includeGlucose)
         {
-            var config = new DemoModeConfiguration { BackfillDays = days };
             var generator = new DemoDataGenerator(
                 Options.Create(config),
                 _loggerFactory.CreateLogger<DemoDataGenerator>(),
                 _loggerFactory);
 
-            var entries = generator.GenerateHistoricalEntries()
-                .Select(e =>
-                {
-                    e.DataSource = dataSource;
-                    episodeTracker.Observe(
-                        DateTimeOffset.FromUnixTimeMilliseconds(e.Mills).UtcDateTime, e.Sgv);
-                    return e;
-                });
-
-            foreach (var batch in entries.Chunk(BatchSize))
-            {
-                var created = await _entryService.CreateEntriesAsync(batch, cancellationToken: ct);
-                entryCount += created.Count();
-            }
-
-            // "Scheduled Basal" is a demo-service event type the treatment
-            // decomposer doesn't recognize — it decomposes to nothing and logs
-            // a warning per record.
-            var treatments = generator.GenerateHistoricalTreatments()
-                .Where(t => t.EventType != "Scheduled Basal")
-                .Select(t =>
-                {
-                    t.DataSource = dataSource;
-                    return t;
-                });
-
+            var entryBatch = new List<Entry>(BatchSize);
+            var treatmentBatch = new List<Treatment>(BatchSize);
+            var statusBatch = new List<DeviceStatus>(BatchSize);
             var requestedTreatments = 0;
-            foreach (var batch in treatments.Chunk(BatchSize))
+
+            async Task FlushEntriesAsync()
             {
-                requestedTreatments += batch.Length;
-                var created = await _treatmentService.CreateTreatmentsAsync(batch, ct);
-                treatmentCount += created.Count();
+                if (entryBatch.Count == 0) return;
+                var created = await _entryService.CreateEntriesAsync(entryBatch, cancellationToken: ct);
+                entryCount += created.Count();
+                entryBatch.Clear();
             }
+
+            async Task FlushTreatmentsAsync()
+            {
+                if (treatmentBatch.Count == 0) return;
+                requestedTreatments += treatmentBatch.Count;
+                var created = await _treatmentService.CreateTreatmentsAsync(treatmentBatch, ct);
+                treatmentCount += created.Count();
+                treatmentBatch.Clear();
+            }
+
+            async Task FlushStatusesAsync()
+            {
+                foreach (var status in statusBatch)
+                {
+                    await _deviceStatusDecomposer.DecomposeAsync(
+                        status, dataSource, Core.Contracts.V4.WriteOrigin.Backfill, ct);
+                    deviceStatusCount++;
+                }
+                statusBatch.Clear();
+            }
+
+            foreach (var step in generator.GenerateHistoricalTimeline())
+            {
+                ct.ThrowIfCancellationRequested();
+
+                step.Entry.DataSource = dataSource;
+                episodeTracker.Observe(
+                    DateTimeOffset.FromUnixTimeMilliseconds(step.Entry.Mills).UtcDateTime, step.Entry.Sgv);
+                entryBatch.Add(step.Entry);
+                foreach (var extra in step.ExtraEntries)
+                {
+                    extra.DataSource = dataSource;
+                    entryBatch.Add(extra);
+                }
+
+                foreach (var treatment in step.Treatments)
+                {
+                    treatment.DataSource = dataSource;
+                    treatmentBatch.Add(treatment);
+                    if (treatment.EventType == "Carbs" && treatment.FoodType is { Length: > 0 })
+                        mealCarbLinks.Add((DateTimeOffset.FromUnixTimeMilliseconds(treatment.Mills).UtcDateTime, treatment.FoodType));
+                }
+
+                if (step.Time.Minute % DeviceStatusMinutes == 0)
+                {
+                    var status = DemoDeviceStatusGenerator.Create(
+                        step.Time,
+                        step.Entry.Sgv ?? step.Entry.Mgdl,
+                        step.Iob,
+                        step.Cob,
+                        step.TempBasalRate,
+                        step.TempBasalDuration,
+                        step.EffectiveIsf,
+                        step.EffectiveCarbRatio,
+                        config.TargetGlucose,
+                        DemoTherapyProfile.ScheduledRateAt(step.Time, config.BasalRate),
+                        step.Scenario);
+                    // Deterministic legacy id so re-seeding updates in place.
+                    status.Id = status.Mills.ToString("x24");
+                    statusBatch.Add(status);
+                }
+
+                if (entryBatch.Count >= BatchSize) await FlushEntriesAsync();
+                if (treatmentBatch.Count >= BatchSize) await FlushTreatmentsAsync();
+                if (statusBatch.Count >= BatchSize) await FlushStatusesAsync();
+            }
+
+            await FlushEntriesAsync();
+            await FlushTreatmentsAsync();
+            await FlushStatusesAsync();
 
             // CreateTreatmentsAsync decomposes each treatment into its v4 canonical
             // records and swallows per-record decomposition failures, returning only
@@ -191,8 +273,8 @@ public class SampleDataSeeder
         }
         else
         {
-            // Replay the stored stream (the demo container posted it over v1)
-            // so seeded alarm history matches the chart exactly.
+            // Replay the stored stream so seeded alarm history matches the
+            // chart exactly.
             var since = DateTime.UtcNow.AddDays(-days);
             var stored = _db.SensorGlucose
                 .AsNoTracking()
@@ -233,18 +315,50 @@ public class SampleDataSeeder
         var (alertRules, alertExcursions) =
             await SeedAlertsAsync(tenant.TenantId, episodeTracker.Episodes, ct);
 
+        var foodCount = await SeedFoodsAsync(mealCarbLinks, ownerSubjectId, ct);
+        var stateSpanCount = await SeedStateSpansAsync(localToday, days, dataSource, ct);
+        await SeedPatientProfileAsync(ct);
+        await SeedBodyWeightAsync(localToday, days, dataSource, ct);
+        await SeedTimezoneTimelineAsync(localToday, days, ct);
+        await SeedDndWindowAsync(localToday, ct);
+        var clockFaces = await SeedClockFacesAsync(ownerSubjectId, ct);
+        var notificationCount = await SeedNotificationsAsync(
+            ownerSubjectId, tenant.TenantId, episodeTracker.Episodes, ct);
+
         _logger.LogInformation(
             "Seeded tenant {Slug} ({Days} days): {Entries} entries, {Treatments} treatments, "
-            + "{DeviceChanges} device changes, {Sleep} sleep sessions, {HeartRates} heart rates, "
-            + "{Steps} step buckets, {TrackerDefs} tracker definitions, {TrackerInstances} tracker instances, "
-            + "{AlertRules} alert rules, {Excursions} alarm excursions",
-            tenant.Slug, days, entryCount, treatmentCount, deviceTreatments.Count, sleepCount,
-            heartRateCount, stepCount, trackerDefinitions, trackerInstances, alertRules, alertExcursions);
+            + "{DeviceStatuses} device statuses, {Profiles} profiles, {DeviceChanges} device changes, "
+            + "{Sleep} sleep sessions, {HeartRates} heart rates, {Steps} step buckets, "
+            + "{TrackerDefs} tracker definitions, {TrackerInstances} tracker instances, "
+            + "{AlertRules} alert rules, {Excursions} alarm excursions, {Foods} foods, "
+            + "{StateSpans} state spans, {ClockFaces} clock faces, {Notifications} notifications",
+            tenant.Slug, days, entryCount, treatmentCount, deviceStatusCount, profilesCreated,
+            deviceTreatments.Count, sleepCount, heartRateCount, stepCount, trackerDefinitions,
+            trackerInstances, alertRules, alertExcursions, foodCount, stateSpanCount, clockFaces,
+            notificationCount);
 
         return new SampleDataSeedResult(
             entryCount, treatmentCount, sleepCount, heartRateCount, stepCount,
             deviceTreatments.Count, trackerDefinitions, trackerInstances,
-            alertRules, alertExcursions);
+            alertRules, alertExcursions, deviceStatusCount, profilesCreated,
+            foodCount, stateSpanCount, notificationCount);
+    }
+
+    /// <summary>
+    /// Seeds the Nightscout profile document through the profile write service
+    /// (which decomposes it into TherapySettings plus the basal/carb-ratio/
+    /// sensitivity/target schedules), unless the demo profile already exists.
+    /// </summary>
+    private async Task<int> SeedProfileAsync(DemoModeConfiguration config, CancellationToken ct)
+    {
+        var exists = await _db.TherapySettings
+            .AnyAsync(t => t.ProfileName == DemoTherapyProfile.ProfileName, ct);
+        if (exists)
+            return 0;
+
+        await _profileWriteService.CreateProfilesAsync(
+            [DemoTherapyProfile.BuildProfile(config, DateTime.UtcNow)], ct);
+        return 1;
     }
 
     /// <summary>
@@ -477,5 +591,395 @@ public class SampleDataSeeder
         await _db.SaveChangesAsync(ct);
 
         return (rulesCreated, excursionsCreated);
+    }
+
+    /// <summary>
+    /// The food library (found-or-created by name), favorites for the owner,
+    /// and per-meal food attribution lines linking library foods to the carb
+    /// intakes the generated meals decomposed into. Attribution is rebuilt from
+    /// the meal timestamps, so re-seeding stays consistent.
+    /// </summary>
+    private async Task<int> SeedFoodsAsync(
+        List<(DateTime Time, string MealName)> mealCarbLinks, Guid? ownerSubjectId, CancellationToken ct)
+    {
+        var foodsByName = new Dictionary<string, FoodEntity>(StringComparer.OrdinalIgnoreCase);
+        var created = 0;
+
+        var position = 0;
+        foreach (var seed in DemoLifestyleSeeds.FoodLibrary)
+        {
+            position++;
+            var food = await _db.Foods.FirstOrDefaultAsync(f => f.Name == seed.Name, ct);
+            if (food is null)
+            {
+                food = new FoodEntity
+                {
+                    Id = Guid.CreateVersion7(),
+                    TenantId = _db.TenantId,
+                    Name = seed.Name,
+                    Category = seed.Category,
+                    Subcategory = seed.Subcategory,
+                    Portion = seed.Portion,
+                    Unit = seed.Unit,
+                    Carbs = seed.Carbs,
+                    Protein = seed.Protein,
+                    Fat = seed.Fat,
+                    Energy = seed.Energy,
+                    Position = position,
+                };
+                _db.Foods.Add(food);
+                created++;
+            }
+
+            foodsByName[seed.Name] = food;
+        }
+        await _db.SaveChangesAsync(ct);
+
+        // Favorites: the snacks and one dinner, owned by the demo member.
+        if (ownerSubjectId is { } owner)
+        {
+            var userId = owner.ToString();
+            var favoriteNames = new[] { "Jelly beans", "Muesli bar", "Homemade pizza slices" };
+            foreach (var name in favoriteNames)
+            {
+                if (!foodsByName.TryGetValue(name, out var food))
+                    continue;
+                var exists = await _db.UserFoodFavorites
+                    .AnyAsync(f => f.UserId == userId && f.FoodId == food.Id, ct);
+                if (!exists)
+                {
+                    _db.UserFoodFavorites.Add(new UserFoodFavoriteEntity
+                    {
+                        Id = Guid.CreateVersion7(),
+                        TenantId = _db.TenantId,
+                        UserId = userId,
+                        FoodId = food.Id,
+                    });
+                }
+            }
+            await _db.SaveChangesAsync(ct);
+        }
+
+        // Food attribution on the meals' carb intakes (~60% of meals, as a
+        // realistic user would log). Meal timestamps identify the intakes.
+        if (mealCarbLinks.Count > 0)
+        {
+            var mealTimes = mealCarbLinks.Select(m => m.Time).ToList();
+            var intakes = await _db.CarbIntakes
+                .Where(c => mealTimes.Contains(c.Timestamp))
+                .Select(c => new { c.Id, c.Timestamp, c.Carbs })
+                .ToListAsync(ct);
+            var linkedIntakeIds = intakes.Select(i => i.Id).ToList();
+            await _db.TreatmentFoods
+                .Where(tf => linkedIntakeIds.Contains(tf.CarbIntakeId))
+                .ExecuteDeleteAsync(ct);
+
+            foreach (var (time, mealName) in mealCarbLinks)
+            {
+                if (DayScenarios.Roll(time.Date, $"food-link:{time.Hour}", 100) >= 60)
+                    continue;
+
+                var intake = intakes.FirstOrDefault(i => i.Timestamp == time);
+                if (intake is null)
+                    continue;
+
+                foreach (var seed in DemoLifestyleSeeds.MealFoodsFor(time.Date, mealName))
+                {
+                    if (!foodsByName.TryGetValue(seed.Name, out var food))
+                        continue;
+                    _db.TreatmentFoods.Add(new TreatmentFoodEntity
+                    {
+                        Id = Guid.CreateVersion7(),
+                        TenantId = _db.TenantId,
+                        CarbIntakeId = intake.Id,
+                        FoodId = food.Id,
+                        Portions = seed.Carbs > 0 ? Math.Round((decimal)(intake.Carbs / seed.Carbs), 2) : 1,
+                        Carbs = (decimal)intake.Carbs,
+                    });
+                }
+            }
+            await _db.SaveChangesAsync(ct);
+        }
+
+        return created;
+    }
+
+    /// <summary>
+    /// State spans for the window: pump mode with manual/exercise windows, the
+    /// active profile, workout overrides and temporary targets, illness runs,
+    /// and the travel span. Spans carrying our data source are wiped and
+    /// rebuilt (idempotent re-seed).
+    /// </summary>
+    private async Task<int> SeedStateSpansAsync(
+        DateTime localToday, int days, string dataSource, CancellationToken ct)
+    {
+        await _db.StateSpans
+            .Where(s => s.Source == dataSource)
+            .ExecuteDeleteAsync(ct);
+
+        var spans = DemoLifestyleSeeds.BuildSpans(localToday, days);
+        foreach (var seed in spans)
+        {
+            _db.StateSpans.Add(new StateSpanEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _db.TenantId,
+                Category = seed.Category.ToString(),
+                State = seed.State,
+                StartTimestamp = seed.StartLocal.ToUniversalTime(),
+                EndTimestamp = seed.EndLocal?.ToUniversalTime(),
+                Source = dataSource,
+            });
+        }
+        await _db.SaveChangesAsync(ct);
+
+        return spans.Count;
+    }
+
+    /// <summary>
+    /// The patient record singleton, the device roster (CGM, pod, meter), and
+    /// the current insulin — the /settings/patient page and device attribution
+    /// context. Created only when absent.
+    /// </summary>
+    private async Task SeedPatientProfileAsync(CancellationToken ct)
+    {
+        if (!await _db.PatientRecords.AnyAsync(ct))
+        {
+            _db.PatientRecords.Add(new PatientRecordEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _db.TenantId,
+                PreferredName = "Demo",
+                DiabetesType = "type1",
+                DiagnosisDate = new DateOnly(2014, 3, 12),
+                DateOfBirth = new DateOnly(1992, 4, 17),
+                Timezone = TimeZoneInfo.Local.Id,
+            });
+        }
+
+        var deviceSeeds = new (string Category, string Manufacturer, string Model, string? Aid)[]
+        {
+            ("cgm", "Dexcom", "G7", null),
+            ("pump", "Insulet", "Omnipod DASH", DemoDeviceStatusGenerator.DeviceName),
+            ("meter", "Ascensia", "Contour Next One", null),
+        };
+        foreach (var (category, manufacturer, model, aid) in deviceSeeds)
+        {
+            var exists = await _db.PatientDevices
+                .AnyAsync(d => d.Manufacturer == manufacturer && d.Model == model, ct);
+            if (!exists)
+            {
+                _db.PatientDevices.Add(new PatientDeviceEntity
+                {
+                    Id = Guid.CreateVersion7(),
+                    TenantId = _db.TenantId,
+                    DeviceCategory = category,
+                    Manufacturer = manufacturer,
+                    Model = model,
+                    AidAlgorithm = aid,
+                    StartDate = DateOnly.FromDateTime(DateTime.Today.AddMonths(-8)),
+                    IsCurrent = true,
+                });
+            }
+        }
+
+        if (!await _db.PatientInsulins.AnyAsync(ct))
+        {
+            _db.PatientInsulins.Add(new PatientInsulinEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _db.TenantId,
+                InsulinCategory = "RapidActing",
+                Name = "Humalog",
+                IsCurrent = true,
+                Dia = 4.0,
+                Peak = 75,
+                Curve = "rapid-acting",
+                Concentration = 100,
+                Role = "Bolus",
+                IsPrimary = true,
+            });
+        }
+
+        await _db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>Weekly Sunday-morning weigh-ins with a deterministic sync key.</summary>
+    private async Task SeedBodyWeightAsync(
+        DateTime localToday, int days, string dataSource, CancellationToken ct)
+    {
+        var existing = (await _db.BodyWeights
+                .AsNoTracking()
+                .Where(w => w.DataSource == dataSource)
+                .Select(w => w.SyncIdentifier)
+                .ToListAsync(ct))
+            .ToHashSet();
+
+        for (var d = 0; d <= days; d++)
+        {
+            var day = localToday.AddDays(-d);
+            if (day.DayOfWeek != DayOfWeek.Sunday)
+                continue;
+
+            var syncId = $"demo-weight-{day:yyyy-MM-dd}";
+            if (existing.Contains(syncId))
+                continue;
+
+            var weighIn = day.AddHours(7).AddMinutes(DayScenarios.Roll(day, "weigh-in", 40));
+            if (weighIn > DateTime.Now)
+                continue;
+
+            _db.BodyWeights.Add(new BodyWeightEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _db.TenantId,
+                Mills = new DateTimeOffset(weighIn).ToUnixTimeMilliseconds(),
+                WeightKg = (decimal)DemoLifestyleSeeds.WeightKgOn(day),
+                Device = "Demo Scale",
+                DataSource = dataSource,
+                SyncIdentifier = syncId,
+            });
+        }
+
+        await _db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// The timezone timeline: home zone from the window start, with a
+    /// five-day trip (matching the Travel state span) three weeks back.
+    /// Created only when the timeline is empty.
+    /// </summary>
+    private async Task SeedTimezoneTimelineAsync(DateTime localToday, int days, CancellationToken ct)
+    {
+        if (await _db.TimezoneTimeline.AnyAsync(ct))
+            return;
+
+        var home = TimeZoneInfo.Local.Id;
+        var windowStart = localToday.AddDays(-days);
+        var tripStart = localToday.AddDays(-DemoLifestyleSeeds.TripStartDaysAgo).AddHours(14);
+        var tripEnd = tripStart.AddDays(DemoLifestyleSeeds.TripLengthDays).AddHours(-4);
+
+        _db.TimezoneTimeline.Add(new TimezoneTimelineEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _db.TenantId,
+            EffectiveFrom = windowStart.ToUniversalTime(),
+            Timezone = home,
+        });
+
+        if (tripStart > windowStart && tripEnd < DateTime.Now)
+        {
+            _db.TimezoneTimeline.Add(new TimezoneTimelineEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _db.TenantId,
+                EffectiveFrom = tripStart.ToUniversalTime(),
+                Timezone = DemoLifestyleSeeds.TripTimezone,
+            });
+            _db.TimezoneTimeline.Add(new TimezoneTimelineEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _db.TenantId,
+                EffectiveFrom = tripEnd.ToUniversalTime(),
+                Timezone = home,
+            });
+        }
+
+        await _db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// One historical, already-cleared DND window so the alerts pages show a
+    /// worked example without suppressing the demo's live alerts.
+    /// </summary>
+    private async Task SeedDndWindowAsync(DateTime localToday, CancellationToken ct)
+    {
+        if (await _db.DndWindows.AnyAsync(ct))
+            return;
+
+        var start = localToday.AddDays(-1).AddHours(22.5);
+        _db.DndWindows.Add(new DndWindowEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _db.TenantId,
+            StartedAt = start.ToUniversalTime(),
+            EndsAt = start.AddHours(8.5).ToUniversalTime(),
+            ClearedAt = start.AddHours(8.2).ToUniversalTime(),
+            ClearedBy = "demo",
+            Source = "manual",
+        });
+        await _db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>The default clock face for the owner, found-or-created by name.</summary>
+    private async Task<int> SeedClockFacesAsync(Guid? ownerSubjectId, CancellationToken ct)
+    {
+        if (ownerSubjectId is not { } owner)
+            return 0;
+
+        var userId = owner.ToString();
+        var exists = await _db.ClockFaces.AnyAsync(c => c.UserId == userId, ct);
+        if (exists)
+            return 0;
+
+        _db.ClockFaces.Add(new ClockFaceEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _db.TenantId,
+            UserId = userId,
+            Name = "Bedside Clock",
+            ConfigJson = DemoLifestyleSeeds.DefaultClockFaceConfigJson,
+        });
+        await _db.SaveChangesAsync(ct);
+        return 1;
+    }
+
+    /// <summary>
+    /// In-app notifications mirroring the most recent seeded alarm episodes
+    /// (read where the excursion was acknowledged), so /notifications shows the
+    /// same story as /alerts/history. Rebuilt per seed via the data source tag.
+    /// </summary>
+    private async Task<int> SeedNotificationsAsync(
+        Guid? ownerSubjectId,
+        Guid tenantId,
+        IReadOnlyList<DemoAlertSeeds.GlucoseEpisode> episodes,
+        CancellationToken ct)
+    {
+        if (ownerSubjectId is not { } owner)
+            return 0;
+
+        var userId = owner.ToString();
+        await _db.InAppNotifications
+            .Where(n => n.UserId == userId && n.Source == "sample-seed")
+            .ExecuteDeleteAsync(ct);
+
+        var created = 0;
+        foreach (var episode in episodes.OrderByDescending(e => e.StartUtc).Take(MaxAlarmNotifications))
+        {
+            var rng = DayScenarios.RngFor(episode.StartUtc.Date, $"ack:{episode.RuleName}");
+            var acknowledged = rng.NextDouble() < 0.7;
+
+            _db.InAppNotifications.Add(new InAppNotificationEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = tenantId,
+                UserId = userId,
+                Type = "alert.firing",
+                Category = NotificationCategory.Alert,
+                Urgency = episode.RuleName.Contains("Urgent", StringComparison.OrdinalIgnoreCase)
+                    ? NotificationUrgency.Urgent
+                    : NotificationUrgency.Warn,
+                Icon = "bell",
+                Source = "sample-seed",
+                Title = episode.RuleName,
+                Subtitle = $"Resolved after {(episode.EndUtc - episode.StartUtc).TotalMinutes:0} minutes",
+                CreatedAt = episode.StartUtc,
+                ReadAt = acknowledged ? episode.StartUtc.AddMinutes(rng.Next(2, 12)) : null,
+            });
+            created++;
+        }
+
+        await _db.SaveChangesAsync(ct);
+        return created;
     }
 }

--- a/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
+++ b/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
@@ -181,7 +181,10 @@ public class SampleDataSeeder
             async Task FlushEntriesAsync()
             {
                 if (entryBatch.Count == 0) return;
-                var created = await _entryService.CreateEntriesAsync(entryBatch, cancellationToken: ct);
+                // Backfill origin: a 90-day seed must not broadcast tens of
+                // thousands of records over SignalR from one request.
+                var created = await _entryService.CreateEntriesAsync(
+                    entryBatch, WriteOrigin.Backfill, ct);
                 entryCount += created.Count();
                 entryBatch.Clear();
             }
@@ -200,7 +203,7 @@ public class SampleDataSeeder
                 foreach (var status in statusBatch)
                 {
                     await _deviceStatusDecomposer.DecomposeAsync(
-                        status, dataSource, Core.Contracts.V4.WriteOrigin.Backfill, ct);
+                        status, dataSource, WriteOrigin.Backfill, ct);
                     deviceStatusCount++;
                 }
                 statusBatch.Clear();
@@ -676,14 +679,18 @@ public class SampleDataSeeder
 
             foreach (var (time, mealName) in mealCarbLinks)
             {
-                if (DayScenarios.Roll(time.Date, $"food-link:{time.Hour}", 100) >= 60)
+                // Deterministic rolls key on the meal's local calendar day,
+                // like every other demo stream (the UTC day differs east of
+                // Greenwich).
+                var localMeal = time.ToLocalTime();
+                if (DayScenarios.Roll(localMeal.Date, $"food-link:{localMeal.Hour}", 100) >= 60)
                     continue;
 
                 var intake = intakes.FirstOrDefault(i => i.Timestamp == time);
                 if (intake is null)
                     continue;
 
-                foreach (var seed in DemoLifestyleSeeds.MealFoodsFor(time.Date, mealName))
+                foreach (var seed in DemoLifestyleSeeds.MealFoodsFor(localMeal.Date, mealName))
                 {
                     if (!foodsByName.TryGetValue(seed.Name, out var food))
                         continue;
@@ -729,6 +736,7 @@ public class SampleDataSeeder
                 StartTimestamp = seed.StartLocal.ToUniversalTime(),
                 EndTimestamp = seed.EndLocal?.ToUniversalTime(),
                 Source = dataSource,
+                MetadataJson = seed.Metadata is null ? null : JsonSerializer.Serialize(seed.Metadata),
             });
         }
         await _db.SaveChangesAsync(ct);

--- a/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
+++ b/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
@@ -753,7 +753,7 @@ public class SampleDataSeeder
                 DiabetesType = "type1",
                 DiagnosisDate = new DateOnly(2014, 3, 12),
                 DateOfBirth = new DateOnly(1992, 4, 17),
-                Timezone = TimeZoneInfo.Local.Id,
+                Timezone = DemoTherapyProfile.LocalIanaTimezone(),
             });
         }
 
@@ -847,14 +847,15 @@ public class SampleDataSeeder
     /// <summary>
     /// The timezone timeline: home zone from the window start, with a
     /// five-day trip (matching the Travel state span) three weeks back.
-    /// Created only when the timeline is empty.
+    /// EffectiveFrom is a local wall-clock value (Kind=Unspecified), matching
+    /// <c>TimezoneTimelineService</c>. Created only when the timeline is empty.
     /// </summary>
     private async Task SeedTimezoneTimelineAsync(DateTime localToday, int days, CancellationToken ct)
     {
         if (await _db.TimezoneTimeline.AnyAsync(ct))
             return;
 
-        var home = TimeZoneInfo.Local.Id;
+        var home = DemoTherapyProfile.LocalIanaTimezone();
         var windowStart = localToday.AddDays(-days);
         var tripStart = localToday.AddDays(-DemoLifestyleSeeds.TripStartDaysAgo).AddHours(14);
         var tripEnd = tripStart.AddDays(DemoLifestyleSeeds.TripLengthDays).AddHours(-4);
@@ -863,7 +864,7 @@ public class SampleDataSeeder
         {
             Id = Guid.CreateVersion7(),
             TenantId = _db.TenantId,
-            EffectiveFrom = windowStart.ToUniversalTime(),
+            EffectiveFrom = DateTime.SpecifyKind(windowStart, DateTimeKind.Unspecified),
             Timezone = home,
         });
 
@@ -873,14 +874,14 @@ public class SampleDataSeeder
             {
                 Id = Guid.CreateVersion7(),
                 TenantId = _db.TenantId,
-                EffectiveFrom = tripStart.ToUniversalTime(),
+                EffectiveFrom = DateTime.SpecifyKind(tripStart, DateTimeKind.Unspecified),
                 Timezone = DemoLifestyleSeeds.TripTimezone,
             });
             _db.TimezoneTimeline.Add(new TimezoneTimelineEntity
             {
                 Id = Guid.CreateVersion7(),
                 TenantId = _db.TenantId,
-                EffectiveFrom = tripEnd.ToUniversalTime(),
+                EffectiveFrom = DateTime.SpecifyKind(tripEnd, DateTimeKind.Unspecified),
                 Timezone = home,
             });
         }
@@ -902,11 +903,12 @@ public class SampleDataSeeder
         {
             Id = Guid.CreateVersion7(),
             TenantId = _db.TenantId,
+            Scope = DndScope.All,
             StartedAt = start.ToUniversalTime(),
             EndsAt = start.AddHours(8.5).ToUniversalTime(),
             ClearedAt = start.AddHours(8.2).ToUniversalTime(),
             ClearedBy = "demo",
-            Source = "manual",
+            Source = "web",
         });
         await _db.SaveChangesAsync(ct);
     }

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoDataGenerator.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoDataGenerator.cs
@@ -37,6 +37,19 @@ public interface IDemoDataGenerator
     void SeedCurrentGlucose(double glucose);
 
     /// <summary>
+    /// Generates the device status for the current realtime tick, carrying
+    /// IOB/COB continuity from the treatments issued so far.
+    /// </summary>
+    DeviceStatus GenerateCurrentDeviceStatus(Entry entry, IReadOnlyList<Treatment> treatments);
+
+    /// <summary>
+    /// Streams the unified historical timeline: one simulation pass yielding
+    /// entries, treatments, and simulator state per 5-minute step, so every
+    /// derived stream (chart, treatments, device status, alarm episodes) agrees.
+    /// </summary>
+    IEnumerable<DemoTimeStep> GenerateHistoricalTimeline();
+
+    /// <summary>
     /// Generates historical entries using streaming/yield pattern to minimize memory usage.
     /// </summary>
     IEnumerable<Entry> GenerateHistoricalEntries();
@@ -45,14 +58,6 @@ public interface IDemoDataGenerator
     /// Generates historical treatments using streaming/yield pattern to minimize memory usage.
     /// </summary>
     IEnumerable<Treatment> GenerateHistoricalTreatments();
-
-    /// <summary>
-    /// Generates historical data for the configured time period.
-    /// </summary>
-    [Obsolete(
-        "Use GenerateHistoricalEntries() and GenerateHistoricalTreatments() for streaming pattern"
-    )]
-    (List<Entry> Entries, List<Treatment> Treatments) GenerateHistoricalData();
 }
 
 /// <summary>
@@ -77,6 +82,7 @@ public class DemoDataGenerator : IDemoDataGenerator
     private double _trendTargetGlucose;
     private int _trendStepsRemaining;
     private DateTime? _lastTempBasalIssuedAt;
+    private OrefPhysiologySimulator? _realtimeSimulator;
 
     public bool IsRunning { get; internal set; }
 
@@ -201,57 +207,40 @@ public class DemoDataGenerator : IDemoDataGenerator
         }
     }
 
-    public (List<Entry> Entries, List<Treatment> Treatments) GenerateHistoricalData()
+    /// <summary>
+    /// Generates historical entries as a projection of the unified timeline.
+    /// Includes the fingerstick (mbg) and calibration (cal) entries.
+    /// </summary>
+    public IEnumerable<Entry> GenerateHistoricalEntries()
     {
-        // Local-time day iteration — see GenerateHistoricalEntries.
-        var endDate = DateTime.Now;
-        var startDate = endDate.AddDays(-_config.BackfillDays);
-
-        var entries = new List<Entry>();
-        var treatments = new List<Treatment>();
-
-        _logger.LogInformation(
-            "Generating historical demo data from {StartDate} to {EndDate}",
-            startDate,
-            endDate
-        );
-
-        var currentDay = startDate.Date;
-        double? previousDayEndingGlucose = null;
-        double previousDayMomentum = 0;
-
-        while (currentDay <= endDate.Date)
+        foreach (var step in GenerateHistoricalTimeline())
         {
-            var dayScenario = SelectDayScenario(currentDay);
-            var (dayEntries, dayTreatments, endingGlucose, endingMomentum) = GenerateDayData(
-                currentDay,
-                dayScenario,
-                previousDayEndingGlucose,
-                previousDayMomentum
-            );
-
-            entries.AddRange(dayEntries);
-            treatments.AddRange(dayTreatments);
-
-            previousDayEndingGlucose = endingGlucose;
-            previousDayMomentum = endingMomentum;
-            currentDay = currentDay.AddDays(1);
+            yield return step.Entry;
+            foreach (var extra in step.ExtraEntries)
+                yield return extra;
         }
-
-        _logger.LogInformation(
-            "Generated {EntryCount} entries and {TreatmentCount} treatments",
-            entries.Count,
-            treatments.Count
-        );
-
-        return (entries, treatments);
     }
 
     /// <summary>
-    /// Generates historical entries using streaming/yield pattern to minimize memory usage.
-    /// Each entry is yielded immediately after generation, avoiding large in-memory collections.
+    /// Generates historical treatments as a projection of the unified timeline.
     /// </summary>
-    public IEnumerable<Entry> GenerateHistoricalEntries()
+    public IEnumerable<Treatment> GenerateHistoricalTreatments()
+    {
+        foreach (var step in GenerateHistoricalTimeline())
+        {
+            foreach (var treatment in step.Treatments)
+                yield return treatment;
+        }
+    }
+
+    /// <summary>
+    /// The single historical simulation pass. Runs the oref simulator over the
+    /// backfill window and yields one <see cref="DemoTimeStep"/> per 5 minutes
+    /// carrying the CGM entry, the treatments issued at that step, and the
+    /// simulator's IOB/COB — so the chart, the treatment history, the device
+    /// status stream, and the alarm episodes all derive from the same run.
+    /// </summary>
+    public IEnumerable<DemoTimeStep> GenerateHistoricalTimeline()
     {
         // Local-time day iteration: meals land at local wall-clock mealtimes,
         // and the per-date DayScenario key matches the sleep/activity/device
@@ -261,7 +250,7 @@ public class DemoDataGenerator : IDemoDataGenerator
         var startDate = endDate.AddDays(-_config.BackfillDays);
 
         _logger.LogInformation(
-            "Streaming historical entries from {StartDate} to {EndDate}",
+            "Streaming historical timeline from {StartDate} to {EndDate}",
             startDate,
             endDate
         );
@@ -269,7 +258,10 @@ public class DemoDataGenerator : IDemoDataGenerator
         var currentDay = startDate.Date;
         double? previousDayEndingGlucose = null;
         double previousDayMomentum = 0;
-        var totalEntries = 0;
+        var totalSteps = 0;
+        // Treatments timestamped past a day boundary (late boluses near
+        // midnight) carry into the next day's step buckets.
+        var carriedOver = new List<(DateTime Time, Treatment Treatment)>();
 
         while (currentDay <= endDate.Date)
         {
@@ -287,7 +279,10 @@ public class DemoDataGenerator : IDemoDataGenerator
             var mealPlan = GenerateMealPlan(currentDay, dayScenario);
             var basalAdjustments = GenerateBasalAdjustments(currentDay, dayScenario);
 
-            // Pre-populate events into simulator
+            // Pre-populate the simulator with the day's meals and boluses, and
+            // bucket the corresponding treatments by their actual timestamps.
+            var pending = new List<(DateTime Time, Treatment Treatment)>(carriedOver);
+            carriedOver = [];
             foreach (var meal in mealPlan)
             {
                 var absorptionHours =
@@ -296,173 +291,22 @@ public class DemoDataGenerator : IDemoDataGenerator
                 var bolusTime = meal.MealTime.AddMinutes(meal.BolusOffsetMinutes);
                 var bolus = CalculateMealBolus(meal.Carbs, glucose, scenarioParams);
                 simulator.AddInsulinDose(bolusTime, bolus);
-            }
 
-            double glucoseMomentum = previousDayMomentum * 0.5;
-            double lastGlucose = glucose;
-            double estimatedIob = 0;
-            var targetGlucose = _config.TargetGlucose;
-            var currentTime = currentDay;
-            // Cap endTime to now to prevent generating future data
-            var endTime = currentDay.Date == endDate.Date
-                ? endDate
-                : currentDay.AddDays(1);
-
-            while (currentTime < endTime)
-            {
-                var basalAdj = basalAdjustments.FirstOrDefault(b =>
-                    Math.Abs((b.Time - currentTime).TotalMinutes) < 2.5
-                );
-                var adjustedRate = NormalizeBasalRate(basalAdj.Rate);
-                if (adjustedRate > 0 || basalAdj.Duration > 0)
-                {
-                    simulator.AddInsulinDose(
-                        currentTime,
-                        adjustedRate * basalAdj.Duration / 60.0,
-                        isTempBasal: true,
-                        duration: basalAdj.Duration
-                    );
-                }
-
-                glucose = SimulateGlucoseWithOref(
-                    glucose,
-                    currentTime,
-                    simulator,
-                    scenarioParams,
-                    dayScenario,
-                    ref glucoseMomentum
-                );
-
-                glucose = Math.Max(40, Math.Min(_config.MaxGlucose, glucose));
-
-                var iobDecayRate = 1.0 - (5.0 / _config.InsulinDurationMinutes);
-                estimatedIob *= iobDecayRate;
-
-                var hour = currentTime.Hour;
-                var isWakingHours = hour >= 7 && hour < 22;
-
-                // Handle reactive glucose management (simplified for entry generation - treatments handled separately)
-                if (glucose < 70)
-                {
-                    var correctionCarbs =
-                        glucose < 55 ? _random.Next(15, 25) : _random.Next(10, 18);
-                    simulator.AddCarbs(currentTime, correctionCarbs, 0.4);
-                }
-                else if (glucose > targetGlucose + 10)
-                {
-                    var glucoseAboveTarget = glucose - targetGlucose;
-                    var effectiveIsf =
-                        _config.InsulinSensitivityFactor
-                        * scenarioParams.InsulinSensitivityMultiplier;
-                    var insulinNeeded = glucoseAboveTarget / effectiveIsf;
-                    var insulinToDeliver = Math.Max(0, insulinNeeded - estimatedIob * 0.6);
-
-                    if (currentTime.Minute == 0 || currentTime.Minute == 30)
-                    {
-                        var tempBasalMultiplier = 1.1 + Math.Min(0.3, glucoseAboveTarget / 150.0);
-                        var highTempRate = NormalizeBasalRate(_config.BasalRate * tempBasalMultiplier);
-                        var extraInsulin =
-                            Math.Max(0, highTempRate - _config.BasalRate) * (30 / 60.0);
-                        if (extraInsulin > 0)
-                        {
-                            simulator.AddInsulinDose(
-                                currentTime,
-                                extraInsulin,
-                                isTempBasal: true,
-                                duration: 30
-                            );
-                            estimatedIob += extraInsulin;
-                        }
-                    }
-
-                    if (
-                        glucose > targetGlucose + 15
-                        && currentTime.Minute % 5 == 0
-                        && insulinToDeliver > 0.1
-                    )
-                    {
-                        var correctionBolus = insulinToDeliver * (0.5 + _random.NextDouble() * 0.2);
-                        correctionBolus = NormalizeBolus(Math.Clamp(correctionBolus, 0.1, 4.0));
-                        simulator.AddInsulinDose(currentTime, correctionBolus);
-                        estimatedIob += correctionBolus;
-                    }
-                }
-
-                var delta = glucose - lastGlucose;
-                yield return CreateEntry(currentTime, glucose, delta);
-                totalEntries++;
-
-                lastGlucose = glucose;
-                currentTime = currentTime.AddMinutes(5);
-                simulator.CleanupExpired(currentTime);
-            }
-
-            previousDayEndingGlucose = glucose;
-            previousDayMomentum = glucoseMomentum;
-            currentDay = currentDay.AddDays(1);
-        }
-
-        _logger.LogInformation("Streamed {EntryCount} entries", totalEntries);
-    }
-
-    /// <summary>
-    /// Generates historical treatments using streaming/yield pattern to minimize memory usage.
-    /// Each treatment is yielded immediately after generation, avoiding large in-memory collections.
-    /// </summary>
-    public IEnumerable<Treatment> GenerateHistoricalTreatments()
-    {
-        // Local-time day iteration — see GenerateHistoricalEntries.
-        var endDate = DateTime.Now;
-        var startDate = endDate.AddDays(-_config.BackfillDays);
-
-        _logger.LogInformation(
-            "Streaming historical treatments from {StartDate} to {EndDate}",
-            startDate,
-            endDate
-        );
-
-        var currentDay = startDate.Date;
-        double? previousDayEndingGlucose = null;
-        double previousDayMomentum = 0;
-        var totalTreatments = 0;
-
-        while (currentDay <= endDate.Date)
-        {
-            var dayScenario = SelectDayScenario(currentDay);
-            var scenarioParams = GetScenarioParameters(dayScenario);
-            var orefProfile = CreateOrefProfile(scenarioParams);
-            var simulator = new OrefPhysiologySimulator(
-                _loggerFactory.CreateLogger<OrefPhysiologySimulator>(),
-                orefProfile
-            );
-
-            double glucose =
-                previousDayEndingGlucose
-                ?? scenarioParams.FastingGlucose + (_random.NextDouble() - 0.5) * 20;
-            var mealPlan = GenerateMealPlan(currentDay, dayScenario);
-            var basalAdjustments = GenerateBasalAdjustments(currentDay, dayScenario);
-
-            // Yield meal treatments
-            foreach (var meal in mealPlan)
-            {
-                var absorptionHours =
-                    _config.CarbAbsorptionDurationMinutes / 60.0 / meal.GlycemicIndex;
-                simulator.AddCarbs(meal.MealTime, meal.Carbs, absorptionHours);
-
-                var bolusTime = meal.MealTime.AddMinutes(meal.BolusOffsetMinutes);
-                var bolus = CalculateMealBolus(meal.Carbs, glucose, scenarioParams);
-                simulator.AddInsulinDose(bolusTime, bolus);
-
-                yield return CreateCarbTreatment(meal.MealTime, meal.Carbs, meal.FoodType);
-                totalTreatments++;
-
-                yield return CreateBolusTreatment(
+                pending.Add((meal.MealTime, CreateCarbTreatment(meal.MealTime, meal.Carbs, meal.FoodType)));
+                pending.Add((bolusTime, CreateBolusTreatment(
                     bolusTime,
                     bolus,
                     meal.FoodType == "Snack" ? "Snack Bolus" : "Meal Bolus"
-                );
-                totalTreatments++;
+                )));
             }
+
+            pending.AddRange(PlanNotes(currentDay));
+            pending.Sort((a, b) => a.Time.CompareTo(b.Time));
+            var fingerstickTimes = PlanFingersticks(currentDay);
+            var calibrations = PlanCalibrations(currentDay);
+
+            var effectiveIsf =
+                _config.InsulinSensitivityFactor * scenarioParams.InsulinSensitivityMultiplier;
 
             double glucoseMomentum = previousDayMomentum * 0.5;
             double lastGlucose = glucose;
@@ -476,18 +320,27 @@ public class DemoDataGenerator : IDemoDataGenerator
 
             while (currentTime < endTime)
             {
+                var stepEnd = currentTime.AddMinutes(5);
+                var stepTreatments = new List<Treatment>();
+                double? tempRate = null;
+                int? tempDuration = null;
+
+                // Consume planned treatments due this step.
+                while (pending.Count > 0 && pending[0].Time < stepEnd)
+                {
+                    stepTreatments.Add(pending[0].Treatment);
+                    pending.RemoveAt(0);
+                }
+
                 var basalAdj = basalAdjustments.FirstOrDefault(b =>
                     Math.Abs((b.Time - currentTime).TotalMinutes) < 2.5
                 );
                 var adjustedRate = NormalizeBasalRate(basalAdj.Rate);
                 if (adjustedRate > 0 || basalAdj.Duration > 0)
                 {
-                    yield return CreateTempBasalTreatment(
-                        currentTime,
-                        adjustedRate,
-                        basalAdj.Duration
-                    );
-                    totalTreatments++;
+                    stepTreatments.Add(CreateTempBasalTreatment(currentTime, adjustedRate, basalAdj.Duration));
+                    tempRate = adjustedRate;
+                    tempDuration = basalAdj.Duration;
                     simulator.AddInsulinDose(
                         currentTime,
                         adjustedRate * basalAdj.Duration / 60.0,
@@ -513,22 +366,22 @@ public class DemoDataGenerator : IDemoDataGenerator
                 var hour = currentTime.Hour;
                 var isWakingHours = hour >= 7 && hour < 22;
 
-                // Handle LOW glucose - yield carb correction treatment
+                // Handle LOW glucose - treat with fast carbs, often confirmed
+                // with a fingerstick as a real user would.
                 if (glucose < 70)
                 {
                     var correctionCarbs =
                         glucose < 55 ? _random.Next(15, 25) : _random.Next(10, 18);
-                    yield return CreateCarbCorrectionTreatment(currentTime, correctionCarbs);
-                    totalTreatments++;
+                    stepTreatments.Add(CreateCarbCorrectionTreatment(currentTime, correctionCarbs));
                     simulator.AddCarbs(currentTime, correctionCarbs, 0.4);
+
+                    if (_random.NextDouble() < 0.4)
+                        stepTreatments.Add(CreateBGCheckTreatment(currentTime, glucose));
                 }
-                // Handle HIGH glucose - yield insulin treatments
+                // Handle HIGH glucose - aggressive AID-style insulin delivery
                 else if (glucose > targetGlucose + 10)
                 {
                     var glucoseAboveTarget = glucose - targetGlucose;
-                    var effectiveIsf =
-                        _config.InsulinSensitivityFactor
-                        * scenarioParams.InsulinSensitivityMultiplier;
                     var insulinNeeded = glucoseAboveTarget / effectiveIsf;
                     var insulinToDeliver = Math.Max(0, insulinNeeded - estimatedIob * 0.6);
 
@@ -536,12 +389,9 @@ public class DemoDataGenerator : IDemoDataGenerator
                     {
                         var tempBasalMultiplier = 1.1 + Math.Min(0.3, glucoseAboveTarget / 150.0);
                         var highTempRate = NormalizeBasalRate(_config.BasalRate * tempBasalMultiplier);
-                        yield return CreateTempBasalTreatment(
-                            currentTime,
-                            highTempRate,
-                            30
-                        );
-                        totalTreatments++;
+                        stepTreatments.Add(CreateTempBasalTreatment(currentTime, highTempRate, 30));
+                        tempRate = highTempRate;
+                        tempDuration = 30;
                         var extraInsulin =
                             Math.Max(0, highTempRate - _config.BasalRate) * (30 / 60.0);
                         if (extraInsulin > 0)
@@ -556,24 +406,18 @@ public class DemoDataGenerator : IDemoDataGenerator
                         }
                     }
 
-                    if (
-                        isWakingHours
-                        && glucose > targetGlucose + 30
-                        && _random.NextDouble() < 0.25
-                    )
+                    // MANUAL CORRECTION BOLUS - during waking hours, user may manually correct
+                    if (isWakingHours && glucose > targetGlucose + 30 && _random.NextDouble() < 0.25)
                     {
                         var manualCorrectionBolus = glucoseAboveTarget / effectiveIsf;
                         manualCorrectionBolus = NormalizeBolus(
                             Math.Clamp(manualCorrectionBolus, 0.5, 6.0)
                         );
-                        yield return CreateManualCorrectionBolusTreatment(
-                            currentTime,
-                            manualCorrectionBolus
-                        );
-                        totalTreatments++;
+                        stepTreatments.Add(CreateManualCorrectionBolusTreatment(currentTime, manualCorrectionBolus));
                         simulator.AddInsulinDose(currentTime, manualCorrectionBolus);
                         estimatedIob += manualCorrectionBolus;
                     }
+                    // AID correction bolus every 5 minutes when significantly high
                     else if (
                         glucose > targetGlucose + 15
                         && currentTime.Minute % 5 == 0
@@ -582,14 +426,11 @@ public class DemoDataGenerator : IDemoDataGenerator
                     {
                         var correctionBolus = insulinToDeliver * (0.5 + _random.NextDouble() * 0.2);
                         correctionBolus = NormalizeBolus(Math.Clamp(correctionBolus, 0.1, 4.0));
-                        yield return CreateCorrectionBolusTreatment(
-                            currentTime,
-                            correctionBolus
-                        );
-                        totalTreatments++;
+                        stepTreatments.Add(CreateCorrectionBolusTreatment(currentTime, correctionBolus));
                         simulator.AddInsulinDose(currentTime, correctionBolus);
                         estimatedIob += correctionBolus;
                     }
+                    // SMBs every 5 minutes for fine-tuning when moderately high
                     else if (glucose > targetGlucose + 10 && insulinToDeliver > 0.05)
                     {
                         var algorithmBolus = NormalizeBolus(
@@ -597,16 +438,13 @@ public class DemoDataGenerator : IDemoDataGenerator
                         );
                         if (algorithmBolus >= PumpBolusIncrementUnits)
                         {
-                            yield return CreateAlgorithmBolusTreatment(
-                                currentTime,
-                                algorithmBolus
-                            );
-                            totalTreatments++;
+                            stepTreatments.Add(CreateAlgorithmBolusTreatment(currentTime, algorithmBolus));
                         }
                         simulator.AddInsulinDose(currentTime, algorithmBolus);
                         estimatedIob += algorithmBolus;
                     }
                 }
+                // Reduce basal when trending low (predictive low glucose suspend)
                 else if (glucose < 90 || (glucose < 100 && glucoseMomentum < -0.3))
                 {
                     var reductionFactor =
@@ -617,34 +455,70 @@ public class DemoDataGenerator : IDemoDataGenerator
 
                     if (currentTime.Minute == 0 || currentTime.Minute == 30)
                     {
-                        yield return CreateTempBasalTreatment(
+                        stepTreatments.Add(CreateTempBasalTreatment(currentTime, reducedRate, 30));
+                        tempRate = reducedRate;
+                        tempDuration = 30;
+                        // Reduced basal means less insulin than scheduled (negative dose).
+                        var insulinReduction =
+                            -(Math.Max(0, _config.BasalRate - reducedRate)) * (30 / 60.0);
+                        simulator.AddInsulinDose(
                             currentTime,
-                            reducedRate,
-                            30
+                            insulinReduction,
+                            isTempBasal: true,
+                            duration: 30
                         );
-                        totalTreatments++;
                     }
                 }
 
+                var delta = glucose - lastGlucose;
+                var entry = CreateEntry(currentTime, glucose, delta);
+
+                List<Entry> extraEntries = [];
+                while (fingerstickTimes.Count > 0 && fingerstickTimes[0] < stepEnd)
+                {
+                    extraEntries.Add(CreateFingerstickEntry(fingerstickTimes[0], glucose));
+                    fingerstickTimes.RemoveAt(0);
+                }
+                while (calibrations.Count > 0 && calibrations[0].Time < stepEnd)
+                {
+                    extraEntries.Add(CreateCalibrationEntry(calibrations[0]));
+                    calibrations.RemoveAt(0);
+                }
+
+                yield return new DemoTimeStep
+                {
+                    Time = currentTime,
+                    Entry = entry,
+                    ExtraEntries = extraEntries,
+                    Treatments = stepTreatments,
+                    Iob = Math.Max(0, simulator.CalculateIob(currentTime)),
+                    Cob = Math.Max(0, simulator.CalculateCob(currentTime)),
+                    TempBasalRate = tempRate,
+                    TempBasalDuration = tempDuration,
+                    EffectiveIsf = effectiveIsf,
+                    EffectiveCarbRatio = scenarioParams.CarbRatio,
+                    Scenario = dayScenario,
+                };
+                totalSteps++;
+
                 lastGlucose = glucose;
-                currentTime = currentTime.AddMinutes(5);
+                currentTime = stepEnd;
                 simulator.CleanupExpired(currentTime);
             }
 
-            // Yield scheduled basal treatments for the day
-            foreach (var basalTreatment in GenerateScheduledBasal(currentDay, scenarioParams))
-            {
-                yield return basalTreatment;
-                totalTreatments++;
-            }
+            // Unconsumed items (late boluses past midnight) carry into the next
+            // day. On the final day they would be future-dated — drop them.
+            if (currentDay != endDate.Date)
+                carriedOver = pending;
 
             previousDayEndingGlucose = glucose;
             previousDayMomentum = glucoseMomentum;
             currentDay = currentDay.AddDays(1);
         }
 
-        _logger.LogInformation("Streamed {TreatmentCount} treatments", totalTreatments);
+        _logger.LogInformation("Streamed {StepCount} timeline steps", totalSteps);
     }
+
 
     /// <summary>
     /// Deterministic per-date selection (see <see cref="DayScenarios"/>): the
@@ -653,267 +527,6 @@ public class DemoDataGenerator : IDemoDataGenerator
     /// </summary>
     private static DayScenario SelectDayScenario(DateTime date) => DayScenarios.For(date);
 
-    private (
-        List<Entry> Entries,
-        List<Treatment> Treatments,
-        double EndingGlucose,
-        double EndingMomentum
-    ) GenerateDayData(
-        DateTime date,
-        DayScenario scenario,
-        double? previousDayEndingGlucose = null,
-        double previousDayMomentum = 0
-    )
-    {
-        var entries = new List<Entry>();
-        var treatments = new List<Treatment>();
-
-        var scenarioParams = GetScenarioParameters(scenario);
-
-        // Create oref profile for this scenario
-        var orefProfile = CreateOrefProfile(scenarioParams);
-
-        // Create oref physiology simulator for this day
-        var simulator = new OrefPhysiologySimulator(
-            _loggerFactory.CreateLogger<OrefPhysiologySimulator>(),
-            orefProfile
-        );
-
-        // Start from previous day's ending glucose if available, otherwise use fasting glucose
-        double glucose;
-        if (previousDayEndingGlucose.HasValue)
-        {
-            glucose = previousDayEndingGlucose.Value;
-        }
-        else
-        {
-            glucose = scenarioParams.FastingGlucose + (_random.NextDouble() - 0.5) * 20;
-        }
-
-        var currentTime = date;
-        // Cap endTime to now on the final day to prevent generating future
-        // data. Local basis, matching the day iteration.
-        var now = DateTime.Now;
-        var endTime = date.Date == now.Date
-            ? now
-            : date.AddDays(1);
-
-        var mealPlan = GenerateMealPlan(date, scenario);
-        var basalAdjustments = GenerateBasalAdjustments(date, scenario);
-
-        // Pre-populate insulin and carb events from meal plan into oref simulator
-        foreach (var meal in mealPlan)
-        {
-            // Add carbs to simulator with absorption time based on glycemic index
-            var absorptionHours = _config.CarbAbsorptionDurationMinutes / 60.0 / meal.GlycemicIndex;
-            simulator.AddCarbs(meal.MealTime, meal.Carbs, absorptionHours);
-
-            var bolusTime = meal.MealTime.AddMinutes(meal.BolusOffsetMinutes);
-            var bolus = CalculateMealBolus(meal.Carbs, glucose, scenarioParams);
-            simulator.AddInsulinDose(bolusTime, bolus);
-
-            treatments.Add(CreateCarbTreatment(meal.MealTime, meal.Carbs, meal.FoodType));
-            treatments.Add(
-                CreateBolusTreatment(
-                    bolusTime,
-                    bolus,
-                    meal.FoodType == "Snack" ? "Snack Bolus" : "Meal Bolus"
-                )
-            );
-        }
-
-        // Use previous day's momentum for continuity if available
-        double glucoseMomentum = previousDayMomentum * 0.5;
-        double lastGlucose = glucose;
-
-        // Track IOB to prevent insulin stacking
-        double estimatedIob = 0;
-        var targetGlucose = _config.TargetGlucose;
-
-        while (currentTime < endTime)
-        {
-            var basalAdj = basalAdjustments.FirstOrDefault(b =>
-                Math.Abs((b.Time - currentTime).TotalMinutes) < 2.5
-            );
-            var adjustedRate = NormalizeBasalRate(basalAdj.Rate);
-            if (adjustedRate > 0 || basalAdj.Duration > 0)
-            {
-                treatments.Add(
-                    CreateTempBasalTreatment(currentTime, adjustedRate, basalAdj.Duration)
-                );
-                // Add temp basal to simulator
-                simulator.AddInsulinDose(
-                    currentTime,
-                    adjustedRate * basalAdj.Duration / 60.0,
-                    isTempBasal: true,
-                    duration: basalAdj.Duration
-                );
-            }
-
-            // Use oref simulator for glucose prediction
-            glucose = SimulateGlucoseWithOref(
-                glucose,
-                currentTime,
-                simulator,
-                scenarioParams,
-                scenario,
-                ref glucoseMomentum
-            );
-
-            // Clamp to realistic CGM range
-            glucose = Math.Max(40, Math.Min(_config.MaxGlucose, glucose));
-
-            // Decay estimated IOB based on configured DIA
-            // For 4-hour (240 min) DIA: decay ~2% per 5 min interval
-            var iobDecayRate = 1.0 - (5.0 / _config.InsulinDurationMinutes);
-            estimatedIob *= iobDecayRate;
-
-            // === REACTIVE GLUCOSE MANAGEMENT (simulates AID/closed-loop behavior) ===
-
-            var hour = currentTime.Hour;
-            var isWakingHours = hour >= 7 && hour < 22; // 7am to 10pm
-            var tempBasalDuration = _config.TempBasalDurationMinutes;
-
-            // Handle LOW glucose - treat with fast carbs
-            if (glucose < 70)
-            {
-                var correctionCarbs = glucose < 55 ? _random.Next(15, 25) : _random.Next(10, 18);
-                treatments.Add(CreateCarbCorrectionTreatment(currentTime, correctionCarbs));
-                simulator.AddCarbs(currentTime, correctionCarbs, 0.4); // Very fast carbs
-            }
-            // Handle HIGH glucose - aggressive AID-style insulin delivery
-            // Real AID systems are aggressive about bringing glucose down
-            else if (glucose > targetGlucose + 10)
-            {
-                // Calculate how much insulin would be needed to bring glucose to target
-                var glucoseAboveTarget = glucose - targetGlucose;
-                // Use ISF adjusted by scenario's insulin sensitivity multiplier
-                var effectiveIsf =
-                    _config.InsulinSensitivityFactor * scenarioParams.InsulinSensitivityMultiplier;
-                var insulinNeeded = glucoseAboveTarget / effectiveIsf;
-
-                // Account for IOB - don't stack insulin too much
-                var insulinToDeliver = Math.Max(0, insulinNeeded - estimatedIob * 0.6);
-
-                // HIGH TEMP BASAL - modest increase (typical AID systems use 1.0-1.5x)
-                // Only add temp basal every 30 minutes to reduce basal contribution
-                if (currentTime.Minute == 0 || currentTime.Minute == 30)
-                {
-                    // Scale from 1.1x to 1.4x basal rate based on how high glucose is
-                    var tempBasalMultiplier = 1.1 + Math.Min(0.3, glucoseAboveTarget / 150.0);
-                    var highTempRate = NormalizeBasalRate(_config.BasalRate * tempBasalMultiplier);
-
-                    treatments.Add(
-                        CreateTempBasalTreatment(currentTime, highTempRate, 30)
-                    );
-                    // Add to simulator for glucose effect (only the extra insulin above scheduled)
-                    var extraInsulin = Math.Max(0, highTempRate - _config.BasalRate) * (30 / 60.0);
-                    if (extraInsulin > 0)
-                    {
-                        simulator.AddInsulinDose(
-                            currentTime,
-                            extraInsulin,
-                            isTempBasal: true,
-                            duration: 30
-                        );
-                        estimatedIob += extraInsulin;
-                    }
-                }
-
-                // MANUAL CORRECTION BOLUS - during waking hours, user may manually correct
-                if (isWakingHours && glucose > targetGlucose + 30 && _random.NextDouble() < 0.25)
-                {
-                    // Manual correction uses exact ISF formula
-                    var manualCorrectionBolus = glucoseAboveTarget / effectiveIsf;
-                    manualCorrectionBolus = NormalizeBolus(
-                        Math.Clamp(manualCorrectionBolus, 0.5, 6.0)
-                    );
-
-                    treatments.Add(
-                        CreateManualCorrectionBolusTreatment(
-                            currentTime,
-                            manualCorrectionBolus
-                        )
-                    );
-                    simulator.AddInsulinDose(currentTime, manualCorrectionBolus);
-                    estimatedIob += manualCorrectionBolus;
-                }
-                // AID correction bolus every 5 minutes when significantly high
-                else if (
-                    glucose > targetGlucose + 15
-                    && currentTime.Minute % 5 == 0
-                    && insulinToDeliver > 0.1
-                )
-                {
-                    // Deliver 50-70% of needed correction as a bolus
-                    var correctionBolus = insulinToDeliver * (0.5 + _random.NextDouble() * 0.2);
-                    correctionBolus = NormalizeBolus(Math.Clamp(correctionBolus, 0.1, 4.0));
-
-                    treatments.Add(
-                        CreateCorrectionBolusTreatment(currentTime, correctionBolus)
-                    );
-                    simulator.AddInsulinDose(currentTime, correctionBolus);
-                    estimatedIob += correctionBolus;
-                }
-                // SMBs every 5 minutes for fine-tuning when moderately high
-                else if (glucose > targetGlucose + 10 && insulinToDeliver > 0.05)
-                {
-                    var algorithmBolus = NormalizeBolus(
-                        Math.Clamp(insulinToDeliver * 0.25, 0.05, 1.2)
-                    );
-
-                    if (algorithmBolus >= PumpBolusIncrementUnits)
-                    {
-                        treatments.Add(
-                            CreateAlgorithmBolusTreatment(currentTime, algorithmBolus)
-                        );
-                    }
-                    simulator.AddInsulinDose(currentTime, algorithmBolus);
-                    estimatedIob += algorithmBolus;
-                }
-            }
-            // Reduce basal when trending low or already low (predictive low glucose suspend)
-            else if (glucose < 90 || (glucose < 100 && glucoseMomentum < -0.3))
-            {
-                // Basal reduction when lower
-                var reductionFactor =
-                    glucose < 75 ? 0.0
-                    : glucose < 85 ? 0.2
-                    : 0.4;
-                var reducedRate = NormalizeBasalRate(_config.BasalRate * reductionFactor);
-
-                // Apply reduced temp basal every 30 minutes
-                if (currentTime.Minute == 0 || currentTime.Minute == 30)
-                {
-                    treatments.Add(
-                        CreateTempBasalTreatment(currentTime, reducedRate, 30)
-                    );
-                    // Add to simulator for reduced basal effect (negative = less insulin)
-                    var insulinReduction =
-                        -(Math.Max(0, _config.BasalRate - reducedRate)) * (30 / 60.0);
-                    simulator.AddInsulinDose(
-                        currentTime,
-                        insulinReduction,
-                        isTempBasal: true,
-                        duration: 30
-                    );
-                }
-            }
-
-            var delta = glucose - lastGlucose;
-            entries.Add(CreateEntry(currentTime, glucose, delta));
-            lastGlucose = glucose;
-
-            currentTime = currentTime.AddMinutes(5);
-
-            // Clean up expired doses in the simulator
-            simulator.CleanupExpired(currentTime);
-        }
-
-        treatments.AddRange(GenerateScheduledBasal(date, scenarioParams));
-
-        return (entries, treatments, glucose, glucoseMomentum);
-    }
 
     /// <summary>
     /// Simulates glucose changes using oref pharmacokinetic models plus scenario-specific effects.
@@ -1276,42 +889,6 @@ public class DemoDataGenerator : IDemoDataGenerator
         return adjustments;
     }
 
-    private List<Treatment> GenerateScheduledBasal(DateTime date, ScenarioParameters @params)
-    {
-        var basalTreatments = new List<Treatment>();
-
-        for (var hour = 0; hour < 24; hour++)
-        {
-            var baseRate = _config.BasalRate * @params.BasalMultiplier;
-            var circadianMultiplier = hour switch
-            {
-                >= 3 and < 8 => 1.0
-                    + (@params.DawnPhenomenonStrength * (1 - Math.Abs(hour - 5.5) / 2.5)),
-                >= 12 and < 14 => 1.1,
-                >= 22 or < 3 => 0.9,
-                _ => 1.0,
-            };
-
-            var rate = NormalizeBasalRate(baseRate * circadianMultiplier);
-            var time = date.AddHours(hour);
-            var mills = new DateTimeOffset(time).ToUnixTimeMilliseconds();
-
-            basalTreatments.Add(
-                new Treatment
-                {
-                    EventType = "Scheduled Basal",
-                    Rate = rate,
-                    Duration = 60,
-                    Mills = mills,
-                    Created_at = time.ToString("o"),
-                    EnteredBy = "demo-pump",
-                    DataSource = DataSources.DemoService,
-                }
-            );
-        }
-
-        return basalTreatments;
-    }
 
     private double CalculateMealBolus(
         double carbs,
@@ -1491,6 +1068,229 @@ public class DemoDataGenerator : IDemoDataGenerator
 
         return !_lastTempBasalIssuedAt.HasValue
             || (time - _lastTempBasalIssuedAt.Value).TotalMinutes >= durationMinutes;
+    }
+
+    /// <summary>
+    /// Fingerstick times for a day: a usual morning check plus a frequent
+    /// pre-dinner one. Deterministic per date so re-seeds are idempotent.
+    /// </summary>
+    private static List<DateTime> PlanFingersticks(DateTime day)
+    {
+        var rng = DayScenarios.RngFor(day, "fingerstick");
+        var times = new List<DateTime>();
+        if (rng.NextDouble() < 0.85)
+            times.Add(day.AddHours(6).AddMinutes(40 + rng.Next(0, 55)));
+        if (rng.NextDouble() < 0.6)
+            times.Add(day.AddHours(17).AddMinutes(15 + rng.Next(0, 75)));
+        return times;
+    }
+
+    private sealed record CalibrationPlan(DateTime Time, double Slope, double Intercept);
+
+    /// <summary>
+    /// Two calibrations roughly two hours after a sensor start, mirroring a
+    /// sensor warmup ritual. Empty on non-sensor-change days.
+    /// </summary>
+    private static List<CalibrationPlan> PlanCalibrations(DateTime day)
+    {
+        var sensorStart = DemoDeviceLifecycle.ChangeTimeOn(day, "Sensor Start");
+        if (sensorStart is null)
+            return [];
+
+        var rng = DayScenarios.RngFor(day, "calibration");
+        var first = sensorStart.Value.AddMinutes(115 + rng.Next(0, 20));
+        return
+        [
+            new CalibrationPlan(first, 1000 + rng.Next(0, 120), 30000 + rng.Next(0, 4000)),
+            new CalibrationPlan(
+                first.AddMinutes(12 + rng.Next(0, 10)),
+                1000 + rng.Next(0, 120),
+                30000 + rng.Next(0, 4000)),
+        ];
+    }
+
+    private static readonly string[] NotePool =
+    [
+        "Site a bit sore today, watching absorption",
+        "Long walk after lunch",
+        "Slept in, skipped breakfast",
+        "Coffee seemed to spike me more than usual",
+        "Feeling a cold coming on",
+        "New sensor reading close to fingerstick",
+        "Pizza night - extended the bolus",
+        "Forgot to prebolus, chasing the spike",
+        "Gym session went well, no lows",
+        "Stressful workday, running high",
+        "Tried a lower-carb lunch today",
+        "Pod alarm went off during meeting",
+        "Swapped infusion site to left side",
+        "Grazing at a family BBQ, lots of small boluses",
+    ];
+
+    private static readonly string[] AnnouncementPool =
+    [
+        "Endo appointment booked for next month",
+        "Started new insulin cartridge batch",
+        "Reviewing basal rates with the care team this week",
+        "Travelling next weekend - remember spare supplies",
+    ];
+
+    /// <summary>
+    /// Occasional diary notes plus a weekly announcement, as standalone
+    /// treatments the decomposer turns into Note records.
+    /// </summary>
+    private static List<(DateTime Time, Treatment Treatment)> PlanNotes(DateTime day)
+    {
+        var rng = DayScenarios.RngFor(day, "notes");
+        var planned = new List<(DateTime, Treatment)>();
+
+        if (rng.NextDouble() < 0.35)
+        {
+            var time = day.AddHours(8 + rng.Next(0, 13)).AddMinutes(rng.Next(0, 60));
+            planned.Add((time, CreateNoteTreatment(time, NotePool[rng.Next(NotePool.Length)], announcement: false)));
+        }
+
+        if (day.DayOfWeek == DayOfWeek.Sunday && rng.NextDouble() < 0.5)
+        {
+            var time = day.AddHours(10).AddMinutes(rng.Next(0, 40));
+            planned.Add((time, CreateNoteTreatment(time, AnnouncementPool[rng.Next(AnnouncementPool.Length)], announcement: true)));
+        }
+
+        return planned;
+    }
+
+    /// <summary>Fingerstick (mbg) entry near the CGM value, with meter-scale noise.</summary>
+    private Entry CreateFingerstickEntry(DateTime time, double cgmGlucose)
+    {
+        var value = Math.Round(cgmGlucose * (0.92 + _random.NextDouble() * 0.16) + (_random.NextDouble() - 0.5) * 6, 0);
+        value = Math.Max(40, value);
+
+        return new Entry
+        {
+            Type = "mbg",
+            Device = "Contour Next One",
+            Mills = new DateTimeOffset(time).ToUnixTimeMilliseconds(),
+            Date = time,
+            DateString = time.ToString("o"),
+            Mbg = value,
+            Mgdl = value,
+            DataSource = DataSources.DemoService,
+            CreatedAt = time.ToString("o"),
+            ModifiedAt = time,
+        };
+    }
+
+    /// <summary>Sensor calibration (cal) entry in xDrip-style slope/intercept form.</summary>
+    private Entry CreateCalibrationEntry(CalibrationPlan plan)
+    {
+        return new Entry
+        {
+            Type = "cal",
+            Device = _config.Device,
+            Mills = new DateTimeOffset(plan.Time).ToUnixTimeMilliseconds(),
+            Date = plan.Time,
+            DateString = plan.Time.ToString("o"),
+            Slope = plan.Slope,
+            Intercept = plan.Intercept,
+            Scale = 1,
+            DataSource = DataSources.DemoService,
+            CreatedAt = plan.Time.ToString("o"),
+            ModifiedAt = plan.Time,
+        };
+    }
+
+    /// <summary>Fingerstick BG Check treatment confirming a CGM low.</summary>
+    private Treatment CreateBGCheckTreatment(DateTime time, double glucose)
+    {
+        return new Treatment
+        {
+            EventType = "BG Check",
+            Glucose = Math.Max(40, Math.Round(glucose + (_random.NextDouble() - 0.5) * 8, 0)),
+            GlucoseType = "Finger",
+            Units = "mg/dl",
+            Mills = new DateTimeOffset(time).ToUnixTimeMilliseconds(),
+            Created_at = time.ToString("o"),
+            EnteredBy = "demo-user",
+            DataSource = DataSources.DemoService,
+        };
+    }
+
+    private static Treatment CreateNoteTreatment(DateTime time, string text, bool announcement)
+    {
+        return new Treatment
+        {
+            EventType = announcement ? "Announcement" : "Note",
+            Notes = text,
+            Mills = new DateTimeOffset(time).ToUnixTimeMilliseconds(),
+            Created_at = time.ToString("o"),
+            EnteredBy = "demo-user",
+            DataSource = DataSources.DemoService,
+        };
+    }
+
+    /// <summary>
+    /// Realtime device status: IOB/COB continuity comes from a persistent
+    /// simulator fed with the treatments issued by the realtime ticks;
+    /// consumable levels are the same wall-clock functions the historical
+    /// stream uses, so the two streams agree across the seed/realtime boundary.
+    /// </summary>
+    public DeviceStatus GenerateCurrentDeviceStatus(Entry entry, IReadOnlyList<Treatment> treatments)
+    {
+        lock (_lock)
+        {
+            var nowUtc = entry.Date ?? DateTime.UtcNow;
+            var nowLocal = nowUtc.Kind == DateTimeKind.Utc ? nowUtc.ToLocalTime() : nowUtc;
+
+            _realtimeSimulator ??= new OrefPhysiologySimulator(
+                _loggerFactory.CreateLogger<OrefPhysiologySimulator>(),
+                CreateOrefProfile(new ScenarioParameters
+                {
+                    FastingGlucose = _config.TargetGlucose,
+                    CarbRatio = _config.CarbRatio,
+                    BasalMultiplier = 1.0,
+                    InsulinSensitivityMultiplier = 1.0,
+                    DawnPhenomenonStrength = 0.2,
+                })
+            );
+
+            double? tempRate = null;
+            int? tempDuration = null;
+            foreach (var treatment in treatments)
+            {
+                if (treatment.Insulin is > 0)
+                    _realtimeSimulator.AddInsulinDose(nowUtc, treatment.Insulin.Value);
+                if (treatment.Carbs is > 0)
+                    _realtimeSimulator.AddCarbs(nowUtc, treatment.Carbs.Value);
+                if (treatment.EventType == "Temp Basal" && treatment.Rate is { } rate)
+                {
+                    tempRate = rate;
+                    tempDuration = treatment.Duration is > 0 ? (int)treatment.Duration.Value : null;
+                    var extra = (rate - _config.BasalRate) * (treatment.Duration ?? 0) / 60.0;
+                    if (Math.Abs(extra) > 0.001)
+                    {
+                        _realtimeSimulator.AddInsulinDose(
+                            nowUtc, extra, isTempBasal: true, duration: treatment.Duration ?? 0);
+                    }
+                }
+            }
+
+            _realtimeSimulator.CleanupExpired(nowUtc);
+            var iob = Math.Max(0, _realtimeSimulator.CalculateIob(nowUtc));
+            var cob = Math.Max(0, _realtimeSimulator.CalculateCob(nowUtc));
+
+            return DemoDeviceStatusGenerator.Create(
+                nowLocal,
+                entry.Sgv ?? entry.Mgdl,
+                iob,
+                cob,
+                tempRate,
+                tempDuration,
+                _config.InsulinSensitivityFactor,
+                _config.CarbRatio,
+                _config.TargetGlucose,
+                DemoTherapyProfile.ScheduledRateAt(nowLocal, _config.BasalRate),
+                DayScenarios.For(nowLocal.Date));
+        }
     }
 
     private double GetNextTrendGlucose()

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoDataGenerator.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoDataGenerator.cs
@@ -45,19 +45,11 @@ public interface IDemoDataGenerator
     /// <summary>
     /// Streams the unified historical timeline: one simulation pass yielding
     /// entries, treatments, and simulator state per 5-minute step, so every
-    /// derived stream (chart, treatments, device status, alarm episodes) agrees.
+    /// derived stream (chart, treatments, device status, alarm episodes)
+    /// agrees. Each call runs a fresh simulation — consumers must enumerate
+    /// once and project what they need.
     /// </summary>
     IEnumerable<DemoTimeStep> GenerateHistoricalTimeline();
-
-    /// <summary>
-    /// Generates historical entries using streaming/yield pattern to minimize memory usage.
-    /// </summary>
-    IEnumerable<Entry> GenerateHistoricalEntries();
-
-    /// <summary>
-    /// Generates historical treatments using streaming/yield pattern to minimize memory usage.
-    /// </summary>
-    IEnumerable<Treatment> GenerateHistoricalTreatments();
 }
 
 /// <summary>
@@ -208,32 +200,6 @@ public class DemoDataGenerator : IDemoDataGenerator
     }
 
     /// <summary>
-    /// Generates historical entries as a projection of the unified timeline.
-    /// Includes the fingerstick (mbg) and calibration (cal) entries.
-    /// </summary>
-    public IEnumerable<Entry> GenerateHistoricalEntries()
-    {
-        foreach (var step in GenerateHistoricalTimeline())
-        {
-            yield return step.Entry;
-            foreach (var extra in step.ExtraEntries)
-                yield return extra;
-        }
-    }
-
-    /// <summary>
-    /// Generates historical treatments as a projection of the unified timeline.
-    /// </summary>
-    public IEnumerable<Treatment> GenerateHistoricalTreatments()
-    {
-        foreach (var step in GenerateHistoricalTimeline())
-        {
-            foreach (var treatment in step.Treatments)
-                yield return treatment;
-        }
-    }
-
-    /// <summary>
     /// The single historical simulation pass. Runs the oref simulator over the
     /// backfill window and yields one <see cref="DemoTimeStep"/> per 5 minutes
     /// carrying the CGM entry, the treatments issued at that step, and the
@@ -321,12 +287,15 @@ public class DemoDataGenerator : IDemoDataGenerator
             while (currentTime < endTime)
             {
                 var stepEnd = currentTime.AddMinutes(5);
+                // The final (partial) step must not emit anything past "now" —
+                // a future-dated planned item would outrank the realtime stream.
+                var consumeUntil = stepEnd < endTime ? stepEnd : endTime;
                 var stepTreatments = new List<Treatment>();
                 double? tempRate = null;
                 int? tempDuration = null;
 
                 // Consume planned treatments due this step.
-                while (pending.Count > 0 && pending[0].Time < stepEnd)
+                while (pending.Count > 0 && pending[0].Time < consumeUntil)
                 {
                     stepTreatments.Add(pending[0].Treatment);
                     pending.RemoveAt(0);
@@ -474,12 +443,12 @@ public class DemoDataGenerator : IDemoDataGenerator
                 var entry = CreateEntry(currentTime, glucose, delta);
 
                 List<Entry> extraEntries = [];
-                while (fingerstickTimes.Count > 0 && fingerstickTimes[0] < stepEnd)
+                while (fingerstickTimes.Count > 0 && fingerstickTimes[0] < consumeUntil)
                 {
                     extraEntries.Add(CreateFingerstickEntry(fingerstickTimes[0], glucose));
                     fingerstickTimes.RemoveAt(0);
                 }
-                while (calibrations.Count > 0 && calibrations[0].Time < stepEnd)
+                while (calibrations.Count > 0 && calibrations[0].Time < consumeUntil)
                 {
                     extraEntries.Add(CreateCalibrationEntry(calibrations[0]));
                     calibrations.RemoveAt(0);

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoDeviceLifecycle.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoDeviceLifecycle.cs
@@ -60,20 +60,57 @@ public static class DemoDeviceLifecycle
         {
             for (var d = backfillDays + kind.CycleDays; d >= 0; d--)
             {
-                var day = localToday.AddDays(-d);
-                var dayNumber = (int)(day.Ticks / TimeSpan.TicksPerDay);
-                if ((dayNumber % kind.CycleDays + kind.CycleDays) % kind.CycleDays != kind.Phase)
+                var local = ChangeTimeOn(localToday.AddDays(-d), kind.Tracker.TriggerEventType);
+                if (local is null || local > DateTime.Now)
                     continue;
-
-                var jitter = DayScenarios.RngFor(day, $"device:{kind.Tracker.TriggerEventType}");
-                var local = day.AddHours(kind.HourOfDay).AddMinutes(jitter.Next(-90, 90));
-                if (local > DateTime.Now)
-                    continue;
-                events.Add(new DeviceChangeEvent(kind.Tracker.TriggerEventType, local.ToUniversalTime()));
+                events.Add(new DeviceChangeEvent(kind.Tracker.TriggerEventType, local.Value.ToUniversalTime()));
             }
         }
 
         return events.OrderBy(e => e.TimestampUtc).ToList();
+    }
+
+    /// <summary>
+    /// The local change time of the given kind on <paramref name="localDay"/>,
+    /// or null when that calendar day is not a change day. The single source of
+    /// the day-number modulo anchoring and per-day jitter, so consumable levels
+    /// in device status and the calibration schedule agree with the seeded
+    /// DeviceEvents.
+    /// </summary>
+    public static DateTime? ChangeTimeOn(DateTime localDay, string eventType)
+    {
+        var kind = Kinds.FirstOrDefault(k => k.Tracker.TriggerEventType == eventType);
+        if (kind is null)
+            return null;
+
+        var day = localDay.Date;
+        var dayNumber = (int)(day.Ticks / TimeSpan.TicksPerDay);
+        if ((dayNumber % kind.CycleDays + kind.CycleDays) % kind.CycleDays != kind.Phase)
+            return null;
+
+        var jitter = DayScenarios.RngFor(day, $"device:{eventType}");
+        return day.AddHours(kind.HourOfDay).AddMinutes(jitter.Next(-90, 90));
+    }
+
+    /// <summary>
+    /// Time since the most recent change of the given kind at or before
+    /// <paramref name="localTime"/>.
+    /// </summary>
+    public static TimeSpan TimeSinceLastChange(DateTime localTime, string eventType)
+    {
+        var kind = Kinds.FirstOrDefault(k => k.Tracker.TriggerEventType == eventType);
+        if (kind is null)
+            return TimeSpan.Zero;
+
+        for (var back = 0; back <= kind.CycleDays * 2; back++)
+        {
+            var changeAt = ChangeTimeOn(localTime.Date.AddDays(-back), eventType);
+            if (changeAt is not null && changeAt <= localTime)
+                return localTime - changeAt.Value;
+        }
+
+        // Unreachable with a valid phase; degrade to one full cycle.
+        return TimeSpan.FromDays(kind.CycleDays);
     }
 
     /// <summary>

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoDeviceStatusGenerator.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoDeviceStatusGenerator.cs
@@ -1,0 +1,265 @@
+using Nocturne.Core.Constants;
+using Nocturne.Core.Models;
+
+namespace Nocturne.Services.Demo.Services;
+
+/// <summary>
+/// Builds Trio-style <see cref="DeviceStatus"/> documents for the demo tenant:
+/// an <c>openaps</c> block with suggested/enacted actions and prediction curves
+/// derived from the simulation state, a pump block with reservoir and battery,
+/// and an uploader (phone) block. Documents feed the same decomposer as real
+/// uploads, so APS/pump/uploader snapshots, suspension spans, and battery
+/// reports light up exactly as they do for a live Trio rig.
+///
+/// Pump consumable levels are pure functions of wall-clock time against the
+/// <see cref="DemoDeviceLifecycle"/> change schedule — reservoir refills on
+/// Insulin Change days, pump battery resets on Pump Battery Change days — so
+/// history, realtime ticks, and re-seeds all agree without carrying state.
+/// </summary>
+public static class DemoDeviceStatusGenerator
+{
+    /// <summary>Device string carried on every demo device status.</summary>
+    public const string DeviceName = "Trio";
+
+    private const string AidVersion = "0.5.1";
+    private const double ReservoirCapacityUnits = 200.0;
+    private const double AssumedDailyInsulinUnits = 34.0;
+    private const double PumpBatteryDrainPerDayPercent = 4.4;
+
+    /// <summary>Prediction curve length: 42 five-minute points = 3.5 hours, matching oref.</summary>
+    private const int PredictionPoints = 42;
+
+    /// <summary>
+    /// Builds the device status for one simulation step (historical) or one
+    /// realtime tick. <paramref name="localTime"/> is the step's local time;
+    /// the emitted mills convert via its Kind.
+    /// </summary>
+    public static DeviceStatus Create(
+        DateTime localTime,
+        double glucose,
+        double iob,
+        double cob,
+        double? tempBasalRate,
+        int? tempBasalDuration,
+        double effectiveIsf,
+        double effectiveCarbRatio,
+        double targetGlucose,
+        double scheduledBasalRate,
+        DayScenario scenario)
+    {
+        var mills = new DateTimeOffset(localTime).ToUnixTimeMilliseconds();
+        var isoTime = new DateTimeOffset(localTime).UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+        var rng = DayScenarios.RngFor(localTime.Date, $"devicestatus:{localTime.Hour}:{localTime.Minute}");
+
+        var eventualBg = EstimateEventualBg(glucose, iob, cob, effectiveIsf, effectiveCarbRatio, targetGlucose);
+        var sensitivityRatio = SensitivityRatioFor(scenario);
+        var predictions = BuildPredictions(glucose, eventualBg, cob, targetGlucose, rng);
+
+        // Basal IOB is the temp-basal component; the demo's simulator tracks a
+        // single pool, so split it with a plausible ratio rather than pretending
+        // to more precision than the simulation has.
+        var bolusIob = Math.Round(iob * 0.85, 3);
+        var basalIob = Math.Round(iob - bolusIob, 3);
+
+        var insulinReq = Math.Round((glucose - targetGlucose) / effectiveIsf - iob * 0.5, 2);
+        var reason = BuildReason(glucose, eventualBg, iob, cob, effectiveIsf, targetGlucose,
+            sensitivityRatio, tempBasalRate, tempBasalDuration, insulinReq);
+
+        var suggested = new OpenApsSuggested
+        {
+            Timestamp = isoTime,
+            DeliverAt = isoTime,
+            Bg = Math.Round(glucose, 0),
+            EventualBG = Math.Round(eventualBg, 0),
+            TargetBG = targetGlucose,
+            IOB = Math.Round(iob, 3),
+            COB = Math.Round(cob, 1),
+            InsulinReq = insulinReq,
+            SensitivityRatio = sensitivityRatio,
+            Rate = tempBasalRate,
+            Duration = tempBasalDuration,
+            Reason = reason,
+            PredBGs = predictions,
+        };
+
+        var enacted = new OpenApsEnacted
+        {
+            Timestamp = isoTime,
+            DeliverAt = isoTime,
+            Bg = suggested.Bg,
+            EventualBG = suggested.EventualBG,
+            TargetBG = suggested.TargetBG,
+            IOB = suggested.IOB,
+            COB = suggested.COB,
+            InsulinReq = suggested.InsulinReq,
+            SensitivityRatio = suggested.SensitivityRatio,
+            Rate = tempBasalRate ?? scheduledBasalRate,
+            Duration = tempBasalDuration ?? 0,
+            Reason = reason,
+            PredBGs = predictions,
+            Received = true,
+        };
+
+        return new DeviceStatus
+        {
+            Device = DeviceName,
+            Mills = mills,
+            CreatedAt = new DateTimeOffset(localTime).UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+            UtcOffset = (int)TimeZoneInfo.Local.GetUtcOffset(localTime).TotalMinutes,
+            OpenAps = new OpenApsStatus
+            {
+                Suggested = suggested,
+                Enacted = enacted,
+                Version = AidVersion,
+                Iob = new OpenApsIobData
+                {
+                    Iob = Math.Round(iob, 3),
+                    BolusIob = bolusIob,
+                    BasalIob = basalIob,
+                    Timestamp = isoTime,
+                },
+                Cob = Math.Round(cob, 1),
+            },
+            Pump = new PumpStatus
+            {
+                Manufacturer = "Insulet",
+                Model = "Omnipod DASH",
+                Reservoir = ReservoirAt(localTime),
+                Battery = new PumpBattery { Percent = PumpBatteryAt(localTime) },
+                Clock = isoTime,
+                Status = new PumpStatusDetails
+                {
+                    Status = "normal",
+                    Bolusing = false,
+                    Suspended = false,
+                },
+            },
+            Uploader = new UploaderStatus
+            {
+                Battery = UploaderBatteryAt(localTime),
+                IsCharging = IsUploaderCharging(localTime),
+            },
+        };
+    }
+
+    /// <summary>
+    /// Reservoir level as a function of time since the last Insulin Change in
+    /// the lifecycle schedule, draining at the assumed daily rate.
+    /// </summary>
+    public static double ReservoirAt(DateTime localTime)
+    {
+        var sinceChange = DemoDeviceLifecycle.TimeSinceLastChange(localTime, "Insulin Change");
+        var used = AssumedDailyInsulinUnits * sinceChange.TotalDays;
+        return Math.Round(Math.Max(8, ReservoirCapacityUnits - used), 1);
+    }
+
+    /// <summary>Pump battery percent, resetting on Pump Battery Change days.</summary>
+    public static int PumpBatteryAt(DateTime localTime)
+    {
+        var sinceChange = DemoDeviceLifecycle.TimeSinceLastChange(localTime, "Pump Battery Change");
+        var drained = PumpBatteryDrainPerDayPercent * sinceChange.TotalDays;
+        return (int)Math.Clamp(100 - drained, 4, 100);
+    }
+
+    /// <summary>
+    /// Phone battery: overnight charge to 100% by ~06:30, then a daytime drain
+    /// to ~30% with a deterministic per-day wobble.
+    /// </summary>
+    public static int UploaderBatteryAt(DateTime localTime)
+    {
+        var hour = localTime.Hour + localTime.Minute / 60.0;
+        var wobble = DayScenarios.Roll(localTime.Date, "uploader-battery", 12) - 6;
+
+        if (IsUploaderCharging(localTime))
+        {
+            // Charging window 23:00–06:30: ramp from ~35 to 100.
+            var chargeHours = hour >= 23 ? hour - 23 : hour + 1;
+            var pct = 35 + chargeHours / 7.5 * 65;
+            return (int)Math.Clamp(pct + wobble, 20, 100);
+        }
+
+        // Discharge from 100 at 06:30 to ~32 at 23:00.
+        var dischargeHours = hour - 6.5;
+        var level = 100 - dischargeHours / 16.5 * 68;
+        return (int)Math.Clamp(level + wobble, 20, 100);
+    }
+
+    /// <summary>Phone charges overnight (23:00–06:30).</summary>
+    public static bool IsUploaderCharging(DateTime localTime)
+    {
+        var hour = localTime.Hour + localTime.Minute / 60.0;
+        return hour >= 23 || hour < 6.5;
+    }
+
+    private static double EstimateEventualBg(
+        double glucose, double iob, double cob, double effectiveIsf, double effectiveCarbRatio, double targetGlucose)
+    {
+        // oref's core arithmetic: remaining insulin pulls glucose down by ISF,
+        // remaining carbs push it up by ISF-per-carb-ratio.
+        var insulinEffect = iob * effectiveIsf;
+        var carbEffect = cob / effectiveCarbRatio * effectiveIsf;
+        return Math.Clamp(glucose - insulinEffect + carbEffect, 40, 320);
+    }
+
+    private static double SensitivityRatioFor(DayScenario scenario) => scenario switch
+    {
+        DayScenario.Exercise => 1.25,
+        DayScenario.LowDay => 1.15,
+        DayScenario.SickDay => 0.78,
+        DayScenario.StressDay => 0.88,
+        DayScenario.HighDay => 0.9,
+        _ => 1.0,
+    };
+
+    private static OpenApsPredBGs BuildPredictions(
+        double glucose, double eventualBg, double cob, double targetGlucose, Random rng)
+    {
+        // IOB curve: exponential approach from current glucose to eventualBG.
+        var iobCurve = Curve(glucose, eventualBg, PredictionPoints, rng);
+
+        // Zero-temp curve: what happens if basal stops — drifts higher than the
+        // IOB curve, bottoming out above it.
+        var ztTarget = Math.Max(eventualBg + 25, Math.Min(glucose, targetGlucose + 10));
+        var ztCurve = Curve(glucose, ztTarget, 15, rng);
+
+        // UAM curve: unannounced-meal detection decays a little below eventual.
+        var uamCurve = Curve(glucose, Math.Max(40, eventualBg - 12), PredictionPoints - 1, rng);
+
+        var predictions = new OpenApsPredBGs { IOB = iobCurve, ZT = ztCurve, UAM = uamCurve };
+
+        // COB curve only exists while carbs remain, as in real oref output:
+        // absorption pushes the near curve up before insulin brings it down.
+        if (cob > 0.5)
+            predictions.COB = Curve(glucose + Math.Min(40, cob * 1.5), eventualBg, PredictionPoints, rng);
+
+        return predictions;
+    }
+
+    private static List<double?> Curve(double from, double to, int points, Random rng)
+    {
+        var curve = new List<double?>(points);
+        for (var i = 0; i < points; i++)
+        {
+            // 1 - e^-kt approach with ~85% completion at the end of the curve.
+            var progress = 1 - Math.Exp(-2.0 * i / points);
+            var value = from + (to - from) * progress + (rng.NextDouble() - 0.5) * 2;
+            curve.Add(Math.Round(Math.Clamp(value, 39, 400), 0));
+        }
+
+        return curve;
+    }
+
+    private static string BuildReason(
+        double glucose, double eventualBg, double iob, double cob, double effectiveIsf,
+        double targetGlucose, double sensitivityRatio, double? tempBasalRate, int? tempBasalDuration,
+        double insulinReq)
+    {
+        var action = tempBasalRate is { } rate && tempBasalDuration is { } duration
+            ? $"setting {duration}m temp basal of {rate:0.0#}U/h."
+            : "temp basal within range, no action.";
+
+        return $"Autosens ratio: {sensitivityRatio:0.0#}, ISF: {effectiveIsf:0}, COB: {cob:0.#}, "
+            + $"IOB: {iob:0.0##}, Target: {targetGlucose:0}, "
+            + $"Eventual BG {eventualBg:0} vs BG {glucose:0}, insulinReq {insulinReq:0.0#}; {action}";
+    }
+}

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoHealthDataGenerator.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoHealthDataGenerator.cs
@@ -15,13 +15,6 @@ public static class DemoHealthDataGenerator
     private const string WearableDevice = "Demo Watch";
 
     /// <summary>
-    /// Heart rate samples (5-minute cadence) and hourly step-count deltas for
-    /// one local calendar day. <paramref name="localDay"/> is a local midnight;
-    /// timestamps are stored UTC. <paramref name="dataSource"/> stamps every
-    /// record and prefixes the deterministic sync identifiers, so re-seeding
-    /// updates in place via the (DataSource, SyncIdentifier) dedup key.
-    /// </summary>
-    /// <summary>
     /// The day's 75-minute late-afternoon workout window. Deterministic per
     /// date and shared with the state-span seeding, so Exercise spans cover
     /// exactly the step spike and heart-rate ramp.
@@ -34,6 +27,13 @@ public static class DemoHealthDataGenerator
         return (start, start.AddMinutes(75));
     }
 
+    /// <summary>
+    /// Heart rate samples (5-minute cadence) and hourly step-count deltas for
+    /// one local calendar day. <paramref name="localDay"/> is a local midnight;
+    /// timestamps are stored UTC. <paramref name="dataSource"/> stamps every
+    /// record and prefixes the deterministic sync identifiers, so re-seeding
+    /// updates in place via the (DataSource, SyncIdentifier) dedup key.
+    /// </summary>
     public static (List<HeartRate> HeartRates, List<StepCount> StepCounts) GenerateDailyActivity(
         DateTime localDay, string dataSource)
     {

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoHealthDataGenerator.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoHealthDataGenerator.cs
@@ -21,6 +21,19 @@ public static class DemoHealthDataGenerator
     /// record and prefixes the deterministic sync identifiers, so re-seeding
     /// updates in place via the (DataSource, SyncIdentifier) dedup key.
     /// </summary>
+    /// <summary>
+    /// The day's 75-minute late-afternoon workout window. Deterministic per
+    /// date and shared with the state-span seeding, so Exercise spans cover
+    /// exactly the step spike and heart-rate ramp.
+    /// </summary>
+    public static (DateTime Start, DateTime End) WorkoutWindowFor(DateTime localDay)
+    {
+        var rng = DayScenarios.RngFor(localDay, "workout-window");
+        var startHour = 16 + DayScenarios.Roll(localDay, "workout", 4); // 16-19
+        var start = localDay.AddHours(startHour).AddMinutes(rng.Next(0, 45));
+        return (start, start.AddMinutes(75));
+    }
+
     public static (List<HeartRate> HeartRates, List<StepCount> StepCounts) GenerateDailyActivity(
         DateTime localDay, string dataSource)
     {
@@ -28,9 +41,7 @@ public static class DemoHealthDataGenerator
         var rng = DayScenarios.RngFor(localDay, "activity");
 
         // Exercise window: a 75-minute workout starting late afternoon.
-        var workoutStartHour = 16 + DayScenarios.Roll(localDay, "workout", 4); // 16-19
-        var workoutStart = localDay.AddHours(workoutStartHour).AddMinutes(rng.Next(0, 45));
-        var workoutEnd = workoutStart.AddMinutes(75);
+        var (workoutStart, workoutEnd) = WorkoutWindowFor(localDay);
         var hasWorkout = scenario == DayScenario.Exercise;
 
         var heartRates = new List<HeartRate>();

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoLifestyleSeeds.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoLifestyleSeeds.cs
@@ -60,9 +60,18 @@ public static class DemoLifestyleSeeds
         return Math.Round(77.5 + drift + wobble, 1);
     }
 
-    /// <summary>One state span to seed; local times, null end = still active.</summary>
+    /// <summary>
+    /// One state span to seed; local times, null end = still active. Metadata
+    /// follows the decomposer's conventions (e.g. Profile spans carry the name
+    /// in <c>profileName</c>, temporary targets carry <c>targetTop/Bottom</c>)
+    /// so the resolvers that read spans see the same shape as real uploads.
+    /// </summary>
     public sealed record SpanSeed(
-        StateSpanCategory Category, string State, DateTime StartLocal, DateTime? EndLocal);
+        StateSpanCategory Category,
+        string State,
+        DateTime StartLocal,
+        DateTime? EndLocal,
+        IReadOnlyDictionary<string, object>? Metadata = null);
 
     /// <summary>The timezone-timeline trip: NYC for five days, three weeks back.</summary>
     public const string HomeTimezoneFallback = "Australia/Sydney";
@@ -83,7 +92,11 @@ public static class DemoLifestyleSeeds
         var now = DateTime.Now;
 
         // Profile: the seeded therapy profile is active for the whole window.
-        spans.Add(new SpanSeed(StateSpanCategory.Profile, DemoTherapyProfile.ProfileName, windowStart, null));
+        // Resolvers read the name from metadata, not from State (which is the
+        // ProfileState enum name).
+        spans.Add(new SpanSeed(
+            StateSpanCategory.Profile, nameof(ProfileState.Active), windowStart, null,
+            new Dictionary<string, object> { ["profileName"] = DemoTherapyProfile.ProfileName }));
 
         // Pump mode: Automatic, interrupted by occasional Manual windows and
         // by Exercise mode during workouts on exercise days.
@@ -100,8 +113,10 @@ public static class DemoLifestyleSeeds
 
                 spans.Add(new SpanSeed(StateSpanCategory.Override, "Workout Mode",
                     workoutStart.AddMinutes(-10), workoutEnd.AddMinutes(10)));
-                spans.Add(new SpanSeed(StateSpanCategory.TemporaryTarget, "140",
-                    workoutStart.AddMinutes(-10), workoutEnd.AddMinutes(10)));
+                spans.Add(new SpanSeed(
+                    StateSpanCategory.TemporaryTarget, nameof(TemporaryTargetState.Active),
+                    workoutStart.AddMinutes(-10), workoutEnd.AddMinutes(10),
+                    new Dictionary<string, object> { ["targetTop"] = 150.0, ["targetBottom"] = 140.0 }));
             }
             else if (DayScenarios.Roll(day, "manual-mode", 100) < 9)
             {

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoLifestyleSeeds.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoLifestyleSeeds.cs
@@ -1,0 +1,174 @@
+using Nocturne.Core.Models;
+
+namespace Nocturne.Services.Demo.Services;
+
+/// <summary>
+/// Deterministic lifestyle sample data: the food library with per-meal
+/// attribution, body-weight trend, state spans (pump mode, profile, overrides,
+/// exercise, illness, travel), the timezone-timeline trip, and the default
+/// clock face. All keyed off <see cref="DayScenarios"/> so every stream tells
+/// the same story as the glucose it sits beside.
+/// </summary>
+public static class DemoLifestyleSeeds
+{
+    /// <summary>A food library item; carbs/fat/protein per portion in grams.</summary>
+    public sealed record FoodSeed(
+        string Name, string Category, string Subcategory,
+        double Portion, string Unit, double Carbs, double Protein, double Fat, double Energy);
+
+    /// <summary>Foods referenced by generated meals, plus a few browsables.</summary>
+    public static readonly IReadOnlyList<FoodSeed> FoodLibrary =
+    [
+        new("Porridge with berries", "Breakfast", "Cereal", 250, "g", 42, 8, 6, 260),
+        new("Wholegrain toast with eggs", "Breakfast", "Bread", 160, "g", 28, 16, 14, 300),
+        new("Greek yoghurt with granola", "Breakfast", "Dairy", 200, "g", 34, 12, 9, 280),
+        new("Chicken salad wrap", "Lunch", "Wrap", 220, "g", 38, 24, 11, 350),
+        new("Leftover pasta bake", "Lunch", "Pasta", 300, "g", 52, 18, 13, 400),
+        new("Sushi set", "Lunch", "Rice", 250, "g", 55, 15, 5, 330),
+        new("Beef stir-fry with rice", "Dinner", "Rice", 350, "g", 58, 28, 15, 480),
+        new("Roast chicken with potatoes", "Dinner", "Roast", 380, "g", 45, 32, 18, 470),
+        new("Homemade pizza slices", "Dinner", "Pizza", 280, "g", 62, 22, 20, 520),
+        new("Lentil curry with naan", "Dinner", "Curry", 400, "g", 60, 20, 12, 450),
+        new("Apple", "Snack", "Fruit", 150, "g", 16, 0, 0, 62),
+        new("Muesli bar", "Snack", "Bar", 35, "g", 18, 3, 5, 130),
+        new("Crackers and cheese", "Snack", "Crackers", 60, "g", 15, 7, 9, 170),
+        new("Banana", "Snack", "Fruit", 120, "g", 20, 1, 0, 80),
+        new("Jelly beans", "Snack", "Hypo treatment", 30, "g", 25, 0, 0, 100),
+    ];
+
+    /// <summary>
+    /// The library foods plausibly making up a generated meal, deterministic per
+    /// date. Meal names come from the generator's meal plan ("Breakfast",
+    /// "Lunch", "Dinner", "Snack").
+    /// </summary>
+    public static IReadOnlyList<FoodSeed> MealFoodsFor(DateTime localDay, string mealName)
+    {
+        var candidates = FoodLibrary.Where(f => f.Category == mealName).ToList();
+        if (candidates.Count == 0)
+            return [];
+
+        var rng = DayScenarios.RngFor(localDay, $"food:{mealName}");
+        return [candidates[rng.Next(candidates.Count)]];
+    }
+
+    /// <summary>Weekly weigh-in weight: a slow seasonal drift with wobble, deterministic per date.</summary>
+    public static double WeightKgOn(DateTime localDay)
+    {
+        var dayNumber = (int)(localDay.Date.Ticks / TimeSpan.TicksPerDay);
+        var drift = 1.2 * Math.Sin(dayNumber / 120.0 * 2 * Math.PI);
+        var wobble = (DayScenarios.Roll(localDay, "weight", 13) - 6) * 0.1;
+        return Math.Round(77.5 + drift + wobble, 1);
+    }
+
+    /// <summary>One state span to seed; local times, null end = still active.</summary>
+    public sealed record SpanSeed(
+        StateSpanCategory Category, string State, DateTime StartLocal, DateTime? EndLocal);
+
+    /// <summary>The timezone-timeline trip: NYC for five days, three weeks back.</summary>
+    public const string HomeTimezoneFallback = "Australia/Sydney";
+    public const string TripTimezone = "America/New_York";
+    public const int TripStartDaysAgo = 21;
+    public const int TripLengthDays = 5;
+
+    /// <summary>
+    /// State spans for the backfill window: pump mode (Automatic, with weekly
+    /// Manual windows and Exercise mode during workouts), the active profile,
+    /// workout overrides + temporary targets, illness spans on sick days, and
+    /// the travel span matching the timezone-timeline trip.
+    /// </summary>
+    public static List<SpanSeed> BuildSpans(DateTime localToday, int days)
+    {
+        var spans = new List<SpanSeed>();
+        var windowStart = localToday.AddDays(-days);
+        var now = DateTime.Now;
+
+        // Profile: the seeded therapy profile is active for the whole window.
+        spans.Add(new SpanSeed(StateSpanCategory.Profile, DemoTherapyProfile.ProfileName, windowStart, null));
+
+        // Pump mode: Automatic, interrupted by occasional Manual windows and
+        // by Exercise mode during workouts on exercise days.
+        var interruptions = new List<(DateTime Start, DateTime End, string State)>();
+        for (var d = 0; d <= days; d++)
+        {
+            var day = windowStart.AddDays(d);
+            var scenario = DayScenarios.For(day);
+
+            if (scenario == DayScenario.Exercise)
+            {
+                var (workoutStart, workoutEnd) = DemoHealthDataGenerator.WorkoutWindowFor(day);
+                interruptions.Add((workoutStart.AddMinutes(-10), workoutEnd.AddMinutes(10), nameof(PumpModeState.Exercise)));
+
+                spans.Add(new SpanSeed(StateSpanCategory.Override, "Workout Mode",
+                    workoutStart.AddMinutes(-10), workoutEnd.AddMinutes(10)));
+                spans.Add(new SpanSeed(StateSpanCategory.TemporaryTarget, "140",
+                    workoutStart.AddMinutes(-10), workoutEnd.AddMinutes(10)));
+            }
+            else if (DayScenarios.Roll(day, "manual-mode", 100) < 9)
+            {
+                // An occasional afternoon in manual mode (pump maintenance, pool day).
+                var start = day.AddHours(13 + DayScenarios.Roll(day, "manual-start", 4));
+                interruptions.Add((start, start.AddHours(2.5), nameof(PumpModeState.Manual)));
+            }
+        }
+
+        var cursor = windowStart;
+        foreach (var (start, end, state) in interruptions.Where(i => i.Start > windowStart).OrderBy(i => i.Start))
+        {
+            if (start > cursor)
+                spans.Add(new SpanSeed(StateSpanCategory.PumpMode, nameof(PumpModeState.Automatic), cursor, start));
+            spans.Add(new SpanSeed(StateSpanCategory.PumpMode, state, start, end));
+            cursor = end;
+        }
+        spans.Add(new SpanSeed(StateSpanCategory.PumpMode, nameof(PumpModeState.Automatic), cursor, null));
+
+        // Illness: contiguous sick-day runs become one span.
+        DateTime? sickStart = null;
+        for (var d = 0; d <= days + 1; d++)
+        {
+            var day = windowStart.AddDays(d);
+            var isSick = d <= days && DayScenarios.For(day) == DayScenario.SickDay;
+            if (isSick && sickStart is null)
+                sickStart = day.AddHours(6);
+            else if (!isSick && sickStart is not null)
+            {
+                spans.Add(new SpanSeed(StateSpanCategory.Illness, "Sick day", sickStart.Value, day.AddHours(-2)));
+                sickStart = null;
+            }
+        }
+
+        // Travel: matches the timezone-timeline trip.
+        var tripStart = localToday.AddDays(-TripStartDaysAgo).AddHours(14);
+        var tripEnd = tripStart.AddDays(TripLengthDays).AddHours(-4);
+        if (tripStart > windowStart)
+            spans.Add(new SpanSeed(StateSpanCategory.Travel, TripTimezone, tripStart, tripEnd));
+
+        // Clamp everything to the past; drop spans that never started.
+        return spans
+            .Where(s => s.StartLocal < now)
+            .Select(s => s.EndLocal is { } end && end > now ? s with { EndLocal = null } : s)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Default clock-face config matching the web app's starter layout: big
+    /// glucose + trend arrow on top, delta and time-ago beneath.
+    /// </summary>
+    public const string DefaultClockFaceConfigJson = """
+        {
+          "rows": [
+            {
+              "elements": [
+                { "type": "sg", "size": 40, "style": { "color": "dynamic", "font": "system", "fontWeight": "medium", "opacity": 1.0 } },
+                { "type": "arrow", "size": 25, "style": { "color": "dynamic", "font": "system", "fontWeight": "medium", "opacity": 1.0 } }
+              ]
+            },
+            {
+              "elements": [
+                { "type": "delta", "size": 14, "style": { "color": "muted", "font": "system", "fontWeight": "regular", "opacity": 0.9 } },
+                { "type": "ago", "size": 14, "style": { "color": "muted", "font": "system", "fontWeight": "regular", "opacity": 0.9 } }
+              ]
+            }
+          ]
+        }
+        """;
+}

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoTherapyProfile.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoTherapyProfile.cs
@@ -1,0 +1,112 @@
+using Nocturne.Core.Models;
+using Nocturne.Services.Demo.Configuration;
+
+namespace Nocturne.Services.Demo.Services;
+
+/// <summary>
+/// The demo tenant's therapy profile: one place defining the basal schedule,
+/// carb ratio, sensitivity, and targets that the simulator runs on, the
+/// Nightscout profile document seeded through the profile decomposer, and the
+/// scheduled rates reported in device status. Keeping these together means the
+/// basal-analysis report compares delivery against the same schedule the
+/// simulation actually used.
+/// </summary>
+public static class DemoTherapyProfile
+{
+    public const string ProfileName = "Demo Profile";
+
+    /// <summary>
+    /// Basal blocks as (start time, multiplier on the configured base rate).
+    /// Mirrors the circadian shape the generator uses: reduced overnight, a
+    /// dawn-phenomenon ramp in the early morning, a lunch bump.
+    /// </summary>
+    public static readonly IReadOnlyList<(TimeSpan Start, double Multiplier)> BasalBlocks =
+    [
+        (TimeSpan.Zero, 0.9),
+        (TimeSpan.FromHours(3), 1.0),
+        (TimeSpan.FromHours(4.5), 1.15),
+        (TimeSpan.FromHours(6.5), 1.05),
+        (TimeSpan.FromHours(8), 1.0),
+        (TimeSpan.FromHours(12), 1.1),
+        (TimeSpan.FromHours(14), 1.0),
+        (TimeSpan.FromHours(22), 0.9),
+    ];
+
+    /// <summary>Scheduled basal rate at a wall-clock time for the configured base rate.</summary>
+    public static double ScheduledRateAt(DateTime localTime, double baseRate)
+    {
+        var timeOfDay = localTime.TimeOfDay;
+        var multiplier = BasalBlocks[0].Multiplier;
+        foreach (var (start, m) in BasalBlocks)
+        {
+            if (timeOfDay >= start)
+                multiplier = m;
+        }
+
+        return Math.Round(baseRate * multiplier, 2);
+    }
+
+    /// <summary>
+    /// The Nightscout profile document for the demo tenant. Seeding it through
+    /// the normal profile ingestion produces TherapySettings plus the four
+    /// schedule tables, exactly like a Trio profile upload.
+    /// </summary>
+    public static Profile BuildProfile(DemoModeConfiguration config, DateTime nowUtc)
+    {
+        var basal = BasalBlocks
+            .Select(b => new TimeValue
+            {
+                Time = $"{b.Start.Hours:00}:{b.Start.Minutes:00}",
+                Value = Math.Round(config.BasalRate * b.Multiplier, 2),
+                TimeAsSeconds = (int)b.Start.TotalSeconds,
+            })
+            .ToList();
+
+        var profileData = new ProfileData
+        {
+            Dia = config.InsulinDurationMinutes / 60.0,
+            CarbsHr = 20,
+            Timezone = TimeZoneInfo.Local.Id,
+            Units = "mg/dL",
+            Basal = basal,
+            CarbRatio =
+            [
+                new TimeValue { Time = "00:00", Value = config.CarbRatio + 2, TimeAsSeconds = 0 },
+                new TimeValue { Time = "06:00", Value = config.CarbRatio - 1, TimeAsSeconds = 21600 },
+                new TimeValue { Time = "11:00", Value = config.CarbRatio, TimeAsSeconds = 39600 },
+                new TimeValue { Time = "17:00", Value = config.CarbRatio - 0.5, TimeAsSeconds = 61200 },
+                new TimeValue { Time = "21:00", Value = config.CarbRatio + 2, TimeAsSeconds = 75600 },
+            ],
+            Sens =
+            [
+                new TimeValue { Time = "00:00", Value = config.InsulinSensitivityFactor + 8, TimeAsSeconds = 0 },
+                new TimeValue { Time = "06:00", Value = config.InsulinSensitivityFactor - 5, TimeAsSeconds = 21600 },
+                new TimeValue { Time = "12:00", Value = config.InsulinSensitivityFactor, TimeAsSeconds = 43200 },
+                new TimeValue { Time = "20:00", Value = config.InsulinSensitivityFactor + 5, TimeAsSeconds = 72000 },
+            ],
+            TargetLow =
+            [
+                new TimeValue { Time = "00:00", Value = 100, TimeAsSeconds = 0 },
+                new TimeValue { Time = "07:00", Value = 95, TimeAsSeconds = 25200 },
+                new TimeValue { Time = "21:00", Value = 100, TimeAsSeconds = 75600 },
+            ],
+            TargetHigh =
+            [
+                new TimeValue { Time = "00:00", Value = 120, TimeAsSeconds = 0 },
+                new TimeValue { Time = "07:00", Value = 115, TimeAsSeconds = 25200 },
+                new TimeValue { Time = "21:00", Value = 120, TimeAsSeconds = 75600 },
+            ],
+        };
+
+        return new Profile
+        {
+            DefaultProfile = ProfileName,
+            StartDate = nowUtc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+            Mills = new DateTimeOffset(nowUtc).ToUnixTimeMilliseconds(),
+            CreatedAt = nowUtc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+            Units = "mg/dL",
+            EnteredBy = DemoDeviceStatusGenerator.DeviceName,
+            Store = new Dictionary<string, ProfileData> { [ProfileName] = profileData },
+        };
+    }
+}

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoTherapyProfile.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoTherapyProfile.cs
@@ -32,6 +32,21 @@ public static class DemoTherapyProfile
         (TimeSpan.FromHours(22), 0.9),
     ];
 
+    /// <summary>
+    /// The server's zone as an IANA id — <see cref="TimeZoneInfo.Local"/>
+    /// reports a Windows id on Windows dev machines, which timezone pickers
+    /// and profile consumers don't recognize.
+    /// </summary>
+    public static string LocalIanaTimezone()
+    {
+        var local = TimeZoneInfo.Local;
+        if (local.HasIanaId)
+            return local.Id;
+        return TimeZoneInfo.TryConvertWindowsIdToIanaId(local.Id, out var iana)
+            ? iana
+            : DemoLifestyleSeeds.HomeTimezoneFallback;
+    }
+
     /// <summary>Scheduled basal rate at a wall-clock time for the configured base rate.</summary>
     public static double ScheduledRateAt(DateTime localTime, double baseRate)
     {
@@ -66,7 +81,7 @@ public static class DemoTherapyProfile
         {
             Dia = config.InsulinDurationMinutes / 60.0,
             CarbsHr = 20,
-            Timezone = TimeZoneInfo.Local.Id,
+            Timezone = LocalIanaTimezone(),
             Units = "mg/dL",
             Basal = basal,
             CarbRatio =

--- a/src/Services/Nocturne.Services.Demo.Generation/Services/DemoTimeStep.cs
+++ b/src/Services/Nocturne.Services.Demo.Generation/Services/DemoTimeStep.cs
@@ -1,0 +1,48 @@
+using Nocturne.Core.Models;
+
+namespace Nocturne.Services.Demo.Services;
+
+/// <summary>
+/// One 5-minute step of the demo simulation. Every generated stream — CGM
+/// entries, treatments, device status, alarm episodes — derives from the same
+/// timeline, so IOB/COB in device status match the boluses on the chart and
+/// the fingersticks land near the CGM trace they were generated from.
+/// </summary>
+public sealed record DemoTimeStep
+{
+    /// <summary>Step time (local, 5-minute cadence).</summary>
+    public required DateTime Time { get; init; }
+
+    /// <summary>The CGM entry for this step.</summary>
+    public required Entry Entry { get; init; }
+
+    /// <summary>
+    /// Additional non-sgv entries at this step: fingerstick <c>mbg</c> entries
+    /// and sensor-calibration <c>cal</c> entries.
+    /// </summary>
+    public IReadOnlyList<Entry> ExtraEntries { get; init; } = [];
+
+    /// <summary>Treatments issued at this step (boluses, carbs, temp basals, notes).</summary>
+    public IReadOnlyList<Treatment> Treatments { get; init; } = [];
+
+    /// <summary>Insulin on board from the oref simulator, after this step's doses.</summary>
+    public required double Iob { get; init; }
+
+    /// <summary>Carbs on board from the oref simulator, after this step's doses.</summary>
+    public required double Cob { get; init; }
+
+    /// <summary>Rate of the temp basal issued at this step, if any.</summary>
+    public double? TempBasalRate { get; init; }
+
+    /// <summary>Duration (minutes) of the temp basal issued at this step, if any.</summary>
+    public int? TempBasalDuration { get; init; }
+
+    /// <summary>Scenario-effective insulin sensitivity (mg/dL per U) at this step.</summary>
+    public required double EffectiveIsf { get; init; }
+
+    /// <summary>Scenario-effective carb ratio (g per U) at this step.</summary>
+    public required double EffectiveCarbRatio { get; init; }
+
+    /// <summary>The day's scenario, for downstream generators that shade by day type.</summary>
+    public required DayScenario Scenario { get; init; }
+}

--- a/src/Services/Nocturne.Services.Demo/Program.cs
+++ b/src/Services/Nocturne.Services.Demo/Program.cs
@@ -43,7 +43,10 @@ public class Program
         builder.Services.AddHttpClient("DemoAdmin", client =>
         {
             client.BaseAddress = new Uri(apiUrl.TrimEnd('/') + "/");
-            client.Timeout = TimeSpan.FromMinutes(5); // Backfill can be slow
+            // The full server-side seed (90 days of glucose, treatments, and
+            // device status through the ingestion services) runs inside one
+            // request.
+            client.Timeout = TimeSpan.FromMinutes(20);
             if (!string.IsNullOrEmpty(instanceKeyHash))
             {
                 client.DefaultRequestHeaders.Add("X-Instance-Key", instanceKeyHash);

--- a/src/Services/Nocturne.Services.Demo/Services/DemoApiClient.cs
+++ b/src/Services/Nocturne.Services.Demo/Services/DemoApiClient.cs
@@ -113,15 +113,20 @@ public sealed class DemoApiClient
 
             if (treatment.EventType == "Temp Basal" && treatment.Rate is { } rate)
             {
-                var response = await client.PostAsJsonAsync("api/v4/insulin/temp-basals", new
+                // The temp-basal endpoint is array-only (uploaders batch).
+                var payload = new[]
                 {
-                    timestamp,
-                    rate,
-                    durationMinutes = treatment.Duration,
-                    origin = (int)TempBasalOrigin.Algorithm,
-                    device = DemoDeviceStatusGenerator.DeviceName,
-                    dataSource = treatment.DataSource,
-                }, SerializerOptions, ct);
+                    new
+                    {
+                        timestamp,
+                        rate,
+                        durationMinutes = treatment.Duration,
+                        origin = (int)TempBasalOrigin.Algorithm,
+                        device = DemoDeviceStatusGenerator.DeviceName,
+                        dataSource = treatment.DataSource,
+                    },
+                };
+                var response = await client.PostAsJsonAsync("api/v4/insulin/temp-basals", payload, SerializerOptions, ct);
                 response.EnsureSuccessStatusCode();
             }
             else if (treatment.Insulin is > 0)

--- a/src/Services/Nocturne.Services.Demo/Services/DemoApiClient.cs
+++ b/src/Services/Nocturne.Services.Demo/Services/DemoApiClient.cs
@@ -1,14 +1,18 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
 
 namespace Nocturne.Services.Demo.Services;
 
 /// <summary>
-/// HTTP client that communicates with the Nocturne API to write demo data.
-/// Uses the V1 entries/treatments endpoints for data ingestion and admin
-/// endpoints for tenant provisioning and lifecycle management.
+/// HTTP client that communicates with the Nocturne API. Historical backfill is
+/// seeded server-side through the demo admin endpoint; the realtime tick posts
+/// the current entry, treatments, and device status through the V4 API,
+/// exactly like a native uploader. Admin endpoints handle tenant provisioning
+/// and lifecycle.
 /// </summary>
 public sealed class DemoApiClient
 {
@@ -70,53 +74,194 @@ public sealed class DemoApiClient
     }
 
     /// <summary>
-    /// Posts entries to the V1 entries endpoint, routed to the demo tenant via Host header.
+    /// Posts the current CGM entry to the V4 sensor-glucose endpoint, routed to
+    /// the demo tenant via Host header.
     /// </summary>
-    public async Task PostEntriesAsync(IReadOnlyList<Entry> entries, CancellationToken ct)
+    public async Task PostCurrentEntryAsync(Entry entry, CancellationToken ct)
     {
-        if (entries.Count == 0)
-            return;
-
         var client = _httpClientFactory.CreateClient("DemoTenant");
-        var response = await client.PostAsJsonAsync("api/v1/entries", entries, SerializerOptions, ct);
+        var payload = new[]
+        {
+            new
+            {
+                timestamp = DateTimeOffset.FromUnixTimeMilliseconds(entry.Mills),
+                device = entry.Device,
+                dataSource = entry.DataSource,
+                mgdl = entry.Sgv ?? entry.Mgdl,
+                direction = Enum.TryParse<GlucoseDirection>(entry.Direction, out var dir) ? (int?)dir : null,
+                delta = entry.Delta,
+                noise = entry.Noise,
+                filtered = entry.Filtered,
+                unfiltered = entry.Unfiltered,
+            },
+        };
+        var response = await client.PostAsJsonAsync("api/v4/glucose/sensor/bulk", payload, SerializerOptions, ct);
         response.EnsureSuccessStatusCode();
-        _logger.LogDebug("Posted {Count} entries to API", entries.Count);
+        _logger.LogDebug("Posted current entry via V4 API");
     }
 
     /// <summary>
-    /// Posts treatments to the V1 treatments endpoint, routed to the demo tenant via Host header.
+    /// Posts the tick's treatments through the per-type V4 endpoints
+    /// (temp basals, boluses, carb intakes).
     /// </summary>
-    public async Task PostTreatmentsAsync(IReadOnlyList<Treatment> treatments, CancellationToken ct)
+    public async Task PostCurrentTreatmentsAsync(IReadOnlyList<Treatment> treatments, CancellationToken ct)
     {
-        if (treatments.Count == 0)
-            return;
-
         var client = _httpClientFactory.CreateClient("DemoTenant");
-        var response = await client.PostAsJsonAsync("api/v1/treatments", treatments, SerializerOptions, ct);
-        response.EnsureSuccessStatusCode();
-        _logger.LogDebug("Posted {Count} treatments to API", treatments.Count);
+        foreach (var treatment in treatments)
+        {
+            var timestamp = DateTimeOffset.FromUnixTimeMilliseconds(treatment.Mills);
+
+            if (treatment.EventType == "Temp Basal" && treatment.Rate is { } rate)
+            {
+                var response = await client.PostAsJsonAsync("api/v4/insulin/temp-basals", new
+                {
+                    timestamp,
+                    rate,
+                    durationMinutes = treatment.Duration,
+                    origin = (int)TempBasalOrigin.Algorithm,
+                    device = DemoDeviceStatusGenerator.DeviceName,
+                    dataSource = treatment.DataSource,
+                }, SerializerOptions, ct);
+                response.EnsureSuccessStatusCode();
+            }
+            else if (treatment.Insulin is > 0)
+            {
+                var response = await client.PostAsJsonAsync("api/v4/insulin/boluses", new
+                {
+                    timestamp,
+                    insulin = treatment.Insulin.Value,
+                    kind = (int)(treatment.EventType == "SMB" ? BolusKind.Algorithm : BolusKind.Manual),
+                    automatic = treatment.EventType == "SMB",
+                    device = DemoDeviceStatusGenerator.DeviceName,
+                    dataSource = treatment.DataSource,
+                }, SerializerOptions, ct);
+                response.EnsureSuccessStatusCode();
+            }
+            else if (treatment.Carbs is > 0)
+            {
+                var response = await client.PostAsJsonAsync("api/v4/nutrition/carbs", new
+                {
+                    timestamp,
+                    carbs = treatment.Carbs.Value,
+                    dataSource = treatment.DataSource,
+                }, SerializerOptions, ct);
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        if (treatments.Count > 0)
+            _logger.LogDebug("Posted {Count} treatments via V4 API", treatments.Count);
     }
 
     /// <summary>
-    /// Wipes all demo entries via the admin endpoint.
+    /// Posts the tick's device status as the V4 APS/pump/uploader snapshot
+    /// triple, correlated like a decomposed legacy upload.
     /// </summary>
-    public async Task WipeEntriesAsync(CancellationToken ct)
+    public async Task PostDeviceStatusAsync(DeviceStatus status, CancellationToken ct)
     {
-        var client = _httpClientFactory.CreateClient("DemoAdmin");
-        var response = await client.DeleteAsync("api/v4/admin/demo/entries", ct);
-        response.EnsureSuccessStatusCode();
-        _logger.LogInformation("Wiped demo entries via API");
+        var client = _httpClientFactory.CreateClient("DemoTenant");
+        var timestamp = DateTimeOffset.FromUnixTimeMilliseconds(status.Mills);
+        var correlationId = Guid.CreateVersion7();
+        var suggested = status.OpenAps?.Suggested;
+        var enacted = status.OpenAps?.Enacted;
+
+        var apsPayload = new[]
+        {
+            new
+            {
+                timestamp,
+                device = status.Device,
+                dataSource = DataSources.DemoService,
+                syncIdentifier = $"demo-aps-{status.Mills}",
+                correlationId,
+                aidAlgorithm = (int)AidAlgorithm.Trio,
+                aidVersion = status.OpenAps?.Version,
+                iob = status.OpenAps?.Iob?.Iob,
+                bolusIob = status.OpenAps?.Iob?.BolusIob,
+                basalIob = status.OpenAps?.Iob?.BasalIob,
+                cob = status.OpenAps?.Cob,
+                currentBg = suggested?.Bg,
+                eventualBg = suggested?.EventualBG,
+                targetBg = suggested?.TargetBG,
+                recommendedBolus = suggested?.InsulinReq,
+                sensitivityRatio = suggested?.SensitivityRatio,
+                enacted = enacted is not null,
+                enactedRate = enacted?.Rate,
+                enactedDuration = enacted?.Duration,
+                suggestedJson = Serialize(suggested),
+                enactedJson = Serialize(enacted),
+                predictedIobJson = Serialize(suggested?.PredBGs?.IOB),
+                predictedZtJson = Serialize(suggested?.PredBGs?.ZT),
+                predictedCobJson = Serialize(suggested?.PredBGs?.COB),
+                predictedUamJson = Serialize(suggested?.PredBGs?.UAM),
+                predictedStartTimestamp = timestamp,
+            },
+        };
+        var apsResponse = await client.PostAsJsonAsync("api/v4/device-status/aps", apsPayload, SerializerOptions, ct);
+        apsResponse.EnsureSuccessStatusCode();
+
+        var pumpPayload = new[]
+        {
+            new
+            {
+                timestamp,
+                device = status.Device,
+                dataSource = DataSources.DemoService,
+                syncIdentifier = $"demo-pump-{status.Mills}",
+                correlationId,
+                manufacturer = status.Pump?.Manufacturer,
+                model = status.Pump?.Model,
+                reservoir = status.Pump?.Reservoir,
+                batteryPercent = status.Pump?.Battery?.Percent,
+                bolusing = status.Pump?.Status?.Bolusing ?? false,
+                suspended = status.Pump?.Status?.Suspended ?? false,
+                pumpStatus = status.Pump?.Status?.Status,
+                clock = status.Pump?.Clock,
+            },
+        };
+        var pumpResponse = await client.PostAsJsonAsync("api/v4/device-status/pump", pumpPayload, SerializerOptions, ct);
+        pumpResponse.EnsureSuccessStatusCode();
+
+        var uploaderPayload = new[]
+        {
+            new
+            {
+                timestamp,
+                device = status.Device,
+                dataSource = DataSources.DemoService,
+                syncIdentifier = $"demo-uploader-{status.Mills}",
+                correlationId,
+                battery = status.Uploader?.Battery,
+                isCharging = status.Uploader?.IsCharging,
+            },
+        };
+        var uploaderResponse = await client.PostAsJsonAsync("api/v4/device-status/uploader", uploaderPayload, SerializerOptions, ct);
+        uploaderResponse.EnsureSuccessStatusCode();
+
+        _logger.LogDebug("Posted device status triple via V4 API");
     }
 
     /// <summary>
-    /// Wipes all demo treatments via the admin endpoint.
+    /// The most recent sensor-glucose value, used to continue the realtime
+    /// stream from where the seeded history ended.
     /// </summary>
-    public async Task WipeTreatmentsAsync(CancellationToken ct)
+    public async Task<double?> GetLatestGlucoseAsync(CancellationToken ct)
     {
-        var client = _httpClientFactory.CreateClient("DemoAdmin");
-        var response = await client.DeleteAsync("api/v4/admin/demo/treatments", ct);
-        response.EnsureSuccessStatusCode();
-        _logger.LogInformation("Wiped demo treatments via API");
+        var client = _httpClientFactory.CreateClient("DemoTenant");
+        try
+        {
+            var response = await client.GetAsync("api/v4/glucose/sensor?limit=1", ct);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var page = await response.Content.ReadFromJsonAsync<SensorGlucosePage>(SerializerOptions, ct);
+            return page?.Data is [{ Mgdl: > 0 } latest, ..] ? latest.Mgdl : null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read latest glucose for realtime continuity");
+            return null;
+        }
     }
 
     /// <summary>
@@ -144,29 +289,32 @@ public sealed class DemoApiClient
     }
 
     /// <summary>
-    /// Ensures the demo PatientInsulin record exists via the admin endpoint.
+    /// Seeds the full sample set server-side via the admin endpoint: glucose,
+    /// treatments, device status, therapy profile, and every lifestyle type.
+    /// One call replaces the old streamed v1 backfill.
     /// </summary>
-    public async Task EnsurePatientInsulinAsync(CancellationToken ct)
-    {
-        var client = _httpClientFactory.CreateClient("DemoAdmin");
-        var response = await client.PostAsync("api/v4/admin/demo/ensure-insulin", null, ct);
-        response.EnsureSuccessStatusCode();
-        _logger.LogDebug("Ensured demo PatientInsulin record exists");
-    }
-
-    /// <summary>
-    /// Seeds the non-glucose sample set (device changes, sleep, heart rate,
-    /// steps, trackers, alert rules + alarm history) via the admin endpoint.
-    /// Runs server-side against the entries/treatments already posted.
-    /// </summary>
-    public async Task SeedExtrasAsync(int days, CancellationToken ct)
+    public async Task SeedAsync(int days, CancellationToken ct)
     {
         var client = _httpClientFactory.CreateClient("DemoAdmin");
         var response = await client.PostAsJsonAsync(
-            "api/v4/admin/demo/seed-extras", new { days }, SerializerOptions, ct);
+            "api/v4/admin/demo/seed-extras", new { days, includeGlucose = true }, SerializerOptions, ct);
         response.EnsureSuccessStatusCode();
-        _logger.LogInformation("Seeded demo extras (sleep/activity/trackers/alerts) via API");
+        _logger.LogInformation("Seeded full demo sample set via API");
     }
+
+    private static string? Serialize<T>(T? value) =>
+        value is null ? null : JsonSerializer.Serialize(value, SerializerOptions);
+}
+
+/// <summary>Minimal projection of the V4 paginated sensor-glucose response.</summary>
+internal sealed class SensorGlucosePage
+{
+    public List<SensorGlucoseItem>? Data { get; set; }
+}
+
+internal sealed class SensorGlucoseItem
+{
+    public double Mgdl { get; set; }
 }
 
 /// <summary>

--- a/src/Services/Nocturne.Services.Demo/Services/DemoDataHostedService.cs
+++ b/src/Services/Nocturne.Services.Demo/Services/DemoDataHostedService.cs
@@ -245,7 +245,9 @@ public class DemoDataHostedService : BackgroundService
     }
 
     /// <summary>
-    /// Clears all demo data and regenerates historical data via the API using streaming pattern.
+    /// Resets the tenant and seeds the full sample set server-side — glucose,
+    /// treatments, device status, therapy profile, and every lifestyle type —
+    /// through the demo admin endpoint (the same seeder the dev tools use).
     /// </summary>
     public async Task RegenerateDataAsync(CancellationToken cancellationToken)
     {
@@ -261,106 +263,32 @@ public class DemoDataHostedService : BackgroundService
             _logger.LogWarning(ex, "Failed to reset the demo tenant (may not exist yet), continuing with regeneration");
         }
 
-        // Ensure demo PatientInsulin record exists
-        try
-        {
-            await _apiClient.EnsurePatientInsulinAsync(cancellationToken);
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogWarning(ex, "Failed to ensure PatientInsulin (endpoint may not exist yet)");
-        }
-
-        // Generate and post data using streaming pattern to minimize memory usage
         var startTime = DateTime.UtcNow;
-        const int batchSize = 1000;
 
-        // Stream and post entries in batches
-        var entryCount = 0;
-        var entryBatch = new List<Entry>(batchSize);
-        Entry? latestEntry = null;
-
-        foreach (var entry in _generator.GenerateHistoricalEntries())
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            entryBatch.Add(entry);
-            latestEntry = entry;
-
-            if (entryBatch.Count >= batchSize)
-            {
-                await _apiClient.PostEntriesAsync(entryBatch, cancellationToken);
-                entryCount += entryBatch.Count;
-                entryBatch.Clear();
-            }
-        }
-
-        // Post remaining entries
-        if (entryBatch.Count > 0)
-        {
-            await _apiClient.PostEntriesAsync(entryBatch, cancellationToken);
-            entryCount += entryBatch.Count;
-            entryBatch.Clear();
-        }
-
-        if (latestEntry is not null)
-        {
-            var seedGlucose = latestEntry.Sgv ?? latestEntry.Mgdl;
-            _generator.SeedCurrentGlucose(seedGlucose);
-        }
-
-        _logger.LogInformation("Posted {Count} entries using streaming pattern", entryCount);
-
-        // Stream and post treatments in batches
-        var treatmentCount = 0;
-        var treatmentBatch = new List<Treatment>(batchSize);
-
-        foreach (var treatment in _generator.GenerateHistoricalTreatments())
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            treatmentBatch.Add(treatment);
-
-            if (treatmentBatch.Count >= batchSize)
-            {
-                await _apiClient.PostTreatmentsAsync(treatmentBatch, cancellationToken);
-                treatmentCount += treatmentBatch.Count;
-                treatmentBatch.Clear();
-            }
-        }
-
-        // Post remaining treatments
-        if (treatmentBatch.Count > 0)
-        {
-            await _apiClient.PostTreatmentsAsync(treatmentBatch, cancellationToken);
-            treatmentCount += treatmentBatch.Count;
-            treatmentBatch.Clear();
-        }
-
-        _logger.LogInformation("Posted {Count} treatments using streaming pattern", treatmentCount);
-
-        // Non-glucose sample set (device changes, sleep, activity, trackers,
-        // alert rules + alarm history) seeds server-side against the data just
-        // posted. Failure is non-fatal — the demo still has glucose/treatments.
-        // The filter keeps real shutdown cancellation propagating, but an
-        // HttpClient timeout (TaskCanceledException with an uncancelled
-        // stoppingToken) must not fault ExecuteAsync or be mistaken for
-        // shutdown by the reset loop's OperationCanceledException handler.
+        // Seeding failure is non-fatal — realtime ticks keep building a live
+        // chart even without history. The filter keeps real shutdown
+        // cancellation propagating, but an HttpClient timeout
+        // (TaskCanceledException with an uncancelled stoppingToken) must not
+        // fault ExecuteAsync or be mistaken for shutdown by the reset loop's
+        // OperationCanceledException handler.
         try
         {
-            await _apiClient.SeedExtrasAsync(_config.BackfillDays, cancellationToken);
+            await _apiClient.SeedAsync(_config.BackfillDays, cancellationToken);
         }
         catch (Exception ex) when (
             ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
         {
-            _logger.LogWarning(ex, "Failed to seed demo extras (endpoint may not exist yet or timed out)");
+            _logger.LogError(ex, "Failed to seed the demo sample set");
         }
 
-        var duration = DateTime.UtcNow - startTime;
+        // Continue the realtime stream from the seeded history's latest value.
+        var latestGlucose = await _apiClient.GetLatestGlucoseAsync(cancellationToken);
+        if (latestGlucose is { } glucose)
+            _generator.SeedCurrentGlucose(glucose);
+
         _logger.LogInformation(
-            "Completed demo data regeneration: {Entries} entries, {Treatments} treatments in {Duration}",
-            entryCount,
-            treatmentCount,
-            duration
-        );
+            "Completed demo data regeneration in {Duration}",
+            DateTime.UtcNow - startTime);
     }
 
     private async Task GenerateAndPostEntryAsync(CancellationToken cancellationToken)
@@ -375,13 +303,16 @@ public class DemoDataHostedService : BackgroundService
                 entry.Direction
             );
 
-            await _apiClient.PostEntriesAsync(new[] { entry }, cancellationToken);
+            await _apiClient.PostCurrentEntryAsync(entry, cancellationToken);
 
             var treatments = _generator.GenerateCurrentTreatments(entry).ToList();
             if (treatments.Count > 0)
             {
-                await _apiClient.PostTreatmentsAsync(treatments, cancellationToken);
+                await _apiClient.PostCurrentTreatmentsAsync(treatments, cancellationToken);
             }
+
+            var deviceStatus = _generator.GenerateCurrentDeviceStatus(entry, treatments);
+            await _apiClient.PostDeviceStatusAsync(deviceStatus, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Services/Nocturne.Services.Demo/Services/DemoSettingsGenerator.cs
+++ b/src/Services/Nocturne.Services.Demo/Services/DemoSettingsGenerator.cs
@@ -51,7 +51,9 @@ public class DemoSettingsGenerator
                 new()
                 {
                     Id = "demo-pump-1",
-                    Name = "Omnipod 5",
+                    // Matches the seeded patient-device roster: Trio driving an
+                    // Omnipod DASH.
+                    Name = "Omnipod DASH",
                     Type = "pump",
                     Status = "connected",
                     Battery = 72,

--- a/tests/Unit/Nocturne.API.Tests/Services/Seeding/DemoTimelineTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Seeding/DemoTimelineTests.cs
@@ -36,17 +36,16 @@ public class DemoTimelineTests
     }
 
     [Fact]
-    public void Timeline_EntriesAndTreatmentsAreProjectionsOfTheSameRun()
+    public void Timeline_CarriesBothStreamsFromOneRun()
     {
-        // Both projections must re-run the same simulation shape: same step
-        // count, same treatment count, no divergence between the streams.
-        var generator = CreateGenerator(3);
-        var entries = generator.GenerateHistoricalEntries().ToList();
-        var treatments = generator.GenerateHistoricalTreatments().ToList();
+        // One enumeration yields the chart and the treatment history together —
+        // the old divergent per-stream simulation passes are gone.
+        var steps = CreateGenerator(3).GenerateHistoricalTimeline().ToList();
 
-        entries.Should().NotBeEmpty();
+        var entries = steps.SelectMany(s => new[] { s.Entry }.Concat(s.ExtraEntries)).ToList();
+        var treatments = steps.SelectMany(s => s.Treatments).ToList();
+
         treatments.Should().NotBeEmpty();
-
         // sgv entries at 5-minute cadence plus mbg/cal extras.
         entries.Count(e => e.Type == "sgv").Should().BeGreaterThan(3 * 280);
         entries.Should().Contain(e => e.Type == "mbg", "fingersticks ride the timeline");
@@ -58,7 +57,9 @@ public class DemoTimelineTests
         // "Scheduled Basal" was dropped: the decomposer never recognized it and
         // every regenerate logged ~2k warnings. Scheduled basal now comes from
         // the seeded therapy profile.
-        var treatments = CreateGenerator(3).GenerateHistoricalTreatments().ToList();
+        var treatments = CreateGenerator(3).GenerateHistoricalTimeline()
+            .SelectMany(s => s.Treatments)
+            .ToList();
 
         treatments.Should().NotBeEmpty();
         treatments.Should().NotContain(t => t.EventType == "Scheduled Basal");
@@ -67,13 +68,19 @@ public class DemoTimelineTests
     }
 
     [Fact]
-    public void Timeline_TreatmentsAreNeverFutureDated()
+    public void Timeline_NothingIsFutureDated()
     {
         var nowMills = DateTimeOffset.Now.ToUnixTimeMilliseconds();
-        var treatments = CreateGenerator(2).GenerateHistoricalTreatments().ToList();
+        var steps = CreateGenerator(2).GenerateHistoricalTimeline().ToList();
+
+        var treatments = steps.SelectMany(s => s.Treatments).ToList();
+        var extras = steps.SelectMany(s => s.ExtraEntries).ToList();
 
         treatments.Should().NotBeEmpty();
+        // The final partial step clamps planned-item consumption to "now";
+        // small slack covers the wall-clock advancing during enumeration.
         treatments.Should().OnlyContain(t => t.Mills <= nowMills + 60_000);
+        extras.Should().OnlyContain(e => e.Mills <= nowMills + 60_000);
     }
 
     [Fact]
@@ -88,10 +95,13 @@ public class DemoTimelineTests
     }
 
     [Fact]
-    public void Timeline_IncludesNotesAndBgChecks()
+    public void Timeline_IncludesNotes()
     {
-        // 14 days is enough for the deterministic note/fingerstick rolls to hit.
-        var treatments = CreateGenerator(14).GenerateHistoricalTreatments().ToList();
+        // Note rolls hit ~35% of days; over 30 days the chance of an empty
+        // window is negligible (0.65^30) even though rolls are date-anchored.
+        var treatments = CreateGenerator(30).GenerateHistoricalTimeline()
+            .SelectMany(s => s.Treatments)
+            .ToList();
 
         treatments.Should().Contain(t => t.EventType == "Note" || t.EventType == "Announcement");
     }
@@ -101,7 +111,9 @@ public class DemoTimelineTests
     {
         // A 21-day window always contains at least two sensor changes
         // (10-day cycle), each followed by cal entries.
-        var entries = CreateGenerator(21).GenerateHistoricalEntries().ToList();
+        var entries = CreateGenerator(21).GenerateHistoricalTimeline()
+            .SelectMany(s => s.ExtraEntries)
+            .ToList();
 
         var calibrations = entries.Where(e => e.Type == "cal").ToList();
         calibrations.Should().NotBeEmpty();
@@ -240,6 +252,27 @@ public class DemoTimelineTests
                 && s.StartLocal == start.AddMinutes(-10),
                 $"exercise day {day:yyyy-MM-dd} carries a workout override at the workout window");
         }
+    }
+
+    [Fact]
+    public void LifestyleSeeds_ProfileAndTargetSpansCarryDecomposerShapedMetadata()
+    {
+        // Resolvers read the profile name and target values from metadata, not
+        // from State — a name-in-State span silently resolves as "Default".
+        var spans = DemoLifestyleSeeds.BuildSpans(DateTime.Now.Date, 60);
+
+        var profile = spans.Single(s => s.Category == StateSpanCategory.Profile);
+        profile.State.Should().Be(nameof(ProfileState.Active));
+        profile.Metadata.Should().ContainKey("profileName")
+            .WhoseValue.Should().Be(DemoTherapyProfile.ProfileName);
+
+        var targets = spans.Where(s => s.Category == StateSpanCategory.TemporaryTarget).ToList();
+        targets.Should().NotBeEmpty("60 days contain exercise days with temp targets");
+        targets.Should().OnlyContain(t =>
+            t.State == nameof(TemporaryTargetState.Active)
+            && t.Metadata != null
+            && t.Metadata.ContainsKey("targetTop")
+            && t.Metadata.ContainsKey("targetBottom"));
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Seeding/DemoTimelineTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Seeding/DemoTimelineTests.cs
@@ -1,0 +1,303 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nocturne.Core.Models;
+using Nocturne.Services.Demo.Configuration;
+using Nocturne.Services.Demo.Services;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Seeding;
+
+/// <summary>
+/// Tests for the unified demo timeline and the streams derived from it —
+/// device status, fingersticks, calibrations, notes, therapy profile, and
+/// lifestyle seeds.
+/// </summary>
+public class DemoTimelineTests
+{
+    private static DemoDataGenerator CreateGenerator(int days = 5) => new(
+        Options.Create(new DemoModeConfiguration { BackfillDays = days }),
+        NullLogger<DemoDataGenerator>.Instance,
+        NullLoggerFactory.Instance);
+
+    [Fact]
+    public void Timeline_StepsAreChronologicalFiveMinuteAndNeverFuture()
+    {
+        var steps = CreateGenerator(3).GenerateHistoricalTimeline().ToList();
+
+        steps.Should().NotBeEmpty();
+        steps.Should().BeInAscendingOrder(s => s.Time);
+        steps.Zip(steps.Skip(1))
+            .Should().OnlyContain(pair =>
+                pair.Second.Time - pair.First.Time == TimeSpan.FromMinutes(5)
+                // Day boundaries on the last partial day may clip the step.
+                || pair.Second.Time - pair.First.Time < TimeSpan.FromMinutes(5));
+        steps[^1].Time.Should().BeOnOrBefore(DateTime.Now);
+    }
+
+    [Fact]
+    public void Timeline_EntriesAndTreatmentsAreProjectionsOfTheSameRun()
+    {
+        // Both projections must re-run the same simulation shape: same step
+        // count, same treatment count, no divergence between the streams.
+        var generator = CreateGenerator(3);
+        var entries = generator.GenerateHistoricalEntries().ToList();
+        var treatments = generator.GenerateHistoricalTreatments().ToList();
+
+        entries.Should().NotBeEmpty();
+        treatments.Should().NotBeEmpty();
+
+        // sgv entries at 5-minute cadence plus mbg/cal extras.
+        entries.Count(e => e.Type == "sgv").Should().BeGreaterThan(3 * 280);
+        entries.Should().Contain(e => e.Type == "mbg", "fingersticks ride the timeline");
+    }
+
+    [Fact]
+    public void Timeline_NeverEmitsScheduledBasalTreatments()
+    {
+        // "Scheduled Basal" was dropped: the decomposer never recognized it and
+        // every regenerate logged ~2k warnings. Scheduled basal now comes from
+        // the seeded therapy profile.
+        var treatments = CreateGenerator(3).GenerateHistoricalTreatments().ToList();
+
+        treatments.Should().NotBeEmpty();
+        treatments.Should().NotContain(t => t.EventType == "Scheduled Basal");
+        treatments.Should().Contain(t => t.EventType == "Temp Basal");
+        treatments.Should().Contain(t => t.EventType == "Carbs");
+    }
+
+    [Fact]
+    public void Timeline_TreatmentsAreNeverFutureDated()
+    {
+        var nowMills = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+        var treatments = CreateGenerator(2).GenerateHistoricalTreatments().ToList();
+
+        treatments.Should().NotBeEmpty();
+        treatments.Should().OnlyContain(t => t.Mills <= nowMills + 60_000);
+    }
+
+    [Fact]
+    public void Timeline_CarriesSimulatorStateForDeviceStatus()
+    {
+        var steps = CreateGenerator(2).GenerateHistoricalTimeline().ToList();
+
+        steps.Should().OnlyContain(s => s.Iob >= 0 && s.Cob >= 0);
+        steps.Should().Contain(s => s.Iob > 0, "boluses must show up as IOB");
+        steps.Should().Contain(s => s.Cob > 0, "meals must show up as COB");
+        steps.Should().OnlyContain(s => s.EffectiveIsf > 0 && s.EffectiveCarbRatio > 0);
+    }
+
+    [Fact]
+    public void Timeline_IncludesNotesAndBgChecks()
+    {
+        // 14 days is enough for the deterministic note/fingerstick rolls to hit.
+        var treatments = CreateGenerator(14).GenerateHistoricalTreatments().ToList();
+
+        treatments.Should().Contain(t => t.EventType == "Note" || t.EventType == "Announcement");
+    }
+
+    [Fact]
+    public void Timeline_CalibrationsFollowSensorStarts()
+    {
+        // A 21-day window always contains at least two sensor changes
+        // (10-day cycle), each followed by cal entries.
+        var entries = CreateGenerator(21).GenerateHistoricalEntries().ToList();
+
+        var calibrations = entries.Where(e => e.Type == "cal").ToList();
+        calibrations.Should().NotBeEmpty();
+        calibrations.Should().OnlyContain(c => c.Slope > 0 && c.Intercept > 0 && c.Scale == 1);
+    }
+
+    [Fact]
+    public void DeviceStatus_IsDeterministicAndCarriesAllThreeBlocks()
+    {
+        var time = new DateTime(2026, 3, 17, 14, 30, 0);
+        DeviceStatus Create() => DemoDeviceStatusGenerator.Create(
+            time, glucose: 160, iob: 1.2, cob: 25, tempBasalRate: 1.4, tempBasalDuration: 30,
+            effectiveIsf: 40, effectiveCarbRatio: 10, targetGlucose: 110,
+            scheduledBasalRate: 1.0, scenario: DayScenario.Normal);
+
+        var status = Create();
+
+        status.Device.Should().Be("Trio");
+        status.OpenAps!.Suggested!.Bg.Should().Be(160);
+        status.OpenAps.Suggested.Rate.Should().Be(1.4);
+        status.OpenAps.Suggested.PredBGs!.IOB.Should().HaveCountGreaterThan(30);
+        status.OpenAps.Suggested.PredBGs.COB.Should().NotBeNull("carbs on board produce a COB curve");
+        status.OpenAps.Enacted!.Received.Should().BeTrue();
+        status.OpenAps.Iob!.Iob.Should().Be(1.2);
+        status.OpenAps.Cob.Should().Be(25);
+        status.Pump!.Reservoir.Should().BeInRange(8, 200);
+        status.Pump.Battery!.Percent.Should().BeInRange(4, 100);
+        status.Uploader!.Battery.Should().BeInRange(20, 100);
+
+        // Deterministic: the same inputs produce the same document.
+        Create().Should().BeEquivalentTo(status);
+    }
+
+    [Fact]
+    public void DeviceStatus_EventualBgRespondsToIobAndCob()
+    {
+        DeviceStatus Create(double iob, double cob) => DemoDeviceStatusGenerator.Create(
+            new DateTime(2026, 3, 17, 14, 30, 0), glucose: 160, iob: iob, cob: cob,
+            tempBasalRate: null, tempBasalDuration: null,
+            effectiveIsf: 40, effectiveCarbRatio: 10, targetGlucose: 110,
+            scheduledBasalRate: 1.0, scenario: DayScenario.Normal);
+
+        var withInsulin = Create(iob: 3, cob: 0).OpenAps!.Suggested!.EventualBG;
+        var withCarbs = Create(iob: 0, cob: 40).OpenAps!.Suggested!.EventualBG;
+
+        withInsulin.Should().BeLessThan(160, "insulin on board pulls eventual BG down");
+        withCarbs.Should().BeGreaterThan(160, "carbs on board push eventual BG up");
+    }
+
+    [Fact]
+    public void DeviceStatus_ReservoirDrainsBetweenChangesAndRefills()
+    {
+        // Find an Insulin Change day and compare just-before vs just-after.
+        var day = Enumerable.Range(0, 10)
+            .Select(d => new DateTime(2026, 3, 10).AddDays(d))
+            .First(d => DemoDeviceLifecycle.ChangeTimeOn(d, "Insulin Change") is not null);
+        var changeAt = DemoDeviceLifecycle.ChangeTimeOn(day, "Insulin Change")!.Value;
+
+        var before = DemoDeviceStatusGenerator.ReservoirAt(changeAt.AddMinutes(-30));
+        var after = DemoDeviceStatusGenerator.ReservoirAt(changeAt.AddMinutes(30));
+
+        after.Should().BeGreaterThan(before, "the reservoir refills at an Insulin Change");
+        before.Should().BeLessThan(200 - 60, "three days of use drain a meaningful amount");
+    }
+
+    [Fact]
+    public void DeviceStatus_UploaderChargesOvernightAndDrainsByEvening()
+    {
+        var day = new DateTime(2026, 3, 17);
+
+        DemoDeviceStatusGenerator.IsUploaderCharging(day.AddHours(3)).Should().BeTrue();
+        DemoDeviceStatusGenerator.IsUploaderCharging(day.AddHours(14)).Should().BeFalse();
+        DemoDeviceStatusGenerator.UploaderBatteryAt(day.AddHours(8))
+            .Should().BeGreaterThan(DemoDeviceStatusGenerator.UploaderBatteryAt(day.AddHours(22)));
+    }
+
+    [Fact]
+    public void TherapyProfile_ScheduledRateFollowsTheBlocks()
+    {
+        const double baseRate = 1.0;
+
+        DemoTherapyProfile.ScheduledRateAt(new DateTime(2026, 3, 17, 0, 30, 0), baseRate).Should().Be(0.9);
+        DemoTherapyProfile.ScheduledRateAt(new DateTime(2026, 3, 17, 5, 0, 0), baseRate).Should().Be(1.15);
+        DemoTherapyProfile.ScheduledRateAt(new DateTime(2026, 3, 17, 12, 30, 0), baseRate).Should().Be(1.1);
+        DemoTherapyProfile.ScheduledRateAt(new DateTime(2026, 3, 17, 23, 0, 0), baseRate).Should().Be(0.9);
+    }
+
+    [Fact]
+    public void TherapyProfile_BuildsACompleteNightscoutProfile()
+    {
+        var profile = DemoTherapyProfile.BuildProfile(new DemoModeConfiguration(), DateTime.UtcNow);
+
+        profile.DefaultProfile.Should().Be(DemoTherapyProfile.ProfileName);
+        var store = profile.Store[DemoTherapyProfile.ProfileName];
+        store.Basal.Should().HaveCount(DemoTherapyProfile.BasalBlocks.Count);
+        store.Basal.Should().BeInAscendingOrder(b => b.TimeAsSeconds);
+        store.CarbRatio.Should().NotBeEmpty();
+        store.Sens.Should().NotBeEmpty();
+        store.TargetLow.Should().HaveCount(store.TargetHigh.Count);
+        store.Basal.Should().OnlyContain(b => b.Value > 0);
+    }
+
+    [Fact]
+    public void LifestyleSeeds_PumpModeSpansAreContiguousAndNonOverlapping()
+    {
+        var spans = DemoLifestyleSeeds.BuildSpans(DateTime.Now.Date, 30);
+        var pumpModes = spans
+            .Where(s => s.Category == StateSpanCategory.PumpMode)
+            .OrderBy(s => s.StartLocal)
+            .ToList();
+
+        pumpModes.Should().NotBeEmpty();
+        pumpModes[^1].EndLocal.Should().BeNull("the current mode is still active");
+        pumpModes.Zip(pumpModes.Skip(1))
+            .Should().OnlyContain(pair => pair.First.EndLocal == pair.Second.StartLocal,
+                "pump mode is a continuous state — every span hands over to the next");
+    }
+
+    [Fact]
+    public void LifestyleSeeds_ExerciseArtifactsAlignWithTheWorkoutWindow()
+    {
+        var today = DateTime.Now.Date;
+        var spans = DemoLifestyleSeeds.BuildSpans(today, 60);
+
+        var exerciseDays = Enumerable.Range(1, 60)
+            .Select(d => today.AddDays(-d))
+            .Where(d => DayScenarios.For(d) == DayScenario.Exercise)
+            .ToList();
+        exerciseDays.Should().NotBeEmpty("60 days must contain exercise days");
+
+        foreach (var day in exerciseDays)
+        {
+            var (start, _) = DemoHealthDataGenerator.WorkoutWindowFor(day);
+            spans.Should().Contain(s =>
+                s.Category == StateSpanCategory.Override
+                && s.StartLocal == start.AddMinutes(-10),
+                $"exercise day {day:yyyy-MM-dd} carries a workout override at the workout window");
+        }
+    }
+
+    [Fact]
+    public void LifestyleSeeds_SpansNeverStartInTheFuture()
+    {
+        var spans = DemoLifestyleSeeds.BuildSpans(DateTime.Now.Date, 30);
+
+        spans.Should().NotBeEmpty();
+        spans.Should().OnlyContain(s => s.StartLocal < DateTime.Now);
+        spans.Should().OnlyContain(s => s.EndLocal == null || s.EndLocal > s.StartLocal);
+    }
+
+    [Fact]
+    public void LifestyleSeeds_WeightIsPlausibleAndDeterministic()
+    {
+        var day = new DateTime(2026, 3, 15);
+
+        DemoLifestyleSeeds.WeightKgOn(day).Should().BeInRange(70, 85);
+        DemoLifestyleSeeds.WeightKgOn(day).Should().Be(DemoLifestyleSeeds.WeightKgOn(day));
+    }
+
+    [Fact]
+    public void LifestyleSeeds_MealFoodsResolveForEveryGeneratedMealName()
+    {
+        var day = new DateTime(2026, 3, 17);
+        foreach (var meal in new[] { "Breakfast", "Lunch", "Dinner", "Snack" })
+        {
+            DemoLifestyleSeeds.MealFoodsFor(day, meal).Should().NotBeEmpty(
+                $"the food library must cover generated {meal} meals");
+        }
+    }
+
+    [Fact]
+    public void RealtimeDeviceStatus_TracksTreatmentsAcrossTicks()
+    {
+        var generator = CreateGenerator();
+        var entry = new Entry
+        {
+            Type = "sgv",
+            Mills = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            Date = DateTime.UtcNow,
+            Sgv = 150,
+            Mgdl = 150,
+        };
+
+        var bolus = new Treatment
+        {
+            EventType = "Correction Bolus",
+            Insulin = 2.0,
+            Mills = entry.Mills,
+        };
+
+        var idle = generator.GenerateCurrentDeviceStatus(entry, []);
+        var afterBolus = generator.GenerateCurrentDeviceStatus(entry, [bolus]);
+
+        idle.OpenAps!.Iob!.Iob.Should().Be(0);
+        afterBolus.OpenAps!.Iob!.Iob.Should().BeGreaterThan(1.5, "the bolus lands in IOB");
+        afterBolus.Pump!.Reservoir.Should().NotBeNull();
+        afterBolus.Uploader!.Battery.Should().BeInRange(20, 100);
+    }
+}


### PR DESCRIPTION
## Why

The demo tenant is meant to showcase everything, but it only generated glucose, treatments, sleep, activity, trackers, and alarm history. Everything else rendered empty: `/reports/battery` (no devicestatus at all), the reservoir pill, `/settings/profile` (no therapy schedules), `/food`, `/settings/patient`, `/settings/weight`, `/settings/timezone`, `/clock`, `/notifications`, `/alerts/dnd`, `/time-spans`, fingersticks/calibrations, and basal analysis had no schedule to compare against. It also posted ~2k "Scheduled Basal" treatments per regenerate that the decomposer dropped with a warning each.

## What

**One simulation pass.** The three divergent passes in `DemoDataGenerator` (entries, treatments, and the dead `GenerateHistoricalData` path — each running its own sim off a shared unseeded `Random`) are replaced by `GenerateHistoricalTimeline()`: one oref run yielding a `DemoTimeStep` per 5 minutes with the entry, that step's treatments, and the simulator's IOB/COB. The chart, treatment history, device status, and alarm episodes now genuinely agree.

**Device status** (`DemoDeviceStatusGenerator`): Trio-style docs modeled on defiantt1d's real uploads — `openaps` suggested/enacted with prediction curves (IOB/ZT/COB/UAM) derived from simulator state, Insulet pump with reservoir/battery, phone battery with overnight charging. Consumable levels are pure wall-clock functions of the `DemoDeviceLifecycle` schedule, so reservoir refills land exactly on the seeded Insulin Change events and history/realtime/re-seeds always agree. History decomposes through the same `IDeviceStatusDecomposer` as real uploads (15-min cadence, deterministic legacy ids → idempotent).

**Everything else seeded** (`SampleDataSeeder`, shared by dev-sample and demo): therapy profile through the profile decomposer (`TherapySettings` + all four schedules — replaces "Scheduled Basal"), fingerstick `mbg` entries + BG-check-on-low treatments + `cal` entries after sensor starts, notes/announcements, food library with per-meal `TreatmentFood` attribution and favorites, state spans (continuous pump mode with manual/exercise windows, active profile with decomposer-shaped metadata, workout overrides + temp targets, illness runs, travel), patient record + device roster + insulin, weekly body weight, timezone timeline with a 5-day NYC trip, a default clock face, in-app notifications mirroring the seeded alarms, and one cleared DND window.

**Demo container on V4.** Regenerate collapses to reset + one server-side `seed-extras` call (`includeGlucose: true`) — the v1 streaming backfill is gone. The realtime tick posts like a native uploader: `glucose/sensor/bulk`, per-type treatment endpoints, and the correlated `device-status/aps|pump|uploader` triple, with IOB/COB continuity from a persistent simulator and stream continuity via a V4 readback of the latest value.

## Verification

- 31 new unit tests (timeline coherence, device-status determinism/physics, profile schedule, span contiguity + metadata shape, workout alignment); full API suite green (5,384).
- End-to-end against local Postgres via `seed-tenant`: 30-day seed → HTTP 200 in ~3 min (8.8k entries, 3.6k treatments, 2.9k device statuses); final 10-day pass after review fixes → 200 in 68s with every type populated. APS/pump snapshots, profile schedules, timezone timeline, and fingersticks verified reading back through the V4 API.
- The e2e pass caught real bugs the unit tests couldn't: naive-timestamp `timezone_timeline` column, Windows-vs-IANA zone ids.
- A review pass caught a blocker (temp-basal tick posted an object to the array-only endpoint), the profile-span metadata shape (resolvers read `Metadata["profileName"]`, not `State`), a future-emission window on the final step, and Backfill write-origin for the bulk seed.

## Notes

- Late-night boluses crossing midnight now land on the next day instead of being future-dated on the final day (pre-existing bug).
- Deliberately out of scope: demo members/care-team, connector configurations (need credentials), OAuth client examples, migration runs.
- Seeded activity noise values shift wholesale vs main (workout-window jitter moved to its own RNG stream); data is regenerated on every reset so nothing persists across the change.

https://claude.ai/code/session_011VsmdVEXvQ6GaegVwedj8H
