### PR TITLE
fix(audit): system-attribute the injected-context writes a manual connector sync makes

### DIFF
--- a/src/API/Nocturne.API/Services/Alerts/AlertAcknowledgementService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertAcknowledgementService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -19,7 +20,8 @@ internal sealed class AlertAcknowledgementService(
     IDbContextFactory<NocturneDbContext> contextFactory,
     ITenantAccessor tenantAccessor,
     ISignalRBroadcastService broadcastService,
-    ILogger<AlertAcknowledgementService> logger)
+    ILogger<AlertAcknowledgementService> logger,
+    IAuditContext? auditContext = null)
     : IAlertAcknowledgementService
 {
     /// <summary>
@@ -27,6 +29,9 @@ internal sealed class AlertAcknowledgementService(
     /// set from the supplied tenant or the ambient <see cref="ITenantAccessor"/>. Necessary because
     /// <see cref="IDbContextFactory{TContext}.CreateDbContextAsync"/> hands back a raw context
     /// (TenantId == Guid.Empty) which the global tenant query filter then uses to exclude every row.
+    /// The scope's audit context is carried too, as <c>ITenantDbContextFactory</c> does: the pooled
+    /// context is leased with the property cleared, and an auto-acknowledgement made during a
+    /// connector sync would otherwise fall back to the enclosing HTTP request's actor.
     /// </summary>
     private async Task<NocturneDbContext> CreateContextForAsync(Guid tenantId, CancellationToken ct)
     {
@@ -34,6 +39,7 @@ internal sealed class AlertAcknowledgementService(
         db.TenantId = tenantId == Guid.Empty
             ? (tenantAccessor.IsResolved ? tenantAccessor.TenantId : Guid.Empty)
             : tenantId;
+        db.AuditContext = auditContext;
         return db;
     }
 

--- a/src/API/Nocturne.API/Services/Alerts/AlertSweepService.cs
+++ b/src/API/Nocturne.API/Services/Alerts/AlertSweepService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Nocturne.API.Services.Alerts.Evaluators;
+using Nocturne.API.Services.Audit;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
@@ -30,6 +31,17 @@ public class AlertSweepService : BackgroundService
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<AlertSweepService> _logger;
+
+    /// <summary>
+    /// Audit endpoint recorded for the sweep's writes. The sweep runs with no request and no
+    /// actor, and <see cref="AlertAcknowledgementService"/> — reached through the orchestrator's
+    /// Info-severity auto-acknowledgement — stamps the scope's ambient context onto its own
+    /// contexts, so without an explicit push those acks are recorded as user mutations with every
+    /// actor field null. The other scopes' writers fall to the null-context system default today;
+    /// they carry the push so attribution is explicit rather than an accident of which context
+    /// path a writer uses.
+    /// </summary>
+    private const string AuditEndpoint = "service:alert-sweep";
 
     /// <summary>
     /// Initializes a new instance of <see cref="AlertSweepService"/>.
@@ -133,6 +145,9 @@ public class AlertSweepService : BackgroundService
                 true,
                 IsDemo: false));
 
+            using var systemScope = SystemAuditScope.PushForScope(
+                tenantScope.ServiceProvider, AuditEndpoint);
+
             var tracker = tenantScope.ServiceProvider.GetRequiredService<IExcursionTracker>();
             var resolutionHandler = tenantScope.ServiceProvider.GetRequiredService<IExcursionResolutionHandler>();
 
@@ -206,6 +221,9 @@ public class AlertSweepService : BackgroundService
                     using var tenantScope = _serviceProvider.CreateScope();
                     var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
                     tenantAccessor.SetTenant(new TenantContext(tenantContext.TenantId, tenantContext.Slug ?? string.Empty, tenantContext.DisplayName ?? string.Empty, true, IsDemo: false));
+
+                    using var systemScope = SystemAuditScope.PushForScope(
+                        tenantScope.ServiceProvider, AuditEndpoint);
 
                     var excursionTracker = tenantScope.ServiceProvider.GetRequiredService<IExcursionTracker>();
                     await excursionTracker.ProcessEvaluationAsync(rule.Id, true, ct);
@@ -489,6 +507,9 @@ public class AlertSweepService : BackgroundService
                 true,
                 IsDemo: false));
 
+            using var systemScope = SystemAuditScope.PushForScope(
+                tenantScope.ServiceProvider, AuditEndpoint);
+
             var engine = tenantScope.ServiceProvider.GetRequiredService<IAlertEvaluationEngine>();
             var enricher = tenantScope.ServiceProvider.GetRequiredService<ISensorContextEnricher>();
             var resolutionHandler = tenantScope.ServiceProvider.GetRequiredService<IExcursionResolutionHandler>();
@@ -548,7 +569,7 @@ public class AlertSweepService : BackgroundService
     /// "sensor expired" alert. The excursion state machine dedupes: once opened, further
     /// sweep passes are ExcursionContinues no-ops.
     /// </summary>
-    private async Task EvaluateTrackerAgeRulesAsync(CancellationToken ct)
+    internal async Task EvaluateTrackerAgeRulesAsync(CancellationToken ct)
     {
         using var lookupScope = _serviceProvider.CreateScope();
         var lookupRepository = lookupScope.ServiceProvider.GetRequiredService<IAlertRepository>();
@@ -571,6 +592,9 @@ public class AlertSweepService : BackgroundService
                 tenantContext.DisplayName ?? string.Empty,
                 true,
                 IsDemo: false));
+
+            using var systemScope = SystemAuditScope.PushForScope(
+                tenantScope.ServiceProvider, AuditEndpoint);
 
             var orchestrator = tenantScope.ServiceProvider.GetRequiredService<IAlertOrchestrator>();
 

--- a/src/API/Nocturne.API/Services/Audit/SystemAuditScope.cs
+++ b/src/API/Nocturne.API/Services/Audit/SystemAuditScope.cs
@@ -1,4 +1,5 @@
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Infrastructure.Data;
 
 namespace Nocturne.API.Services.Audit;
 
@@ -49,6 +50,24 @@ public sealed class SystemAuditScope : IDisposable
         => ambient is AuditContext mutable
             ? new SystemAuditScope(mutable)
             : NoOpScope.Instance;
+
+    /// <summary>
+    /// System-attributes every write a DI scope makes, on both context paths: the scope's own
+    /// <see cref="NocturneDbContext"/> carries its own <see cref="IAuditContext"/> property, which
+    /// the interceptor prefers over the ambient one, while the contexts
+    /// <c>ITenantDbContextFactory</c> creates are stamped from the scoped ambient context. Covering
+    /// only one leaves the other attributing the scope's writes to whoever started it — and the
+    /// interceptor derives <c>DeletedByUser</c> from that, which blocks a later resync from
+    /// re-creating rows a sync soft-deleted.
+    /// </summary>
+    /// <param name="scopeServices">The child scope's service provider.</param>
+    /// <param name="endpoint">Descriptive identifier, e.g. <c>"connector:dexcom"</c>.</param>
+    public static IDisposable PushForScope(IServiceProvider scopeServices, string endpoint)
+    {
+        scopeServices.GetRequiredService<NocturneDbContext>().AuditContext =
+            SystemAuditContext.ForService(endpoint);
+        return Push(scopeServices.GetRequiredService<IAuditContext>());
+    }
 
     public void Dispose()
     {

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
-using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
@@ -358,16 +357,11 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         var tenantAccessor = scope.ServiceProvider.GetRequiredService<ITenantAccessor>();
         tenantAccessor.SetTenant(new TenantContext(tenantId, tenantSlug, displayName, true, IsDemo: false));
 
-        // Populate audit context so mutations are attributed to this connector
-        var dbContext = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
-        dbContext.AuditContext = SystemAuditContext.ForService($"connector:{ConnectorName}");
+        // Attribute this connector's mutations to the connector rather than to a human actor.
+        using var systemScope = SystemAuditScope.PushForScope(
+            scope.ServiceProvider, $"connector:{ConnectorName}");
 
-        // TenantDbContextFactory stamps the scoped IAuditContext onto every context it
-        // creates for the V4 repositories, and in a background scope that context is a
-        // blank user context (IsSystem = false) — without this push, their writes are
-        // audited as null-attributed user mutations instead of being skipped as system.
-        using var systemScope = SystemAuditScope.Push(
-            scope.ServiceProvider.GetRequiredService<IAuditContext>());
+        var dbContext = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
 
         // Pin the RLS tenant on the scoped DbContext. NocturneDbContext is pooled and the
         // CarrierResettingDbContextFactory leases it with TenantId reset to Guid.Empty; the scoped

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorSyncService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorSyncService.cs
@@ -1,7 +1,6 @@
 using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
-using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 
 namespace Nocturne.API.Services.Connectors;
@@ -83,14 +82,6 @@ public class ConnectorSyncService : IConnectorSyncService
                 scopedTenantAccessor.SetTenant(tenantContext);
             }
 
-            // A manual trigger ingests the same connector data as the scheduled sync and must be
-            // attributed the same way. TenantDbContextFactory stamps this scope's IAuditContext
-            // onto every context it creates for the V4 repositories, and a child scope's is a
-            // blank user context (IsSystem = false) — without this push the imports are audited
-            // as null-attributed user mutations. Mirrors ConnectorBackgroundService.
-            using var systemScope = SystemAuditScope.Push(
-                scope.ServiceProvider.GetRequiredService<IAuditContext>());
-
             var executors = scope.ServiceProvider.GetServices<IConnectorSyncExecutor>();
             var executor = executors.FirstOrDefault(e =>
                 e.ConnectorId.Equals(connectorId, StringComparison.OrdinalIgnoreCase));
@@ -105,6 +96,11 @@ public class ConnectorSyncService : IConnectorSyncService
                     Message = $"Unknown connector: {connectorId}",
                 };
             }
+
+            // A manual trigger ingests the same connector data as the scheduled sync and must be
+            // attributed the same way. Mirrors ConnectorBackgroundService.
+            using var systemScope = SystemAuditScope.PushForScope(
+                scope.ServiceProvider, $"connector:{executor.ConnectorId}");
 
             var result = await executor.ExecuteSyncAsync(scope.ServiceProvider, request, ct, _progressReporter);
 

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -464,14 +464,10 @@ internal class MigrationJob
 
         // Attribute the imported records to the migration rather than to a human actor. A backfill
         // writes one row per historical treatment/entry, and without this every one of them also
-        // appends a mutation_audit_log row. The property covers writes made on this scope's own
-        // context; the pushed scope covers the contexts ITenantDbContextFactory creates for the V4
-        // repositories and decomposers. Mirrors ConnectorBackgroundService.
-        scope.ServiceProvider.GetRequiredService<NocturneDbContext>().AuditContext =
-            SystemAuditContext.ForService(AuditEndpoint);
+        // appends a mutation_audit_log row. Mirrors ConnectorBackgroundService.
         return new SystemAttributedScope(
             scope,
-            SystemAuditScope.Push(scope.ServiceProvider.GetRequiredService<IAuditContext>()));
+            SystemAuditScope.PushForScope(scope.ServiceProvider, AuditEndpoint));
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertAcknowledgementServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertAcknowledgementServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.Alerts;
 using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -20,6 +21,7 @@ public class AlertAcknowledgementServiceTests
     private readonly AlertAcknowledgementService _service;
 
     private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly ITenantAccessor _tenantAccessor;
 
     public AlertAcknowledgementServiceTests()
     {
@@ -36,9 +38,11 @@ public class AlertAcknowledgementServiceTests
         tenantAccessor.Setup(t => t.IsResolved).Returns(true);
         tenantAccessor.Setup(t => t.TenantId).Returns(_tenantId);
 
+        _tenantAccessor = tenantAccessor.Object;
+
         _service = new AlertAcknowledgementService(
             _factory,
-            tenantAccessor.Object,
+            _tenantAccessor,
             _broadcast.Object,
             NullLogger<AlertAcknowledgementService>.Instance);
     }
@@ -244,12 +248,35 @@ public class AlertAcknowledgementServiceTests
             Times.Never);
     }
 
+    [Fact]
+    public async Task AcknowledgeAllAsync_CarriesTheScopeAuditContextOntoEachContext()
+    {
+        // Acknowledgement mutates an auditable entity, and the pooled context is leased with
+        // AuditContext cleared. Left unset, an auto-acknowledgement made inside a connector
+        // sync's scope is attributed to whichever HTTP request the interceptor falls back to.
+        await SeedActiveExcursionAsync();
+        var audit = SystemAuditContext.ForService("connector:test");
+        var service = new AlertAcknowledgementService(
+            _factory,
+            _tenantAccessor,
+            _broadcast.Object,
+            NullLogger<AlertAcknowledgementService>.Instance,
+            audit);
+
+        await service.AcknowledgeAllAsync(_tenantId, "system", CancellationToken.None);
+
+        _factory.Created.Should().NotBeEmpty();
+        _factory.Created.Should().OnlyContain(c => c.AuditContext == audit);
+    }
+
     private sealed class TestDbContextFactory(DbContextOptions<NocturneDbContext> options)
         : IDbContextFactory<NocturneDbContext>
     {
         // Optional override so AcknowledgeExcursionAsync (which doesn't take a tenant) can still
         // resolve the excursion across tenants under the global query filter.
         public Guid? TenantOverride { get; set; }
+
+        public List<NocturneDbContext> Created { get; } = [];
 
         public NocturneDbContext CreateDbContext()
         {
@@ -258,6 +285,7 @@ public class AlertAcknowledgementServiceTests
             {
                 ctx.TenantId = t;
             }
+            Created.Add(ctx);
             return ctx;
         }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertSweepServiceAuditAttributionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/AlertSweepServiceAuditAttributionTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Alerts;
+using Nocturne.API.Services.Audit;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Alerts;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Alerts;
+
+[Trait("Category", "Unit")]
+public class AlertSweepServiceAuditAttributionTests
+{
+    private static readonly Guid Tenant = Guid.NewGuid();
+
+    /// <summary>
+    /// The orchestrator auto-acknowledges Info-severity excursions, and
+    /// <see cref="AlertAcknowledgementService"/> carries the scope's audit context onto the
+    /// contexts it creates. The sweep has no request and no actor, so both the ambient context
+    /// and the scope's own DbContext must be system-attributed or those acknowledgements land as
+    /// user mutations with every actor field null.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateTrackerAgeRulesAsync_SystemAttributesTheTenantScope()
+    {
+        var rule = new AlertRuleSnapshot(
+            Guid.NewGuid(), Tenant, "sensor expired", AlertConditionType.TrackerAge,
+            "{}", AlertRuleSeverity.Info, "{}", 0, false, null);
+
+        var repository = new Mock<IAlertRepository>();
+        repository
+            .Setup(x => x.GetEnabledRulesByConditionTypeAsync(AlertConditionType.TrackerAge, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([rule]);
+        repository
+            .Setup(x => x.GetTenantAlertContextAsync(Tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TenantAlertContext(Tenant, "owner", "slug", "Slug", true, null));
+
+        IAuditContext? scopeContextAudit = null;
+        bool? ambientIsSystemMutation = null;
+
+        var services = new ServiceCollection();
+        services.AddSingleton(repository.Object);
+        services.AddScoped<ITenantAccessor>(_ => Mock.Of<ITenantAccessor>());
+        services.AddScoped<IAuditContext, AuditContext>();
+        services.AddScoped(_ => new NocturneDbContext(
+            new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+                .Options));
+        services.AddScoped<IAlertOrchestrator>(sp =>
+        {
+            var orchestrator = new Mock<IAlertOrchestrator>();
+            orchestrator
+                .Setup(x => x.EvaluateRulesAsync(
+                    It.IsAny<IReadOnlyList<AlertRuleSnapshot>>(),
+                    It.IsAny<SensorContext>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    scopeContextAudit = sp.GetRequiredService<NocturneDbContext>().AuditContext;
+                    ambientIsSystemMutation = sp.GetRequiredService<IAuditContext>().IsSystemMutation();
+                    return Task.CompletedTask;
+                });
+            return orchestrator.Object;
+        });
+
+        var sut = new AlertSweepService(
+            services.BuildServiceProvider(),
+            NullLogger<AlertSweepService>.Instance);
+
+        // Act
+        await sut.EvaluateTrackerAgeRulesAsync(CancellationToken.None);
+
+        // Assert
+        scopeContextAudit.Should().NotBeNull();
+        scopeContextAudit!.IsSystem.Should().BeTrue();
+        scopeContextAudit.Endpoint.Should().Be("service:alert-sweep");
+        ambientIsSystemMutation.Should().BeTrue();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorSyncServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorSyncServiceTests.cs
@@ -1,4 +1,6 @@
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -8,6 +10,7 @@ using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.Connectors;
@@ -46,6 +49,15 @@ public class ConnectorSyncServiceTests
         // Mirrors the production registration (Program.cs) — the sync scope resolves
         // the mutable scoped AuditContext to mark it system for the sync's duration.
         services.AddScoped<IAuditContext, AuditContext>();
+
+        // A real NocturneDbContext: the sync scope stamps its AuditContext property, which the
+        // mutation interceptor prefers over the ambient context. Sqlite rather than InMemory so
+        // the relational model builds; no connection is ever opened because nothing queries.
+        services.AddScoped(_ => new NocturneDbContext(
+            new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseSqlite("DataSource=:memory:")
+                .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+                .Options));
 
         foreach (var executor in executors)
         {
@@ -139,6 +151,29 @@ public class ConnectorSyncServiceTests
 
         // Assert
         capturedIsSystemMutation.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TriggerSyncAsync_SystemAttributesTheScopeInjectedDbContext()
+    {
+        // The other half of the same hole: writes made on the scope's directly-injected
+        // NocturneDbContext (state spans, alert excursions) are attributed by that context's own
+        // AuditContext, and when it is unset the interceptor falls back to the enclosing HTTP
+        // request's — the person who clicked sync. That flags the sync's soft-deletes
+        // DeletedByUser, which stops a later resync re-creating those rows.
+        IAuditContext? captured = null;
+        var executor = CreateMockExecutor(
+            "test",
+            onSyncScope: sp => captured = sp.GetRequiredService<NocturneDbContext>().AuditContext);
+        var sut = CreateService(BuildProvider(executor));
+
+        // Act
+        await sut.TriggerSyncAsync("test", new SyncRequest(), CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.IsSystem.Should().BeTrue();
+        captured.Endpoint.Should().Be("connector:test");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorSyncServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorSyncServiceTests.cs
@@ -156,11 +156,8 @@ public class ConnectorSyncServiceTests
     [Fact]
     public async Task TriggerSyncAsync_SystemAttributesTheScopeInjectedDbContext()
     {
-        // The other half of the same hole: writes made on the scope's directly-injected
-        // NocturneDbContext (state spans, alert excursions) are attributed by that context's own
-        // AuditContext, and when it is unset the interceptor falls back to the enclosing HTTP
-        // request's — the person who clicked sync. That flags the sync's soft-deletes
-        // DeletedByUser, which stops a later resync re-creating those rows.
+        // Writes on the scope's directly-injected context are attributed by that context's own
+        // AuditContext, not the ambient one, so it needs stamping too.
         IAuditContext? captured = null;
         var executor = CreateMockExecutor(
             "test",


### PR DESCRIPTION
## What
#713 system-attributed the `ITenantDbContextFactory` path of `ConnectorSyncService.TriggerSyncAsync` and deliberately left the other half open. This closes it.

Writes made on the sync scope's directly-injected `NocturneDbContext` read that context's own `AuditContext` property, and when it is unset `MutationAuditInterceptor` falls back to `IHttpContextAccessor` — the **enclosing HTTP request**, i.e. the person who clicked "sync now". So the child scope's `SystemAuditScope.Push` never touched them. Affected auditable writes: `StateSpanEntity` (`StateSpanRepository`, via `MetadataPublisher.PublishStateSpansAsync` / `ActivityService` / the activity, treatment and device-status decomposers), `AlertExcursionEntity` (`AlertTrackerRepository`, via `CanonicalAlertEvaluator` from `GlucosePublisher`), and `BasalInjectionEntity` (`BasalInjectionRepository` — the one V4 repository that is not factory-based), found while sweeping the scope's object graph.

The sharp consequence is not the audit rows: the interceptor derives `DeletedByUser = !IsSystemMutation()`, so a manual sync's soft-deletes were flagged user-deleted, and resync respects user deletions — a later sync could not re-create those rows.

## Also fixed
`AlertAcknowledgementService` builds contexts from the raw pooled `IDbContextFactory`, which leases them with `AuditContext` cleared. `AlertOrchestrator` auto-acknowledges Info-severity rules on every excursion it opens, and that runs inside the sync's evaluation, so those acknowledgements were attributed to the triggering user too (manual-sync-only — a background sync has no `HttpContext` and fell through to system). It now carries the scope's audit context the way `ITenantDbContextFactory` does; controller acks are unaffected.

Because the acknowledgement service now stamps the ambient context, `AlertSweepService`'s per-tenant scopes — which resolve a blank, non-system `AuditContext` — push system attribution too (`service:alert-sweep`). The tracker-age scope reaches the orchestrator's auto-ack path and would otherwise have written null-actor audit rows; the other three scopes' writers fall to the null-context system default today and carry the push so attribution is explicit rather than an accident of which context path a writer uses.

## Shape
Both halves of the attribution now live in `SystemAuditScope.PushForScope`. `ConnectorBackgroundService` and `MigrationJobService` already needed both and were spelling them out separately; they now call the shared helper.

## Tests
New `TriggerSyncAsync_SystemAttributesTheScopeInjectedDbContext` (fixture extended with a SQLite-backed scoped `NocturneDbContext`), `AcknowledgeAllAsync_CarriesTheScopeAuditContextOntoEachContext`, and `EvaluateTrackerAgeRulesAsync_SystemAttributesTheTenantScope`. All mutation-proven: removing each attribution assignment fails the corresponding test. Full `Nocturne.API.Tests`: 5406 passed, 0 failed.
