### PR TITLE
fix(v4): stop temp-basal upsert retries dropping device attribution

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -163,7 +163,7 @@ public class TempBasalRepository : ITempBasalRepository
                     ct);
             if (existing != null)
             {
-                TempBasalMapper.UpdateEntity(existing, model);
+                ApplySyncUpsert(existing, model);
                 await ctx.SaveChangesAsync(ct);
                 var upserted = TempBasalMapper.ToDomainModel(existing);
                 // A single explicit upsert always broadcasts (no material-change gate on the single path).
@@ -178,6 +178,35 @@ public class TempBasalRepository : ITempBasalRepository
         var created = TempBasalMapper.ToDomainModel(entity);
         await RaiseBroadcastAsync([created], [], [], origin, ct);
         return created;
+    }
+
+    /// <summary>
+    /// Applies an upserted record onto the row matched by (DataSource, SyncIdentifier), keeping the
+    /// stored value of every field the write path cannot express.
+    /// </summary>
+    /// <remarks>
+    /// The match is made from the incoming record alone — the caller never read the stored row, so a
+    /// retry carries no value for server-resolved links (device attribution, resolved insulin context)
+    /// or for identity carried in from an import. Taking the incoming null for those would drop state
+    /// the retry never disputed: a re-upload after a device's usage window moved, or after the device
+    /// was removed, would unattribute a row that back-stamping had already resolved. Fields the request
+    /// can carry stay unconditional, so an omitted one still means "clear it".
+    /// </remarks>
+    private static void ApplySyncUpsert(TempBasalEntity entity, TempBasal model)
+    {
+        var deviceId = entity.DeviceId;
+        var patientDeviceId = entity.PatientDeviceId;
+        var legacyId = entity.LegacyId;
+        var insulinContextJson = entity.InsulinContextJson;
+        var additionalPropertiesJson = entity.AdditionalPropertiesJson;
+
+        TempBasalMapper.UpdateEntity(entity, model);
+
+        entity.DeviceId ??= deviceId;
+        entity.PatientDeviceId ??= patientDeviceId;
+        entity.LegacyId ??= legacyId;
+        entity.InsulinContextJson ??= insulinContextJson;
+        entity.AdditionalPropertiesJson ??= additionalPropertiesJson;
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalRepositorySyncUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalRepositorySyncUpsertTests.cs
@@ -64,6 +64,72 @@ public class TempBasalRepositorySyncUpsertTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateAsync_WithMatchingSyncKey_KeepsStoredPatientDeviceIdWhenRetryCarriesNone()
+    {
+        var patientDeviceId = Guid.CreateVersion7();
+        var stamped = CreateRecord("sync-1");
+        stamped.PatientDeviceId = patientDeviceId;
+        await _repository.CreateAsync(stamped, WriteOrigin.Live);
+
+        var result = await _repository.CreateAsync(CreateRecord("sync-1", rate: 2.5), WriteOrigin.Live);
+
+        _context.TempBasals.Single().PatientDeviceId.Should().Be(patientDeviceId);
+        result.PatientDeviceId.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithMatchingSyncKey_TakesRequestedPatientDeviceIdOverStoredOne()
+    {
+        var stamped = CreateRecord("sync-1");
+        stamped.PatientDeviceId = Guid.CreateVersion7();
+        await _repository.CreateAsync(stamped, WriteOrigin.Live);
+
+        var restamped = CreateRecord("sync-1");
+        restamped.PatientDeviceId = Guid.CreateVersion7();
+        var result = await _repository.CreateAsync(restamped, WriteOrigin.Live);
+
+        _context.TempBasals.Single().PatientDeviceId.Should().Be(restamped.PatientDeviceId);
+        result.PatientDeviceId.Should().Be(restamped.PatientDeviceId);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithMatchingSyncKey_KeepsStoredLinksAndImportedIdentityWhenRetryCarriesNone()
+    {
+        var seed = CreateRecord("sync-1");
+        seed.DeviceId = Guid.CreateVersion7();
+        seed.LegacyId = "legacy-1";
+        seed.InsulinContext = new TreatmentInsulinContext { InsulinName = "Fiasp", Dia = 6, Peak = 55 };
+        seed.AdditionalProperties = new Dictionary<string, object?> { ["pumpMode"] = "closedLoop" };
+        await _repository.CreateAsync(seed, WriteOrigin.Live);
+
+        var result = await _repository.CreateAsync(CreateRecord("sync-1", rate: 2.5), WriteOrigin.Live);
+
+        var stored = _context.TempBasals.Single();
+        stored.DeviceId.Should().Be(seed.DeviceId);
+        stored.LegacyId.Should().Be("legacy-1");
+        stored.AdditionalPropertiesJson.Should().Contain("closedLoop");
+        result.InsulinContext!.InsulinName.Should().Be("Fiasp");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithMatchingSyncKey_ClearsFieldsTheRequestCanCarry()
+    {
+        var seed = CreateRecord("sync-1", end: new DateTime(2026, 5, 1, 12, 30, 0, DateTimeKind.Utc));
+        seed.ScheduledRate = 0.8;
+        seed.PumpRecordId = "pump-1";
+        seed.CorrelationId = Guid.CreateVersion7();
+        await _repository.CreateAsync(seed, WriteOrigin.Live);
+
+        await _repository.CreateAsync(CreateRecord("sync-1", rate: 2.5), WriteOrigin.Live);
+
+        var stored = _context.TempBasals.Single();
+        stored.EndTimestamp.Should().BeNull();
+        stored.ScheduledRate.Should().BeNull();
+        stored.PumpRecordId.Should().BeNull();
+        stored.CorrelationId.Should().BeNull();
+    }
+
+    [Fact]
     public async Task CreateAsync_WithDifferentSyncKey_Inserts()
     {
         await _repository.CreateAsync(CreateRecord("sync-1"), WriteOrigin.Live);


### PR DESCRIPTION
## Problem

`TempBasalRepository.CreateAsync` upserts on `(DataSource, SyncIdentifier)` so uploader retries stay idempotent, but it maps the incoming record straight over the matched row via `TempBasalMapper.UpdateEntity`, which assigns `PatientDeviceId` unconditionally. The controller never reads the stored row — it stamps a freshly-mapped model — so a retry sent after a device's usage window was edited, or after the device was removed, arrives with a null link and nulls the stored one. Temp basals are also in the back-stamp backlog (`GetUnattributedAsync`/`SetPatientDeviceIdsAsync`), so a link resolved asynchronously is wiped by the next retry too. Attribution is a read-time selector input, so this changes what users see.

Same shape as the bolus/meter PUT bug in #703, on a create/bulk-upsert path — the case #703 listed as a follow-up.

## Design

#703 distinguished "omitted" from "explicitly cleared" with the `Guid.Empty` sentinel on a `patientDeviceId` **request field**. This path has no such field and no update endpoint — POST is the only write — and the repository, which owns the match, has no channel for caller intent. An explicit clear genuinely cannot be expressed here, so omitted means **preserve**: on the sync-upsert branch only, keep the stored value of every field the create request cannot carry. Fields the request *can* carry stay unconditional, so omitting one still clears it. An explicitly supplied id still wins, leaving the seam open for the deferred set/clear semantic.

## Siblings audited

`UpdateEntity` assigns 18 fields unconditionally. Beyond `PatientDeviceId`, four more are inexpressible on this path and share the shape: `DeviceId` (the sibling device FK — `BolusController.MapUpdateToModel` preserves it from `existing` for the same reason), `LegacyId` (nulling it also makes `SoftDeleteAbsentBySourceAndDateRangeAsync` treat the row as absent and soft-delete it), `InsulinContextJson`, `AdditionalPropertiesJson`. Those three are currently only populated on decomposer-written rows, which carry no `SyncIdentifier` and so can't be matched by this upsert — structural rather than live, but the same fix covers them.

## Tests

4 new tests in `TempBasalRepositorySyncUpsertTests`; each of the five preserved fields is individually pinned, plus a negative guard that request-carryable fields still clear on retry. Mutation-proven in both directions: dropping a preserve fails exactly the corresponding preserve test; adding an over-preserve on `PumpRecordId` fails exactly the clear test. `Nocturne.Infrastructure.Data.Tests` 597/597, API temp-basal filter 96/96.

Follow-up from #703.
