### PR TITLE
fix(audit): system-attribute the connector cursor reset job's background scope

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetJobService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorCursorResetJobService.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 
@@ -180,6 +182,8 @@ public class ConnectorCursorResetJobService : IConnectorCursorResetJobService
 /// </summary>
 internal sealed class ConnectorResetJob : IConnectorResetProgress
 {
+    private const string AuditEndpoint = "service:connector-cursor-reset";
+
     private readonly Guid _id;
     private readonly Guid _tenantId;
     private readonly string _tenantSlug;
@@ -251,6 +255,18 @@ internal sealed class ConnectorResetJob : IConnectorResetProgress
             // Fresh DI scope for the background work — the engine sets the target tenant's context on
             // this scope (DbContext.TenantId, RLS GUC, ITenantAccessor) before fanning out.
             using var scope = _serviceProvider.CreateScope();
+
+            // A reset is an operator-triggered re-ingest, not a person editing data, and the job
+            // outlives the request that started it. The audit interceptor falls back to the ambient
+            // HTTP request's scope while that request is still open, so without explicit attribution
+            // whether this job's writes land on the triggering admin depends on a race with the 202
+            // response. The property covers this scope's own context; the pushed scope covers the
+            // contexts ITenantDbContextFactory creates. Mirrors the migration job service.
+            scope.ServiceProvider.GetRequiredService<NocturneDbContext>().AuditContext =
+                SystemAuditContext.ForService(AuditEndpoint);
+            using var systemScope = SystemAuditScope.Push(
+                scope.ServiceProvider.GetRequiredService<IAuditContext>());
+
             var engine = scope.ServiceProvider.GetRequiredService<IConnectorCursorResetService>();
 
             var result = await engine.ResetTenantCursorsAsync(_tenantId, _from, _dataTypes, this, ct);

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorCursorResetJobServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorCursorResetJobServiceTests.cs
@@ -3,8 +3,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.Connectors;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Infrastructure.Data;
 using Xunit;
 
@@ -37,10 +39,19 @@ public class ConnectorCursorResetJobServiceTests
     private static (ConnectorCursorResetJobService Service, IServiceProvider Provider) BuildService(
         IConnectorCursorResetService engine,
         IServiceProvider? existingProvider = null)
+        => BuildService(_ => engine, existingProvider);
+
+    /// <inheritdoc cref="BuildService(IConnectorCursorResetService, IServiceProvider?)"/>
+    private static (ConnectorCursorResetJobService Service, IServiceProvider Provider) BuildService(
+        Func<IServiceProvider, IConnectorCursorResetService> engineFactory,
+        IServiceProvider? existingProvider = null)
     {
         var dbName = $"reset-jobs-{Guid.NewGuid():N}";
         var provider = existingProvider ?? new ServiceCollection()
-            .AddScoped(_ => engine)
+            .AddScoped(engineFactory)
+            // Mirrors the production registration: the job's background scope marks its own
+            // ambient audit context as system for the fan-out's duration.
+            .AddScoped<IAuditContext, AuditContext>()
             .AddDbContext<NocturneDbContext>(o => o.UseInMemoryDatabase(dbName))
             .BuildServiceProvider();
 
@@ -143,6 +154,58 @@ public class ConnectorCursorResetJobServiceTests
             c.ConnectorName == "nightscout" && c.State == ConnectorResetConnectorState.Succeeded);
         status.Connectors.Should().Contain(c =>
             c.ConnectorName == "dexcom" && c.State == ConnectorResetConnectorState.Failed && c.Message == "nope");
+    }
+
+    [Fact]
+    public async Task StartResetAsync_AttributesTheBackgroundScopeToTheSystem()
+    {
+        // The fan-out re-ingests connector data; none of it is a person editing records. The audit
+        // interceptor reads the context-level audit context first and otherwise falls back to the
+        // ambient HTTP request's scope, so both paths of the background scope must say "system" or
+        // the job's writes are attributed to the admin who triggered it.
+        AttributionCapturingEngine? engine = null;
+        var (service, _) = BuildService(
+            sp => engine = new AttributionCapturingEngine(sp, Connectors(_tenantId)));
+
+        var info = await service.StartResetAsync(_tenantId, null, null, CancellationToken.None);
+        await WaitForTerminalAsync(service, info!.JobId);
+
+        engine!.AmbientIsSystemMutation.Should().BeTrue();
+        // A context left unstamped is not neutral: the interceptor then falls back to the
+        // triggering request's user context, so this must be a system context, not merely null.
+        engine.ContextAuditContext.Should().BeOfType<SystemAuditContext>();
+    }
+
+    /// <summary>
+    /// Stands in for the reset engine and records how the scope it was resolved from is
+    /// audit-attributed at the moment the fan-out runs.
+    /// </summary>
+    private sealed class AttributionCapturingEngine(
+        IServiceProvider scopeServices,
+        TenantConnectorsDto connectors) : IConnectorCursorResetService
+    {
+        public bool? AmbientIsSystemMutation { get; private set; }
+
+        public IAuditContext? ContextAuditContext { get; private set; }
+
+        public Task<TenantConnectorsDto?> GetTenantConnectorsAsync(Guid tenantId, CancellationToken ct)
+            => Task.FromResult<TenantConnectorsDto?>(connectors);
+
+        public Task<TenantCursorResetResult?> ResetTenantCursorsAsync(
+            Guid tenantId,
+            DateTime? from,
+            List<SyncDataType>? dataTypes,
+            IConnectorResetProgress? progress,
+            CancellationToken ct)
+        {
+            AmbientIsSystemMutation = scopeServices
+                .GetRequiredService<IAuditContext>().IsSystemMutation();
+            ContextAuditContext = scopeServices
+                .GetRequiredService<NocturneDbContext>().AuditContext;
+
+            return Task.FromResult<TenantCursorResetResult?>(
+                new TenantCursorResetResult(tenantId, connectors.TenantSlug, []));
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## What

`ConnectorCursorResetJobService` creates four child DI scopes with no audit attribution. The background execution scope needed it: the job is detached from the request that started it, but `MutationAuditInterceptor` falls back to `IHttpContextAccessor.HttpContext.RequestServices`' `IAuditContext` whenever the context-level property is unset — and the accessor's `AsyncLocal` holder is captured by the `Task.Run`, so for the whole window before the 202 completes, anything this job writes on its own scope would be audited as a mutation by the triggering platform admin. Correct attribution should not depend on that race.

Fixed on both paths the migration job service uses: the context property for the scope's own `NocturneDbContext`, `SystemAuditScope.Push` for the contexts `ITenantDbContextFactory` creates. Endpoint `service:connector-cursor-reset`.

## Audit of the other three scopes (no change needed)

- **`StartResetAsync` validation scope** — `GetTenantConnectorsAsync` reads only (`AsNoTracking` tenant + connector-config queries; `PinTenantAsync` is a `set_config` round-trip, not a save).
- **`FindRecordAsync`** — a single `FindAsync`.
- **`PersistSnapshotAsync`** — writes `ConnectorResetJobEntity`, which is deliberately *not* `IAuditable` (non-tenant-scoped operator metadata). The interceptor only walks `Entries<IAuditable>()`, so no audit row is ever produced. Same shape as `MigrationJobService.PersistSnapshotAsync`, which is likewise unattributed.

## Where the ingest writes actually go

Worth recording because it bounds this PR: the fan-out's writes do **not** happen on this job's scope. `ConnectorCursorResetService` only reads; every write happens in the child scope `ConnectorSyncService.TriggerSyncAsync` creates, and DI scopes don't inherit — that scope is rooted at the root provider. Those writes are covered by #713 on the factory path and by the in-flight fix for the injected-context path. This PR closes the job's own scope, not theirs.

## Test

`StartResetAsync_AttributesTheBackgroundScopeToTheSystem`, structured like #713's: a fake engine captures both the ambient `IAuditContext` and the scope's `NocturneDbContext.AuditContext` from inside the fan-out. The context path asserts `BeOfType<SystemAuditContext>()` rather than `IsSystemMutation()`, since the latter is true for a null context and would not have failed on removal.

Mutation-proven: removing the push fails with `AmbientIsSystemMutation ... found False`; removing the context stamp fails with `ContextAuditContext ... found <null>`; both restored, green. Full `Nocturne.API.Tests`: 5403 passed, 1 pre-existing unrelated failure (`DocumentProcessingServiceTests` memory benchmark).
