### PR TITLE
fix(auth): reject grant-shaped JWTs on the session cookie path

### DIFF
--- a/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
@@ -63,6 +63,15 @@ public class SessionCookieHandler : IAuthHandler
 
             if (validationResult.IsValid && validationResult.Claims != null)
             {
+                if (IsGrantShaped(validationResult.Claims))
+                {
+                    _logger.LogWarning(
+                        "Rejected a grant-shaped JWT presented in the session cookie for subject {SubjectId}",
+                        validationResult.Claims.SubjectId
+                    );
+                    return AuthResult.Failure("Session expired or revoked");
+                }
+
                 return AuthResult.Success(
                     BuildAuthContextFromClaims(validationResult.Claims, accessToken)
                 );
@@ -173,6 +182,30 @@ public class SessionCookieHandler : IAuthHandler
 
         return null;
     }
+
+    /// <summary>
+    /// Whether these claims belong to a grant-derived token (OAuth access token, platform-access
+    /// grant) rather than a first-party session token.
+    /// </summary>
+    /// <remarks>
+    /// Session JWTs and grant JWTs are signed with the same key, issuer, and audience, so
+    /// <see cref="IJwtService.ValidateAccessToken"/> accepts either. Only the claim shape tells
+    /// them apart: a grant carries the pins and ceilings that bound its authority — a tenant pin,
+    /// a consent scope list, the client it was issued to, the grant it came from, or the
+    /// platform-access marker. The session path ignores all of those, and
+    /// <see cref="AuthType.SessionCookie"/> is treated as an unscoped credential, so accepting a
+    /// grant here would let a holder move it into the session cookie and shed both its tenant pin
+    /// and its scope ceiling. Session tokens are minted only via the overload that cannot emit any
+    /// of these claims, so their absence is the session shape.
+    /// The refresh-token cookie needs no equivalent check: it holds an opaque random string that
+    /// is looked up server-side, and the access token it yields is re-minted here.
+    /// </remarks>
+    private static bool IsGrantShaped(JwtClaims claims) =>
+        claims.TenantId.HasValue
+        || claims.Scopes is { Count: > 0 }
+        || !string.IsNullOrEmpty(claims.ClientId)
+        || claims.GrantId.HasValue
+        || claims.PlatformAccess;
 
     /// <summary>
     /// Build an AuthContext from JWT claims

--- a/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
@@ -191,8 +191,9 @@ public class SessionCookieHandler : IAuthHandler
     /// Session JWTs and grant JWTs are signed with the same key, issuer, and audience, so
     /// <see cref="IJwtService.ValidateAccessToken"/> accepts either. Only the claim shape tells
     /// them apart: a grant carries the pins and ceilings that bound its authority — a tenant pin,
-    /// a consent scope list, the client it was issued to, the grant it came from, or the
-    /// platform-access marker. The session path ignores all of those, and
+    /// a consent scope list, the client it was issued to, the grant it came from, the
+    /// 24-hour data ceiling, or the platform-access marker. The session path ignores all of
+    /// those, and
     /// <see cref="AuthType.SessionCookie"/> is treated as an unscoped credential, so accepting a
     /// grant here would let a holder move it into the session cookie and shed both its tenant pin
     /// and its scope ceiling. Session tokens are minted only via the overload that cannot emit any
@@ -205,7 +206,8 @@ public class SessionCookieHandler : IAuthHandler
         || claims.Scopes is { Count: > 0 }
         || !string.IsNullOrEmpty(claims.ClientId)
         || claims.GrantId.HasValue
-        || claims.PlatformAccess;
+        || claims.PlatformAccess
+        || claims.LimitTo24Hours;
 
     /// <summary>
     /// Build an AuthContext from JWT claims

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/SessionCookieHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/SessionCookieHandlerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -98,6 +99,7 @@ public class SessionCookieHandlerTests
     [InlineData("tenant_id")]
     [InlineData("grant_id")]
     [InlineData("platform_access")]
+    [InlineData("limit_24h")]
     public async Task AnyIndividualGrantClaim_IsNotAuthenticated(string claim)
     {
         var token = MintGrant(
@@ -105,12 +107,77 @@ public class SessionCookieHandlerTests
             clientId: claim == "client_id" ? "third-party-app" : null,
             tenantId: claim == "tenant_id" ? _tenantId : null,
             grantId: claim == "grant_id" ? Guid.CreateVersion7() : null,
-            platformAccess: claim == "platform_access");
+            platformAccess: claim == "platform_access",
+            limitTo24Hours: claim == "limit_24h");
 
         var result = await _handler.AuthenticateAsync(BuildContext(token));
 
         result.Succeeded.Should().BeFalse();
     }
+
+    /// <summary>
+    /// The claims the session overload of <see cref="IJwtService.GenerateAccessToken"/> can emit
+    /// (sub, name, email, roles, permission, jti, iat, exp). A session JWT carrying only these is
+    /// the shape the handler accepts.
+    /// </summary>
+    private static readonly HashSet<string> SessionShapeClaims =
+    [
+        nameof(JwtClaims.SubjectId),
+        nameof(JwtClaims.Name),
+        nameof(JwtClaims.Email),
+        nameof(JwtClaims.Roles),
+        nameof(JwtClaims.Permissions),
+        nameof(JwtClaims.JwtId),
+        nameof(JwtClaims.IssuedAt),
+        nameof(JwtClaims.ExpiresAt),
+    ];
+
+    [Fact]
+    public void EveryJwtClaim_IsSessionShapedOrRejectedByTheGuard()
+    {
+        var guard = typeof(SessionCookieHandler).GetMethod(
+            "IsGrantShaped",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        guard.Should().NotBeNull(
+            "this test drives SessionCookieHandler.IsGrantShaped directly; if it was renamed or "
+            + "its signature changed, update the reflection lookup here");
+
+        var uncovered = typeof(JwtClaims)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => !SessionShapeClaims.Contains(p.Name))
+            .Where(p =>
+            {
+                var claims = new JwtClaims();
+                p.SetValue(claims, NonDefaultValueFor(p));
+                return !(bool)guard!.Invoke(null, [claims])!;
+            })
+            .Select(p => p.Name)
+            .ToList();
+
+        uncovered.Should().BeEmpty(
+            "every claim on JwtClaims must be explicitly triaged. Each of these is neither in "
+            + "SessionShapeClaims (a claim the session overload of IJwtService.GenerateAccessToken "
+            + "can emit) nor caught by SessionCookieHandler.IsGrantShaped. Decide which it is: if "
+            + "the session overload emits it, add it to SessionShapeClaims; otherwise it is a "
+            + "grant-only pin or ceiling, so add it to IsGrantShaped and add a row to "
+            + "AnyIndividualGrantClaim_IsNotAuthenticated. Uncovered: {0}",
+            string.Join(", ", uncovered));
+    }
+
+    private static object NonDefaultValueFor(PropertyInfo property) =>
+        property.PropertyType switch
+        {
+            var t when t == typeof(Guid) || t == typeof(Guid?) => Guid.CreateVersion7(),
+            var t when t == typeof(bool) || t == typeof(bool?) => true,
+            var t when t == typeof(string) => "set",
+            var t when t == typeof(List<string>) => new List<string> { "set" },
+            var t when t == typeof(DateTimeOffset) || t == typeof(DateTimeOffset?) =>
+                DateTimeOffset.UtcNow,
+            _ => throw new NotSupportedException(
+                $"JwtClaims.{property.Name} has type {property.PropertyType} which this test "
+                + "cannot populate. Add a case here so the claim can be triaged."),
+        };
 
     [Fact]
     public async Task NoCookies_Skips()
@@ -125,14 +192,15 @@ public class SessionCookieHandlerTests
         string? clientId = null,
         Guid? tenantId = null,
         Guid? grantId = null,
-        bool platformAccess = false) =>
+        bool platformAccess = false,
+        bool limitTo24Hours = false) =>
         _jwt.GenerateAccessToken(
             new SubjectInfo { Id = _subjectId, Name = "Member", Email = "member@example.com" },
             permissions: ["api:read"],
             roles: ["reader"],
             scopes: scopes ?? [],
             clientId: clientId,
-            limitTo24Hours: false,
+            limitTo24Hours: limitTo24Hours,
             tenantId: tenantId,
             lifetime: TimeSpan.FromMinutes(15),
             platformAccess: platformAccess,

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/SessionCookieHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/SessionCookieHandlerTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware.Handlers;
+
+/// <summary>
+/// Verifies that <see cref="SessionCookieHandler"/> only accepts first-party, session-shaped
+/// JWTs from the session access-token cookie. Grant-derived tokens (OAuth access tokens,
+/// platform-access grants) are signed with the same key/issuer/audience, so a holder could
+/// otherwise move one into the session cookie and shed its tenant pin and scope ceiling.
+/// </summary>
+public class SessionCookieHandlerTests
+{
+    private readonly Guid _subjectId = Guid.CreateVersion7();
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+
+    private readonly IJwtService _jwt;
+    private readonly SessionCookieHandler _handler;
+    private readonly OidcOptions _oidc = new();
+
+    public SessionCookieHandlerTests()
+    {
+        var jwtOptions = Options.Create(new JwtOptions
+        {
+            SecretKey = "session-cookie-handler-test-secret-key-32+chars",
+            Issuer = "nocturne",
+            Audience = "nocturne-api",
+            AccessTokenLifetimeMinutes = 15,
+        });
+        _jwt = new JwtService(jwtOptions, NullLogger<JwtService>.Instance);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(_jwt);
+        var provider = services.BuildServiceProvider();
+
+        _handler = new SessionCookieHandler(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<SessionCookieHandler>.Instance,
+            Options.Create(_oidc));
+    }
+
+    [Fact]
+    public async Task SessionShapedToken_Authenticates()
+    {
+        // Regression guard: the shape a real login mints (SessionService / OidcAuthService both
+        // use the overload with no scope, client_id, tenant_id, grant_id or platform_access).
+        var token = _jwt.GenerateAccessToken(
+            new SubjectInfo { Id = _subjectId, Name = "Member", Email = "member@example.com" },
+            permissions: ["api:read"],
+            roles: ["reader"]);
+
+        var result = await _handler.AuthenticateAsync(BuildContext(token));
+
+        result.Succeeded.Should().BeTrue();
+        result.AuthContext!.AuthType.Should().Be(AuthType.SessionCookie);
+        result.AuthContext.SubjectId.Should().Be(_subjectId);
+    }
+
+    [Fact]
+    public async Task TenantPinnedScopedOAuthToken_IsNotAuthenticated()
+    {
+        // The headline vector: a tenant-pinned, scope-limited OAuth access token moved into the
+        // session cookie would authenticate as an unscoped session credential.
+        var token = MintGrant(
+            scopes: ["glucose.read"],
+            clientId: "third-party-app",
+            tenantId: _tenantId,
+            grantId: Guid.CreateVersion7());
+
+        var result = await _handler.AuthenticateAsync(BuildContext(token));
+
+        result.Succeeded.Should().BeFalse();
+        result.AuthContext.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PlatformAccessGrant_IsNotAuthenticated()
+    {
+        var token = MintGrant(platformAccess: true);
+
+        var result = await _handler.AuthenticateAsync(BuildContext(token));
+
+        result.Succeeded.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("scope")]
+    [InlineData("client_id")]
+    [InlineData("tenant_id")]
+    [InlineData("grant_id")]
+    [InlineData("platform_access")]
+    public async Task AnyIndividualGrantClaim_IsNotAuthenticated(string claim)
+    {
+        var token = MintGrant(
+            scopes: claim == "scope" ? ["glucose.read"] : [],
+            clientId: claim == "client_id" ? "third-party-app" : null,
+            tenantId: claim == "tenant_id" ? _tenantId : null,
+            grantId: claim == "grant_id" ? Guid.CreateVersion7() : null,
+            platformAccess: claim == "platform_access");
+
+        var result = await _handler.AuthenticateAsync(BuildContext(token));
+
+        result.Succeeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task NoCookies_Skips()
+    {
+        var result = await _handler.AuthenticateAsync(BuildContext(null));
+
+        result.ShouldSkip.Should().BeTrue();
+    }
+
+    private string MintGrant(
+        IEnumerable<string>? scopes = null,
+        string? clientId = null,
+        Guid? tenantId = null,
+        Guid? grantId = null,
+        bool platformAccess = false) =>
+        _jwt.GenerateAccessToken(
+            new SubjectInfo { Id = _subjectId, Name = "Member", Email = "member@example.com" },
+            permissions: ["api:read"],
+            roles: ["reader"],
+            scopes: scopes ?? [],
+            clientId: clientId,
+            limitTo24Hours: false,
+            tenantId: tenantId,
+            lifetime: TimeSpan.FromMinutes(15),
+            platformAccess: platformAccess,
+            grantId: grantId);
+
+    private DefaultHttpContext BuildContext(string? accessToken)
+    {
+        var context = new DefaultHttpContext();
+        if (accessToken is not null)
+        {
+            context.Request.Headers["Cookie"] = $"{_oidc.Cookie.AccessTokenName}={accessToken}";
+        }
+        return context;
+    }
+}


### PR DESCRIPTION
## The smuggling vector

Session JWTs and grant JWTs (OAuth access tokens, platform-access grants) are minted by the same `JwtService`, signed with the same key, and carry the same issuer and audience. `IJwtService.ValidateAccessToken` therefore accepts either.

`SessionCookieHandler` read the session access-token cookie, called `ValidateAccessToken`, and — if valid — built an `AuthContext` straight from `BuildAuthContextFromClaims`, which ignores `TenantId`, `Scopes`, `ClientId`, `GrantId` and `PlatformAccess` entirely. Anyone holding a tenant-pinned, scope-limited OAuth access token (e.g. a third-party app's token for their own account) could paste it into the session cookie and be authenticated as `AuthType.SessionCookie` with their real `SubjectId`.

## Why that escalates

`AuthType.SessionCookie` is in `MemberScopeResolver.UnscopedCredentialTypes` — a session is assumed to be first-party and therefore not subject to a consent scope ceiling. So the smuggled token loses:

- its **tenant pin** (`tenant_id`), which nothing on the session path checks, and
- its **scope ceiling** (`scope`), because the resolver treats the credential as unscoped

everywhere `MemberScopeResolver` is consulted — the REST overview endpoint on `main` today, and the `/hubs/overview` hub in #467.

`PlatformAccessCookieHandler` already documents and defends against exactly this token-moving class for its own cookie (it requires the `platform_access` marker *and* a matching tenant pin, precisely so an ordinary tenant-pinned token can't be moved in). The session path had no symmetric defense.

## The invariant, verified

Every place a session access-token JWT is minted uses the `IJwtService.GenerateAccessToken` overload that takes only `(subject, permissions, roles, lifetime?)` — that overload **cannot** emit `scope`, `client_id`, `tenant_id`, `grant_id` or `platform_access`:

- `SessionService.IssueSessionAsync` (login: OIDC, passkey, TOTP, setup)
- `SessionService.RotateSessionAsync` (rotating refresh path)
- `OidcAuthService.RefreshSessionAsync` non-rotating branch (re-mints with the same overload)
- `PasskeyController` recovery cookie (a separate cookie, same shape)

All other `GenerateAccessToken` callers (`OAuthTokenService`, `PlatformAccessController`, `AuthorizationService`, `CareLinkConnectController`) use the grant overload and never write the session cookie. So "carries none of these claims" is a faithful description of a legitimate session token, and the guard breaks no login path.

## The fix

A single guard in `SessionCookieHandler`, applied to the token read from the session access-token cookie:

```csharp
private static bool IsGrantShaped(JwtClaims claims) =>
    claims.TenantId.HasValue
    || claims.Scopes is { Count: > 0 }
    || !string.IsNullOrEmpty(claims.ClientId)
    || claims.GrantId.HasValue
    || claims.PlatformAccess;
```

A grant-shaped token fails the handler exactly as an invalid token does (`AuthResult.Failure("Session expired or revoked")` — same message, no extra detail leaked), with a server-side warning log. The rationale lives at that one site.

The refresh-token cookie needs no equivalent check: it holds an opaque random string looked up server-side, and the access token it yields is re-minted through the session overload here.

## Tests

New `tests/Unit/Nocturne.API.Tests/Middleware/Handlers/SessionCookieHandlerTests.cs` (9 cases):

- a tenant-pinned + scoped + client_id + grant_id OAuth-shaped JWT in the session cookie -> not authenticated
- a `platform_access`-only grant -> not authenticated
- each of `scope`, `client_id`, `tenant_id`, `grant_id`, `platform_access` individually -> not authenticated
- a legitimate session-shaped JWT -> still authenticates as `AuthType.SessionCookie` (regression guard)
- no cookies -> skip

Mutation-proofed: disabling the guard turns 7 of the 9 red (the two survivors are the legitimate-session and no-cookie cases); restoring it returns all 9 green.

Full `Nocturne.API.Tests` unit suite: **5396 passed, 0 failed, 5 skipped (5401 total)**. Integration-category tests were excluded locally as usual and run in CI.

https://claude.ai/code/session_014gZWTmjMDSLtxp22i2cJe3
