### PR TITLE
fix(alerts): require E.164 with a leading + for whatsapp_dm destinations

### DIFF
--- a/src/Core/Nocturne.Core.Models/Alerts/ChannelDestinations.cs
+++ b/src/Core/Nocturne.Core.Models/Alerts/ChannelDestinations.cs
@@ -72,6 +72,8 @@ public static partial class ChannelDestinations
         [ChannelType.TelegramDm] = new(TelegramUserId(), "a Telegram user ID (digits)"),
         [ChannelType.TelegramGroup] = new(
             TelegramGroupId(), "a Telegram group chat ID (-100…) or an @username"),
+        [ChannelType.WhatsAppDm] = new(
+            WhatsAppPhoneNumber(), "an E.164 phone number with a leading + (+15551234567)"),
     };
 
     /// <summary>The channel types the rule editor offers, each classified by destination mode.</summary>
@@ -129,4 +131,10 @@ public static partial class ChannelDestinations
 
     [GeneratedRegex(@"^(-\d+|@[A-Za-z][A-Za-z0-9_]{4,31})$")]
     private static partial Regex TelegramGroupId();
+
+    // The Cloud API prepends the business phone number's own country calling code to any `to`
+    // value that omits the leading +, so a destination stored without one is delivered to a
+    // different number entirely.
+    [GeneratedRegex(@"^\+[1-9]\d{6,14}$")]
+    private static partial Regex WhatsAppPhoneNumber();
 }

--- a/src/Web/packages/app/src/lib/components/alerts/channelMeta.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/channelMeta.ts
@@ -133,6 +133,11 @@ export const CHANNEL_META: ChannelMetaEntry[] = [
     platform: "whatsapp",
     destinationLabel: "Phone (E.164)",
     destinationPlaceholder: "+15551234567",
+    destinationHelper:
+      "Include the + and country code. Without the +, WhatsApp prepends the sending business number's country code.",
+    destinationPattern: /^\+[1-9]\d{6,14}$/,
+    destinationPatternMessage:
+      "A phone number starts with + and a country code, digits only.",
   },
   {
     type: ChannelType.ResendEmail,

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/AlertRulesControllerChannelDestinationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/AlertRulesControllerChannelDestinationTests.cs
@@ -229,6 +229,46 @@ public class AlertRulesControllerChannelDestinationTests
     }
 
     [Theory]
+    [InlineData("+15551234567")]
+    [InlineData("+61412345678")]
+    [InlineData("+441632960001")]
+    [InlineData("+1234567")]         // 7 digits — the E.164 minimum
+    [InlineData("+123456789012345")] // 15 digits — the E.164 maximum
+    public async Task CreateRule_accepts_a_whatsapp_destination_in_e164(string destination)
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.WhatsAppDm, destination),
+            CancellationToken.None);
+
+        var created = result.Result.Should().BeOfType<CreatedAtActionResult>()
+            .Subject.Value.Should().BeOfType<AlertRuleResponse>().Subject;
+        created.Channels.Should().ContainSingle()
+            .Which.Destination.Should().Be(destination);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("  ")]
+    [InlineData("15551234567")]        // a webhook wa_id — no leading +
+    [InlineData("+1 (555) 123-4567")]  // separators the Cloud API tolerates, we do not store
+    [InlineData("+0155512345")]        // no country calling code starts with 0
+    [InlineData("+123456")]            // 6 digits — one short
+    [InlineData("+1234567890123456")]  // 16 digits — one past the E.164 maximum
+    [InlineData("whatsapp:+15551234567")]
+    public async Task CreateRule_rejects_a_whatsapp_destination_outside_e164(string? destination)
+    {
+        var (controller, _) = CreateController();
+
+        var result = await controller.CreateRule(
+            RuleWith(ChannelType.WhatsAppDm, destination),
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Theory]
     [InlineData(ChannelType.Telegram, "telegram_dm")]
     [InlineData(ChannelType.WhatsApp, "whatsapp_dm")]
     public async Task CreateRule_rejects_a_channel_type_with_no_delivery_path(


### PR DESCRIPTION
#717 left `whatsapp_dm` as the only bot-delivered channel type with no entry in `ChannelDestinations.Shapes`, because the `+`-prefixed placeholder vs Meta's digits-only `wa_id` was unverified. Verified now — and the answer goes the other way from what that mismatch suggested.

**What Meta's docs say.** [Send messages](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-messages/): "If the plus sign is omitted, your business phone number's country calling code is prepended to the customer's phone number." The page's own table shows an Indian (`91`) business number sending to `1 (631) 555-1234` and delivering to `+9116315551234`. The API accepts digits-only, but does not normalize it to E.164 — it re-homes it under the *sender's* country code. The [webhook `wa_id`](https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components/) is separately digits-only (`"wa_id": "16505551234"`).

**So the two shapes are genuinely different values, and only one is safe to send.** Nothing in Nocturne matches an inbound WhatsApp sender against a stored destination — `whatsapp_dm` is `UserSupplied`, so the identity-directory resolver never runs for it — so there is no round-trip to preserve. `deliver.ts` hands the destination to `openDM`, which puts it verbatim into `to`. A destination stored without the `+` therefore alerts a stranger, silently, in a way that depends on where the deployment's business number happens to be registered.

**Change:** shape `^\+[1-9]\d{6,14}$` on `whatsapp_dm`, mirrored as `destinationPattern` in `channelMeta.ts` alongside the existing `telegram_group` / `slack_channel` patterns. The `+15551234567` placeholder was already correct and is unchanged. No normalization: nothing else in `ResolveAndValidateChannelsAsync` rewrites a destination, and prefixing `+` onto digits would silently corrupt a local-format number like `0412345678`. Separators are rejected even though the API tolerates them, so storage keeps one canonical form.

**Tests:** 49 passed in `AlertRulesControllerChannelDestinationTests` (was 36). Accepts 5 valid forms including both E.164 length bounds; rejects 8 including a raw `wa_id`, separators, a leading zero, and each length bound one step out. `ChannelsSection` 9 passed. Mutation-proven three ways: making the `+` optional (`^\+?…`) fails only the raw-`wa_id` reject case; `{7,14}` fails only the 7-digit accept case; `{6,13}` fails only the 15-digit accept case.

**Follow-ups**
- The #717 guard tests don't require an offered type to carry a shape at all — that's how this gap survived. `Webhook` and `ResendEmail` are also shapeless, so a blanket guard needs those two decided first.
- `whatsapp_dm` is `UserSupplied` despite WhatsApp having both a bot adapter and an identity-directory platform key; the other DM types are `LinkedIdentity`. Whoever flips it must normalize at the resolver, since the directory stores the digits-only `wa_id` and would now 400 against this shape.
- Related asymmetry to record while that's open: the adapter encodes an outbound thread as `whatsapp:{phoneNumberId}:+15551234567` from our stored destination, but encodes the user's inbound reply as `whatsapp:{phoneNumberId}:15551234567` from `inbound.from`. Nothing correlates the two today, but any future thread-keyed state would treat them as different conversations.
