### PR TITLE
feat(web): serve the cross-tenant dashboard on tenantless hosts

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -685,64 +685,26 @@ public class OidcController : ControllerBase
     /// <summary>
     /// Set the OIDC state cookie
     /// </summary>
-    private void SetStateCookie(string state, DateTimeOffset expiresAt)
-    {
-        Response.Cookies.Append(
-            _options.Cookie.StateCookieName,
-            state,
-            new CookieOptions
-            {
-                HttpOnly = true,
-                Secure = _options.Cookie.Secure,
-                SameSite = SessionCookieExtensions.MapSameSiteMode(_options.Cookie.SameSite),
-                Path = _options.Cookie.Path,
-                Domain = _options.Cookie.Domain,
-                Expires = expiresAt,
-            }
-        );
-    }
+    private void SetStateCookie(string state, DateTimeOffset expiresAt) =>
+        Response.SetStateCookie(_options.Cookie.StateCookieName, state, expiresAt, _options);
 
     /// <summary>
     /// Clear the OIDC state cookie
     /// </summary>
-    private void ClearStateCookie()
-    {
-        Response.Cookies.Delete(
-            _options.Cookie.StateCookieName,
-            new CookieOptions { Path = _options.Cookie.Path, Domain = _options.Cookie.Domain }
-        );
-    }
+    private void ClearStateCookie() =>
+        Response.ClearStateCookie(_options.Cookie.StateCookieName, _options);
 
     /// <summary>
     /// Set the OIDC link state cookie
     /// </summary>
-    private void SetLinkStateCookie(string state, DateTimeOffset expiresAt)
-    {
-        Response.Cookies.Append(
-            _options.Cookie.LinkStateCookieName,
-            state,
-            new CookieOptions
-            {
-                HttpOnly = true,
-                Secure = _options.Cookie.Secure,
-                SameSite = SessionCookieExtensions.MapSameSiteMode(_options.Cookie.SameSite),
-                Path = _options.Cookie.Path,
-                Domain = _options.Cookie.Domain,
-                Expires = expiresAt,
-            }
-        );
-    }
+    private void SetLinkStateCookie(string state, DateTimeOffset expiresAt) =>
+        Response.SetStateCookie(_options.Cookie.LinkStateCookieName, state, expiresAt, _options);
 
     /// <summary>
     /// Clear the OIDC link state cookie
     /// </summary>
-    private void ClearLinkStateCookie()
-    {
-        Response.Cookies.Delete(
-            _options.Cookie.LinkStateCookieName,
-            new CookieOptions { Path = _options.Cookie.Path, Domain = _options.Cookie.Domain }
-        );
-    }
+    private void ClearLinkStateCookie() =>
+        Response.ClearStateCookie(_options.Cookie.LinkStateCookieName, _options);
 
     /// <summary>
     /// Set session cookies (access token and refresh token)

--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -747,69 +747,14 @@ public class OidcController : ControllerBase
     /// <summary>
     /// Set session cookies (access token and refresh token)
     /// </summary>
-    private void SetSessionCookies(OidcTokenResponse tokens)
-    {
-        // Access token cookie (short-lived)
-        Response.Cookies.Append(
-            _options.Cookie.AccessTokenName,
-            tokens.AccessToken,
-            new CookieOptions
-            {
-                HttpOnly = _options.Cookie.HttpOnly,
-                Secure = _options.Cookie.Secure,
-                SameSite = SessionCookieExtensions.MapSameSiteMode(_options.Cookie.SameSite),
-                Path = _options.Cookie.Path,
-                Domain = _options.Cookie.Domain,
-                Expires = tokens.ExpiresAt,
-            }
-        );
-
-        // Refresh token cookie (longer-lived)
-        Response.Cookies.Append(
-            _options.Cookie.RefreshTokenName,
-            tokens.RefreshToken,
-            new CookieOptions
-            {
-                HttpOnly = true, // Always HttpOnly for refresh tokens
-                Secure = _options.Cookie.Secure,
-                SameSite = SessionCookieExtensions.MapSameSiteMode(_options.Cookie.SameSite),
-                Path = _options.Cookie.Path,
-                Domain = _options.Cookie.Domain,
-                Expires = DateTimeOffset.UtcNow.Add(_options.Session.RefreshTokenLifetime),
-            }
-        );
-
-        // Also set a non-HttpOnly cookie with just auth status for JavaScript
-        Response.Cookies.Append(
-            "IsAuthenticated",
-            "true",
-            new CookieOptions
-            {
-                HttpOnly = false,
-                Secure = _options.Cookie.Secure,
-                SameSite = SessionCookieExtensions.MapSameSiteMode(_options.Cookie.SameSite),
-                Path = _options.Cookie.Path,
-                Domain = _options.Cookie.Domain,
-                Expires = DateTimeOffset.UtcNow.Add(_options.Session.RefreshTokenLifetime),
-            }
-        );
-    }
+    private void SetSessionCookies(OidcTokenResponse tokens) =>
+        Response.SetSessionCookies(
+            tokens.AccessToken, tokens.RefreshToken, tokens.ExpiresAt, _options);
 
     /// <summary>
     /// Clear session cookies
     /// </summary>
-    private void ClearSessionCookies()
-    {
-        var cookieOptions = new CookieOptions
-        {
-            Path = _options.Cookie.Path,
-            Domain = _options.Cookie.Domain,
-        };
-
-        Response.Cookies.Delete(_options.Cookie.AccessTokenName, cookieOptions);
-        Response.Cookies.Delete(_options.Cookie.RefreshTokenName, cookieOptions);
-        Response.Cookies.Delete("IsAuthenticated", cookieOptions);
-    }
+    private void ClearSessionCookies() => Response.ClearSessionCookies(_options);
 
     /// <summary>
     /// Get the refresh token from cookie or request body

--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -682,40 +682,22 @@ public class OidcController : ControllerBase
             && string.IsNullOrEmpty(target.UserInfo);
     }
 
-    /// <summary>
-    /// Set the OIDC state cookie
-    /// </summary>
     private void SetStateCookie(string state, DateTimeOffset expiresAt) =>
         Response.SetStateCookie(_options.Cookie.StateCookieName, state, expiresAt, _options);
 
-    /// <summary>
-    /// Clear the OIDC state cookie
-    /// </summary>
     private void ClearStateCookie() =>
         Response.ClearStateCookie(_options.Cookie.StateCookieName, _options);
 
-    /// <summary>
-    /// Set the OIDC link state cookie
-    /// </summary>
     private void SetLinkStateCookie(string state, DateTimeOffset expiresAt) =>
         Response.SetStateCookie(_options.Cookie.LinkStateCookieName, state, expiresAt, _options);
 
-    /// <summary>
-    /// Clear the OIDC link state cookie
-    /// </summary>
     private void ClearLinkStateCookie() =>
         Response.ClearStateCookie(_options.Cookie.LinkStateCookieName, _options);
 
-    /// <summary>
-    /// Set session cookies (access token and refresh token)
-    /// </summary>
     private void SetSessionCookies(OidcTokenResponse tokens) =>
         Response.SetSessionCookies(
             tokens.AccessToken, tokens.RefreshToken, tokens.ExpiresAt, _options);
 
-    /// <summary>
-    /// Clear session cookies
-    /// </summary>
     private void ClearSessionCookies() => Response.ClearSessionCookies(_options);
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/Platform/StatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/StatusController.cs
@@ -58,10 +58,11 @@ public class StatusController : ControllerBase
         {
             var status = await _statusService.GetSystemStatusAsync();
 
-            // Stamped here rather than in the service: the service caches its response per
-            // tenant, and this must also be right on the error path below, where no service
-            // response exists at all — which is exactly the apex-with-several-tenants case
-            // the web app reads this field to detect.
+            // Stamped here rather than in the service, which caches its response per tenant, and
+            // stamped again on the error path below, which builds a document of its own. The web
+            // app reads this field to tell an apex that auto-resolved its sole tenant from one
+            // that resolved nothing; both come back as a normal response (the tenantless case is
+            // a "setup_required" document, not a throw), so the field has to be right here.
             status.TenantSlug = _tenantAccessor.Context?.Slug;
 
             _logger.LogDebug("Successfully generated V4 status response");

--- a/src/API/Nocturne.API/Controllers/V4/Platform/StatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/StatusController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Platform;
 using Nocturne.Core.Models;
 using OpenApi.Remote.Attributes;
@@ -20,16 +21,22 @@ namespace Nocturne.API.Controllers.V4.Platform;
 public class StatusController : ControllerBase
 {
     private readonly IStatusService _statusService;
+    private readonly ITenantAccessor _tenantAccessor;
     private readonly ILogger<StatusController> _logger;
 
     /// <summary>
     /// Initializes a new instance of <see cref="StatusController"/>.
     /// </summary>
     /// <param name="statusService">Service providing system status information.</param>
+    /// <param name="tenantAccessor">Accessor for the tenant this request resolved to, if any.</param>
     /// <param name="logger">Logger instance.</param>
-    public StatusController(IStatusService statusService, ILogger<StatusController> logger)
+    public StatusController(
+        IStatusService statusService,
+        ITenantAccessor tenantAccessor,
+        ILogger<StatusController> logger)
     {
         _statusService = statusService;
+        _tenantAccessor = tenantAccessor;
         _logger = logger;
     }
 
@@ -51,6 +58,12 @@ public class StatusController : ControllerBase
         {
             var status = await _statusService.GetSystemStatusAsync();
 
+            // Stamped here rather than in the service: the service caches its response per
+            // tenant, and this must also be right on the error path below, where no service
+            // response exists at all — which is exactly the apex-with-several-tenants case
+            // the web app reads this field to detect.
+            status.TenantSlug = _tenantAccessor.Context?.Slug;
+
             _logger.LogDebug("Successfully generated V4 status response");
 
             return Ok(status);
@@ -67,6 +80,7 @@ public class StatusController : ControllerBase
                     Name = "Nocturne",
                     Version = "unknown",
                     ServerTime = DateTime.UtcNow,
+                    TenantSlug = _tenantAccessor.Context?.Slug,
                 }
             );
         }

--- a/src/API/Nocturne.API/Controllers/V4/Platform/StatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/StatusController.cs
@@ -58,11 +58,11 @@ public class StatusController : ControllerBase
         {
             var status = await _statusService.GetSystemStatusAsync();
 
-            // Stamped here rather than in the service, which caches its response per tenant, and
-            // stamped again on the error path below, which builds a document of its own. The web
-            // app reads this field to tell an apex that auto-resolved its sole tenant from one
-            // that resolved nothing; both come back as a normal response (the tenantless case is
-            // a "setup_required" document, not a throw), so the field has to be right here.
+            // Mutating the service's cached document is safe only because that cache is keyed per
+            // tenant, so every request stamps the same value. The web app reads this field to tell
+            // an apex that auto-resolved its sole tenant from one that resolved nothing; both come
+            // back as a normal response (the tenantless case is a "setup_required" document, not a
+            // throw), so the field has to be right here and on the error path below.
             status.TenantSlug = _tenantAccessor.Context?.Slug;
 
             _logger.LogDebug("Successfully generated V4 status response");

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -590,35 +590,13 @@ public partial class SetupController : ControllerBase
             subjectId, CancellationToken.None);
     }
 
-    private void SetOidcStateCookie(string state, DateTimeOffset expiresAt)
-    {
-        var cookieSameSite = _oidcOptions.Cookie.SameSite switch
-        {
-            SameSiteMode.Strict => Microsoft.AspNetCore.Http.SameSiteMode.Strict,
-            SameSiteMode.Lax => Microsoft.AspNetCore.Http.SameSiteMode.Lax,
-            SameSiteMode.None => Microsoft.AspNetCore.Http.SameSiteMode.None,
-            _ => Microsoft.AspNetCore.Http.SameSiteMode.Lax,
-        };
+    // Through the shared writer: the setup flow reuses the login flow's state-cookie name, so a
+    // scope of its own would leave two same-named cookies the callback cannot tell apart.
+    private void SetOidcStateCookie(string state, DateTimeOffset expiresAt) =>
+        Response.SetStateCookie(_oidcOptions.Cookie.StateCookieName, state, expiresAt, _oidcOptions);
 
-        Response.Cookies.Append(_oidcOptions.Cookie.StateCookieName, state, new CookieOptions
-        {
-            HttpOnly = true,
-            Secure = _oidcOptions.Cookie.Secure,
-            SameSite = cookieSameSite,
-            Path = _oidcOptions.Cookie.Path,
-            Domain = _oidcOptions.Cookie.Domain,
-            Expires = expiresAt,
-        });
-    }
-
-    private void ClearOidcStateCookie()
-    {
-        Response.Cookies.Delete(_oidcOptions.Cookie.StateCookieName, new CookieOptions
-        {
-            Path = _oidcOptions.Cookie.Path,
-            Domain = _oidcOptions.Cookie.Domain,
-        });
-    }
+    private void ClearOidcStateCookie() =>
+        Response.ClearStateCookie(_oidcOptions.Cookie.StateCookieName, _oidcOptions);
 
     #endregion
 }

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -256,6 +256,15 @@ public static class ServiceRegistrationExtensions
             opts.BaseDomain = configuration[BaseDomainOptions.ConfigKey] ?? ""
         );
 
+        // Widen session cookies to ".{base-domain}" so one sign-in carries across tenant
+        // subdomains and the apex dashboard. Post-configure so explicit configuration still
+        // wins, and so every session-cookie writer and deleter — which all read
+        // Cookie.SessionDomain — picks the value up from this one place.
+        services.PostConfigure<OidcOptions>(opts =>
+            opts.Cookie.SessionDomain ??=
+                opts.Cookie.Domain ?? SessionCookieExtensions.ResolveCookieDomain(baseDomain)
+        );
+
         // Operator (SaaS platform policy)
         services.AddOptions<OperatorConfiguration>()
             .Bind(configuration.GetSection(OperatorConfiguration.SectionName))

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -256,8 +256,8 @@ public static class ServiceRegistrationExtensions
             opts.BaseDomain = configuration[BaseDomainOptions.ConfigKey] ?? ""
         );
 
-        // Derive the session- and state-cookie Domain attributes from the base domain, in one
-        // place, so every writer and deleter of those cookies agrees on their scope.
+        // Derive the session-, state-, and platform-access cookie Domain attributes from the base
+        // domain, in one place, so every writer and deleter of those cookies agrees on their scope.
         services.PostConfigure<OidcOptions>(opts =>
             SessionCookieExtensions.ApplyCookieDomainDefaults(opts, baseDomain)
         );

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -259,10 +259,11 @@ public static class ServiceRegistrationExtensions
         // Widen session cookies to ".{base-domain}" so one sign-in carries across tenant
         // subdomains and the apex dashboard. Post-configure so explicit configuration still
         // wins, and so every session-cookie writer and deleter — which all read
-        // Cookie.SessionDomain — picks the value up from this one place.
+        // Cookie.SessionDomain — picks the value up from this one place. Derived from the base
+        // domain alone: Cookie.Domain scopes an unrelated set of cookies (see CookieSettings), so
+        // inheriting from it would make session scope a silent side effect of that operator knob.
         services.PostConfigure<OidcOptions>(opts =>
-            opts.Cookie.SessionDomain ??=
-                opts.Cookie.Domain ?? SessionCookieExtensions.ResolveCookieDomain(baseDomain)
+            opts.Cookie.SessionDomain ??= SessionCookieExtensions.ResolveCookieDomain(baseDomain)
         );
 
         // Operator (SaaS platform policy)

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -256,14 +256,10 @@ public static class ServiceRegistrationExtensions
             opts.BaseDomain = configuration[BaseDomainOptions.ConfigKey] ?? ""
         );
 
-        // Widen session cookies to ".{base-domain}" so one sign-in carries across tenant
-        // subdomains and the apex dashboard. Post-configure so explicit configuration still
-        // wins, and so every session-cookie writer and deleter — which all read
-        // Cookie.SessionDomain — picks the value up from this one place. Derived from the base
-        // domain alone: Cookie.Domain scopes an unrelated set of cookies (see CookieSettings), so
-        // inheriting from it would make session scope a silent side effect of that operator knob.
+        // Derive the session- and state-cookie Domain attributes from the base domain, in one
+        // place, so every writer and deleter of those cookies agrees on their scope.
         services.PostConfigure<OidcOptions>(opts =>
-            opts.Cookie.SessionDomain ??= SessionCookieExtensions.ResolveCookieDomain(baseDomain)
+            SessionCookieExtensions.ApplyCookieDomainDefaults(opts, baseDomain)
         );
 
         // Operator (SaaS platform policy)

--- a/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Nocturne.API.Multitenancy;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Configuration;
@@ -21,10 +22,13 @@ public static class SessionCookieExtensions
     /// tenants the subject belongs to. Returns null (host-only cookies) when widening is unsafe.
     /// </summary>
     /// <remarks>
-    /// Two cases yield null. A single-label host ("localhost") cannot carry a Domain attribute at
-    /// all — browsers reject it. And Chromium does not reliably scope cookies across
+    /// Three cases yield null. A single-label host ("localhost") cannot carry a Domain attribute at
+    /// all — browsers reject it. Chromium does not reliably scope cookies across
     /// <c>*.localhost</c> names, so local development keeps host-only cookies rather than silently
-    /// dropping every session cookie; dev works per-host as it always has.
+    /// dropping every session cookie; dev works per-host as it always has. And an IP literal has no
+    /// domain hierarchy to widen into — a browser discards any cookie whose Domain attribute is set
+    /// on an IP host, so a LAN install reached at <c>192.168.1.10:1612</c> would be unable to hold a
+    /// session at all.
     /// </remarks>
     public static string? ResolveCookieDomain(string? baseDomain)
     {
@@ -32,6 +36,11 @@ public static class SessionCookieExtensions
         // discarded wholesale by the browser (taking the session with it).
         var (host, _) = BaseDomainOptions.SplitHostPort(baseDomain ?? "");
         if (string.IsNullOrEmpty(host))
+            return null;
+
+        // Covers IPv4 ("192.168.1.10", which contains dots and would otherwise widen) and bare
+        // IPv6. A bracketed IPv6 literal fails to parse here but is caught by the dot check below.
+        if (IPAddress.TryParse(host, out _))
             return null;
 
         if (!host.Contains('.'))

--- a/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
@@ -53,20 +53,27 @@ public static class SessionCookieExtensions
     }
 
     /// <summary>
-    /// Fill in the cookie <c>Domain</c> attributes that are derived from the base domain rather
-    /// than configured. Applied as a post-configure so explicit configuration still wins.
+    /// Fill in the cookie <c>Domain</c> attributes, all three of which are derived from the base
+    /// domain rather than configured. Applied as a post-configure so explicit configuration
+    /// still wins.
     /// </summary>
     /// <remarks>
-    /// Two independent scopes, for two different reasons. Session cookies widen so one sign-in
-    /// carries across tenant subdomains and the apex dashboard. State cookies widen so a login
-    /// begun on any host can be completed at the apex callback, which is the registered
-    /// redirect_uri; an operator who already set <see cref="CookieSettings.Domain"/> made that
-    /// choice explicitly, so it is inherited rather than overridden.
+    /// Three scopes, one source. Session cookies widen so one sign-in carries across tenant
+    /// subdomains and the apex dashboard. The platform-access grant widens because it is minted
+    /// on the apex and redeemed on the tenant subdomain it is pinned to. State cookies widen so a
+    /// login begun on any host can be completed at the apex callback, which is the registered
+    /// redirect_uri.
+    /// <para>
+    /// <see cref="CookieSettings.Domain"/> is defaulted before <see cref="CookieSettings.StateDomain"/>
+    /// reads it, so an operator override moves both together while the derived value reaches both
+    /// as well.
+    /// </para>
     /// </remarks>
     public static void ApplyCookieDomainDefaults(OidcOptions options, string? baseDomain)
     {
         options.Cookie.SessionDomain ??= ResolveCookieDomain(baseDomain);
-        options.Cookie.StateDomain ??= options.Cookie.Domain ?? ResolveCookieDomain(baseDomain);
+        options.Cookie.Domain ??= ResolveCookieDomain(baseDomain);
+        options.Cookie.StateDomain ??= options.Cookie.Domain;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
@@ -1,3 +1,4 @@
+using Nocturne.API.Multitenancy;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Configuration;
 using ConfigSameSiteMode = Nocturne.Core.Models.Configuration.SameSiteMode;
@@ -10,46 +11,146 @@ namespace Nocturne.API.Extensions;
 public static class SessionCookieExtensions
 {
     /// <summary>
+    /// The non-HttpOnly flag cookie the frontend reads to know a session exists.
+    /// </summary>
+    public const string IsAuthenticatedCookieName = "IsAuthenticated";
+
+    /// <summary>
+    /// Derive the session-cookie <c>Domain</c> attribute from the configured base domain, so a
+    /// session established on one tenant subdomain is carried to the apex dashboard and to sibling
+    /// tenants the subject belongs to. Returns null (host-only cookies) when widening is unsafe.
+    /// </summary>
+    /// <remarks>
+    /// Two cases yield null. A single-label host ("localhost") cannot carry a Domain attribute at
+    /// all — browsers reject it. And Chromium does not reliably scope cookies across
+    /// <c>*.localhost</c> names, so local development keeps host-only cookies rather than silently
+    /// dropping every session cookie; dev works per-host as it always has.
+    /// </remarks>
+    public static string? ResolveCookieDomain(string? baseDomain)
+    {
+        // A Domain attribute is a bare hostname: it carries no port, and a value with one is
+        // discarded wholesale by the browser (taking the session with it).
+        var (host, _) = BaseDomainOptions.SplitHostPort(baseDomain ?? "");
+        if (string.IsNullOrEmpty(host))
+            return null;
+
+        if (!host.Contains('.'))
+            return null;
+
+        if (host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return $".{host}";
+    }
+
+    /// <summary>
     /// Append access-token, refresh-token, and IsAuthenticated cookies to the response,
     /// using the centralized <see cref="OidcOptions"/> configuration for names, domain,
     /// path, security flags, and refresh-token lifetime.
     /// </summary>
     public static void SetSessionCookies(
-        this HttpResponse response, SessionTokenPair session, OidcOptions options)
+        this HttpResponse response, SessionTokenPair session, OidcOptions options) =>
+        response.SetSessionCookies(
+            session.AccessToken,
+            session.RefreshToken,
+            DateTimeOffset.UtcNow.AddSeconds(session.ExpiresInSeconds),
+            options);
+
+    /// <summary>
+    /// The single session-cookie writer. Every auth flow (OIDC callback, passkey, TOTP, setup,
+    /// demo, dev, and the silent refresh in <c>SessionCookieHandler</c>) funnels through here so
+    /// the cookie attributes — above all <c>Domain</c> — cannot drift between them.
+    /// </summary>
+    public static void SetSessionCookies(
+        this HttpResponse response,
+        string accessToken,
+        string refreshToken,
+        DateTimeOffset accessTokenExpiresAt,
+        OidcOptions options)
     {
         var sameSite = MapSameSiteMode(options.Cookie.SameSite);
+        var refreshExpiresAt = DateTimeOffset.UtcNow.Add(options.Session.RefreshTokenLifetime);
 
-        response.Cookies.Append(options.Cookie.AccessTokenName, session.AccessToken, new CookieOptions
+        // Expire any host-scoped cookie of the same name before writing the domain-wide one.
+        // A client that authenticated before the domain was widened holds both, and the browser
+        // sends both under one Cookie header with no way for the server to tell them apart, so
+        // whichever the server reads is arbitrary. Clearing the narrow variant first makes every
+        // client converge on the domain-wide cookie after a single authenticated response.
+        // Order matters: Response.Cookies.Delete strips already-appended Set-Cookie headers that
+        // match by path, so deleting after appending would cancel the write we just made.
+        ExpireHostScopedSessionCookies(response, options);
+
+        response.Cookies.Append(options.Cookie.AccessTokenName, accessToken, new CookieOptions
         {
             HttpOnly = options.Cookie.HttpOnly,
             Secure = options.Cookie.Secure,
             SameSite = sameSite,
             Path = options.Cookie.Path,
-            Domain = options.Cookie.Domain,
+            Domain = options.Cookie.SessionDomain,
             IsEssential = true,
-            Expires = DateTimeOffset.UtcNow.AddSeconds(session.ExpiresInSeconds),
+            Expires = accessTokenExpiresAt,
         });
 
-        response.Cookies.Append(options.Cookie.RefreshTokenName, session.RefreshToken, new CookieOptions
+        response.Cookies.Append(options.Cookie.RefreshTokenName, refreshToken, new CookieOptions
         {
             HttpOnly = true, // Always HttpOnly for refresh tokens
             Secure = options.Cookie.Secure,
             SameSite = sameSite,
             Path = options.Cookie.Path,
-            Domain = options.Cookie.Domain,
+            Domain = options.Cookie.SessionDomain,
             IsEssential = true,
-            Expires = DateTimeOffset.UtcNow.Add(options.Session.RefreshTokenLifetime),
+            Expires = refreshExpiresAt,
         });
 
-        response.Cookies.Append("IsAuthenticated", "true", new CookieOptions
+        response.Cookies.Append(IsAuthenticatedCookieName, "true", new CookieOptions
         {
             HttpOnly = false,
             Secure = options.Cookie.Secure,
             SameSite = sameSite,
             Path = options.Cookie.Path,
-            Domain = options.Cookie.Domain,
-            Expires = DateTimeOffset.UtcNow.Add(options.Session.RefreshTokenLifetime),
+            Domain = options.Cookie.SessionDomain,
+            Expires = refreshExpiresAt,
         });
+    }
+
+    /// <summary>
+    /// Delete the session cookies, mirroring <see cref="SetSessionCookies(HttpResponse, string, string, DateTimeOffset, OidcOptions)"/>.
+    /// A cookie is keyed by name, domain, and path, so sign-out must present the same
+    /// <c>Domain</c> the write used or the browser keeps the session cookie.
+    /// </summary>
+    public static void ClearSessionCookies(this HttpResponse response, OidcOptions options)
+    {
+        // Sign-out must also drop the pre-widening host-scoped cookies, or the stale narrow
+        // cookie survives and re-authenticates the "signed-out" browser. First, for the same
+        // header-stripping reason as in the writer.
+        ExpireHostScopedSessionCookies(response, options);
+
+        var cookieOptions = new CookieOptions
+        {
+            Path = options.Cookie.Path,
+            Domain = options.Cookie.SessionDomain,
+        };
+
+        response.Cookies.Delete(options.Cookie.AccessTokenName, cookieOptions);
+        response.Cookies.Delete(options.Cookie.RefreshTokenName, cookieOptions);
+        response.Cookies.Delete(IsAuthenticatedCookieName, cookieOptions);
+    }
+
+    /// <summary>
+    /// Expire the host-only variants of the session cookies, i.e. the same names written without a
+    /// <c>Domain</c> attribute. No-op when cookies are already host-scoped, which would otherwise
+    /// emit an expiry for the very cookie being written.
+    /// </summary>
+    private static void ExpireHostScopedSessionCookies(HttpResponse response, OidcOptions options)
+    {
+        if (string.IsNullOrEmpty(options.Cookie.SessionDomain))
+            return;
+
+        var hostScoped = new CookieOptions { Path = options.Cookie.Path };
+
+        response.Cookies.Delete(options.Cookie.AccessTokenName, hostScoped);
+        response.Cookies.Delete(options.Cookie.RefreshTokenName, hostScoped);
+        response.Cookies.Delete(IsAuthenticatedCookieName, hostScoped);
     }
 
     internal static Microsoft.AspNetCore.Http.SameSiteMode MapSameSiteMode(

--- a/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
@@ -53,6 +53,23 @@ public static class SessionCookieExtensions
     }
 
     /// <summary>
+    /// Fill in the cookie <c>Domain</c> attributes that are derived from the base domain rather
+    /// than configured. Applied as a post-configure so explicit configuration still wins.
+    /// </summary>
+    /// <remarks>
+    /// Two independent scopes, for two different reasons. Session cookies widen so one sign-in
+    /// carries across tenant subdomains and the apex dashboard. State cookies widen so a login
+    /// begun on any host can be completed at the apex callback, which is the registered
+    /// redirect_uri; an operator who already set <see cref="CookieSettings.Domain"/> made that
+    /// choice explicitly, so it is inherited rather than overridden.
+    /// </remarks>
+    public static void ApplyCookieDomainDefaults(OidcOptions options, string? baseDomain)
+    {
+        options.Cookie.SessionDomain ??= ResolveCookieDomain(baseDomain);
+        options.Cookie.StateDomain ??= options.Cookie.Domain ?? ResolveCookieDomain(baseDomain);
+    }
+
+    /// <summary>
     /// Append access-token, refresh-token, and IsAuthenticated cookies to the response,
     /// using the centralized <see cref="OidcOptions"/> configuration for names, domain,
     /// path, security flags, and refresh-token lifetime.
@@ -160,6 +177,58 @@ public static class SessionCookieExtensions
         response.Cookies.Delete(options.Cookie.AccessTokenName, hostScoped);
         response.Cookies.Delete(options.Cookie.RefreshTokenName, hostScoped);
         response.Cookies.Delete(IsAuthenticatedCookieName, hostScoped);
+    }
+
+    /// <summary>
+    /// The single OIDC state-cookie writer, shared by the login, account-link, and setup flows so
+    /// their <c>Domain</c> cannot drift — the setup flow reuses the login flow's cookie name, and
+    /// two same-named cookies at different scopes are indistinguishable in the request header.
+    /// </summary>
+    public static void SetStateCookie(
+        this HttpResponse response,
+        string name,
+        string state,
+        DateTimeOffset expiresAt,
+        OidcOptions options)
+    {
+        // Same reason and same ordering as the session cookies: a browser holding a pre-widening
+        // host-only cookie of this name would otherwise send both, and the server cannot tell
+        // which it read. A stale one shadowing the fresh one costs a login attempt.
+        ExpireHostScopedStateCookie(response, name, options);
+
+        response.Cookies.Append(name, state, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = options.Cookie.Secure,
+            SameSite = MapSameSiteMode(options.Cookie.SameSite),
+            Path = options.Cookie.Path,
+            Domain = options.Cookie.StateDomain,
+            Expires = expiresAt,
+        });
+    }
+
+    /// <summary>
+    /// Delete an OIDC state cookie, mirroring <see cref="SetStateCookie"/>. State is single-use,
+    /// so this runs on every callback, successful or not.
+    /// </summary>
+    public static void ClearStateCookie(this HttpResponse response, string name, OidcOptions options)
+    {
+        ExpireHostScopedStateCookie(response, name, options);
+
+        response.Cookies.Delete(name, new CookieOptions
+        {
+            Path = options.Cookie.Path,
+            Domain = options.Cookie.StateDomain,
+        });
+    }
+
+    private static void ExpireHostScopedStateCookie(
+        HttpResponse response, string name, OidcOptions options)
+    {
+        if (string.IsNullOrEmpty(options.Cookie.StateDomain))
+            return;
+
+        response.Cookies.Delete(name, new CookieOptions { Path = options.Cookie.Path });
     }
 
     internal static Microsoft.AspNetCore.Http.SameSiteMode MapSameSiteMode(

--- a/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
@@ -7,7 +7,8 @@ using ConfigSameSiteMode = Nocturne.Core.Models.Configuration.SameSiteMode;
 namespace Nocturne.API.Extensions;
 
 /// <summary>
-/// Shared cookie-writing logic for session token pairs issued by any auth flow.
+/// Shared cookie-writing logic for the auth cookies: the session token pairs issued by any auth
+/// flow, the OIDC state cookies, and the <c>Domain</c> attributes all of them are written with.
 /// </summary>
 public static class SessionCookieExtensions
 {
@@ -58,16 +59,9 @@ public static class SessionCookieExtensions
     /// still wins.
     /// </summary>
     /// <remarks>
-    /// Three scopes, one source. Session cookies widen so one sign-in carries across tenant
-    /// subdomains and the apex dashboard. The platform-access grant widens because it is minted
-    /// on the apex and redeemed on the tenant subdomain it is pinned to. State cookies widen so a
-    /// login begun on any host can be completed at the apex callback, which is the registered
-    /// redirect_uri.
-    /// <para>
     /// <see cref="CookieSettings.Domain"/> is defaulted before <see cref="CookieSettings.StateDomain"/>
     /// reads it, so an operator override moves both together while the derived value reaches both
     /// as well.
-    /// </para>
     /// </remarks>
     public static void ApplyCookieDomainDefaults(OidcOptions options, string? baseDomain)
     {
@@ -104,11 +98,6 @@ public static class SessionCookieExtensions
         var sameSite = MapSameSiteMode(options.Cookie.SameSite);
         var refreshExpiresAt = DateTimeOffset.UtcNow.Add(options.Session.RefreshTokenLifetime);
 
-        // Expire any host-scoped cookie of the same name before writing the domain-wide one.
-        // A client that authenticated before the domain was widened holds both, and the browser
-        // sends both under one Cookie header with no way for the server to tell them apart, so
-        // whichever the server reads is arbitrary. Clearing the narrow variant first makes every
-        // client converge on the domain-wide cookie after a single authenticated response.
         // Order matters: Response.Cookies.Delete strips already-appended Set-Cookie headers that
         // match by path, so deleting after appending would cancel the write we just made.
         ExpireHostScopedSessionCookies(response, options);
@@ -153,9 +142,8 @@ public static class SessionCookieExtensions
     /// </summary>
     public static void ClearSessionCookies(this HttpResponse response, OidcOptions options)
     {
-        // Sign-out must also drop the pre-widening host-scoped cookies, or the stale narrow
-        // cookie survives and re-authenticates the "signed-out" browser. First, for the same
-        // header-stripping reason as in the writer.
+        // Order matters: Response.Cookies.Delete strips already-appended Set-Cookie headers that
+        // match by path, so deleting after appending would cancel the deletes below.
         ExpireHostScopedSessionCookies(response, options);
 
         var cookieOptions = new CookieOptions
@@ -174,6 +162,14 @@ public static class SessionCookieExtensions
     /// <c>Domain</c> attribute. No-op when cookies are already host-scoped, which would otherwise
     /// emit an expiry for the very cookie being written.
     /// </summary>
+    /// <remarks>
+    /// A client that authenticated before the domain was widened holds both variants, and the
+    /// browser sends both under one <c>Cookie</c> header with no way for the server to tell them
+    /// apart, so whichever the server reads is arbitrary. Clearing the narrow variant alongside
+    /// every write makes every client converge on the domain-wide cookie after a single
+    /// authenticated response; doing it on sign-out too stops the stale narrow cookie surviving
+    /// and re-authenticating the "signed-out" browser.
+    /// </remarks>
     private static void ExpireHostScopedSessionCookies(HttpResponse response, OidcOptions options)
     {
         if (string.IsNullOrEmpty(options.Cookie.SessionDomain))
@@ -198,9 +194,8 @@ public static class SessionCookieExtensions
         DateTimeOffset expiresAt,
         OidcOptions options)
     {
-        // Same reason and same ordering as the session cookies: a browser holding a pre-widening
-        // host-only cookie of this name would otherwise send both, and the server cannot tell
-        // which it read. A stale one shadowing the fresh one costs a login attempt.
+        // Order matters: Response.Cookies.Delete strips already-appended Set-Cookie headers that
+        // match by path, so deleting after appending would cancel the write we just made.
         ExpireHostScopedStateCookie(response, name, options);
 
         response.Cookies.Append(name, state, new CookieOptions
@@ -229,6 +224,11 @@ public static class SessionCookieExtensions
         });
     }
 
+    /// <summary>
+    /// The state-cookie counterpart of <see cref="ExpireHostScopedSessionCookies"/>: a browser
+    /// holding a pre-widening host-only cookie of this name sends both, and a stale one shadowing
+    /// the fresh one costs a login attempt.
+    /// </summary>
     private static void ExpireHostScopedStateCookie(
         HttpResponse response, string name, OidcOptions options)
     {

--- a/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
@@ -232,53 +232,9 @@ public class SessionCookieHandler : IAuthHandler
     /// <summary>
     /// Set session cookies in the response
     /// </summary>
-    private void SetSessionCookies(HttpContext context, OidcTokenResponse tokens)
-    {
-        // Access token cookie (short-lived)
-        context.Response.Cookies.Append(
-            _options.Cookie.AccessTokenName,
-            tokens.AccessToken,
-            new CookieOptions
-            {
-                HttpOnly = _options.Cookie.HttpOnly,
-                Secure = _options.Cookie.Secure,
-                SameSite = SessionCookieExtensions.MapSameSiteMode(_options.Cookie.SameSite),
-                Path = _options.Cookie.Path,
-                Domain = _options.Cookie.Domain,
-                Expires = tokens.ExpiresAt,
-            }
-        );
-
-        // Refresh token cookie (longer-lived)
-        context.Response.Cookies.Append(
-            _options.Cookie.RefreshTokenName,
-            tokens.RefreshToken,
-            new CookieOptions
-            {
-                HttpOnly = true, // Always HttpOnly for refresh tokens
-                Secure = _options.Cookie.Secure,
-                SameSite = SessionCookieExtensions.MapSameSiteMode(_options.Cookie.SameSite),
-                Path = _options.Cookie.Path,
-                Domain = _options.Cookie.Domain,
-                Expires = DateTimeOffset.UtcNow.Add(_options.Session.RefreshTokenLifetime),
-            }
-        );
-
-        // Also update the non-HttpOnly IsAuthenticated cookie for frontend state tracking
-        context.Response.Cookies.Append(
-            "IsAuthenticated",
-            "true",
-            new CookieOptions
-            {
-                HttpOnly = false,
-                Secure = _options.Cookie.Secure,
-                SameSite = SessionCookieExtensions.MapSameSiteMode(_options.Cookie.SameSite),
-                Path = "/",
-                Domain = _options.Cookie.Domain,
-                Expires = DateTimeOffset.UtcNow.Add(_options.Session.RefreshTokenLifetime),
-            }
-        );
-    }
+    private void SetSessionCookies(HttpContext context, OidcTokenResponse tokens) =>
+        context.Response.SetSessionCookies(
+            tokens.AccessToken, tokens.RefreshToken, tokens.ExpiresAt, _options);
 
     /// <summary>
     /// Get client IP address

--- a/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/SessionCookieHandler.cs
@@ -229,9 +229,6 @@ public class SessionCookieHandler : IAuthHandler
         };
     }
 
-    /// <summary>
-    /// Set session cookies in the response
-    /// </summary>
     private void SetSessionCookies(HttpContext context, OidcTokenResponse tokens) =>
         context.Response.SetSessionCookies(
             tokens.AccessToken, tokens.RefreshToken, tokens.ExpiresAt, _options);

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -35,10 +35,29 @@ public class TenantResolutionMiddleware
     }
 
     /// <summary>
+    /// A path served without a resolved tenant, optionally narrowed to a single HTTP method.
+    /// </summary>
+    /// <param name="Path">The exact path, matched case-insensitively.</param>
+    /// <param name="Method">
+    /// The only method admitted tenantlessly, or null to admit every method. Naming a method
+    /// matters where a path carries both a cross-tenant read and a tenant-affecting write.
+    /// </param>
+    private readonly record struct TenantlessPath(string Path, string? Method = null)
+    {
+        /// <summary>Admit every method on a path, which is the case for most of the list.</summary>
+        public static implicit operator TenantlessPath(string path) => new(path);
+
+        public bool Matches(string path, string? method) =>
+            Path.Equals(path, StringComparison.OrdinalIgnoreCase) &&
+            (Method is null || string.IsNullOrEmpty(method) ||
+             Method.Equals(method, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
     /// Paths that operate across all tenants and don't require a resolved tenant context.
     /// These are allowed through even when no matching tenant is found.
     /// </summary>
-    private static readonly string[] TenantlessAllowedPaths =
+    private static readonly TenantlessPath[] TenantlessAllowedPaths =
     [
         // Aspire ServiceDefaults health endpoints — must never be tenant-gated;
         // they are used by Kubernetes liveness/readiness probes and external
@@ -55,10 +74,14 @@ public class TenantResolutionMiddleware
         "/api/v4/me/tenants/overview",
         // The subject's tenant list, which drives the tenantless dashboard's navigation
         // and the tenant switcher. Keyed on SubjectId alone, like the overview above.
-        "/api/v4/me/tenants",
-        // The subject's granted scopes. Tenantless it resolves to an empty set (scopes
-        // come from tenant membership), which is the correct answer on a host that
-        // exposes no tenant data.
+        // GET only: the same path takes a POST that creates a tenant, and self-service
+        // provisioning is a tenant-affecting write with no place on a host that resolves
+        // no tenant — in the hosted deployment it goes through billing instead.
+        new TenantlessPath("/api/v4/me/tenants", HttpMethods.Get),
+        // The caller's own global subject-role scopes. Tenantless, MemberScopeMiddleware
+        // returns before applying tenant-derived scopes, so this reports whatever the JWT
+        // carries — empty for an ordinary subject, non-empty for one holding global roles.
+        // Caller-scoped either way, so nothing about a tenant is exposed.
         "/api/v4/me/permissions",
         "/api/v4/admin/tenants/validate-slug",
         "/api/metadata",
@@ -106,11 +129,16 @@ public class TenantResolutionMiddleware
     ];
 
     /// <summary>
-    /// Whether a request path is served without a resolved tenant. Public so the authorization
+    /// Whether a request is served without a resolved tenant. Public so the authorization
     /// guard tests can enumerate the same surface rather than restating these lists.
     /// </summary>
-    public static bool IsTenantlessAllowed(string path) =>
-        TenantlessAllowedPaths.Any(p => path.Equals(p, StringComparison.OrdinalIgnoreCase)) ||
+    /// <param name="path">The request path.</param>
+    /// <param name="method">
+    /// The request method. Omit it to ask whether the path is reachable tenantlessly under any
+    /// method, which is what a coverage sweep over the whole surface wants.
+    /// </param>
+    public static bool IsTenantlessAllowed(string path, string? method = null) =>
+        TenantlessAllowedPaths.Any(p => p.Matches(path, method)) ||
         TenantlessAllowedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase));
 
     public async Task InvokeAsync(HttpContext context)
@@ -155,7 +183,7 @@ public class TenantResolutionMiddleware
         }
 
         var path = context.Request.Path.Value ?? "";
-        var isTenantlessAllowedPath = IsTenantlessAllowed(path);
+        var isTenantlessAllowedPath = IsTenantlessAllowed(path, context.Request.Method);
 
         // On the apex (no subdomain), GET /api/v4/status is tenant-scoped yet listed as
         // tenantless-allowed (so a fresh apex doesn't 404). On a single-tenant install,

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -93,6 +93,12 @@ public class TenantResolutionMiddleware
         // so login must not be tenant-gated. On a subdomain the tenant still resolves
         // normally; this only allows the apex (tenantless) case through.
         "/api/auth/oidc/login",
+        // The provider list the login page renders its buttons from. On a tenantless host the
+        // identity-provider path is the only one that can complete a sign-in, so a 404 here
+        // leaves the page with no sign-in control at all. The data is already served
+        // tenantlessly by the allow-listed login above, which reads the same enabled-provider
+        // set; the providers themselves are not tenant-scoped. GET is the only verb served.
+        new TenantlessPath("/api/auth/oidc/providers", HttpMethods.Get),
         // The OIDC callback is the registered redirect_uri (apex). For apex-initiated
         // logins the state carries no TenantSlug, so OidcCallbackRedirectMiddleware
         // can't bounce it to a subdomain and it must process here. The session it

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -49,7 +49,7 @@ public class TenantResolutionMiddleware
 
         public bool Matches(string path, string? method) =>
             Path.Equals(path, StringComparison.OrdinalIgnoreCase) &&
-            (Method is null || string.IsNullOrEmpty(method) ||
+            (Method is null || method is null ||
              Method.Equals(method, StringComparison.OrdinalIgnoreCase));
     }
 

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -53,6 +53,13 @@ public class TenantResolutionMiddleware
         // so it must be reachable from the apex in multi-tenant deployments. The
         // service pins each tenant itself and never uses the request-scoped context.
         "/api/v4/me/tenants/overview",
+        // The subject's tenant list, which drives the tenantless dashboard's navigation
+        // and the tenant switcher. Keyed on SubjectId alone, like the overview above.
+        "/api/v4/me/tenants",
+        // The subject's granted scopes. Tenantless it resolves to an empty set (scopes
+        // come from tenant membership), which is the correct answer on a host that
+        // exposes no tenant data.
+        "/api/v4/me/permissions",
         "/api/v4/admin/tenants/validate-slug",
         "/api/metadata",
         "/api/v4/chat-identity/directory/resolve",
@@ -69,6 +76,14 @@ public class TenantResolutionMiddleware
         // issues is subject-scoped (no tenant needed). Subdomain-originated callbacks
         // are already redirected to their subdomain before reaching this point.
         "/api/auth/oidc/callback",
+        // Session introspection, called on every page load — including on the tenantless
+        // dashboard host, which would otherwise 404 before rendering anything. The session
+        // it reports is subject-scoped; the only tenant-dependent field (member roles) is
+        // already skipped when no tenant is resolved.
+        "/api/auth/oidc/session",
+        // Sign-out from the tenantless dashboard. Revokes the refresh token and clears the
+        // session cookies, neither of which is tenant-scoped.
+        "/api/auth/oidc/logout",
     ];
 
     /// <summary>

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -107,6 +107,13 @@ public class TenantResolutionMiddleware
         // Sign-out from the tenantless dashboard. Revokes the refresh token and clears the
         // session cookies, neither of which is tenant-scoped.
         "/api/auth/oidc/logout",
+        // Session refresh, driven by the client's expiry timer on every host — including the
+        // tenantless dashboard, where a 404 would flip the shell to a signed-out UI while the
+        // server-side session is still valid. Subject-scoped like the two above: it validates
+        // the refresh token, reads global subject roles, and mints an access token with no
+        // tenant pin, so it can confer no tenant-scoped authority. POST only, matching the
+        // only verb the endpoint serves.
+        new TenantlessPath("/api/auth/oidc/refresh", HttpMethods.Post),
     ];
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
@@ -70,9 +70,25 @@ public class CookieSettings
     public string LinkStateCookieName { get; set; } = ".Nocturne.OidcLinkState";
 
     /// <summary>
-    /// Cookie domain for the platform-access grant, and the operator's override for
-    /// <see cref="StateDomain"/> (null = current domain).
+    /// Domain attribute for the platform-access grant cookie, and the operator's override for
+    /// <see cref="StateDomain"/>. Defaults, like the other two domains, to ".{base-domain}".
     /// </summary>
+    /// <remarks>
+    /// Derived rather than left unset because the grant is minted on the apex — where the platform
+    /// admin signs in — and redeemed on the <c>{slug}.{base-domain}</c> host it is pinned to. A
+    /// host-only cookie is never sent to that second host, so an underived value silently breaks
+    /// platform access altogether; anything wider than the base domain broadcasts a superuser
+    /// credential past the app. Tenants are always reached at a subdomain of the base domain, so
+    /// no deployment topology makes a third value correct. Within it the grant is sent to every
+    /// host, including the <c>{token}.share.{base-domain}</c> names served to untrusted share
+    /// recipients, which is safe: the cookie is HttpOnly and Secure, and
+    /// <c>PlatformAccessCookieHandler</c> skips it unless the resolved tenant is the one it is
+    /// pinned to, so it confers nothing on a host belonging to any other tenant.
+    /// <para>
+    /// Retained as an override for an operator with a reason to narrow or move it. Setting it also
+    /// moves <see cref="StateDomain"/>, which defaults from this value.
+    /// </para>
+    /// </remarks>
     public string? Domain { get; set; }
 
     /// <summary>
@@ -81,18 +97,17 @@ public class CookieSettings
     /// also presented at the apex dashboard and at sibling tenants the subject belongs to.
     /// </summary>
     /// <remarks>
-    /// Derived from the base domain and deliberately independent of <see cref="Domain"/>, which is
-    /// an operator-set option scoping the platform-access grant. That one is left to the operator:
-    /// it is minted on the apex, where the operator still is, and redeemed on the tenant subdomain
-    /// it is pinned to, so its scope is a deployment decision rather than something the session
-    /// widening should decide for them. The OIDC state cookies take <see cref="StateDomain"/>.
+    /// Derived from the base domain, as <see cref="Domain"/> and <see cref="StateDomain"/> are.
+    /// Kept a separate knob from those so an operator can narrow one scope without dragging the
+    /// others with it: this one carries the ordinary session, <see cref="Domain"/> the
+    /// platform-access grant, and <see cref="StateDomain"/> the OIDC state cookies.
     /// </remarks>
     public string? SessionDomain { get; set; }
 
     /// <summary>
     /// Domain attribute for the short-lived OIDC state cookies (login state, link state, and the
-    /// setup flow's reuse of the login-state cookie name). Defaults to <see cref="Domain"/> when
-    /// the operator set it, and otherwise to ".{base-domain}".
+    /// setup flow's reuse of the login-state cookie name). Defaults to <see cref="Domain"/>, which
+    /// is itself ".{base-domain}" unless the operator overrode it.
     /// </summary>
     /// <remarks>
     /// The registered redirect_uri is the apex callback, so a login begun on any other host has to

--- a/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
@@ -70,7 +70,8 @@ public class CookieSettings
     public string LinkStateCookieName { get; set; } = ".Nocturne.OidcLinkState";
 
     /// <summary>
-    /// Cookie domain (null = current domain)
+    /// Cookie domain for the platform-access grant, and the operator's override for
+    /// <see cref="StateDomain"/> (null = current domain).
     /// </summary>
     public string? Domain { get; set; }
 
@@ -81,13 +82,32 @@ public class CookieSettings
     /// </summary>
     /// <remarks>
     /// Derived from the base domain and deliberately independent of <see cref="Domain"/>, which is
-    /// an operator-set option scoping a different set of cookies: the OIDC and setup state cookies
-    /// and the platform-access grant. Those are left to the operator because at least one of them
-    /// genuinely spans hosts — the platform-access grant is minted on the apex, where the operator
-    /// still is, and redeemed on the tenant subdomain it is pinned to — so their scope is a
-    /// deployment decision rather than something the session widening should decide for them.
+    /// an operator-set option scoping the platform-access grant. That one is left to the operator:
+    /// it is minted on the apex, where the operator still is, and redeemed on the tenant subdomain
+    /// it is pinned to, so its scope is a deployment decision rather than something the session
+    /// widening should decide for them. The OIDC state cookies take <see cref="StateDomain"/>.
     /// </remarks>
     public string? SessionDomain { get; set; }
+
+    /// <summary>
+    /// Domain attribute for the short-lived OIDC state cookies (login state, link state, and the
+    /// setup flow's reuse of the login-state cookie name). Defaults to <see cref="Domain"/> when
+    /// the operator set it, and otherwise to ".{base-domain}".
+    /// </summary>
+    /// <remarks>
+    /// The registered redirect_uri is the apex callback, so a login begun on any other host has to
+    /// present its state cookie at the apex to be verifiable. A host-only state cookie cannot: the
+    /// apex never receives it and the callback fails with <c>invalid_state</c>. That is invisible
+    /// on a tenant subdomain, where <c>OidcCallbackRedirectMiddleware</c> bounces the callback back
+    /// to the originating host before the cookie is read, and fatal on a host that names no tenant
+    /// — a reserved dashboard slug — because there is no slug in the state to bounce to.
+    /// <para>
+    /// Widening is safe: the state cookie is single-use, expires in minutes, and is only ever
+    /// compared against the <c>state</c> parameter the provider echoes back, which is itself
+    /// integrity-protected. It confers no access on its own.
+    /// </para>
+    /// </remarks>
+    public string? StateDomain { get; set; }
 
     /// <summary>
     /// Cookie path

--- a/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
@@ -75,6 +75,20 @@ public class CookieSettings
     public string? Domain { get; set; }
 
     /// <summary>
+    /// Domain attribute for the session cookies (access token, refresh token, IsAuthenticated)
+    /// only. Defaults to ".{base-domain}" so a session established on one tenant subdomain is
+    /// also presented at the apex dashboard and at sibling tenants the subject belongs to.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately separate from <see cref="Domain"/>, which still scopes the OIDC state,
+    /// platform-access, and recovery cookies. Those carry a narrower grant that is only ever
+    /// redeemed on the host that minted it, so widening them would hand the same credential to
+    /// every subdomain — including the anonymous <c>{token}.share.{base-domain}</c> hosts — for
+    /// no benefit.
+    /// </remarks>
+    public string? SessionDomain { get; set; }
+
+    /// <summary>
     /// Cookie path
     /// </summary>
     public string Path { get; set; } = "/";

--- a/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
@@ -80,11 +80,12 @@ public class CookieSettings
     /// also presented at the apex dashboard and at sibling tenants the subject belongs to.
     /// </summary>
     /// <remarks>
-    /// Deliberately separate from <see cref="Domain"/>, which still scopes the OIDC state,
-    /// platform-access, and recovery cookies. Those carry a narrower grant that is only ever
-    /// redeemed on the host that minted it, so widening them would hand the same credential to
-    /// every subdomain — including the anonymous <c>{token}.share.{base-domain}</c> hosts — for
-    /// no benefit.
+    /// Derived from the base domain and deliberately independent of <see cref="Domain"/>, which is
+    /// an operator-set option scoping a different set of cookies: the OIDC and setup state cookies
+    /// and the platform-access grant. Those are left to the operator because at least one of them
+    /// genuinely spans hosts — the platform-access grant is minted on the apex, where the operator
+    /// still is, and redeemed on the tenant subdomain it is pinned to — so their scope is a
+    /// deployment decision rather than something the session widening should decide for them.
     /// </remarks>
     public string? SessionDomain { get; set; }
 

--- a/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
@@ -84,10 +84,6 @@ public class CookieSettings
     /// recipients, which is safe: the cookie is HttpOnly and Secure, and
     /// <c>PlatformAccessCookieHandler</c> skips it unless the resolved tenant is the one it is
     /// pinned to, so it confers nothing on a host belonging to any other tenant.
-    /// <para>
-    /// Retained as an override for an operator with a reason to narrow or move it. Setting it also
-    /// moves <see cref="StateDomain"/>, which defaults from this value.
-    /// </para>
     /// </remarks>
     public string? Domain { get; set; }
 
@@ -96,12 +92,6 @@ public class CookieSettings
     /// only. Defaults to ".{base-domain}" so a session established on one tenant subdomain is
     /// also presented at the apex dashboard and at sibling tenants the subject belongs to.
     /// </summary>
-    /// <remarks>
-    /// Derived from the base domain, as <see cref="Domain"/> and <see cref="StateDomain"/> are.
-    /// Kept a separate knob from those so an operator can narrow one scope without dragging the
-    /// others with it: this one carries the ordinary session, <see cref="Domain"/> the
-    /// platform-access grant, and <see cref="StateDomain"/> the OIDC state cookies.
-    /// </remarks>
     public string? SessionDomain { get; set; }
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/StatusResponse.cs
+++ b/src/Core/Nocturne.Core.Models/StatusResponse.cs
@@ -137,4 +137,14 @@ public class StatusResponse
     /// </summary>
     [JsonPropertyName("anonymousReadAccess")]
     public bool AnonymousReadAccess { get; set; }
+
+    /// <summary>
+    /// Slug of the tenant this request resolved to, or null when none did. On a tenant subdomain
+    /// this is simply that tenant. On the apex it answers the question the web app cannot answer
+    /// from the hostname alone: a single-tenant install auto-resolves its sole tenant there and so
+    /// serves the full app, while an install with none or several resolves nothing and serves the
+    /// cross-tenant dashboard instead.
+    /// </summary>
+    [JsonPropertyName("tenantSlug")]
+    public string? TenantSlug { get; set; }
 }

--- a/src/Web/packages/app/src/app.d.ts
+++ b/src/Web/packages/app/src/app.d.ts
@@ -31,6 +31,9 @@ export interface AuthUser {
 	avatarUrl?: string;
 }
 
+/** The tenant status document, as returned by the API's status endpoint. */
+type TenantStatusResponse = Awaited<ReturnType<ApiClient["status"]["getStatus"]>>;
+
 declare global {
 	namespace App {
 		interface Error {
@@ -38,8 +41,27 @@ declare global {
 			details?: string;
 			errorId?: string;
 		}
+		type TenantStatus = TenantStatusResponse;
 		interface Locals {
 			apiClient: ApiClient;
+			/**
+			 * Whether this request arrived on a public share host ({token}.share.{base-domain}).
+			 * Computed once so the handlers that must stay credential-free there — the auth
+			 * handler, the /api proxy, and the API client — cannot drift apart.
+			 */
+			isShareHost: boolean;
+			/**
+			 * Raw Set-Cookie headers to append verbatim to the outgoing response. SvelteKit's
+			 * cookie jar is keyed by name alone, so a deliberate pair of same-named cookies
+			 * (a host-scoped expiry alongside the domain-wide value) collapses to one; this
+			 * carries the variant the jar cannot hold. See auth-cookie-propagation.
+			 */
+			rawSetCookies: string[];
+			/**
+			 * Memoized tenant status for this request. Read it through getRequestStatus rather
+			 * than touching it directly.
+			 */
+			statusPromise?: Promise<TenantStatusResponse | null>;
 			/**
 			 * Current authenticated user, or null if not authenticated
 			 */

--- a/src/Web/packages/app/src/app.d.ts
+++ b/src/Web/packages/app/src/app.d.ts
@@ -44,17 +44,11 @@ declare global {
 		type TenantStatus = TenantStatusResponse;
 		interface Locals {
 			apiClient: ApiClient;
-			/**
-			 * Whether this request arrived on a public share host ({token}.share.{base-domain}).
-			 * Computed once so the handlers that must stay credential-free there — the auth
-			 * handler, the /api proxy, and the API client — cannot drift apart.
-			 */
+			/** Whether this request arrived on a public share host ({token}.share.{base-domain}). */
 			isShareHost: boolean;
 			/**
-			 * Raw Set-Cookie headers to append verbatim to the outgoing response. SvelteKit's
-			 * cookie jar is keyed by name alone, so a deliberate pair of same-named cookies
-			 * (a host-scoped expiry alongside the domain-wide value) collapses to one; this
-			 * carries the variant the jar cannot hold. See auth-cookie-propagation.
+			 * Set-Cookie headers to append verbatim to the outgoing response, for the half of a
+			 * same-named pair SvelteKit's cookie jar cannot hold. See propagateAuthCookies.
 			 */
 			rawSetCookies: string[];
 			/**

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -55,6 +55,16 @@ const authHandle: Handle = async ({ event, resolve }) => {
     return resolve(event);
   }
 
+  // The share host is anonymous for everyone, including the owner of the data behind it: a
+  // share link has to show its sender exactly what it shows a stranger. Session cookies are
+  // scoped to ".{base-domain}", so the browser now presents them here too — leave them
+  // unread. The API applies the same rule (AuthenticationMiddleware returns an unauthenticated
+  // context whenever ShareAccess is set), so this keeps SSR agreeing with it rather than
+  // rendering a signed-in shell over an anonymous API.
+  if (isShareHost(getOriginalHost(event.request))) {
+    return resolve(event);
+  }
+
   // Check for auth cookie
   const authCookie = event.cookies.get("IsAuthenticated");
   const accessToken = event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
@@ -364,11 +374,16 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
     );
   }
 
-  // Get auth tokens from cookies to forward to the backend
-  const accessToken = event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
-  const refreshToken = event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
-  const guestSessionToken = event.cookies.get(AUTH_COOKIE_NAMES.guestSession);
-  const platformAccessToken = event.cookies.get(AUTH_COOKIE_NAMES.platformAccess);
+  // Get auth tokens from cookies to forward to the backend. On a share host none are read:
+  // that host is anonymous for everyone (see authHandle), and the widened cookie domain means
+  // the browser now sends session cookies there. The API ignores them under ShareAccess, so
+  // this is belt-and-braces — but it also keeps a token rotation from being triggered by a
+  // page that is meant to be credential-free.
+  const onShareHost = isShareHost(getOriginalHost(event.request));
+  const accessToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
+  const refreshToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
+  const guestSessionToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.guestSession);
+  const platformAccessToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.platformAccess);
 
   const extraHeaders: Record<string, string> = {
     "X-Forwarded-Proto": getOriginalProto(event.request),

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -18,6 +18,7 @@ import {
 import { sequence } from "@sveltejs/kit/hooks";
 import type { AuthUser } from "./app.d";
 import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
+import { buildProxyHeaders } from "$lib/server/api-proxy-headers";
 import { getOriginalProto, getEffectiveHost, getOriginalHost, isShareHost } from "$lib/server/request-host";
 import { STATIC_ASSET_PREFIXES, isPublicRoute } from "$lib/server/public-routes";
 import {
@@ -61,7 +62,7 @@ const authHandle: Handle = async ({ event, resolve }) => {
   // unread. The API applies the same rule (AuthenticationMiddleware returns an unauthenticated
   // context whenever ShareAccess is set), so this keeps SSR agreeing with it rather than
   // rendering a signed-in shell over an anonymous API.
-  if (isShareHost(getOriginalHost(event.request))) {
+  if (event.locals.isShareHost) {
     return resolve(event);
   }
 
@@ -129,6 +130,7 @@ const authHandle: Handle = async ({ event, resolve }) => {
       hashedInstanceKey: getHashedInstanceKey(),
       extraHeaders: authExtraHeaders,
       responseCookies: event.cookies,
+      rawSetCookies: event.locals.rawSetCookies,
     });
 
     // Validate session with the API using the typed client
@@ -306,44 +308,13 @@ const proxyHandle: Handle = async ({ event, resolve }) => {
     // Construct the target URL
     const targetUrl = new URL(event.url.pathname + event.url.search, apiBaseUrl);
 
-    // Forward the request to the backend API
-    const headers = new Headers(event.request.headers);
-    // Forward original Host for tenant resolution behind reverse proxies
-    const effectiveHost = getEffectiveHost(event.request, event.cookies);
-    if (effectiveHost) {
-      headers.set("X-Forwarded-Host", effectiveHost);
-    }
-    headers.set("X-Forwarded-Proto", getOriginalProto(event.request));
-    // NB: this proxies end-user browser calls to /api, so it forwards ONLY the
-    // user's own credentials (cookies) — never the instance key. Attaching the
-    // instance key here would authenticate anonymous visitors as admin and
-    // bypass per-tenant public access.
-    // Strip any client-supplied instance-service / instance-key headers so a
-    // browser can't smuggle service auth through the proxy.
-    headers.delete("X-Instance-Key");
-    headers.delete("X-Instance-Service");
-
-    // Forward auth and guest session cookies for authentication
-    const accessToken = event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
-    const refreshToken = event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
-    const guestSession = event.cookies.get(AUTH_COOKIE_NAMES.guestSession);
-    const platformAccess = event.cookies.get(AUTH_COOKIE_NAMES.platformAccess);
-    const cookies: string[] = [];
-    if (accessToken) {
-      cookies.push(`${AUTH_COOKIE_NAMES.accessToken}=${accessToken}`);
-    }
-    if (refreshToken) {
-      cookies.push(`${AUTH_COOKIE_NAMES.refreshToken}=${refreshToken}`);
-    }
-    if (guestSession) {
-      cookies.push(`${AUTH_COOKIE_NAMES.guestSession}=${guestSession}`);
-    }
-    if (platformAccess) {
-      cookies.push(`${AUTH_COOKIE_NAMES.platformAccess}=${platformAccess}`);
-    }
-    if (cookies.length > 0) {
-      headers.set("Cookie", cookies.join("; "));
-    }
+    const headers = buildProxyHeaders({
+      requestHeaders: event.request.headers,
+      effectiveHost: getEffectiveHost(event.request, event.cookies),
+      proto: getOriginalProto(event.request),
+      isShareHost: event.locals.isShareHost,
+      cookies: event.cookies,
+    });
 
     const proxyResponse = await fetch(targetUrl.toString(), {
       method: event.request.method,
@@ -379,7 +350,7 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
   // the browser now sends session cookies there. The API ignores them under ShareAccess, so
   // this is belt-and-braces — but it also keeps a token rotation from being triggered by a
   // page that is meant to be credential-free.
-  const onShareHost = isShareHost(getOriginalHost(event.request));
+  const onShareHost = event.locals.isShareHost;
   const accessToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
   const refreshToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
   const guestSessionToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.guestSession);
@@ -412,6 +383,7 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
     platformAccessToken,
     extraHeaders,
     responseCookies: event.cookies,
+    rawSetCookies: event.locals.rawSetCookies,
     signal: event.request.signal,
   });
 
@@ -544,11 +516,35 @@ installRequestScopedBitsIdCounter();
 const resetBitsId: Handle = ({ event, resolve }) =>
   withFreshBitsIdCounter(() => resolve(event));
 
+/**
+ * Per-request facts every later handler shares, established before any of them run.
+ *
+ * The share-host classification is one of them: the auth handler, the /api proxy, and the API
+ * client each have to stay credential-free there, and three separate readings of the same host
+ * are three chances to drift.
+ *
+ * It also drains the raw Set-Cookie sink on the way out. SvelteKit's cookie jar keys by name, so
+ * the API's deliberate same-name pairs (host-scoped expiry plus domain-wide value) can only be
+ * carried in full by appending the second header to the finished response.
+ */
+const requestContextHandle: Handle = async ({ event, resolve }) => {
+  event.locals.isShareHost = isShareHost(getOriginalHost(event.request));
+  event.locals.rawSetCookies = [];
+
+  const response = await resolve(event);
+
+  for (const header of event.locals.rawSetCookies) {
+    response.headers.append("set-cookie", header);
+  }
+
+  return response;
+};
+
 // Public share host: keep the token-bearing URL out of Referer headers and search indexes on
 // every response (SSR page, /api proxy, realtime ticket), not just the page document.
 const shareHostSecurityHandle: Handle = async ({ event, resolve }) => {
   const response = await resolve(event);
-  if (isShareHost(getOriginalHost(event.request))) {
+  if (event.locals.isShareHost) {
     response.headers.set("Referrer-Policy", "no-referrer");
     response.headers.set("X-Robots-Tag", "noindex, nofollow");
   }
@@ -568,5 +564,7 @@ const healthHandle: Handle = async ({ event, resolve }) => {
   return resolve(event);
 };
 
-// Chain the auth handler, site security handler, proxy handler, and API client handler
-export const handle: Handle = sequence(healthHandle, shareHostSecurityHandle, resetBitsId, authHandle, siteSecurityHandle, proxyHandle, apiClientHandle, locale);
+// Chain the auth handler, site security handler, proxy handler, and API client handler.
+// requestContextHandle comes first of the request-serving handlers: everything after it reads
+// the facts it establishes.
+export const handle: Handle = sequence(healthHandle, requestContextHandle, shareHostSecurityHandle, resetBitsId, authHandle, siteSecurityHandle, proxyHandle, apiClientHandle, locale);

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -345,11 +345,9 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
     );
   }
 
-  // Get auth tokens from cookies to forward to the backend. On a share host none are read:
-  // that host is anonymous for everyone (see authHandle), and the widened cookie domain means
-  // the browser now sends session cookies there. The API ignores them under ShareAccess, so
-  // this is belt-and-braces — but it also keeps a token rotation from being triggered by a
-  // page that is meant to be credential-free.
+  // Get auth tokens from cookies to forward to the backend. None are read on a share host (see
+  // authHandle), which also keeps a token rotation from being triggered by a page that is meant
+  // to be credential-free.
   const onShareHost = event.locals.isShareHost;
   const accessToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.accessToken);
   const refreshToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
@@ -520,12 +518,10 @@ const resetBitsId: Handle = ({ event, resolve }) =>
  * Per-request facts every later handler shares, established before any of them run.
  *
  * The share-host classification is one of them: the auth handler, the /api proxy, and the API
- * client each have to stay credential-free there, and three separate readings of the same host
- * are three chances to drift.
+ * client each have to stay credential-free there (see authHandle), and three separate readings
+ * of the same host are three chances to drift.
  *
- * It also drains the raw Set-Cookie sink on the way out. SvelteKit's cookie jar keys by name, so
- * the API's deliberate same-name pairs (host-scoped expiry plus domain-wide value) can only be
- * carried in full by appending the second header to the finished response.
+ * It also drains the raw Set-Cookie sink on the way out; see propagateAuthCookies.
  */
 const requestContextHandle: Handle = async ({ event, resolve }) => {
   event.locals.isShareHost = isShareHost(getOriginalHost(event.request));

--- a/src/Web/packages/app/src/lib/coach-marks/adapter.ts
+++ b/src/Web/packages/app/src/lib/coach-marks/adapter.ts
@@ -38,12 +38,19 @@ function isAuthError(err: unknown): boolean {
 /**
  * Creates a {@link CoachMarkAdapter} backed by the generated remote functions,
  * with localStorage fallback when unauthenticated.
+ *
+ * @param localOnly Skip the remote functions entirely and keep every mark in localStorage. Set
+ * this where the coach-mark endpoints cannot answer — they are tenant-scoped, so a host that
+ * resolves no tenant would only 404 — rather than relying on the 401 fallback, which that 404
+ * would never trip.
  */
-export function createCoachMarkAdapter(): CoachMarkAdapter {
-  let usingLocal = false;
+export function createCoachMarkAdapter(localOnly = false): CoachMarkAdapter {
+  let usingLocal = localOnly;
 
   return {
     async fetchAll(): Promise<MarkState[]> {
+      if (usingLocal) return [...readLocal().values()];
+
       try {
         const states = await getAll();
         // Authenticated — merge any localStorage marks into the server response

--- a/src/Web/packages/app/src/lib/components/alerts/AlertSurfaces.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/AlertSurfaces.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import AlertBanner from "./AlertBanner.svelte";
+  import FiringToast from "./FiringToast.svelte";
+  import { pollActiveAlerts } from "./active-alerts-poll.svelte";
+
+  // One poll for both surfaces — they read the same query. Mounting the poll with the surfaces
+  // keeps the two from drifting apart: a host that must not show them never starts it either.
+  pollActiveAlerts();
+</script>
+
+<AlertBanner />
+<FiringToast />

--- a/src/Web/packages/app/src/lib/components/alerts/active-alerts-poll.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/active-alerts-poll.svelte.ts
@@ -1,4 +1,5 @@
 import { getActiveAlerts } from "$api/generated/alerts.generated.remote";
+import { pollWhileVisible } from "$lib/utils/poll-while-visible.svelte";
 
 /** How often to re-read the active-alert surface while the tab is visible. */
 const POLL_MS = 10_000;
@@ -6,45 +7,12 @@ const POLL_MS = 10_000;
 /**
  * Keeps the shared `getActiveAlerts` query fresh.
  *
- * Call this exactly once, from the layout that mounts the alert surfaces. Every
+ * Call this exactly once, from the component that mounts the alert surfaces. Every
  * component that reads `getActiveAlerts().current` sees the refreshed data, so a
  * second caller would just double the request rate for the same result — which
  * is what happened when the banner and the fresh-fire toast each ran their own
  * timer at different cadences.
- *
- * Polling stops while the tab is hidden and catches up on return, so a
- * backgrounded tab isn't billing requests for a surface nobody can see.
  */
 export function pollActiveAlerts(): void {
-  $effect(() => {
-    let timer: ReturnType<typeof setInterval> | null = null;
-
-    function stop() {
-      if (timer) clearInterval(timer);
-      timer = null;
-    }
-
-    function start() {
-      if (timer) return;
-      timer = setInterval(() => getActiveAlerts().refresh(), POLL_MS);
-    }
-
-    function onVisibilityChange() {
-      if (document.hidden) {
-        stop();
-      } else {
-        // Whatever fired while hidden is unseen, so catch up immediately.
-        getActiveAlerts().refresh();
-        start();
-      }
-    }
-
-    if (!document.hidden) start();
-    document.addEventListener("visibilitychange", onVisibilityChange);
-
-    return () => {
-      stop();
-      document.removeEventListener("visibilitychange", onVisibilityChange);
-    };
-  });
+  pollWhileVisible(() => getActiveAlerts().refresh(), POLL_MS);
 }

--- a/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte
+++ b/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte
@@ -292,49 +292,49 @@
 
     {#if mode === "default"}
       {#if !tenantless}
-      <!-- Primary: discoverable passkey sign-in. Needs JavaScript for the
-           WebAuthn ceremony, so there is no server-side counterpart. -->
-      <form onsubmit={handleDiscoverableLogin}>
-        <Button
-          type="submit"
-          class="w-full h-12"
-          size="lg"
-          disabled={isLoading || isRedirecting || !passkeysSupported}
-        >
-          {#if isLoading}
-            <Loader2 class="mr-2 h-5 w-5 animate-spin" />
-            Waiting for passkey...
-          {:else}
-            <Fingerprint class="mr-2 h-5 w-5" />
-            {signInMethodLabels.passkey}
-          {/if}
-        </Button>
-      </form>
+        <!-- Primary: discoverable passkey sign-in. Needs JavaScript for the
+             WebAuthn ceremony, so there is no server-side counterpart. -->
+        <form onsubmit={handleDiscoverableLogin}>
+          <Button
+            type="submit"
+            class="w-full h-12"
+            size="lg"
+            disabled={isLoading || isRedirecting || !passkeysSupported}
+          >
+            {#if isLoading}
+              <Loader2 class="mr-2 h-5 w-5 animate-spin" />
+              Waiting for passkey...
+            {:else}
+              <Fingerprint class="mr-2 h-5 w-5" />
+              {signInMethodLabels.passkey}
+            {/if}
+          </Button>
+        </form>
 
-      <!-- Secondary: username-based sign-in -->
-      <Button
-        variant="outline"
-        class="w-full"
-        disabled={isLoading || isRedirecting || !passkeysSupported}
-        onclick={() => switchMode("username")}
-      >
-        <User class="mr-2 h-4 w-4" />
-        {signInMethodLabels.username}
-      </Button>
+        <!-- Secondary: username-based sign-in -->
+        <Button
+          variant="outline"
+          class="w-full"
+          disabled={isLoading || isRedirecting || !passkeysSupported}
+          onclick={() => switchMode("username")}
+        >
+          <User class="mr-2 h-4 w-4" />
+          {signInMethodLabels.username}
+        </Button>
       {/if}
 
       {#if hasOidc && oidc}
         {#if !tenantless}
-        <div class="relative">
-          <div class="absolute inset-0 flex items-center">
-            <span class="w-full border-t"></span>
+          <div class="relative">
+            <div class="absolute inset-0 flex items-center">
+              <span class="w-full border-t"></span>
+            </div>
+            <div class="relative flex justify-center text-xs uppercase">
+              <span class="bg-background px-2 text-muted-foreground">
+                Or continue with
+              </span>
+            </div>
           </div>
-          <div class="relative flex justify-center text-xs uppercase">
-            <span class="bg-background px-2 text-muted-foreground">
-              Or continue with
-            </span>
-          </div>
-        </div>
         {/if}
 
         <div class="space-y-3">

--- a/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte
+++ b/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte
@@ -36,9 +36,16 @@
   interface Props {
     returnUrl?: string;
     onSuccess?: () => void;
+    /**
+     * Whether this page is served on a host that resolves no tenant. Passkeys, authenticator
+     * codes, and recovery codes are all checked against a resolved tenant's members, so on such
+     * a host only the identity-provider path can complete a sign-in and it is the only one
+     * offered.
+     */
+    tenantless?: boolean;
   }
 
-  let { returnUrl = "/", onSuccess }: Props = $props();
+  let { returnUrl = "/", onSuccess, tenantless = false }: Props = $props();
 
   const oidcQuery = getOidcProviders();
 
@@ -262,7 +269,17 @@
   {@const hasOidc = oidc?.enabled && oidc.providers.length > 0}
 
   <div class="space-y-4">
-    {#if !passkeysSupported}
+    {#if tenantless}
+      <p class="text-sm text-muted-foreground">
+        Passkeys, authenticator codes, and recovery codes are checked against one
+        tenant, so they are used at that tenant's own web address.
+        {#if !hasOidc}
+          Open your tenant's address to sign in.
+        {/if}
+      </p>
+    {/if}
+
+    {#if !passkeysSupported && !tenantless}
       <div class="flex items-start gap-3 rounded-md border border-yellow-500/30 bg-yellow-500/5 p-3">
         <ShieldAlert class="mt-0.5 h-4 w-4 shrink-0 text-yellow-600 dark:text-yellow-500" />
         <p class="text-sm text-yellow-700 dark:text-yellow-400">
@@ -274,6 +291,7 @@
     <FormError issues={passkeyError} focusOnShow />
 
     {#if mode === "default"}
+      {#if !tenantless}
       <!-- Primary: discoverable passkey sign-in. Needs JavaScript for the
            WebAuthn ceremony, so there is no server-side counterpart. -->
       <form onsubmit={handleDiscoverableLogin}>
@@ -303,8 +321,10 @@
         <User class="mr-2 h-4 w-4" />
         {signInMethodLabels.username}
       </Button>
+      {/if}
 
       {#if hasOidc && oidc}
+        {#if !tenantless}
         <div class="relative">
           <div class="absolute inset-0 flex items-center">
             <span class="w-full border-t"></span>
@@ -315,6 +335,7 @@
             </span>
           </div>
         </div>
+        {/if}
 
         <div class="space-y-3">
           {#each oidc.providers as provider}
@@ -337,9 +358,11 @@
         </div>
       {/if}
 
-      <div class="flex justify-center gap-3 text-xs">
-        {@render otherMethodLinks()}
-      </div>
+      {#if !tenantless}
+        <div class="flex justify-center gap-3 text-xs">
+          {@render otherMethodLinks()}
+        </div>
+      {/if}
 
     {:else if mode === "username"}
       <!-- Username-first passkey sign-in. JavaScript-only, as above. -->

--- a/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte.test.ts
@@ -1,0 +1,84 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * On a tenantless host every passkey, authenticator and recovery-code control is hidden,
+ * because each is checked against a resolved tenant's members. That leaves the identity
+ * providers as the only thing that can sign anyone in, so these pin that the provider
+ * buttons actually render there — and that the page says what to do when there are none.
+ */
+
+interface StubProvider {
+  id: string;
+  name: string;
+  icon?: string;
+  buttonColor?: string;
+}
+
+let providers: StubProvider[] = [];
+let providersLoading = false;
+
+vi.mock("$routes/(unauthenticated)/auth/auth.remote", () => ({
+  getOidcProviders: () => ({
+    get loading() {
+      return providersLoading;
+    },
+    get current() {
+      return { enabled: providers.length > 0, providers };
+    },
+  }),
+  setAuthCookies: vi.fn(),
+  signInWithAuthenticator: {
+    pending: 0,
+    enhance: () => ({}),
+    fields: { code: { issues: () => [] } },
+  },
+  signInWithRecoveryCode: {
+    pending: 0,
+    enhance: () => ({}),
+    fields: {
+      username: { issues: () => [] },
+      code: { issues: () => [] },
+    },
+  },
+}));
+
+vi.mock("$lib/api/generated/passkeys.generated.remote", () => ({
+  discoverableLoginOptions: vi.fn(),
+  loginOptions: vi.fn(),
+  loginComplete: vi.fn(),
+}));
+
+import LoginForm from "./LoginForm.svelte";
+
+describe("LoginForm on a tenantless host", () => {
+  beforeEach(() => {
+    providers = [];
+    providersLoading = false;
+  });
+
+  it("renders a provider sign-in button when a provider is available", async () => {
+    providers = [{ id: "provider-1", name: "Example SSO" }];
+
+    render(LoginForm, { props: { tenantless: true } });
+
+    // The only sign-in affordance the tenantless page can offer.
+    await expect
+      .element(page.getByRole("button", { name: "Sign in with Example SSO" }))
+      .toBeVisible();
+  });
+
+  it("tells the visitor where to sign in when no provider is available", async () => {
+    providers = [];
+
+    render(LoginForm, { props: { tenantless: true } });
+
+    await expect
+      .element(page.getByText("Open your tenant's address to sign in."))
+      .toBeVisible();
+    await expect
+      .element(page.getByRole("button", { name: /^Sign in with/ }))
+      .not.toBeInTheDocument();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/command-palette/CommandPalette.svelte
+++ b/src/Web/packages/app/src/lib/components/command-palette/CommandPalette.svelte
@@ -12,7 +12,7 @@
   } from "$lib/stores/appearance-store.svelte";
   import { userPrefersMode } from "mode-watcher";
   import {
-    items,
+    paletteItemsFor,
     groupMeta,
     type CommandPaletteItem,
     type CommandPaletteGroup,
@@ -29,9 +29,11 @@
 
   interface Props {
     open: boolean;
+    /** Whether the host resolves no tenant (the apex, or a reserved dashboard slug). */
+    tenantless?: boolean;
   }
 
-  let { open = $bindable(false) }: Props = $props();
+  let { open = $bindable(false), tenantless = false }: Props = $props();
 
   let searchValue = $state("");
 
@@ -39,7 +41,7 @@
   const realtimeStore = getRealtimeStore();
 
   const visibleItems = $derived(
-    items.filter(
+    paletteItemsFor(tenantless).filter(
       (item) =>
         (!item.permission || authStore.hasPermission(item.permission)) &&
         (!item.role || authStore.hasRole(item.role))
@@ -262,7 +264,10 @@
 <Command.Dialog bind:open>
   <Command.Input placeholder="Search commands..." bind:value={searchValue} />
 
-  <CommandPaletteVitals />
+  <!-- The vitals strip reads one tenant's live glucose, which a tenantless host has none of. -->
+  {#if !tenantless}
+    <CommandPaletteVitals />
+  {/if}
 
   <Command.List class="max-h-[400px]">
     <Command.Empty>No results found.</Command.Empty>

--- a/src/Web/packages/app/src/lib/components/command-palette/CommandPalette.svelte
+++ b/src/Web/packages/app/src/lib/components/command-palette/CommandPalette.svelte
@@ -264,7 +264,7 @@
 <Command.Dialog bind:open>
   <Command.Input placeholder="Search commands..." bind:value={searchValue} />
 
-  <!-- The vitals strip reads one tenant's live glucose, which a tenantless host has none of. -->
+  <!-- The vitals strip reads one tenant's live glucose. -->
   {#if !tenantless}
     <CommandPaletteVitals />
   {/if}

--- a/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.test.ts
+++ b/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { items, paletteItemsFor } from "./command-palette-items";
+import { isTenantlessRoute } from "$lib/navigation/tenantless-navigation";
+
+describe("paletteItemsFor", () => {
+  it("offers the whole list on a host that resolves a tenant", () => {
+    expect(paletteItemsFor(false)).toEqual(items);
+  });
+
+  it("offers only the dashboard on a tenantless host", () => {
+    // Everything else bounces back to "/" via the route guard, so Cmd-K must not advertise it.
+    expect(paletteItemsFor(true).map((item) => item.id)).toEqual(["page-dashboard"]);
+  });
+
+  it("keeps no entry whose destination needs a resolved tenant", () => {
+    for (const item of paletteItemsFor(true)) {
+      const destination = item.href ?? item.linkedHref;
+
+      expect(destination, `${item.id} has no destination to reach`).toBeDefined();
+      expect(isTenantlessRoute(destination!), `${item.id} leads to ${destination}`).toBe(true);
+    }
+  });
+
+  it("drops the tenant-scoped groups the full list is mostly made of", () => {
+    // Non-vacuity: the assertions above would pass on an empty or trivially small source list.
+    const groups = new Set(items.map((item) => item.group));
+    expect(groups).toContain("reports");
+    expect(groups).toContain("settings");
+    expect(groups).toContain("actions");
+
+    const tenantlessGroups = new Set(paletteItemsFor(true).map((item) => item.group));
+    expect(tenantlessGroups).toEqual(new Set(["pages"]));
+  });
+});

--- a/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
+++ b/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
@@ -48,6 +48,7 @@ import {
 	Wrench,
 	ZoomIn,
 } from "lucide-svelte";
+import { filterTenantlessNav } from "$lib/navigation/tenantless-navigation";
 
 export type CommandPaletteGroup =
 	| "stats"
@@ -550,3 +551,13 @@ export const items: CommandPaletteItem[] = [
 		icon: RefreshCw,
 	},
 ];
+
+/**
+ * The entries a host can actually use. On a tenantless host every one of these but the dashboard
+ * leads somewhere the route guard bounces back to "/" — the stats navigate to a report, and the
+ * actions and quick settings write through to tenant-scoped endpoints — so the palette is narrowed
+ * to the same surface the sidebar draws, from the same list of hrefs, rather than keeping a second.
+ */
+export function paletteItemsFor(tenantless: boolean): CommandPaletteItem[] {
+	return tenantless ? filterTenantlessNav(items) : items;
+}

--- a/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
+++ b/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.ts
@@ -553,10 +553,8 @@ export const items: CommandPaletteItem[] = [
 ];
 
 /**
- * The entries a host can actually use. On a tenantless host every one of these but the dashboard
- * leads somewhere the route guard bounces back to "/" — the stats navigate to a report, and the
- * actions and quick settings write through to tenant-scoped endpoints — so the palette is narrowed
- * to the same surface the sidebar draws, from the same list of hrefs, rather than keeping a second.
+ * The entries a host can actually use. Narrowed on a tenantless host from the same list of hrefs
+ * the sidebar narrows from, rather than a second one. See tenantless-navigation.
  */
 export function paletteItemsFor(tenantless: boolean): CommandPaletteItem[] {
 	return tenantless ? filterTenantlessNav(items) : items;

--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -388,14 +388,17 @@
     <Sidebar.Trigger />
   </Sidebar.Header>
 
-  <!-- Glucose Widget (fixed, not scrollable) -->
-  <Sidebar.Group>
-    <Sidebar.GroupContent>
-      <SidebarGlucoseWidget />
-    </Sidebar.GroupContent>
-  </Sidebar.Group>
+  <!-- Glucose Widget (fixed, not scrollable). One tenant's latest reading, so there is nothing
+       for it to show on a host that resolves none. -->
+  {#if !tenantless}
+    <Sidebar.Group>
+      <Sidebar.GroupContent>
+        <SidebarGlucoseWidget />
+      </Sidebar.GroupContent>
+    </Sidebar.Group>
 
-  <Sidebar.Separator />
+    <Sidebar.Separator />
+  {/if}
 
   <!-- Platform-admin access indicator: viewing a tenant you're NOT a member of,
        via a short-lived platform-access grant (distinct from the member switcher). -->
@@ -541,8 +544,11 @@
     <Sidebar.Menu>
       {#if !langPrefKnown}
         <Sidebar.MenuItem class="group-data-[collapsible=icon]:hidden">
+          <!-- The language choice still applies to this page; only persisting it needs a tenant
+               (the preferences write is tenant-scoped), so a tenantless host keeps the selector
+               and drops the write rather than losing the control entirely. -->
           <LanguageSelector
-            onLanguageChange={user
+            onLanguageChange={user && !tenantless
               ? (locale: string) =>
                   updateLanguagePreference({ preferredLanguage: locale })
               : undefined}
@@ -552,13 +558,14 @@
       <Sidebar.MenuItem
         class="flex items-center gap-2 min-w-0 group-data-[collapsible=icon]:flex-col"
       >
-        {#if user && !isGuestSession}
+        {#if user && !isGuestSession && !tenantless}
           <SidebarNotifications />
         {/if}
         <UserMenu
           {user}
           {isPlatformAdmin}
           {isGuestSession}
+          {tenantless}
           collapsed={sidebar.state === "collapsed"}
           class="flex-1 min-w-0"
         />

--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -47,6 +47,7 @@
     History as HistoryIcon,
   } from "lucide-svelte";
   import { getSidebarReportItems } from "$lib/navigation/report-navigation";
+  import { filterTenantlessNav } from "$lib/navigation/tenantless-navigation";
   import { tenantUrl } from "$lib/utils/tenant-host";
   import type { AuthUser } from "$lib/stores/auth-store.svelte";
 
@@ -63,6 +64,8 @@
     currentSlug?: string | null;
     /** Public base domain tenant subdomains hang off (from layout data) */
     baseDomain?: string | null;
+    /** Whether this host serves the cross-tenant dashboard rather than one tenant (from layout data) */
+    tenantless?: boolean;
   }
 
   const {
@@ -72,6 +75,7 @@
     isGuestSession = false,
     currentSlug = null,
     baseDomain = null,
+    tenantless = false,
   }: Props = $props();
 
   const sidebar = Sidebar.useSidebar();
@@ -307,6 +311,12 @@
           : []),
       ],
     });
+
+    // A tenantless host has no tenant for the API to resolve, so every tenant-scoped page
+    // would render and then 404. Trim to the cross-tenant surface.
+    if (tenantless) {
+      return filterTenantlessNav(items);
+    }
 
     return items;
   });

--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -312,8 +312,7 @@
       ],
     });
 
-    // A tenantless host has no tenant for the API to resolve, so every tenant-scoped page
-    // would render and then 404. Trim to the cross-tenant surface.
+    // See tenantless-navigation for why the tenant-scoped pages come out.
     if (tenantless) {
       return filterTenantlessNav(items);
     }
@@ -388,8 +387,7 @@
     <Sidebar.Trigger />
   </Sidebar.Header>
 
-  <!-- Glucose Widget (fixed, not scrollable). One tenant's latest reading, so there is nothing
-       for it to show on a host that resolves none. -->
+  <!-- Glucose Widget (fixed, not scrollable). One tenant's latest reading. -->
   {#if !tenantless}
     <Sidebar.Group>
       <Sidebar.GroupContent>

--- a/src/Web/packages/app/src/lib/components/layout/UserMenu.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/UserMenu.svelte
@@ -17,9 +17,15 @@
     isPlatformAdmin?: boolean;
     /** Whether the current session is a guest link session */
     isGuestSession?: boolean;
+    /**
+     * Whether this host serves the cross-tenant dashboard rather than one tenant. Every account
+     * entry below points at /settings/*, which the authenticated layout bounces back to "/" on
+     * such a host, so they are hidden rather than left to silently do nothing.
+     */
+    tenantless?: boolean;
   }
 
-  const { user, collapsed = false, class: className = "", isPlatformAdmin = false, isGuestSession = false }: Props = $props();
+  const { user, collapsed = false, class: className = "", isPlatformAdmin = false, isGuestSession = false, tenantless = false }: Props = $props();
 
   let isOpen = $state(false);
   let showRequestDialog = $state(false);
@@ -106,22 +112,24 @@
           <DropdownMenu.Separator />
         {/if}
 
-        <DropdownMenu.Group>
-          <DropdownMenu.Item onSelect={() => goto("/settings/account")}>
-            <User class="mr-2 h-4 w-4" />
-            <span>Account</span>
-          </DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => goto("/settings")}>
-            <Settings class="mr-2 h-4 w-4" />
-            <span>Settings</span>
-          </DropdownMenu.Item>
-          {#if isPlatformAdmin}
-            <DropdownMenu.Item onSelect={() => goto("/settings/admin")}>
-              <Shield class="mr-2 h-4 w-4" />
-              <span>Admin</span>
+        {#if !tenantless}
+          <DropdownMenu.Group>
+            <DropdownMenu.Item onSelect={() => goto("/settings/account")}>
+              <User class="mr-2 h-4 w-4" />
+              <span>Account</span>
             </DropdownMenu.Item>
-          {/if}
-        </DropdownMenu.Group>
+            <DropdownMenu.Item onSelect={() => goto("/settings")}>
+              <Settings class="mr-2 h-4 w-4" />
+              <span>Settings</span>
+            </DropdownMenu.Item>
+            {#if isPlatformAdmin}
+              <DropdownMenu.Item onSelect={() => goto("/settings/admin")}>
+                <Shield class="mr-2 h-4 w-4" />
+                <span>Admin</span>
+              </DropdownMenu.Item>
+            {/if}
+          </DropdownMenu.Group>
+        {/if}
       {:else}
         <DropdownMenu.Group>
           <DropdownMenu.Item onSelect={() => (showRequestDialog = true)}>

--- a/src/Web/packages/app/src/lib/components/layout/UserMenu.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/UserMenu.svelte
@@ -18,9 +18,8 @@
     /** Whether the current session is a guest link session */
     isGuestSession?: boolean;
     /**
-     * Whether this host serves the cross-tenant dashboard rather than one tenant. Every account
-     * entry below points at /settings/*, which the authenticated layout bounces back to "/" on
-     * such a host, so they are hidden rather than left to silently do nothing.
+     * Whether this host serves the cross-tenant dashboard rather than one tenant. Hides the
+     * /settings/* entries below, which the route guard bounces back to "/" there.
      */
     tenantless?: boolean;
   }

--- a/src/Web/packages/app/src/lib/components/tenants/TenantsOverview.svelte
+++ b/src/Web/packages/app/src/lib/components/tenants/TenantsOverview.svelte
@@ -26,6 +26,10 @@
   });
 </script>
 
+<svelte:head>
+  <title>Tenants overview - Nocturne</title>
+</svelte:head>
+
 <div class="container mx-auto space-y-6 p-4 md:p-6">
   <div>
     <h1 class="text-2xl font-bold">Tenants overview</h1>

--- a/src/Web/packages/app/src/lib/components/tenants/TenantsOverview.svelte
+++ b/src/Web/packages/app/src/lib/components/tenants/TenantsOverview.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import { page } from "$app/state";
+  import { getOverview } from "$lib/api/generated/myTenants.generated.remote";
+  import TenantOverviewTile from "$lib/components/tenants/TenantOverviewTile.svelte";
+  import { Button } from "$lib/components/ui/button";
+  import { sortTenantsByUrgency } from "$lib/utils/glucose-status";
+
+  const overviewQuery = getOverview();
+  const data = $derived(overviewQuery.current);
+  const loadError = $derived(overviewQuery.error);
+
+  const baseDomain = $derived(page.data.baseDomain ?? null);
+
+  let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+  onMount(() => {
+    refreshInterval = setInterval(() => {
+      // Detached callback: use .refresh(), not a bare await (no reactive context here).
+      overviewQuery.refresh();
+    }, 60_000);
+  });
+
+  onDestroy(() => {
+    if (refreshInterval) clearInterval(refreshInterval);
+  });
+</script>
+
+<div class="container mx-auto space-y-6 p-4 md:p-6">
+  <div>
+    <h1 class="text-2xl font-bold">Tenants overview</h1>
+    <p class="text-sm text-muted-foreground">
+      Latest glucose across the tenants you have access to. Refreshes every
+      minute.
+    </p>
+  </div>
+
+  {#if loadError}
+    <div class="space-y-2">
+      <p class="text-sm text-muted-foreground">
+        Failed to load the tenants overview.
+      </p>
+      <Button
+        variant="outline"
+        size="sm"
+        onclick={() => overviewQuery.refresh()}
+      >
+        Retry
+      </Button>
+    </div>
+  {:else if overviewQuery.loading && !data}
+    <p class="text-sm text-muted-foreground">Loading…</p>
+  {:else if data}
+    {@const tenants = sortTenantsByUrgency(data.tenants ?? [])}
+    {#if tenants.length === 0}
+      <p class="text-sm text-muted-foreground">
+        No tenants with glucose access.
+      </p>
+    {:else}
+      <div class="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4">
+        {#each tenants as tenant (tenant.tenantId)}
+          <TenantOverviewTile {tenant} {baseDomain} />
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/src/Web/packages/app/src/lib/components/tenants/TenantsOverview.svelte
+++ b/src/Web/packages/app/src/lib/components/tenants/TenantsOverview.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-  import { onDestroy, onMount } from "svelte";
   import { page } from "$app/state";
   import { getOverview } from "$lib/api/generated/myTenants.generated.remote";
   import TenantOverviewTile from "$lib/components/tenants/TenantOverviewTile.svelte";
   import { Button } from "$lib/components/ui/button";
   import { sortTenantsByUrgency } from "$lib/utils/glucose-status";
+  import { pollWhileVisible } from "$lib/utils/poll-while-visible.svelte";
+
+  /** How often to re-read the cross-tenant overview while the tab is visible. */
+  const POLL_MS = 60_000;
 
   const overviewQuery = getOverview();
   const data = $derived(overviewQuery.current);
@@ -12,18 +15,8 @@
 
   const baseDomain = $derived(page.data.baseDomain ?? null);
 
-  let refreshInterval: ReturnType<typeof setInterval> | null = null;
-
-  onMount(() => {
-    refreshInterval = setInterval(() => {
-      // Detached callback: use .refresh(), not a bare await (no reactive context here).
-      overviewQuery.refresh();
-    }, 60_000);
-  });
-
-  onDestroy(() => {
-    if (refreshInterval) clearInterval(refreshInterval);
-  });
+  // Detached callback: use .refresh(), not a bare await (no reactive context here).
+  pollWhileVisible(() => overviewQuery.refresh(), POLL_MS);
 </script>
 
 <svelte:head>

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
@@ -17,7 +17,10 @@ describe("filterTenantlessNav", () => {
     expect(filterTenantlessNav(items)).toEqual([{ title: "Dashboard", href: "/" }]);
   });
 
-  it("keeps only subject-scoped settings children", () => {
+  it("drops the settings group, whose pages all need a resolved tenant", () => {
+    // Account and appearance look subject-scoped but call /api/auth/passkey/*, /api/v4/totp/*,
+    // and /api/v4/settings, none of which the API serves without a tenant. Listing them would
+    // put entries in the sidebar that 404 when opened.
     const items = [
       {
         title: "Settings",
@@ -31,15 +34,7 @@ describe("filterTenantlessNav", () => {
       },
     ];
 
-    expect(filterTenantlessNav(items)).toEqual([
-      {
-        title: "Settings",
-        children: [
-          { title: "Account", href: "/settings/account" },
-          { title: "Appearance", href: "/settings/appearance" },
-        ],
-      },
-    ]);
+    expect(filterTenantlessNav(items)).toEqual([]);
   });
 
   it("drops a group whose children are all tenant-scoped, leaving no empty heading", () => {
@@ -73,6 +68,16 @@ describe("filterTenantlessNav", () => {
   });
 });
 
+describe("TENANTLESS_NAV_HREFS", () => {
+  it("lists only routes whose data the API serves without a tenant", () => {
+    // The API's tenantless surface (TenantResolutionMiddleware.TenantlessAllowedPaths) admits
+    // the cross-tenant overview and the session/auth endpoints, and nothing else that a page
+    // renders from. Anything added here has to have its endpoints admitted there first, or the
+    // nav gains an entry that 404s.
+    expect(TENANTLESS_NAV_HREFS).toEqual(["/"]);
+  });
+});
+
 describe("isTenantlessRoute", () => {
   it("admits exactly the tenantless hrefs", () => {
     for (const href of TENANTLESS_NAV_HREFS) {
@@ -84,11 +89,12 @@ describe("isTenantlessRoute", () => {
     expect(isTenantlessRoute("/calendar")).toBe(false);
     expect(isTenantlessRoute("/tenants")).toBe(false);
     expect(isTenantlessRoute("/settings/members")).toBe(false);
+    expect(isTenantlessRoute("/settings/account")).toBe(false);
+    expect(isTenantlessRoute("/settings/appearance")).toBe(false);
   });
 
   it("matches whole paths, not prefixes", () => {
-    // "/" must not admit every path, and a deeper settings path is not the account page.
-    expect(isTenantlessRoute("/settings/account/danger")).toBe(false);
+    // "/" must not admit every path.
     expect(isTenantlessRoute("/reports")).toBe(false);
   });
 });

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  TENANTLESS_NAV_HREFS,
+  filterTenantlessNav,
+  isTenantlessRoute,
+} from "./tenantless-navigation";
+
+describe("filterTenantlessNav", () => {
+  it("keeps the cross-tenant dashboard and drops tenant-scoped pages", () => {
+    const items = [
+      { title: "Dashboard", href: "/" },
+      { title: "Calendar", href: "/calendar" },
+      { title: "Clock", href: "/clock" },
+      { title: "Tenants", href: "/tenants" },
+    ];
+
+    expect(filterTenantlessNav(items)).toEqual([{ title: "Dashboard", href: "/" }]);
+  });
+
+  it("keeps only subject-scoped settings children", () => {
+    const items = [
+      {
+        title: "Settings",
+        children: [
+          { title: "Setup", href: "/setup" },
+          { title: "Account", href: "/settings/account" },
+          { title: "Therapy", href: "/settings/profile" },
+          { title: "Appearance", href: "/settings/appearance" },
+          { title: "Sharing & Privacy", href: "/settings/members" },
+        ],
+      },
+    ];
+
+    expect(filterTenantlessNav(items)).toEqual([
+      {
+        title: "Settings",
+        children: [
+          { title: "Account", href: "/settings/account" },
+          { title: "Appearance", href: "/settings/appearance" },
+        ],
+      },
+    ]);
+  });
+
+  it("drops a group whose children are all tenant-scoped, leaving no empty heading", () => {
+    const items = [
+      {
+        title: "Alerts",
+        children: [
+          { title: "Rules", href: "/alerts" },
+          { title: "History", href: "/alerts/history" },
+        ],
+      },
+    ];
+
+    expect(filterTenantlessNav(items)).toEqual([]);
+  });
+
+  it("does not mutate the input", () => {
+    const items = [
+      { title: "Settings", children: [{ title: "Setup", href: "/setup" }] },
+    ];
+
+    filterTenantlessNav(items);
+
+    expect(items[0]!.children).toHaveLength(1);
+  });
+
+  it("drops an item that carries neither an href nor children", () => {
+    const items = [{ title: "Separator", href: undefined }];
+
+    expect(filterTenantlessNav(items)).toEqual([]);
+  });
+});
+
+describe("isTenantlessRoute", () => {
+  it("admits exactly the tenantless hrefs", () => {
+    for (const href of TENANTLESS_NAV_HREFS) {
+      expect(isTenantlessRoute(href)).toBe(true);
+    }
+  });
+
+  it("rejects tenant-scoped routes", () => {
+    expect(isTenantlessRoute("/calendar")).toBe(false);
+    expect(isTenantlessRoute("/tenants")).toBe(false);
+    expect(isTenantlessRoute("/settings/members")).toBe(false);
+  });
+
+  it("matches whole paths, not prefixes", () => {
+    // "/" must not admit every path, and a deeper settings path is not the account page.
+    expect(isTenantlessRoute("/settings/account/danger")).toBe(false);
+    expect(isTenantlessRoute("/reports")).toBe(false);
+  });
+});

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  TENANTLESS_NAV_HREFS,
-  filterTenantlessNav,
-  isTenantlessRoute,
-} from "./tenantless-navigation";
+import { filterTenantlessNav, isTenantlessRoute } from "./tenantless-navigation";
 
 describe("filterTenantlessNav", () => {
   it("keeps the cross-tenant dashboard and drops tenant-scoped pages", () => {
@@ -68,23 +64,7 @@ describe("filterTenantlessNav", () => {
   });
 });
 
-describe("TENANTLESS_NAV_HREFS", () => {
-  it("lists only routes whose data the API serves without a tenant", () => {
-    // The API's tenantless surface (TenantResolutionMiddleware.TenantlessAllowedPaths) admits
-    // the cross-tenant overview and the session/auth endpoints, and nothing else that a page
-    // renders from. Anything added here has to have its endpoints admitted there first, or the
-    // nav gains an entry that 404s.
-    expect(TENANTLESS_NAV_HREFS).toEqual(["/"]);
-  });
-});
-
 describe("isTenantlessRoute", () => {
-  it("admits exactly the tenantless hrefs", () => {
-    for (const href of TENANTLESS_NAV_HREFS) {
-      expect(isTenantlessRoute(href)).toBe(true);
-    }
-  });
-
   it("rejects tenant-scoped routes", () => {
     expect(isTenantlessRoute("/calendar")).toBe(false);
     expect(isTenantlessRoute("/tenants")).toBe(false);

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
@@ -1,0 +1,43 @@
+/**
+ * Navigation filtering for tenantless hosts (the apex and reserved dashboard slugs).
+ *
+ * Almost every page in the app reads or writes one tenant's data, and on a tenantless host there
+ * is no tenant for the API to resolve — those pages would render a shell and then 404. The
+ * tenantless surface is therefore deliberately minimal: the cross-tenant dashboard, plus the
+ * settings that belong to the signed-in subject rather than to a tenant.
+ */
+
+/** Hrefs that are meaningful without a resolved tenant. */
+export const TENANTLESS_NAV_HREFS: readonly string[] = [
+  "/", // the cross-tenant overview
+  "/settings/account", // the subject's own credentials and profile
+  "/settings/appearance", // display preferences, stored per subject
+];
+
+interface NavLike {
+  href?: string;
+  children?: NavLike[];
+}
+
+/**
+ * Keep only the navigation reachable on a tenantless host. A parent whose children are all
+ * tenant-scoped is dropped along with them, so no empty group is left behind.
+ */
+export function filterTenantlessNav<T extends NavLike>(items: readonly T[]): T[] {
+  const allowed = new Set(TENANTLESS_NAV_HREFS);
+
+  return items
+    .map((item) => {
+      if (!item.children) return item;
+      const children = item.children.filter((c) => c.href && allowed.has(c.href));
+      return { ...item, children } as T;
+    })
+    .filter((item) =>
+      item.children ? item.children.length > 0 : !!item.href && allowed.has(item.href)
+    );
+}
+
+/** Whether a pathname is reachable on a tenantless host. */
+export function isTenantlessRoute(pathname: string): boolean {
+  return TENANTLESS_NAV_HREFS.includes(pathname);
+}

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
@@ -3,15 +3,19 @@
  *
  * Almost every page in the app reads or writes one tenant's data, and on a tenantless host there
  * is no tenant for the API to resolve — those pages would render a shell and then 404. The
- * tenantless surface is therefore deliberately minimal: the cross-tenant dashboard, plus the
- * settings that belong to the signed-in subject rather than to a tenant.
+ * tenantless surface is therefore whatever the API admits without a tenant, which today is the
+ * cross-tenant overview and nothing else.
+ *
+ * The account and appearance settings pages look subject-scoped and are not: they call
+ * /api/auth/passkey/*, /api/v4/totp/*, and /api/v4/settings, none of which the API serves off a
+ * tenant. Listing them would put two entries in the sidebar that 404 when opened. Widening the
+ * auth endpoints to tenantless hosts is a security-relevant change, and /api/v4/settings is
+ * genuinely tenant-scoped, so they stay off the list until the API surface catches up.
  */
 
 /** Hrefs that are meaningful without a resolved tenant. */
 export const TENANTLESS_NAV_HREFS: readonly string[] = [
   "/", // the cross-tenant overview
-  "/settings/account", // the subject's own credentials and profile
-  "/settings/appearance", // display preferences, stored per subject
 ];
 
 interface NavLike {

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
@@ -13,7 +13,14 @@
  * genuinely tenant-scoped, so they stay off the list until the API surface catches up.
  */
 
-/** Hrefs that are meaningful without a resolved tenant. */
+/**
+ * Hrefs that are meaningful without a resolved tenant.
+ *
+ * The API's tenantless surface (TenantResolutionMiddleware.TenantlessAllowedPaths) admits the
+ * cross-tenant overview and the session/auth endpoints, and nothing else that a page renders
+ * from. Anything added here has to have its endpoints admitted there first, or the nav gains an
+ * entry that 404s.
+ */
 export const TENANTLESS_NAV_HREFS: readonly string[] = [
   "/", // the cross-tenant overview
 ];

--- a/src/Web/packages/app/src/lib/server/api-client-factory.ts
+++ b/src/Web/packages/app/src/lib/server/api-client-factory.ts
@@ -27,6 +27,12 @@ export interface ServerHttpClientOptions {
   hashedInstanceKey?: string | null;
   extraHeaders?: Record<string, string>;
   responseCookies?: CookieSetter;
+  /**
+   * Sink for Set-Cookie headers that SvelteKit's name-keyed cookie jar cannot hold — the
+   * host-scoped half of a deliberate pair. A handler appends these to the outgoing response
+   * verbatim. See propagateAuthCookies.
+   */
+  rawSetCookies?: string[];
   signal?: AbortSignal;
 }
 
@@ -98,9 +104,11 @@ export function createServerHttpClient(
       });
 
       if (options?.responseCookies) {
+        const rawSink = options.rawSetCookies;
         propagateAuthCookies(
           response.headers.getSetCookie(),
-          options.responseCookies
+          options.responseCookies,
+          rawSink && ((header) => rawSink.push(header))
         );
       }
 

--- a/src/Web/packages/app/src/lib/server/api-client-factory.ts
+++ b/src/Web/packages/app/src/lib/server/api-client-factory.ts
@@ -28,9 +28,8 @@ export interface ServerHttpClientOptions {
   extraHeaders?: Record<string, string>;
   responseCookies?: CookieSetter;
   /**
-   * Sink for Set-Cookie headers that SvelteKit's name-keyed cookie jar cannot hold — the
-   * host-scoped half of a deliberate pair. A handler appends these to the outgoing response
-   * verbatim. See propagateAuthCookies.
+   * Sink for Set-Cookie headers SvelteKit's cookie jar cannot hold, appended verbatim to the
+   * outgoing response by a handler. See propagateAuthCookies.
    */
   rawSetCookies?: string[];
   signal?: AbortSignal;

--- a/src/Web/packages/app/src/lib/server/api-proxy-headers.test.ts
+++ b/src/Web/packages/app/src/lib/server/api-proxy-headers.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
+import { buildProxyHeaders } from "./api-proxy-headers";
+
+const JAR: Record<string, string> = {
+  [AUTH_COOKIE_NAMES.accessToken]: "access-value",
+  [AUTH_COOKIE_NAMES.refreshToken]: "refresh-value",
+  [AUTH_COOKIE_NAMES.guestSession]: "guest-value",
+  [AUTH_COOKIE_NAMES.platformAccess]: "platform-value",
+};
+
+const cookies = { get: (name: string) => JAR[name] };
+const emptyCookies = { get: () => undefined };
+
+/** A browser request to a share host: the widened cookie domain means it carries the session. */
+function shareRequestHeaders(): Headers {
+  return new Headers({
+    Cookie: `${AUTH_COOKIE_NAMES.accessToken}=access-value; ${AUTH_COOKIE_NAMES.refreshToken}=refresh-value`,
+    Accept: "application/json",
+  });
+}
+
+describe("buildProxyHeaders", () => {
+  it("sends no cookies to the API from a share host", () => {
+    const headers = buildProxyHeaders({
+      requestHeaders: shareRequestHeaders(),
+      effectiveHost: "tok.share.nocturne.run",
+      proto: "https",
+      isShareHost: true,
+      cookies,
+    });
+
+    // Both halves matter: the jar must not be read, AND the raw Cookie header copied from the
+    // browser request must be removed — it already carries the session and refresh tokens.
+    expect(headers.has("Cookie")).toBe(false);
+    expect([...headers.keys()].map((k) => k.toLowerCase())).not.toContain("cookie");
+  });
+
+  it("keeps forwarding the caller's cookies off a share host", () => {
+    const headers = buildProxyHeaders({
+      requestHeaders: new Headers(),
+      effectiveHost: "acme.nocturne.run",
+      proto: "https",
+      isShareHost: false,
+      cookies,
+    });
+
+    const cookie = headers.get("Cookie")!;
+    expect(cookie).toContain(`${AUTH_COOKIE_NAMES.accessToken}=access-value`);
+    expect(cookie).toContain(`${AUTH_COOKIE_NAMES.refreshToken}=refresh-value`);
+    expect(cookie).toContain(`${AUTH_COOKIE_NAMES.guestSession}=guest-value`);
+    expect(cookie).toContain(`${AUTH_COOKIE_NAMES.platformAccess}=platform-value`);
+  });
+
+  it("leaves the incoming Cookie header alone when the jar holds no auth cookies", () => {
+    const headers = buildProxyHeaders({
+      requestHeaders: new Headers({ Cookie: "nocturne-language=fr" }),
+      effectiveHost: "acme.nocturne.run",
+      proto: "https",
+      isShareHost: false,
+      cookies: emptyCookies,
+    });
+
+    // Non-auth cookies (locale, preferences) are not the proxy's business to strip.
+    expect(headers.get("Cookie")).toBe("nocturne-language=fr");
+  });
+
+  it("strips client-supplied instance auth on every host", () => {
+    for (const isShareHost of [true, false]) {
+      const headers = buildProxyHeaders({
+        requestHeaders: new Headers({
+          "X-Instance-Key": "smuggled",
+          "X-Instance-Service": "web",
+        }),
+        effectiveHost: "acme.nocturne.run",
+        proto: "https",
+        isShareHost,
+        cookies: emptyCookies,
+      });
+
+      expect(headers.has("X-Instance-Key")).toBe(false);
+      expect(headers.has("X-Instance-Service")).toBe(false);
+    }
+  });
+
+  it("forwards the host and scheme the browser used", () => {
+    const headers = buildProxyHeaders({
+      requestHeaders: new Headers(),
+      effectiveHost: "acme.nocturne.run",
+      proto: "https",
+      isShareHost: false,
+      cookies: emptyCookies,
+    });
+
+    expect(headers.get("X-Forwarded-Host")).toBe("acme.nocturne.run");
+    expect(headers.get("X-Forwarded-Proto")).toBe("https");
+  });
+
+  it("omits the forwarded host when there is none to forward", () => {
+    const headers = buildProxyHeaders({
+      requestHeaders: new Headers(),
+      effectiveHost: null,
+      proto: "http",
+      isShareHost: false,
+      cookies: emptyCookies,
+    });
+
+    expect(headers.has("X-Forwarded-Host")).toBe(false);
+  });
+});

--- a/src/Web/packages/app/src/lib/server/api-proxy-headers.ts
+++ b/src/Web/packages/app/src/lib/server/api-proxy-headers.ts
@@ -1,0 +1,72 @@
+import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
+
+/** The subset of SvelteKit's Cookies the proxy reads. */
+export interface ProxyCookieReader {
+  get(name: string): string | undefined;
+}
+
+export interface ProxyHeaderInput {
+  /** Headers of the incoming browser request, forwarded onward as-is apart from the below. */
+  requestHeaders: Headers;
+  /** Host the API should resolve the tenant from, or null to leave the header off. */
+  effectiveHost: string | null | undefined;
+  /** Scheme the browser used, for the API's URL building behind the proxy. */
+  proto: string;
+  /** Whether this request arrived on a public share host. */
+  isShareHost: boolean;
+  cookies: ProxyCookieReader;
+}
+
+/**
+ * Headers for one proxied /api request.
+ *
+ * This proxy carries end-user browser calls, so it forwards only the user's own credentials and
+ * never the instance key — attaching that would authenticate anonymous visitors as admin and
+ * bypass per-tenant public access. Any client-supplied instance headers are stripped for the
+ * same reason.
+ *
+ * On a share host it forwards no credentials at all. That host is anonymous for everyone,
+ * including the owner of the data behind it, and since session cookies are scoped to
+ * ".{base-domain}" the browser now presents them here — so the incoming Cookie header has to be
+ * dropped, not merely left unread.
+ */
+export function buildProxyHeaders({
+  requestHeaders,
+  effectiveHost,
+  proto,
+  isShareHost,
+  cookies,
+}: ProxyHeaderInput): Headers {
+  const headers = new Headers(requestHeaders);
+
+  if (effectiveHost) {
+    headers.set("X-Forwarded-Host", effectiveHost);
+  }
+  headers.set("X-Forwarded-Proto", proto);
+
+  headers.delete("X-Instance-Key");
+  headers.delete("X-Instance-Service");
+
+  if (isShareHost) {
+    headers.delete("Cookie");
+    return headers;
+  }
+
+  const forwarded = [
+    AUTH_COOKIE_NAMES.accessToken,
+    AUTH_COOKIE_NAMES.refreshToken,
+    AUTH_COOKIE_NAMES.guestSession,
+    AUTH_COOKIE_NAMES.platformAccess,
+  ]
+    .map((name) => {
+      const value = cookies.get(name);
+      return value ? `${name}=${value}` : null;
+    })
+    .filter((pair) => pair !== null);
+
+  if (forwarded.length > 0) {
+    headers.set("Cookie", forwarded.join("; "));
+  }
+
+  return headers;
+}

--- a/src/Web/packages/app/src/lib/server/api-proxy-headers.ts
+++ b/src/Web/packages/app/src/lib/server/api-proxy-headers.ts
@@ -25,10 +25,9 @@ export interface ProxyHeaderInput {
  * bypass per-tenant public access. Any client-supplied instance headers are stripped for the
  * same reason.
  *
- * On a share host it forwards no credentials at all. That host is anonymous for everyone,
- * including the owner of the data behind it, and since session cookies are scoped to
- * ".{base-domain}" the browser now presents them here — so the incoming Cookie header has to be
- * dropped, not merely left unread.
+ * On a share host it forwards no credentials at all (see authHandle). Here the incoming Cookie
+ * header has to be deleted rather than merely left unread, since it is passed through onward
+ * as-is.
  */
 export function buildProxyHeaders({
   requestHeaders,

--- a/src/Web/packages/app/src/lib/server/auth-cookie-propagation.test.ts
+++ b/src/Web/packages/app/src/lib/server/auth-cookie-propagation.test.ts
@@ -222,3 +222,96 @@ describe("propagateAuthCookies", () => {
     });
   });
 });
+
+describe("propagateAuthCookies with a same-name pair", () => {
+  const EXPIRED = "Thu, 01 Jan 1970 00:00:00 GMT";
+
+  /** What the API emits on sign-out: the domain-wide cookie and the pre-widening host-scoped one. */
+  const signOutHeaders = [
+    `${AUTH_COOKIE_NAMES.accessToken}=; Path=/; Expires=${EXPIRED}`,
+    `${AUTH_COOKIE_NAMES.accessToken}=; Path=/; Domain=.nocturne.run; Expires=${EXPIRED}`,
+    `${AUTH_COOKIE_NAMES.refreshToken}=; Path=/; Expires=${EXPIRED}`,
+    `${AUTH_COOKIE_NAMES.refreshToken}=; Path=/; Domain=.nocturne.run; Expires=${EXPIRED}`,
+  ];
+
+  /** What the API emits on a silent refresh: host-scoped expiry, then the domain-wide value. */
+  const refreshHeaders = [
+    `${AUTH_COOKIE_NAMES.accessToken}=; Path=/; Expires=${EXPIRED}`,
+    `${AUTH_COOKIE_NAMES.accessToken}=rotated; Path=/; Domain=.nocturne.run; HttpOnly; Secure; SameSite=Lax; Max-Age=900`,
+  ];
+
+  it("keeps both halves of a sign-out pair alive", () => {
+    const { cookies, calls } = createRecordingCookies();
+    const raw: string[] = [];
+
+    propagateAuthCookies(signOutHeaders, cookies, (h) => raw.push(h));
+
+    // SvelteKit's jar keys pending cookies by name alone, so passing both halves through it
+    // would drop one — leaving a host-scoped access token valid on the tenant host for the rest
+    // of its lifetime after the user signed out.
+    for (const name of [AUTH_COOKIE_NAMES.accessToken, AUTH_COOKIE_NAMES.refreshToken]) {
+      expect(calls).toContainEqual({
+        op: "delete",
+        name,
+        opts: { path: "/", domain: ".nocturne.run" },
+      });
+      expect(raw).toContainEqual(`${name}=; Path=/; Expires=${EXPIRED}`);
+    }
+    expect(calls).toHaveLength(2);
+    expect(raw).toHaveLength(2);
+  });
+
+  it("keeps the host-scoped expiry alongside the rotated domain-wide value", () => {
+    const { cookies, calls } = createRecordingCookies();
+    const raw: string[] = [];
+
+    propagateAuthCookies(refreshHeaders, cookies, (h) => raw.push(h));
+
+    // Losing the expiry leaves the stale host-scoped cookie in the browser for its full life,
+    // and the browser sends both under one indistinguishable Cookie header.
+    expect(calls).toEqual([
+      {
+        op: "set",
+        name: AUTH_COOKIE_NAMES.accessToken,
+        value: "rotated",
+        opts: {
+          path: "/",
+          domain: ".nocturne.run",
+          httpOnly: true,
+          secure: true,
+          sameSite: "lax",
+          maxAge: 900,
+        },
+      },
+    ]);
+    expect(raw).toEqual([
+      `${AUTH_COOKIE_NAMES.accessToken}=; Path=/; Expires=${EXPIRED}`,
+    ]);
+  });
+
+  it("routes a lone host-scoped cookie through the jar, not the raw sink", () => {
+    const { cookies, calls } = createRecordingCookies();
+    const raw: string[] = [];
+
+    // A host-only deployment (localhost, an IP literal) emits no domain-wide sibling at all.
+    propagateAuthCookies(
+      [`${AUTH_COOKIE_NAMES.accessToken}=t; Path=/; HttpOnly; Secure`],
+      cookies,
+      (h) => raw.push(h)
+    );
+
+    expect(raw).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ op: "set", name: AUTH_COOKIE_NAMES.accessToken });
+  });
+
+  it("keeps the domain-wide half when no sink is supplied", () => {
+    const { cookies, calls } = createRecordingCookies();
+
+    propagateAuthCookies(signOutHeaders, cookies);
+
+    // No worse than before the sink existed: the wide cookie, which every host presents, is the
+    // one that has to go.
+    expect(calls.filter((c) => c.opts.domain === ".nocturne.run")).toHaveLength(2);
+  });
+});

--- a/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
+++ b/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
@@ -45,15 +45,37 @@ const AUTH_COOKIE_SET: ReadonlySet<string> = new Set([
  *
  * Only auth cookies are propagated; unrelated Set-Cookie headers from the
  * backend are ignored.
+ *
+ * The API deliberately emits some cookies twice under one name: a host-scoped
+ * expiry alongside the domain-wide value or expiry, so a browser holding a
+ * cookie from before the domain was widened converges on the wide one, and so
+ * sign-out clears both. SvelteKit's cookie jar is keyed by name alone and would
+ * keep only the last of such a pair — silently defeating both. `emitRaw`
+ * receives the host-scoped half verbatim, for a caller to append to the
+ * response as its own Set-Cookie header. Without it, only the domain-wide half
+ * survives, which is the older behaviour and no worse than it was.
  */
 export function propagateAuthCookies(
   setCookieHeaders: readonly string[],
-  cookies: CookieSetter
+  cookies: CookieSetter,
+  emitRaw?: (header: string) => void
 ): void {
   for (const header of setCookieHeaders) {
     const parsed = parseSetCookieHeader(header);
     if (!parsed) continue;
     if (!AUTH_COOKIE_SET.has(parsed.name)) continue;
+
+    // The pair is distinguished by the Domain attribute, so a host-scoped header that shares
+    // its name with a domain-wide one is the half the jar cannot hold. Passed through raw,
+    // attributes untouched, since nothing else in the request needs to observe it.
+    if (
+      emitRaw &&
+      parsed.domain === undefined &&
+      hasDomainWideSibling(setCookieHeaders, parsed.name)
+    ) {
+      emitRaw(header);
+      continue;
+    }
 
     if (parsed.isDeletion) {
       cookies.delete(parsed.name, {
@@ -75,6 +97,17 @@ export function propagateAuthCookies(
 
     cookies.set(parsed.name, parsed.value, opts);
   }
+}
+
+/** Whether another header of the same name carries a Domain attribute. */
+function hasDomainWideSibling(
+  setCookieHeaders: readonly string[],
+  name: string
+): boolean {
+  return setCookieHeaders.some((header) => {
+    const parsed = parseSetCookieHeader(header);
+    return parsed?.name === name && parsed.domain !== undefined;
+  });
 }
 
 interface ParsedSetCookie {

--- a/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
+++ b/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
@@ -65,9 +65,8 @@ export function propagateAuthCookies(
     if (!parsed) continue;
     if (!AUTH_COOKIE_SET.has(parsed.name)) continue;
 
-    // The pair is distinguished by the Domain attribute, so a host-scoped header that shares
-    // its name with a domain-wide one is the half the jar cannot hold. Passed through raw,
-    // attributes untouched, since nothing else in the request needs to observe it.
+    // The pair is distinguished by the Domain attribute, so the host-scoped header is the half
+    // routed to `emitRaw`.
     if (
       emitRaw &&
       parsed.domain === undefined &&

--- a/src/Web/packages/app/src/lib/server/onboarding-check.test.ts
+++ b/src/Web/packages/app/src/lib/server/onboarding-check.test.ts
@@ -92,6 +92,36 @@ describe("checkOnboarding", () => {
     expect(result).toEqual({ isComplete: true });
   });
 
+  it("returns isComplete: false on the 503 the API serves when no tenant exists", async () => {
+    // The fresh-install signal, and the only one available on a host that resolves no tenant:
+    // the status endpoint reports "setup_required" for a populated multi-tenant apex too.
+    const { cookies } = createCookies();
+    const getAuthStatus = vi.fn().mockRejectedValue({ status: 503 });
+
+    const result = await checkOnboarding(
+      cookies,
+      { passkey: { getAuthStatus } },
+      true,
+    );
+
+    expect(result).toEqual({ isComplete: false });
+  });
+
+  it("returns isComplete: true on the 404 a populated tenantless host serves", async () => {
+    // A multi-tenant apex or a reserved dashboard slug: tenants exist, this host just names
+    // none of them. Sending it to the fresh-install wizard would be wrong.
+    const { cookies } = createCookies();
+    const getAuthStatus = vi.fn().mockRejectedValue({ status: 404 });
+
+    const result = await checkOnboarding(
+      cookies,
+      { passkey: { getAuthStatus } },
+      true,
+    );
+
+    expect(result).toEqual({ isComplete: true });
+  });
+
   it("returns isComplete: true when the request aborts (timeout)", async () => {
     const { cookies } = createCookies();
     const getAuthStatus = vi.fn().mockImplementation(

--- a/src/Web/packages/app/src/lib/server/onboarding-check.ts
+++ b/src/Web/packages/app/src/lib/server/onboarding-check.ts
@@ -12,6 +12,11 @@ export interface OnboardingResult {
  * serves on a host that names no tenant. It is the one API failure that positively identifies a
  * fresh install: every other host with no resolved tenant (a multi-tenant apex, a reserved
  * dashboard slug, an unknown subdomain) gets a 404 instead.
+ *
+ * Only sound for an endpoint marked [AllowDuringSetup]. TenantSetupMiddleware serves its own 503
+ * to every other endpoint while an instance awaits first-run setup, which this would read as the
+ * tenant-resolution 503 and so as a fresh install. GET /api/auth/passkey/status, the caller
+ * below, is [AllowDuringSetup] and short-circuits that middleware.
  */
 export function isFreshInstallError(err: unknown): boolean {
   return !!err && typeof err === "object" && "status" in err && err.status === 503;

--- a/src/Web/packages/app/src/lib/server/onboarding-check.ts
+++ b/src/Web/packages/app/src/lib/server/onboarding-check.ts
@@ -8,6 +8,16 @@ export interface OnboardingResult {
 }
 
 /**
+ * Whether an API failure is the "no tenant exists yet" 503 the tenant-resolution middleware
+ * serves on a host that names no tenant. It is the one API failure that positively identifies a
+ * fresh install: every other host with no resolved tenant (a multi-tenant apex, a reserved
+ * dashboard slug, an unknown subdomain) gets a 404 instead.
+ */
+export function isFreshInstallError(err: unknown): boolean {
+  return !!err && typeof err === "object" && "status" in err && err.status === 503;
+}
+
+/**
  * Check if onboarding has been completed.
  * Fast path: cookie check (no API call).
  * Slow path: if cookie missing, query the API and re-set the cookie if complete.
@@ -39,7 +49,14 @@ export async function checkOnboarding(
       return { isComplete: true };
     }
     return { isComplete: false };
-  } catch {
+  } catch (err) {
+    // No tenant exists yet: onboarding is genuinely incomplete, and this is the only signal
+    // for it on a host that resolves no tenant — the status endpoint says "setup_required"
+    // for a populated multi-tenant apex too.
+    if (isFreshInstallError(err)) {
+      return { isComplete: false };
+    }
+
     // API unreachable or timed out — allow through rather than trapping users
     // in a redirect loop. The setup layout invalidates this cookie on entry,
     // so falling through to /setup here would just re-trigger the slow path

--- a/src/Web/packages/app/src/lib/server/request-status.ts
+++ b/src/Web/packages/app/src/lib/server/request-status.ts
@@ -1,0 +1,17 @@
+/**
+ * The tenant status for the current request, fetched at most once.
+ *
+ * Several loads need it — the root layout to tell an apex that resolves a tenant from one that
+ * does not, the authenticated layout for the anonymous-access gate and the demo banner — and
+ * they run on every page load, so without sharing one promise each page costs an extra
+ * round-trip to the API for an answer that cannot change mid-request.
+ *
+ * A failed call resolves to null rather than rejecting: every caller has a conservative default
+ * and none of them should turn an unreachable status endpoint into a 500.
+ */
+export function getRequestStatus(locals: App.Locals): Promise<App.TenantStatus | null> {
+  locals.statusPromise ??= locals.apiClient.status
+    .getStatus()
+    .catch(() => null);
+  return locals.statusPromise;
+}

--- a/src/Web/packages/app/src/lib/server/request-status.ts
+++ b/src/Web/packages/app/src/lib/server/request-status.ts
@@ -7,7 +7,9 @@
  * round-trip to the API for an answer that cannot change mid-request.
  *
  * A failed call resolves to null rather than rejecting: every caller has a conservative default
- * and none of them should turn an unreachable status endpoint into a 500.
+ * and none of them should turn an unreachable status endpoint into a 500. For the apex that means
+ * a failed call answers "no tenant", which is the safe direction — the dashboard renders for any
+ * signed-in subject, whereas the tenant app would render a shell over an API resolving nothing.
  */
 export function getRequestStatus(locals: App.Locals): Promise<App.TenantStatus | null> {
   locals.statusPromise ??= locals.apiClient.status

--- a/src/Web/packages/app/src/lib/server/tenantless-host.test.ts
+++ b/src/Web/packages/app/src/lib/server/tenantless-host.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_DASHBOARD_SLUGS,
+  apexResolvedTenant,
   classifyHost,
   isTenantlessHost,
   parseDashboardSlugs,
@@ -25,13 +26,13 @@ describe("parseDashboardSlugs", () => {
 });
 
 describe("classifyHost", () => {
-  it("classifies the apex as tenantless", () => {
-    expect(classifyHost(BASE, BASE)).toEqual({ kind: "tenantless", slug: null });
+  it("classifies the apex as the apex, leaving whether it serves a tenant to the API", () => {
+    expect(classifyHost(BASE, BASE)).toEqual({ kind: "apex", slug: null });
   });
 
   it("ignores ports on both sides", () => {
     expect(classifyHost("nocturne.run:1612", "nocturne.run")).toEqual({
-      kind: "tenantless",
+      kind: "apex",
       slug: null,
     });
     expect(classifyHost("acme.nocturne.run:1612", "nocturne.run:1612")).toEqual({
@@ -44,10 +45,10 @@ describe("classifyHost", () => {
     expect(classifyHost("AcMe.nocturne.run", BASE)).toEqual({ kind: "tenant", slug: "AcMe" });
   });
 
-  it("classifies reserved dashboard slugs as tenantless", () => {
-    expect(classifyHost("dashboard.nocturne.run", BASE).kind).toBe("tenantless");
-    expect(classifyHost("app.nocturne.run", BASE).kind).toBe("tenantless");
-    expect(classifyHost("DASHBOARD.nocturne.run", BASE).kind).toBe("tenantless");
+  it("classifies reserved dashboard slugs as dashboard slugs", () => {
+    expect(classifyHost("dashboard.nocturne.run", BASE).kind).toBe("dashboard-slug");
+    expect(classifyHost("app.nocturne.run", BASE).kind).toBe("dashboard-slug");
+    expect(classifyHost("DASHBOARD.nocturne.run", BASE).kind).toBe("dashboard-slug");
   });
 
   it("treats a reserved slug as a tenant once it is no longer reserved", () => {
@@ -76,8 +77,8 @@ describe("classifyHost", () => {
 
   it("is suffix-based, not label-counting, for multi-label base domains", () => {
     const deep = "nocturne.example.com";
-    expect(classifyHost(deep, deep).kind).toBe("tenantless");
-    expect(classifyHost("dashboard.nocturne.example.com", deep).kind).toBe("tenantless");
+    expect(classifyHost(deep, deep).kind).toBe("apex");
+    expect(classifyHost("dashboard.nocturne.example.com", deep).kind).toBe("dashboard-slug");
     expect(classifyHost("acme.nocturne.example.com", deep)).toEqual({
       kind: "tenant",
       slug: "acme",
@@ -91,11 +92,50 @@ describe("classifyHost", () => {
 });
 
 describe("isTenantlessHost", () => {
-  it("is true only for the apex and reserved slugs", () => {
-    expect(isTenantlessHost(BASE, BASE)).toBe(true);
-    expect(isTenantlessHost("dashboard.nocturne.run", BASE)).toBe(true);
-    expect(isTenantlessHost("acme.nocturne.run", BASE)).toBe(false);
-    expect(isTenantlessHost("tok.share.nocturne.run", BASE)).toBe(false);
-    expect(isTenantlessHost("evil.com", BASE)).toBe(false);
+  it("serves the full app on an apex that resolves a sole tenant", () => {
+    // The single-tenant self-hosted install: nocturne.example.com IS the app. Calling it
+    // tenantless trims its sidebar and bounces it to a wildcard subdomain that, per the
+    // deployment's TLS shape, may not resolve or may present an invalid certificate.
+    expect(isTenantlessHost("apex", true)).toBe(false);
+  });
+
+  it("serves the dashboard on an apex that resolves nothing", () => {
+    // Zero tenants, or several: either way the apex names no tenant of its own.
+    expect(isTenantlessHost("apex", false)).toBe(true);
+  });
+
+  it("serves the dashboard on a reserved slug regardless of what the apex resolves", () => {
+    expect(isTenantlessHost("dashboard-slug", true)).toBe(true);
+    expect(isTenantlessHost("dashboard-slug", false)).toBe(true);
+  });
+
+  it("never serves the dashboard on a tenant, share, or unrelated host", () => {
+    for (const resolved of [true, false]) {
+      expect(isTenantlessHost("tenant", resolved)).toBe(false);
+      expect(isTenantlessHost("share", resolved)).toBe(false);
+      expect(isTenantlessHost("unknown", resolved)).toBe(false);
+    }
+  });
+});
+
+describe("apexResolvedTenant", () => {
+  it("reports the tenant the API resolved for this request", async () => {
+    await expect(apexResolvedTenant(async () => ({ tenantSlug: "theconen" }))).resolves.toBe(true);
+  });
+
+  it("reports no tenant when the status names none", async () => {
+    await expect(apexResolvedTenant(async () => ({ tenantSlug: null }))).resolves.toBe(false);
+    await expect(apexResolvedTenant(async () => ({}))).resolves.toBe(false);
+    await expect(apexResolvedTenant(async () => null)).resolves.toBe(false);
+  });
+
+  it("reports no tenant when status cannot be reached", async () => {
+    // Falling back to the dashboard is the recoverable direction: it renders for any signed-in
+    // subject, whereas the tenant app would render a shell over an API resolving nothing.
+    await expect(
+      apexResolvedTenant(async () => {
+        throw new Error("API unreachable");
+      })
+    ).resolves.toBe(false);
   });
 });

--- a/src/Web/packages/app/src/lib/server/tenantless-host.test.ts
+++ b/src/Web/packages/app/src/lib/server/tenantless-host.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DASHBOARD_SLUGS,
+  classifyHost,
+  isTenantlessHost,
+  parseDashboardSlugs,
+} from "./tenantless-host";
+
+const BASE = "nocturne.run";
+
+describe("parseDashboardSlugs", () => {
+  it("takes the defaults when unset", () => {
+    expect(parseDashboardSlugs(undefined)).toEqual(DEFAULT_DASHBOARD_SLUGS);
+    expect(parseDashboardSlugs(null)).toEqual(DEFAULT_DASHBOARD_SLUGS);
+  });
+
+  it("reserves nothing when explicitly empty", () => {
+    expect(parseDashboardSlugs("")).toEqual([]);
+    expect(parseDashboardSlugs("  ")).toEqual([]);
+  });
+
+  it("splits, trims, and lowercases", () => {
+    expect(parseDashboardSlugs(" Home , Portal ")).toEqual(["home", "portal"]);
+  });
+});
+
+describe("classifyHost", () => {
+  it("classifies the apex as tenantless", () => {
+    expect(classifyHost(BASE, BASE)).toEqual({ kind: "tenantless", slug: null });
+  });
+
+  it("ignores ports on both sides", () => {
+    expect(classifyHost("nocturne.run:1612", "nocturne.run")).toEqual({
+      kind: "tenantless",
+      slug: null,
+    });
+    expect(classifyHost("acme.nocturne.run:1612", "nocturne.run:1612")).toEqual({
+      kind: "tenant",
+      slug: "acme",
+    });
+  });
+
+  it("classifies a tenant subdomain, preserving slug casing", () => {
+    expect(classifyHost("AcMe.nocturne.run", BASE)).toEqual({ kind: "tenant", slug: "AcMe" });
+  });
+
+  it("classifies reserved dashboard slugs as tenantless", () => {
+    expect(classifyHost("dashboard.nocturne.run", BASE).kind).toBe("tenantless");
+    expect(classifyHost("app.nocturne.run", BASE).kind).toBe("tenantless");
+    expect(classifyHost("DASHBOARD.nocturne.run", BASE).kind).toBe("tenantless");
+  });
+
+  it("treats a reserved slug as a tenant once it is no longer reserved", () => {
+    expect(classifyHost("app.nocturne.run", BASE, ["dashboard"])).toEqual({
+      kind: "tenant",
+      slug: "app",
+    });
+  });
+
+  it("classifies a share host as share, never as tenant or dashboard", () => {
+    expect(classifyHost("k7m2q9x4r3wt.share.nocturne.run", BASE)).toEqual({
+      kind: "share",
+      slug: null,
+    });
+    // A share token that happens to spell a reserved slug is still a share host.
+    expect(classifyHost("dashboard.share.nocturne.run", BASE).kind).toBe("share");
+  });
+
+  it("classifies unrelated hosts and missing config as unknown", () => {
+    expect(classifyHost("evil.com", BASE).kind).toBe("unknown");
+    // Suffix match, not substring: a host that merely ends with the base domain's text.
+    expect(classifyHost("notnocturne.run", BASE).kind).toBe("unknown");
+    expect(classifyHost(BASE, null).kind).toBe("unknown");
+    expect(classifyHost(null, BASE).kind).toBe("unknown");
+  });
+
+  it("is suffix-based, not label-counting, for multi-label base domains", () => {
+    const deep = "nocturne.example.com";
+    expect(classifyHost(deep, deep).kind).toBe("tenantless");
+    expect(classifyHost("dashboard.nocturne.example.com", deep).kind).toBe("tenantless");
+    expect(classifyHost("acme.nocturne.example.com", deep)).toEqual({
+      kind: "tenant",
+      slug: "acme",
+    });
+    // A three-label host under a two-label base is a tenant, not an apex.
+    expect(classifyHost("acme.example.com", "example.com")).toEqual({
+      kind: "tenant",
+      slug: "acme",
+    });
+  });
+});
+
+describe("isTenantlessHost", () => {
+  it("is true only for the apex and reserved slugs", () => {
+    expect(isTenantlessHost(BASE, BASE)).toBe(true);
+    expect(isTenantlessHost("dashboard.nocturne.run", BASE)).toBe(true);
+    expect(isTenantlessHost("acme.nocturne.run", BASE)).toBe(false);
+    expect(isTenantlessHost("tok.share.nocturne.run", BASE)).toBe(false);
+    expect(isTenantlessHost("evil.com", BASE)).toBe(false);
+  });
+});

--- a/src/Web/packages/app/src/lib/server/tenantless-host.test.ts
+++ b/src/Web/packages/app/src/lib/server/tenantless-host.test.ts
@@ -10,9 +10,10 @@ import {
 const BASE = "nocturne.run";
 
 describe("parseDashboardSlugs", () => {
-  it("takes the defaults when unset", () => {
-    expect(parseDashboardSlugs(undefined)).toEqual(DEFAULT_DASHBOARD_SLUGS);
-    expect(parseDashboardSlugs(null)).toEqual(DEFAULT_DASHBOARD_SLUGS);
+  it("reserves nothing when unset, so reserving a slug stays opt-in", () => {
+    expect(DEFAULT_DASHBOARD_SLUGS).toEqual([]);
+    expect(parseDashboardSlugs(undefined)).toEqual([]);
+    expect(parseDashboardSlugs(null)).toEqual([]);
   });
 
   it("reserves nothing when explicitly empty", () => {
@@ -46,15 +47,20 @@ describe("classifyHost", () => {
   });
 
   it("classifies reserved dashboard slugs as dashboard slugs", () => {
-    expect(classifyHost("dashboard.nocturne.run", BASE).kind).toBe("dashboard-slug");
-    expect(classifyHost("app.nocturne.run", BASE).kind).toBe("dashboard-slug");
-    expect(classifyHost("DASHBOARD.nocturne.run", BASE).kind).toBe("dashboard-slug");
+    const reserved = ["dashboard", "app"];
+    expect(classifyHost("dashboard.nocturne.run", BASE, reserved).kind).toBe("dashboard-slug");
+    expect(classifyHost("app.nocturne.run", BASE, reserved).kind).toBe("dashboard-slug");
+    expect(classifyHost("DASHBOARD.nocturne.run", BASE, reserved).kind).toBe("dashboard-slug");
   });
 
-  it("treats a reserved slug as a tenant once it is no longer reserved", () => {
+  it("treats an unreserved slug as a tenant, which is every slug by default", () => {
     expect(classifyHost("app.nocturne.run", BASE, ["dashboard"])).toEqual({
       kind: "tenant",
       slug: "app",
+    });
+    expect(classifyHost("dashboard.nocturne.run", BASE)).toEqual({
+      kind: "tenant",
+      slug: "dashboard",
     });
   });
 
@@ -78,7 +84,9 @@ describe("classifyHost", () => {
   it("is suffix-based, not label-counting, for multi-label base domains", () => {
     const deep = "nocturne.example.com";
     expect(classifyHost(deep, deep).kind).toBe("apex");
-    expect(classifyHost("dashboard.nocturne.example.com", deep).kind).toBe("dashboard-slug");
+    expect(classifyHost("dashboard.nocturne.example.com", deep, ["dashboard"]).kind).toBe(
+      "dashboard-slug"
+    );
     expect(classifyHost("acme.nocturne.example.com", deep)).toEqual({
       kind: "tenant",
       slug: "acme",

--- a/src/Web/packages/app/src/lib/server/tenantless-host.test.ts
+++ b/src/Web/packages/app/src/lib/server/tenantless-host.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  DEFAULT_DASHBOARD_SLUGS,
-  apexResolvedTenant,
   classifyHost,
   isTenantlessHost,
   parseDashboardSlugs,
@@ -11,7 +9,6 @@ const BASE = "nocturne.run";
 
 describe("parseDashboardSlugs", () => {
   it("reserves nothing when unset, so reserving a slug stays opt-in", () => {
-    expect(DEFAULT_DASHBOARD_SLUGS).toEqual([]);
     expect(parseDashboardSlugs(undefined)).toEqual([]);
     expect(parseDashboardSlugs(null)).toEqual([]);
   });
@@ -123,27 +120,5 @@ describe("isTenantlessHost", () => {
       expect(isTenantlessHost("share", resolved)).toBe(false);
       expect(isTenantlessHost("unknown", resolved)).toBe(false);
     }
-  });
-});
-
-describe("apexResolvedTenant", () => {
-  it("reports the tenant the API resolved for this request", async () => {
-    await expect(apexResolvedTenant(async () => ({ tenantSlug: "theconen" }))).resolves.toBe(true);
-  });
-
-  it("reports no tenant when the status names none", async () => {
-    await expect(apexResolvedTenant(async () => ({ tenantSlug: null }))).resolves.toBe(false);
-    await expect(apexResolvedTenant(async () => ({}))).resolves.toBe(false);
-    await expect(apexResolvedTenant(async () => null)).resolves.toBe(false);
-  });
-
-  it("reports no tenant when status cannot be reached", async () => {
-    // Falling back to the dashboard is the recoverable direction: it renders for any signed-in
-    // subject, whereas the tenant app would render a shell over an API resolving nothing.
-    await expect(
-      apexResolvedTenant(async () => {
-        throw new Error("API unreachable");
-      })
-    ).resolves.toBe(false);
   });
 });

--- a/src/Web/packages/app/src/lib/server/tenantless-host.ts
+++ b/src/Web/packages/app/src/lib/server/tenantless-host.ts
@@ -4,8 +4,8 @@
  * Most hosts name a tenant ({slug}.{base-domain}). Two do not, and either may serve the
  * cross-tenant caregiver dashboard instead of a single tenant's app:
  *
- * - a reserved dashboard slug (dashboard.{base-domain}, app.{base-domain}), for hosted
- *   deployments whose apex is already taken by a marketing site — always the dashboard;
+ * - a reserved dashboard slug (opt-in via DASHBOARD_SLUGS, e.g. dashboard.{base-domain}), for
+ *   hosted deployments whose apex is already taken by a marketing site — always the dashboard;
  * - the apex (the base domain itself) — the dashboard only when it resolves no tenant.
  *   The API auto-resolves a sole tenant on the apex, which is how a single-tenant
  *   self-hosted install serves the whole app at https://nocturne.example.com/, so the
@@ -20,15 +20,20 @@ import { extractTenantSlug, isShareHost } from "./request-host";
 
 /**
  * Reserved slugs that serve the dashboard rather than a tenant, when DASHBOARD_SLUGS is unset.
+ *
+ * Empty: reserving a slug is opt-in. A reserved slug is a host that offers only identity-provider
+ * sign-in, so reserving one by default would hand every wildcard-DNS deployment two extra hosts
+ * whose sign-in depends on the OIDC state cookie reaching the apex callback. The apex serves the
+ * dashboard whenever it resolves no tenant either way, so nothing is lost by default.
  */
-export const DEFAULT_DASHBOARD_SLUGS = ["dashboard", "app"];
+export const DEFAULT_DASHBOARD_SLUGS: readonly string[] = [];
 
 /**
- * Parse the DASHBOARD_SLUGS env var (comma-separated). An unset value takes the defaults; an
- * explicitly empty value reserves nothing, so the apex alone serves the dashboard.
+ * Parse the DASHBOARD_SLUGS env var (comma-separated). Unset or empty reserves nothing, so the
+ * apex alone serves the dashboard.
  */
 export function parseDashboardSlugs(raw: string | null | undefined): string[] {
-  if (raw === null || raw === undefined) return DEFAULT_DASHBOARD_SLUGS;
+  if (raw === null || raw === undefined) return [...DEFAULT_DASHBOARD_SLUGS];
   return raw
     .split(",")
     .map((slug) => slug.trim().toLowerCase())

--- a/src/Web/packages/app/src/lib/server/tenantless-host.ts
+++ b/src/Web/packages/app/src/lib/server/tenantless-host.ts
@@ -31,6 +31,13 @@ export const DEFAULT_DASHBOARD_SLUGS: readonly string[] = [];
 /**
  * Parse the DASHBOARD_SLUGS env var (comma-separated). Unset or empty reserves nothing, so the
  * apex alone serves the dashboard.
+ *
+ * Reserve a slug only after first-run setup is complete. A reserved slug names no tenant, and the
+ * API answers a host that resolves no tenant with 404 whether the instance holds zero tenants or
+ * a thousand — so the fresh-install signal (the 503 from tenant resolution) never reaches the web
+ * app on such a host, and an operator who opens the reserved host on a brand-new instance is sent
+ * to sign in on an instance that has no accounts yet. Complete setup on the apex or on the
+ * tenant's own host first, then set DASHBOARD_SLUGS.
  */
 export function parseDashboardSlugs(raw: string | null | undefined): string[] {
   if (raw === null || raw === undefined) return [...DEFAULT_DASHBOARD_SLUGS];

--- a/src/Web/packages/app/src/lib/server/tenantless-host.ts
+++ b/src/Web/packages/app/src/lib/server/tenantless-host.ts
@@ -1,0 +1,81 @@
+/**
+ * Tenantless-host classification.
+ *
+ * Most hosts name a tenant ({slug}.{base-domain}). Two do not, and both serve the
+ * cross-tenant caregiver dashboard instead of a single tenant's app:
+ *
+ * - the apex (the base domain itself), which is what a self-hosted family deployment uses;
+ * - a reserved dashboard slug (dashboard.{base-domain}, app.{base-domain}), for hosted
+ *   deployments whose apex is already taken by a marketing site.
+ *
+ * Classification is suffix-based throughout, mirroring extractTenantSlug and the API's
+ * SubdomainParser: `nocturne.example.com` is as valid a base domain as `example.com`, so
+ * hostname label counts carry no meaning.
+ */
+
+import { extractTenantSlug, isShareHost } from "./request-host";
+
+/**
+ * Reserved slugs that serve the dashboard rather than a tenant, when DASHBOARD_SLUGS is unset.
+ */
+export const DEFAULT_DASHBOARD_SLUGS = ["dashboard", "app"];
+
+/**
+ * Parse the DASHBOARD_SLUGS env var (comma-separated). An unset value takes the defaults; an
+ * explicitly empty value reserves nothing, so the apex alone serves the dashboard.
+ */
+export function parseDashboardSlugs(raw: string | null | undefined): string[] {
+  if (raw === null || raw === undefined) return DEFAULT_DASHBOARD_SLUGS;
+  return raw
+    .split(",")
+    .map((slug) => slug.trim().toLowerCase())
+    .filter((slug) => slug.length > 0);
+}
+
+export type HostKind = "tenantless" | "tenant" | "share" | "unknown";
+
+/**
+ * Classify a request host against the base domain.
+ *
+ * - "tenantless" — the apex, or a reserved dashboard slug: serves the cross-tenant dashboard.
+ * - "tenant"     — {slug}.{base-domain}: serves that tenant's app. `slug` is set.
+ * - "share"      — {token}.share.{base-domain}: the anonymous read-only view.
+ * - "unknown"    — an unrelated host, or no base domain configured.
+ */
+export function classifyHost(
+  host: string | null | undefined,
+  baseDomain: string | null | undefined,
+  dashboardSlugs: readonly string[] = DEFAULT_DASHBOARD_SLUGS
+): { kind: HostKind; slug: string | null } {
+  if (!host || !baseDomain) return { kind: "unknown", slug: null };
+
+  const hostname = host.split(":")[0]!;
+  const baseHostname = baseDomain.split(":")[0]!;
+  if (!baseHostname) return { kind: "unknown", slug: null };
+
+  if (hostname.toLowerCase() === baseHostname.toLowerCase()) {
+    return { kind: "tenantless", slug: null };
+  }
+
+  // Checked before the slug split: a share host's "{token}.share" is not a tenant slug, and
+  // must never be mistaken for a reserved dashboard slug either.
+  if (isShareHost(host)) return { kind: "share", slug: null };
+
+  const slug = extractTenantSlug(host, baseDomain);
+  if (!slug) return { kind: "unknown", slug: null };
+
+  if (dashboardSlugs.includes(slug.toLowerCase())) {
+    return { kind: "tenantless", slug: null };
+  }
+
+  return { kind: "tenant", slug };
+}
+
+/** Whether the host serves the cross-tenant dashboard rather than a single tenant's app. */
+export function isTenantlessHost(
+  host: string | null | undefined,
+  baseDomain: string | null | undefined,
+  dashboardSlugs: readonly string[] = DEFAULT_DASHBOARD_SLUGS
+): boolean {
+  return classifyHost(host, baseDomain, dashboardSlugs).kind === "tenantless";
+}

--- a/src/Web/packages/app/src/lib/server/tenantless-host.ts
+++ b/src/Web/packages/app/src/lib/server/tenantless-host.ts
@@ -1,12 +1,15 @@
 /**
  * Tenantless-host classification.
  *
- * Most hosts name a tenant ({slug}.{base-domain}). Two do not, and both serve the
+ * Most hosts name a tenant ({slug}.{base-domain}). Two do not, and either may serve the
  * cross-tenant caregiver dashboard instead of a single tenant's app:
  *
- * - the apex (the base domain itself), which is what a self-hosted family deployment uses;
  * - a reserved dashboard slug (dashboard.{base-domain}, app.{base-domain}), for hosted
- *   deployments whose apex is already taken by a marketing site.
+ *   deployments whose apex is already taken by a marketing site — always the dashboard;
+ * - the apex (the base domain itself) — the dashboard only when it resolves no tenant.
+ *   The API auto-resolves a sole tenant on the apex, which is how a single-tenant
+ *   self-hosted install serves the whole app at https://nocturne.example.com/, so the
+ *   hostname alone cannot decide this one. See apexResolvedTenant.
  *
  * Classification is suffix-based throughout, mirroring extractTenantSlug and the API's
  * SubdomainParser: `nocturne.example.com` is as valid a base domain as `example.com`, so
@@ -32,15 +35,16 @@ export function parseDashboardSlugs(raw: string | null | undefined): string[] {
     .filter((slug) => slug.length > 0);
 }
 
-export type HostKind = "tenantless" | "tenant" | "share" | "unknown";
+export type HostKind = "apex" | "dashboard-slug" | "tenant" | "share" | "unknown";
 
 /**
  * Classify a request host against the base domain.
  *
- * - "tenantless" — the apex, or a reserved dashboard slug: serves the cross-tenant dashboard.
- * - "tenant"     — {slug}.{base-domain}: serves that tenant's app. `slug` is set.
- * - "share"      — {token}.share.{base-domain}: the anonymous read-only view.
- * - "unknown"    — an unrelated host, or no base domain configured.
+ * - "apex"           — the base domain itself. Tenantless only when it resolves no tenant.
+ * - "dashboard-slug" — a reserved dashboard slug: always serves the cross-tenant dashboard.
+ * - "tenant"         — {slug}.{base-domain}: serves that tenant's app. `slug` is set.
+ * - "share"          — {token}.share.{base-domain}: the anonymous read-only view.
+ * - "unknown"        — an unrelated host, or no base domain configured.
  */
 export function classifyHost(
   host: string | null | undefined,
@@ -54,7 +58,7 @@ export function classifyHost(
   if (!baseHostname) return { kind: "unknown", slug: null };
 
   if (hostname.toLowerCase() === baseHostname.toLowerCase()) {
-    return { kind: "tenantless", slug: null };
+    return { kind: "apex", slug: null };
   }
 
   // Checked before the slug split: a share host's "{token}.share" is not a tenant slug, and
@@ -65,17 +69,42 @@ export function classifyHost(
   if (!slug) return { kind: "unknown", slug: null };
 
   if (dashboardSlugs.includes(slug.toLowerCase())) {
-    return { kind: "tenantless", slug: null };
+    return { kind: "dashboard-slug", slug: null };
   }
 
   return { kind: "tenant", slug };
 }
 
-/** Whether the host serves the cross-tenant dashboard rather than a single tenant's app. */
-export function isTenantlessHost(
-  host: string | null | undefined,
-  baseDomain: string | null | undefined,
-  dashboardSlugs: readonly string[] = DEFAULT_DASHBOARD_SLUGS
-): boolean {
-  return classifyHost(host, baseDomain, dashboardSlugs).kind === "tenantless";
+/**
+ * Whether the host serves the cross-tenant dashboard rather than a single tenant's app.
+ *
+ * A reserved dashboard slug always does — that is what the operator reserved it for. The apex
+ * does so only when nothing resolved behind it: a single-tenant install auto-resolves its sole
+ * tenant there and must keep serving the full app, or its owner is trimmed to a dashboard and
+ * then bounced to a wildcard subdomain that may not even have a certificate.
+ */
+export function isTenantlessHost(kind: HostKind, apexResolvesTenant: boolean): boolean {
+  if (kind === "dashboard-slug") return true;
+  if (kind === "apex") return !apexResolvesTenant;
+  return false;
+}
+
+/**
+ * Whether the API resolved a tenant for this request, which on the apex means a sole tenant was
+ * auto-resolved. Reported by the status endpoint because only the API can answer it: it is a
+ * question about how many tenants exist, not about the hostname.
+ *
+ * An unreachable or erroring status call answers "no tenant", which serves the dashboard. That is
+ * the safe direction — the dashboard renders for any signed-in subject, whereas the tenant app
+ * would render a shell over an API that resolves nothing.
+ */
+export async function apexResolvedTenant(
+  getStatus: () => Promise<{ tenantSlug?: string | null } | null | undefined>
+): Promise<boolean> {
+  try {
+    const status = await getStatus();
+    return !!status?.tenantSlug;
+  } catch {
+    return false;
+  }
 }

--- a/src/Web/packages/app/src/lib/server/tenantless-host.ts
+++ b/src/Web/packages/app/src/lib/server/tenantless-host.ts
@@ -9,38 +9,29 @@
  * - the apex (the base domain itself) — the dashboard only when it resolves no tenant.
  *   The API auto-resolves a sole tenant on the apex, which is how a single-tenant
  *   self-hosted install serves the whole app at https://nocturne.example.com/, so the
- *   hostname alone cannot decide this one. See apexResolvedTenant.
+ *   hostname alone cannot decide this one; the status endpoint answers it.
  *
  * Classification is suffix-based throughout, mirroring extractTenantSlug and the API's
  * SubdomainParser: `nocturne.example.com` is as valid a base domain as `example.com`, so
  * hostname label counts carry no meaning.
+ *
+ * Reserving a slug is opt-in, and only once first-run setup is complete. A reserved slug names no
+ * tenant, and the API answers a host that resolves no tenant with 404 whether the instance holds
+ * zero tenants or a thousand — so the fresh-install signal (the 503 from tenant resolution) never
+ * reaches the web app on such a host, and an operator who opens the reserved host on a brand-new
+ * instance is sent to sign in on an instance that has no accounts yet. Complete setup on the apex
+ * or on the tenant's own host first, then set DASHBOARD_SLUGS. Nothing is lost by leaving it
+ * unset: the apex serves the dashboard whenever it resolves no tenant either way.
  */
 
 import { extractTenantSlug, isShareHost } from "./request-host";
 
 /**
- * Reserved slugs that serve the dashboard rather than a tenant, when DASHBOARD_SLUGS is unset.
- *
- * Empty: reserving a slug is opt-in. A reserved slug is a host that offers only identity-provider
- * sign-in, so reserving one by default would hand every wildcard-DNS deployment two extra hosts
- * whose sign-in depends on the OIDC state cookie reaching the apex callback. The apex serves the
- * dashboard whenever it resolves no tenant either way, so nothing is lost by default.
- */
-export const DEFAULT_DASHBOARD_SLUGS: readonly string[] = [];
-
-/**
  * Parse the DASHBOARD_SLUGS env var (comma-separated). Unset or empty reserves nothing, so the
  * apex alone serves the dashboard.
- *
- * Reserve a slug only after first-run setup is complete. A reserved slug names no tenant, and the
- * API answers a host that resolves no tenant with 404 whether the instance holds zero tenants or
- * a thousand — so the fresh-install signal (the 503 from tenant resolution) never reaches the web
- * app on such a host, and an operator who opens the reserved host on a brand-new instance is sent
- * to sign in on an instance that has no accounts yet. Complete setup on the apex or on the
- * tenant's own host first, then set DASHBOARD_SLUGS.
  */
 export function parseDashboardSlugs(raw: string | null | undefined): string[] {
-  if (raw === null || raw === undefined) return [...DEFAULT_DASHBOARD_SLUGS];
+  if (!raw) return [];
   return raw
     .split(",")
     .map((slug) => slug.trim().toLowerCase())
@@ -61,7 +52,7 @@ export type HostKind = "apex" | "dashboard-slug" | "tenant" | "share" | "unknown
 export function classifyHost(
   host: string | null | undefined,
   baseDomain: string | null | undefined,
-  dashboardSlugs: readonly string[] = DEFAULT_DASHBOARD_SLUGS
+  dashboardSlugs: readonly string[] = []
 ): { kind: HostKind; slug: string | null } {
   if (!host || !baseDomain) return { kind: "unknown", slug: null };
 
@@ -99,24 +90,4 @@ export function isTenantlessHost(kind: HostKind, apexResolvesTenant: boolean): b
   if (kind === "dashboard-slug") return true;
   if (kind === "apex") return !apexResolvesTenant;
   return false;
-}
-
-/**
- * Whether the API resolved a tenant for this request, which on the apex means a sole tenant was
- * auto-resolved. Reported by the status endpoint because only the API can answer it: it is a
- * question about how many tenants exist, not about the hostname.
- *
- * An unreachable or erroring status call answers "no tenant", which serves the dashboard. That is
- * the safe direction — the dashboard renders for any signed-in subject, whereas the tenant app
- * would render a shell over an API that resolves nothing.
- */
-export async function apexResolvedTenant(
-  getStatus: () => Promise<{ tenantSlug?: string | null } | null | undefined>
-): Promise<boolean> {
-  try {
-    const status = await getStatus();
-    return !!status?.tenantSlug;
-  } catch {
-    return false;
-  }
 }

--- a/src/Web/packages/app/src/lib/stores/auth-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/auth-store.svelte.ts
@@ -14,7 +14,6 @@ import { browser } from "$app/environment";
 import { goto } from "$app/navigation";
 import {
   getSessionInfo,
-  getProvidersInfo,
   refreshSession as refreshSessionRemote,
   logoutSession as logoutSessionRemote,
 } from "../../routes/(unauthenticated)/auth/auth.remote";
@@ -32,16 +31,6 @@ export interface AuthUser {
   permissions: string[];
   expiresAt?: Date;
   avatarUrl?: string;
-}
-
-/**
- * OIDC Provider information for login UI
- */
-export interface OidcProvider {
-  id: string;
-  name: string;
-  icon?: string;
-  buttonColor?: string;
 }
 
 /**
@@ -68,7 +57,6 @@ export class AuthStore {
   private _state = $state<AuthState>("idle");
   private _user = $state<AuthUser | null>(null);
   private _error = $state<string | null>(null);
-  private _providers = $state<OidcProvider[]>([]);
 
   // Login dialog state
   private _loginDialogOpen = $state(false);
@@ -77,7 +65,6 @@ export class AuthStore {
   state = $derived(this._state);
   user = $derived(this._user);
   error = $derived(this._error);
-  providers = $derived(this._providers);
   loginDialogOpen = $derived(this._loginDialogOpen);
 
   isAuthenticated = $derived(this._state === "authenticated" && this._user !== null);
@@ -208,48 +195,6 @@ export class AuthStore {
       this._user = null;
       this._expiresAt = null;
     }
-  }
-
-  /**
-   * Load available OIDC providers
-   */
-  async loadProviders(): Promise<OidcProvider[]> {
-    if (!browser) return [];
-
-    try {
-      const result = await getProvidersInfo().run();
-      this._providers = result.providers.map((p) => ({
-        id: p.id ?? "",
-        name: p.name ?? "",
-        icon: p.icon,
-        buttonColor: p.buttonColor,
-      }));
-
-      return this._providers;
-    } catch (e) {
-      console.error("Failed to load providers:", e);
-      return [];
-    }
-  }
-
-  /**
-   * Initiate OIDC login flow
-   * @param providerId - Optional provider ID (uses default if not specified)
-   * @param returnUrl - URL to return to after login
-   */
-  login(providerId?: string, returnUrl?: string): void {
-    if (!browser) return;
-
-    const params = new URLSearchParams();
-    if (providerId) {
-      params.set("provider", providerId);
-    }
-    if (returnUrl) {
-      params.set("returnUrl", returnUrl);
-    }
-
-    const loginUrl = `/api/auth/login${params.toString() ? `?${params.toString()}` : ""}`;
-    window.location.href = loginUrl;
   }
 
   /**

--- a/src/Web/packages/app/src/lib/stores/settings-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/settings-store.svelte.ts
@@ -63,9 +63,9 @@ export class SettingsStore {
   private _isSaving = $state(false);
   isSaving = $derived(this._isSaving);
 
-  constructor() {
+  constructor(autoLoad = true) {
     // Auto-load settings when store is created in browser
-    if (browser) {
+    if (browser && autoLoad) {
       this.load();
     }
   }
@@ -306,10 +306,14 @@ export class SettingsStore {
 }
 
 /**
- * Creates a settings store and sets it in context
+ * Creates a settings store and sets it in context.
+ *
+ * @param autoLoad Whether to fetch the settings immediately. Pass false where the settings
+ * endpoint cannot answer — it is tenant-scoped, so a host that resolves no tenant would only 404.
+ * The store is still placed in context, so every consumer keeps resolving it.
  */
-export function createSettingsStore(): SettingsStore {
-  const store = new SettingsStore();
+export function createSettingsStore(autoLoad = true): SettingsStore {
+  const store = new SettingsStore(autoLoad);
   setContext(SETTINGS_STORE_KEY, store);
   return store;
 }

--- a/src/Web/packages/app/src/lib/utils/poll-while-visible.svelte.ts
+++ b/src/Web/packages/app/src/lib/utils/poll-while-visible.svelte.ts
@@ -1,0 +1,43 @@
+/**
+ * Runs `refresh` on an interval, but only while the tab is visible.
+ *
+ * A backgrounded tab shows nobody anything, so polling one bills a request a minute (or a request
+ * every ten seconds) for a surface no one can see. Polling stops while the tab is hidden and
+ * catches up immediately on return, so what the viewer sees on coming back is current.
+ *
+ * Call during component initialization: the timer and the listener are owned by an `$effect` and
+ * are torn down with the component.
+ */
+export function pollWhileVisible(refresh: () => void, intervalMs: number): void {
+  $effect(() => {
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    function stop() {
+      if (timer) clearInterval(timer);
+      timer = null;
+    }
+
+    function start() {
+      if (timer) return;
+      timer = setInterval(refresh, intervalMs);
+    }
+
+    function onVisibilityChange() {
+      if (document.hidden) {
+        stop();
+      } else {
+        // Whatever fired while hidden is unseen, so catch up immediately.
+        refresh();
+        start();
+      }
+    }
+
+    if (!document.hidden) start();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  });
+}

--- a/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
@@ -69,4 +69,25 @@ describe("resolveSingleTenantLanding", () => {
     expect(resolveSingleTenantLanding([{ slug: "alice" }], null, "https:")).toBeNull();
     expect(resolveSingleTenantLanding([{ slug: "alice" }], "", "https:")).toBeNull();
   });
+
+  it("does not redirect to a sole tenant whose slug is itself a dashboard slug", () => {
+    // That tenant's host IS the dashboard host, so the redirect would land back on this same
+    // load and redirect again, forever. DASHBOARD_SLUGS is an operator setting and may name a
+    // slug some tenant already holds.
+    expect(
+      resolveSingleTenantLanding([{ slug: "home" }], "example.com", "https:", ["home"])
+    ).toBeNull();
+    expect(
+      resolveSingleTenantLanding([{ slug: "HOME" }], "example.com", "https:", ["home"])
+    ).toBeNull();
+  });
+
+  it("still redirects to a sole tenant that is not a dashboard slug", () => {
+    expect(
+      resolveSingleTenantLanding([{ slug: "alice" }], "example.com", "https:", [
+        "dashboard",
+        "app",
+      ])
+    ).toBe("https://alice.example.com/");
+  });
 });

--- a/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { tenantUrl } from "./tenant-host";
+import { resolveSingleTenantLanding, tenantUrl } from "./tenant-host";
 
 describe("tenantUrl", () => {
   it("builds a tenant subdomain URL", () => {
@@ -24,5 +24,49 @@ describe("tenantUrl", () => {
     expect(tenantUrl("alice", "cgm.example.co.uk", "https:")).toBe(
       "https://alice.cgm.example.co.uk/"
     );
+  });
+});
+
+describe("resolveSingleTenantLanding", () => {
+  it("sends a caregiver with exactly one tenant straight to it", () => {
+    expect(
+      resolveSingleTenantLanding([{ slug: "alice" }], "example.com", "https:")
+    ).toBe("https://alice.example.com/");
+  });
+
+  it("renders the dashboard for several tenants", () => {
+    expect(
+      resolveSingleTenantLanding(
+        [{ slug: "alice" }, { slug: "bob" }],
+        "example.com",
+        "https:"
+      )
+    ).toBeNull();
+  });
+
+  it("renders the dashboard when there are no tenants", () => {
+    expect(resolveSingleTenantLanding([], "example.com", "https:")).toBeNull();
+    expect(resolveSingleTenantLanding(null, "example.com", "https:")).toBeNull();
+    expect(
+      resolveSingleTenantLanding(undefined, "example.com", "https:")
+    ).toBeNull();
+  });
+
+  it("ignores tenants with no slug, and counts what remains", () => {
+    expect(
+      resolveSingleTenantLanding(
+        [{ slug: "alice" }, { slug: null }],
+        "example.com",
+        "https:"
+      )
+    ).toBe("https://alice.example.com/");
+    expect(
+      resolveSingleTenantLanding([{ slug: null }], "example.com", "https:")
+    ).toBeNull();
+  });
+
+  it("cannot build a URL without a base domain", () => {
+    expect(resolveSingleTenantLanding([{ slug: "alice" }], null, "https:")).toBeNull();
+    expect(resolveSingleTenantLanding([{ slug: "alice" }], "", "https:")).toBeNull();
   });
 });

--- a/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
@@ -72,8 +72,8 @@ describe("resolveSingleTenantLanding", () => {
 
   it("does not redirect to a sole tenant whose slug is itself a dashboard slug", () => {
     // That tenant's host IS the dashboard host, so the redirect would land back on this same
-    // load and redirect again, forever. DASHBOARD_SLUGS is an operator setting and may name a
-    // slug some tenant already holds.
+    // load and redirect again, forever. Nothing is reserved by default, so this only arises once
+    // an operator sets DASHBOARD_SLUGS — and it may name a slug some tenant already holds.
     expect(
       resolveSingleTenantLanding([{ slug: "home" }], "example.com", "https:", ["home"])
     ).toBeNull();

--- a/src/Web/packages/app/src/lib/utils/tenant-host.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.ts
@@ -25,16 +25,25 @@ export function tenantUrl(
  * would be a single tile in front of the app they actually want: send them straight to it.
  * Returns null — meaning "render the dashboard" — for zero or several tenants, or when no base
  * domain is configured and so no tenant URL can be built.
+ *
+ * It also returns null when the sole tenant's own slug is a reserved dashboard slug. Its host is
+ * then the dashboard host, so redirecting there would land back on this same load and redirect
+ * again, forever. The default reserved slugs cannot name a tenant, but DASHBOARD_SLUGS is an
+ * operator setting and may name one that already exists.
  */
 export function resolveSingleTenantLanding(
   tenants: readonly { slug?: string | null }[] | null | undefined,
   baseDomain: string | null | undefined,
-  protocol?: string
+  protocol?: string,
+  dashboardSlugs: readonly string[] = []
 ): string | null {
   if (!baseDomain) return null;
 
   const slugs = (tenants ?? []).map((t) => t.slug).filter((s): s is string => !!s);
   if (slugs.length !== 1) return null;
 
-  return tenantUrl(slugs[0]!, baseDomain, protocol);
+  const slug = slugs[0]!;
+  if (dashboardSlugs.includes(slug.toLowerCase())) return null;
+
+  return tenantUrl(slug, baseDomain, protocol);
 }

--- a/src/Web/packages/app/src/lib/utils/tenant-host.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.ts
@@ -28,8 +28,8 @@ export function tenantUrl(
  *
  * It also returns null when the sole tenant's own slug is a reserved dashboard slug. Its host is
  * then the dashboard host, so redirecting there would land back on this same load and redirect
- * again, forever. The default reserved slugs cannot name a tenant, but DASHBOARD_SLUGS is an
- * operator setting and may name one that already exists.
+ * again, forever. Nothing is reserved by default, so this only arises once an operator sets
+ * DASHBOARD_SLUGS — and it may name a slug some tenant already holds.
  */
 export function resolveSingleTenantLanding(
   tenants: readonly { slug?: string | null }[] | null | undefined,

--- a/src/Web/packages/app/src/lib/utils/tenant-host.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.ts
@@ -17,3 +17,24 @@ export function tenantUrl(
 ): string {
   return `${protocol}//${slug}.${baseDomain}/`;
 }
+
+/**
+ * Where a tenantless host should send a signed-in visitor.
+ *
+ * A caregiver with access to exactly one tenant has nothing to choose between, so the dashboard
+ * would be a single tile in front of the app they actually want: send them straight to it.
+ * Returns null — meaning "render the dashboard" — for zero or several tenants, or when no base
+ * domain is configured and so no tenant URL can be built.
+ */
+export function resolveSingleTenantLanding(
+  tenants: readonly { slug?: string | null }[] | null | undefined,
+  baseDomain: string | null | undefined,
+  protocol?: string
+): string | null {
+  if (!baseDomain) return null;
+
+  const slugs = (tenants ?? []).map((t) => t.slug).filter((s): s is string => !!s);
+  if (slugs.length !== 1) return null;
+
+  return tenantUrl(slugs[0]!, baseDomain, protocol);
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -1,8 +1,7 @@
 import { redirect } from "@sveltejs/kit";
 import type { LayoutServerLoad } from "./$types";
 import { checkOnboarding } from "$lib/server/onboarding-check";
-import { getOriginalHost, isShareHost } from "$lib/server/request-host";
-import { isTenantlessHost, parseDashboardSlugs } from "$lib/server/tenantless-host";
+import { getRequestStatus } from "$lib/server/request-status";
 import { isTenantlessRoute } from "$lib/navigation/tenantless-navigation";
 import { toIsoString } from "$lib/utils/api-date";
 
@@ -22,7 +21,7 @@ function hasGlucoseReadPermission(permissions: string[]): boolean {
   return permissions.some((p) => GLUCOSE_READ_PERMISSIONS.includes(p));
 }
 
-export const load: LayoutServerLoad = async ({ locals, cookies, url, request }) => {
+export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) => {
   // Guest sessions bypass onboarding — the data owner's instance is already set up.
   if (!locals.isGuestSession) {
     // Check onboarding first — if the instance needs setup, redirect there
@@ -38,14 +37,10 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, request }) 
     }
   }
 
-  // Fetch tenant status once — it drives both the anonymous-access gate and the demo banner.
-  // Default to no anonymous access on failure (fail safe: require sign-in rather than over-expose).
-  let status: Awaited<ReturnType<typeof locals.apiClient.status.getStatus>> | null = null;
-  try {
-    status = await locals.apiClient.status.getStatus();
-  } catch {
-    // Swallow — handled below by the conservative defaults.
-  }
+  // Tenant status drives the anonymous-access gate and the demo banner. Shared with the root
+  // layout's tenantless check, and null on failure — default to no anonymous access then
+  // (fail safe: require sign-in rather than over-expose).
+  const status = await getRequestStatus(locals);
   const anonymousReadAccess = status?.anonymousReadAccess ?? false;
 
   // Public read is served only on the share host ({token}.share.{baseDomain}); the bare tenant
@@ -54,8 +49,7 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, request }) 
   // then bursting 401s on the bare host.
   // Security headers for the share host (Referrer-Policy, X-Robots-Tag) are applied for every
   // response in hooks.server.ts (shareHostSecurityHandle).
-  const onShareHost = isShareHost(getOriginalHost(request));
-  const publicViewAllowed = onShareHost && anonymousReadAccess;
+  const publicViewAllowed = locals.isShareHost && anonymousReadAccess;
 
   // A fresh instance with no resolved tenant reports "setup_required" — send it to setup rather
   // than bouncing an anonymous visitor to login. (checkOnboarding fails open on a missing cookie
@@ -78,11 +72,7 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, request }) 
   // then 404 against the API. The nav hides those entries; this catches direct navigation and
   // stale links, and runs only once the visitor is known to be signed in (above) so it can
   // never pre-empt the login redirect.
-  const tenantless = isTenantlessHost(
-    getOriginalHost(request),
-    process.env.BASE_DOMAIN ?? null,
-    parseDashboardSlugs(process.env.DASHBOARD_SLUGS),
-  );
+  const { tenantless } = await parent();
   if (tenantless && !isTenantlessRoute(url.pathname)) {
     throw redirect(303, "/");
   }

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -2,6 +2,8 @@ import { redirect } from "@sveltejs/kit";
 import type { LayoutServerLoad } from "./$types";
 import { checkOnboarding } from "$lib/server/onboarding-check";
 import { getOriginalHost, isShareHost } from "$lib/server/request-host";
+import { isTenantlessHost, parseDashboardSlugs } from "$lib/server/tenantless-host";
+import { isTenantlessRoute } from "$lib/navigation/tenantless-navigation";
 import { toIsoString } from "$lib/utils/api-date";
 
 /** Permissions that grant read access to glucose data (mirrors API's CanRead + OAuth scopes). */
@@ -70,6 +72,19 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, request }) 
       const returnUrl = encodeURIComponent(url.pathname + url.search);
       throw redirect(303, `/auth/login?returnUrl=${returnUrl}`);
     }
+  }
+
+  // A tenantless host resolves no tenant, so a tenant-scoped page would render its shell and
+  // then 404 against the API. The nav hides those entries; this catches direct navigation and
+  // stale links, and runs only once the visitor is known to be signed in (above) so it can
+  // never pre-empt the login redirect.
+  const tenantless = isTenantlessHost(
+    getOriginalHost(request),
+    process.env.BASE_DOMAIN ?? null,
+    parseDashboardSlugs(process.env.DASHBOARD_SLUGS),
+  );
+  if (tenantless && !isTenantlessRoute(url.pathname)) {
+    throw redirect(303, "/");
   }
 
   // Enable realtime glucose data for:

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -22,6 +22,10 @@ function hasGlucoseReadPermission(permissions: string[]): boolean {
 }
 
 export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) => {
+  // Resolved by the root layout from the request host and the API's answer for the apex. Read
+  // first because it qualifies the setup redirect below as well as the route guard further down.
+  const { tenantless } = await parent();
+
   // Guest sessions bypass onboarding — the data owner's instance is already set up.
   if (!locals.isGuestSession) {
     // Check onboarding first — if the instance needs setup, redirect there
@@ -52,9 +56,15 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) =
   const publicViewAllowed = locals.isShareHost && anonymousReadAccess;
 
   // A fresh instance with no resolved tenant reports "setup_required" — send it to setup rather
-  // than bouncing an anonymous visitor to login. (checkOnboarding fails open on a missing cookie
-  // or an unreachable auth-status call, so this is the authoritative no-tenant signal.)
-  if (status?.status === "setup_required") {
+  // than bouncing an anonymous visitor to login.
+  //
+  // Not on a tenantless host. So does every apex of a multi-tenant install and every reserved
+  // dashboard slug, because the status endpoint reports "setup_required" for any request that
+  // resolves no tenant, whatever the reason. Redirecting those would put the fresh-install wizard
+  // in front of a production deployment that already has tenants, and the dashboard would never
+  // render at all. A genuinely fresh install is caught above instead: checkOnboarding reads the
+  // 503 the API serves when no tenant exists.
+  if (!tenantless && status?.status === "setup_required") {
     throw redirect(303, "/setup");
   }
 
@@ -70,9 +80,7 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) =
 
   // A tenantless host resolves no tenant, so a tenant-scoped page would render its shell and
   // then 404 against the API. The nav hides those entries; this catches direct navigation and
-  // stale links, and runs only once the visitor is known to be signed in (above) so it can
-  // never pre-empt the login redirect.
-  const { tenantless } = await parent();
+  // stale links, and stays below the login redirect so it can never pre-empt it.
   if (tenantless && !isTenantlessRoute(url.pathname)) {
     throw redirect(303, "/");
   }

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -89,9 +89,16 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) =
   // - Authenticated users with a glucose read permission
   // - Anonymous visitors on the share host of a tenant that grants public read access
   // The API enforces authorization on each endpoint as defense in depth.
-  const canViewRealtimeData = locals.isAuthenticated
-    ? hasGlucoseReadPermission(locals.effectivePermissions ?? [])
-    : publicViewAllowed;
+  //
+  // Never on a tenantless host: there is no tenant whose glucose could be read, and the
+  // permissions reported there are the raw JWT scopes rather than tenant-derived ones — so a
+  // platform admin carrying "*" would otherwise open a websocket that reconnects forever and
+  // burst a day of entries, devicestatus, profile and tracker reads against 404s.
+  const canViewRealtimeData = tenantless
+    ? false
+    : locals.isAuthenticated
+      ? hasGlucoseReadPermission(locals.effectivePermissions ?? [])
+      : publicViewAllowed;
 
   const isDemo = status?.isDemo ?? false;
   const nextResetAt = toIsoString(status?.nextResetAt);

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -15,9 +15,7 @@
   import { beforeNavigate } from "$app/navigation";
   import * as Card from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
-  import AlertBanner from "$lib/components/alerts/AlertBanner.svelte";
-  import FiringToast from "$lib/components/alerts/FiringToast.svelte";
-  import { pollActiveAlerts } from "$lib/components/alerts/active-alerts-poll.svelte";
+  import AlertSurfaces from "$lib/components/alerts/AlertSurfaces.svelte";
   import DemoBanner from "$lib/components/layout/DemoBanner.svelte";
   import GuestBanner from "$lib/components/layout/GuestBanner.svelte";
   import MembershipRequestAutoSubmit from "$lib/components/members/MembershipRequestAutoSubmit.svelte";
@@ -46,6 +44,13 @@
 
   const { data, children } = $props<{ data: LayoutData; children: any }>();
 
+  // A tenantless host (the apex of a multi-tenant install, or a reserved dashboard slug) resolves
+  // no tenant, so every tenant-scoped surface this shell mounts would render and then 404 against
+  // the API — forever, for every visitor, in the case of the polled ones. Read once: the host
+  // cannot change without a fresh load.
+  // svelte-ignore state_referenced_locally
+  const tenantless: boolean = data.tenantless === true;
+
   const realtimeStore = createRealtimeStore(config);
   createAuthStore(); // Initialize auth store in context
 
@@ -56,16 +61,16 @@
   });
 
   // Create settings store in context for the entire app
-  // This makes feature settings available on all pages including the main dashboard
-  createSettingsStore();
+  // This makes feature settings available on all pages including the main dashboard.
+  // The store is always in context so getSettingsStore() resolves everywhere; only the fetch of
+  // /api/v4/ui-settings, which is tenant-scoped, is withheld on a tenantless host.
+  createSettingsStore(!tenantless);
 
   let commandPaletteOpen = $state(false);
 
-  // One poll for the alert surfaces this layout mounts (AlertBanner and
-  // FiringToast both read the same query).
-  pollActiveAlerts();
-
-  const coachMarkAdapter = createCoachMarkAdapter();
+  // Coach-mark state is tenant-scoped, so on a tenantless host the adapter stays on its
+  // localStorage path rather than asking for marks no tenant owns.
+  const coachMarkAdapter = createCoachMarkAdapter(tenantless);
 
   // Title/Favicon service for dynamic updates
   const titleFaviconService = getTitleFaviconService();
@@ -216,12 +221,13 @@
       {#if data.isGuestSession && data.guestExpiresAt}
         <GuestBanner expiresAt={data.guestExpiresAt} />
       {/if}
-      <MembershipRequestAutoSubmit
-        isAuthenticated={!!data.user}
-        isGuestSession={data.isGuestSession}
-      />
-      <AlertBanner />
-      <FiringToast />
+      {#if !tenantless}
+        <MembershipRequestAutoSubmit
+          isAuthenticated={!!data.user}
+          isGuestSession={data.isGuestSession}
+        />
+        <AlertSurfaces />
+      {/if}
       <main class="flex-1 overflow-auto">
         <svelte:boundary>
           {@render children()}

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -207,7 +207,7 @@
   <CoachParamHandler />
   <ChartPrintPatterns />
   <Sidebar.Provider>
-    <AppSidebar user={data.user} isPlatformAdmin={data.isPlatformAdmin} isPlatformAccessGrant={data.isPlatformAccessGrant} isGuestSession={data.isGuestSession} currentSlug={data.tenantSlug} baseDomain={data.baseDomain} />
+    <AppSidebar user={data.user} isPlatformAdmin={data.isPlatformAdmin} isPlatformAccessGrant={data.isPlatformAccessGrant} isGuestSession={data.isGuestSession} currentSlug={data.tenantSlug} baseDomain={data.baseDomain} tenantless={data.tenantless} />
     <Sidebar.Inset>
       <MobileHeader />
       {#if data.isDemo}

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -255,5 +255,5 @@
       </main>
     </Sidebar.Inset>
   </Sidebar.Provider>
-  <CommandPalette bind:open={commandPaletteOpen} />
+  <CommandPalette bind:open={commandPaletteOpen} {tenantless} />
 </CoachMarkProvider>

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -44,10 +44,8 @@
 
   const { data, children } = $props<{ data: LayoutData; children: any }>();
 
-  // A tenantless host (the apex of a multi-tenant install, or a reserved dashboard slug) resolves
-  // no tenant, so every tenant-scoped surface this shell mounts would render and then 404 against
-  // the API — forever, for every visitor, in the case of the polled ones. Read once: the host
-  // cannot change without a fresh load.
+  // A tenantless host leaves the tenant-scoped surfaces below unmounted; see
+  // tenantless-navigation. Read once: the host cannot change without a fresh load.
   // svelte-ignore state_referenced_locally
   const tenantless: boolean = data.tenantless === true;
 
@@ -62,14 +60,10 @@
 
   // Create settings store in context for the entire app
   // This makes feature settings available on all pages including the main dashboard.
-  // The store is always in context so getSettingsStore() resolves everywhere; only the fetch of
-  // /api/v4/ui-settings, which is tenant-scoped, is withheld on a tenantless host.
   createSettingsStore(!tenantless);
 
   let commandPaletteOpen = $state(false);
 
-  // Coach-mark state is tenant-scoped, so on a tenantless host the adapter stays on its
-  // localStorage path rather than asking for marks no tenant owns.
   const coachMarkAdapter = createCoachMarkAdapter(tenantless);
 
   // Title/Favicon service for dynamic updates

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
@@ -1,7 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { getOriginalHost, getOriginalProto } from '$lib/server/request-host';
-import { isTenantlessHost, parseDashboardSlugs } from '$lib/server/tenantless-host';
+import { getOriginalProto } from '$lib/server/request-host';
+import { parseDashboardSlugs } from '$lib/server/tenantless-host';
 import { resolveSingleTenantLanding } from '$lib/utils/tenant-host';
 import { transformChartData, type TransformedChartData } from '$lib/utils/chart-data-transform';
 
@@ -10,15 +10,11 @@ const INITIAL_HOURS = 6;
 // Total hours to fetch (matches GLUCOSE_CHART_FETCH_HOURS)
 const TOTAL_HOURS = 48;
 
-export const load: PageServerLoad = async ({ locals, request }) => {
+export const load: PageServerLoad = async ({ locals, request, parent }) => {
 	const { apiClient } = locals;
 
 	const baseDomain = process.env.BASE_DOMAIN ?? null;
-	const tenantless = isTenantlessHost(
-		getOriginalHost(request),
-		baseDomain,
-		parseDashboardSlugs(process.env.DASHBOARD_SLUGS)
-	);
+	const { tenantless } = await parent();
 
 	// A tenantless host serves the cross-tenant overview instead of one tenant's dashboard, so
 	// there is no tenant whose chart data could be loaded here. The overview itself is fetched
@@ -27,7 +23,8 @@ export const load: PageServerLoad = async ({ locals, request }) => {
 		const landing = resolveSingleTenantLanding(
 			await getOverviewTenants(apiClient),
 			baseDomain,
-			getOriginalProto(request) + ':'
+			getOriginalProto(request) + ':',
+			parseDashboardSlugs(process.env.DASHBOARD_SLUGS)
 		);
 		if (landing) throw redirect(303, landing);
 

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
@@ -1,7 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { getOriginalProto } from '$lib/server/request-host';
-import { parseDashboardSlugs } from '$lib/server/tenantless-host';
 import { resolveSingleTenantLanding } from '$lib/utils/tenant-host';
 import { transformChartData, type TransformedChartData } from '$lib/utils/chart-data-transform';
 
@@ -13,18 +12,17 @@ const TOTAL_HOURS = 48;
 export const load: PageServerLoad = async ({ locals, request, parent }) => {
 	const { apiClient } = locals;
 
-	const baseDomain = process.env.BASE_DOMAIN ?? null;
-	const { tenantless } = await parent();
+	const { tenantless, baseDomain, dashboardSlugs } = await parent();
 
 	// A tenantless host serves the cross-tenant overview instead of one tenant's dashboard, so
 	// there is no tenant whose chart data could be loaded here. The overview itself is fetched
 	// client-side by the same remote query /tenants uses.
 	if (tenantless) {
 		const landing = resolveSingleTenantLanding(
-			await getOverviewTenants(apiClient),
+			await getAccessibleTenants(apiClient),
 			baseDomain,
 			getOriginalProto(request) + ':',
-			parseDashboardSlugs(process.env.DASHBOARD_SLUGS)
+			dashboardSlugs
 		);
 		if (landing) throw redirect(303, landing);
 
@@ -73,15 +71,19 @@ export const load: PageServerLoad = async ({ locals, request, parent }) => {
 };
 
 /**
- * The tenants this subject can see, or an empty list if the overview cannot be fetched.
+ * The tenants this subject belongs to, or an empty list if the list cannot be fetched.
+ *
+ * The bare list, not the overview: all that is wanted here is how many there are and what the
+ * sole one is called, and the overview aggregates each tenant's latest glucose to answer that.
+ * TenantsOverview fetches the aggregate itself once the page renders.
+ *
  * A failure here must not block the dashboard: it only costs the single-tenant shortcut.
  */
-async function getOverviewTenants(apiClient: App.Locals['apiClient']) {
+async function getAccessibleTenants(apiClient: App.Locals['apiClient']) {
 	try {
-		const overview = await apiClient.myTenants.getOverview();
-		return overview.tenants ?? [];
+		return await apiClient.myTenants.getMyTenants();
 	} catch (err) {
-		console.error('Error loading tenants overview:', err);
+		console.error('Error loading the tenant list:', err);
 		return [];
 	}
 }

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
@@ -1,4 +1,8 @@
+import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import { getOriginalHost, getOriginalProto } from '$lib/server/request-host';
+import { isTenantlessHost, parseDashboardSlugs } from '$lib/server/tenantless-host';
+import { resolveSingleTenantLanding } from '$lib/utils/tenant-host';
 import { transformChartData, type TransformedChartData } from '$lib/utils/chart-data-transform';
 
 // Hours of data for initial fast load (most recent)
@@ -6,8 +10,29 @@ const INITIAL_HOURS = 6;
 // Total hours to fetch (matches GLUCOSE_CHART_FETCH_HOURS)
 const TOTAL_HOURS = 48;
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, request }) => {
 	const { apiClient } = locals;
+
+	const baseDomain = process.env.BASE_DOMAIN ?? null;
+	const tenantless = isTenantlessHost(
+		getOriginalHost(request),
+		baseDomain,
+		parseDashboardSlugs(process.env.DASHBOARD_SLUGS)
+	);
+
+	// A tenantless host serves the cross-tenant overview instead of one tenant's dashboard, so
+	// there is no tenant whose chart data could be loaded here. The overview itself is fetched
+	// client-side by the same remote query /tenants uses.
+	if (tenantless) {
+		const landing = resolveSingleTenantLanding(
+			await getOverviewTenants(apiClient),
+			baseDomain,
+			getOriginalProto(request) + ':'
+		);
+		if (landing) throw redirect(303, landing);
+
+		return { tenantless: true, initialChartData: null };
+	}
 
 	const now = Date.now();
 	const intervalMs = 5 * 60 * 1000;
@@ -42,9 +67,24 @@ export const load: PageServerLoad = async ({ locals }) => {
 	})();
 
 	return {
+		tenantless: false,
 		initialChartData,
 		streamed: {
 			historicalChartData: historicalDataPromise,
 		},
 	};
 };
+
+/**
+ * The tenants this subject can see, or an empty list if the overview cannot be fetched.
+ * A failure here must not block the dashboard: it only costs the single-tenant shortcut.
+ */
+async function getOverviewTenants(apiClient: App.Locals['apiClient']) {
+	try {
+		const overview = await apiClient.myTenants.getOverview();
+		return overview.tenants ?? [];
+	} catch (err) {
+		console.error('Error loading tenants overview:', err);
+		return [];
+	}
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
@@ -26,7 +26,7 @@ export const load: PageServerLoad = async ({ locals, request, parent }) => {
 		);
 		if (landing) throw redirect(303, landing);
 
-		return { tenantless: true, initialChartData: null };
+		return { initialChartData: null };
 	}
 
 	const now = Date.now();
@@ -62,7 +62,6 @@ export const load: PageServerLoad = async ({ locals, request, parent }) => {
 	})();
 
 	return {
-		tenantless: false,
 		initialChartData,
 		streamed: {
 			historicalChartData: historicalDataPromise,

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
@@ -11,6 +11,7 @@
   import { WidgetId } from "$lib/api/generated/nocturne-api-client";
   import { isWidgetEnabled } from "$lib/types/dashboard-widgets";
   import { coachmark } from "@nocturne/coach";
+  import TenantsOverview from "$lib/components/tenants/TenantsOverview.svelte";
   import type { PageData } from "./$types";
 
   const { data }: { data: PageData } = $props();
@@ -36,6 +37,10 @@
   );
 </script>
 
+{#if data.tenantless}
+  <!-- Apex / reserved dashboard slug: no tenant to show, so serve the cross-tenant overview. -->
+  <TenantsOverview />
+{:else}
 <div class="@container p-3 @md:p-6 space-y-3 @md:space-y-6">
   <div
     {@attach coachmark({
@@ -90,3 +95,4 @@
     <RecentTreatmentsCard />
   {/if}
 </div>
+{/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
@@ -38,7 +38,6 @@
 </script>
 
 {#if data.tenantless}
-  <!-- Apex / reserved dashboard slug: no tenant to show, so serve the cross-tenant overview. -->
   <TenantsOverview />
 {:else}
 <div class="@container p-3 @md:p-6 space-y-3 @md:space-y-6">

--- a/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { isRedirect, type Cookies } from "@sveltejs/kit";
+import { classifyHost, isTenantlessHost } from "$lib/server/tenantless-host";
+import { load } from "./+layout.server";
+
+/**
+ * The authenticated shell's load, exercised end to end from a hostname rather than through the
+ * host-classification helpers it depends on.
+ *
+ * Those helpers were unit-tested and correct while the shell still bounced every tenantless host
+ * to /setup, because the redirect lived above the branch that reads them — a shape no test over
+ * classifyHost/isTenantlessHost could see. These drive the load itself, one host situation per
+ * test, and assert where the visitor ends up.
+ */
+
+type LoadEvent = Parameters<typeof load>[0];
+
+const BASE = "nocturne.run";
+
+interface Situation {
+  /** The request host, classified with the real helpers to produce the layout's `tenantless`. */
+  host: string;
+  /** Whether the API auto-resolved a sole tenant behind the apex. */
+  apexResolvesTenant?: boolean;
+  /** Slugs the operator reserved for the dashboard (none by default). */
+  dashboardSlugs?: string[];
+  /** The /api/v4/status document. */
+  status: { status?: string; tenantSlug?: string | null };
+  /** The passkey auth-status answer; a number rejects with that HTTP status. */
+  authStatus: { onboardingCompleted?: boolean } | number;
+  signedIn?: boolean;
+  pathname?: string;
+}
+
+function runLoad(situation: Situation) {
+  const { kind } = classifyHost(situation.host, BASE, situation.dashboardSlugs ?? []);
+  const tenantless = isTenantlessHost(kind, situation.apexResolvesTenant ?? false);
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- a stub of the three Cookies methods this load touches; implementing the full interface would say nothing
+  const cookies = {
+    get: () => undefined,
+    set: () => {},
+    delete: () => {},
+  } as unknown as Cookies;
+
+  const signedIn = situation.signedIn ?? true;
+  const locals = {
+    isGuestSession: false,
+    isShareHost: false,
+    isAuthenticated: signedIn,
+    user: signedIn ? { subjectId: "s1", name: "Sam" } : null,
+    effectivePermissions: ["*"],
+    apiClient: {
+      status: { getStatus: async () => situation.status },
+      passkey: {
+        getAuthStatus: async () => {
+          if (typeof situation.authStatus === "number") throw { status: situation.authStatus };
+          return situation.authStatus;
+        },
+      },
+    },
+  };
+
+  const event = {
+    locals,
+    cookies,
+    url: new URL(`https://${situation.host}${situation.pathname ?? "/"}`),
+    parent: async () => ({ tenantless }),
+  };
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the load reads five fields of the request event; the rest of SvelteKit's ServerLoadEvent is not reachable from here
+  return load(event as unknown as LoadEvent);
+}
+
+/** The Location of the redirect the load threw, or null if it returned page data. */
+async function redirectLocation(situation: Situation): Promise<string | null> {
+  try {
+    await runLoad(situation);
+    return null;
+  } catch (err) {
+    if (isRedirect(err)) return err.location;
+    throw err;
+  }
+}
+
+/** A host that resolves no tenant: tenants exist, this host just names none of them. */
+const populatedTenantless = {
+  status: { status: "setup_required", tenantSlug: null },
+  authStatus: 404,
+} as const;
+
+describe("(authenticated) layout load — where each host situation lands", () => {
+  it("renders the dashboard on an apex with several tenants", async () => {
+    // The API reports "setup_required" for any request that resolves no tenant, and a
+    // multi-tenant apex resolves none. Redirecting on that alone put the fresh-install wizard
+    // in front of a production deployment and the dashboard never rendered at all.
+    await expect(
+      redirectLocation({ host: BASE, ...populatedTenantless })
+    ).resolves.toBeNull();
+  });
+
+  it("renders the dashboard on a reserved dashboard slug", async () => {
+    await expect(
+      redirectLocation({
+        host: `dashboard.${BASE}`,
+        dashboardSlugs: ["dashboard"],
+        // The apex behind it resolves a tenant; the reserved slug is the dashboard regardless.
+        apexResolvesTenant: true,
+        ...populatedTenantless,
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("renders the tenant app on an apex that resolves its sole tenant", async () => {
+    await expect(
+      redirectLocation({
+        host: BASE,
+        apexResolvesTenant: true,
+        status: { status: "ok", tenantSlug: "acme" },
+        authStatus: { onboardingCompleted: true },
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("still sends an apex with zero tenants to setup", async () => {
+    // The one host situation that IS a fresh install. The API serves 503 setup_required when no
+    // tenant exists anywhere, which is what separates it from the multi-tenant apex above.
+    await expect(
+      redirectLocation({
+        host: BASE,
+        status: { status: "setup_required", tenantSlug: null },
+        authStatus: 503,
+      })
+    ).resolves.toBe("/setup");
+  });
+
+  it("still sends a tenant host awaiting first-run setup to setup", async () => {
+    await expect(
+      redirectLocation({
+        host: `acme.${BASE}`,
+        status: { status: "setup_required", tenantSlug: "acme" },
+        authStatus: { onboardingCompleted: false },
+      })
+    ).resolves.toBe("/setup");
+  });
+
+  it("sends a signed-out visitor on a tenantless host to login, not to the wizard", async () => {
+    await expect(
+      redirectLocation({ host: BASE, signedIn: false, ...populatedTenantless })
+    ).resolves.toBe("/auth/login?returnUrl=%2F");
+  });
+
+  it("bounces a tenant-scoped route on a tenantless host back to the overview", async () => {
+    await expect(
+      redirectLocation({
+        host: BASE,
+        pathname: "/settings/account",
+        ...populatedTenantless,
+      })
+    ).resolves.toBe("/");
+  });
+
+  it("sends a signed-out visitor to login before the tenantless route guard runs", async () => {
+    // Order matters: the guard would otherwise swallow the returnUrl and drop the visitor on a
+    // page they still cannot see.
+    await expect(
+      redirectLocation({
+        host: BASE,
+        signedIn: false,
+        pathname: "/settings/account",
+        ...populatedTenantless,
+      })
+    ).resolves.toBe("/auth/login?returnUrl=%2Fsettings%2Faccount");
+  });
+});

--- a/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
@@ -30,6 +30,8 @@ interface Situation {
   authStatus: { onboardingCompleted?: boolean } | number;
   signedIn?: boolean;
   pathname?: string;
+  /** The caller's effective permissions, as /api/v4/me/permissions reports them. */
+  permissions?: string[];
 }
 
 function runLoad(situation: Situation) {
@@ -49,7 +51,7 @@ function runLoad(situation: Situation) {
     isShareHost: false,
     isAuthenticated: signedIn,
     user: signedIn ? { subjectId: "s1", name: "Sam" } : null,
-    effectivePermissions: ["*"],
+    effectivePermissions: situation.permissions ?? ["*"],
     apiClient: {
       status: { getStatus: async () => situation.status },
       passkey: {
@@ -70,6 +72,12 @@ function runLoad(situation: Situation) {
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the load reads five fields of the request event; the rest of SvelteKit's ServerLoadEvent is not reachable from here
   return load(event as unknown as LoadEvent);
+}
+
+/** The page data the load returned, for situations that render rather than redirect. */
+async function loadedData(situation: Situation): Promise<{ canViewRealtimeData: boolean }> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the load's declared return includes void, for the paths that throw a redirect; these situations render
+  return (await runLoad(situation)) as { canViewRealtimeData: boolean };
 }
 
 /** The Location of the redirect the load threw, or null if it returned page data. */
@@ -171,5 +179,46 @@ describe("(authenticated) layout load — where each host situation lands", () =
         ...populatedTenantless,
       })
     ).resolves.toBe("/auth/login?returnUrl=%2Fsettings%2Faccount");
+  });
+});
+
+describe("(authenticated) layout load — realtime data", () => {
+  it("withholds realtime data on a tenantless host from a platform admin holding *", async () => {
+    // On a tenantless host /api/v4/me/permissions reports the raw JWT scopes, and a platform
+    // admin's carry "*" — which reads as glucose access even though no tenant resolved. Left
+    // ungated, that session opens a websocket that reconnects forever and bursts a day of
+    // entries, devicestatus, profile and tracker reads against a host that answers 404.
+    const data = await loadedData({ host: BASE, ...populatedTenantless });
+    expect(data.canViewRealtimeData).toBe(false);
+  });
+
+  it("withholds realtime data on a reserved dashboard slug", async () => {
+    const data = await loadedData({
+      host: `dashboard.${BASE}`,
+      dashboardSlugs: ["dashboard"],
+      apexResolvesTenant: true,
+      ...populatedTenantless,
+    });
+    expect(data.canViewRealtimeData).toBe(false);
+  });
+
+  it("enables realtime data on a tenant host for a caller with glucose read", async () => {
+    const data = await loadedData({
+      host: `acme.${BASE}`,
+      permissions: ["glucose.read"],
+      status: { status: "ok", tenantSlug: "acme" },
+      authStatus: { onboardingCompleted: true },
+    });
+    expect(data.canViewRealtimeData).toBe(true);
+  });
+
+  it("withholds realtime data on a tenant host from a caller without glucose read", async () => {
+    const data = await loadedData({
+      host: `acme.${BASE}`,
+      permissions: ["treatments.read"],
+      status: { status: "ok", tenantSlug: "acme" },
+      authStatus: { onboardingCompleted: true },
+    });
+    expect(data.canViewRealtimeData).toBe(false);
   });
 });

--- a/src/Web/packages/app/src/routes/(authenticated)/tenants/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/tenants/+page.svelte
@@ -2,8 +2,4 @@
   import TenantsOverview from "$lib/components/tenants/TenantsOverview.svelte";
 </script>
 
-<svelte:head>
-  <title>Tenants overview - Nocturne</title>
-</svelte:head>
-
 <TenantsOverview />

--- a/src/Web/packages/app/src/routes/(authenticated)/tenants/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/tenants/+page.svelte
@@ -1,71 +1,9 @@
 <script lang="ts">
-  import { onDestroy, onMount } from "svelte";
-  import { page } from "$app/state";
-  import { getOverview } from "$lib/api/generated/myTenants.generated.remote";
-  import TenantOverviewTile from "$lib/components/tenants/TenantOverviewTile.svelte";
-  import { Button } from "$lib/components/ui/button";
-  import { sortTenantsByUrgency } from "$lib/utils/glucose-status";
-
-  const overviewQuery = getOverview();
-  const data = $derived(overviewQuery.current);
-  const loadError = $derived(overviewQuery.error);
-
-  const baseDomain = $derived(page.data.baseDomain ?? null);
-
-  let refreshInterval: ReturnType<typeof setInterval> | null = null;
-
-  onMount(() => {
-    refreshInterval = setInterval(() => {
-      // Detached callback: use .refresh(), not a bare await (no reactive context here).
-      overviewQuery.refresh();
-    }, 60_000);
-  });
-
-  onDestroy(() => {
-    if (refreshInterval) clearInterval(refreshInterval);
-  });
+  import TenantsOverview from "$lib/components/tenants/TenantsOverview.svelte";
 </script>
 
 <svelte:head>
   <title>Tenants overview - Nocturne</title>
 </svelte:head>
 
-<div class="container mx-auto space-y-6 p-4 md:p-6">
-  <div>
-    <h1 class="text-2xl font-bold">Tenants overview</h1>
-    <p class="text-sm text-muted-foreground">
-      Latest glucose across the tenants you have access to. Refreshes every
-      minute.
-    </p>
-  </div>
-
-  {#if loadError}
-    <div class="space-y-2">
-      <p class="text-sm text-muted-foreground">
-        Failed to load the tenants overview.
-      </p>
-      <Button
-        variant="outline"
-        size="sm"
-        onclick={() => overviewQuery.refresh()}
-      >
-        Retry
-      </Button>
-    </div>
-  {:else if overviewQuery.loading && !data}
-    <p class="text-sm text-muted-foreground">Loading…</p>
-  {:else if data}
-    {@const tenants = sortTenantsByUrgency(data.tenants ?? [])}
-    {#if tenants.length === 0}
-      <p class="text-sm text-muted-foreground">
-        No tenants with glucose access.
-      </p>
-    {:else}
-      <div class="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4">
-        {#each tenants as tenant (tenant.tenantId)}
-          <TenantOverviewTile {tenant} {baseDomain} />
-        {/each}
-      </div>
-    {/if}
-  {/if}
-</div>
+<TenantsOverview />

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.server.ts
@@ -1,6 +1,5 @@
 import { redirect } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
-import { getOriginalHost, isShareHost } from "$lib/server/request-host";
 import type { PageServerLoad } from "./$types";
 
 // Marker appended to returnUrl so a single auto-login attempt can be detected
@@ -24,8 +23,8 @@ const AUTO_LOGIN_MARKER = "__autologin";
 const DEV_LOGIN_ENDPOINT = "/api/v4/dev-only/auth/login";
 const DEMO_LOGIN_ENDPOINT = "/api/v4/demo/session";
 
-export const load: PageServerLoad = async ({ url, locals, request }) => {
-  const endpoint = await resolveAutoLoginEndpoint(locals, request);
+export const load: PageServerLoad = async ({ url, locals }) => {
+  const endpoint = await resolveAutoLoginEndpoint(locals);
   if (!endpoint) return;
 
   const raw = url.searchParams.get("returnUrl") || "/";
@@ -58,13 +57,12 @@ export const load: PageServerLoad = async ({ url, locals, request }) => {
  */
 async function resolveAutoLoginEndpoint(
   locals: App.Locals,
-  request: Request,
 ): Promise<string | null> {
   if (env.NOCTURNE_DEV_AUTO_LOGIN === "true") return DEV_LOGIN_ENDPOINT;
 
   // The share host serves the anonymous read-only view and never honors
   // credentials, so there is no session to be had there.
-  if (isShareHost(getOriginalHost(request))) return null;
+  if (locals.isShareHost) return null;
 
   // Fail closed to the passkey UI: an unreachable status call must not bounce a
   // real tenant's owner through an endpoint that will 404.

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/login/+page.svelte
@@ -21,6 +21,9 @@
   // Get return URL from query params
   const returnUrl = $derived(page.url.searchParams.get("returnUrl") || "/");
 
+  // Resolved once by the root layout; here it decides which sign-in methods can work at all.
+  const tenantless = $derived(page.data.tenantless === true);
+
   // Redirect if already authenticated
   $effect(() => {
     const currentAuth = authStateQuery.current;
@@ -51,7 +54,7 @@
     </Card.Header>
 
     <Card.Content>
-      <LoginForm {returnUrl} />
+      <LoginForm {returnUrl} {tenantless} />
     </Card.Content>
 
     <Card.Footer class="flex flex-col space-y-2">

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/+page.server.ts
@@ -1,9 +1,11 @@
 import { redirect } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 import { SETUP_TENANT_COOKIE } from "$lib/server/request-host";
+import { isFreshInstallError } from "$lib/server/onboarding-check";
 
-export const load: PageServerLoad = async ({ locals, cookies }) => {
+export const load: PageServerLoad = async ({ locals, cookies, parent }) => {
   const setupTenantSlug = cookies.get(SETUP_TENANT_COOKIE) ?? null;
+  const { tenantless } = await parent();
 
   if (locals.isAuthenticated) {
     return { setupRequired: false, tenantExists: true, setupTenantSlug };
@@ -22,8 +24,15 @@ export const load: PageServerLoad = async ({ locals, cookies }) => {
     }
   } catch (err) {
     // 503 means zero tenants exist — setup is definitely required
-    if (err && typeof err === "object" && "status" in err && err.status === 503) {
+    if (isFreshInstallError(err)) {
       return { setupRequired: true, tenantExists: false, setupTenantSlug };
+    }
+    // On a host that serves the cross-tenant dashboard the auth-status call has no tenant to
+    // report on and fails for that reason alone, not because the instance is unconfigured. The
+    // fresh-install wizard on a deployment that already has tenants would be actively
+    // misleading, so send the visitor to the sign-in it actually needs.
+    if (tenantless) {
+      redirect(302, "/auth/login?returnUrl=/setup");
     }
     // Any other API failure (network error, 500, etc.) — also show setup,
     // since we can't confirm the instance is healthy

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -1,5 +1,6 @@
 import type { LayoutServerLoad } from "./$types";
-import { extractTenantSlug, getOriginalHost, isShareHost } from "$lib/server/request-host";
+import { getOriginalHost } from "$lib/server/request-host";
+import { classifyHost, parseDashboardSlugs } from "$lib/server/tenantless-host";
 import {
   LANGUAGE_COOKIE_NAME,
   PREFS_COOKIE_NAME,
@@ -17,10 +18,17 @@ import {
 export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
   // Tenant identity is resolved here, from the request host against BASE_DOMAIN,
   // so the browser never has to guess it by counting hostname labels. A share
-  // host carries a token rather than a slug, so it has no tenant to name.
+  // host carries a token rather than a slug, so it has no tenant to name, and a
+  // tenantless host (apex or a reserved dashboard slug) names no single tenant either.
   const host = getOriginalHost(request);
   const baseDomain = process.env.BASE_DOMAIN ?? null;
-  const tenantSlug = isShareHost(host) ? null : extractTenantSlug(host, baseDomain);
+  const { kind, slug } = classifyHost(
+    host,
+    baseDomain,
+    parseDashboardSlugs(process.env.DASHBOARD_SLUGS)
+  );
+  const tenantSlug = slug;
+  const tenantless = kind === "tenantless";
 
   // Display preferences for SSR, in the same precedence the browser applies them
   // (backend blob over the mirrored cookie) so the markup matches hydration.
@@ -44,6 +52,7 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
     isPlatformAdmin: locals.isPlatformAdmin,
     isPlatformAccessGrant: locals.isPlatformAccessGrant ?? false,
     tenantSlug,
+    tenantless,
     baseDomain,
   };
 };

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -1,6 +1,12 @@
 import type { LayoutServerLoad } from "./$types";
 import { getOriginalHost } from "$lib/server/request-host";
-import { classifyHost, parseDashboardSlugs } from "$lib/server/tenantless-host";
+import {
+  apexResolvedTenant,
+  classifyHost,
+  isTenantlessHost,
+  parseDashboardSlugs,
+} from "$lib/server/tenantless-host";
+import { getRequestStatus } from "$lib/server/request-status";
 import {
   LANGUAGE_COOKIE_NAME,
   PREFS_COOKIE_NAME,
@@ -19,7 +25,7 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
   // Tenant identity is resolved here, from the request host against BASE_DOMAIN,
   // so the browser never has to guess it by counting hostname labels. A share
   // host carries a token rather than a slug, so it has no tenant to name, and a
-  // tenantless host (apex or a reserved dashboard slug) names no single tenant either.
+  // reserved dashboard slug names no single tenant either.
   const host = getOriginalHost(request);
   const baseDomain = process.env.BASE_DOMAIN ?? null;
   const { kind, slug } = classifyHost(
@@ -28,7 +34,14 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
     parseDashboardSlugs(process.env.DASHBOARD_SLUGS)
   );
   const tenantSlug = slug;
-  const tenantless = kind === "tenantless";
+
+  // Resolved once here, for every route: the apex needs the API's answer (does a sole tenant
+  // resolve behind it?) and asking per-page would repeat both the question and the round-trip.
+  // Children read `tenantless` from this layout's data via parent().
+  const tenantless = isTenantlessHost(
+    kind,
+    kind === "apex" ? await apexResolvedTenant(() => getRequestStatus(locals)) : false
+  );
 
   // Display preferences for SSR, in the same precedence the browser applies them
   // (backend blob over the mirrored cookie) so the markup matches hydration.

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -28,11 +28,8 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
   // reserved dashboard slug names no single tenant either.
   const host = getOriginalHost(request);
   const baseDomain = process.env.BASE_DOMAIN ?? null;
-  const { kind, slug } = classifyHost(
-    host,
-    baseDomain,
-    parseDashboardSlugs(process.env.DASHBOARD_SLUGS)
-  );
+  const dashboardSlugs = parseDashboardSlugs(process.env.DASHBOARD_SLUGS);
+  const { kind, slug } = classifyHost(host, baseDomain, dashboardSlugs);
   const tenantSlug = slug;
 
   // Resolved once here, for every route: the apex needs the API's answer (does a sole tenant
@@ -67,5 +64,6 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
     tenantSlug,
     tenantless,
     baseDomain,
+    dashboardSlugs,
   };
 };

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -1,7 +1,6 @@
 import type { LayoutServerLoad } from "./$types";
 import { getOriginalHost } from "$lib/server/request-host";
 import {
-  apexResolvedTenant,
   classifyHost,
   isTenantlessHost,
   parseDashboardSlugs,
@@ -37,7 +36,7 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
   // Children read `tenantless` from this layout's data via parent().
   const tenantless = isTenantlessHost(
     kind,
-    kind === "apex" ? await apexResolvedTenant(() => getRequestStatus(locals)) : false
+    kind === "apex" ? Boolean((await getRequestStatus(locals))?.tenantSlug) : false
   );
 
   // Display preferences for SSR, in the same precedence the browser applies them

--- a/src/Web/packages/app/src/routes/realtime/ticket/+server.ts
+++ b/src/Web/packages/app/src/routes/realtime/ticket/+server.ts
@@ -58,6 +58,7 @@ export const GET: RequestHandler = async (event) => {
       "Cache-Control": "no-cache, no-store",
     },
     responseCookies: event.cookies,
+    rawSetCookies: event.locals.rawSetCookies,
     signal: event.request.signal,
   });
 

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
@@ -49,6 +49,8 @@ public class TenantlessDemoSubjectCoverageTests
             // deletes any it picked up elsewhere — so both return the tenant already on screen.
             ["PlatformController.GetTenants"] = "lists the caller's own memberships, which for the demo subject is the demo tenant",
             ["MyTenantsController.GetOverview"] = "aggregates over the caller's own memberships, which for the demo subject is the demo tenant",
+            ["MyTenantsController.GetMyTenants"] = "lists the caller's own memberships, which for the demo subject is the demo tenant",
+            ["MyPermissionsController.GetMyPermissions"] = "returns the caller's own scopes, which off a tenant resolve to the empty set",
 
             ["PlatformController.GetTransitionStatus"] = "reports the deployment's multitenancy configuration, not subject state",
         };

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
@@ -50,7 +50,7 @@ public class TenantlessDemoSubjectCoverageTests
             ["PlatformController.GetTenants"] = "lists the caller's own memberships, which for the demo subject is the demo tenant",
             ["MyTenantsController.GetOverview"] = "aggregates over the caller's own memberships, which for the demo subject is the demo tenant",
             ["MyTenantsController.GetMyTenants"] = "lists the caller's own memberships, which for the demo subject is the demo tenant",
-            ["MyPermissionsController.GetMyPermissions"] = "returns the caller's own scopes, which off a tenant resolve to the empty set",
+            ["MyPermissionsController.GetMyPermissions"] = "returns the caller's own global subject-role scopes; tenant-derived scopes are not applied off a tenant",
 
             ["PlatformController.GetTransitionStatus"] = "reports the deployment's multitenancy configuration, not subject state",
         };
@@ -129,8 +129,10 @@ public class TenantlessDemoSubjectCoverageTests
                 if (!AuthenticationIsTheOnlyGate(action, controller))
                     continue;
 
+                // No method: this sweeps the whole tenantless surface, so a path reachable under
+                // any method has to be covered.
                 if (!ControllerActionReflection.GetRoutes(controller, action)
-                        .Any(TenantResolutionMiddleware.IsTenantlessAllowed))
+                        .Any(route => TenantResolutionMiddleware.IsTenantlessAllowed(route)))
                     continue;
 
                 yield return (controller, action);

--- a/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Nocturne.API.Extensions;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Extensions;
+
+/// <summary>
+/// Covers the session-cookie Domain widening: the value derived from the base domain, that every
+/// writer and the deleter agree on it, and that the pre-widening host-scoped cookies are expired
+/// so a browser holding both converges on one.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class SessionCookieExtensionsTests
+{
+    private const string AccessName = ".Nocturne.AccessToken";
+    private const string RefreshName = ".Nocturne.RefreshToken";
+    private const string FlagName = "IsAuthenticated";
+
+    private static OidcOptions Options(string? sessionDomain) => new()
+    {
+        Cookie = new CookieSettings { SessionDomain = sessionDomain, Secure = true },
+    };
+
+    private static (HttpResponse Response, Func<IReadOnlyList<string>> Cookies) NewResponse()
+    {
+        var ctx = new DefaultHttpContext();
+        return (ctx.Response, () => ctx.Response.Headers.SetCookie.ToArray()!);
+    }
+
+    [Theory]
+    // Ports are not part of a Domain attribute; a value carrying one is discarded by the browser.
+    [InlineData("nocturne.run", ".nocturne.run")]
+    [InlineData("nocturne.run:1612", ".nocturne.run")]
+    [InlineData("cgm.example.co.uk", ".cgm.example.co.uk")]
+    // Single-label hosts cannot carry a Domain attribute at all.
+    [InlineData("localhost", null)]
+    [InlineData("localhost:1612", null)]
+    // Chromium does not reliably scope cookies across *.localhost names.
+    [InlineData("nocturne.localhost", null)]
+    [InlineData("nocturne.localhost:1612", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void ResolveCookieDomain_derives_the_widened_domain(string? baseDomain, string? expected)
+    {
+        SessionCookieExtensions.ResolveCookieDomain(baseDomain).Should().Be(expected);
+    }
+
+    [Fact]
+    public void SetSessionCookies_stamps_the_domain_on_every_session_cookie()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.SetSessionCookies("access", "refresh", DateTimeOffset.UtcNow.AddMinutes(5),
+            Options(".nocturne.run"));
+
+        foreach (var name in new[] { AccessName, RefreshName, FlagName })
+        {
+            Written(cookies(), name).Should().Contain("domain=.nocturne.run",
+                $"{name} must be presented to every host under the base domain");
+        }
+    }
+
+    [Fact]
+    public void SetSessionCookies_expires_the_host_scoped_cookies_it_replaces()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.SetSessionCookies("access", "refresh", DateTimeOffset.UtcNow.AddMinutes(5),
+            Options(".nocturne.run"));
+
+        foreach (var name in new[] { AccessName, RefreshName, FlagName })
+        {
+            var headers = cookies().Where(c => c.StartsWith($"{name}=", StringComparison.Ordinal)).ToList();
+            headers.Should().HaveCount(2,
+                $"{name} needs one domain-wide write plus one host-scoped expiry");
+
+            var hostScoped = headers.Single(h => !h.Contains("domain=", StringComparison.OrdinalIgnoreCase));
+            hostScoped.Should().Contain("expires=Thu, 01 Jan 1970",
+                "the host-scoped variant must be deleted, not merely left behind");
+        }
+    }
+
+    [Fact]
+    public void SetSessionCookies_writes_a_single_host_scoped_cookie_when_not_widened()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.SetSessionCookies("access", "refresh", DateTimeOffset.UtcNow.AddMinutes(5),
+            Options(null));
+
+        foreach (var name in new[] { AccessName, RefreshName, FlagName })
+        {
+            cookies().Count(c => c.StartsWith($"{name}=", StringComparison.Ordinal)).Should().Be(1,
+                $"{name} must not be expired and re-written when cookies are already host-scoped");
+            Written(cookies(), name).Should().NotContain("domain=");
+        }
+    }
+
+    [Fact]
+    public void SetSessionCookies_carries_the_supplied_access_token_expiry()
+    {
+        var (response, cookies) = NewResponse();
+        var expires = DateTimeOffset.UtcNow.AddMinutes(37);
+
+        response.SetSessionCookies("access", "refresh", expires, Options(".nocturne.run"));
+
+        Written(cookies(), AccessName).Should()
+            .Contain(expires.ToString("ddd, dd MMM yyyy HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void ClearSessionCookies_deletes_with_the_same_domain_the_write_used()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.ClearSessionCookies(Options(".nocturne.run"));
+
+        foreach (var name in new[] { AccessName, RefreshName, FlagName })
+        {
+            var headers = cookies().Where(c => c.StartsWith($"{name}=", StringComparison.Ordinal)).ToList();
+            headers.Should().HaveCount(2, "sign-out must clear both the widened and the host-scoped cookie");
+            headers.Should().AllSatisfy(h => h.Should().Contain("expires=Thu, 01 Jan 1970"));
+            headers.Should().ContainSingle(h => h.Contains("domain=.nocturne.run", StringComparison.OrdinalIgnoreCase),
+                "a cookie is keyed by domain, so the delete must present the domain the write used");
+        }
+    }
+
+    [Fact]
+    public void ClearSessionCookies_deletes_host_scoped_cookies_when_not_widened()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.ClearSessionCookies(Options(null));
+
+        foreach (var name in new[] { AccessName, RefreshName, FlagName })
+        {
+            var headers = cookies().Where(c => c.StartsWith($"{name}=", StringComparison.Ordinal)).ToList();
+            headers.Should().ContainSingle();
+            headers[0].Should().Contain("expires=Thu, 01 Jan 1970").And.NotContain("domain=");
+        }
+    }
+
+    /// <summary>The live (non-expiring) Set-Cookie header for a cookie name.</summary>
+    private static string Written(IReadOnlyList<string> cookies, string name) =>
+        cookies.Single(c =>
+            c.StartsWith($"{name}=", StringComparison.Ordinal) &&
+            !c.Contains("expires=Thu, 01 Jan 1970", StringComparison.OrdinalIgnoreCase));
+}

--- a/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
@@ -40,6 +40,13 @@ public sealed class SessionCookieExtensionsTests
     // Chromium does not reliably scope cookies across *.localhost names.
     [InlineData("nocturne.localhost", null)]
     [InlineData("nocturne.localhost:1612", null)]
+    // An IP literal has no domain hierarchy: a browser discards any cookie carrying a Domain
+    // attribute on an IP host, so widening a LAN install's session cookies would lose them all.
+    [InlineData("192.168.1.10", null)]
+    [InlineData("192.168.1.10:1612", null)]
+    [InlineData("127.0.0.1", null)]
+    [InlineData("[::1]", null)]
+    [InlineData("[2001:db8::1]", null)]
     [InlineData("", null)]
     [InlineData(null, null)]
     public void ResolveCookieDomain_derives_the_widened_domain(string? baseDomain, string? expected)
@@ -96,6 +103,33 @@ public sealed class SessionCookieExtensionsTests
                 $"{name} must not be expired and re-written when cookies are already host-scoped");
             Written(cookies(), name).Should().NotContain("domain=");
         }
+    }
+
+    [Fact]
+    public void SetSessionCookies_keeps_the_protective_attributes_on_the_widened_cookies()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.SetSessionCookies("access", "refresh", DateTimeOffset.UtcNow.AddMinutes(5),
+            Options(".nocturne.run"));
+
+        // Widening the domain hands these cookies to every subdomain, including the anonymous
+        // share hosts, so the attributes that keep them off script and off cross-site requests
+        // matter more here than they did when each cookie was host-only.
+        foreach (var name in new[] { AccessName, RefreshName })
+        {
+            Written(cookies(), name).Should()
+                .Contain("httponly", "a session token must stay out of reach of page script")
+                .And.Contain("secure")
+                .And.Contain("samesite=lax");
+        }
+
+        // The flag cookie carries no credential and is read by the frontend, so it alone is not
+        // HttpOnly — but it still travels only over HTTPS and only on same-site navigations.
+        Written(cookies(), FlagName).Should()
+            .NotContain("httponly")
+            .And.Contain("secure")
+            .And.Contain("samesite=lax");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
@@ -176,6 +176,123 @@ public sealed class SessionCookieExtensionsTests
         }
     }
 
+    [Fact]
+    public void ApplyCookieDomainDefaults_widens_both_scopes_from_the_base_domain()
+    {
+        var options = new OidcOptions();
+
+        SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.run:1612");
+
+        options.Cookie.SessionDomain.Should().Be(".nocturne.run");
+        options.Cookie.StateDomain.Should().Be(".nocturne.run",
+            "a login begun on a reserved dashboard slug has no slug in its state to be bounced " +
+            "back by, so its state cookie has to be readable at the apex callback");
+    }
+
+    [Fact]
+    public void ApplyCookieDomainDefaults_lets_the_operators_cookie_domain_win_for_state()
+    {
+        var options = new OidcOptions
+        {
+            Cookie = new CookieSettings { Domain = ".ops.example.com" },
+        };
+
+        SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.run");
+
+        options.Cookie.StateDomain.Should().Be(".ops.example.com",
+            "an operator who set Cookie.Domain already scoped the state cookies deliberately");
+        options.Cookie.SessionDomain.Should().Be(".nocturne.run",
+            "session scope stays derived from the base domain, not a side effect of that knob");
+    }
+
+    [Fact]
+    public void ApplyCookieDomainDefaults_leaves_both_host_scoped_where_widening_is_unsafe()
+    {
+        var options = new OidcOptions();
+
+        SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.localhost:1612");
+
+        options.Cookie.SessionDomain.Should().BeNull();
+        options.Cookie.StateDomain.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyCookieDomainDefaults_never_overwrites_an_explicit_value()
+    {
+        var options = new OidcOptions
+        {
+            Cookie = new CookieSettings { SessionDomain = ".a.example", StateDomain = ".b.example" },
+        };
+
+        SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.run");
+
+        options.Cookie.SessionDomain.Should().Be(".a.example");
+        options.Cookie.StateDomain.Should().Be(".b.example");
+    }
+
+    [Fact]
+    public void SetStateCookie_stamps_the_state_domain_so_the_apex_callback_can_read_it()
+    {
+        var (response, cookies) = NewResponse();
+        var options = new OidcOptions
+        {
+            Cookie = new CookieSettings { StateDomain = ".nocturne.run", Secure = true },
+        };
+
+        response.SetStateCookie(".Nocturne.OidcState", "abc", DateTimeOffset.UtcNow.AddMinutes(15), options);
+
+        // The registered redirect_uri is the apex callback. A login begun on any other host —
+        // a tenant subdomain, or a reserved dashboard slug that has no slug in its state for
+        // OidcCallbackRedirectMiddleware to bounce back to — must present this cookie there.
+        Written(cookies(), ".Nocturne.OidcState").Should()
+            .Contain("domain=.nocturne.run")
+            .And.Contain("httponly")
+            .And.Contain("secure")
+            .And.Contain("samesite=lax");
+    }
+
+    [Fact]
+    public void SetStateCookie_expires_the_host_scoped_cookie_it_replaces()
+    {
+        var (response, cookies) = NewResponse();
+        var options = new OidcOptions
+        {
+            Cookie = new CookieSettings { StateDomain = ".nocturne.run", Secure = true },
+        };
+
+        response.SetStateCookie(".Nocturne.OidcState", "abc", DateTimeOffset.UtcNow.AddMinutes(15), options);
+
+        var headers = cookies().Where(c => c.StartsWith(".Nocturne.OidcState=", StringComparison.Ordinal)).ToList();
+        headers.Should().HaveCount(2, "a browser holding the pre-widening host-only cookie sends both");
+        headers.Single(h => !h.Contains("domain=", StringComparison.OrdinalIgnoreCase))
+            .Should().Contain("expires=Thu, 01 Jan 1970");
+    }
+
+    [Fact]
+    public void SetStateCookie_stays_host_scoped_when_no_state_domain_is_resolved()
+    {
+        var (response, cookies) = NewResponse();
+        var options = new OidcOptions { Cookie = new CookieSettings { StateDomain = null } };
+
+        response.SetStateCookie(".Nocturne.OidcState", "abc", DateTimeOffset.UtcNow.AddMinutes(15), options);
+
+        cookies().Should().ContainSingle().Which.Should().NotContain("domain=");
+    }
+
+    [Fact]
+    public void ClearStateCookie_deletes_both_scopes_so_single_use_state_is_really_single_use()
+    {
+        var (response, cookies) = NewResponse();
+        var options = new OidcOptions { Cookie = new CookieSettings { StateDomain = ".nocturne.run" } };
+
+        response.ClearStateCookie(".Nocturne.OidcState", options);
+
+        var headers = cookies().Where(c => c.StartsWith(".Nocturne.OidcState=", StringComparison.Ordinal)).ToList();
+        headers.Should().HaveCount(2);
+        headers.Should().AllSatisfy(h => h.Should().Contain("expires=Thu, 01 Jan 1970"));
+        headers.Should().ContainSingle(h => h.Contains("domain=.nocturne.run", StringComparison.OrdinalIgnoreCase));
+    }
+
     /// <summary>The live (non-expiring) Set-Cookie header for a cookie name.</summary>
     private static string Written(IReadOnlyList<string> cookies, string name) =>
         cookies.Single(c =>

--- a/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
@@ -7,9 +7,9 @@ using Xunit;
 namespace Nocturne.API.Tests.Extensions;
 
 /// <summary>
-/// Covers the session-cookie Domain widening: the value derived from the base domain, that every
-/// writer and the deleter agree on it, and that the pre-widening host-scoped cookies are expired
-/// so a browser holding both converges on one.
+/// Covers the cookie Domain widening — session, state, and platform-access grant: the value
+/// derived from the base domain, that every writer and the deleter agree on it, and that the
+/// pre-widening host-scoped cookies are expired so a browser holding both converges on one.
 /// </summary>
 [Trait("Category", "Unit")]
 public sealed class SessionCookieExtensionsTests
@@ -177,7 +177,7 @@ public sealed class SessionCookieExtensionsTests
     }
 
     [Fact]
-    public void ApplyCookieDomainDefaults_widens_both_scopes_from_the_base_domain()
+    public void ApplyCookieDomainDefaults_widens_all_three_scopes_from_the_base_domain()
     {
         var options = new OidcOptions();
 
@@ -187,6 +187,30 @@ public sealed class SessionCookieExtensionsTests
         options.Cookie.StateDomain.Should().Be(".nocturne.run",
             "a login begun on a reserved dashboard slug has no slug in its state to be bounced " +
             "back by, so its state cookie has to be readable at the apex callback");
+        options.Cookie.Domain.Should().Be(".nocturne.run",
+            "the platform-access grant is minted on the apex and redeemed on the tenant " +
+            "subdomain it is pinned to, so a host-only grant never arrives");
+    }
+
+    [Theory]
+    // Single-label hosts, *.localhost, and IP literals cannot carry a Domain attribute; the
+    // platform-access grant stays host-only there for the same reasons the session cookies do.
+    [InlineData("localhost")]
+    [InlineData("nocturne.localhost:1612")]
+    [InlineData("192.168.1.10")]
+    [InlineData("[2001:db8::1]")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ApplyCookieDomainDefaults_leaves_every_scope_host_scoped_where_widening_is_unsafe(
+        string? baseDomain)
+    {
+        var options = new OidcOptions();
+
+        SessionCookieExtensions.ApplyCookieDomainDefaults(options, baseDomain);
+
+        options.Cookie.SessionDomain.Should().BeNull();
+        options.Cookie.StateDomain.Should().BeNull();
+        options.Cookie.Domain.Should().BeNull();
     }
 
     [Fact]
@@ -199,21 +223,12 @@ public sealed class SessionCookieExtensionsTests
 
         SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.run");
 
+        options.Cookie.Domain.Should().Be(".ops.example.com",
+            "the derived default must not overwrite an operator's explicit scope");
         options.Cookie.StateDomain.Should().Be(".ops.example.com",
             "an operator who set Cookie.Domain already scoped the state cookies deliberately");
         options.Cookie.SessionDomain.Should().Be(".nocturne.run",
             "session scope stays derived from the base domain, not a side effect of that knob");
-    }
-
-    [Fact]
-    public void ApplyCookieDomainDefaults_leaves_both_host_scoped_where_widening_is_unsafe()
-    {
-        var options = new OidcOptions();
-
-        SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.localhost:1612");
-
-        options.Cookie.SessionDomain.Should().BeNull();
-        options.Cookie.StateDomain.Should().BeNull();
     }
 
     [Fact]
@@ -227,7 +242,10 @@ public sealed class SessionCookieExtensionsTests
         SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.run");
 
         options.Cookie.SessionDomain.Should().Be(".a.example");
-        options.Cookie.StateDomain.Should().Be(".b.example");
+        options.Cookie.StateDomain.Should().Be(".b.example",
+            "an explicit state scope survives the derivation of Cookie.Domain, which it would " +
+            "otherwise have defaulted from");
+        options.Cookie.Domain.Should().Be(".nocturne.run");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/AuthenticationMiddlewareShareAccessTests.cs
@@ -12,6 +12,7 @@ using Nocturne.API.Middleware;
 using Nocturne.API.Middleware.Handlers;
 using Nocturne.API.Services.Auth;
 using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
@@ -50,19 +51,56 @@ public sealed class AuthenticationMiddlewareShareAccessTests
             new MemoryCache(new MemoryCacheOptions()), factory.Object, NullLogger<PublicAccessCacheService>.Instance);
     }
 
-    private AuthenticationMiddleware Build(params IAuthHandler[] handlers) => new(
+    private AuthenticationMiddleware Build(params IAuthHandler[] handlers) =>
+        Build(Mock.Of<IServiceScopeFactory>(), handlers);
+
+    private AuthenticationMiddleware Build(IServiceScopeFactory scopeFactory, params IAuthHandler[] handlers) => new(
         next: _ => Task.CompletedTask,
         logger: NullLogger<AuthenticationMiddleware>.Instance,
         handlers: handlers,
         environment: Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Production"),
         publicAccessCacheService: _publicAccess,
         oidcOptions: Options.Create(new OidcOptions()),
-        scopeFactory: Mock.Of<IServiceScopeFactory>());
+        scopeFactory: scopeFactory);
+
+    /// <summary>
+    /// A real session-cookie credential for the seeded member subject, plus the scope factory the
+    /// middleware needs to resolve it (subject lookup for the platform-admin flag).
+    /// </summary>
+    private (SessionCookieHandler Handler, IServiceScopeFactory ScopeFactory, string Token) RealSessionCredential()
+    {
+        var jwt = new JwtService(
+            Options.Create(new JwtOptions { SecretKey = new string('k', 48) }),
+            NullLogger<JwtService>.Instance);
+
+        var token = jwt.GenerateAccessToken(
+            new SubjectInfo { Id = TestDatabaseSeeder.TestSubjectId, Name = "owner" },
+            permissions: ["*"],
+            roles: ["Owner"]);
+
+        // Sanity: the credential really is valid, so a "not authenticated" result below is the
+        // share gate at work rather than a token that would have been rejected anyway.
+        jwt.ValidateAccessToken(token).IsValid.Should().BeTrue();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IJwtService>(jwt);
+        services.AddScoped(_ => TestDbContextFactory.CreateInMemoryContext(_dbName));
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        var handler = new SessionCookieHandler(
+            scopeFactory, NullLogger<SessionCookieHandler>.Instance, Options.Create(new OidcOptions()));
+
+        return (handler, scopeFactory, token);
+    }
 
     private static DefaultHttpContext ContextFor(bool shareAccess)
     {
         var services = new ServiceCollection();
         services.AddScoped<ICategoryReadContext, CategoryReadContext>();
+        // The seeded subject is a member of the seeded tenant; the middleware's membership check
+        // is orthogonal to the share gate under test, so it is satisfied rather than exercised.
+        services.AddSingleton(Mock.Of<ITenantMemberService>(m =>
+            m.IsMemberAsync(TestDatabaseSeeder.TestSubjectId, TestDatabaseSeeder.TenantId) == Task.FromResult(true)));
         var ctx = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
         ctx.Items["TenantContext"] =
             new TenantContext(TestDatabaseSeeder.TenantId, "acme", "Acme", true, false);
@@ -259,6 +297,50 @@ public sealed class AuthenticationMiddlewareShareAccessTests
         var auth = ctx.Items["AuthContext"] as AuthContext;
         auth!.IsAuthenticated.Should().BeFalse("the share host must never honor credentials");
         auth.SubjectId.Should().Be(TestDatabaseSeeder.PublicSubjectId);
+    }
+
+    [Fact]
+    public async Task Share_host_ignores_a_real_session_cookie()
+    {
+        // Session cookies are scoped to ".{base-domain}" so one sign-in reaches the apex
+        // dashboard and every tenant subdomain. That also means the browser now presents them on
+        // {token}.share.{base-domain}, a host that must stay anonymous for everyone: an owner
+        // following their own share link has to see exactly what a stranger sees. Unlike the
+        // fake-handler test above, this drives the real SessionCookieHandler with a genuinely
+        // valid JWT, so it fails if the share gate ever moves below credential resolution.
+        var (handler, scopeFactory, token) = RealSessionCredential();
+
+        var ctx = ContextFor(shareAccess: true);
+        ctx.Request.Headers.Cookie = $".Nocturne.AccessToken={token}";
+
+        await Build(scopeFactory, handler).InvokeAsync(ctx);
+
+        var auth = ctx.Items["AuthContext"] as AuthContext;
+        auth!.IsAuthenticated.Should().BeFalse(
+            "a valid session cookie must not authenticate on a share host");
+        auth.SubjectId.Should().Be(TestDatabaseSeeder.PublicSubjectId,
+            "the share host resolves to the anonymous Public subject, never the cookie's owner");
+        auth.Permissions.Should().NotContain("*");
+        ctx.User.Identity?.IsAuthenticated.Should().NotBe(true,
+            "[Authorize] reads the principal, so it must be anonymous too");
+    }
+
+    [Fact]
+    public async Task Bare_host_honours_the_same_session_cookie()
+    {
+        // The sensitivity guard for the test above: the identical credential on a non-share host
+        // authenticates. Without this, "not authenticated" could pass for the wrong reason (an
+        // unparseable token, a misnamed cookie) and the share gate would go untested.
+        var (handler, scopeFactory, token) = RealSessionCredential();
+
+        var ctx = ContextFor(shareAccess: false);
+        ctx.Request.Headers.Cookie = $".Nocturne.AccessToken={token}";
+
+        await Build(scopeFactory, handler).InvokeAsync(ctx);
+
+        var auth = ctx.Items["AuthContext"] as AuthContext;
+        auth!.IsAuthenticated.Should().BeTrue();
+        auth.SubjectId.Should().Be(TestDatabaseSeeder.TestSubjectId);
     }
 
     private sealed class AlwaysAuthHandler : IAuthHandler

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
@@ -70,11 +70,12 @@ public sealed class TenantResolutionMiddlewareApexTests : IDisposable
     }
 
     // Host == BaseDomain → apex, no subdomain.
-    private DefaultHttpContext ApexRequest(IServiceScope scope, string path)
+    private DefaultHttpContext ApexRequest(IServiceScope scope, string path, string method = "GET")
     {
         var ctx = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
         ctx.Request.Headers["X-Forwarded-Host"] = BaseDomain;
         ctx.Request.Path = path;
+        ctx.Request.Method = method;
         ctx.Response.Body = new MemoryStream();
         return ctx;
     }
@@ -133,6 +134,47 @@ public sealed class TenantResolutionMiddlewareApexTests : IDisposable
         // through, so the apex status response is unchanged for multi-tenant deployments.
         nextCalled.Should().BeTrue();
         scope.ServiceProvider.GetRequiredService<ITenantAccessor>().IsResolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Apex_status_with_a_sole_tenant_names_it_so_the_web_serves_the_full_app()
+    {
+        SeedTenant("theconen");
+        using var scope = _root.CreateScope();
+
+        var mw = Build(_ => Task.CompletedTask);
+        var ctx = ApexRequest(scope, "/api/v4/status");
+
+        await mw.InvokeAsync(ctx);
+
+        // The status response carries this slug, and it is the only thing that tells the web app
+        // an apex serving a single-tenant install apart from one serving the dashboard. Getting
+        // it wrong trims that install's sidebar and bounces it to a wildcard subdomain.
+        scope.ServiceProvider.GetRequiredService<ITenantAccessor>().Context!.Slug
+            .Should().Be("theconen");
+    }
+
+    [Fact]
+    public async Task Apex_tenant_list_is_readable_but_not_creatable()
+    {
+        SeedTenant("alpha");
+        SeedTenant("beta");
+        using var scope = _root.CreateScope();
+
+        var read = false;
+        var readCtx = ApexRequest(scope, "/api/v4/me/tenants");
+        await Build(_ => { read = true; return Task.CompletedTask; }).InvokeAsync(readCtx);
+
+        var created = false;
+        var createCtx = ApexRequest(scope, "/api/v4/me/tenants", "POST");
+        await Build(_ => { created = true; return Task.CompletedTask; }).InvokeAsync(createCtx);
+
+        // The list is keyed on the caller's subject and is what the dashboard navigates by. The
+        // POST on the same path provisions a tenant, which is not a cross-tenant read and has no
+        // business on a host that resolves none — so it falls through to the ordinary apex 404.
+        read.Should().BeTrue();
+        created.Should().BeFalse();
+        createCtx.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Nocturne.API.Multitenancy;
 using Xunit;
 
@@ -21,7 +22,7 @@ public sealed class TenantlessDashboardPathsTests
     [InlineData("/api/v4/me/tenants/overview")]
     // Drives the navigation and tenant switcher.
     [InlineData("/api/v4/me/tenants")]
-    // Resolves to an empty scope set tenantlessly, which is the correct answer.
+    // Reports the caller's own global subject-role scopes; nothing tenant-derived.
     [InlineData("/api/v4/me/permissions")]
     public void The_tenantless_dashboard_paths_are_allowed(string path)
     {
@@ -48,5 +49,37 @@ public sealed class TenantlessDashboardPathsTests
         TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants").Should().BeTrue();
         TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants/anything-else")
             .Should().BeFalse();
+    }
+
+    [Fact]
+    public void The_subject_tenant_list_admits_only_the_read()
+    {
+        // The same path takes a POST that creates a tenant (MyTenantsController.Create).
+        // Self-service provisioning affects tenants rather than reading across them, and in the
+        // hosted deployment it goes through billing, so it stays off a host with no tenant.
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants", HttpMethods.Get)
+            .Should().BeTrue();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants", HttpMethods.Post)
+            .Should().BeFalse();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants", HttpMethods.Delete)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void An_unrestricted_path_admits_every_method()
+    {
+        // Most entries name no method, so narrowing one must not narrow the rest.
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/oidc/logout", HttpMethods.Post)
+            .Should().BeTrue();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants/overview", HttpMethods.Get)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Omitting_the_method_asks_about_the_path_under_any_method()
+    {
+        // The authorization coverage sweep enumerates the whole tenantless surface and has no
+        // request to take a method from, so a method-restricted path must still be reported.
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants").Should().BeTrue();
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
@@ -18,6 +18,8 @@ public sealed class TenantlessDashboardPathsTests
     [InlineData("/api/auth/oidc/session")]
     // Sign-out from the dashboard.
     [InlineData("/api/auth/oidc/logout")]
+    // Driven by the client's expiry timer; a 404 here signs the shell out of a live session.
+    [InlineData("/api/auth/oidc/refresh")]
     // Drives the dashboard tiles.
     [InlineData("/api/v4/me/tenants/overview")]
     // Drives the navigation and tenant switcher.
@@ -62,6 +64,20 @@ public sealed class TenantlessDashboardPathsTests
         TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants", HttpMethods.Post)
             .Should().BeFalse();
         TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants", HttpMethods.Delete)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void The_session_refresh_admits_only_the_post()
+    {
+        // Refresh is subject-scoped — it validates the refresh token, reads global subject roles,
+        // and mints an access token with no tenant pin — so it is safe without a tenant. POST is
+        // the only verb the endpoint serves, and naming it keeps any future sibling verb gated.
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/oidc/refresh", HttpMethods.Post)
+            .Should().BeTrue();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/oidc/refresh", HttpMethods.Get)
+            .Should().BeFalse();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/oidc/refresh", HttpMethods.Delete)
             .Should().BeFalse();
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
@@ -82,4 +82,12 @@ public sealed class TenantlessDashboardPathsTests
         // request to take a method from, so a method-restricted path must still be reported.
         TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants").Should().BeTrue();
     }
+
+    [Fact]
+    public void An_empty_method_is_a_method_not_an_omission()
+    {
+        // Only an omitted method means "any". A real request always carries one, and treating
+        // the empty string as a wildcard would admit a blank-verb request to a narrowed path.
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants", "").Should().BeFalse();
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Nocturne.API.Multitenancy;
+using Xunit;
+
+namespace Nocturne.API.Tests.Multitenancy;
+
+/// <summary>
+/// The tenantless dashboard host (apex, or a reserved dashboard slug) resolves no tenant, so every
+/// request it makes 404s unless the path is tenantless-allowed. These pin the paths that host
+/// actually calls, and the tenant-scoped ones that must keep 404ing there.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class TenantlessDashboardPathsTests
+{
+    [Theory]
+    // Called on every page load; without it the dashboard 404s before rendering.
+    [InlineData("/api/auth/oidc/session")]
+    // Sign-out from the dashboard.
+    [InlineData("/api/auth/oidc/logout")]
+    // Drives the dashboard tiles.
+    [InlineData("/api/v4/me/tenants/overview")]
+    // Drives the navigation and tenant switcher.
+    [InlineData("/api/v4/me/tenants")]
+    // Resolves to an empty scope set tenantlessly, which is the correct answer.
+    [InlineData("/api/v4/me/permissions")]
+    public void The_tenantless_dashboard_paths_are_allowed(string path)
+    {
+        TenantResolutionMiddleware.IsTenantlessAllowed(path).Should().BeTrue();
+    }
+
+    [Theory]
+    // Tenant-scoped reads must not become reachable without a tenant.
+    [InlineData("/api/v4/entries")]
+    [InlineData("/api/v4/treatments")]
+    [InlineData("/api/v4/chart-data/dashboard")]
+    [InlineData("/api/v4/me/tenants/overview/extra")]
+    [InlineData("/api/v4/me/permissions/grant")]
+    public void Tenant_scoped_paths_stay_gated(string path)
+    {
+        TenantResolutionMiddleware.IsTenantlessAllowed(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void The_subject_tenant_list_is_matched_exactly_not_as_a_prefix()
+    {
+        // "/api/v4/me/tenants" is an exact-match entry: adding it as a prefix would expose every
+        // per-tenant sub-route under it (member management, settings) on a host with no tenant.
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants").Should().BeTrue();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/v4/me/tenants/anything-else")
+            .Should().BeFalse();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
@@ -26,6 +26,8 @@ public sealed class TenantlessDashboardPathsTests
     [InlineData("/api/v4/me/tenants")]
     // Reports the caller's own global subject-role scopes; nothing tenant-derived.
     [InlineData("/api/v4/me/permissions")]
+    // The login page's provider buttons — the only sign-in affordance on a tenantless host.
+    [InlineData("/api/auth/oidc/providers")]
     public void The_tenantless_dashboard_paths_are_allowed(string path)
     {
         TenantResolutionMiddleware.IsTenantlessAllowed(path).Should().BeTrue();
@@ -78,6 +80,20 @@ public sealed class TenantlessDashboardPathsTests
         TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/oidc/refresh", HttpMethods.Get)
             .Should().BeFalse();
         TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/oidc/refresh", HttpMethods.Delete)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void The_provider_list_admits_only_the_read()
+    {
+        // Listing the enabled providers exposes nothing tenant-scoped — the allow-listed
+        // /api/auth/oidc/login already reads the same set on a tenantless host. GET is the only
+        // verb the endpoint serves, and naming it keeps any future sibling verb gated.
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/oidc/providers", HttpMethods.Get)
+            .Should().BeTrue();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/oidc/providers", HttpMethods.Post)
+            .Should().BeFalse();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/oidc/providers", HttpMethods.Delete)
             .Should().BeFalse();
     }
 


### PR DESCRIPTION
Stacked on #466 (the `/tenants` overview page). Review that one first; this PR reuses its components and remote query rather than duplicating them.

Families currently have to visit a tenant subdomain's `/tenants` path to see everyone they care for. This serves that overview on the hosts that name no tenant.

## Design: which hosts are tenantless

Two, both classified suffix-first against `BASE_DOMAIN` in `$lib/server/tenantless-host.ts`, next to the existing `extractTenantSlug`:

- **the apex** — what a self-hosted family deployment uses;
- **a reserved dashboard slug** — new `DASHBOARD_SLUGS` env var, default `dashboard,app`, for hosted deployments whose apex is already a marketing site.

Label counts carry no meaning (`nocturne.example.com` is as valid a base domain as `example.com`), so nothing counts labels. Share hosts are classified *before* the slug split, so a share token that happens to spell `dashboard` is still a share host.

Root `/` renders the overview through a `TenantsOverview` component that `/tenants` also renders, so the two surfaces cannot drift. `/tenants` stays available for tenant hosts.

**Single-tenant redirect.** A caregiver whose overview holds exactly one tenant is redirected (303) to that tenant's host instead of being shown a one-tile page. Zero or several tenants render the dashboard. An overview fetch that fails costs only the shortcut, never the page.

**Trimmed surface.** Tenant-scoped nav is hidden on tenantless hosts, and direct navigation to it redirects to `/` — those pages would otherwise render a shell and then 404, since there is no tenant to resolve. What remains: the dashboard, plus `/settings/account` and `/settings/appearance`, which belong to the subject rather than a tenant. Signed-out visitors get the normal login page.

**API reachability.** `GET /api/v4/me/tenants/overview` was already tenantless-allowed. Four more paths the dashboard and its page loads actually call were not, and 404'd on a tenantless host: `/api/auth/oidc/session` (every page load), `/api/auth/oidc/logout`, `/api/v4/me/tenants`, `/api/v4/me/permissions`. All are keyed on SubjectId alone or resolve to the empty set off a tenant. Added as exact-match entries, not prefixes, so per-tenant sub-routes stay gated.

## Session continuity across subdomains

Session cookies now carry `Domain=.{base-domain}`, so signing in on one tenant subdomain lands you on the apex dashboard already signed in.

- **One writer.** The three writers (`SessionCookieExtensions.SetSessionCookies`, `OidcController`, the post-refresh writer in `SessionCookieHandler`) were three copies of the same attribute list — exactly how a `Domain` drifts between them. They now delegate to one implementation, so deletion parity is structural rather than maintained by hand.
- **Scope.** The widening is confined to a new `Cookie.SessionDomain`. The OIDC state, platform-access, and recovery cookies keep the host-scoped `Cookie.Domain`: those grants are only ever redeemed on the host that minted them, and widening them would hand the same credential to every subdomain including the anonymous share hosts. Noted at the definition site.
- **Transition.** A browser that authenticated before this change holds a host-scoped cookie and will be sent a domain-wide one; it presents both under a single `Cookie` header with no way for the server to tell them apart, so which one is read would be arbitrary. Every successful auth/refresh therefore expires the host-scoped variant first, and clients converge on one cookie after a single authenticated response. Order matters: `Response.Cookies.Delete` strips already-appended `Set-Cookie` headers matching by path, so deleting after appending would cancel the write. Sign-out clears both variants.
- **Ports.** `Domain` attributes carry no port; a value with one is discarded wholesale, taking the session with it. Stripped via the existing `BaseDomainOptions.SplitHostPort`.
- **Dev caveat.** Widening is skipped when the base domain is a single label (`localhost` — browsers reject a `Domain` there outright) or a `.localhost` name, because Chromium does not reliably scope cookies across `*.localhost`. Local dev keeps host-only cookies and behaves exactly as before; cross-subdomain continuity is not exercisable locally without a real domain. Commented at the definition site.

### Share hosts

`{token}.share.{base-domain}` now also receives the widened cookie, so this needed proving rather than assuming.

The API was already correct — `AuthenticationMiddleware` returns `AuthContext.Unauthenticated()` whenever `Items["ShareAccess"]` is set — but the only test covering it drove a stub handler and **passed for the wrong reason**: with the share gate inverted it still passed, because the stubbed scope factory threw before the credential was ever resolved. Replaced with a test that drives the real `SessionCookieHandler` over a genuinely valid JWT, plus a bare-host counterpart so "not authenticated" cannot pass on a token that was never valid. Mutation-checked: inverting the gate fails the share test and only the share test.

On the web side the answer was *not* already true — `authHandle` read session cookies unconditionally, so a signed-in owner would have had SSR render a signed-in shell over an anonymous API (and, because share-host permissions come back empty, actually see *less* than a stranger). The web app now ignores session cookies on share hosts entirely and stops forwarding them to the API, matching the API's rule.

## Testing

- C#: 12 new cookie tests (derived domain incl. port/localhost cases, `Domain` on all session cookies, host-scoped cleanup, no self-expiry when not widened, deletion parity both ways), 8 tenantless-path tests, 2 share-host tests. Full `Nocturne.API.Tests` unit suite green: **5407 passed, 0 failed, 5 skipped**.
- Web: 29 vitest cases over the pure host-classification, nav-filter, and single-tenant-redirect functions; full suite 691 passed.
- `pnpm check`: **64 errors, matching the baseline exactly — zero new** (verified by diffing the error lists against a stashed tree, not just the count).

## Follow-ups (deliberately not done here)

1. **Apex-first sign-in.** The spec assumed passkey login works on the apex because the WebAuthn RP ID is already the base domain. It does not: `PasskeyService.CompleteAssertionAsync` requires the credential's subject to be a member of *the resolved tenant*, and there is none. TOTP and the username passkey flow are gated the same way. Making them tenantless is a security-relevant auth change that deserves its own review, so it is not in this PR. Practical impact is limited — session continuity means anyone signed in on any tenant arrives at the apex signed in — but a user whose only entry point is the apex cannot yet sign in there.
2. nocturne-cloud YARP/marketing routing and billing slug reservation for a cloud dashboard subdomain (`DASHBOARD_SLUGS` must not collide with a provisionable tenant slug).
3. The SignalR hub is not served on tenantless hosts, so the dashboard polls on its existing 60s refresh rather than updating live.
4. Marketing changes.

https://claude.ai/code/session_014gZWTmjMDSLtxp22i2cJe3
