### PR TITLE
fix(api): rate limit the statistics compute endpoints

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Nocturne.API.Attributes;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Analytics;
@@ -22,8 +24,8 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 /// time-in-range, glycemic variability, GMI, GRI, basal/bolus ratios, and AID system metrics.
 /// </summary>
 /// <remarks>
-/// Several computation endpoints accept large payloads (up to 100 MB) to accommodate
-/// 90-day datasets. These are decorated with <c>[RequestSizeLimit(100 * 1024 * 1024)]</c>.
+/// Several computation endpoints accept large payloads and are decorated with
+/// <c>[RequestSizeLimit(ComputeBodyLimitBytes)]</c>.
 ///
 /// <c>GET /periods</c> and <c>GET /basal-analysis</c> fetch data directly from the database
 /// using the injected V4 repositories, apply profile-based scheduled-basal fallback when no
@@ -44,6 +46,13 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 [Produces("application/json")]
 public class StatisticsController : ControllerBase
 {
+    /// <summary>
+    /// Body ceiling for the actions that compute over a caller-supplied collection. A report
+    /// covering a year posts every reading in the range in one body, so the bound is set by the
+    /// longest range a report can ask for rather than by a typical request.
+    /// </summary>
+    public const int ComputeBodyLimitBytes = 100 * 1024 * 1024;
+
     private readonly IStatisticsService _statisticsService;
     private readonly ICacheService _cacheService;
     private readonly IProfileProjectionService _profileProjectionService;
@@ -114,6 +123,7 @@ public class StatisticsController : ControllerBase
     /// <param name="values">Array of glucose values in mg/dL</param>
     /// <returns>Basic glucose statistics including mean, median, percentiles, etc.</returns>
     [HttpPost("basic-stats")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     public ActionResult<BasicGlucoseStats> CalculateBasicStats([FromBody] double[] values)
     {
@@ -134,6 +144,7 @@ public class StatisticsController : ControllerBase
     /// <param name="request">Request containing glucose values and entries</param>
     /// <returns>Comprehensive glycemic variability metrics</returns>
     [HttpPost("glycemic-variability")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     public ActionResult<GlycemicVariability> CalculateGlycemicVariability(
         [FromBody] GlycemicVariabilityRequest request
@@ -159,9 +170,10 @@ public class StatisticsController : ControllerBase
     /// <param name="request">Request containing entries and optional thresholds</param>
     /// <returns>Time in range metrics including percentages, durations, and episodes</returns>
     [HttpPost("time-in-range")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     [RemoteQuery]
-    [RequestSizeLimit(100 * 1024 * 1024)] // 100 MB
+    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<TimeInRangeMetrics> CalculateTimeInRange(
         [FromBody] TimeInRangeRequest request
     )
@@ -186,8 +198,9 @@ public class StatisticsController : ControllerBase
     /// <param name="request">Request containing entries and optional bins</param>
     /// <returns>Collection of distribution data points</returns>
     [HttpPost("glucose-distribution")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
-    [RequestSizeLimit(100 * 1024 * 1024)] // 100 MB
+    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<IEnumerable<DistributionDataPoint>> CalculateGlucoseDistribution(
         [FromBody] GlucoseDistributionRequest request
     )
@@ -212,9 +225,10 @@ public class StatisticsController : ControllerBase
     /// <param name="entries">Array of sensor glucose readings</param>
     /// <returns>Collection of averaged statistics for each hour</returns>
     [HttpPost("averaged-stats")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     [RemoteQuery]
-    [RequestSizeLimit(100 * 1024 * 1024)] // 100 MB
+    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<IEnumerable<AveragedStats>> CalculateAveragedStats(
         [FromBody] SensorGlucose[] entries
     )
@@ -236,6 +250,7 @@ public class StatisticsController : ControllerBase
     /// <param name="request">Request containing boluses and carb intakes</param>
     /// <returns>Treatment summary with totals and counts</returns>
     [HttpPost("treatment-summary")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     public ActionResult<TreatmentSummary> CalculateTreatmentSummary(
         [FromBody] TreatmentSummaryRequest request
@@ -261,6 +276,7 @@ public class StatisticsController : ControllerBase
     /// <param name="dailyDataPoints">Array of daily data points</param>
     /// <returns>Overall averages or null if no data</returns>
     [HttpPost("overall-averages")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     public ActionResult<OverallAverages> CalculateOverallAverages(
         [FromBody] DayData[] dailyDataPoints
@@ -287,8 +303,9 @@ public class StatisticsController : ControllerBase
     /// <param name="request">Request containing sensor glucose readings, boluses, carb intakes, and configuration</param>
     /// <returns>Comprehensive glucose analytics</returns>
     [HttpPost("comprehensive-analytics")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
-    [RequestSizeLimit(100 * 1024 * 1024)] // 100 MB
+    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<GlucoseAnalytics> AnalyzeGlucoseData(
         [FromBody] GlucoseAnalyticsRequest request
     )
@@ -315,8 +332,9 @@ public class StatisticsController : ControllerBase
     /// <param name="request">Request containing sensor glucose readings, boluses, carb intakes, population type, and configuration</param>
     /// <returns>Extended glucose analytics with modern clinical metrics</returns>
     [HttpPost("extended-analytics")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
-    [RequestSizeLimit(100 * 1024 * 1024)] // 100 MB - needed for large datasets (90+ days)
+    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<ExtendedGlucoseAnalytics> AnalyzeGlucoseDataExtended(
         [FromBody] ExtendedGlucoseAnalyticsRequest request
     )
@@ -511,6 +529,7 @@ public class StatisticsController : ControllerBase
     /// <param name="timeInRange">Time in range metrics</param>
     /// <returns>GRI with score, zone, and interpretation</returns>
     [HttpPost("gri")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     public ActionResult<GlycemicRiskIndex> CalculateGRI([FromBody] TimeInRangeMetrics timeInRange)
     {
@@ -531,6 +550,7 @@ public class StatisticsController : ControllerBase
     /// <param name="request">Request containing analytics and population type</param>
     /// <returns>Clinical target assessment with actionable insights</returns>
     [HttpPost("clinical-assessment")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     public ActionResult<ClinicalTargetAssessment> AssessAgainstTargets(
         [FromBody] ClinicalAssessmentRequest request
@@ -556,6 +576,7 @@ public class StatisticsController : ControllerBase
     /// <param name="request">Request containing entries and optional period settings</param>
     /// <returns>Data sufficiency assessment</returns>
     [HttpPost("data-sufficiency")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     public ActionResult<DataSufficiencyAssessment> AssessDataSufficiency(
         [FromBody] DataSufficiencyRequest request
@@ -702,6 +723,7 @@ public class StatisticsController : ControllerBase
     /// <param name="treatment">Treatment to validate</param>
     /// <returns>True if treatment data is valid</returns>
     [HttpPost("validate/treatment")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     public ActionResult<bool> ValidateTreatmentData([FromBody] Treatment treatment)
     {
@@ -722,6 +744,7 @@ public class StatisticsController : ControllerBase
     /// <param name="treatments">Array of treatments to clean</param>
     /// <returns>Cleaned collection of treatments</returns>
     [HttpPost("clean/treatments")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
     public ActionResult<IEnumerable<Treatment>> CleanTreatmentData(
         [FromBody] Treatment[] treatments
@@ -975,8 +998,9 @@ public class StatisticsController : ControllerBase
     /// <param name="request">Request containing sensor glucose readings, device events, and analysis parameters</param>
     /// <returns>Site change impact analysis with averaged glucose patterns</returns>
     [HttpPost("site-change-impact")]
+    [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(OAuthScopes.ReportsRead)]
-    [RequestSizeLimit(100 * 1024 * 1024)] // 100 MB
+    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<SiteChangeImpactAnalysis> CalculateSiteChangeImpact(
         [FromBody] SiteChangeImpactRequest request
     )

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -92,6 +92,25 @@ public static class ServiceRegistrationExtensions
     public const string DocsRateLimitPolicy = "docs";
 
     /// <summary>
+    /// Rate-limiting policy for the statistics actions that compute over a caller-supplied body.
+    /// Named here rather than inline so the guard test asserting every one of them carries it
+    /// reads the same value the registration does.
+    /// </summary>
+    public const string StatisticsComputeRateLimitPolicy = "statistics-compute";
+
+    /// <summary>
+    /// Partition key for <see cref="StatisticsComputeRateLimitPolicy"/>: the request host, lowered.
+    /// </summary>
+    /// <remarks>
+    /// A host is case-insensitive and tenant resolution lower-cases the subdomain it reads, so a
+    /// caller sending the same host in another casing reaches the same tenant. Keying on the raw
+    /// string would hand them a fresh window per variant, and the caller this policy bounds — an
+    /// anonymous share-link holder — writes the header themselves.
+    /// </remarks>
+    internal static string StatisticsComputePartitionKey(HttpContext context) =>
+        context.Request.Host.Host.ToLowerInvariant();
+
+    /// <summary>
     /// Core API utility and calculation services (status, versioning, time queries,
     /// IOB/COB, predictions, statistics, etc.)
     /// </summary>
@@ -427,6 +446,27 @@ public static class ServiceRegistrationExtensions
                         factory: _ => new FixedWindowRateLimiterOptions
                         {
                             PermitLimit = 30,
+                            Window = TimeSpan.FromMinutes(1),
+                            QueueLimit = 0,
+                        }
+                    )
+            );
+
+            // Statistics compute POSTs: 60 per tenant host per minute. These actions compute over a
+            // caller-supplied body rather than over stored data, and reports.read — the scope
+            // gating them — is held by every public share link, so an anonymous viewer can post
+            // them. The partition is the Host rather than the IP because the limiter runs before
+            // tenant resolution, the tenant (or share token) is the subdomain, and the browser does
+            // not reach these actions directly: the SvelteKit server calls them, so every tenant's
+            // traffic arrives from one address.
+            options.AddPolicy(
+                StatisticsComputeRateLimitPolicy,
+                context =>
+                    RateLimitPartition.GetFixedWindowLimiter(
+                        partitionKey: StatisticsComputePartitionKey(context),
+                        factory: _ => new FixedWindowRateLimiterOptions
+                        {
+                            PermitLimit = 60,
                             Window = TimeSpan.FromMinutes(1),
                             QueueLimit = 0,
                         }

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -346,8 +346,8 @@ app.UseRouting();
 // Ahead of the documentation branch below, which jumps straight to its endpoint and would
 // otherwise skip the limiter entirely; the policies are attached to endpoints, so this needs
 // UseRouting to have run. Everything without a policy passes through untouched, and every
-// policy that exists partitions on the remote address alone, so none of their accounting
-// depends on running after UseAuthorization.
+// policy that exists partitions on pre-auth request data (the remote address or the Host),
+// so none of their accounting depends on running after UseAuthorization.
 app.UseRateLimiter();
 
 app.UseMiddleware<PublicDocsMiddleware>();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.API.Extensions;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Analytics;
+
+/// <summary>
+/// Guards the bounds on the statistics actions that compute over a caller-supplied body.
+/// </summary>
+/// <remarks>
+/// These actions are gated on <c>reports.read</c>, which every public share link holds, so an
+/// anonymous viewer can reach them; nothing they compute is stored, so what a caller spends is
+/// the API's CPU and the bytes it reads. The sweep pins the rule rather than today's action list,
+/// so a new compute POST that ships without the policy fails here.
+/// </remarks>
+public class StatisticsComputeLimitTests
+{
+    [Fact]
+    public void EveryStatisticsComputePost_CarriesTheComputeRateLimitPolicy()
+    {
+        var actions = ComputePosts();
+
+        // A sweep that discovers nothing would pass while guarding nothing.
+        actions.Should().HaveCountGreaterThan(10,
+            "the scan should discover the statistics actions that take a body");
+
+        var uncovered = actions
+            .Where(a => a.GetCustomAttribute<EnableRateLimitingAttribute>()?.PolicyName
+                        != ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)
+            .Select(a => a.Name)
+            .ToList();
+
+        uncovered.Should().BeEmpty(
+            "an action computing over a caller-supplied body must be rate limited, or a share link "
+            + "holder can spend the API's CPU without bound. Uncovered: " + string.Join(", ", uncovered));
+    }
+
+    [Fact]
+    public void TheComputePartitionKey_IsTheSameForEitherCasingOfAHost()
+    {
+        const string host = "AbC123.share.example.com";
+
+        var upper = ServiceRegistrationExtensions.StatisticsComputePartitionKey(
+            ContextFor(host));
+        var lower = ServiceRegistrationExtensions.StatisticsComputePartitionKey(
+            ContextFor(host.ToLowerInvariant()));
+
+        upper.Should().Be(lower,
+            "a host is case-insensitive, so a caller writing its own Host header would otherwise "
+            + "get a fresh window per casing of the same tenant");
+    }
+
+    private static HttpContext ContextFor(string host)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Host = new HostString(host);
+        return context;
+    }
+
+    /// <summary>
+    /// The declared body limit has to cover the largest range a report can ask for: the web client
+    /// pages every reading in the range into one <c>site-change-impact</c> post, so a year of
+    /// 5-minute readings from one CGM arrives in a single body.
+    /// </summary>
+    [Fact]
+    public void TheDeclaredBodyLimit_CoversAYearOfReadings()
+    {
+        const int readingsPerYear = 365 * 24 * 12;
+
+        ComputePosts()
+            .Count(a => a.GetCustomAttribute<RequestSizeLimitAttribute>() is not null)
+            .Should().BeGreaterThan(0, "the collection-taking posts declare a body ceiling");
+
+        (readingsPerYear * (long)SerializedReadingBytes()).Should()
+            .BeLessThan(StatisticsController.ComputeBodyLimitBytes,
+            "a year-long report legitimately posts every reading in the range, so a lower bound "
+            + "would fail the report rather than an abusive caller");
+    }
+
+    /// <summary>
+    /// One reading as the client posts it back: every field populated, MVC's serializer settings,
+    /// and the null fields still written out.
+    /// </summary>
+    private static int SerializedReadingBytes()
+    {
+        var reading = new SensorGlucose
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow,
+            UtcOffset = 600,
+            Device = "Dexcom G7 (Nocturne Connect)",
+            App = "nocturne-connect",
+            DataSource = "dexcom-share",
+            CorrelationId = Guid.NewGuid(),
+            PatientDeviceId = Guid.NewGuid(),
+            LegacyId = "6650f3b1a2c4d5e6f7089abc",
+            SyncIdentifier = "dexcom:6650f3b1a2c4d5e6f7089abc",
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            Mgdl = 123.45678,
+            Direction = GlucoseDirection.Flat,
+            TrendRate = 0.123456,
+            Noise = 1,
+            Filtered = 123456.789,
+            Unfiltered = 123456.789,
+            Delta = -1.2345,
+            SmoothedMgdl = 123.456789,
+            UnsmoothedMgdl = 123.456789,
+        };
+
+        return JsonSerializer
+            .SerializeToUtf8Bytes(reading, new JsonSerializerOptions(JsonSerializerDefaults.Web))
+            .Length;
+    }
+
+    private static List<MethodInfo> ComputePosts() =>
+        typeof(StatisticsController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetCustomAttributes<HttpPostAttribute>().Any())
+            .ToList();
+}


### PR DESCRIPTION
The POST actions on `StatisticsController` compute over a caller-supplied body rather than over stored data, and they are gated on `reports.read` — a scope that both `TenantPermissions.PublicShareScopes` and `OAuthScopes.AllowedGuestScopes` grant, and which `RequireScopeAttribute` admits an unauthenticated principal for. Anyone holding a reports-granted share link could post large synthetic payloads to them repeatedly. Nothing is disclosed and nothing is stored; what a caller spends is CPU and ingest.

Every POST on the controller now carries a named rate-limit policy (60 per minute, fixed window, sharing the existing 429 rejection handler). The partition key is the request Host rather than the remote IP that the other policies use, for two reasons: `UseRateLimiter` runs ahead of tenant resolution and authentication, so there is no subject or tenant to key on yet; and the browser does not call these actions directly — the SvelteKit server does, so every tenant's traffic arrives from one address. The Host carries the tenant subdomain or the share token, and the key is lower-cased to match the case-insensitive subdomain resolution, so casing variants of one host share one window. A sweep test asserts the policy is present on every POST, so a new compute action cannot ship uncovered, and the key selector is pinned case-insensitive.

The body limit was re-checked against what the web app actually posts and left where it is. A fully-populated `SensorGlucose` serializes to 849 bytes, and the only caller that pages an entire range into one body (`site-change-impact`) posts every reading in it — a year from one CGM is ~105k readings, about 85 MB. A tighter ceiling would fail a long-range report rather than an abusive caller. The six duplicated `100 * 1024 * 1024` literals collapse into one `ComputeBodyLimitBytes` constant, and a test pins that a year of readings still fits under it.
