### PR TITLE
chore(constants): drop the dead DefaultConstants.Connectors block

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Shared/Constants/DefaultConstants.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Shared/Constants/DefaultConstants.cs
@@ -22,51 +22,6 @@ public static class DefaultConstants
     }
 
     /// <summary>
-    /// Connector defaults
-    /// </summary>
-    public static class Connectors
-    {
-        /// <summary>
-        /// Glooko defaults
-        /// </summary>
-        public static class Glooko
-        {
-            public const string Server = "eu.api.glooko.com";
-            public const int TimezoneOffset = 0;
-        }
-
-        /// <summary>
-        /// CareLink defaults
-        /// </summary>
-        public static class CareLink
-        {
-            public const string Region = "us";
-        }
-
-        /// <summary>
-        /// Dexcom defaults
-        /// </summary>
-        public static class Dexcom
-        {
-            public const string Region = "us";
-        }
-
-        /// <summary>
-        /// LibreLinkUp defaults
-        /// </summary>
-        public static class LibreLinkUp
-        {
-            public const string Region = "EU";
-        }
-
-        public static class MyLife
-        {
-            public const int AppPlatform = 2;
-            public const int AppVersion = 20403;
-        }
-    }
-
-    /// <summary>
     /// Loop defaults
     /// </summary>
     public static class Loop


### PR DESCRIPTION
## What
Deletes `DefaultConstants.Connectors` — `Glooko.Server`/`TimezoneOffset`, `CareLink.Region`, `Dexcom.Region`, `LibreLinkUp.Region`, `MyLife.AppPlatform`/`AppVersion`. Follow-up to the item noted in #712.

## Why it's safe
`git grep -l DefaultConstants` over all tracked files returns exactly one path: the declaring file. No file imports `Nocturne.Infrastructure.Shared.Constants`, and there is no `using static` on any constants class in the repo. These are nested static classes, so `DefaultConstants.Connectors.X` is the only way to reach them — and that appears zero times across `src`, `tests` and `src/Web`. The values are supplied at runtime by each connector's `[ConnectorProperty(DefaultValue = …)]` attribute.

## Values checked before deleting
Two of the deleted values disagreed with what actually ships, both regional inversions:
- Glooko: dead block said `eu.api.glooko.com`; live default is region `US` → `api.glooko.com`.
- CareLink: dead block said `us`; live `CareLinkConnectorConfiguration.Server` defaults to `"EU"`.

`ConnectorDefaults` (Core.Constants) carries the same two stale values. They look like fossils of the legacy Nightscout env-var defaults rather than an intended change, and nothing reads them either way — flagged here rather than silently "fixed".

## Not done here
`DefaultConstants.Core` and `.Loop` are equally dead, as are the connector members of `ConnectorDefaults` (referenced only by `<seealso cref=…>` doc comments). Both are larger dedups; left for a follow-up.

## Verification
`dotnet build nocturne.sln -p:GenerateNSwagClient=false` → 0 errors. No test project references `DefaultConstants`.
