### PR TITLE
fix(v4): bound the four V4 reads that paged past their own clamp

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
@@ -300,6 +300,11 @@ public class StateSpansController : ControllerBase
     /// <summary>
     /// Get all activity state spans (exercise, illness, travel)
     /// </summary>
+    /// <remarks>
+    /// This read merges three categories in memory before it paginates, so the page is bounded by
+    /// <see cref="V4ReadLimits.ClampMergedPage"/> rather than the plain page-size ceiling, and each
+    /// category is fetched only as deep as the requested page reaches.
+    /// </remarks>
     [HttpGet("activities")]
     [ProducesResponseType(typeof(PaginatedResponse<StateSpan>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -314,17 +319,22 @@ public class StateSpansController : ControllerBase
         if (sort is not "timestamp_desc" and not "timestamp_asc")
             return Problem(detail: $"Invalid sort value '{sort}'. Must be 'timestamp_asc' or 'timestamp_desc'.", statusCode: 400, title: "Bad Request");
 
-        limit = V4ReadLimits.ClampLimit(limit);
         offset = V4ReadLimits.ClampOffset(offset);
+        limit = V4ReadLimits.ClampMergedPage(limit, offset);
 
         var descending = sort == "timestamp_desc";
         var activityCategories = new[] { StateSpanCategory.Exercise, StateSpanCategory.Illness, StateSpanCategory.Travel };
         var allSpans = new List<StateSpan>();
         var total = 0;
 
+        // Every span on the requested page is within the first offset + limit of its own category,
+        // a sum ClampMergedPage has already held inside the merged window — or driven to a zero
+        // limit, a page no category has to be read for at all.
+        var perCategoryWindow = limit == 0 ? 0 : offset + limit;
+
         foreach (var category in activityCategories)
         {
-            var spans = await _stateSpanService.GetStateSpansAsync(category, from: from, to: to, count: int.MaxValue, descending: descending, cancellationToken: cancellationToken);
+            var spans = await _stateSpanService.GetStateSpansAsync(category, from: from, to: to, count: perCategoryWindow, descending: descending, cancellationToken: cancellationToken);
             allSpans.AddRange(spans);
             total += await _stateSpanService.CountStateSpansAsync(category, from: from, to: to, cancellationToken: cancellationToken);
         }

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4ReadLimits.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4ReadLimits.cs
@@ -38,6 +38,17 @@ public static class V4ReadLimits
     public const int MaxMergedPageWindow = 10_000;
 
     /// <summary>
+    /// Maximum records one page of a page-numbered V4 read may return.
+    /// </summary>
+    /// <remarks>
+    /// Three orders of magnitude below <see cref="MaxPageSize"/>, because a route addressing a page
+    /// by ordinal exists to back a paged table rather than a bulk export: the alert-history pages
+    /// ask for 25 and 50 rows, and pairing a larger page with a page number would also let a caller
+    /// reach much further into the table for the same clamp.
+    /// </remarks>
+    public const int MaxOrdinalPageSize = 100;
+
+    /// <summary>
     /// Maximum span, in days, between the <c>from</c> and <c>to</c> bounds of a V4 range read.
     /// </summary>
     /// <remarks>
@@ -59,6 +70,27 @@ public static class V4ReadLimits
     /// </summary>
     public static int ClampMergedPage(int limit, int offset) =>
         Math.Clamp(limit, 0, MaxMergedPageWindow - Math.Min(ClampOffset(offset), MaxMergedPageWindow));
+
+    /// <summary>
+    /// Clamp a caller-supplied page size on a page-numbered read to <see cref="MaxOrdinalPageSize"/>.
+    /// </summary>
+    /// <remarks>
+    /// The floor is one rather than zero: a page-numbered read reports a page count derived from the
+    /// page size, so a zero page size has no meaning on this shape.
+    /// </remarks>
+    public static int ClampPageSize(int pageSize) => Math.Clamp(pageSize, 1, MaxOrdinalPageSize);
+
+    /// <summary>
+    /// Clamp a caller-supplied 1-based page number so the offset it implies stays within the first
+    /// <see cref="MaxPageSize"/> records.
+    /// </summary>
+    /// <remarks>
+    /// A page number is multiplied by the page size to reach an offset, so leaving it unbounded
+    /// leaves the skip unbounded — and past <see cref="int"/> it wraps negative. Pass
+    /// <paramref name="pageSize"/> already through <see cref="ClampPageSize"/>.
+    /// </remarks>
+    public static int ClampPageNumber(int page, int pageSize) =>
+        Math.Clamp(page, 1, MaxPageSize / Math.Clamp(pageSize, 1, MaxPageSize));
 
     /// <summary>
     /// Whether a range read's bounds are further apart than <see cref="MaxDateSpanDays"/>.

--- a/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
@@ -24,6 +24,9 @@ namespace Nocturne.API.Controllers.V4.Health;
 [Produces("application/json")]
 public class HeartRateController : ControllerBase
 {
+    /// <summary>Records returned when a caller supplies no <c>count</c> and no date range.</summary>
+    private const int DefaultCount = 10;
+
     private readonly IHeartRateService _heartRateService;
     private readonly ILogger<HeartRateController> _logger;
 
@@ -36,35 +39,42 @@ public class HeartRateController : ControllerBase
     /// <summary>
     /// Get heart rate records with optional pagination and date filtering
     /// </summary>
-    /// <param name="count">Maximum number of records to return (default: 10, ignored when from/to are specified)</param>
-    /// <param name="skip">Number of records to skip for pagination (default: 0, ignored when from/to are specified)</param>
-    /// <param name="from">Start of date range (inclusive). When specified with 'to', returns all records in range.</param>
-    /// <param name="to">End of date range (exclusive). When specified with 'from', returns all records in range.</param>
+    /// <param name="count">Maximum number of records to return (default: 10, or up to the ceiling when from/to are specified)</param>
+    /// <param name="skip">Number of records to skip for pagination (default: 0)</param>
+    /// <param name="from">Start of date range (inclusive).</param>
+    /// <param name="to">End of date range (exclusive).</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>List of heart rate records</returns>
+    /// <remarks>
+    /// A date range without a <paramref name="count"/> reads up to
+    /// <see cref="V4ReadLimits.MaxPageSize"/> records rather than the whole range, so a wide range
+    /// cannot load the table into memory. Page through the rest with <paramref name="skip"/>.
+    /// </remarks>
     [HttpGet]
     [RemoteQuery]
     [RequireScope(OAuthScopes.HeartRateRead)]
     [ProducesResponseType(typeof(IEnumerable<HeartRate>), 200)]
     [ProducesResponseType(500)]
     public async Task<ActionResult<IEnumerable<HeartRate>>> GetHeartRates(
-        [FromQuery] int count = 10,
+        [FromQuery] int? count = null,
         [FromQuery] int skip = 0,
         [FromQuery] DateTime? from = null,
         [FromQuery] DateTime? to = null,
         CancellationToken cancellationToken = default
     )
     {
-        count = V4ReadLimits.ClampLimit(count);
         skip = V4ReadLimits.ClampOffset(skip);
 
         try
         {
             IEnumerable<HeartRate> records;
             if (from.HasValue && to.HasValue)
-                records = await _heartRateService.GetHeartRatesByDateRangeAsync(from.Value, to.Value, cancellationToken);
+                records = await _heartRateService.GetHeartRatesByDateRangeAsync(
+                    from.Value, to.Value,
+                    V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize), skip, cancellationToken);
             else
-                records = await _heartRateService.GetHeartRatesAsync(count, skip, cancellationToken);
+                records = await _heartRateService.GetHeartRatesAsync(
+                    V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, cancellationToken);
 
             return Ok(records);
         }

--- a/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
@@ -24,6 +24,9 @@ namespace Nocturne.API.Controllers.V4.Health;
 [Produces("application/json")]
 public class StepCountController : ControllerBase
 {
+    /// <summary>Records returned when a caller supplies no <c>count</c> and no date range.</summary>
+    private const int DefaultCount = 10;
+
     private readonly IStepCountService _stepCountService;
     private readonly ILogger<StepCountController> _logger;
 
@@ -36,35 +39,42 @@ public class StepCountController : ControllerBase
     /// <summary>
     /// Get step count records with optional pagination and date filtering
     /// </summary>
-    /// <param name="count">Maximum number of records to return (default: 10, ignored when from/to are specified)</param>
-    /// <param name="skip">Number of records to skip for pagination (default: 0, ignored when from/to are specified)</param>
-    /// <param name="from">Start of date range (inclusive). When specified with 'to', returns all records in range.</param>
-    /// <param name="to">End of date range (exclusive). When specified with 'from', returns all records in range.</param>
+    /// <param name="count">Maximum number of records to return (default: 10, or up to the ceiling when from/to are specified)</param>
+    /// <param name="skip">Number of records to skip for pagination (default: 0)</param>
+    /// <param name="from">Start of date range (inclusive).</param>
+    /// <param name="to">End of date range (exclusive).</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>List of step count records</returns>
+    /// <remarks>
+    /// A date range without a <paramref name="count"/> reads up to
+    /// <see cref="V4ReadLimits.MaxPageSize"/> records rather than the whole range, so a wide range
+    /// cannot load the table into memory. Page through the rest with <paramref name="skip"/>.
+    /// </remarks>
     [HttpGet]
     [RemoteQuery]
     [RequireScope(OAuthScopes.StepCountRead)]
     [ProducesResponseType(typeof(IEnumerable<StepCount>), 200)]
     [ProducesResponseType(500)]
     public async Task<ActionResult<IEnumerable<StepCount>>> GetStepCounts(
-        [FromQuery] int count = 10,
+        [FromQuery] int? count = null,
         [FromQuery] int skip = 0,
         [FromQuery] DateTime? from = null,
         [FromQuery] DateTime? to = null,
         CancellationToken cancellationToken = default
     )
     {
-        count = V4ReadLimits.ClampLimit(count);
         skip = V4ReadLimits.ClampOffset(skip);
 
         try
         {
             IEnumerable<StepCount> records;
             if (from.HasValue && to.HasValue)
-                records = await _stepCountService.GetStepCountsByDateRangeAsync(from.Value, to.Value, cancellationToken);
+                records = await _stepCountService.GetStepCountsByDateRangeAsync(
+                    from.Value, to.Value,
+                    V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize), skip, cancellationToken);
             else
-                records = await _stepCountService.GetStepCountsAsync(count, skip, cancellationToken);
+                records = await _stepCountService.GetStepCountsAsync(
+                    V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, cancellationToken);
 
             return Ok(records);
         }

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertsController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Alerts;
@@ -108,6 +109,11 @@ public class AlertsController : ControllerBase
     /// Get paginated history of resolved excursions. Test fires are excluded
     /// by default; pass <paramref name="includeTest"/> = true to include them.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="pageSize"/> is capped at <see cref="V4ReadLimits.MaxOrdinalPageSize"/> and
+    /// <paramref name="page"/> at the page that reaches the last record within
+    /// <see cref="V4ReadLimits.MaxPageSize"/>; both are clamped rather than rejected.
+    /// </remarks>
     [HttpGet("history")]
     [RemoteQuery]
     [ProducesResponseType(typeof(AlertHistoryResponse), StatusCodes.Status200OK)]
@@ -118,9 +124,8 @@ public class AlertsController : ControllerBase
         [FromQuery] bool includeTest = false,
         CancellationToken ct = default)
     {
-        if (page < 1) page = 1;
-        if (pageSize < 1) pageSize = 1;
-        if (pageSize > 100) pageSize = 100;
+        pageSize = V4ReadLimits.ClampPageSize(pageSize);
+        page = V4ReadLimits.ClampPageNumber(page, pageSize);
 
         await using var db = await _contextFactory.CreateAsync(ct);
 

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/FoodsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/FoodsController.cs
@@ -93,6 +93,11 @@ public class FoodsController : ControllerBase, IWriteScopedController
     /// List foods with optional filtering and pagination.
     /// This is a V4 endpoint (not Nightscout-legacy) used by the meal attribution UI.
     /// </summary>
+    /// <remarks>
+    /// The picker and the food page ask for no <c>count</c> and render the whole catalog, so an
+    /// absent <c>count</c> reads up to <see cref="V4ReadLimits.MaxPageSize"/> records rather than
+    /// every row. <c>find</c> matches name, category, and subcategory.
+    /// </remarks>
     [HttpGet]
     [RemoteQuery]
     [Authorize]
@@ -103,7 +108,11 @@ public class FoodsController : ControllerBase, IWriteScopedController
         [FromQuery] int? skip = null,
         CancellationToken ct = default)
     {
-        var foods = await _foodService.GetFoodAsync(find, count, skip, ct);
+        var foods = await _foodService.GetFoodAsync(
+            find,
+            V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize),
+            V4ReadLimits.ClampOffset(skip ?? 0),
+            ct);
         return Ok(foods.ToArray());
     }
 

--- a/src/API/Nocturne.API/Services/Analytics/ActogramReportService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/ActogramReportService.cs
@@ -93,13 +93,13 @@ public sealed class ActogramReportService : IActogramReportService
         var stepRecords = await _stepCountService.GetStepCountsByDateRangeAsync(
             fromDt,
             toDt,
-            cancellationToken
+            cancellationToken: cancellationToken
         );
 
         var heartRateRecords = await _heartRateService.GetHeartRatesByDateRangeAsync(
             fromDt,
             toDt,
-            cancellationToken
+            cancellationToken: cancellationToken
         );
 
         var thresholdsRaw = await BuildThresholdsAsync(endTime, cancellationToken);

--- a/src/API/Nocturne.API/Services/ChartData/Stages/DataFetchStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/DataFetchStage.cs
@@ -230,14 +230,14 @@ internal sealed class DataFetchStage(
         var heartRateList = (await heartRateService.GetHeartRatesByDateRangeAsync(
             MillsToDateTime(startTime)!.Value,
             MillsToDateTime(endTime)!.Value,
-            cancellationToken
+            cancellationToken: cancellationToken
         )).ToList();
 
         // Step count data
         var stepCountList = (await stepCountService.GetStepCountsByDateRangeAsync(
             MillsToDateTime(startTime)!.Value,
             MillsToDateTime(endTime)!.Value,
-            cancellationToken
+            cancellationToken: cancellationToken
         )).ToList();
 
         // Sleep sessions

--- a/src/API/Nocturne.API/Services/Health/HeartRateService.cs
+++ b/src/API/Nocturne.API/Services/Health/HeartRateService.cs
@@ -69,13 +69,20 @@ public class HeartRateService
     public async Task<IEnumerable<HeartRate>> GetHeartRatesByDateRangeAsync(
         DateTime from,
         DateTime to,
+        int? count = null,
+        int skip = 0,
         CancellationToken cancellationToken = default
     )
     {
-        var entities = await EntitySet
+        var query = EntitySet
             .Where(h => h.Timestamp >= from && h.Timestamp < to)
             .OrderBy(h => h.Timestamp)
-            .ToListAsync(cancellationToken);
+            .Skip(skip);
+
+        if (count is { } take)
+            query = query.Take(take);
+
+        var entities = await query.ToListAsync(cancellationToken);
 
         return entities.Select(ToDomainModel);
     }

--- a/src/API/Nocturne.API/Services/Health/StepCountService.cs
+++ b/src/API/Nocturne.API/Services/Health/StepCountService.cs
@@ -69,13 +69,20 @@ public class StepCountService
     public async Task<IEnumerable<StepCount>> GetStepCountsByDateRangeAsync(
         DateTime from,
         DateTime to,
+        int? count = null,
+        int skip = 0,
         CancellationToken cancellationToken = default
     )
     {
-        var entities = await EntitySet
+        var query = EntitySet
             .Where(s => s.Timestamp >= from && s.Timestamp < to)
             .OrderBy(s => s.Timestamp)
-            .ToListAsync(cancellationToken);
+            .Skip(skip);
+
+        if (count is { } take)
+            query = query.Take(take);
+
+        var entities = await query.ToListAsync(cancellationToken);
 
         return entities.Select(ToDomainModel);
     }

--- a/src/API/Nocturne.API/Services/Treatments/FoodService.cs
+++ b/src/API/Nocturne.API/Services/Treatments/FoodService.cs
@@ -61,8 +61,8 @@ public class FoodService : IFoodService
     /// <inheritdoc />
     public async Task<IEnumerable<Food>> GetFoodAsync(
         string? find = null,
-        int? count = null,
-        int? skip = null,
+        int count = 100,
+        int skip = 0,
         CancellationToken cancellationToken = default
     )
     {
@@ -74,8 +74,13 @@ public class FoodService : IFoodService
                 count,
                 skip
             );
-            // Note: MongoDB service doesn't support find/count/skip parameters for food yet
-            return await _food.GetFoodAsync(cancellationToken);
+            return await _food.GetFoodWithAdvancedFilterAsync(
+                count,
+                skip,
+                find,
+                reverseResults: false,
+                cancellationToken
+            );
         }
         catch (Exception ex)
         {

--- a/src/Core/Nocturne.Core.Contracts/Health/IHeartRateService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Health/IHeartRateService.cs
@@ -25,11 +25,15 @@ public interface IHeartRateService
     /// </summary>
     /// <param name="from">Start of date range (inclusive)</param>
     /// <param name="to">End of date range (exclusive)</param>
+    /// <param name="count">Maximum number of records to return; <see langword="null"/> for every record in the range</param>
+    /// <param name="skip">Number of records to skip for pagination</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Collection of heart rate records ordered by timestamp ascending</returns>
     Task<IEnumerable<HeartRate>> GetHeartRatesByDateRangeAsync(
         DateTime from,
         DateTime to,
+        int? count = null,
+        int skip = 0,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Core/Nocturne.Core.Contracts/Health/IStepCountService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Health/IStepCountService.cs
@@ -25,11 +25,15 @@ public interface IStepCountService
     /// </summary>
     /// <param name="from">Start of date range (inclusive)</param>
     /// <param name="to">End of date range (exclusive)</param>
+    /// <param name="count">Maximum number of records to return; <see langword="null"/> for every record in the range</param>
+    /// <param name="skip">Number of records to skip for pagination</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Collection of step count records ordered by timestamp ascending</returns>
     Task<IEnumerable<StepCount>> GetStepCountsByDateRangeAsync(
         DateTime from,
         DateTime to,
+        int? count = null,
+        int skip = 0,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Core/Nocturne.Core.Contracts/Treatments/IFoodService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Treatments/IFoodService.cs
@@ -9,17 +9,17 @@ namespace Nocturne.Core.Contracts.Treatments;
 public interface IFoodService
 {
     /// <summary>
-    /// Get food records with optional filtering and pagination
+    /// Get a page of food records, ordered by name
     /// </summary>
-    /// <param name="find">Optional MongoDB query filter</param>
+    /// <param name="find">Optional text matched against name, category, and subcategory</param>
     /// <param name="count">Maximum number of records to return</param>
     /// <param name="skip">Number of records to skip for pagination</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Collection of food records</returns>
     Task<IEnumerable<Food>> GetFoodAsync(
         string? find = null,
-        int? count = null,
-        int? skip = null,
+        int count = 100,
+        int skip = 0,
         CancellationToken cancellationToken = default
     );
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/AlertHistoryEndpointTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/AlertHistoryEndpointTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Controllers.V4.Monitoring;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -138,5 +139,64 @@ public class AlertHistoryEndpointTests
 
         var withoutTest = Body(await controller.GetAlertHistory(ct: CancellationToken.None));
         withoutTest.Items.Should().ContainSingle().Which.Id.Should().Be(realId);
+    }
+
+    [Fact]
+    public async Task GetAlertHistory_PageSizeAtCeiling_IsServedUnchanged()
+    {
+        var controller = CreateController();
+
+        var body = Body(await controller.GetAlertHistory(
+            pageSize: V4ReadLimits.MaxOrdinalPageSize, ct: CancellationToken.None));
+
+        body.PageSize.Should().Be(V4ReadLimits.MaxOrdinalPageSize);
+    }
+
+    [Fact]
+    public async Task GetAlertHistory_PageSizeAboveCeiling_IsClamped()
+    {
+        var controller = CreateController();
+
+        var body = Body(await controller.GetAlertHistory(
+            pageSize: V4ReadLimits.MaxOrdinalPageSize + 1, ct: CancellationToken.None));
+
+        body.PageSize.Should().Be(V4ReadLimits.MaxOrdinalPageSize);
+    }
+
+    [Fact]
+    public async Task GetAlertHistory_PageBelowTheFirst_IsNormalized()
+    {
+        var controller = CreateController();
+
+        var body = Body(await controller.GetAlertHistory(page: 0, ct: CancellationToken.None));
+
+        body.Page.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetAlertHistory_PageAtTheDeepestReachable_IsServedUnchanged()
+    {
+        const int pageSize = V4ReadLimits.MaxOrdinalPageSize;
+        var deepest = V4ReadLimits.MaxPageSize / pageSize;
+        var controller = CreateController();
+
+        var body = Body(await controller.GetAlertHistory(
+            page: deepest, pageSize: pageSize, ct: CancellationToken.None));
+
+        body.Page.Should().Be(deepest);
+    }
+
+    [Fact]
+    public async Task GetAlertHistory_PagePastTheDeepestReachable_IsClamped()
+    {
+        const int pageSize = V4ReadLimits.MaxOrdinalPageSize;
+        var deepest = V4ReadLimits.MaxPageSize / pageSize;
+        var controller = CreateController();
+
+        // int.MaxValue also overflows the page-to-offset multiplication when it is not clamped.
+        var body = Body(await controller.GetAlertHistory(
+            page: int.MaxValue, pageSize: pageSize, ct: CancellationToken.None));
+
+        body.Page.Should().Be(deepest);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4ReadLimitCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4ReadLimitCoverageTests.cs
@@ -24,11 +24,12 @@ public class V4ReadLimitCoverageTests
     private const string V4Namespace = "Nocturne.API.Controllers.V4";
 
     /// <summary>
-    /// Parameter names that carry a caller-supplied page size on this surface. <c>offset</c> and
-    /// <c>skip</c> are not listed: they are meaningless without a page size, so an action that
-    /// declares one declares the other, and the page-size name is what selects the action.
+    /// Parameter names that carry a caller-supplied page size on this surface. <c>offset</c>,
+    /// <c>skip</c> and <c>page</c> are not listed: they are meaningless without a page size, so an
+    /// action that declares one declares the other, and the page-size name is what selects the
+    /// action.
     /// </summary>
-    private static readonly string[] PageSizeParameterNames = ["limit", "count"];
+    private static readonly string[] PageSizeParameterNames = ["limit", "count", "pageSize"];
 
     /// <summary>
     /// Actions exempt from the rule, keyed <c>Controller.Action</c>, with what bounds them instead.
@@ -41,11 +42,6 @@ public class V4ReadLimitCoverageTests
             // A monolithic legacy-shaped profile carries every schedule array inline, so the page
             // is far heavier per record than the rest of this surface.
             ["ProfileController.GetProfileRecords"] = "clamps to its own tighter ceiling",
-
-            // count and skip are inert: FoodService.GetFoodAsync ignores them and returns the whole
-            // catalog, so clamping them would bound nothing. Bounding this read means teaching the
-            // food repository to page, not clamping a parameter it never sees.
-            ["FoodsController.GetFoods"] = "parameter never reaches the query",
         };
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/FoodsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/FoodsControllerTests.cs
@@ -276,6 +276,42 @@ public class FoodsControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task GetFoods_WithoutCount_ReadsNoMoreThanTheCeiling()
+    {
+        var controller = CreateController(null);
+
+        await controller.GetFoods();
+
+        VerifyCatalogRead(count: V4ReadLimits.MaxPageSize, skip: 0);
+    }
+
+    [Fact]
+    public async Task GetFoods_CountAtCeiling_ReachesServiceUnchanged()
+    {
+        var controller = CreateController(null);
+
+        await controller.GetFoods(count: V4ReadLimits.MaxPageSize, skip: 0);
+
+        VerifyCatalogRead(count: V4ReadLimits.MaxPageSize, skip: 0);
+    }
+
+    [Fact]
+    public async Task GetFoods_CountAboveCeiling_IsClamped()
+    {
+        var controller = CreateController(null);
+
+        await controller.GetFoods(count: V4ReadLimits.MaxPageSize + 1, skip: -1);
+
+        VerifyCatalogRead(count: V4ReadLimits.MaxPageSize, skip: 0);
+    }
+
+    private void VerifyCatalogRead(int count, int skip) =>
+        _foodServiceMock.Verify(
+            x => x.GetFoodAsync(null, count, skip, It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+
+    [Fact]
     public async Task GetRecentFoods_LimitAtCeiling_ReachesServiceUnchanged()
     {
         var controller = CreateController(null);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/V4ReadLimitClampTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/V4ReadLimitClampTests.cs
@@ -50,6 +50,11 @@ public class V4ReadLimitClampTests
 {
     private const int Ceiling = V4ReadLimits.MaxPageSize;
     private const int AboveCeiling = V4ReadLimits.MaxPageSize + 1;
+    private const int MergedWindow = V4ReadLimits.MaxMergedPageWindow;
+
+    /// <summary>The bounds of the date range that selects a range read's own branch.</summary>
+    private static readonly DateTime RangeFrom = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime RangeTo = RangeFrom.AddDays(30);
 
     // ── State spans ─────────────────────────────────────────────────
 
@@ -98,18 +103,62 @@ public class V4ReadLimitClampTests
     }
 
     [Fact]
-    public async Task StateSpanActivities_LimitAboveCeiling_IsClampedInTheReportedPage()
+    public async Task StateSpanActivities_LimitAboveWindow_IsClampedInTheReportedPage()
     {
         var service = new Mock<IStateSpanService>();
         var controller = new StateSpansController(service.Object);
 
-        var result = await controller.GetActivities(limit: AboveCeiling, offset: -1);
+        var result = await controller.GetActivities(limit: MergedWindow + 1, offset: -1);
 
         var page = result.Result.Should().BeOfType<OkObjectResult>().Subject
             .Value.Should().BeOfType<PaginatedResponse<StateSpan>>().Subject;
-        page.Pagination.Limit.Should().Be(Ceiling);
+        page.Pagination.Limit.Should().Be(MergedWindow);
         page.Pagination.Offset.Should().Be(0);
     }
+
+    [Fact]
+    public async Task StateSpanActivities_LimitAboveWindow_FetchesEachCategoryOnlyToTheWindow()
+    {
+        var service = new Mock<IStateSpanService>();
+        var controller = new StateSpansController(service.Object);
+
+        await controller.GetActivities(limit: MergedWindow + 1, offset: 0);
+
+        VerifyActivityCategoriesFetched(service, MergedWindow);
+    }
+
+    [Fact]
+    public async Task StateSpanActivities_OffsetInsideWindow_FetchesOnlyAsDeepAsThePageReaches()
+    {
+        var service = new Mock<IStateSpanService>();
+        var controller = new StateSpansController(service.Object);
+
+        await controller.GetActivities(limit: 100, offset: 50);
+
+        VerifyActivityCategoriesFetched(service, 150);
+    }
+
+    [Fact]
+    public async Task StateSpanActivities_OffsetPastWindow_FetchesNothingRatherThanReopeningIt()
+    {
+        var service = new Mock<IStateSpanService>();
+        var controller = new StateSpansController(service.Object);
+
+        var result = await controller.GetActivities(limit: 100, offset: MergedWindow * 10);
+
+        var page = result.Result.Should().BeOfType<OkObjectResult>().Subject
+            .Value.Should().BeOfType<PaginatedResponse<StateSpan>>().Subject;
+        page.Data.Should().BeEmpty();
+        VerifyActivityCategoriesFetched(service, 0);
+    }
+
+    /// <summary>The categories <c>/state-spans/activities</c> merges.</summary>
+    private const int ActivityCategoryCount = 3;
+
+    private static void VerifyActivityCategoriesFetched(Mock<IStateSpanService> service, int count) =>
+        service.Verify(s => s.GetStateSpansAsync(
+            It.IsAny<StateSpanCategory?>(), null, null, null, null, null,
+            count, 0, true, It.IsAny<CancellationToken>()), Times.Exactly(ActivityCategoryCount));
 
     /// <summary>The <c>/state-spans</c> sub-routes that pre-filter by a single category.</summary>
     private const int CategorySubRouteCount = 8;
@@ -272,6 +321,46 @@ public class V4ReadLimitClampTests
         service.Verify(s => s.GetHeartRatesAsync(Ceiling, 0, It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task HeartRates_DateRangeWithoutCount_ReadsNoMoreThanTheCeiling()
+    {
+        var service = new Mock<IHeartRateService>();
+        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+
+        var result = await controller.GetHeartRates(from: RangeFrom, to: RangeTo);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyHeartRateRangeFetched(service, Ceiling, 0);
+    }
+
+    [Fact]
+    public async Task HeartRates_DateRangeCountAtCeiling_ReachesServiceUnchanged()
+    {
+        var service = new Mock<IHeartRateService>();
+        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+
+        var result = await controller.GetHeartRates(count: Ceiling, skip: 0, from: RangeFrom, to: RangeTo);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyHeartRateRangeFetched(service, Ceiling, 0);
+    }
+
+    [Fact]
+    public async Task HeartRates_DateRangeCountAboveCeiling_IsClamped()
+    {
+        var service = new Mock<IHeartRateService>();
+        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+
+        var result = await controller.GetHeartRates(count: AboveCeiling, skip: -1, from: RangeFrom, to: RangeTo);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyHeartRateRangeFetched(service, Ceiling, 0);
+    }
+
+    private static void VerifyHeartRateRangeFetched(Mock<IHeartRateService> service, int count, int skip) =>
+        service.Verify(s => s.GetHeartRatesByDateRangeAsync(
+            RangeFrom, RangeTo, count, skip, It.IsAny<CancellationToken>()), Times.Once);
+
     // ── Step count ──────────────────────────────────────────────────
 
     [Fact]
@@ -297,6 +386,46 @@ public class V4ReadLimitClampTests
         result.Result.Should().BeOfType<OkObjectResult>();
         service.Verify(s => s.GetStepCountsAsync(Ceiling, 0, It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task StepCounts_DateRangeWithoutCount_ReadsNoMoreThanTheCeiling()
+    {
+        var service = new Mock<IStepCountService>();
+        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+
+        var result = await controller.GetStepCounts(from: RangeFrom, to: RangeTo);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyStepCountRangeFetched(service, Ceiling, 0);
+    }
+
+    [Fact]
+    public async Task StepCounts_DateRangeCountAtCeiling_ReachesServiceUnchanged()
+    {
+        var service = new Mock<IStepCountService>();
+        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+
+        var result = await controller.GetStepCounts(count: Ceiling, skip: 0, from: RangeFrom, to: RangeTo);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyStepCountRangeFetched(service, Ceiling, 0);
+    }
+
+    [Fact]
+    public async Task StepCounts_DateRangeCountAboveCeiling_IsClamped()
+    {
+        var service = new Mock<IStepCountService>();
+        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+
+        var result = await controller.GetStepCounts(count: AboveCeiling, skip: -1, from: RangeFrom, to: RangeTo);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        VerifyStepCountRangeFetched(service, Ceiling, 0);
+    }
+
+    private static void VerifyStepCountRangeFetched(Mock<IStepCountService> service, int count, int skip) =>
+        service.Verify(s => s.GetStepCountsByDateRangeAsync(
+            RangeFrom, RangeTo, count, skip, It.IsAny<CancellationToken>()), Times.Once);
 
     // ── Compatibility analyses ──────────────────────────────────────
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/ActogramReportServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/ActogramReportServiceTests.cs
@@ -120,11 +120,11 @@ public class ActogramReportServiceTests
             .ReturnsAsync(new[] { sleepSession });
         _steps
             .Setup(s => s.GetStepCountsByDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<int?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { stepRow });
         _heartRates
             .Setup(h => h.GetHeartRatesByDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<int?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { hrRow });
         _therapy.Setup(t => t.HasDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
@@ -198,11 +198,11 @@ public class ActogramReportServiceTests
             .ReturnsAsync(Array.Empty<SleepSession>());
         _steps
             .Setup(s => s.GetStepCountsByDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<int?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<StepCount>());
         _heartRates
             .Setup(h => h.GetHeartRatesByDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<int?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<HeartRate>());
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/Stages/DataFetchStageTests.cs
@@ -179,12 +179,14 @@ public class DataFetchStageTests
 
         _mockHeartRateService
             .Setup(s => s.GetHeartRatesByDateRangeAsync(
-                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<int?>(), It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<HeartRate>());
 
         _mockStepCountService
             .Setup(s => s.GetStepCountsByDateRangeAsync(
-                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<int?>(), It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<StepCount>());
 
         _mockSleepService

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/FoodServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/FoodServiceTests.cs
@@ -134,7 +134,7 @@ public class FoodServiceTests
     [Fact]
     [Trait("Category", "Unit")]
     [Parity]
-    public async Task GetFoodAsync_WithoutParameters_ReturnsAllFood()
+    public async Task GetFoodAsync_WithoutParameters_ReturnsTheDefaultPage()
     {
         // Arrange
         var expectedFoods = new List<Food>
@@ -162,7 +162,9 @@ public class FoodServiceTests
         };
 
         _mockFoodRepository
-            .Setup(x => x.GetFoodAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetFoodWithAdvancedFilterAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedFoods);
 
         // Act
@@ -172,7 +174,9 @@ public class FoodServiceTests
         result.Should().NotBeNull();
         result.Should().BeEquivalentTo(expectedFoods);
         _mockFoodRepository.Verify(
-            x => x.GetFoodAsync(It.IsAny<CancellationToken>()),
+            x => x.GetFoodWithAdvancedFilterAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
             Times.Once
         );
     }
@@ -180,10 +184,10 @@ public class FoodServiceTests
     [Fact]
     [Trait("Category", "Unit")]
     [Parity]
-    public async Task GetFoodAsync_WithParameters_CallsMongoDbServiceCorrectly()
+    public async Task GetFoodAsync_WithParameters_PagesTheRepository()
     {
         // Arrange
-        var find = "{\"category\":\"Fruit\"}";
+        var find = "Fruit";
         var count = 10;
         var skip = 5;
         var expectedFoods = new List<Food>
@@ -197,7 +201,9 @@ public class FoodServiceTests
         };
 
         _mockFoodRepository
-            .Setup(x => x.GetFoodAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetFoodWithAdvancedFilterAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedFoods);
 
         // Act
@@ -207,7 +213,7 @@ public class FoodServiceTests
         result.Should().NotBeNull();
         result.Should().BeEquivalentTo(expectedFoods);
         _mockFoodRepository.Verify(
-            x => x.GetFoodAsync(It.IsAny<CancellationToken>()),
+            x => x.GetFoodWithAdvancedFilterAsync(count, skip, find, false, It.IsAny<CancellationToken>()),
             Times.Once
         );
     }
@@ -220,7 +226,9 @@ public class FoodServiceTests
         // Arrange
         var expectedException = new InvalidOperationException("Database error");
         _mockFoodRepository
-            .Setup(x => x.GetFoodAsync(It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetFoodWithAdvancedFilterAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
             .ThrowsAsync(expectedException);
 
         // Act & Assert


### PR DESCRIPTION
## What

#718 clamped 24 V4 routes and flagged four reads it could not fix in name-scope. This fixes all four.

- **`state-spans/activities`** fetched `count: int.MaxValue` from each of three categories behind its clamped page. It merges in memory, so it now uses `ClampOffset` + `ClampMergedPage` (the `ActivityController` idiom from #694) and reads each category only to `offset + limit` — zero once the offset passes the window. The reported page ceiling therefore drops from `MaxPageSize` to `MaxMergedPageWindow`, which is what a merged read already meant elsewhere.
- **`HeartRate` / `StepCount`** honoured `count`/`skip` on the paged branch and dropped both on the `from`+`to` branch, returning the whole range. `count` became `int?`; the range branch now pages, and an absent `count` reads to `MaxPageSize` rather than without bound. The default of 10 still belongs only to the non-range branch, so a caller passing just a range is not truncated to 10. `GetHeartRatesByDateRangeAsync`/`GetStepCountsByDateRangeAsync` gained optional `count`/`skip`; the actogram and chart-data callers pass `cancellationToken:` by name and are otherwise unchanged. **No first-party caller of either route exists** — the heart-rate report and the charts call the services directly.
- **`FoodsController.GetFoods`** (#718's second exemption): `count`/`skip` never reached the query because `FoodService` called the repository's unpaged `GetFoodAsync`. The repository already had a paging overload (`GetFoodWithAdvancedFilterAsync`), so the service now delegates there and the controller clamps. Every UI caller (`food-state.svelte.ts`, `TreatmentFoodSelectorDialog`, `TreatmentFoodEntryEditDialog`) asks for no `count` and renders the whole catalog, so the absent-`count` default is the ceiling, not a page. Side effect worth a look: `find` now actually filters (name/category/subcategory) where it was previously dropped.
- **`AlertsController.GetAlertHistory`** clamped `page`/`pageSize` inline and outside the sweep. Folded into `V4ReadLimits` as `MaxOrdinalPageSize` (100) + `ClampPageSize`, and `ClampPageNumber`, which caps the offset at `MaxPageSize` records — and stops `(page - 1) * pageSize` overflowing to a negative `Skip`. The ceiling stays 100 rather than becoming `MaxPageSize`: routing it through `ClampLimit` would have raised it 1000×, the trap #718 avoided for `ProfileController.GetProfileRecords`. The UI asks for 25 and 50.

## The sweep

`V4ReadLimitCoverageTests` now selects on `pageSize` as well as `limit`/`count`, which folds the alert-history shape in. The `FoodsController.GetFoods` exemption is deleted; only `ProfileController.GetProfileRecords` remains.

## Tests

Boundary pairs per route, in the existing classes where one existed (`FoodsControllerTests` +3, `AlertHistoryEndpointTests` +5) and in `V4ReadLimitClampTests` for the rest. Mutation-proven four times, each restored: unwinding the activities window fails 3 window tests; un-paging the heart-rate range branch fails its 3 while step-count's 3 stay green; un-paging step-count and unclamping Foods together fail 5 boundary tests **and** the sweep by name; reverting the alert clamps fails 2 boundary tests **and** the sweep by name. Full `Nocturne.API.Tests`: 5415 passed, 0 failed, 5 skipped.
