### PR TITLE
fix(security): scope-gate the V4 analytics reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,10 +212,16 @@ Design notes:
   table from that map — so a new entity gets a policy on the next boot, and a table
   with no governing scope is **hidden from shares** (fail-safe). A guard test asserts
   every `ITenantScoped` table is classified.
-- **Response-cache invariant.** `ChartDataController` is `[ResponseCache]`d; RLS
-  gates the DB read, not a cache hit. Safe only because a share is its own subdomain
-  (per-tenant Host cache key, `UseForwardedHeaders` before `UseResponseCaching`).
-  A public-scope toggle has up to a 60s staleness window.
+- **Response-cache invariant.** RLS gates the DB read, not a cache hit, so any
+  `[ResponseCache]`d share-reachable read is safe only because a share is its own
+  subdomain (per-tenant Host cache key, `UseForwardedHeaders` before
+  `UseResponseCaching`), and a public-scope toggle has up to a 60s staleness window.
+  A response whose body is additionally narrowed per *caller scope* cannot use the
+  shared cache at all — its key is only host + query + `Cookie`, so a credential
+  presenting neither a cookie nor an `Authorization` header (the legacy `api-secret`
+  header) would be served another credential's unredacted body. Those endpoints
+  (`ChartDataController`'s dashboard, `ActogramController`) declare
+  `ResponseCacheLocation.Client`.
 
 ## Testing
 

--- a/src/API/Nocturne.API/Authorization/AnalyticsReadScopeGuards.cs
+++ b/src/API/Nocturne.API/Authorization/AnalyticsReadScopeGuards.cs
@@ -1,0 +1,299 @@
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Widget;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Per-category read scopes for the V4 analytics payloads that merge several data categories into
+/// one response, the shape <see cref="ActogramReadScopeGuard"/> documents: the controller attribute
+/// lists the categories as an OR so any caller holding one of them is admitted, and the guard
+/// empties the categories the caller does not hold. Attribute arguments must be compile-time
+/// constants, so each attribute repeats its admission list inline and the <c>AdmissionScopes</c>
+/// members here are what the guard tests pin it against.
+/// </summary>
+internal static class AnalyticsReadScopes
+{
+    /// <summary>
+    /// The two categories the retrospective, prediction and correlation payloads span. Glucose
+    /// covers the sensor/meter/calibration/BG-check readings and everything derived from them;
+    /// treatments covers insulin, carbs and the basal and IOB/COB series computed from them.
+    /// </summary>
+    public static readonly IReadOnlyList<string> GlucoseAndTreatments =
+    [
+        OAuthScopes.GlucoseRead,
+        OAuthScopes.TreatmentsRead,
+    ];
+
+    public static bool Allows(IReadOnlySet<string> grantedScopes, string scope) =>
+        OAuthScopes.SatisfiesScope(grantedScopes, scope);
+}
+
+/// <summary>
+/// Per-category read scopes for the dashboard chart, the widest merge in the API: glucose readings
+/// and their threshold band, the treatment markers and the IOB/COB/basal series derived from them,
+/// device and system events, profile switches, and the heart-rate and step overlays.
+/// </summary>
+/// <seealso cref="AnalyticsReadScopes"/>
+internal static class ChartDataReadScopeGuard
+{
+    public static readonly IReadOnlyList<string> AdmissionScopes =
+    [
+        OAuthScopes.GlucoseRead,
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.DevicesRead,
+        OAuthScopes.TherapyRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead,
+    ];
+
+    public static DashboardChartData Redact(
+        DashboardChartData data,
+        IReadOnlySet<string> grantedScopes)
+    {
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.GlucoseRead))
+        {
+            // Thresholds are the band edges of the glucose series, so they leave with it.
+            data.GlucoseData = [];
+            data.Thresholds = new ChartThresholdsDto();
+            data.BgCheckMarkers = [];
+        }
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.TreatmentsRead))
+        {
+            data.IobSeries = [];
+            data.CobSeries = [];
+            data.BasalSeries = [];
+            data.BolusMarkers = [];
+            data.CarbMarkers = [];
+            data.BasalInjectionMarkers = [];
+            data.OverrideSpans = [];
+            data.TempBasalSpans = [];
+            data.BasalDeliverySpans = [];
+            data.DefaultBasalRate = 0;
+            data.MaxBasalRate = 0;
+            data.MaxIob = 0;
+            data.MaxCob = 0;
+        }
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.DevicesRead))
+        {
+            data.DeviceEventMarkers = [];
+            data.SystemEventMarkers = [];
+            data.PumpModeSpans = [];
+        }
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.TherapyRead))
+            data.ProfileSpans = [];
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.HeartRateRead))
+            data.HeartRateSeries = [];
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.StepCountRead))
+            data.StepSeries = [];
+
+        // ActivitySpans is the one field with two governing categories: the exercise, illness and
+        // travel state spans are treatment annotations, while the sleep sessions projected in
+        // beside them are their own category, so it is filtered per span rather than emptied.
+        data.ActivitySpans = [.. data.ActivitySpans.Where(s => AnalyticsReadScopes.Allows(
+            grantedScopes,
+            s.Kind == ChartSpanKind.Sleep ? OAuthScopes.SleepRead : OAuthScopes.TreatmentsRead))];
+
+        return data;
+    }
+}
+
+/// <summary>
+/// Per-category read scopes for the retrospective "what was happening at this moment" payloads:
+/// the glucose value and direction on one side, the IOB/COB/basal state and the recent treatments
+/// that produced it on the other.
+/// </summary>
+/// <seealso cref="AnalyticsReadScopes"/>
+internal static class RetrospectiveReadScopeGuard
+{
+    public static readonly IReadOnlyList<string> AdmissionScopes = AnalyticsReadScopes.GlucoseAndTreatments;
+
+    public static RetrospectiveDataResponse Redact(
+        RetrospectiveDataResponse data,
+        IReadOnlySet<string> grantedScopes)
+    {
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.GlucoseRead))
+            data.Glucose = null;
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.TreatmentsRead))
+        {
+            data.Iob = null;
+            data.Cob = null;
+            data.Basal = null;
+            data.RecentTreatments = [];
+        }
+
+        return data;
+    }
+
+    public static RetrospectiveTimelineResponse Redact(
+        RetrospectiveTimelineResponse data,
+        IReadOnlySet<string> grantedScopes)
+    {
+        var glucose = AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.GlucoseRead);
+        var treatments = AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.TreatmentsRead);
+
+        if (glucose && treatments)
+            return data;
+
+        // The timeline interleaves both categories in every point, so redaction is per field
+        // rather than per collection; the frontend already renders a point with a null glucose.
+        foreach (var point in data.Data ?? [])
+        {
+            if (!glucose)
+            {
+                point.Glucose = null;
+                point.GlucoseDirection = null;
+            }
+
+            if (!treatments)
+            {
+                point.Iob = 0;
+                point.BolusIob = 0;
+                point.BasalIob = 0;
+                point.Cob = 0;
+                point.BasalRate = 0;
+                point.IsTemp = false;
+            }
+        }
+
+        return data;
+    }
+}
+
+/// <summary>
+/// Per-category read scopes for the glucose forecast: the curves and the current/eventual glucose
+/// they run from are the glucose category, while the insulin and carb state the forecast was
+/// computed against is the treatment category.
+/// </summary>
+/// <seealso cref="AnalyticsReadScopes"/>
+internal static class PredictionReadScopeGuard
+{
+    public static readonly IReadOnlyList<string> AdmissionScopes = AnalyticsReadScopes.GlucoseAndTreatments;
+
+    public static GlucosePredictionResponse Redact(
+        GlucosePredictionResponse data,
+        IReadOnlySet<string> grantedScopes)
+    {
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.GlucoseRead))
+        {
+            data.CurrentBg = 0;
+            data.Delta = 0;
+            data.EventualBg = 0;
+            data.Predictions = new PredictionCurves();
+        }
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.TreatmentsRead))
+        {
+            data.Iob = 0;
+            data.Cob = 0;
+            data.SensitivityRatio = null;
+        }
+
+        return data;
+    }
+}
+
+/// <summary>
+/// Per-category read scopes for the correlation lookup, which fans one correlation id out across
+/// the glucose repositories (sensor, meter, calibration, BG check) and the treatment repositories
+/// (bolus, carb intake, note, bolus calculation).
+/// </summary>
+/// <remarks>
+/// Redaction here is a decision not to query rather than a decision to empty: the controller skips
+/// the repositories whose category the caller does not hold, so a partial read costs less than a
+/// full one.
+/// </remarks>
+/// <seealso cref="AnalyticsReadScopes"/>
+internal static class CorrelationReadScopeGuard
+{
+    public static readonly IReadOnlyList<string> AdmissionScopes = AnalyticsReadScopes.GlucoseAndTreatments;
+
+    public static bool AllowsGlucose(IReadOnlySet<string> grantedScopes) =>
+        AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.GlucoseRead);
+
+    public static bool AllowsTreatments(IReadOnlySet<string> grantedScopes) =>
+        AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.TreatmentsRead);
+}
+
+/// <summary>
+/// Per-category read scopes for the widget summary, which packs the current and historical glucose,
+/// the IOB/COB state, the tracker statuses and the firing alarm into one small payload.
+/// </summary>
+/// <remarks>
+/// Trackers carry no <see cref="ShareDataCategories"/> category and are gated by the fallback
+/// policy wherever else they are served, so they are not redacted here.
+/// </remarks>
+/// <seealso cref="AnalyticsReadScopes"/>
+internal static class WidgetSummaryReadScopeGuard
+{
+    public static readonly IReadOnlyList<string> AdmissionScopes =
+    [
+        OAuthScopes.GlucoseRead,
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.AlertsRead,
+    ];
+
+    public static V4SummaryResponse Redact(
+        V4SummaryResponse data,
+        IReadOnlySet<string> grantedScopes)
+    {
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.GlucoseRead))
+        {
+            data.Current = null;
+            data.History = [];
+            data.Predictions = null;
+        }
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.TreatmentsRead))
+        {
+            data.Iob = 0;
+            data.Cob = 0;
+        }
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.AlertsRead))
+            data.Alarm = null;
+
+        return data;
+    }
+}
+
+/// <summary>
+/// Per-category read scopes for the "right now" therapy state: the pump mode and the pump's
+/// reservoir and battery readings are the device category, while the sensitivity adjustment is read
+/// off the active therapy profile.
+/// </summary>
+/// <seealso cref="AnalyticsReadScopes"/>
+internal static class CurrentTherapyStateReadScopeGuard
+{
+    public static readonly IReadOnlyList<string> AdmissionScopes =
+    [
+        OAuthScopes.DevicesRead,
+        OAuthScopes.TherapyRead,
+    ];
+
+    public static CurrentTherapyStateResponse Redact(
+        CurrentTherapyStateResponse data,
+        IReadOnlySet<string> grantedScopes)
+    {
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.DevicesRead))
+        {
+            data.CurrentPumpMode = null;
+            data.Reservoir = null;
+            data.PumpBatteryPercent = null;
+            data.PumpBatteryVoltage = null;
+        }
+
+        if (!AnalyticsReadScopes.Allows(grantedScopes, OAuthScopes.TherapyRead))
+            data.SensitivityPercent = null;
+
+        return data;
+    }
+}

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/ActogramController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/ActogramController.cs
@@ -53,7 +53,7 @@ public class ActogramController : ControllerBase
         OAuthScopes.HeartRateRead,
         OAuthScopes.StepCountRead,
         OAuthScopes.SleepRead)]
-    [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
+    [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Client)]
     [ProducesResponseType(typeof(ActogramReportData), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/AnalyticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/AnalyticsController.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.Core.Contracts.Analytics;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
 
@@ -21,6 +23,10 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 [Tags("Analytics")]
 [Route("api/v4/[controller]")]
 [Produces("application/json")]
+// Usage telemetry and its collection switch are a tenant-wide operational setting, not a data
+// category: nothing here is per-subject and the payloads carry no PHI, so the gate is the same
+// permission TenantSettingsController checks rather than any health-data scope.
+[RequireScope(TenantPermissions.TenantSettings)]
 public class AnalyticsController : ControllerBase
 {
     private readonly IAnalyticsService _analyticsService;

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/ChartDataController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/ChartDataController.cs
@@ -1,7 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Analytics;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
 
@@ -12,8 +16,12 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 /// state spans, system events, and tracker markers.
 /// </summary>
 /// <remarks>
-/// Responses are cached for 60 seconds, varying by query keys,
-/// to avoid redundant recalculation when the browser reconnects.
+/// Responses are cached for 60 seconds in the caller's own client cache, so a browser that
+/// reconnects does not force a recalculation. The cache is deliberately private:
+/// <see cref="ChartDataReadScopeGuard"/> makes the body depend on the caller's scopes, and the
+/// shared response cache keys only on host, query and <c>Cookie</c>, so a credential that presents
+/// neither a cookie nor an <c>Authorization</c> header — the legacy <c>api-secret</c> header —
+/// would otherwise be served another credential's unredacted body.
 /// </remarks>
 /// <seealso cref="IChartDataService"/>
 /// <seealso cref="DashboardChartData"/>
@@ -49,7 +57,15 @@ public class ChartDataController : ControllerBase
     /// <exception cref="Exception">Returns HTTP 500 if chart data calculation fails.</exception>
     [HttpGet("dashboard")]
     [RemoteQuery]
-    [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
+    [RequireScope(
+        OAuthScopes.GlucoseRead,
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.DevicesRead,
+        OAuthScopes.TherapyRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead)]
+    [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Client)]
     [ProducesResponseType(typeof(DashboardChartData), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -75,7 +91,7 @@ public class ChartDataController : ControllerBase
                 cancellationToken
             );
 
-            return Ok(result);
+            return Ok(ChartDataReadScopeGuard.Redact(result, HttpContext.GetGrantedScopes()));
         }
         catch (Exception ex)
         {
@@ -96,6 +112,7 @@ public class ChartDataController : ControllerBase
     /// <returns>A list of <see cref="BasalPoint"/> representing basal delivery over time.</returns>
     [HttpGet("basal-series")]
     [RemoteQuery]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
     [ProducesResponseType(typeof(List<BasalPoint>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/CorrelationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/CorrelationController.cs
@@ -1,6 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
 
@@ -67,19 +71,24 @@ public class CorrelationController : ControllerBase
     /// Arrays are empty when no matching records exist in that category.
     /// </returns>
     [HttpGet("{correlationId:guid}")]
+    [RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult> GetCorrelated(Guid correlationId, CancellationToken ct = default)
     {
+        var granted = HttpContext.GetGrantedScopes();
+        var glucose = CorrelationReadScopeGuard.AllowsGlucose(granted);
+        var treatments = CorrelationReadScopeGuard.AllowsTreatments(granted);
+
         var result = new
         {
-            SensorGlucose = await _sensorRepo.GetByCorrelationIdAsync(correlationId, ct),
-            MeterGlucose = await _meterRepo.GetByCorrelationIdAsync(correlationId, ct),
-            Calibrations = await _calibrationRepo.GetByCorrelationIdAsync(correlationId, ct),
-            Boluses = await _bolusRepo.GetByCorrelationIdAsync(correlationId, ct),
-            CarbIntakes = await _carbIntakeRepo.GetByCorrelationIdAsync(correlationId, ct),
-            BGChecks = await _bgCheckRepo.GetByCorrelationIdAsync(correlationId, ct),
-            Notes = await _noteRepo.GetByCorrelationIdAsync(correlationId, ct),
-            BolusCalculations = await _bolusCalcRepo.GetByCorrelationIdAsync(correlationId, ct),
+            SensorGlucose = glucose ? await _sensorRepo.GetByCorrelationIdAsync(correlationId, ct) : [],
+            MeterGlucose = glucose ? await _meterRepo.GetByCorrelationIdAsync(correlationId, ct) : [],
+            Calibrations = glucose ? await _calibrationRepo.GetByCorrelationIdAsync(correlationId, ct) : [],
+            Boluses = treatments ? await _bolusRepo.GetByCorrelationIdAsync(correlationId, ct) : [],
+            CarbIntakes = treatments ? await _carbIntakeRepo.GetByCorrelationIdAsync(correlationId, ct) : [],
+            BGChecks = glucose ? await _bgCheckRepo.GetByCorrelationIdAsync(correlationId, ct) : [],
+            Notes = treatments ? await _noteRepo.GetByCorrelationIdAsync(correlationId, ct) : [],
+            BolusCalculations = treatments ? await _bolusCalcRepo.GetByCorrelationIdAsync(correlationId, ct) : [],
         };
         return Ok(result);
     }

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/CurrentTherapyStateController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/CurrentTherapyStateController.cs
@@ -1,10 +1,14 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
 
@@ -39,6 +43,7 @@ public class CurrentTherapyStateController : ControllerBase
     /// </summary>
     [HttpGet]
     [RemoteQuery]
+    [RequireScope(OAuthScopes.DevicesRead, OAuthScopes.TherapyRead)]
     [ProducesResponseType(typeof(CurrentTherapyStateResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<CurrentTherapyStateResponse>> GetCurrentTherapyState(
         CancellationToken cancellationToken = default)
@@ -46,14 +51,16 @@ public class CurrentTherapyStateController : ControllerBase
         var pumpMode = await _stateSpanService.GetCurrentPumpModeAsync(cancellationToken);
         var sensitivityPercent = await _sensitivityResolver.GetCurrentSensitivityPercentAsync(cancellationToken);
         var latestPump = await _pumpSnapshotRepository.GetLatestAsync(asOf: null, cancellationToken);
-        return Ok(new CurrentTherapyStateResponse
-        {
-            CurrentPumpMode = pumpMode,
-            SensitivityPercent = sensitivityPercent,
-            Reservoir = latestPump?.Reservoir,
-            PumpBatteryPercent = latestPump?.BatteryPercent,
-            PumpBatteryVoltage = latestPump?.BatteryVoltage,
-        });
+        return Ok(CurrentTherapyStateReadScopeGuard.Redact(
+            new CurrentTherapyStateResponse
+            {
+                CurrentPumpMode = pumpMode,
+                SensitivityPercent = sensitivityPercent,
+                Reservoir = latestPump?.Reservoir,
+                PumpBatteryPercent = latestPump?.BatteryPercent,
+                PumpBatteryVoltage = latestPump?.BatteryVoltage,
+            },
+            HttpContext.GetGrantedScopes()));
     }
 }
 

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
@@ -2,7 +2,11 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
 using Nocturne.API.Services.Glucose;
+using Nocturne.Core.Models.Authorization;
 
 namespace Nocturne.API.Controllers.V4.Analytics;
 
@@ -54,6 +58,7 @@ public class PredictionController : ControllerBase
     /// <returns>Glucose predictions including IOB, UAM, COB, and zero-temp curves</returns>
     [HttpGet]
     [RemoteQuery]
+    [RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead)]
     [ProducesResponseType(typeof(GlucosePredictionResponse), 200)]
     [ProducesResponseType(typeof(PredictionErrorResponse), 400)]
     [ProducesResponseType(typeof(PredictionErrorResponse), 404)]
@@ -73,7 +78,7 @@ public class PredictionController : ControllerBase
         try
         {
             var result = await _predictionService.GetPredictionsAsync(profileId, asOf: null, cancellationToken);
-            return Ok(result);
+            return Ok(PredictionReadScopeGuard.Redact(result, HttpContext.GetGrantedScopes()));
         }
         catch (InvalidOperationException ex)
         {
@@ -95,6 +100,7 @@ public class PredictionController : ControllerBase
     /// <returns>Status of the prediction service including configured source</returns>
     [HttpGet("status")]
     [RemoteQuery]
+    [RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead)]
     [ProducesResponseType(typeof(PredictionStatusResponse), 200)]
     public ActionResult<PredictionStatusResponse> GetStatus()
     {
@@ -124,6 +130,7 @@ public class PredictionController : ControllerBase
     /// <param name="cancellationToken">Cancellation token.</param>
     [HttpGet("profile-snapshot")]
     [RemoteQuery]
+    [RequireScope(OAuthScopes.TherapyRead)]
     [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     [ProducesResponseType(typeof(ProfileSnapshotResponse), 200)]
     [ProducesResponseType(typeof(PredictionErrorResponse), 500)]

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/RetrospectiveController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/RetrospectiveController.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
 using Nocturne.API.Services.Treatments;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.API.Services.Devices;
@@ -7,6 +10,7 @@ using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using System.Linq;
 namespace Nocturne.API.Controllers.V4.Analytics;
@@ -79,6 +83,7 @@ public class RetrospectiveController : ControllerBase
     /// <response code="500">If there was an internal server error</response>
     [HttpGet("at")]
     [RemoteQuery]
+    [RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead)]
     [ProducesResponseType(typeof(RetrospectiveDataResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -192,7 +197,7 @@ public class RetrospectiveController : ControllerBase
                 Basal = basalData,
                 RecentTreatments = recentTreatments
             };
-            return Ok(response);
+            return Ok(RetrospectiveReadScopeGuard.Redact(response, HttpContext.GetGrantedScopes()));
         }
         catch (Exception ex)
         {
@@ -213,6 +218,7 @@ public class RetrospectiveController : ControllerBase
     /// <response code="500">If there was an internal server error</response>
     [HttpGet("timeline")]
     [RemoteQuery]
+    [RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead)]
     [ProducesResponseType(typeof(RetrospectiveTimelineResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -321,7 +327,7 @@ public class RetrospectiveController : ControllerBase
                 TotalPoints = dataPoints.Count,
                 Data = dataPoints
             };
-            return Ok(response);
+            return Ok(RetrospectiveReadScopeGuard.Redact(response, HttpContext.GetGrantedScopes()));
         }
         catch (Exception ex)
         {
@@ -339,6 +345,7 @@ public class RetrospectiveController : ControllerBase
     /// <returns>Basal rate timeline for the day</returns>
     [HttpGet("basal-timeline")]
     [RemoteQuery]
+    [RequireScope(OAuthScopes.TreatmentsRead)]
     [ProducesResponseType(typeof(BasalTimelineResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/SummaryController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/SummaryController.cs
@@ -1,7 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Widget;
 using Nocturne.API.Services.Glucose;
 
@@ -57,6 +60,7 @@ public class SummaryController : ControllerBase
     /// <returns>Widget summary response with aggregated diabetes management data</returns>
     [HttpGet]
     [Authorize]
+    [RequireScope(OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsRead, OAuthScopes.AlertsRead)]
     [ProducesResponseType(typeof(V4SummaryResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<V4SummaryResponse>> GetSummary(
@@ -87,7 +91,7 @@ public class SummaryController : ControllerBase
                 HttpContext.RequestAborted
             );
 
-            return Ok(summary);
+            return Ok(WidgetSummaryReadScopeGuard.Redact(summary, HttpContext.GetGrantedScopes()));
         }
         catch (Exception ex)
         {

--- a/tests/Unit/Nocturne.API.Tests/Authorization/AnalyticsReadScopeGuardTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/AnalyticsReadScopeGuardTests.cs
@@ -1,0 +1,776 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.API.Services.Glucose;
+using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.V4;
+using Nocturne.Core.Models.Widget;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// Admission and redaction for the V4 analytics controllers whose responses merge several data
+/// categories. Modelled on <see cref="ActogramReadScopeGuardTests"/>: each guard is exercised
+/// directly, each controller attribute is pinned to its guard's admission list, and each handler is
+/// driven once to prove it actually calls the guard.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AnalyticsReadScopeGuardTests
+{
+    private static IReadOnlySet<string> Granted(params string[] scopes) => new HashSet<string>(scopes);
+
+    private static ControllerContext ContextWith(IReadOnlySet<string> scopes)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = scopes;
+        return new ControllerContext { HttpContext = httpContext };
+    }
+
+    private static RequireScopeAttribute? GateOn<TController>(string action) =>
+        typeof(TController).GetMethod(action)!.GetCustomAttribute<RequireScopeAttribute>();
+
+    // ── Chart data ──────────────────────────────────────────────────────────────────────────
+
+    private static DashboardChartData OneRecordPerCategory() => new()
+    {
+        GlucoseData = [new GlucosePointDto { Time = 1, Sgv = 120 }],
+        Thresholds = new ChartThresholdsDto { Low = 70, High = 180 },
+        BgCheckMarkers = [new BgCheckMarkerDto { Time = 1, Glucose = 110 }],
+        IobSeries = [new TimeSeriesPoint { Timestamp = 1, Value = 2 }],
+        CobSeries = [new TimeSeriesPoint { Timestamp = 1, Value = 3 }],
+        BasalSeries = [new BasalPoint { Timestamp = 1, Rate = 0.5 }],
+        BolusMarkers = [new BolusMarkerDto { Time = 1, Insulin = 1 }],
+        CarbMarkers = [new CarbMarkerDto { Time = 1, Carbs = 30 }],
+        BasalInjectionMarkers = [new BasalInjectionMarkerDto { Id = "i", Time = 1 }],
+        TempBasalSpans = [new ChartStateSpanDto { Id = "tb" }],
+        BasalDeliverySpans = [new BasalDeliverySpanDto { Id = "bd" }],
+        DefaultBasalRate = 0.9,
+        MaxBasalRate = 1.2,
+        MaxIob = 4,
+        MaxCob = 40,
+        DeviceEventMarkers = [new DeviceEventMarkerDto { Time = 1 }],
+        SystemEventMarkers = [new SystemEventMarkerDto { Id = "se", Time = 1 }],
+        PumpModeSpans = [new ChartStateSpanDto { Id = "pm", Category = StateSpanCategory.PumpMode }],
+        ProfileSpans = [new ChartStateSpanDto { Id = "p", Category = StateSpanCategory.Profile }],
+        OverrideSpans = [new ChartStateSpanDto { Id = "o", Category = StateSpanCategory.Override }],
+        ActivitySpans =
+        [
+            new ChartStateSpanDto { Id = "ex", Kind = ChartSpanKind.StateSpan, Category = StateSpanCategory.Exercise },
+            new ChartStateSpanDto { Id = "sl", Kind = ChartSpanKind.Sleep },
+        ],
+        HeartRateSeries = [new HeartRatePointDto { Time = 1, Bpm = 60 }],
+        StepSeries = [new StepBubbleDto { Time = 1, Steps = 500 }],
+    };
+
+    [Fact]
+    public void ChartData_GlucoseOnlyGrant_KeepsGlucoseAndItsBand()
+    {
+        var data = ChartDataReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.GlucoseRead));
+
+        data.GlucoseData.Should().HaveCount(1);
+        data.BgCheckMarkers.Should().HaveCount(1);
+        data.Thresholds.Low.Should().Be(70);
+        data.IobSeries.Should().BeEmpty();
+        data.CobSeries.Should().BeEmpty();
+        data.BasalSeries.Should().BeEmpty();
+        data.BolusMarkers.Should().BeEmpty();
+        data.CarbMarkers.Should().BeEmpty();
+        data.BasalInjectionMarkers.Should().BeEmpty();
+        data.TempBasalSpans.Should().BeEmpty();
+        data.BasalDeliverySpans.Should().BeEmpty();
+        data.OverrideSpans.Should().BeEmpty();
+        data.DeviceEventMarkers.Should().BeEmpty();
+        data.SystemEventMarkers.Should().BeEmpty();
+        data.PumpModeSpans.Should().BeEmpty();
+        data.ProfileSpans.Should().BeEmpty();
+        data.HeartRateSeries.Should().BeEmpty();
+        data.StepSeries.Should().BeEmpty();
+        data.ActivitySpans.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ChartData_WithoutTreatments_ClearsTheAxisMaximaDerivedFromThem()
+    {
+        // The scaling maxima are computed from the series they scale, so leaving them behind would
+        // publish the peak IOB, COB and basal rate of a window the caller may not read.
+        var data = ChartDataReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.GlucoseRead));
+
+        data.DefaultBasalRate.Should().Be(0);
+        data.MaxBasalRate.Should().Be(0);
+        data.MaxIob.Should().Be(0);
+        data.MaxCob.Should().Be(0);
+    }
+
+    [Fact]
+    public void ChartData_WithoutGlucose_ClearsTheThresholds()
+    {
+        var data = ChartDataReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.DevicesRead));
+
+        data.Thresholds.Should().BeEquivalentTo(new ChartThresholdsDto());
+        data.DeviceEventMarkers.Should().HaveCount(1);
+        data.SystemEventMarkers.Should().HaveCount(1);
+        data.PumpModeSpans.Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// The activity track is the one field carrying two categories, so it is filtered per span:
+    /// a treatments grant keeps the exercise/illness/travel annotations and drops the sleep
+    /// sessions projected in beside them, and a sleep grant does the reverse.
+    /// </summary>
+    [Fact]
+    public void ChartData_ActivitySpans_AreFilteredPerSpanNotPerField()
+    {
+        var treatments = ChartDataReadScopeGuard.Redact(
+            OneRecordPerCategory(), Granted(OAuthScopes.TreatmentsRead));
+        treatments.ActivitySpans.Should().ContainSingle().Which.Id.Should().Be("ex");
+
+        var sleep = ChartDataReadScopeGuard.Redact(
+            OneRecordPerCategory(), Granted(OAuthScopes.SleepRead));
+        sleep.ActivitySpans.Should().ContainSingle().Which.Id.Should().Be("sl");
+    }
+
+    [Fact]
+    public void ChartData_TherapyOnlyGrant_KeepsOnlyTheProfileSwitches()
+    {
+        var data = ChartDataReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.TherapyRead));
+
+        data.ProfileSpans.Should().HaveCount(1);
+        data.GlucoseData.Should().BeEmpty();
+        data.PumpModeSpans.Should().BeEmpty();
+        data.OverrideSpans.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ChartData_FullAccess_KeepsEveryCategory()
+    {
+        var data = ChartDataReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.FullAccess));
+
+        data.GlucoseData.Should().HaveCount(1);
+        data.IobSeries.Should().HaveCount(1);
+        data.DeviceEventMarkers.Should().HaveCount(1);
+        data.ProfileSpans.Should().HaveCount(1);
+        data.HeartRateSeries.Should().HaveCount(1);
+        data.StepSeries.Should().HaveCount(1);
+        data.ActivitySpans.Should().HaveCount(2);
+        data.MaxIob.Should().Be(4);
+    }
+
+    [Fact]
+    public void ChartData_ReadWriteGrant_SatisfiesTheReadCategory()
+    {
+        var data = ChartDataReadScopeGuard.Redact(OneRecordPerCategory(), Granted(OAuthScopes.HeartRateReadWrite));
+
+        data.HeartRateSeries.Should().HaveCount(1);
+        data.GlucoseData.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ChartData_NoScopes_EmptiesEveryCategory()
+    {
+        var data = ChartDataReadScopeGuard.Redact(OneRecordPerCategory(), Granted());
+
+        data.GlucoseData.Should().BeEmpty();
+        data.IobSeries.Should().BeEmpty();
+        data.DeviceEventMarkers.Should().BeEmpty();
+        data.ProfileSpans.Should().BeEmpty();
+        data.HeartRateSeries.Should().BeEmpty();
+        data.StepSeries.Should().BeEmpty();
+        data.ActivitySpans.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ChartData_AdmissionScopes_CoverEveryMergedCategory()
+    {
+        ChartDataReadScopeGuard.AdmissionScopes.Should().BeEquivalentTo(new[]
+        {
+            OAuthScopes.GlucoseRead,
+            OAuthScopes.TreatmentsRead,
+            OAuthScopes.DevicesRead,
+            OAuthScopes.TherapyRead,
+            OAuthScopes.HeartRateRead,
+            OAuthScopes.StepCountRead,
+            OAuthScopes.SleepRead,
+        });
+    }
+
+    [Fact]
+    public void ChartData_GateMatchesItsGuard()
+    {
+        var gate = GateOn<ChartDataController>(nameof(ChartDataController.GetDashboardChartData));
+
+        gate.Should().NotBeNull();
+        gate!.RequiresAll.Should().BeFalse("holding one category must admit the caller");
+        gate.RequiredScopes.Should().BeEquivalentTo(ChartDataReadScopeGuard.AdmissionScopes);
+
+        GateOn<ChartDataController>(nameof(ChartDataController.GetBasalSeries))!
+            .RequiredScopes.Should().Equal(OAuthScopes.TreatmentsRead);
+    }
+
+    /// <summary>
+    /// Per-scope redaction makes the body depend on the caller's credential, so a redacted
+    /// response must not sit in the shared response cache, whose key is host + query + Cookie: a
+    /// credential presenting neither a cookie nor an <c>Authorization</c> header (the legacy
+    /// <c>api-secret</c> header) would otherwise be served another caller's unredacted body.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(ChartDataController), nameof(ChartDataController.GetDashboardChartData))]
+    [InlineData(typeof(ActogramController), nameof(ActogramController.GetActogram))]
+    public void RedactedResponses_AreNotSharedCacheable(Type controller, string action)
+    {
+        var cache = controller.GetMethod(action)!.GetCustomAttribute<ResponseCacheAttribute>();
+
+        cache!.Location.Should().Be(ResponseCacheLocation.Client);
+    }
+
+    [Fact]
+    public async Task ChartData_Handler_RedactsTheCategoriesTheCallerLacks()
+    {
+        var service = new Mock<IChartDataService>();
+        service
+            .Setup(s => s.GetDashboardChartDataAsync(
+                It.IsAny<long>(), It.IsAny<long>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OneRecordPerCategory());
+
+        var controller = new ChartDataController(service.Object, NullLogger<ChartDataController>.Instance)
+        {
+            ControllerContext = ContextWith(Granted(OAuthScopes.GlucoseRead)),
+        };
+
+        var result = await controller.GetDashboardChartData(startTime: 0, endTime: 1);
+
+        var data = result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<DashboardChartData>().Subject;
+        data.GlucoseData.Should().HaveCount(1);
+        data.IobSeries.Should().BeEmpty();
+        data.HeartRateSeries.Should().BeEmpty();
+    }
+
+    // ── Retrospective ───────────────────────────────────────────────────────────────────────
+
+    private static RetrospectiveDataResponse BothCategories() => new()
+    {
+        Time = 1,
+        Glucose = new GlucoseData { Value = 120 },
+        Iob = new IobData { Total = 2 },
+        Cob = new CobData { Total = 20 },
+        Basal = new BasalData { Rate = 0.8 },
+        RecentTreatments = [new TreatmentSummaryData { Id = "b", Mills = 1 }],
+    };
+
+    [Fact]
+    public void Retrospective_GlucoseOnlyGrant_DropsTheDosingState()
+    {
+        var data = RetrospectiveReadScopeGuard.Redact(BothCategories(), Granted(OAuthScopes.GlucoseRead));
+
+        data.Glucose.Should().NotBeNull();
+        data.Iob.Should().BeNull();
+        data.Cob.Should().BeNull();
+        data.Basal.Should().BeNull();
+        data.RecentTreatments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Retrospective_TreatmentsOnlyGrant_DropsTheGlucose()
+    {
+        var data = RetrospectiveReadScopeGuard.Redact(BothCategories(), Granted(OAuthScopes.TreatmentsRead));
+
+        data.Glucose.Should().BeNull();
+        data.Iob.Should().NotBeNull();
+        data.RecentTreatments.Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// The timeline interleaves both categories in every point, so redaction has to reach inside
+    /// the points rather than empty a collection.
+    /// </summary>
+    [Fact]
+    public void Retrospective_Timeline_RedactsPerFieldWithinEachPoint()
+    {
+        var timeline = new RetrospectiveTimelineResponse
+        {
+            Data = [new RetrospectiveDataPoint
+            {
+                Glucose = 120, GlucoseDirection = "Flat",
+                Iob = 2, BolusIob = 1, BasalIob = 1, Cob = 20, BasalRate = 0.8, IsTemp = true,
+            }],
+        };
+
+        var point = RetrospectiveReadScopeGuard
+            .Redact(timeline, Granted(OAuthScopes.GlucoseRead)).Data!.Single();
+
+        point.Glucose.Should().Be(120);
+        point.GlucoseDirection.Should().Be("Flat");
+        point.Iob.Should().Be(0);
+        point.BolusIob.Should().Be(0);
+        point.BasalIob.Should().Be(0);
+        point.Cob.Should().Be(0);
+        point.BasalRate.Should().Be(0);
+        point.IsTemp.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Retrospective_Timeline_TreatmentsOnlyGrant_DropsTheGlucose()
+    {
+        var timeline = new RetrospectiveTimelineResponse
+        {
+            Data = [new RetrospectiveDataPoint { Glucose = 120, GlucoseDirection = "Flat", Iob = 2 }],
+        };
+
+        var point = RetrospectiveReadScopeGuard
+            .Redact(timeline, Granted(OAuthScopes.TreatmentsRead)).Data!.Single();
+
+        point.Glucose.Should().BeNull();
+        point.GlucoseDirection.Should().BeNull();
+        point.Iob.Should().Be(2);
+    }
+
+    [Fact]
+    public void Retrospective_GatesMatchTheirGuard()
+    {
+        foreach (var action in new[]
+                 {
+                     nameof(RetrospectiveController.GetRetrospectiveData),
+                     nameof(RetrospectiveController.GetRetrospectiveTimeline),
+                 })
+        {
+            var gate = GateOn<RetrospectiveController>(action)!;
+
+            gate.RequiredScopes.Should().BeEquivalentTo(RetrospectiveReadScopeGuard.AdmissionScopes);
+            gate.RequiresAll.Should().BeFalse("holding one category must admit the caller");
+        }
+
+        // The basal timeline is wholly the treatment category, so it is not broadened to the OR.
+        GateOn<RetrospectiveController>(nameof(RetrospectiveController.GetBasalTimeline))!
+            .RequiredScopes.Should().Equal(OAuthScopes.TreatmentsRead);
+    }
+
+    [Fact]
+    public async Task Retrospective_Handler_RedactsTheCategoriesTheCallerLacks()
+    {
+        var entries = new Mock<IEntryService>();
+        entries
+            .Setup(s => s.GetEntriesWithAdvancedFilterAsync(
+                It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new Entry { Mills = 1_000, Sgv = 120, Direction = "Flat" }]);
+
+        var boluses = new Mock<IBolusRepository>();
+        boluses
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<BolusKind?>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var carbs = new Mock<ICarbIntakeRepository>();
+        carbs
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var tempBasals = new Mock<ITempBasalRepository>();
+        tempBasals
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var iob = new Mock<IIobCalculator>();
+        iob
+            .Setup(c => c.CalculateTotalAsync(
+                It.IsAny<List<Bolus>>(), It.IsAny<List<TempBasal>?>(),
+                It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IobResult());
+
+        var cob = new Mock<ICobCalculator>();
+        cob
+            .Setup(c => c.CalculateTotalAsync(
+                It.IsAny<List<CarbIntake>>(), It.IsAny<List<Bolus>?>(),
+                It.IsAny<List<TempBasal>?>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CobResult());
+
+        var basal = new Mock<IBasalRateResolver>();
+        basal.Setup(r => r.GetBasalRateAsync(It.IsAny<long>())).ReturnsAsync(0.8);
+
+        var controller = new RetrospectiveController(
+            iob.Object, cob.Object, entries.Object, boluses.Object, carbs.Object,
+            tempBasals.Object, projectionService: null!, basal.Object,
+            NullLogger<RetrospectiveController>.Instance)
+        {
+            ControllerContext = ContextWith(Granted(OAuthScopes.GlucoseRead)),
+        };
+
+        var result = await controller.GetRetrospectiveData(time: 1_000);
+
+        var data = result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<RetrospectiveDataResponse>().Subject;
+        data.Glucose.Should().NotBeNull();
+        data.Iob.Should().BeNull();
+        data.Cob.Should().BeNull();
+        data.Basal.Should().BeNull();
+    }
+
+    // ── Predictions ─────────────────────────────────────────────────────────────────────────
+
+    private static GlucosePredictionResponse Forecast() => new()
+    {
+        CurrentBg = 120,
+        Delta = 3,
+        EventualBg = 140,
+        Iob = 2,
+        Cob = 20,
+        SensitivityRatio = 1.1,
+        Predictions = new PredictionCurves { Default = [120, 125] },
+    };
+
+    [Fact]
+    public void Prediction_GlucoseOnlyGrant_DropsTheDosingScalars()
+    {
+        var data = PredictionReadScopeGuard.Redact(Forecast(), Granted(OAuthScopes.GlucoseRead));
+
+        data.CurrentBg.Should().Be(120);
+        data.Predictions.Default.Should().HaveCount(2);
+        data.Iob.Should().Be(0);
+        data.Cob.Should().Be(0);
+        data.SensitivityRatio.Should().BeNull();
+    }
+
+    [Fact]
+    public void Prediction_TreatmentsOnlyGrant_DropsTheCurves()
+    {
+        var data = PredictionReadScopeGuard.Redact(Forecast(), Granted(OAuthScopes.TreatmentsRead));
+
+        data.CurrentBg.Should().Be(0);
+        data.Delta.Should().Be(0);
+        data.EventualBg.Should().Be(0);
+        data.Predictions.Default.Should().BeNull();
+        data.Iob.Should().Be(2);
+    }
+
+    /// <summary>
+    /// The profile snapshot is the resolved therapy profile — basal schedule, ISF, carb ratio,
+    /// targets — so it is the therapy category alone, not the forecast's OR.
+    /// </summary>
+    [Fact]
+    public void Prediction_GatesMatchTheirCategories()
+    {
+        foreach (var action in new[]
+                 {
+                     nameof(PredictionController.GetPredictions),
+                     nameof(PredictionController.GetStatus),
+                 })
+        {
+            var gate = GateOn<PredictionController>(action)!;
+
+            gate.RequiredScopes.Should().BeEquivalentTo(PredictionReadScopeGuard.AdmissionScopes);
+            gate.RequiresAll.Should().BeFalse("holding one category must admit the caller");
+        }
+
+        GateOn<PredictionController>(nameof(PredictionController.GetProfileSnapshot))!
+            .RequiredScopes.Should().Equal(OAuthScopes.TherapyRead);
+    }
+
+    [Fact]
+    public async Task Prediction_Handler_RedactsTheCategoriesTheCallerLacks()
+    {
+        var predictions = new Mock<IPredictionService>();
+        predictions
+            .Setup(s => s.GetPredictionsAsync(
+                It.IsAny<string?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Forecast());
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Predictions:Source"] = "DeviceStatus" })
+            .Build();
+
+        var controller = new PredictionController(
+            NullLogger<PredictionController>.Instance,
+            configuration,
+            Mock.Of<IProfileSnapshotService>(),
+            predictions.Object)
+        {
+            ControllerContext = ContextWith(Granted(OAuthScopes.GlucoseRead)),
+        };
+
+        var result = await controller.GetPredictions();
+
+        var data = result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<GlucosePredictionResponse>().Subject;
+        data.CurrentBg.Should().Be(120);
+        data.Iob.Should().Be(0);
+        data.SensitivityRatio.Should().BeNull();
+    }
+
+    // ── Correlation ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Correlation_GateMatchesItsGuard()
+    {
+        var gate = GateOn<CorrelationController>(nameof(CorrelationController.GetCorrelated))!;
+
+        gate.RequiredScopes.Should().BeEquivalentTo(CorrelationReadScopeGuard.AdmissionScopes);
+        gate.RequiresAll.Should().BeFalse("holding one category must admit the caller");
+    }
+
+    /// <summary>
+    /// A glucose-only caller must not learn that a bolus, carb intake, note or calculation shares
+    /// the correlation id, so the treatment repositories are not queried at all.
+    /// </summary>
+    [Fact]
+    public async Task Correlation_Handler_SkipsTheRepositoriesTheCallerCannotRead()
+    {
+        var sensor = new Mock<ISensorGlucoseRepository>();
+        var bolus = new Mock<IBolusRepository>();
+        sensor.Setup(r => r.GetByCorrelationIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var controller = new CorrelationController(
+            sensor.Object,
+            Mock.Of<IMeterGlucoseRepository>(),
+            Mock.Of<ICalibrationRepository>(),
+            bolus.Object,
+            Mock.Of<IBolusCalculationRepository>(),
+            Mock.Of<ICarbIntakeRepository>(),
+            Mock.Of<IBGCheckRepository>(),
+            Mock.Of<INoteRepository>())
+        {
+            ControllerContext = ContextWith(Granted(OAuthScopes.GlucoseRead)),
+        };
+
+        await controller.GetCorrelated(Guid.NewGuid());
+
+        sensor.Verify(r => r.GetByCorrelationIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+        bolus.Verify(r => r.GetByCorrelationIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Widget summary ──────────────────────────────────────────────────────────────────────
+
+    private static V4SummaryResponse Summary() => new()
+    {
+        Current = new V4GlucoseReading { Sgv = 120 },
+        History = [new V4GlucoseReading { Sgv = 118 }],
+        Iob = 2,
+        Cob = 20,
+        Alarm = new V4AlarmState(),
+        Predictions = new V4Predictions(),
+        Trackers = [new V4TrackerStatus()],
+    };
+
+    [Fact]
+    public void WidgetSummary_GlucoseOnlyGrant_DropsDosingAndAlarm()
+    {
+        var data = WidgetSummaryReadScopeGuard.Redact(Summary(), Granted(OAuthScopes.GlucoseRead));
+
+        data.Current.Should().NotBeNull();
+        data.History.Should().HaveCount(1);
+        data.Predictions.Should().NotBeNull();
+        data.Iob.Should().Be(0);
+        data.Cob.Should().Be(0);
+        data.Alarm.Should().BeNull();
+    }
+
+    [Fact]
+    public void WidgetSummary_AlertsOnlyGrant_KeepsOnlyTheAlarm()
+    {
+        var data = WidgetSummaryReadScopeGuard.Redact(Summary(), Granted(OAuthScopes.AlertsRead));
+
+        data.Alarm.Should().NotBeNull();
+        data.Current.Should().BeNull();
+        data.History.Should().BeEmpty();
+        data.Predictions.Should().BeNull();
+        data.Iob.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Tracker statuses carry no share data category and are served by the fallback policy
+    /// everywhere else, so they are not part of the redaction.
+    /// </summary>
+    [Fact]
+    public void WidgetSummary_NoScopes_LeavesTheTrackersAlone()
+    {
+        var data = WidgetSummaryReadScopeGuard.Redact(Summary(), Granted());
+
+        data.Trackers.Should().HaveCount(1);
+        data.Current.Should().BeNull();
+        data.Alarm.Should().BeNull();
+    }
+
+    [Fact]
+    public void WidgetSummary_GateMatchesItsGuard()
+    {
+        var gate = GateOn<SummaryController>(nameof(SummaryController.GetSummary));
+
+        gate!.RequiresAll.Should().BeFalse("holding one category must admit the caller");
+        gate.RequiredScopes.Should().BeEquivalentTo(WidgetSummaryReadScopeGuard.AdmissionScopes);
+    }
+
+    [Fact]
+    public async Task WidgetSummary_Handler_RedactsTheCategoriesTheCallerLacks()
+    {
+        var service = new Mock<IWidgetSummaryService>();
+        service
+            .Setup(s => s.GetSummaryAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Summary());
+
+        var context = ContextWith(Granted(OAuthScopes.GlucoseRead));
+        context.HttpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            SubjectId = Guid.NewGuid(),
+        };
+
+        var controller = new SummaryController(service.Object, NullLogger<SummaryController>.Instance)
+        {
+            ControllerContext = context,
+        };
+
+        var result = await controller.GetSummary();
+
+        var data = result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<V4SummaryResponse>().Subject;
+        data.Current.Should().NotBeNull();
+        data.Iob.Should().Be(0);
+        data.Alarm.Should().BeNull();
+    }
+
+    // ── Current therapy state ───────────────────────────────────────────────────────────────
+
+    private static CurrentTherapyStateResponse TherapyState() => new()
+    {
+        CurrentPumpMode = PumpModeState.Manual,
+        SensitivityPercent = 90,
+        Reservoir = 42,
+        PumpBatteryPercent = 80,
+        PumpBatteryVoltage = 1.4,
+    };
+
+    [Fact]
+    public void CurrentTherapyState_DevicesOnlyGrant_DropsTheSensitivity()
+    {
+        var data = CurrentTherapyStateReadScopeGuard.Redact(TherapyState(), Granted(OAuthScopes.DevicesRead));
+
+        data.CurrentPumpMode.Should().Be(PumpModeState.Manual);
+        data.Reservoir.Should().Be(42);
+        data.PumpBatteryPercent.Should().Be(80);
+        data.PumpBatteryVoltage.Should().Be(1.4);
+        data.SensitivityPercent.Should().BeNull();
+    }
+
+    [Fact]
+    public void CurrentTherapyState_TherapyOnlyGrant_DropsThePumpReadings()
+    {
+        var data = CurrentTherapyStateReadScopeGuard.Redact(TherapyState(), Granted(OAuthScopes.TherapyRead));
+
+        data.SensitivityPercent.Should().Be(90);
+        data.CurrentPumpMode.Should().BeNull();
+        data.Reservoir.Should().BeNull();
+        data.PumpBatteryPercent.Should().BeNull();
+        data.PumpBatteryVoltage.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The Viewer role holds glucose and reports only, so it reaches neither category here.
+    /// </summary>
+    [Fact]
+    public void CurrentTherapyState_ViewerScopes_SeeNothing()
+    {
+        var viewer = OAuthScopes.NormalizeMemberPermissions(
+            TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Viewer]);
+
+        CurrentTherapyStateReadScopeGuard.AdmissionScopes
+            .Should().NotContain(s => OAuthScopes.SatisfiesScope(viewer, s));
+    }
+
+    [Fact]
+    public void CurrentTherapyState_GateMatchesItsGuard()
+    {
+        var gate = GateOn<CurrentTherapyStateController>(
+            nameof(CurrentTherapyStateController.GetCurrentTherapyState));
+
+        gate!.RequiresAll.Should().BeFalse("holding one category must admit the caller");
+        gate.RequiredScopes.Should().BeEquivalentTo(CurrentTherapyStateReadScopeGuard.AdmissionScopes);
+    }
+
+    [Fact]
+    public async Task CurrentTherapyState_Handler_RedactsTheCategoriesTheCallerLacks()
+    {
+        var stateSpans = new Mock<IStateSpanService>();
+        stateSpans.Setup(s => s.GetCurrentPumpModeAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PumpModeState.Manual);
+
+        var sensitivity = new Mock<ISensitivityResolver>();
+        sensitivity.Setup(s => s.GetCurrentSensitivityPercentAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(90);
+
+        var pumps = new Mock<IPumpSnapshotRepository>();
+        pumps.Setup(r => r.GetLatestAsync(It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PumpSnapshot { Reservoir = 42 });
+
+        var controller = new CurrentTherapyStateController(
+            stateSpans.Object, sensitivity.Object, pumps.Object)
+        {
+            ControllerContext = ContextWith(Granted(OAuthScopes.TherapyRead)),
+        };
+
+        var result = await controller.GetCurrentTherapyState();
+
+        var data = result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<CurrentTherapyStateResponse>().Subject;
+        data.SensitivityPercent.Should().Be(90);
+        data.CurrentPumpMode.Should().BeNull();
+        data.Reservoir.Should().BeNull();
+    }
+
+    // ── Usage analytics ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The usage-analytics controller carries no health data: its reads are the collection switch,
+    /// system info and usage counters, and its writes reconfigure or wipe them. So it is gated on
+    /// the tenant-settings permission rather than any data category, and a member holding only a
+    /// health-read scope — the whole Viewer, Clinician and Caretaker surface — is refused.
+    /// </summary>
+    [Fact]
+    public void UsageAnalytics_IsGatedOnTheTenantSettingsPermission()
+    {
+        var gate = typeof(AnalyticsController).GetCustomAttribute<RequireScopeAttribute>();
+
+        gate.Should().NotBeNull();
+        gate!.RequiredScopes.Should().Equal(TenantPermissions.TenantSettings);
+
+        foreach (var role in new[]
+                 {
+                     TenantPermissions.SeedRoles.Viewer,
+                     TenantPermissions.SeedRoles.Clinician,
+                     TenantPermissions.SeedRoles.Caretaker,
+                 })
+        {
+            OAuthScopes.SatisfiesScope(
+                OAuthScopes.NormalizeMemberPermissions(TenantPermissions.SeedRolePermissions[role]),
+                TenantPermissions.TenantSettings)
+                .Should().BeFalse($"{role} does not administer the tenant");
+        }
+
+        OAuthScopes.SatisfiesScope(
+            OAuthScopes.NormalizeMemberPermissions(
+                TenantPermissions.SeedRolePermissions[TenantPermissions.SeedRoles.Admin]),
+            TenantPermissions.TenantSettings)
+            .Should().BeTrue("an administrator must keep managing analytics collection");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
@@ -51,17 +51,6 @@ public class ControllerAuthorizationCoverageTests
     private static readonly IReadOnlyDictionary<string, string> FallbackGatedControllers =
         new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            // ── V4 public-share read analytics ──────────────────────────────────────────────
-            // Read-only (GET) aggregates over glucose/treatment data that the public-share
-            // dashboard renders for an anonymous share visitor. The fallback admits the share
-            // subject; the per-category share RLS policy (ShareDataCategories) then restricts the
-            // underlying rows to the categories the share was granted. Adding [Authorize] here
-            // would 401 the anonymous share dashboard. All actions are GET, so there is no write
-            // surface to expose.
-            ["Nocturne.API.Controllers.V4.Analytics.ChartDataController"] = "public-share read analytics (fallback + share RLS)",
-            ["Nocturne.API.Controllers.V4.Analytics.RetrospectiveController"] = "public-share read analytics (fallback + share RLS)",
-            ["Nocturne.API.Controllers.V4.Analytics.PredictionController"] = "public-share read analytics (fallback + share RLS)",
-
             // ── V4 tracker reads ─────────────────────────────────────────────────────────────
             // GET definitions/instances lean on the fallback policy: a bare unauthenticated request
             // on a tenant subdomain has an empty trie and is rejected, so a private tenant exposes

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ShareReadSurfaceReachabilityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ShareReadSurfaceReachabilityTests.cs
@@ -65,6 +65,13 @@ public class ShareReadSurfaceReachabilityTests
             // ActogramReadScopeGuard empties the rest. Listed against glucose because the default
             // share grant is glucose-only and the report still renders its glucose overlay.
             ["Nocturne.API.Controllers.V4.Analytics.ActogramController"] = OAuthScopes.GlucoseRead,
+            // The dashboard chart, the day-in-review pages and the forecast overlay. Each merges
+            // several categories, so its gate is an OR across them and the matching read-scope
+            // guard empties the rest; listed against glucose because that is the default share
+            // grant and the glucose series is what those pages render from it.
+            ["Nocturne.API.Controllers.V4.Analytics.ChartDataController"] = OAuthScopes.GlucoseRead,
+            ["Nocturne.API.Controllers.V4.Analytics.RetrospectiveController"] = OAuthScopes.GlucoseRead,
+            ["Nocturne.API.Controllers.V4.Analytics.PredictionController"] = OAuthScopes.GlucoseRead,
             // Feeds the data quality report. Its rows are hidden from shares by RLS
             // (compression_low_suggestions has no ShareDataCategories entry), so the gate decides
             // error-vs-empty-list, not what a share can see.
@@ -144,6 +151,27 @@ public class ShareReadSurfaceReachabilityTests
         {
             ["StatisticsController.GetMultiPeriodStatistics"] = OAuthScopes.GlucoseRead,
             ["StatisticsController.GetPunchCardData"] = OAuthScopes.GlucoseRead,
+            // Basal delivery is wholly the treatment category, so neither action is broadened to
+            // the OR its controller's mixed payloads need.
+            ["ChartDataController.GetBasalSeries"] = OAuthScopes.TreatmentsRead,
+            ["RetrospectiveController.GetBasalTimeline"] = OAuthScopes.TreatmentsRead,
+        };
+
+    /// <summary>
+    /// Read actions on a share-facing controller that require a read scope outside
+    /// <see cref="TenantPermissions.PublicShareScopes"/>, keyed <c>Controller.Action</c> with the
+    /// scope, so no share can reach them however the owner configures the link. Listing one is a
+    /// deliberate narrowing and is exempt from
+    /// <see cref="EveryRequiredScope_IsGrantableToAShare"/>; everything else on these controllers
+    /// must name a scope a share can hold.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> MemberOnlyReadScopeActions =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // The resolved therapy profile — basal schedule, ISF, carb ratio, targets — served for
+            // an on-device oref run. V1/V3 profile reads require the same scope, and the sharing UI
+            // deliberately offers no therapy category.
+            ["PredictionController.GetProfileSnapshot"] = OAuthScopes.TherapyRead,
         };
 
     private static Assembly ApiAssembly => typeof(RequireScopeAttribute).Assembly;
@@ -213,8 +241,9 @@ public class ShareReadSurfaceReachabilityTests
 
                 shareReadActions++;
 
-                var expected = ActionScopeOverrides.TryGetValue($"{type.Name}.{action.Name}", out var o)
-                    ? o
+                var key = $"{type.Name}.{action.Name}";
+                var expected = MemberOnlyReadScopeActions.TryGetValue(key, out var m) ? m
+                    : ActionScopeOverrides.TryGetValue(key, out var o) ? o
                     : ShareReadableControllers[type.FullName!];
 
                 var effective = classScopes.Concat(ScopesOf(actionAttributes)).ToList();
@@ -226,6 +255,16 @@ public class ShareReadSurfaceReachabilityTests
                 // requirement naming anything else makes RequireScope demand authentication.
                 if (effective.Any(s => !s.EndsWith(".read", StringComparison.Ordinal)))
                     violations.Add($"{type.Name}.{action.Name}: names a non-read scope, which excludes the anonymous share");
+
+                // A multi-category gate must be an OR. An AND over categories a share cannot hold
+                // all of refuses every share, and the checks above cannot see it: the scope list is
+                // unchanged and each scope is still share-grantable on its own.
+                var conjunctions = actionAttributes.Concat(type.GetCustomAttributes(inherit: true))
+                    .OfType<RequireScopeAttribute>()
+                    .Where(a => a.RequiresAll && a.Scopes.Count > 1);
+                if (conjunctions.Any())
+                    violations.Add($"{type.Name}.{action.Name}: requires ALL of its categories, so a share "
+                        + "granted only some of them is refused the whole endpoint");
             }
 
             if (shareReadActions == 0)
@@ -244,6 +283,11 @@ public class ShareReadSurfaceReachabilityTests
         // would silently turn "share-reachable" into "member-only" without any test failing.
         var scopes = ShareReadableControllers.Values.Concat(ActionScopeOverrides.Values).Distinct();
         scopes.Should().OnlyContain(s => TenantPermissions.PublicShareScopes.Contains(s));
+
+        // The converse for the exemptions: an action listed as member-only whose scope a share can
+        // in fact hold is not member-only, and the entry is hiding a gate nobody is checking.
+        MemberOnlyReadScopeActions.Values.Should()
+            .OnlyContain(s => !TenantPermissions.PublicShareScopes.Contains(s));
     }
 
     [Fact]
@@ -252,12 +296,12 @@ public class ShareReadSurfaceReachabilityTests
         foreach (var (name, _) in ShareReadableControllers)
             ApiAssembly.GetType(name).Should().NotBeNull($"{name} is listed but does not exist");
 
-        foreach (var (key, _) in ActionScopeOverrides)
+        foreach (var (key, _) in ActionScopeOverrides.Concat(MemberOnlyReadScopeActions))
         {
             var (controller, action) = (key.Split('.')[0], key.Split('.')[1]);
             Controllers().Should().Contain(
                 t => t.Name == controller && Actions(t).Any(a => a.Name == action),
-                $"{key} is listed in ActionScopeOverrides but no such action exists");
+                $"{key} is listed as a per-action scope but no such action exists");
         }
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/CurrentTherapyStateControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/CurrentTherapyStateControllerTests.cs
@@ -1,10 +1,12 @@
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Nocturne.API.Controllers.V4.Analytics;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Xunit;
 
@@ -19,10 +21,17 @@ public class CurrentTherapyStateControllerTests
 
     public CurrentTherapyStateControllerTests()
     {
+        // The pump readings are the device category, so the response is redacted without it.
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["GrantedScopes"] = new HashSet<string> { OAuthScopes.DevicesRead };
+
         _controller = new CurrentTherapyStateController(
             _stateSpanService.Object,
             _sensitivityResolver.Object,
-            _pumpSnapshotRepository.Object);
+            _pumpSnapshotRepository.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
     }
 
     [Fact]


### PR DESCRIPTION
## What
Seven V4 analytics controllers decided nothing about what their responses may contain. `ChartDataController`, `RetrospectiveController` and `PredictionController` were gated only by the default-deny fallback (any non-empty permission trie); `AnalyticsController`, `CorrelationController`, `CurrentTherapyStateController` and `SummaryController` only by `[Authorize]`, which proves a session exists, not that it signed up for a data category. Member requests are not category-filtered by RLS — only shares are — so a Viewer holding `glucose.read` read every category they serve.

The multi-category payloads take the #716 actogram shape: the attribute lists the categories as an **OR** for admission, and a read-scope guard empties the categories the caller doesn't hold. All six guards live in one file so the shape is stated once.

| Endpoint | Gate |
|---|---|
| ChartData `/dashboard` | OR glucose/treatments/devices/therapy/heartrate/stepcount/sleep + redaction |
| ChartData `/basal-series` | `treatments.read` |
| Retrospective `/at`, `/timeline` | OR glucose/treatments + redaction |
| Retrospective `/basal-timeline` | `treatments.read` |
| Prediction `GET /`, `/status` | OR glucose/treatments + redaction |
| Prediction `/profile-snapshot` | `therapy.read` (member-only by design) |
| CurrentTherapyState | OR devices/therapy + redaction |
| Correlation | OR glucose/treatments, redaction by not querying |
| Summary | OR glucose/treatments/alerts + redaction |
| Analytics | `tenant.settings` (class-level) |

`ChartDataController`'s activity track is the one field with two governing categories, so it's filtered per span rather than emptied: exercise/illness/travel are treatment annotations, the sleep sessions projected in beside them are their own category. `CorrelationController` redacts by *not querying* the repositories the caller can't read, so a glucose-only caller can't even learn that a bolus shares the id. `AnalyticsController` carries no health data at all — usage counters, system info, the collection switch and a wipe — so it's gated on `tenant.settings`, matching `TenantSettingsController`.

## Why not `requireAll`
`sleep.read`, `therapy.read` and `alerts.read` are outside `PublicShareScopes`, so an AND gate would 403 every public share forever — the #635 failure class. Shares are additionally narrowed by per-category share RLS at the DB.

The share-read sweep now rejects **any** multi-category gate declared with `requireAll`. Review caught that a later flip to the `requireAll: true` ctor on the glucose+treatments gates would have passed every existing assertion — each scope is individually share-grantable, so the scope-list, `.read`-suffix and grantability checks all hold while the conjunction refuses every default glucose-only share. Six per-controller `RequiresAll` assertions plus one sweep, so a future controller can't reintroduce it.

## Response cache
`[ResponseCache]` here is `public`; the shared key is host + query + `Cookie`. That covers tenant, share (own subdomain) and session, but not the legacy `api-secret` header — not a cookie, not `Authorization`, not in the Vary set (flagged as pre-existing in #716). Per-scope redaction turns that from harmless into a bypass: a full-access `api-secret` caller populates the entry and a narrow one is served it. Both redacting endpoints — the chart dashboard and, retroactively, the actogram from #716 — now declare `ResponseCacheLocation.Client`, which the shared middleware refuses to store, and which also makes correctness independent of the middleware's Authorization-header carve-out. The stated intent (browser reconnects) is unchanged. The response-cache invariant in `CLAUDE.md` is updated.

## Tests
New `AnalyticsReadScopeGuardTests`: per-guard redaction, admission-list completeness, each attribute pinned to its guard with `RequiresAll` false, a driven handler per controller, and the shared-cache assertion. Three controllers move from `FallbackGatedControllers` to `ShareReadableControllers`; `ShareReadSurfaceReachabilityTests` gains `MemberOnlyReadScopeActions` for `profile-snapshot`, with a converse assertion so an entry whose scope a share *can* hold fails.

Nine mutations, each applied → failed → restored → green: dashboard gate removed (3 failures), redaction call removed with the attribute kept (1), a category branch dropped (3), the per-span activity filter dropped (3), shared cache restored plus profile-snapshot gate removed (4), the four remaining handler guard calls removed (4), the five remaining attributes removed (7), and `requireAll: true` on `/retrospective/at` (2 — the per-controller assertion and the sweep).

Full API unit suite: 5439 passed, 0 failed. Two pre-existing `CurrentTherapyStateControllerTests` needed a `devices.read` context (the pump readings are now that category).

## Honest residuals
- `ChartThresholdsDto.TargetLow/High` are profile-derived but travel with glucose, and `DefaultBasalRate` with treatments — a conscious sign-off: both are constituents of the chart the caller was granted, and #716 set the precedent for thresholds. Neither is separately gated.
- **Evidence horizon:** a new field added to any of these DTOs ships unredacted, because no test forces a category decision for it. Consistent with #716 (and unlike #726's `[ReplayFact]`, which makes the decision structural). Deliberate follow-up, not fixed here.
- `CurrentTherapyStateController` and `SummaryController` keep `[Authorize]`, so no share can read them. For the former that's a pre-existing #635-class narrowing of the dashboard reservoir tile; `realtime-store` already swallows the error. Untouched.
- Legacy `api-secret` callers are still absent from the Vary set on endpoints keeping the shared cache. Safe there — those bodies are uniform for anyone admitted — but the gap is unfixed.
- Viewer loses the pump reservoir/battery tile and the profile-span overlay, consistent with `PumpSnapshotController` already requiring `devices.read`. An alerts-only grant loses `/predictions/status`. No frontend change; the dashboard degrades to empty tracks.
- The dashboard chart is no longer server-side cached, so repeated cold browser loads recompute.
