### PR TITLE
fix(oidc): omit absent discovery metadata instead of sending null

### DIFF
--- a/src/API/Nocturne.API/Controllers/WellKnownController.cs
+++ b/src/API/Nocturne.API/Controllers/WellKnownController.cs
@@ -65,7 +65,6 @@ public class WellKnownController : ControllerBase
                 TokenEndpoint = $"{baseUrl}/api/oauth/token",
                 UserinfoEndpoint = $"{baseUrl}/auth/userinfo",
                 JwksUri = $"{baseUrl}/.well-known/jwks.json",
-                RegistrationEndpoint = null,
                 ScopesSupported = new[] { "openid", "profile", "email", "offline_access" },
                 ResponseTypesSupported = new[]
                 {
@@ -190,6 +189,10 @@ public class WellKnownController : ControllerBase
 /// with <see cref="JsonPropertyNameAttribute"/> rather than left to the camelCase policy MVC
 /// applies by default. Pinning them on the model also keeps the generated OpenAPI schema — and
 /// therefore the generated clients — describing the names that actually go on the wire.
+///
+/// Discovery also requires absent optional metadata to be omitted rather than sent as
+/// <c>null</c>, so every optional member carries <see cref="JsonIgnoreAttribute"/> with
+/// <see cref="JsonIgnoreCondition.WhenWritingNull"/>.
 /// </remarks>
 public class OpenIdConfiguration
 {
@@ -203,15 +206,18 @@ public class OpenIdConfiguration
     public string TokenEndpoint { get; set; } = string.Empty;
 
     [JsonPropertyName("userinfo_endpoint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? UserinfoEndpoint { get; set; }
 
     [JsonPropertyName("jwks_uri")]
     public string JwksUri { get; set; } = string.Empty;
 
     [JsonPropertyName("registration_endpoint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? RegistrationEndpoint { get; set; }
 
     [JsonPropertyName("end_session_endpoint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? EndSessionEndpoint { get; set; }
 
     [JsonPropertyName("scopes_supported")]
@@ -242,6 +248,7 @@ public class OpenIdConfiguration
     public string[] CodeChallengeMethodsSupported { get; set; } = Array.Empty<string>();
 
     [JsonPropertyName("service_documentation")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ServiceDocumentation { get; set; }
 }
 
@@ -282,15 +289,19 @@ public class OAuthAuthorizationServerMetadata
     public string TokenEndpoint { get; set; } = string.Empty;
 
     [JsonPropertyName("device_authorization_endpoint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? DeviceAuthorizationEndpoint { get; set; }
 
     [JsonPropertyName("revocation_endpoint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? RevocationEndpoint { get; set; }
 
     [JsonPropertyName("introspection_endpoint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? IntrospectionEndpoint { get; set; }
 
     [JsonPropertyName("registration_endpoint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? RegistrationEndpoint { get; set; }
 
     [JsonPropertyName("jwks_uri")]
@@ -312,6 +323,7 @@ public class OAuthAuthorizationServerMetadata
     public string[] CodeChallengeMethodsSupported { get; set; } = Array.Empty<string>();
 
     [JsonPropertyName("service_documentation")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ServiceDocumentation { get; set; }
 }
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/WellKnownControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/WellKnownControllerTests.cs
@@ -68,10 +68,7 @@ public sealed class WellKnownControllerTests : IClassFixture<AuthenticationTestF
     {
         using var discovery = await GetDiscoveryDocumentAsync(discoveryPath);
 
-        var memberNames = discovery
-            .RootElement.EnumerateObject()
-            .Select(property => property.Name)
-            .ToArray();
+        var memberNames = MemberNamesOf(discovery);
 
         memberNames.Should().Contain(SpecifiedMemberNames);
         memberNames
@@ -80,6 +77,128 @@ public sealed class WellKnownControllerTests : IClassFixture<AuthenticationTestF
                 name => name == name.ToLowerInvariant(),
                 "discovery members are lower snake_case, so no camelCase name is recognisable"
             );
+    }
+
+    [Theory]
+    [InlineData("/.well-known/openid-configuration")]
+    [InlineData("/.well-known/oauth-authorization-server")]
+    public async Task Discovery_document_omits_the_metadata_it_does_not_advertise(
+        string discoveryPath
+    )
+    {
+        using var discovery = await GetDiscoveryDocumentAsync(discoveryPath);
+
+        discovery
+            .RootElement.EnumerateObject()
+            .Where(property => property.Value.ValueKind == JsonValueKind.Null)
+            .Select(property => property.Name)
+            .Should()
+            .BeEmpty("absent discovery metadata is omitted, never advertised as null");
+    }
+
+    [Fact]
+    public async Task Openid_configuration_omits_the_endpoints_the_local_provider_lacks()
+    {
+        using var discovery = await GetDiscoveryDocumentAsync(
+            "/.well-known/openid-configuration"
+        );
+
+        var memberNames = MemberNamesOf(discovery);
+
+        memberNames.Should().NotContain("registration_endpoint");
+        memberNames.Should().NotContain("end_session_endpoint");
+    }
+
+    [Fact]
+    public async Task Oauth_metadata_omits_the_unadvertised_introspection_endpoint()
+    {
+        using var discovery = await GetDiscoveryDocumentAsync(
+            "/.well-known/oauth-authorization-server"
+        );
+
+        MemberNamesOf(discovery).Should().NotContain("introspection_endpoint");
+    }
+
+    [Fact]
+    public async Task Oauth_metadata_still_advertises_the_endpoints_it_does_serve()
+    {
+        using var discovery = await GetDiscoveryDocumentAsync(
+            "/.well-known/oauth-authorization-server"
+        );
+
+        MemberNamesOf(discovery)
+            .Should()
+            .Contain(
+                ["device_authorization_endpoint", "revocation_endpoint", "registration_endpoint"]
+            );
+    }
+
+    [Fact]
+    public async Task Openid_configuration_still_advertises_its_userinfo_endpoint()
+    {
+        using var discovery = await GetDiscoveryDocumentAsync(
+            "/.well-known/openid-configuration"
+        );
+
+        MemberNamesOf(discovery).Should().Contain("userinfo_endpoint");
+    }
+
+    [Fact]
+    public void Populated_optional_metadata_survives_serialisation()
+    {
+        var openIdMembers = MemberNamesOf(
+            new OpenIdConfiguration
+            {
+                UserinfoEndpoint = "https://example.test/auth/userinfo",
+                RegistrationEndpoint = "https://example.test/api/oauth/register",
+                EndSessionEndpoint = "https://example.test/api/oauth/logout",
+                ServiceDocumentation = "https://example.test/docs",
+            }
+        );
+
+        openIdMembers
+            .Should()
+            .Contain(
+                [
+                    "userinfo_endpoint",
+                    "registration_endpoint",
+                    "end_session_endpoint",
+                    "service_documentation",
+                ]
+            );
+
+        var oauthMembers = MemberNamesOf(
+            new OAuthAuthorizationServerMetadata
+            {
+                DeviceAuthorizationEndpoint = "https://example.test/api/oauth/device",
+                RevocationEndpoint = "https://example.test/api/oauth/revoke",
+                IntrospectionEndpoint = "https://example.test/api/oauth/introspect",
+                RegistrationEndpoint = "https://example.test/api/oauth/register",
+                ServiceDocumentation = "https://example.test/docs",
+            }
+        );
+
+        oauthMembers
+            .Should()
+            .Contain(
+                [
+                    "device_authorization_endpoint",
+                    "revocation_endpoint",
+                    "introspection_endpoint",
+                    "registration_endpoint",
+                    "service_documentation",
+                ]
+            );
+    }
+
+    private static string[] MemberNamesOf(JsonDocument document) =>
+        document.RootElement.EnumerateObject().Select(property => property.Name).ToArray();
+
+    private static string[] MemberNamesOf<T>(T model)
+    {
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(model));
+
+        return MemberNamesOf(document);
     }
 
     private async Task<JsonDocument> GetDiscoveryDocumentAsync(string discoveryPath)


### PR DESCRIPTION
## What

Both discovery documents serialized unset optional metadata as explicit `null` — `/.well-known/openid-configuration` shipped `"registration_endpoint": null` and `"end_session_endpoint": null`, `/.well-known/oauth-authorization-server` shipped `"introspection_endpoint": null`. OpenID Connect Discovery 1.0 and RFC 8414 both say absent optional members are omitted, not advertised as null; a strict relying party can read `"registration_endpoint": null` as a malformed value rather than "not supported". Nothing set a `DefaultIgnoreCondition` on this path — the global `NightscoutJsonFilter` does null-omission for v1–v3 responses only.

Fix: `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]` on every optional member of both DTOs, matching the per-property convention already used in `Summary`, `StatusResponse`, and the entry response extensions. The app-wide JSON policy is deliberately untouched — this is a discovery-document spec requirement, not a house style, and changing the global policy would silently reshape every other response. Members beyond the two offenders got the same treatment so the next unset endpoint doesn't reintroduce the bug: `userinfo_endpoint`, `service_documentation`, `device_authorization_endpoint`, `revocation_endpoint`.

This was scoped out of #722 and flagged there.

None of the attributed members is REQUIRED by either spec (the required members are non-nullable, unattributed properties that always serialize), and the generated OpenAPI schema is unchanged — `WhenWritingNull` does not drop properties from the NSwag schema, so no client shape changes.

## Tests

New tests through the real `Program.cs` pipeline via `WebApplicationFactory`, asserting on raw JSON — a deserialized object cannot distinguish a null member from a missing one, so every assertion reads `JsonDocument` member names and `ValueKind`. One general invariant (no member of either document may be JSON null) plus per-document omit tests, and with-values tests proving populated optional metadata still reaches consumers.

Mutation-proven both directions: stripping the ignore conditions fails 4 tests with precise attribution; flipping `WhenWritingNull` to `Always` fails 5, including all the with-values tests, so the suite catches over-ignoring as well as under-ignoring.
