### PR TITLE
fix(alerts): scope-gate the alert replay reads

### DIFF
--- a/src/API/Nocturne.API/Authorization/AlertReplayReadScopeGuard.cs
+++ b/src/API/Nocturne.API/Authorization/AlertReplayReadScopeGuard.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Enforces per-category OAuth read scopes on the fact timelines an alert replay returns, the
+/// same shape as <see cref="ActogramReadScopeGuard"/>. The replay events and their leaf logs are
+/// the alerts category, which the action's <c>RequireScope</c> admits on, but
+/// <c>AlertReplayResult.FactTimelines</c> additionally carries every
+/// <see cref="ReplayFactAttribute"/>-tagged property on <see cref="SensorContext"/> — glucose,
+/// treatment and device data in one response — so admission alone cannot decide what the response
+/// may contain. Each fact declares its category on the attribute and this guard drops the ones the
+/// caller does not hold.
+/// </summary>
+internal static class AlertReplayReadScopeGuard
+{
+    private static readonly IReadOnlyDictionary<string, string> FactScopes = BuildFactScopes();
+
+    /// <summary>
+    /// Drops every fact timeline whose read scope the caller does not hold. A key with no declared
+    /// category is dropped too, so an unclassified fact is hidden rather than shared.
+    /// </summary>
+    /// <param name="result">The replay result about to be returned.</param>
+    /// <param name="grantedScopes">The caller's normalized granted scopes.</param>
+    public static AlertReplayResult Redact(
+        AlertReplayResult result,
+        IReadOnlySet<string> grantedScopes)
+    {
+        var visible = result.FactTimelines
+            .Where(fact => FactScopes.TryGetValue(fact.Key, out var scope)
+                           && OAuthScopes.SatisfiesScope(grantedScopes, scope))
+            .ToDictionary(fact => fact.Key, fact => fact.Value, StringComparer.Ordinal);
+
+        return visible.Count == result.FactTimelines.Count
+            ? result
+            : result with { FactTimelines = visible };
+    }
+
+    private static Dictionary<string, string> BuildFactScopes() =>
+        typeof(SensorContext)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(property => property.GetCustomAttribute<ReplayFactAttribute>(inherit: false))
+            .Where(attribute => attribute is not null)
+            .ToDictionary(attribute => attribute!.Key, attribute => attribute!.Scope, StringComparer.Ordinal);
+}

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertReplayController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertReplayController.cs
@@ -1,8 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Models.Alerts;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Monitoring;
 
@@ -10,9 +14,11 @@ namespace Nocturne.API.Controllers.V4.Monitoring;
 /// What-if replay of the tenant's enabled alert rules over a historical window.
 /// Returns the events that <em>would</em> have fired had the current rule set been active.
 /// </summary>
+/// <seealso cref="AlertReplayReadScopeGuard"/>
 [ApiController]
 [Tags("Monitoring")]
 [Authorize]
+[RequireScope(OAuthScopes.AlertsRead)]
 [Route("api/v4/alerts/replay")]
 public class AlertReplayController : ControllerBase
 {
@@ -38,7 +44,7 @@ public class AlertReplayController : ControllerBase
         {
             var result = await _replayService.ReplayAsync(
                 request.Date, request.Timezone, request.From, request.To, ct);
-            return Ok(result);
+            return Ok(AlertReplayReadScopeGuard.Redact(result, HttpContext.GetGrantedScopes()));
         }
         catch (ReplayWindowTooLargeException ex)
         {
@@ -72,7 +78,7 @@ public class AlertReplayController : ControllerBase
         {
             var result = await _replayService.ReplayDryRunAsync(
                 request.Date, request.Timezone, request.From, request.To, ruleOverride, ct);
-            return Ok(result);
+            return Ok(AlertReplayReadScopeGuard.Redact(result, HttpContext.GetGrantedScopes()));
         }
         catch (ReplayWindowTooLargeException ex)
         {

--- a/src/Core/Nocturne.Core.Models/AlertModels.cs
+++ b/src/Core/Nocturne.Core.Models/AlertModels.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Nocturne.Core.Models.Alerts;
 using Nocturne.Core.Models.Alerts.Conditions;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.Core.Models;
 
@@ -13,7 +14,7 @@ public record SensorContext
     /// <summary>
     /// Most recent glucose value in mg/dL, or null if no reading is available.
     /// </summary>
-    [ReplayFact("latest_glucose", decimals: 0)]
+    [ReplayFact("latest_glucose", OAuthScopes.GlucoseRead, decimals: 0)]
     public required decimal? LatestValue { get; init; }
 
     /// <summary>
@@ -24,13 +25,13 @@ public record SensorContext
     /// <summary>
     /// Rate of glucose change in mg/dL per minute. Positive = rising, negative = falling.
     /// </summary>
-    [ReplayFact("trend_rate", decimals: 2)]
+    [ReplayFact("trend_rate", OAuthScopes.GlucoseRead, decimals: 2)]
     public required decimal? TrendRate { get; init; }
 
     /// <summary>
     /// Timestamp of the last reading received from the CGM, used for signal loss detection.
     /// </summary>
-    [ReplayFact("staleness_minutes", decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
+    [ReplayFact("staleness_minutes", OAuthScopes.GlucoseRead, decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
     public required DateTime? LastReadingAt { get; init; }
 
     /// <summary>
@@ -41,19 +42,19 @@ public record SensorContext
     /// <summary>
     /// Insulin on board in units, when available from the loop/pump integration.
     /// </summary>
-    [ReplayFact("iob", decimals: 2)]
+    [ReplayFact("iob", OAuthScopes.TreatmentsRead, decimals: 2)]
     public decimal? IobUnits { get; init; }
 
     /// <summary>
     /// Carbohydrates on board in grams, when available from the loop integration.
     /// </summary>
-    [ReplayFact("cob", decimals: 1)]
+    [ReplayFact("cob", OAuthScopes.TreatmentsRead, decimals: 1)]
     public decimal? CobGrams { get; init; }
 
     /// <summary>
     /// Pump reservoir level in units, when available.
     /// </summary>
-    [ReplayFact("reservoir", decimals: 1)]
+    [ReplayFact("reservoir", OAuthScopes.DevicesRead, decimals: 1)]
     public decimal? ReservoirUnits { get; init; }
 
     /// <summary>
@@ -61,19 +62,19 @@ public record SensorContext
     /// (e.g. an Omnipod reports "50+" while the reservoir holds at least 50 units).
     /// Replay emits this fact as 0/1.
     /// </summary>
-    [ReplayFact("reservoir_is_lower_bound", decimals: 0)]
+    [ReplayFact("reservoir_is_lower_bound", OAuthScopes.DevicesRead, decimals: 0)]
     public bool ReservoirIsLowerBound { get; init; }
 
     /// <summary>
     /// Timestamp of the most recent infusion site change. Used by the site-age condition.
     /// </summary>
-    [ReplayFact("site_age_hours", decimals: 1, conversion: ReplayFactConversion.HoursSinceNow)]
+    [ReplayFact("site_age_hours", OAuthScopes.DevicesRead, decimals: 1, conversion: ReplayFactConversion.HoursSinceNow)]
     public DateTime? LastSiteChangeAt { get; init; }
 
     /// <summary>
     /// Timestamp of the most recent CGM sensor start. Used by the sensor-age condition.
     /// </summary>
-    [ReplayFact("sensor_age_days", decimals: 2, conversion: ReplayFactConversion.DaysSinceNow)]
+    [ReplayFact("sensor_age_days", OAuthScopes.DevicesRead, decimals: 2, conversion: ReplayFactConversion.DaysSinceNow)]
     public DateTime? LastSensorStartAt { get; init; }
 
     /// <summary>
@@ -102,15 +103,15 @@ public record SensorContext
     // ----- Looping facts -----
 
     /// <summary>Timestamp of the latest APS cycle (suggested or enacted), or null when none observed.</summary>
-    [ReplayFact("loop_stale_minutes", decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
+    [ReplayFact("loop_stale_minutes", OAuthScopes.DevicesRead, decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
     public DateTime? LastApsCycleAt { get; init; }
 
     /// <summary>Timestamp of the latest enacted APS cycle, or null when none observed.</summary>
-    [ReplayFact("loop_enaction_stale_minutes", decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
+    [ReplayFact("loop_enaction_stale_minutes", OAuthScopes.DevicesRead, decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
     public DateTime? LastApsEnactedAt { get; init; }
 
     /// <summary>Latest pump battery level in percent, when available.</summary>
-    [ReplayFact("pump_battery_percent", decimals: 0)]
+    [ReplayFact("pump_battery_percent", OAuthScopes.DevicesRead, decimals: 0)]
     public decimal? PumpBatteryPercent { get; init; }
 
     /// <summary>Currently active temp basal projection, or null when no temp is active.</summary>
@@ -121,11 +122,11 @@ public record SensorContext
     /// Lives as a separate property purely so it can carry a <see cref="ReplayFactAttribute"/>;
     /// evaluators read <see cref="ActiveTempBasal"/> directly.
     /// </summary>
-    [ReplayFact("temp_basal_rate", decimals: 2)]
+    [ReplayFact("temp_basal_rate", OAuthScopes.TreatmentsRead, decimals: 2)]
     public decimal? TempBasalRate => ActiveTempBasal?.Rate;
 
     /// <summary>Latest uploader (phone) battery level in percent, when available.</summary>
-    [ReplayFact("uploader_battery_percent", decimals: 0)]
+    [ReplayFact("uploader_battery_percent", OAuthScopes.DevicesRead, decimals: 0)]
     public decimal? UploaderBatteryPercent { get; init; }
 
     /// <summary>Currently active override projection, or null when no override is active.</summary>
@@ -138,7 +139,7 @@ public record SensorContext
     public PumpSuspensionSnapshot? ActivePumpSuspension { get; init; }
 
     /// <summary>Latest non-null APS sensitivity ratio (autosens), when available.</summary>
-    [ReplayFact("sensitivity_ratio", decimals: 2)]
+    [ReplayFact("sensitivity_ratio", OAuthScopes.DevicesRead, decimals: 2)]
     public decimal? SensitivityRatio { get; init; }
 
     /// <summary>
@@ -190,11 +191,11 @@ public record SensorContext
     public GlucoseBucket? GlucoseBucket { get; init; }
 
     /// <summary>Timestamp of the latest carb-bearing treatment, or null when none observed.</summary>
-    [ReplayFact("time_since_last_carb_minutes", decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
+    [ReplayFact("time_since_last_carb_minutes", OAuthScopes.TreatmentsRead, decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
     public DateTime? LastCarbAt { get; init; }
 
     /// <summary>Timestamp of the latest insulin-bearing treatment, or null when none observed.</summary>
-    [ReplayFact("time_since_last_bolus_minutes", decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
+    [ReplayFact("time_since_last_bolus_minutes", OAuthScopes.TreatmentsRead, decimals: 0, conversion: ReplayFactConversion.MinutesSinceNow)]
     public DateTime? LastBolusAt { get; init; }
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/Alerts/FactSnapshotPoint.cs
+++ b/src/Core/Nocturne.Core.Models/Alerts/FactSnapshotPoint.cs
@@ -20,7 +20,8 @@ public sealed record FactSnapshotPoint(long AtMs, decimal Value);
 /// each tick. Adding a new fact is a one-line change: drop the attribute on the property
 /// and replay picks it up automatically — no parallel registry to maintain. The
 /// <see cref="Key"/> is the single source of truth for the wire name; the FE's
-/// leaf-to-fact mapping references the same string.
+/// leaf-to-fact mapping references the same string, and <see cref="Scope"/> is the single
+/// source of truth for the read scope that unlocks the fact on the wire.
 /// </summary>
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 public sealed class ReplayFactAttribute : Attribute
@@ -28,6 +29,14 @@ public sealed class ReplayFactAttribute : Attribute
     /// <summary>Snake_case wire key the FE looks up in <c>FactTimelines</c>. Keep stable;
     /// renaming is a wire break.</summary>
     public string Key { get; }
+
+    /// <summary>
+    /// The <see cref="Authorization.OAuthScopes"/> read scope governing the data the fact is
+    /// derived from, matching the category its source tables sit under in
+    /// <see cref="Authorization.ShareDataCategories"/>. Constructor-required so a new fact cannot
+    /// reach the wire without a category decision.
+    /// </summary>
+    public string Scope { get; }
 
     /// <summary>Decimal places to round to before change-detection. Mirrors the precision
     /// the rule sidebar will display so the FE never sees jitter the user can't perceive.</summary>
@@ -41,10 +50,12 @@ public sealed class ReplayFactAttribute : Attribute
 
     public ReplayFactAttribute(
         string key,
+        string scope,
         int decimals = 2,
         ReplayFactConversion conversion = ReplayFactConversion.Direct)
     {
         Key = key;
+        Scope = scope;
         Decimals = decimals;
         Conversion = conversion;
     }

--- a/tests/Unit/Nocturne.API.Tests/Authorization/AlertReplayReadScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/AlertReplayReadScopeTests.cs
@@ -1,0 +1,269 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Guards the read side of the alert replay surface. Both actions are POSTs that persist nothing,
+/// so the write sweep exempts them, but the response carries the tenant's glucose, treatment and
+/// device history as fact timelines over a caller-chosen window.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AlertReplayReadScopeTests
+{
+    private static AlertReplayResult OneTimelinePerCategory() =>
+        new(DateTime.UnixEpoch, DateTime.UnixEpoch.AddHours(24), [])
+        {
+            FactTimelines = new Dictionary<string, IReadOnlyList<FactSnapshotPoint>>(StringComparer.Ordinal)
+            {
+                ["latest_glucose"] = [new FactSnapshotPoint(1, 42m)],
+                ["iob"] = [new FactSnapshotPoint(1, 1.5m)],
+                ["reservoir"] = [new FactSnapshotPoint(1, 80m)],
+            },
+        };
+
+    private static IReadOnlySet<string> Granted(params string[] scopes) =>
+        new HashSet<string>(scopes, StringComparer.Ordinal);
+
+    /// <summary>The maximum a guest link can hold that is not the alerts category.</summary>
+    private static string[] GuestScopesWithoutAlerts() =>
+        OAuthScopes.Normalize([OAuthScopes.HealthRead, OAuthScopes.TherapyRead, OAuthScopes.ReportsRead]).ToArray();
+
+    private static string[] ViewerScopes() =>
+        OAuthScopes.NormalizeMemberPermissions(
+            TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Viewer]).ToArray();
+
+    // ── admission ─────────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(nameof(AlertReplayController.Replay))]
+    [InlineData(nameof(AlertReplayController.ReplayDryRun))]
+    public void ViewerRole_IsRefused(string action)
+    {
+        ViewerScopes().Should().NotContain(OAuthScopes.AlertsRead);
+
+        Evaluate(action, authenticated: true, ViewerScopes())
+            .Should().BeOfType<ForbidResult>("a Viewer holds no alerts scope");
+    }
+
+    [Theory]
+    [InlineData(nameof(AlertReplayController.Replay))]
+    [InlineData(nameof(AlertReplayController.ReplayDryRun))]
+    public void GuestSessionWithoutTheAlertsCategory_IsRefused(string action)
+    {
+        Evaluate(action, authenticated: true, GuestScopesWithoutAlerts())
+            .Should().BeOfType<ForbidResult>();
+    }
+
+    /// <summary>
+    /// A public share is anonymous, and <see cref="OAuthScopes.AlertsRead"/> is outside
+    /// <see cref="TenantPermissions.PublicShareScopes"/>, so no share can hold it however the
+    /// owner configures the link. Requiring the single alerts scope is therefore not the
+    /// share-breaking <c>requireAll</c> shape — a share was never admitted here to begin with.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(AlertReplayController.Replay))]
+    [InlineData(nameof(AlertReplayController.ReplayDryRun))]
+    public void AnonymousShareLink_IsRefused(string action)
+    {
+        TenantPermissions.PublicShareScopes.Should().NotContain(TenantPermissions.AlertsRead);
+
+        Evaluate(action, authenticated: false, [.. TenantPermissions.PublicShareScopes])
+            .Should().BeOfType<ForbidResult>();
+    }
+
+    [Theory]
+    [InlineData(nameof(AlertReplayController.Replay))]
+    [InlineData(nameof(AlertReplayController.ReplayDryRun))]
+    public void AlertsGrant_IsAdmitted(string action)
+    {
+        Evaluate(action, authenticated: true, [OAuthScopes.AlertsRead]).Should().BeNull();
+        Evaluate(action, authenticated: true, [OAuthScopes.AlertsReadWrite]).Should().BeNull();
+        Evaluate(action, authenticated: true, [OAuthScopes.FullAccess]).Should().BeNull();
+    }
+
+    /// <summary>
+    /// Every seed role whose job includes authoring or reviewing alert rules must keep reaching the
+    /// simulator, or the gate has broken the surface it protects.
+    /// </summary>
+    [Theory]
+    [InlineData(TenantPermissions.SeedRoles.Owner)]
+    [InlineData(TenantPermissions.SeedRoles.Admin)]
+    [InlineData(TenantPermissions.SeedRoles.Caretaker)]
+    [InlineData(TenantPermissions.SeedRoles.Clinician)]
+    public void AlertHoldingSeedRoles_KeepReachingReplay(string role)
+    {
+        var scopes = OAuthScopes.NormalizeMemberPermissions(
+            TenantPermissions.SeedRolePermissions[role]).ToArray();
+
+        Evaluate(nameof(AlertReplayController.Replay), authenticated: true, scopes).Should().BeNull();
+    }
+
+    // ── per-category redaction ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Redact_AlertsOnlyGrant_DropsEveryFactTimeline()
+    {
+        var result = AlertReplayReadScopeGuard.Redact(
+            OneTimelinePerCategory(), Granted(OAuthScopes.AlertsRead));
+
+        result.FactTimelines.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Redact_GlucoseGrant_KeepsOnlyTheGlucoseFacts()
+    {
+        var result = AlertReplayReadScopeGuard.Redact(
+            OneTimelinePerCategory(), Granted(OAuthScopes.AlertsRead, OAuthScopes.GlucoseRead));
+
+        result.FactTimelines.Keys.Should().BeEquivalentTo(["latest_glucose"]);
+    }
+
+    [Fact]
+    public void Redact_ReadWriteGrant_SatisfiesTheReadCategory()
+    {
+        var result = AlertReplayReadScopeGuard.Redact(
+            OneTimelinePerCategory(), Granted(OAuthScopes.TreatmentsReadWrite));
+
+        result.FactTimelines.Keys.Should().BeEquivalentTo(["iob"]);
+    }
+
+    [Fact]
+    public void Redact_FullAccess_KeepsEveryFactTimeline()
+    {
+        var result = AlertReplayReadScopeGuard.Redact(
+            OneTimelinePerCategory(), Granted(OAuthScopes.FullAccess));
+
+        result.FactTimelines.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Redact_UnknownFactKey_IsDropped()
+    {
+        var withStray = OneTimelinePerCategory() with
+        {
+            FactTimelines = new Dictionary<string, IReadOnlyList<FactSnapshotPoint>>(StringComparer.Ordinal)
+            {
+                ["not_a_declared_fact"] = [new FactSnapshotPoint(1, 1m)],
+            },
+        };
+
+        AlertReplayReadScopeGuard.Redact(withStray, Granted(OAuthScopes.FullAccess))
+            .FactTimelines.Should().BeEmpty("a fact with no declared category must fail closed");
+    }
+
+    /// <summary>
+    /// The categories are declared on the facts themselves, so a new fact cannot reach the wire
+    /// under a scope the taxonomy does not know or that no share category governs.
+    /// </summary>
+    [Fact]
+    public void EveryReplayFact_DeclaresAGovernedReadScope()
+    {
+        var facts = typeof(SensorContext)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.GetCustomAttribute<ReplayFactAttribute>(inherit: false))
+            .Where(a => a is not null)
+            .Select(a => a!)
+            .ToList();
+
+        facts.Should().HaveCountGreaterThan(10, "the scan must find the fact surface");
+
+        foreach (var fact in facts)
+        {
+            ShareDataCategories.GoverningScopes.Should().Contain(fact.Scope,
+                $"replay fact '{fact.Key}' declares '{fact.Scope}', which governs no data category");
+        }
+    }
+
+    // ── handler wiring ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(nameof(AlertReplayController.Replay))]
+    [InlineData(nameof(AlertReplayController.ReplayDryRun))]
+    public async Task Handler_RedactsTheCategoriesTheCallerLacks(string action)
+    {
+        var service = new Mock<IAlertReplayService>();
+        service
+            .Setup(s => s.ReplayAsync(
+                It.IsAny<DateOnly?>(), It.IsAny<string?>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OneTimelinePerCategory());
+        service
+            .Setup(s => s.ReplayDryRunAsync(
+                It.IsAny<DateOnly?>(), It.IsAny<string?>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<ReplayRuleOverride>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OneTimelinePerCategory());
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = Granted(OAuthScopes.AlertsRead, OAuthScopes.DevicesRead);
+
+        var controller = new AlertReplayController(service.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+
+        var response = action == nameof(AlertReplayController.Replay)
+            ? await controller.Replay(new AlertReplayRequest(null, null), CancellationToken.None)
+            : await controller.ReplayDryRun(
+                new AlertReplayDryRunRequest(null, null, NewRuleDefinition()), CancellationToken.None);
+
+        var result = response.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<AlertReplayResult>().Subject;
+
+        result.FactTimelines.Keys.Should().BeEquivalentTo(["reservoir"]);
+    }
+
+    private static ReplayRuleDefinition NewRuleDefinition() => new(
+        Id: null,
+        Name: "rule",
+        ConditionType: AlertConditionType.Threshold,
+        ConditionParams: "{}",
+        Severity: AlertRuleSeverity.Warning,
+        AllowThroughDnd: false,
+        AutoResolveEnabled: false,
+        AutoResolveParams: null);
+
+    /// <summary>
+    /// Runs the authorization filters the action really answers to — MVC applies class-level
+    /// filters alongside the action's own, and the gate here is declared on the class.
+    /// </summary>
+    private static IActionResult? Evaluate(string actionName, bool authenticated, string[] grantedScopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (authenticated)
+            httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = true };
+        httpContext.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>(grantedScopes, StringComparer.Ordinal);
+
+        var action = typeof(AlertReplayController)
+            .GetMethod(actionName, BindingFlags.Public | BindingFlags.Instance)!;
+
+        var filters = typeof(AlertReplayController).GetCustomAttributes(inherit: true)
+            .Concat(action.GetCustomAttributes(inherit: true))
+            .OfType<IAuthorizationFilter>();
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+        foreach (var filter in filters)
+        {
+            var context = new AuthorizationFilterContext(actionContext, new List<IFilterMetadata>());
+            filter.OnAuthorization(context);
+            if (context.Result is not null)
+                return context.Result;
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -194,7 +194,9 @@ public class V4WriteScopeGatingTests
             // Both replay actions compute over the STORED alert rules and glucose history — the
             // body supplies only the window — and return the events that would have fired.
             // AlertReplayService has no SaveChangesAsync and adds to no DbSet, so a POST here is a
-            // read the body shape forced off GET.
+            // read the body shape forced off GET. As a read it is gated: the class requires
+            // alerts.read and AlertReplayReadScopeGuard drops the fact timelines outside the
+            // caller's categories, asserted by AlertReplayReadScopeTests.
             ["AlertReplayController"] = NotDataCategory.ComputesAndReturns,
 
             ["ClockFacesController"] = NotDataCategory.SplitSharingVocabulary,


### PR DESCRIPTION
`AlertReplayController` was `[Authorize]`-only. Its response carries the rule-replay events plus `FactTimelines`, which spans the glucose, treatment and device categories over a caller-chosen window, so neither the class attribute nor the V4 write-scope sweep (which correctly exempts these POSTs as computing and persisting nothing) decided anything about what the response may contain.

Admission now requires `alerts.read`, and `AlertReplayReadScopeGuard` redacts the fact timelines per category — the `ActogramReadScopeGuard` shape. Each `[ReplayFact]` declares its governing read scope as a constructor argument, so a new fact cannot reach the wire without a category decision, and an unclassified key is dropped rather than shared.

`alerts.read` is outside `PublicShareScopes`, so no share link can hold it and the single-scope gate is not the `requireAll` shape that would break a share-reachable page. Owner, Admin, Caretaker and Clinician keep full access; Viewer, a guest link without the alerts category, and an anonymous share are refused. Tests cover admission, redaction, fact-category coverage and handler wiring; both the attribute and the redaction call were removed to confirm the tests fail without them.
