### PR TITLE
fix(api): require tenant.settings on the connector configuration surface

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Connectors/CareLinkConnectController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/CareLinkConnectController.cs
@@ -1,3 +1,4 @@
+using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -11,6 +12,7 @@ using Nocturne.Connectors.CareLink.Services;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Connectors;
 
@@ -44,8 +46,9 @@ public partial class CareLinkConnectController : ControllerBase
     /// <summary>
     /// Scope carried by a desktop link token. Deliberately outside the OAuth scope vocabulary:
     /// MemberScopeMiddleware intersects member permissions with token scopes, so the resulting
-    /// PermissionTrie is empty and every permission-gated endpoint denies the token — it only
-    /// authenticates plain <c>[Authorize]</c> endpoints such as this controller's.
+    /// PermissionTrie and granted-scope set are both empty and every permission- or scope-gated
+    /// endpoint denies the token — it reaches nothing beyond the two flow actions below, which
+    /// recognise it from the credential's own scope list.
     /// </summary>
     private const string DesktopTokenScope = "connectors:carelink:connect";
     private static readonly TimeSpan DesktopTokenLifetime = TimeSpan.FromMinutes(10);
@@ -87,9 +90,13 @@ public partial class CareLinkConnectController : ControllerBase
     [RemoteCommand]
     [ProducesResponseType(typeof(CareLinkConnectStartResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<CareLinkConnectStartResponse>> Start(
         [FromBody] CareLinkConnectStartRequest request, CancellationToken ct)
     {
+        if (!CanConfigureConnectors())
+            return Forbid();
+
         var server = string.IsNullOrWhiteSpace(request.Server) ? "EU" : request.Server.Trim().ToUpperInvariant();
         if (server != "EU" && server != "US")
             return BadRequest(new { message = "Server must be 'EU' or 'US'." });
@@ -119,9 +126,13 @@ public partial class CareLinkConnectController : ControllerBase
     [RemoteCommand(Invalidates = ["GetConfiguration", "GetAllConnectorStatus"])]
     [ProducesResponseType(typeof(CareLinkConnectCompleteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<CareLinkConnectCompleteResponse>> Complete(
         [FromBody] CareLinkConnectCompleteRequest request, CancellationToken ct)
     {
+        if (!CanConfigureConnectors())
+            return Forbid();
+
         if (string.IsNullOrWhiteSpace(request.Code) || string.IsNullOrWhiteSpace(request.State))
             return BadRequest(new { message = "Both code and state are required." });
 
@@ -186,6 +197,7 @@ public partial class CareLinkConnectController : ControllerBase
     /// </summary>
     [HttpPost("desktop-token")]
     [RemoteCommand]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(typeof(CareLinkDesktopTokenResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public ActionResult<CareLinkDesktopTokenResponse> DesktopToken()
@@ -225,6 +237,19 @@ public partial class CareLinkConnectController : ControllerBase
             ExpiresInSeconds = (int)DesktopTokenLifetime.TotalSeconds,
         });
     }
+
+    /// <summary>
+    /// Whether the caller may sign a CareLink account into this tenant. The flow stores a refresh
+    /// token as the connector secret and writes the signed-in account into the connector
+    /// configuration, so it takes the same <see cref="TenantPermissions.TenantSettings"/> as the
+    /// rest of the connector configuration surface — or a desktop link token, whose scope resolves
+    /// to nothing (see <see cref="DesktopTokenScope"/>) so no scope gate can admit it, and which
+    /// <see cref="DesktopToken"/> mints only for a caller that already held the permission.
+    /// </summary>
+    private bool CanConfigureConnectors() =>
+        TenantPermissions.HasPermission(
+            HttpContext.GetGrantedScopes(), TenantPermissions.TenantSettings)
+        || HttpContext.GetAuthContext()?.Scopes.Contains(DesktopTokenScope) == true;
 
     /// <summary>
     /// Writes what the sign-in established into the connector configuration: the region whose tokens

--- a/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
@@ -1,9 +1,11 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Connectors;
 
@@ -23,6 +25,13 @@ namespace Nocturne.API.Controllers.V4.Connectors;
 // visitor's: the demo's account is shared and obtainable without signing up. A permission gate
 // would not do — the demo member holds tenant.settings.
 [DenyDemoSubject]
+// Reading or changing a connector's configuration is tenant administration, so every action but
+// the schema — which describes a connector's declared fields and holds no tenant state — requires
+// tenant.settings. Repeated per action rather than declared on the class because the schema route
+// is [AllowAnonymous], and an authorization filter on the class would run for it regardless.
+// [RequireAdmin] would not do: it resolves against the PermissionTrie, which ScopeTranslator never
+// populates with a tenant-administration atom, so it admits only a superuser membership and would
+// lock the Administrator role out of the connector settings it holds tenant.settings for.
 public class ConfigurationController : ControllerBase
 {
     private readonly IConnectorConfigurationService _configService;
@@ -50,6 +59,7 @@ public class ConfigurationController : ControllerBase
     /// <returns>Configuration response or 404 if not found</returns>
     [HttpGet("{connectorName}")]
     [RemoteQuery]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(typeof(ConnectorConfigurationResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ConnectorConfigurationResponse>> GetConfiguration(
@@ -93,13 +103,14 @@ public class ConfigurationController : ControllerBase
     /// Gets the effective configuration for a connector: the non-secret runtime values resolved
     /// from stored configuration and environment variables. Secret values (passwords, tokens) are
     /// excluded, but the result includes non-secret account identifiers such as the connector
-    /// account username or email, so it requires authentication (the class-level <c>[Authorize]</c>).
+    /// account username or email.
     /// </summary>
     /// <param name="connectorName">The connector name</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns>Dictionary of property names to effective values</returns>
     [HttpGet("{connectorName}/effective")]
     [RemoteQuery]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(typeof(Dictionary<string, object?>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<Dictionary<string, object?>>> GetEffectiveConfiguration(
@@ -131,6 +142,7 @@ public class ConfigurationController : ControllerBase
     /// <returns>The saved configuration</returns>
     [HttpPut("{connectorName}")]
     [RemoteCommand(Invalidates = ["GetConfiguration", "GetAllConnectorStatus"])]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(typeof(ConnectorConfigurationResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<ConnectorConfigurationResponse>> SaveConfiguration(
@@ -382,6 +394,7 @@ public class ConfigurationController : ControllerBase
     /// <param name="ct">Cancellation token</param>
     [HttpPut("{connectorName}/secrets")]
     [RemoteCommand(Invalidates = ["GetConfiguration", "GetAllConnectorStatus"])]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> SaveSecrets(
@@ -412,6 +425,7 @@ public class ConfigurationController : ControllerBase
     /// <returns>List of connector status information</returns>
     [HttpGet]
     [RemoteQuery]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(typeof(IReadOnlyList<ConnectorStatusInfo>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IReadOnlyList<ConnectorStatusInfo>>> GetAllConnectorStatus(
         CancellationToken ct)
@@ -430,6 +444,7 @@ public class ConfigurationController : ControllerBase
     /// <param name="ct">Cancellation token</param>
     [HttpPatch("{connectorName}/active")]
     [RemoteCommand(Invalidates = ["GetConfiguration", "GetAllConnectorStatus"])]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> SetActive(
         string connectorName,
@@ -451,6 +466,7 @@ public class ConfigurationController : ControllerBase
     /// <param name="ct">Cancellation token</param>
     [HttpDelete("{connectorName}")]
     [RemoteCommand(Invalidates = ["GetConfiguration", "GetAllConnectorStatus"])]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteConfiguration(

--- a/src/API/Nocturne.API/Controllers/V4/Connectors/ConnectorStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/ConnectorStatusController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
 using Nocturne.API.Models;
 using Nocturne.API.Services.Connectors;
+using Nocturne.Core.Models.Authorization;
 using OpenApi.Remote.Attributes;
 
 namespace Nocturne.API.Controllers.V4;
@@ -13,13 +15,15 @@ namespace Nocturne.API.Controllers.V4;
 /// <remarks>
 /// Connector status is maintained by <see cref="IConnectorHealthService"/>, which tracks
 /// the last-seen timestamp and error state for each connector (Dexcom, Glooko, Libre, etc.).
-/// This endpoint is used by the frontend dashboard to display connector health indicators.
+/// This endpoint backs the connector settings screen's health indicators; no patient-facing
+/// dashboard reads it.
 /// </remarks>
 /// <seealso cref="IConnectorHealthService"/>
 [Authorize]
 // Reports the outcome of a fetch to a tenant-configured host — the readback half of the
 // request-forgery shape gated on ConfigurationController.
 [DenyDemoSubject]
+[RequireScope(TenantPermissions.TenantSettings)]
 [ApiController]
 [Tags("Connectors")]
 [Route("api/v4/connectors")]

--- a/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
@@ -1,9 +1,11 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.API.Services.Alerts.Webhooks;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 
 namespace Nocturne.API.Controllers.V4.Connectors;
@@ -22,6 +24,9 @@ namespace Nocturne.API.Controllers.V4.Connectors;
 [Tags("Connectors")]
 [Route("api/v4/ui-settings/notifications/webhooks")]
 [Authorize]
+// Choosing where a tenant's alerts are delivered, and dispatching from the server to a
+// caller-named host, are tenant administration. The GET is left on [Authorize] alone: it returns a
+// fixed disabled stub rather than anything the tenant configured.
 public class WebhookSettingsController(
     WebhookRequestSender requestSender,
     ILogger<WebhookSettingsController> logger)
@@ -51,6 +56,7 @@ public class WebhookSettingsController(
 
     /// <summary>Saves webhook notification settings.</summary>
     [HttpPut]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(typeof(WebhookNotificationSettings), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
@@ -67,11 +73,11 @@ public class WebhookSettingsController(
     /// <remarks>
     /// Gated for the demo's shared visitor because the destination is caller-chosen: the server
     /// makes an outbound POST from its own address. <c>OutboundDestination</c> keeps it off private
-    /// networks, so what remains is a relay to public hosts. The GET and PUT above are a stub and a
-    /// logged no-op, so gating them would only break the demo's notification settings screen.
+    /// networks, so what remains is a relay to public hosts.
     /// </remarks>
     [HttpPost("test")]
     [DenyDemoSubject]
+    [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(typeof(WebhookTestResult), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/MyFitnessPalSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/MyFitnessPalSettingsController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 
 namespace Nocturne.API.Controllers.V4.Profiles;
@@ -12,6 +14,7 @@ namespace Nocturne.API.Controllers.V4.Profiles;
 [ApiController]
 [Tags("Profiles")]
 [Route("api/v4/connectors/myfitnesspal/settings")]
+[RequireScope(TenantPermissions.TenantSettings)]
 public class MyFitnessPalSettingsController : ControllerBase
 {
     private readonly IMyFitnessPalMatchingSettingsService _settingsService;

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ConnectorConfigurationScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ConnectorConfigurationScopeTests.cs
@@ -1,0 +1,357 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4;
+using Nocturne.API.Controllers.V4.Connectors;
+using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Guards the connector configuration surface against a read-only credential. The stored values
+/// name the host the server fetches from and the credentials it presents, so reading them exposes
+/// account identifiers and writing them redirects or silences a CGM feed. Every action there
+/// requires <see cref="TenantPermissions.TenantSettings"/>; the exceptions are enumerated in
+/// <see cref="Ungated"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="V4WriteScopeGatingTests"/> sweeps the whole V4 plane for a data-category scope and
+/// files these controllers as an exemption, because <c>tenant.settings</c> is not one. This class
+/// is what that exemption defers to: it pins the gate that is there instead, and asserts the scope
+/// resolution that decides who keeps access — a seed role through <see cref="MemberScopeResolver"/>,
+/// a guest grant through <see cref="OAuthScopes.ValidateGrantScopes"/>, and the CareLink desktop
+/// link token.
+/// </remarks>
+public class ConnectorConfigurationScopeTests
+{
+    /// <summary>Reason marker for an action whose gate lives in the handler rather than an attribute.</summary>
+    private const string HandlerGuarded = "enforced in the handler; also admits the desktop link token";
+
+    private static readonly Type[] ConnectorSurface =
+    [
+        typeof(ConfigurationController),
+        typeof(ConnectorStatusController),
+        typeof(CareLinkConnectController),
+        typeof(WebhookSettingsController),
+        typeof(MyFitnessPalSettingsController),
+    ];
+
+    /// <summary>
+    /// Actions on the surface that deliberately carry no <c>tenant.settings</c> attribute, with the
+    /// reason. Anything else fails <see cref="EveryConnectorAction_RequiresTenantSettings"/>.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> Ungated =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // The connector's declared field list, not anything a tenant configured, and
+            // deliberately [AllowAnonymous] so the setup wizard can render the form before there is
+            // a tenant to be a member of.
+            ["ConfigurationController.GetSchema"] = "connector metadata, no tenant state",
+
+            // Returns a fixed disabled stub regardless of what the tenant configured — the webhook
+            // channel is not wired to the current alert engine's storage.
+            ["WebhookSettingsController.GetWebhookSettings"] = "fixed stub, no tenant state",
+
+            ["CareLinkConnectController.Start"] = HandlerGuarded,
+            ["CareLinkConnectController.Complete"] = HandlerGuarded,
+        };
+
+    [Fact]
+    public void EveryConnectorAction_RequiresTenantSettings()
+    {
+        var ungated = new List<string>();
+        var checkedActions = 0;
+
+        foreach (var (controller, action) in SurfaceActions())
+        {
+            if (Ungated.ContainsKey($"{controller.Name}.{action.Name}"))
+                continue;
+
+            checkedActions++;
+
+            if (!RequiredScopes(controller, action).Contains(TenantPermissions.TenantSettings, StringComparer.Ordinal))
+                ungated.Add($"{controller.Name}.{action.Name}");
+        }
+
+        // Sanity: the scan must find the surface, or the assertion below passes vacuously.
+        // Thirteen actions carry the gate today: seven on ConfigurationController, two each on
+        // WebhookSettings and MyFitnessPalSettings, and one each on ConnectorStatus and
+        // CareLinkConnect.
+        checkedActions.Should().BeGreaterThan(10,
+            "the reflection scan should discover every action on the connector configuration surface");
+
+        ungated.Should().BeEmpty(
+            "reading or changing a connector's configuration is tenant administration, so it must "
+            + "carry [RequireScope(tenant.settings)] on the action or the class, or be listed in "
+            + "Ungated with a reason. Unprotected: " + string.Join("; ", ungated));
+    }
+
+    [Fact]
+    public void EveryUngatedEntry_NamesALiveAction()
+    {
+        // An entry left behind after its action was gated, renamed or deleted would silently excuse
+        // a future action that reuses the name.
+        var actions = SurfaceActions()
+            .Select(x => $"{x.Controller.Name}.{x.Action.Name}")
+            .ToHashSet(StringComparer.Ordinal);
+
+        Ungated.Keys.Should().BeSubsetOf(actions);
+    }
+
+    [Theory]
+    [InlineData(TenantPermissions.SeedRoles.Owner)]
+    [InlineData(TenantPermissions.SeedRoles.Admin)]
+    public void SeedRoleHoldingTenantSettings_KeepsTheWholeConnectorSurface(string role)
+    {
+        var scopes = SeedRoleScopes(role);
+
+        foreach (var (controller, action) in GatedActions())
+        {
+            Evaluate(controller, action, authenticated: true, scopes)
+                .Should().BeNull(
+                    $"the {role} role administers the tenant, so it must keep {controller.Name}.{action.Name}");
+        }
+    }
+
+    [Theory]
+    [InlineData(TenantPermissions.SeedRoles.Viewer)]
+    [InlineData(TenantPermissions.SeedRoles.Clinician)]
+    [InlineData(TenantPermissions.SeedRoles.Caretaker)]
+    public void SeedRoleWithoutTenantSettings_IsDeniedTheWholeConnectorSurface(string role)
+    {
+        var scopes = SeedRoleScopes(role);
+
+        scopes.Should().NotContain(TenantPermissions.TenantSettings);
+        scopes.Should().NotContain(OAuthScopes.FullAccess);
+
+        foreach (var (controller, action) in GatedActions())
+        {
+            Evaluate(controller, action, authenticated: true, scopes)
+                .Should().BeOfType<ForbidResult>(
+                    $"the {role} role holds no tenant.settings, so it must not reach "
+                    + $"{controller.Name}.{action.Name}");
+        }
+    }
+
+    [Fact]
+    public void ReadOnlyGuestSession_IsDeniedTheWholeConnectorSurface()
+    {
+        foreach (var (controller, action) in GatedActions())
+        {
+            Evaluate(controller, action, authenticated: true, GuestScopes())
+                .Should().BeOfType<ForbidResult>(
+                    $"a read-only guest session must not reach {controller.Name}.{action.Name}");
+        }
+    }
+
+    [Fact]
+    public void UnauthenticatedCaller_IsDeniedTheWholeConnectorSurface()
+    {
+        var tenantSettings = new HashSet<string> { TenantPermissions.TenantSettings };
+
+        foreach (var (controller, action) in GatedActions())
+        {
+            Evaluate(controller, action, authenticated: false, tenantSettings)
+                .Should().BeOfType<UnauthorizedResult>(
+                    $"{controller.Name}.{action.Name} must reject an unauthenticated caller");
+        }
+    }
+
+    [Fact]
+    public void WildcardGrant_KeepsTheWholeConnectorSurface()
+    {
+        // A legacy api-secret and an instance-key service credential both normalise to "*", and the
+        // provisioning paths that configure a connector for a tenant authenticate that way.
+        var wildcard = new HashSet<string> { OAuthScopes.FullAccess };
+
+        foreach (var (controller, action) in GatedActions())
+        {
+            Evaluate(controller, action, authenticated: true, wildcard)
+                .Should().BeNull($"a full-access grant must keep {controller.Name}.{action.Name}");
+        }
+    }
+
+    /// <summary>
+    /// A scoped credential cannot reach the connector surface however wide its membership, because
+    /// <c>tenant.settings</c> is outside <see cref="OAuthScopes.ValidRequestScopes"/> and
+    /// <see cref="MemberScopeResolver"/> re-normalises a credential's scopes through the request
+    /// vocabulary before intersecting. Pinned so the CareLink desktop token's premise — that its
+    /// bespoke scope reaches nothing else — stays true for every scoped credential.
+    /// </summary>
+    [Fact]
+    public void ScopedCredentialOnAnAdminMembership_IsDeniedTheWholeConnectorSurface()
+    {
+        var scopes = MemberScopeResolver.Resolve(
+            new HashSet<string>(TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin]),
+            AuthType.OAuthAccessToken,
+            OAuthScopes.Normalize([OAuthScopes.HealthReadWrite]).ToHashSet());
+
+        scopes.Should().NotContain(TenantPermissions.TenantSettings);
+
+        foreach (var (controller, action) in GatedActions())
+        {
+            Evaluate(controller, action, authenticated: true, scopes)
+                .Should().BeOfType<ForbidResult>(
+                    $"a consented OAuth grant must not reach {controller.Name}.{action.Name}");
+        }
+    }
+
+    // ── the CareLink flow, whose gate is in the handler ────────────────────────────────────────
+
+    [Theory]
+    [InlineData(TenantPermissions.SeedRoles.Viewer)]
+    [InlineData(TenantPermissions.SeedRoles.Caretaker)]
+    public async Task CareLinkFlow_RefusesASeedRoleWithoutTenantSettings(string role)
+    {
+        var controller = NewCareLinkController(SeedRoleScopes(role), credentialScopes: []);
+
+        (await controller.Start(new CareLinkConnectStartRequest { Server = "EU" }, default))
+            .Result.Should().BeOfType<ForbidResult>();
+        (await controller.Complete(new CareLinkConnectCompleteRequest { Code = "c", State = "s" }, default))
+            .Result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task CareLinkFlow_RefusesAReadOnlyGuestSession()
+    {
+        var controller = NewCareLinkController(GuestScopes(), credentialScopes: []);
+
+        (await controller.Start(new CareLinkConnectStartRequest { Server = "EU" }, default))
+            .Result.Should().BeOfType<ForbidResult>();
+        (await controller.Complete(new CareLinkConnectCompleteRequest { Code = "c", State = "s" }, default))
+            .Result.Should().BeOfType<ForbidResult>();
+    }
+
+    /// <summary>
+    /// An administrator and a desktop link token both get past the guard. Asserted by driving each
+    /// action into its own input validation — an unknown region, and a state with no cached flow —
+    /// which is the first thing after the guard and needs no network.
+    /// </summary>
+    [Fact]
+    public async Task CareLinkFlow_AdmitsAnAdministratorAndADesktopLinkToken()
+    {
+        var admin = NewCareLinkController(
+            SeedRoleScopes(TenantPermissions.SeedRoles.Admin), credentialScopes: []);
+
+        // The desktop token's scope survives no intersection, so its resolved scope set is empty.
+        var desktop = NewCareLinkController(
+            new HashSet<string>(), credentialScopes: ["connectors:carelink:connect"]);
+
+        foreach (var controller in new[] { admin, desktop })
+        {
+            (await controller.Start(new CareLinkConnectStartRequest { Server = "XX" }, default))
+                .Result.Should().BeOfType<BadRequestObjectResult>();
+            (await controller.Complete(new CareLinkConnectCompleteRequest { Code = "c", State = "s" }, default))
+                .Result.Should().BeOfType<BadRequestObjectResult>();
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────────────────────
+
+    private static IReadOnlySet<string> SeedRoleScopes(string role) =>
+        MemberScopeResolver.Resolve(
+            new HashSet<string>(TenantPermissions.SeedRolePermissions[role]),
+            AuthType.SessionCookie,
+            new HashSet<string>());
+
+    /// <summary>The widest grant a guest link can hold: <see cref="OAuthScopes.AllowedGuestScopes"/>, read-only.</summary>
+    private static IReadOnlySet<string> GuestScopes() =>
+        OAuthScopes.Normalize(
+            OAuthScopes.ValidateGrantScopes(OAuthScopes.AllowedGuestScopes, OAuthScopes.GrantTypeGuest));
+
+    private static IEnumerable<(Type Controller, MethodInfo Action)> SurfaceActions() =>
+        ConnectorSurface
+            .OrderBy(t => t.Name, StringComparer.Ordinal)
+            .SelectMany(c => Actions(c).Select(a => (Controller: c, Action: a)));
+
+    private static IEnumerable<(Type Controller, MethodInfo Action)> GatedActions() =>
+        SurfaceActions().Where(x => !Ungated.ContainsKey($"{x.Controller.Name}.{x.Action.Name}"));
+
+    /// <summary>The methods MVC would route: declared on the controller, not a property accessor.</summary>
+    private static IEnumerable<MethodInfo> Actions(Type controller) =>
+        controller.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => !m.IsSpecialName && m.GetCustomAttributes(inherit: true).OfType<IActionHttpMethodProvider>().Any())
+            .OrderBy(m => m.Name, StringComparer.Ordinal);
+
+    /// <summary>The scopes an action's gate requires, from the class and the action together.</summary>
+    private static IEnumerable<string> RequiredScopes(Type controller, MethodInfo action) =>
+        Filters(controller, action).OfType<RequireScopeAttribute>().SelectMany(a => a.Scopes);
+
+    private static object[] Filters(Type controller, MethodInfo action) =>
+        [.. controller.GetCustomAttributes(inherit: true), .. action.GetCustomAttributes(inherit: true)];
+
+    /// <summary>
+    /// Runs the authorization filters an action actually declares, class-level first as MVC orders
+    /// them. Returns the short-circuit result, or null when the request would reach the handler.
+    /// </summary>
+    private static IActionResult? Evaluate(
+        Type controller, MethodInfo action, bool authenticated, IReadOnlySet<string> grantedScopes)
+    {
+        var actionContext = new ActionContext(
+            NewHttpContext(authenticated, grantedScopes, credentialScopes: []),
+            new RouteData(),
+            new ActionDescriptor());
+
+        foreach (var filter in Filters(controller, action).OfType<IAuthorizationFilter>())
+        {
+            var authorizationContext = new AuthorizationFilterContext(actionContext, []);
+            filter.OnAuthorization(authorizationContext);
+            if (authorizationContext.Result is not null)
+                return authorizationContext.Result;
+        }
+
+        return null;
+    }
+
+    private static DefaultHttpContext NewHttpContext(
+        bool authenticated, IReadOnlySet<string> grantedScopes, string[] credentialScopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (authenticated)
+        {
+            httpContext.Items["AuthContext"] = new AuthContext
+            {
+                IsAuthenticated = true,
+                SubjectId = Guid.CreateVersion7(),
+                Scopes = [.. credentialScopes],
+            };
+        }
+
+        httpContext.Items["GrantedScopes"] = grantedScopes;
+        return httpContext;
+    }
+
+    private static CareLinkConnectController NewCareLinkController(
+        IReadOnlySet<string> grantedScopes, string[] credentialScopes)
+    {
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.SetupGet(a => a.Context)
+            .Returns(new TenantContext(Guid.CreateVersion7(), "acme", "Acme", IsActive: true, IsDemo: false));
+
+        return new CareLinkConnectController(
+            Mock.Of<IConnectorConfigurationService>(),
+            new MemoryCache(new MemoryCacheOptions()),
+            tenantAccessor.Object,
+            Mock.Of<IJwtService>(),
+            NullLoggerFactory.Instance,
+            NullLogger<CareLinkConnectController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = NewHttpContext(authenticated: true, grantedScopes, credentialScopes),
+            },
+        };
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -81,10 +81,29 @@ public class V4WriteScopeGatingTests
         public const string IdentityAndDelegation = "identity/delegation state, governed by RBAC atoms";
 
         /// <summary>
-        /// Configures a connector: credentials, cursors, sync triggers and webhook targets. The data
-        /// a sync then writes is written by the connector's own publish path, not by the caller.
+        /// Caller-supplied import of raw nutritional records from a connector's companion app
+        /// (MyFitnessPal, Glooko). It writes connector_food_entries, so it is a data write; which
+        /// write scope should govern it is an open question this entry records rather than answers.
         /// </summary>
-        public const string ConnectorAdministration = "connector configuration, not a data write";
+        public const string ConnectorFoodImport = "connector food-entry import; governing write scope undecided";
+
+        /// <summary>
+        /// Connector configuration, gated on <see cref="TenantPermissions.TenantSettings"/> — an
+        /// administration atom, absent from <see cref="OAuthScopes.AllScopes"/>, so no data-category
+        /// scope names it. Asserted per controller by
+        /// <see cref="EveryExemptionClaimingAnAttribute_ActuallyCarriesIt"/>, and behaviourally by
+        /// <see cref="ConnectorConfigurationScopeTests"/>.
+        /// </summary>
+        public const string TenantSettingsScope = "connector configuration, gated on tenant.settings";
+
+        /// <summary>
+        /// The same tenant-administration gate as <see cref="TenantSettingsScope"/>, enforced in the
+        /// handler because the action also admits the CareLink desktop link token, whose scope is
+        /// outside the OAuth vocabulary and resolves to an empty set — no attribute can express it.
+        /// Every controller filed under this must have a test that drives the real handler, which
+        /// <see cref="HandlerGuardedControllers_HaveABehaviouralTest"/> asserts.
+        /// </summary>
+        public const string ConnectorHandlerGuard = "tenant.settings enforced in the handler";
 
         /// <summary>
         /// POST whose handler computes and returns: a statistic over the values in the request
@@ -182,11 +201,13 @@ public class V4WriteScopeGatingTests
             ["SessionsController"] = NotDataCategory.IdentityAndDelegation,
             ["ShareLinkController"] = NotDataCategory.IdentityAndDelegation,
 
-            ["CareLinkConnectController"] = NotDataCategory.ConnectorAdministration,
-            ["ConfigurationController"] = NotDataCategory.ConnectorAdministration,
-            ["ConnectorFoodEntriesController"] = NotDataCategory.ConnectorAdministration,
-            ["MyFitnessPalSettingsController"] = NotDataCategory.ConnectorAdministration,
-            ["WebhookSettingsController"] = NotDataCategory.ConnectorAdministration,
+            ["ConnectorFoodEntriesController"] = NotDataCategory.ConnectorFoodImport,
+
+            ["ConfigurationController"] = NotDataCategory.TenantSettingsScope,
+            ["MyFitnessPalSettingsController"] = NotDataCategory.TenantSettingsScope,
+            ["WebhookSettingsController"] = NotDataCategory.TenantSettingsScope,
+
+            ["CareLinkConnectController"] = NotDataCategory.ConnectorHandlerGuard,
 
             ["DebugController"] = NotDataCategory.ComputesAndReturns,
             ["StatisticsController"] = NotDataCategory.ComputesAndReturns,
@@ -658,6 +679,9 @@ public class V4WriteScopeGatingTests
                     .OfType<AuthorizeAttribute>()
                     .Any(a => a.Roles?.Contains("platform_admin", StringComparison.Ordinal) == true),
                 NotDataCategory.TenantAdminAttribute => CarriesAttribute(controller, "RequireAdminAttribute"),
+                NotDataCategory.TenantSettingsScope => GovernsEveryWrite(controller,
+                    a => a is RequireScopeAttribute scope
+                         && scope.Scopes.Contains(TenantPermissions.TenantSettings, StringComparer.Ordinal)),
                 NotDataCategory.InstanceKey => attributes
                     .Any(a => a.GetType().Name == "RequireInstanceKeyAuthAttribute"),
                 NotDataCategory.DevelopmentOnly => controller.Namespace == V4Namespace + ".DevOnly",
@@ -675,13 +699,34 @@ public class V4WriteScopeGatingTests
     /// Whether the named attribute governs every write action on the controller — present on the
     /// class, or repeated on each write action.
     /// </summary>
-    private static bool CarriesAttribute(Type controller, string attributeTypeName)
-    {
-        bool Named(IEnumerable<object> attributes) =>
-            attributes.Any(a => a.GetType().Name == attributeTypeName);
+    private static bool CarriesAttribute(Type controller, string attributeTypeName) =>
+        GovernsEveryWrite(controller, a => a.GetType().Name == attributeTypeName);
 
-        return Named(controller.GetCustomAttributes(inherit: true))
-               || WriteActions(controller).All(a => Named(a.GetCustomAttributes(inherit: true)));
+    /// <summary>
+    /// Whether an attribute matching <paramref name="predicate"/> governs every write action on the
+    /// controller — present on the class, or repeated on each write action.
+    /// </summary>
+    private static bool GovernsEveryWrite(Type controller, Func<object, bool> predicate) =>
+        controller.GetCustomAttributes(inherit: true).Any(predicate)
+        || WriteActions(controller).All(a => a.GetCustomAttributes(inherit: true).Any(predicate));
+
+    /// <summary>
+    /// <see cref="NotDataCategory.ConnectorHandlerGuard"/> is a method call in the handler, which no
+    /// attribute scan can see — delete the call and the sweep stays green. So each controller filed
+    /// under it must be covered by a test that drives the real handler. That coverage is listed here
+    /// rather than discovered, so filing a controller under it without a behavioural test fails.
+    /// </summary>
+    [Fact]
+    public void HandlerGuardedControllers_HaveABehaviouralTest()
+    {
+        // ConnectorConfigurationScopeTests drives Start and Complete through the real handler.
+        var covered = new[] { "CareLinkConnectController" };
+
+        GateExemptControllers
+            .Where(entry => entry.Value == NotDataCategory.ConnectorHandlerGuard)
+            .Select(entry => entry.Key)
+            .Should().BeEquivalentTo(covered,
+                "every handler-guarded connector controller needs a test that drives its handler");
     }
 
     private static bool IsGateExempt(Type controller, MethodInfo action) =>


### PR DESCRIPTION
The connector configuration controllers carried only a class-level `[Authorize]`, so any authenticated credential could read and change them — including a read-scoped membership or a guest session. `ConfigurationController`, `ConnectorStatusController`, `WebhookSettingsController`'s writes and `MyFitnessPalSettingsController` now require `TenantPermissions.TenantSettings` through `[RequireScope]`.

`tenant.settings` rather than `[RequireAdmin]`: the latter resolves against the `PermissionTrie`, which `ScopeTranslator` never populates with a tenant-administration atom, so it is satisfied only by a superuser membership and would lock the Administrator role out of the settings it is granted `tenant.settings` for. The atom is also outside `ValidRequestScopes`, so `MemberScopeResolver` keeps it off every consented OAuth grant.

Deliberately left open: the connector schema route (connector metadata, anonymous so the setup wizard can render the form before there is a tenant) and the webhook settings GET (a fixed disabled stub). `CareLinkConnect`'s `start`/`complete` enforce the same permission in the handler rather than by attribute, because they also admit the desktop companion's link token, whose bespoke scope resolves to an empty scope set; minting that token now requires the permission.

Callers were checked across the SvelteKit app first — every live consumer is the connector settings area or the first-run setup wizard, so no patient-facing dashboard loses a read.

`V4WriteScopeGatingTests`' exemption map now names the new mechanism and asserts it per controller; `ConnectorConfigurationScopeTests` covers the seed roles, a guest session, an unauthenticated caller, a scoped OAuth grant and the desktop link token. Mutation-proven by removing three gates and confirming 11 test failures.
