### PR TITLE
feat(auth): platform-admin endpoints for tenant-scoped direct grants

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/DirectGrantController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/DirectGrantController.cs
@@ -71,7 +71,7 @@ public class DirectGrantController : ControllerBase
             _dbContext, auth.SubjectId.Value, request.Label, request.Scopes,
             HttpContext.Connection.RemoteIpAddress?.ToString(),
             Request.Headers.UserAgent.ToString(),
-            HttpContext.RequestAborted);
+            ct: HttpContext.RequestAborted);
 
         if (result.Error != null)
         {
@@ -126,7 +126,7 @@ public class DirectGrantController : ControllerBase
             _dbContext, id, auth.SubjectId.Value,
             HttpContext.Connection.RemoteIpAddress?.ToString(),
             Request.Headers.UserAgent.ToString(),
-            HttpContext.RequestAborted);
+            ct: HttpContext.RequestAborted);
 
         if (!found)
         {

--- a/src/API/Nocturne.API/Controllers/Authentication/DirectGrantController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/DirectGrantController.cs
@@ -1,14 +1,10 @@
-using System.Security.Cryptography;
-using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Extensions;
 using Nocturne.API.Middleware.Handlers;
-using Nocturne.Connectors.Core.Utilities;
+using Nocturne.API.Services.Auth;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
-using Nocturne.Infrastructure.Data.Entities;
 
 namespace Nocturne.API.Controllers.Authentication;
 
@@ -30,34 +26,27 @@ namespace Nocturne.API.Controllers.Authentication;
 /// All mutations are audit-logged through <see cref="IAuthAuditService"/>.
 /// </remarks>
 /// <seealso cref="DirectGrantTokenHandler"/>
-/// <seealso cref="IAuthAuditService"/>
+/// <seealso cref="IDirectGrantService"/>
 /// <seealso cref="OAuthScopes"/>
 [ApiController]
 [Route("api/auth/direct-grants")]
 [Tags("Authentication")]
 public class DirectGrantController : ControllerBase
 {
-    private const string TokenPrefix = "noc_";
-    private const int TokenRandomBytes = 32;
-
     private readonly NocturneDbContext _dbContext;
-    private readonly IAuthAuditService _auditService;
-    private readonly ILogger<DirectGrantController> _logger;
+    private readonly IDirectGrantService _directGrantService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DirectGrantController"/> class.
     /// </summary>
     /// <param name="dbContext">The application database context used to read and write grant records.</param>
-    /// <param name="auditService">The audit service for recording token issuance and revocation events.</param>
-    /// <param name="logger">The logger.</param>
+    /// <param name="directGrantService">The service that creates, lists, and revokes direct grants.</param>
     public DirectGrantController(
         NocturneDbContext dbContext,
-        IAuthAuditService auditService,
-        ILogger<DirectGrantController> logger)
+        IDirectGrantService directGrantService)
     {
         _dbContext = dbContext;
-        _auditService = auditService;
-        _logger = logger;
+        _directGrantService = directGrantService;
     }
 
     /// <summary>
@@ -78,70 +67,18 @@ public class DirectGrantController : ControllerBase
             return Problem(detail: "Authentication required", statusCode: 401, title: "Unauthorized");
         }
 
-        if (string.IsNullOrWhiteSpace(request.Label))
+        var result = await _directGrantService.CreateAsync(
+            _dbContext, auth.SubjectId.Value, request.Label, request.Scopes,
+            HttpContext.Connection.RemoteIpAddress?.ToString(),
+            Request.Headers.UserAgent.ToString(),
+            HttpContext.RequestAborted);
+
+        if (result.Error != null)
         {
-            return Problem(detail: "Label is required", statusCode: 400, title: "Bad Request");
+            return Problem(detail: result.Error, statusCode: 400, title: "Bad Request");
         }
 
-        if (request.Scopes == null || request.Scopes.Count == 0)
-        {
-            return Problem(detail: "At least one scope is required", statusCode: 400, title: "Bad Request");
-        }
-
-        var normalizedScopes = OAuthScopes.Normalize(request.Scopes).ToList();
-        if (normalizedScopes.Count == 0)
-        {
-            return Problem(detail: "No valid scopes provided", statusCode: 400, title: "Bad Request");
-        }
-
-        // Generate opaque token
-        var randomBytes = RandomNumberGenerator.GetBytes(TokenRandomBytes);
-        var plaintextToken = TokenPrefix + Base64UrlEncode(randomBytes);
-        var tokenHash = DirectGrantTokenHandler.ComputeSha256Hex(plaintextToken);
-
-        var entity = new OAuthGrantEntity
-        {
-            Id = Guid.CreateVersion7(),
-            ClientEntityId = null,
-            SubjectId = auth.SubjectId.Value,
-            GrantType = OAuthGrantTypes.Direct,
-            Scopes = normalizedScopes,
-            Label = request.Label,
-            TokenHash = tokenHash,
-            // Also store the SHA-1 of the token so uploaders that use the legacy Nightscout
-            // api-secret protocol (Loop, AAPS, Trio, iAPS) — which pre-hash the value with SHA-1
-            // before sending — authenticate with this same token via ApiKeyHandler's legacy path.
-            LegacySecretHash = HashUtils.Sha1Hex(plaintextToken),
-            CreatedAt = DateTime.UtcNow,
-        };
-
-        if (request.ExpiresAt.HasValue)
-        {
-            // Store expiration as part of the grant metadata
-            // Note: Direct grants don't have a built-in expiry field,
-            // but we can track it in the label or via a separate mechanism
-        }
-
-        _dbContext.OAuthGrants.Add(entity);
-        await _dbContext.SaveChangesAsync();
-
-        _logger.LogInformation(
-            "DirectGrantAudit: {Event} grant_id={GrantId} subject_id={SubjectId} scopes={Scopes}",
-            "direct_grant_created", entity.Id, auth.SubjectId.Value, string.Join(" ", normalizedScopes));
-
-        await _auditService.LogAsync(AuthAuditEventType.TokenIssued, auth.SubjectId.Value, success: true,
-            ipAddress: HttpContext.Connection.RemoteIpAddress?.ToString(),
-            userAgent: Request.Headers.UserAgent.ToString(),
-            detailsJson: JsonSerializer.Serialize(new { method = "direct_grant", grant_id = entity.Id }));
-
-        return Ok(new CreateDirectGrantResponse
-        {
-            Id = entity.Id,
-            Token = plaintextToken,
-            Label = entity.Label!,
-            Scopes = normalizedScopes,
-            CreatedAt = entity.CreatedAt,
-        });
+        return Ok(result.Response);
     }
 
     /// <summary>
@@ -161,22 +98,8 @@ public class DirectGrantController : ControllerBase
             return Problem(detail: "Authentication required", statusCode: 401, title: "Unauthorized");
         }
 
-        var grants = await _dbContext.OAuthGrants
-            .AsNoTracking()
-            .Where(g => g.SubjectId == auth.SubjectId.Value
-                     && g.GrantType == OAuthGrantTypes.Direct
-                     && g.RevokedAt == null)
-            .OrderByDescending(g => g.CreatedAt)
-            .Select(g => new DirectGrantDto
-            {
-                Id = g.Id,
-                Label = g.Label ?? string.Empty,
-                Scopes = g.Scopes,
-                CreatedAt = g.CreatedAt,
-                LastUsedAt = g.LastUsedAt,
-                IsLegacy = g.IsMigrated,
-            })
-            .ToListAsync();
+        var grants = await _directGrantService.ListAsync(
+            _dbContext, auth.SubjectId.Value, HttpContext.RequestAborted);
 
         return Ok(grants);
     }
@@ -199,43 +122,18 @@ public class DirectGrantController : ControllerBase
             return Problem(detail: "Authentication required", statusCode: 401, title: "Unauthorized");
         }
 
-        var grant = await _dbContext.OAuthGrants
-            .Where(g => g.Id == id
-                     && g.SubjectId == auth.SubjectId.Value
-                     && g.GrantType == OAuthGrantTypes.Direct)
-            .FirstOrDefaultAsync();
+        var found = await _directGrantService.RevokeAsync(
+            _dbContext, id, auth.SubjectId.Value,
+            HttpContext.Connection.RemoteIpAddress?.ToString(),
+            Request.Headers.UserAgent.ToString(),
+            HttpContext.RequestAborted);
 
-        if (grant == null)
+        if (!found)
         {
             return Problem(detail: "Direct grant not found", statusCode: 404, title: "Not Found");
         }
 
-        if (grant.RevokedAt.HasValue)
-        {
-            return NoContent(); // Already revoked, idempotent
-        }
-
-        grant.RevokedAt = DateTime.UtcNow;
-        await _dbContext.SaveChangesAsync();
-
-        _logger.LogInformation(
-            "DirectGrantAudit: {Event} grant_id={GrantId} subject_id={SubjectId}",
-            "direct_grant_revoked", id, auth.SubjectId.Value);
-
-        await _auditService.LogAsync(AuthAuditEventType.TokenRevoked, auth.SubjectId.Value, success: true,
-            ipAddress: HttpContext.Connection.RemoteIpAddress?.ToString(),
-            userAgent: Request.Headers.UserAgent.ToString(),
-            detailsJson: JsonSerializer.Serialize(new { grant_id = id }));
-
         return NoContent();
-    }
-
-    private static string Base64UrlEncode(byte[] bytes)
-    {
-        return Convert.ToBase64String(bytes)
-            .TrimEnd('=')
-            .Replace('+', '-')
-            .Replace('/', '_');
     }
 }
 
@@ -269,6 +167,7 @@ public class CreateDirectGrantResponse
 public class DirectGrantDto
 {
     public Guid Id { get; set; }
+    public Guid SubjectId { get; set; }
     public string Label { get; set; } = string.Empty;
     public List<string> Scopes { get; set; } = new();
     public DateTime CreatedAt { get; set; }

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantDirectGrantController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantDirectGrantController.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Authorization;
 using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Extensions;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
@@ -72,7 +73,8 @@ public class TenantDirectGrantController : ControllerBase
             dbContext, request.SubjectId, request.Label, request.Scopes,
             HttpContext.Connection.RemoteIpAddress?.ToString(),
             Request.Headers.UserAgent.ToString(),
-            ct);
+            actor: CallerDescription(),
+            ct: ct);
 
         if (result.Error != null)
         {
@@ -116,7 +118,8 @@ public class TenantDirectGrantController : ControllerBase
             dbContext, grantId, subjectId: null,
             HttpContext.Connection.RemoteIpAddress?.ToString(),
             Request.Headers.UserAgent.ToString(),
-            ct);
+            actor: CallerDescription(),
+            ct: ct);
 
         if (!found)
         {
@@ -124,6 +127,16 @@ public class TenantDirectGrantController : ControllerBase
         }
 
         return NoContent();
+    }
+
+    /// <summary>
+    /// Describes the platform-admin caller for the audit trail: their subject ID, or the auth
+    /// type (e.g. <c>InstanceKey</c>) for callers with no subject of their own.
+    /// </summary>
+    private string CallerDescription()
+    {
+        var auth = HttpContext.GetAuthContext();
+        return auth?.SubjectId?.ToString() ?? auth?.AuthType.ToString() ?? "unknown";
     }
 }
 

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantDirectGrantController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantDirectGrantController.cs
@@ -1,0 +1,137 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OpenApi.Remote.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
+
+namespace Nocturne.API.Controllers.V4.PlatformAdmin;
+
+/// <summary>
+/// Platform-admin controller for managing a tenant's direct grant tokens.
+/// </summary>
+/// <remarks>
+/// Lets a platform administrator (including instance-key callers, which have no subject of their
+/// own) mint, list, and revoke direct grants on behalf of a tenant member — for example an
+/// external provisioner issuing a tenant-scoped API token at provision time. The grant is issued
+/// to an explicit subject, who must be a member of the tenant. Token generation and storage are
+/// shared with the self-service <see cref="DirectGrantController"/> via
+/// <see cref="IDirectGrantService"/>.
+/// </remarks>
+/// <seealso cref="IDirectGrantService"/>
+/// <seealso cref="DirectGrantController"/>
+[ApiController]
+[Tags("PlatformAdmin")]
+[Route("api/v4/admin/tenants/{tenantId:guid}/direct-grants")]
+[Produces("application/json")]
+[Authorize(Roles = "platform_admin")]
+[AllowDuringSetup]
+public class TenantDirectGrantController : ControllerBase
+{
+    private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
+    private readonly ITenantMemberService _tenantMemberService;
+    private readonly IDirectGrantService _directGrantService;
+
+    public TenantDirectGrantController(
+        IDbContextFactory<NocturneDbContext> dbContextFactory,
+        ITenantMemberService tenantMemberService,
+        IDirectGrantService directGrantService)
+    {
+        _dbContextFactory = dbContextFactory;
+        _tenantMemberService = tenantMemberService;
+        _directGrantService = directGrantService;
+    }
+
+    /// <summary>
+    /// Create a direct grant for a member of the tenant. The plaintext token is returned once
+    /// and cannot be retrieved again.
+    /// </summary>
+    /// <param name="tenantId">The tenant the grant is bound to.</param>
+    /// <param name="request">The subject to issue the grant to, plus label and scopes.</param>
+    /// <returns>A <see cref="CreateDirectGrantResponse"/> containing the grant ID and the single-use plaintext token.</returns>
+    [HttpPost]
+    [RemoteCommand(Invalidates = ["List"])]
+    [ProducesResponseType(typeof(CreateDirectGrantResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<CreateDirectGrantResponse>> Create(
+        Guid tenantId, [FromBody] AdminCreateDirectGrantRequest request, CancellationToken ct)
+    {
+        if (!await _tenantMemberService.IsMemberAsync(request.SubjectId, tenantId, ct))
+        {
+            return Problem(
+                detail: "Subject is not a member of this tenant", statusCode: 400, title: "Bad Request");
+        }
+
+        await using var dbContext = await _dbContextFactory.CreateTenantPinnedContextAsync(tenantId, ct);
+
+        var result = await _directGrantService.CreateAsync(
+            dbContext, request.SubjectId, request.Label, request.Scopes,
+            HttpContext.Connection.RemoteIpAddress?.ToString(),
+            Request.Headers.UserAgent.ToString(),
+            ct);
+
+        if (result.Error != null)
+        {
+            return Problem(detail: result.Error, statusCode: 400, title: "Bad Request");
+        }
+
+        return Ok(result.Response);
+    }
+
+    /// <summary>
+    /// List all active direct grants on the tenant, across all its members.
+    /// Never returns the token itself.
+    /// </summary>
+    /// <param name="tenantId">The tenant whose grants to list.</param>
+    [HttpGet]
+    [RemoteQuery]
+    [ProducesResponseType(typeof(List<DirectGrantDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<List<DirectGrantDto>>> List(Guid tenantId, CancellationToken ct)
+    {
+        await using var dbContext = await _dbContextFactory.CreateTenantPinnedContextAsync(tenantId, ct);
+
+        var grants = await _directGrantService.ListAsync(dbContext, subjectId: null, ct);
+        return Ok(grants);
+    }
+
+    /// <summary>
+    /// Revoke a direct grant on the tenant. This operation is idempotent.
+    /// </summary>
+    /// <param name="tenantId">The tenant the grant belongs to.</param>
+    /// <param name="grantId">The GUID of the grant to revoke.</param>
+    /// <returns><c>204 No Content</c> on success (including when already revoked); <c>404 Not Found</c> if the grant does not exist on the tenant.</returns>
+    [HttpDelete("{grantId:guid}")]
+    [RemoteCommand(Invalidates = ["List"])]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Revoke(Guid tenantId, Guid grantId, CancellationToken ct)
+    {
+        await using var dbContext = await _dbContextFactory.CreateTenantPinnedContextAsync(tenantId, ct);
+
+        var found = await _directGrantService.RevokeAsync(
+            dbContext, grantId, subjectId: null,
+            HttpContext.Connection.RemoteIpAddress?.ToString(),
+            Request.Headers.UserAgent.ToString(),
+            ct);
+
+        if (!found)
+        {
+            return Problem(detail: "Direct grant not found", statusCode: 404, title: "Not Found");
+        }
+
+        return NoContent();
+    }
+}
+
+/// <summary>
+/// Request to create a direct grant for an explicit subject on a tenant.
+/// </summary>
+public class AdminCreateDirectGrantRequest : CreateDirectGrantRequest
+{
+    /// <summary>The tenant member the grant is issued to.</summary>
+    public Guid SubjectId { get; set; }
+}

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantDirectGrantController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantDirectGrantController.cs
@@ -53,6 +53,7 @@ public class TenantDirectGrantController : ControllerBase
     /// </summary>
     /// <param name="tenantId">The tenant the grant is bound to.</param>
     /// <param name="request">The subject to issue the grant to, plus label and scopes.</param>
+    /// <param name="ct">The cancellation token.</param>
     /// <returns>A <see cref="CreateDirectGrantResponse"/> containing the grant ID and the single-use plaintext token.</returns>
     [HttpPost]
     [RemoteCommand(Invalidates = ["List"])]
@@ -89,6 +90,8 @@ public class TenantDirectGrantController : ControllerBase
     /// Never returns the token itself.
     /// </summary>
     /// <param name="tenantId">The tenant whose grants to list.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The tenant's non-revoked direct grants, newest first.</returns>
     [HttpGet]
     [RemoteQuery]
     [ProducesResponseType(typeof(List<DirectGrantDto>), StatusCodes.Status200OK)]
@@ -105,6 +108,7 @@ public class TenantDirectGrantController : ControllerBase
     /// </summary>
     /// <param name="tenantId">The tenant the grant belongs to.</param>
     /// <param name="grantId">The GUID of the grant to revoke.</param>
+    /// <param name="ct">The cancellation token.</param>
     /// <returns><c>204 No Content</c> on success (including when already revoked); <c>404 Not Found</c> if the grant does not exist on the tenant.</returns>
     [HttpDelete("{grantId:guid}")]
     [RemoteCommand(Invalidates = ["List"])]

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -183,6 +183,7 @@ public static class ServiceRegistrationExtensions
         services.Configure<PlatformOptions>(configuration.GetSection(PlatformOptions.SectionName));
         // Auth services
         services.AddScoped<IAuthAuditService, AuthAuditService>();
+        services.AddScoped<IDirectGrantService, DirectGrantService>();
         services.AddScoped<IJwtService, JwtService>();
         services.AddScoped<IRefreshTokenService, RefreshTokenService>();
         services.AddSingleton<IRotationSuccessorCache, RotationSuccessorCache>();

--- a/src/API/Nocturne.API/Services/Auth/DirectGrantService.cs
+++ b/src/API/Nocturne.API/Services/Auth/DirectGrantService.cs
@@ -34,6 +34,11 @@ public interface IDirectGrantService
     /// <param name="scopes">The requested scopes; normalized before storage.</param>
     /// <param name="ipAddress">The caller's IP address, for the audit trail.</param>
     /// <param name="userAgent">The caller's user agent, for the audit trail.</param>
+    /// <param name="actor">
+    /// Who performed the action when it was not the grant's own subject — a platform admin's
+    /// subject ID or an auth type like <c>InstanceKey</c>. Recorded in the audit details; leave
+    /// null on the self-service path, where the subject acts for themselves.
+    /// </param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The created grant, or an error message describing the invalid input.</returns>
     Task<DirectGrantCreationResult> CreateAsync(
@@ -43,6 +48,7 @@ public interface IDirectGrantService
         IReadOnlyCollection<string>? scopes,
         string? ipAddress,
         string? userAgent,
+        string? actor = null,
         CancellationToken ct = default);
 
     /// <summary>
@@ -64,6 +70,10 @@ public interface IDirectGrantService
     /// <param name="subjectId">When set, the grant must belong to this subject.</param>
     /// <param name="ipAddress">The caller's IP address, for the audit trail.</param>
     /// <param name="userAgent">The caller's user agent, for the audit trail.</param>
+    /// <param name="actor">
+    /// Who performed the action when it was not the grant's own subject; see
+    /// <see cref="CreateAsync"/>.
+    /// </param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns><c>true</c> when the grant was found (revoked now or already); <c>false</c> otherwise.</returns>
     Task<bool> RevokeAsync(
@@ -72,6 +82,7 @@ public interface IDirectGrantService
         Guid? subjectId,
         string? ipAddress,
         string? userAgent,
+        string? actor = null,
         CancellationToken ct = default);
 }
 
@@ -108,6 +119,7 @@ public class DirectGrantService : IDirectGrantService
         IReadOnlyCollection<string>? scopes,
         string? ipAddress,
         string? userAgent,
+        string? actor = null,
         CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(label))
@@ -156,7 +168,9 @@ public class DirectGrantService : IDirectGrantService
         await _auditService.LogAsync(AuthAuditEventType.TokenIssued, subjectId, success: true,
             ipAddress: ipAddress,
             userAgent: userAgent,
-            detailsJson: JsonSerializer.Serialize(new { method = "direct_grant", grant_id = entity.Id }));
+            detailsJson: actor == null
+                ? JsonSerializer.Serialize(new { method = "direct_grant", grant_id = entity.Id })
+                : JsonSerializer.Serialize(new { method = "direct_grant", grant_id = entity.Id, issued_by = actor }));
 
         return DirectGrantCreationResult.Created(new CreateDirectGrantResponse
         {
@@ -198,6 +212,7 @@ public class DirectGrantService : IDirectGrantService
         Guid? subjectId,
         string? ipAddress,
         string? userAgent,
+        string? actor = null,
         CancellationToken ct = default)
     {
         var grant = await dbContext.OAuthGrants
@@ -226,7 +241,9 @@ public class DirectGrantService : IDirectGrantService
         await _auditService.LogAsync(AuthAuditEventType.TokenRevoked, grant.SubjectId, success: true,
             ipAddress: ipAddress,
             userAgent: userAgent,
-            detailsJson: JsonSerializer.Serialize(new { grant_id = grantId }));
+            detailsJson: actor == null
+                ? JsonSerializer.Serialize(new { grant_id = grantId })
+                : JsonSerializer.Serialize(new { grant_id = grantId, revoked_by = actor }));
 
         return true;
     }

--- a/src/API/Nocturne.API/Services/Auth/DirectGrantService.cs
+++ b/src/API/Nocturne.API/Services/Auth/DirectGrantService.cs
@@ -1,0 +1,241 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.API.Services.Auth;
+
+/// <summary>
+/// Creates, lists, and revokes direct grant tokens (<c>noc_</c> opaque bearer tokens).
+/// Shared by the self-service <see cref="DirectGrantController"/> and the platform-admin
+/// tenant grant endpoints so token generation and hashing live in one place.
+/// </summary>
+/// <remarks>
+/// Callers pass the <see cref="NocturneDbContext"/> the operation should run on: the
+/// self-service endpoints use the request-scoped context, while platform-admin endpoints pin a
+/// context to the target tenant. Grant rows are tenant-scoped, so the context's tenant decides
+/// which grants are visible and which tenant a new grant is bound to.
+/// </remarks>
+/// <seealso cref="DirectGrantTokenHandler"/>
+public interface IDirectGrantService
+{
+    /// <summary>
+    /// Creates a new direct grant for <paramref name="subjectId"/>. The plaintext token is
+    /// returned once and cannot be retrieved again.
+    /// </summary>
+    /// <param name="dbContext">The tenant-scoped context to create the grant on.</param>
+    /// <param name="subjectId">The subject the grant is issued to.</param>
+    /// <param name="label">The human-readable label.</param>
+    /// <param name="scopes">The requested scopes; normalized before storage.</param>
+    /// <param name="ipAddress">The caller's IP address, for the audit trail.</param>
+    /// <param name="userAgent">The caller's user agent, for the audit trail.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The created grant, or an error message describing the invalid input.</returns>
+    Task<DirectGrantCreationResult> CreateAsync(
+        NocturneDbContext dbContext,
+        Guid subjectId,
+        string label,
+        IReadOnlyCollection<string>? scopes,
+        string? ipAddress,
+        string? userAgent,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists non-revoked direct grants, newest first. Never returns token material.
+    /// </summary>
+    /// <param name="dbContext">The tenant-scoped context to query.</param>
+    /// <param name="subjectId">
+    /// When set, only grants issued to this subject; otherwise every grant on the context's tenant.
+    /// </param>
+    /// <param name="ct">The cancellation token.</param>
+    Task<List<DirectGrantDto>> ListAsync(
+        NocturneDbContext dbContext, Guid? subjectId = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Revokes a direct grant by setting its <c>RevokedAt</c> timestamp. Idempotent.
+    /// </summary>
+    /// <param name="dbContext">The tenant-scoped context to revoke on.</param>
+    /// <param name="grantId">The grant to revoke.</param>
+    /// <param name="subjectId">When set, the grant must belong to this subject.</param>
+    /// <param name="ipAddress">The caller's IP address, for the audit trail.</param>
+    /// <param name="userAgent">The caller's user agent, for the audit trail.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns><c>true</c> when the grant was found (revoked now or already); <c>false</c> otherwise.</returns>
+    Task<bool> RevokeAsync(
+        NocturneDbContext dbContext,
+        Guid grantId,
+        Guid? subjectId,
+        string? ipAddress,
+        string? userAgent,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// The outcome of a direct grant creation: either the created grant with its single-use
+/// plaintext token, or an error message describing the invalid input.
+/// </summary>
+public sealed record DirectGrantCreationResult(CreateDirectGrantResponse? Response, string? Error)
+{
+    public static DirectGrantCreationResult Created(CreateDirectGrantResponse response) => new(response, null);
+    public static DirectGrantCreationResult Invalid(string error) => new(null, error);
+}
+
+/// <inheritdoc cref="IDirectGrantService"/>
+public class DirectGrantService : IDirectGrantService
+{
+    private const string TokenPrefix = "noc_";
+    private const int TokenRandomBytes = 32;
+
+    private readonly IAuthAuditService _auditService;
+    private readonly ILogger<DirectGrantService> _logger;
+
+    public DirectGrantService(IAuthAuditService auditService, ILogger<DirectGrantService> logger)
+    {
+        _auditService = auditService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<DirectGrantCreationResult> CreateAsync(
+        NocturneDbContext dbContext,
+        Guid subjectId,
+        string label,
+        IReadOnlyCollection<string>? scopes,
+        string? ipAddress,
+        string? userAgent,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(label))
+        {
+            return DirectGrantCreationResult.Invalid("Label is required");
+        }
+
+        if (scopes == null || scopes.Count == 0)
+        {
+            return DirectGrantCreationResult.Invalid("At least one scope is required");
+        }
+
+        var normalizedScopes = OAuthScopes.Normalize(scopes).ToList();
+        if (normalizedScopes.Count == 0)
+        {
+            return DirectGrantCreationResult.Invalid("No valid scopes provided");
+        }
+
+        var randomBytes = RandomNumberGenerator.GetBytes(TokenRandomBytes);
+        var plaintextToken = TokenPrefix + Base64UrlEncode(randomBytes);
+        var tokenHash = DirectGrantTokenHandler.ComputeSha256Hex(plaintextToken);
+
+        var entity = new OAuthGrantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            ClientEntityId = null,
+            SubjectId = subjectId,
+            GrantType = OAuthGrantTypes.Direct,
+            Scopes = normalizedScopes,
+            Label = label,
+            TokenHash = tokenHash,
+            // Also store the SHA-1 of the token so uploaders that use the legacy Nightscout
+            // api-secret protocol (Loop, AAPS, Trio, iAPS) — which pre-hash the value with SHA-1
+            // before sending — authenticate with this same token via ApiKeyHandler's legacy path.
+            LegacySecretHash = HashUtils.Sha1Hex(plaintextToken),
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        dbContext.OAuthGrants.Add(entity);
+        await dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "DirectGrantAudit: {Event} grant_id={GrantId} subject_id={SubjectId} scopes={Scopes}",
+            "direct_grant_created", entity.Id, subjectId, string.Join(" ", normalizedScopes));
+
+        await _auditService.LogAsync(AuthAuditEventType.TokenIssued, subjectId, success: true,
+            ipAddress: ipAddress,
+            userAgent: userAgent,
+            detailsJson: JsonSerializer.Serialize(new { method = "direct_grant", grant_id = entity.Id }));
+
+        return DirectGrantCreationResult.Created(new CreateDirectGrantResponse
+        {
+            Id = entity.Id,
+            Token = plaintextToken,
+            Label = entity.Label!,
+            Scopes = normalizedScopes,
+            CreatedAt = entity.CreatedAt,
+        });
+    }
+
+    /// <inheritdoc />
+    public async Task<List<DirectGrantDto>> ListAsync(
+        NocturneDbContext dbContext, Guid? subjectId = null, CancellationToken ct = default)
+    {
+        return await dbContext.OAuthGrants
+            .AsNoTracking()
+            .Where(g => (subjectId == null || g.SubjectId == subjectId.Value)
+                     && g.GrantType == OAuthGrantTypes.Direct
+                     && g.RevokedAt == null)
+            .OrderByDescending(g => g.CreatedAt)
+            .Select(g => new DirectGrantDto
+            {
+                Id = g.Id,
+                SubjectId = g.SubjectId,
+                Label = g.Label ?? string.Empty,
+                Scopes = g.Scopes,
+                CreatedAt = g.CreatedAt,
+                LastUsedAt = g.LastUsedAt,
+                IsLegacy = g.IsMigrated,
+            })
+            .ToListAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RevokeAsync(
+        NocturneDbContext dbContext,
+        Guid grantId,
+        Guid? subjectId,
+        string? ipAddress,
+        string? userAgent,
+        CancellationToken ct = default)
+    {
+        var grant = await dbContext.OAuthGrants
+            .Where(g => g.Id == grantId
+                     && (subjectId == null || g.SubjectId == subjectId.Value)
+                     && g.GrantType == OAuthGrantTypes.Direct)
+            .FirstOrDefaultAsync(ct);
+
+        if (grant == null)
+        {
+            return false;
+        }
+
+        if (grant.RevokedAt.HasValue)
+        {
+            return true; // Already revoked, idempotent
+        }
+
+        grant.RevokedAt = DateTime.UtcNow;
+        await dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "DirectGrantAudit: {Event} grant_id={GrantId} subject_id={SubjectId}",
+            "direct_grant_revoked", grantId, grant.SubjectId);
+
+        await _auditService.LogAsync(AuthAuditEventType.TokenRevoked, grant.SubjectId, success: true,
+            ipAddress: ipAddress,
+            userAgent: userAgent,
+            detailsJson: JsonSerializer.Serialize(new { grant_id = grantId }));
+
+        return true;
+    }
+
+    private static string Base64UrlEncode(byte[] bytes)
+    {
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/src/API/Nocturne.API/Services/Auth/DirectGrantService.cs
+++ b/src/API/Nocturne.API/Services/Auth/DirectGrantService.cs
@@ -56,11 +56,13 @@ public interface IDirectGrantService
     /// </summary>
     /// <param name="dbContext">The tenant-scoped context to query.</param>
     /// <param name="subjectId">
-    /// When set, only grants issued to this subject; otherwise every grant on the context's tenant.
+    /// When set, only grants issued to this subject; when null, every grant on the context's
+    /// tenant. Passed explicitly so a caller cannot widen the read to the whole tenant by
+    /// omitting it.
     /// </param>
     /// <param name="ct">The cancellation token.</param>
     Task<List<DirectGrantDto>> ListAsync(
-        NocturneDbContext dbContext, Guid? subjectId = null, CancellationToken ct = default);
+        NocturneDbContext dbContext, Guid? subjectId, CancellationToken ct = default);
 
     /// <summary>
     /// Revokes a direct grant by setting its <c>RevokedAt</c> timestamp. Idempotent.
@@ -168,9 +170,8 @@ public class DirectGrantService : IDirectGrantService
         await _auditService.LogAsync(AuthAuditEventType.TokenIssued, subjectId, success: true,
             ipAddress: ipAddress,
             userAgent: userAgent,
-            detailsJson: actor == null
-                ? JsonSerializer.Serialize(new { method = "direct_grant", grant_id = entity.Id })
-                : JsonSerializer.Serialize(new { method = "direct_grant", grant_id = entity.Id, issued_by = actor }));
+            detailsJson: AuditDetails(
+                actor, "issued_by", ("method", "direct_grant"), ("grant_id", entity.Id)));
 
         return DirectGrantCreationResult.Created(new CreateDirectGrantResponse
         {
@@ -184,7 +185,7 @@ public class DirectGrantService : IDirectGrantService
 
     /// <inheritdoc />
     public async Task<List<DirectGrantDto>> ListAsync(
-        NocturneDbContext dbContext, Guid? subjectId = null, CancellationToken ct = default)
+        NocturneDbContext dbContext, Guid? subjectId, CancellationToken ct = default)
     {
         return await dbContext.OAuthGrants
             .AsNoTracking()
@@ -228,7 +229,7 @@ public class DirectGrantService : IDirectGrantService
 
         if (grant.RevokedAt.HasValue)
         {
-            return true; // Already revoked, idempotent
+            return true;
         }
 
         grant.RevokedAt = DateTime.UtcNow;
@@ -241,11 +242,25 @@ public class DirectGrantService : IDirectGrantService
         await _auditService.LogAsync(AuthAuditEventType.TokenRevoked, grant.SubjectId, success: true,
             ipAddress: ipAddress,
             userAgent: userAgent,
-            detailsJson: actor == null
-                ? JsonSerializer.Serialize(new { grant_id = grantId })
-                : JsonSerializer.Serialize(new { grant_id = grantId, revoked_by = actor }));
+            detailsJson: AuditDetails(actor, "revoked_by", ("grant_id", grantId)));
 
         return true;
+    }
+
+    /// <summary>
+    /// Serializes the audit details, appending <paramref name="actorKey"/> only when the action was
+    /// performed by someone other than the grant's own subject.
+    /// </summary>
+    private static string AuditDetails(
+        string? actor, string actorKey, params (string Key, object Value)[] fields)
+    {
+        var details = fields.ToDictionary(f => f.Key, f => f.Value);
+        if (actor != null)
+        {
+            details[actorKey] = actor;
+        }
+
+        return JsonSerializer.Serialize(details);
     }
 
     private static string Base64UrlEncode(byte[] bytes)

--- a/src/API/Nocturne.API/Validators/Admin/AdminCreateDirectGrantRequestValidator.cs
+++ b/src/API/Nocturne.API/Validators/Admin/AdminCreateDirectGrantRequestValidator.cs
@@ -13,6 +13,9 @@ namespace Nocturne.API.Validators.Admin;
 /// <item><description>SubjectId is required.</description></item>
 /// <item><description>Label and scope rules are shared with the self-service endpoint via
 /// <see cref="CreateDirectGrantRequestValidator"/>.</description></item>
+/// <item><description>ExpiresAt must not be set: direct grants do not expire, and the
+/// self-service endpoint's silent-ignore of the field must not carry over to a surface whose
+/// callers are SDKs that would trust a requested expiry.</description></item>
 /// </list>
 /// </remarks>
 /// <seealso cref="AdminCreateDirectGrantRequest"/>
@@ -27,5 +30,7 @@ public class AdminCreateDirectGrantRequestValidator : AbstractValidator<AdminCre
     {
         Include(new CreateDirectGrantRequestValidator());
         RuleFor(x => x.SubjectId).NotEmpty();
+        RuleFor(x => x.ExpiresAt).Null()
+            .WithMessage("Direct grants do not expire; ExpiresAt must not be set");
     }
 }

--- a/src/API/Nocturne.API/Validators/Admin/AdminCreateDirectGrantRequestValidator.cs
+++ b/src/API/Nocturne.API/Validators/Admin/AdminCreateDirectGrantRequestValidator.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+using Nocturne.API.Controllers.V4.PlatformAdmin;
+using Nocturne.API.Validators.Auth;
+
+namespace Nocturne.API.Validators.Admin;
+
+/// <summary>
+/// Validates <see cref="AdminCreateDirectGrantRequest"/> for the platform admin tenant direct
+/// grant endpoint.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+/// <item><description>SubjectId is required.</description></item>
+/// <item><description>Label and scope rules are shared with the self-service endpoint via
+/// <see cref="CreateDirectGrantRequestValidator"/>.</description></item>
+/// </list>
+/// </remarks>
+/// <seealso cref="AdminCreateDirectGrantRequest"/>
+/// <seealso cref="TenantDirectGrantController"/>
+public class AdminCreateDirectGrantRequestValidator : AbstractValidator<AdminCreateDirectGrantRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AdminCreateDirectGrantRequestValidator"/> class
+    /// and configures all validation rules for admin direct grant creation.
+    /// </summary>
+    public AdminCreateDirectGrantRequestValidator()
+    {
+        Include(new CreateDirectGrantRequestValidator());
+        RuleFor(x => x.SubjectId).NotEmpty();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -153,6 +153,7 @@ public class V4WriteScopeGatingTests
             ["PlatformSettingsController"] = NotDataCategory.PlatformAdminRole,
             ["SubjectAdminController"] = NotDataCategory.PlatformAdminRole,
             ["TenantController"] = NotDataCategory.PlatformAdminRole,
+            ["TenantDirectGrantController"] = NotDataCategory.PlatformAdminRole,
 
             ["DeduplicationController"] = NotDataCategory.TenantAdminAttribute,
             ["MigrationController"] = NotDataCategory.TenantAdminAttribute,

--- a/tests/Unit/Nocturne.API.Tests/Controllers/DirectGrantControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/DirectGrantControllerTests.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
@@ -53,10 +55,11 @@ public class DirectGrantControllerTests : IDisposable
         });
         _dbContext.SaveChanges();
 
-        var logger = new Mock<ILogger<DirectGrantController>>();
         var auditService = new Mock<IAuthAuditService>();
+        var directGrantService = new DirectGrantService(
+            auditService.Object, new Mock<ILogger<DirectGrantService>>().Object);
 
-        _controller = new DirectGrantController(_dbContext, auditService.Object, logger.Object);
+        _controller = new DirectGrantController(_dbContext, directGrantService);
 
         // Set up authenticated HttpContext
         var httpContext = new DefaultHttpContext();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/TenantDirectGrantControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/TenantDirectGrantControllerTests.cs
@@ -1,0 +1,266 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Controllers.V4.PlatformAdmin;
+using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Auth;
+using Nocturne.API.Services.Identity;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+public class TenantDirectGrantControllerTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+    private readonly NocturneDbContext _dbContext;
+    private readonly TenantDirectGrantController _controller;
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly Guid _memberSubjectId = Guid.CreateVersion7();
+    private readonly Guid _nonMemberSubjectId = Guid.CreateVersion7();
+
+    public TenantDirectGrantControllerTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        _dbContext = new NocturneDbContext(_dbOptions) { TenantId = _tenantId };
+        _dbContext.Database.EnsureCreated();
+
+        // Seed required entities for FK constraints
+        _dbContext.Tenants.Add(new TenantEntity
+        {
+            Id = _tenantId,
+            Slug = "default",
+            DisplayName = "Default",
+            IsActive = true,
+        });
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = _memberSubjectId,
+            Name = "Member",
+            IsActive = true,
+        });
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = _nonMemberSubjectId,
+            Name = "Outsider",
+            IsActive = true,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            SubjectId = _memberSubjectId,
+        });
+        _dbContext.SaveChanges();
+
+        var factory = new Mock<IDbContextFactory<NocturneDbContext>>();
+        factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new NocturneDbContext(_dbOptions));
+
+        var auditService = new Mock<IAuthAuditService>();
+        var directGrantService = new DirectGrantService(
+            auditService.Object, new Mock<ILogger<DirectGrantService>>().Object);
+        var tenantMemberService = new TenantMemberService(factory.Object);
+
+        _controller = new TenantDirectGrantController(
+            factory.Object, tenantMemberService, directGrantService)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task Create_MemberSubject_ReturnsTokenBoundToTenant()
+    {
+        var request = new AdminCreateDirectGrantRequest
+        {
+            SubjectId = _memberSubjectId,
+            Label = "Partner Integration",
+            Scopes = ["glucose.read"],
+        };
+
+        var result = await _controller.Create(_tenantId, request, CancellationToken.None);
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<CreateDirectGrantResponse>(okResult.Value);
+        Assert.StartsWith("noc_", response.Token);
+        Assert.Equal("Partner Integration", response.Label);
+        Assert.Contains("glucose.read", response.Scopes);
+
+        var grant = await _dbContext.OAuthGrants.FirstOrDefaultAsync(g => g.Id == response.Id);
+        Assert.NotNull(grant);
+        Assert.Equal(_tenantId, grant!.TenantId);
+        Assert.Equal(_memberSubjectId, grant.SubjectId);
+        Assert.Equal(OAuthGrantTypes.Direct, grant.GrantType);
+    }
+
+    [Fact]
+    public async Task Create_StoredHashesMatchReturnedPlaintext()
+    {
+        var request = new AdminCreateDirectGrantRequest
+        {
+            SubjectId = _memberSubjectId,
+            Label = "Hash Test",
+            Scopes = ["glucose.read"],
+        };
+
+        var result = await _controller.Create(_tenantId, request, CancellationToken.None);
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<CreateDirectGrantResponse>(okResult.Value);
+
+        var grant = await _dbContext.OAuthGrants.FirstOrDefaultAsync(g => g.Id == response.Id);
+        Assert.NotNull(grant);
+        Assert.Equal(DirectGrantTokenHandler.ComputeSha256Hex(response.Token), grant!.TokenHash);
+        Assert.Equal(HashUtils.Sha1Hex(response.Token), grant.LegacySecretHash);
+    }
+
+    [Fact]
+    public async Task Create_SubjectNotMemberOfTenant_ReturnsBadRequest()
+    {
+        var request = new AdminCreateDirectGrantRequest
+        {
+            SubjectId = _nonMemberSubjectId,
+            Label = "Should Not Exist",
+            Scopes = ["glucose.read"],
+        };
+
+        var result = await _controller.Create(_tenantId, request, CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(400, objectResult.StatusCode);
+        Assert.False(await _dbContext.OAuthGrants.AnyAsync());
+    }
+
+    [Fact]
+    public async Task Create_InvalidScopes_ReturnsBadRequest()
+    {
+        var request = new AdminCreateDirectGrantRequest
+        {
+            SubjectId = _memberSubjectId,
+            Label = "Bad Scopes",
+            Scopes = ["invalid.scope"],
+        };
+
+        var result = await _controller.Create(_tenantId, request, CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(400, objectResult.StatusCode);
+    }
+
+    [Fact]
+    public void Controller_RequiresPlatformAdminRole()
+    {
+        var authorize = typeof(TenantDirectGrantController)
+            .GetCustomAttributes<AuthorizeAttribute>(inherit: true)
+            .ToList();
+
+        Assert.Contains(authorize, a => a.Roles == "platform_admin");
+    }
+
+    [Fact]
+    public async Task List_ReturnsGrantsAcrossSubjects_ExcludingRevoked()
+    {
+        _dbContext.OAuthGrants.Add(new OAuthGrantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = _memberSubjectId,
+            GrantType = OAuthGrantTypes.Direct,
+            Scopes = ["glucose.read"],
+            Label = "Member Grant",
+            TokenHash = "hash1",
+            CreatedAt = DateTime.UtcNow,
+        });
+        _dbContext.OAuthGrants.Add(new OAuthGrantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = _nonMemberSubjectId,
+            GrantType = OAuthGrantTypes.Direct,
+            Scopes = ["glucose.read"],
+            Label = "Other Subject Grant",
+            TokenHash = "hash2",
+            CreatedAt = DateTime.UtcNow,
+        });
+        _dbContext.OAuthGrants.Add(new OAuthGrantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = _memberSubjectId,
+            GrantType = OAuthGrantTypes.Direct,
+            Scopes = ["glucose.read"],
+            Label = "Revoked Grant",
+            TokenHash = "hash3",
+            CreatedAt = DateTime.UtcNow,
+            RevokedAt = DateTime.UtcNow,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.List(_tenantId, CancellationToken.None);
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var grants = Assert.IsType<List<DirectGrantDto>>(okResult.Value);
+        Assert.Equal(2, grants.Count);
+        Assert.DoesNotContain(grants, g => g.Label == "Revoked Grant");
+        Assert.Contains(grants, g => g.SubjectId == _nonMemberSubjectId);
+    }
+
+    [Fact]
+    public async Task Revoke_SetsRevokedAt()
+    {
+        var grantId = Guid.CreateVersion7();
+        _dbContext.OAuthGrants.Add(new OAuthGrantEntity
+        {
+            Id = grantId,
+            SubjectId = _memberSubjectId,
+            GrantType = OAuthGrantTypes.Direct,
+            Scopes = ["glucose.read"],
+            Label = "ToRevoke",
+            TokenHash = "hashrevoke",
+            CreatedAt = DateTime.UtcNow,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.Revoke(_tenantId, grantId, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+
+        var grant = await _dbContext.OAuthGrants.AsNoTracking().FirstOrDefaultAsync(g => g.Id == grantId);
+        Assert.NotNull(grant);
+        Assert.NotNull(grant!.RevokedAt);
+    }
+
+    [Fact]
+    public async Task Revoke_NonexistentGrant_ReturnsNotFound()
+    {
+        var result = await _controller.Revoke(_tenantId, Guid.CreateVersion7(), CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, objectResult.StatusCode);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/TenantDirectGrantControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/TenantDirectGrantControllerTests.cs
@@ -26,6 +26,7 @@ public class TenantDirectGrantControllerTests : IDisposable
     private readonly DbContextOptions<NocturneDbContext> _dbOptions;
     private readonly NocturneDbContext _dbContext;
     private readonly TenantDirectGrantController _controller;
+    private readonly Mock<IAuthAuditService> _auditService;
     private readonly Guid _tenantId = Guid.CreateVersion7();
     private readonly Guid _memberSubjectId = Guid.CreateVersion7();
     private readonly Guid _nonMemberSubjectId = Guid.CreateVersion7();
@@ -75,9 +76,9 @@ public class TenantDirectGrantControllerTests : IDisposable
         factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new NocturneDbContext(_dbOptions));
 
-        var auditService = new Mock<IAuthAuditService>();
+        _auditService = new Mock<IAuthAuditService>();
         var directGrantService = new DirectGrantService(
-            auditService.Object, new Mock<ILogger<DirectGrantService>>().Object);
+            _auditService.Object, new Mock<ILogger<DirectGrantService>>().Object);
         var tenantMemberService = new TenantMemberService(factory.Object);
 
         _controller = new TenantDirectGrantController(
@@ -262,5 +263,40 @@ public class TenantDirectGrantControllerTests : IDisposable
 
         var objectResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(404, objectResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminActions_RecordTheActorInAuditDetails()
+    {
+        _controller.HttpContext.Items["AuthContext"] = new Nocturne.Core.Models.Authorization.AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = Nocturne.Core.Models.Authorization.AuthType.InstanceKey,
+            SubjectId = null,
+        };
+
+        var request = new AdminCreateDirectGrantRequest
+        {
+            SubjectId = _memberSubjectId,
+            Label = "Provisioner Token",
+            Scopes = ["glucose.read"],
+        };
+        var createResult = await _controller.Create(_tenantId, request, CancellationToken.None);
+        var okResult = Assert.IsType<OkObjectResult>(createResult.Result);
+        var response = Assert.IsType<CreateDirectGrantResponse>(okResult.Value);
+
+        _auditService.Verify(a => a.LogAsync(
+            It.IsAny<string>(), _memberSubjectId, true,
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+            It.Is<string?>(d => d != null && d.Contains("\"issued_by\":\"InstanceKey\"")),
+            It.IsAny<Guid?>()));
+
+        await _controller.Revoke(_tenantId, response.Id, CancellationToken.None);
+
+        _auditService.Verify(a => a.LogAsync(
+            It.IsAny<string>(), _memberSubjectId, true,
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+            It.Is<string?>(d => d != null && d.Contains("\"revoked_by\":\"InstanceKey\"")),
+            It.IsAny<Guid?>()));
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/TenantDirectGrantControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/TenantDirectGrantControllerTests.cs
@@ -232,6 +232,67 @@ public class TenantDirectGrantControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task List_ExcludesGrantsBelongingToAnotherTenant()
+    {
+        var (_, otherGrantId) = await SeedGrantOnOtherTenantAsync();
+
+        var result = await _controller.List(_tenantId, CancellationToken.None);
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var grants = Assert.IsType<List<DirectGrantDto>>(okResult.Value);
+        Assert.DoesNotContain(grants, g => g.Id == otherGrantId);
+    }
+
+    [Fact]
+    public async Task Revoke_GrantOnAnotherTenant_ReturnsNotFoundAndLeavesItActive()
+    {
+        var (otherTenantId, otherGrantId) = await SeedGrantOnOtherTenantAsync();
+
+        var result = await _controller.Revoke(_tenantId, otherGrantId, CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(404, objectResult.StatusCode);
+
+        await using var otherContext = new NocturneDbContext(_dbOptions) { TenantId = otherTenantId };
+        var grant = await otherContext.OAuthGrants.AsNoTracking()
+            .FirstOrDefaultAsync(g => g.Id == otherGrantId);
+        Assert.NotNull(grant);
+        Assert.Null(grant!.RevokedAt);
+    }
+
+    /// <summary>
+    /// Creates a second tenant carrying one active direct grant, so a test can assert the
+    /// controller's reach stops at the tenant named in the route.
+    /// </summary>
+    private async Task<(Guid TenantId, Guid GrantId)> SeedGrantOnOtherTenantAsync()
+    {
+        var otherTenantId = Guid.CreateVersion7();
+        var grantId = Guid.CreateVersion7();
+
+        await using var context = new NocturneDbContext(_dbOptions) { TenantId = otherTenantId };
+        context.Tenants.Add(new TenantEntity
+        {
+            Id = otherTenantId,
+            Slug = "other",
+            DisplayName = "Other",
+            IsActive = true,
+        });
+        context.OAuthGrants.Add(new OAuthGrantEntity
+        {
+            Id = grantId,
+            SubjectId = _memberSubjectId,
+            GrantType = OAuthGrantTypes.Direct,
+            Scopes = ["glucose.read"],
+            Label = "Other Tenant Grant",
+            TokenHash = "hashother",
+            CreatedAt = DateTime.UtcNow,
+        });
+        await context.SaveChangesAsync();
+
+        return (otherTenantId, grantId);
+    }
+
+    [Fact]
     public async Task Revoke_SetsRevokedAt()
     {
         var grantId = Guid.CreateVersion7();
@@ -286,7 +347,7 @@ public class TenantDirectGrantControllerTests : IDisposable
         var response = Assert.IsType<CreateDirectGrantResponse>(okResult.Value);
 
         _auditService.Verify(a => a.LogAsync(
-            It.IsAny<string>(), _memberSubjectId, true,
+            AuthAuditEventType.TokenIssued, _memberSubjectId, true,
             It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
             It.Is<string?>(d => d != null && d.Contains("\"issued_by\":\"InstanceKey\"")),
             It.IsAny<Guid?>()));
@@ -294,7 +355,7 @@ public class TenantDirectGrantControllerTests : IDisposable
         await _controller.Revoke(_tenantId, response.Id, CancellationToken.None);
 
         _auditService.Verify(a => a.LogAsync(
-            It.IsAny<string>(), _memberSubjectId, true,
+            AuthAuditEventType.TokenRevoked, _memberSubjectId, true,
             It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
             It.Is<string?>(d => d != null && d.Contains("\"revoked_by\":\"InstanceKey\"")),
             It.IsAny<Guid?>()));

--- a/tests/Unit/Nocturne.API.Tests/Validators/Admin/AdminCreateDirectGrantRequestValidatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Validators/Admin/AdminCreateDirectGrantRequestValidatorTests.cs
@@ -1,0 +1,53 @@
+using FluentValidation.TestHelper;
+using Nocturne.API.Controllers.V4.PlatformAdmin;
+using Nocturne.API.Validators.Admin;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Validators.Admin;
+
+public class AdminCreateDirectGrantRequestValidatorTests
+{
+    private readonly AdminCreateDirectGrantRequestValidator _validator = new();
+
+    private static AdminCreateDirectGrantRequest ValidRequest() => new()
+    {
+        SubjectId = Guid.CreateVersion7(),
+        Label = "Partner Integration",
+        Scopes = [OAuthScopes.GlucoseRead],
+    };
+
+    [Fact]
+    public void Valid_request_passes()
+    {
+        var result = _validator.TestValidate(ValidRequest());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Empty_subject_fails()
+    {
+        var request = ValidRequest();
+        request.SubjectId = Guid.Empty;
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.SubjectId);
+    }
+
+    [Fact]
+    public void Empty_label_fails_via_shared_rules()
+    {
+        var request = ValidRequest();
+        request.Label = "";
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Label);
+    }
+
+    [Fact]
+    public void Set_expiry_fails()
+    {
+        var request = ValidRequest();
+        request.ExpiresAt = DateTime.UtcNow.AddDays(1);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.ExpiresAt);
+    }
+}


### PR DESCRIPTION
## Problem

Direct grants (`noc_` opaque bearer tokens) are the platform's scoped, revocable API credentials, but they can only be minted through `POST /api/auth/direct-grants`, which requires an authenticated subject. Instance-key (platform_admin) callers have no `SubjectId`, so they get a 401 — and `/api/auth/*` is excluded from the generated SDK spec (`sdk/filter-v4-spec.js` keeps `/api/v4/**` and `/api/oauth/**` only). An external provisioner (e.g. nocturne-cloud's billing service) therefore has no way to issue a tenant-scoped token at tenant-provision time for B2B partner integrations.

## Approach

- **Shared service.** The creation/list/revoke logic moves out of `DirectGrantController` into `DirectGrantService` (`src/API/Nocturne.API/Services/Auth/DirectGrantService.cs`); both controllers call it, so token generation stays in one place: 32 bytes of entropy, `noc_` prefix, SHA-256 `TokenHash` stored, SHA-1 `LegacySecretHash` for legacy api-secret compatibility, scopes normalized via `OAuthScopes.Normalize`, audit-logged via `IAuthAuditService`, plaintext returned once. Callers pass the `NocturneDbContext` the operation runs on, since grant rows are tenant-scoped.
- **New platform-admin controller** `TenantDirectGrantController` at `api/v4/admin/tenants/{tenantId}/direct-grants`, following the `PlatformAdmin` conventions (`[Authorize(Roles = "platform_admin")]`, `[AllowDuringSetup]`):
  - `POST` mints a grant for an explicit `subjectId` with `label` and `scopes[]`. The subject must be a member of the tenant, checked through the existing `ITenantMemberService.IsMemberAsync`. Response is the same `CreateDirectGrantResponse` contract as the self-service endpoint.
  - `GET` lists the tenant's non-revoked grants (same `DirectGrantDto` shape, never token material).
  - `DELETE /{grantId}` revokes, idempotently.
  - Grant operations run on a context pinned to the target tenant via `CreateTenantPinnedContextAsync`, the established pattern for platform-admin cross-tenant reach.
- `DirectGrantDto` gains `SubjectId` so the admin list can tell whose grant each row is (the self-service list now also carries the caller's own subject id).
- `AdminCreateDirectGrantRequest` extends `CreateDirectGrantRequest`; its validator `Include`s the existing `CreateDirectGrantRequestValidator` so the label/scope rules stay shared.
- Landing under `/api/v4/**` puts the endpoints in the filtered SDK spec.

## Testing

- `TenantDirectGrantControllerTests` (SQLite in-memory, same pattern as `DirectGrantControllerTests`): happy path binds the grant to the target tenant and subject; stored SHA-256 hash and SHA-1 legacy hash both match the returned plaintext; subject-not-a-member is rejected with 400 and persists nothing; invalid scopes rejected; list spans subjects and excludes revoked grants; revoke sets `RevokedAt` and 404s on unknown ids.
- Authorization boundary: `Controller_RequiresPlatformAdminRole` asserts the `platform_admin` role gate. Mutation-proofed — with the attribute temporarily weakened to bare `[Authorize]` the test fails; restored, it passes.
- Existing `DirectGrantControllerTests` updated for the service extraction and still pass unchanged in behavior.
- `TenantDirectGrantController` added to `V4WriteScopeGatingTests.GateExemptControllers` under the existing platform-admin-role category (same as `TenantController`).
- Full `Nocturne.API.Tests` unit suite run locally: 5403 passed; the only failure was the pre-existing flaky `ChatIdentityPendingLinkCleanupServiceTests` timing test, which passes in isolation.

https://claude.ai/code/session_01KfeEW2AMTnEANqnLxmmzFZ
