### PR TITLE
test(bot): cover alert delivery adapter routing with vitest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,8 +149,9 @@ jobs:
   # run reliably on GitHub-hosted runners where Docker is available. Other
   # integration projects stay deferred until their fixtures/references are fixed.
   # Typechecks the Svelte library packages that have no build step and no generated API
-  # client, so this needs nothing but pnpm. @nocturne/app and @nocturne/portal are excluded
-  # because their checks depend on the NSwag/Zod codegen and belong with the .NET build.
+  # client, and runs the pure-node vitest suites, so this needs nothing but pnpm.
+  # @nocturne/app and @nocturne/portal are excluded because their checks depend on the
+  # NSwag/Zod codegen and belong with the .NET build.
   #
   # Only glucose-chart and coach are listed. @nocturne/ui and @nocturne/cms still run
   # svelte-check-native, which silently discovers zero files on Linux (see the note on their
@@ -178,6 +179,8 @@ jobs:
       - name: Typecheck library packages
         run: |
           pnpm --filter @nightscout/glucose-chart                --filter @nocturne/coach                run check
+      - name: Bot unit tests
+        run: pnpm --filter @nocturne/bot run test
 
   integration-db:
     runs-on: ubuntu-latest

--- a/src/Web/packages/bot/package.json
+++ b/src/Web/packages/bot/package.json
@@ -9,6 +9,8 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "clean": "rimraf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "bot:register-discord-commands": "node dist/scripts/register-discord-commands.js"
   },
   "author": "Nocturne Project",
@@ -29,7 +31,8 @@
   "devDependencies": {
     "@types/node": "^20.10.6",
     "typescript": "^5.3.3",
-    "rimraf": "^5.0.5"
+    "rimraf": "^5.0.5",
+    "vitest": "^4.1.6"
   },
   "engines": {
     "node": ">=24"

--- a/src/Web/packages/bot/src/alerts/deliver.test.ts
+++ b/src/Web/packages/bot/src/alerts/deliver.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Chat } from "chat";
+import { AlertDeliveryHandler } from "./deliver.js";
+import type { AlertDispatchEvent, BotApiClient } from "../types.js";
+
+vi.mock("../lib/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const ADAPTERS_WITH_DM = ["discord", "slack", "telegram", "whatsapp", "resend"];
+
+function createBot(options: { adaptersWithDm?: string[] } = {}) {
+  const withDm = options.adaptersWithDm ?? ADAPTERS_WITH_DM;
+
+  const post = vi.fn().mockResolvedValue({ id: "platform-message-1" });
+  const openDM = vi.fn(async (userId: string) => `thread-for-${userId}`);
+  const channel = vi.fn(() => ({ post }));
+  const thread = vi.fn(() => ({ post }));
+  const getAdapter = vi.fn((name: string) =>
+    withDm.includes(name) ? { name, openDM } : undefined,
+  );
+
+  const bot = { channel, thread, getAdapter } as unknown as Chat;
+  return { bot, channel, thread, getAdapter, openDM, post };
+}
+
+function createApi() {
+  const markDelivered = vi.fn().mockResolvedValue(undefined);
+  const markFailed = vi.fn().mockResolvedValue(undefined);
+  const api = {
+    alerts: { markDelivered, markFailed },
+  } as unknown as BotApiClient;
+  return { api, markDelivered, markFailed };
+}
+
+function createEvent(
+  channelType: string,
+  destination: string,
+): AlertDispatchEvent {
+  return {
+    deliveryId: "delivery-1",
+    channelType,
+    destination,
+    tenantSlug: "acme",
+    payload: {
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      ruleName: "Urgent low",
+      subjectName: "Alex",
+      glucoseValue: 54,
+      trend: "SingleDown",
+      trendRate: -1.4,
+      readingTimestamp: "2026-01-01T00:00:00.000Z",
+    } as AlertDispatchEvent["payload"],
+  };
+}
+
+describe("AlertDeliveryHandler adapter routing", () => {
+  let bits: ReturnType<typeof createBot>;
+  let apiBits: ReturnType<typeof createApi>;
+  let handler: AlertDeliveryHandler;
+
+  beforeEach(() => {
+    bits = createBot();
+    apiBits = createApi();
+    handler = new AlertDeliveryHandler(bits.bot, apiBits.api);
+  });
+
+  describe("channel-addressed types", () => {
+    const cases: Array<
+      [channelType: string, destination: string, addressed: string]
+    > = [
+      ["discord_channel", "123456789012345678", "discord:123456789012345678"],
+      ["slack_channel", "C01234ABCDE", "slack:C01234ABCDE"],
+      ["telegram_group", "-1001234567890", "telegram:-1001234567890"],
+    ];
+
+    it.each(cases)(
+      "%s addresses the channel with the adapter prefix",
+      async (channelType, destination, addressed) => {
+        await handler.deliver(createEvent(channelType, destination));
+
+        expect(bits.channel).toHaveBeenCalledExactlyOnceWith(addressed);
+        expect(bits.openDM).not.toHaveBeenCalled();
+        expect(bits.thread).not.toHaveBeenCalled();
+        expect(apiBits.markDelivered).toHaveBeenCalledExactlyOnceWith(
+          "delivery-1",
+          { platformMessageId: "platform-message-1" },
+        );
+        expect(apiBits.markFailed).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(cases)(
+      "%s never passes the bare destination to channel()",
+      async (channelType, destination) => {
+        await handler.deliver(createEvent(channelType, destination));
+
+        expect(bits.channel).not.toHaveBeenCalledWith(destination);
+      },
+    );
+  });
+
+  describe("DM-addressed types", () => {
+    const cases: Array<
+      [channelType: string, destination: string, adapter: string]
+    > = [
+      ["discord_dm", "123456789012345678", "discord"],
+      ["slack_dm", "U01234ABCDE", "slack"],
+      ["telegram_dm", "123456789", "telegram"],
+      ["whatsapp_dm", "+61400000000", "whatsapp"],
+      ["resend_email", "alex@example.com", "resend"],
+    ];
+
+    it.each(cases)(
+      "%s opens a DM through the adapter selected by channel type",
+      async (channelType, destination, adapter) => {
+        await handler.deliver(createEvent(channelType, destination));
+
+        expect(bits.getAdapter).toHaveBeenCalledExactlyOnceWith(adapter);
+        expect(bits.openDM).toHaveBeenCalledExactlyOnceWith(destination);
+        expect(bits.thread).toHaveBeenCalledExactlyOnceWith(
+          `thread-for-${destination}`,
+        );
+        expect(bits.channel).not.toHaveBeenCalled();
+        expect(apiBits.markDelivered).toHaveBeenCalledExactlyOnceWith(
+          "delivery-1",
+          { platformMessageId: "platform-message-1" },
+        );
+      },
+    );
+  });
+
+  it("routes numeric destinations by channel type, not by ID format", async () => {
+    const numeric = "123456789012345678";
+
+    await handler.deliver(createEvent("discord_dm", numeric));
+    await handler.deliver(createEvent("telegram_dm", numeric));
+
+    expect(bits.getAdapter.mock.calls).toEqual([["discord"], ["telegram"]]);
+  });
+
+  it("fails the delivery when no adapter serves the channel type", async () => {
+    await handler.deliver(createEvent("carrier_pigeon", "somewhere"));
+
+    expect(bits.channel).not.toHaveBeenCalled();
+    expect(bits.getAdapter).not.toHaveBeenCalled();
+    expect(apiBits.markDelivered).not.toHaveBeenCalled();
+    expect(apiBits.markFailed).toHaveBeenCalledExactlyOnceWith("delivery-1", {
+      error: "No chat adapter delivers 'carrier_pigeon'",
+    });
+  });
+
+  it("fails the delivery when the DM adapter is not configured", async () => {
+    const unconfigured = createBot({ adaptersWithDm: ["discord"] });
+    const handlerWithout = new AlertDeliveryHandler(
+      unconfigured.bot,
+      apiBits.api,
+    );
+
+    await handlerWithout.deliver(
+      createEvent("resend_email", "alex@example.com"),
+    );
+
+    expect(unconfigured.thread).not.toHaveBeenCalled();
+    expect(apiBits.markDelivered).not.toHaveBeenCalled();
+    expect(apiBits.markFailed).toHaveBeenCalledExactlyOnceWith("delivery-1", {
+      error: "Adapter 'resend' cannot open a direct message",
+    });
+  });
+});
+
+describe("AlertDeliveryHandler outcome reporting", () => {
+  it("reports an undefined platform message id when the post returns nothing", async () => {
+    const bits = createBot();
+    bits.post.mockResolvedValue(undefined);
+    const apiBits = createApi();
+
+    await new AlertDeliveryHandler(bits.bot, apiBits.api).deliver(
+      createEvent("slack_channel", "C01234ABCDE"),
+    );
+
+    expect(apiBits.markDelivered).toHaveBeenCalledExactlyOnceWith(
+      "delivery-1",
+      {
+        platformMessageId: undefined,
+      },
+    );
+  });
+
+  it("fails the delivery when the post rejects", async () => {
+    const bits = createBot();
+    bits.post.mockRejectedValue(new Error("channel_not_found"));
+    const apiBits = createApi();
+
+    await new AlertDeliveryHandler(bits.bot, apiBits.api).deliver(
+      createEvent("slack_channel", "C01234ABCDE"),
+    );
+
+    expect(apiBits.markDelivered).not.toHaveBeenCalled();
+    expect(apiBits.markFailed).toHaveBeenCalledExactlyOnceWith("delivery-1", {
+      error: "channel_not_found",
+    });
+  });
+
+  it("stringifies a non-Error rejection", async () => {
+    const bits = createBot();
+    bits.post.mockRejectedValue("rate limited");
+    const apiBits = createApi();
+
+    await new AlertDeliveryHandler(bits.bot, apiBits.api).deliver(
+      createEvent("slack_channel", "C01234ABCDE"),
+    );
+
+    expect(apiBits.markFailed).toHaveBeenCalledExactlyOnceWith("delivery-1", {
+      error: "rate limited",
+    });
+  });
+
+  it("swallows a failure-reporting error", async () => {
+    const bits = createBot();
+    bits.post.mockRejectedValue(new Error("channel_not_found"));
+    const apiBits = createApi();
+    apiBits.markFailed.mockRejectedValue(new Error("api unreachable"));
+
+    await expect(
+      new AlertDeliveryHandler(bits.bot, apiBits.api).deliver(
+        createEvent("slack_channel", "C01234ABCDE"),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/Web/packages/bot/vitest.config.ts
+++ b/src/Web/packages/bot/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -330,6 +330,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.25)(@vitest/browser-playwright@4.1.6)(happy-dom@20.9.0)(vite@8.0.12(@types/node@20.19.25)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
 
   packages/bridge:
     dependencies:


### PR DESCRIPTION
#717 fixed `deliver.ts` addressing its adapters by guessing — `chat.channel(id)` reads the adapter from the ID prefix and `chat.openDM(id)` infers it from the user-ID format, so every explicitly-addressed channel and every `resend_email` destination was undeliverable. That fix landed with no automated coverage: `packages/bot` had no test harness, which #717 flagged as a follow-up. This is that follow-up.

**Harness.** vitest wired into `@nocturne/bot` copying `@nocturne/bridge`'s setup verbatim — same vitest major (`^4.1.6`), same 4-line `vitest.config.ts` (`environment: "node"`, `include: ["src/**/*.test.ts"]`), tests colocated with sources. No JSX config needed: vitest 4's oxc transform picks up the package tsconfig's `jsxImportSource: "chat"`, so the real `AlertCard` renders without extra config (the suite executes the render; it does not assert the card's content). Adapters are mocked at the `Chat` interface — no Discord/Telegram/Slack SDK enters the test process.

**Coverage** — 18 tests over every branch of `deliver.ts`: prefixed `adapter:channel` addressing for `discord_channel`/`slack_channel`/`telegram_group` (asserting the exact string, plus a negative that the bare destination is never passed); adapter selection per DM type including `resend_email`, which openDM-inference can never resolve; the DM/channel split asserted in both directions; the same numeric ID routed to `discord` vs `telegram` purely by channel type; unknown channel type; an adapter with no `openDM`; and the delivered/failed reporting outcomes (`sent?.id` absent, `Error` vs non-`Error` rejection, `markFailed` itself rejecting).

**Mutation-proven.** Reverting `target()` to the pre-#717 shape (unprefixed `channel(destination)`, `bot.openDM` with no adapter selection) fails 14 of the 18 tests — every routing assertion. Restored; `deliver.ts` is untouched by this PR.

**CI.** The pipeline ran no JS/TS tests at all — `web-typecheck` only typechecks `glucose-chart` and `coach`, and no workflow invoked vitest. Added one step to that job so the bot suite is gated. Note this leaves `@nocturne/bridge` (3 test files) and `@nocturne/cms` still ungated; widening the job to every package with a `test` script is a separate call.

18/18 passing; `tsc --noEmit` clean for the package and (checked separately, since tsconfig excludes `*.test.ts`) for the test file.
