### PR TITLE
fix(security): scope-gate the v4 merged activity reads

### DIFF
--- a/src/API/Nocturne.API/Authorization/ActivityReadScopeGuard.cs
+++ b/src/API/Nocturne.API/Authorization/ActivityReadScopeGuard.cs
@@ -34,9 +34,24 @@ internal static class ActivityReadScopeGuard
     ];
 
     /// <summary>
+    /// The categories the caller may read, for a count that asks each source separately instead of
+    /// filtering records the way <see cref="Filter"/> does. Named by the same read scope
+    /// <see cref="IActivityDecomposer.RequiredReadScope"/> returns, so the two agree on what a
+    /// category is.
+    /// </summary>
+    public static IReadOnlySet<string> GrantedCategories(HttpContext httpContext)
+    {
+        var granted = httpContext.GetGrantedScopes();
+        return AdmissionScopes
+            .Where(scope => OAuthScopes.SatisfiesScope(granted, scope))
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    /// <summary>
     /// The result to return instead of a merged activity count, or <see langword="null"/> when the
-    /// caller may have it. A count cannot be filtered the way <see cref="Filter"/> filters records,
-    /// so it takes every category rather than any one of them.
+    /// caller may have it. A single number cannot be attributed to a category the way
+    /// <see cref="GrantedCategories"/> lets a per-category count be, so it takes every category
+    /// rather than any one of them.
     /// </summary>
     public static ActionResult? RefuseUnlessEveryCategory(HttpContext httpContext)
     {

--- a/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
 using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Extensions;
@@ -7,6 +8,7 @@ using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using OpenApi.Remote.Attributes;
 
@@ -43,10 +45,22 @@ public class ActivityController : ControllerBase
     /// <remarks>
     /// This read merges four sources in memory, so the page is bounded by
     /// <see cref="V4ReadLimits.ClampMergedPage"/> rather than the plain page-size ceiling.
+    /// The scope requirement is an OR over the four storages, and
+    /// <see cref="ActivityReadScopeGuard"/> then drops the records whose category the caller does
+    /// not hold — pagination happens in the service before that filter, so a caller holding a
+    /// subset of the categories can receive fewer than <paramref name="limit"/> records. The total
+    /// is counted over only those same categories, both so it stays consistent with what the page
+    /// can contain and so it cannot disclose how many records exist in a category the caller may
+    /// not read.
     /// </remarks>
     [HttpGet]
     [RemoteQuery]
     [ProducesResponseType(typeof(PaginatedResponse<Activity>), StatusCodes.Status200OK)]
+    [RequireScope(
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead)]
     public async Task<ActionResult<PaginatedResponse<Activity>>> GetActivities(
         [FromQuery] int limit = 100,
         [FromQuery] int offset = 0,
@@ -57,11 +71,17 @@ public class ActivityController : ControllerBase
 
         var records = await _activityService.GetActivitiesAsync(
             count: limit, skip: offset, cancellationToken: cancellationToken);
-        var total = (int)await _activityService.CountActivitiesAsync(cancellationToken: cancellationToken);
+        var visible = ActivityReadScopeGuard.Filter(
+            records, _activityDecomposer, HttpContext.GetGrantedScopes());
+
+        var counts = await _activityService.CountActivitiesByCategoryAsync(
+            ActivityReadScopeGuard.GrantedCategories(HttpContext),
+            cancellationToken: cancellationToken);
+        var total = (int)counts.Values.Sum();
 
         return Ok(new PaginatedResponse<Activity>
         {
-            Data = records,
+            Data = visible,
             Pagination = new PaginationInfo(limit, offset, total),
         });
     }
@@ -69,16 +89,29 @@ public class ActivityController : ControllerBase
     /// <summary>
     /// Get a specific activity record by ID
     /// </summary>
+    /// <remarks>
+    /// A record in a category the caller does not hold answers 404 rather than 403, so the
+    /// response does not disclose that the record exists.
+    /// </remarks>
     [HttpGet("{id}")]
     [RemoteQuery]
     [ProducesResponseType(typeof(Activity), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [RequireScope(
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead)]
     public async Task<ActionResult<Activity>> GetActivity(
         string id,
         CancellationToken cancellationToken = default)
     {
         var record = await _activityService.GetActivityByIdAsync(id, cancellationToken);
         if (record == null)
+            return NotFound();
+
+        if (!ActivityReadScopeGuard.CanRead(
+            record, _activityDecomposer, HttpContext.GetGrantedScopes()))
             return NotFound();
 
         return Ok(record);

--- a/src/API/Nocturne.API/Services/Health/ActivityService.cs
+++ b/src/API/Nocturne.API/Services/Health/ActivityService.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Sleep;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.API.Services.Realtime;
 using Nocturne.Infrastructure.Data.Mappers;
 
@@ -42,6 +43,19 @@ public class ActivityService : IActivityService
     /// what a caller may request.
     /// </summary>
     private const int MaxOverFetch = 100_000;
+
+    /// <summary>
+    /// Every source <see cref="CountActivitiesByCategoryAsync"/> knows how to count, named by the
+    /// read scope its records carry.
+    /// </summary>
+    private static readonly IReadOnlySet<string> CountableCategories = new HashSet<string>(
+        StringComparer.Ordinal)
+    {
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead,
+    };
 
     /// <summary>
     /// Initializes a new instance of <see cref="ActivityService"/>.
@@ -564,50 +578,70 @@ public class ActivityService : IActivityService
         CancellationToken cancellationToken = default
     )
     {
+        var counts = await CountActivitiesByCategoryAsync(
+            CountableCategories, find, cancellationToken);
+        return counts.Values.Sum();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<string, long>> CountActivitiesByCategoryAsync(
+        IReadOnlySet<string> categories,
+        string? find = null,
+        CancellationToken cancellationToken = default
+    )
+    {
         try
         {
-            _logger.LogDebug("Counting activity records with find: {Find}", find);
-
-            // Count from each decomposed source and sum
-            var stateSpanTask = _stateSpanService.GetActivitiesAsync(
-                type: find,
-                count: int.MaxValue,
-                skip: 0,
-                cancellationToken: cancellationToken
-            );
-
-            var heartRateTask = _heartRateService.GetHeartRatesAsync(
-                count: int.MaxValue,
-                skip: 0,
-                cancellationToken: cancellationToken
-            );
-
-            var stepCountTask = _stepCountService.GetStepCountsAsync(
-                count: int.MaxValue,
-                skip: 0,
-                cancellationToken: cancellationToken
-            );
+            _logger.LogDebug(
+                "Counting activity records in {Categories} with find: {Find}",
+                string.Join(",", categories),
+                find);
 
             // Sleep sessions are merged into GetActivitiesAsync only when `find` is
             // empty or a sleep type; the count applies the same gate
-            var sleepCountTask = string.IsNullOrEmpty(find) || ActivityStateSpanMapper.IsSleepType(find)
-                ? _sleepService.CountSessionsAsync(cancellationToken: cancellationToken)
-                : Task.FromResult(0);
+            var countSleep = string.IsNullOrEmpty(find) || ActivityStateSpanMapper.IsSleepType(find);
 
-            await Task.WhenAll(stateSpanTask, heartRateTask, stepCountTask, sleepCountTask);
+            var pending = new Dictionary<string, Task<long>>(StringComparer.Ordinal);
+            if (categories.Contains(OAuthScopes.TreatmentsRead))
+                pending[OAuthScopes.TreatmentsRead] = CountOf(_stateSpanService.GetActivitiesAsync(
+                    type: find,
+                    count: int.MaxValue,
+                    skip: 0,
+                    cancellationToken: cancellationToken));
 
-            var total = stateSpanTask.Result.Count()
-                + heartRateTask.Result.Count()
-                + stepCountTask.Result.Count()
-                + sleepCountTask.Result;
+            if (categories.Contains(OAuthScopes.HeartRateRead))
+                pending[OAuthScopes.HeartRateRead] = CountOf(_heartRateService.GetHeartRatesAsync(
+                    count: int.MaxValue,
+                    skip: 0,
+                    cancellationToken: cancellationToken));
 
-            _logger.LogDebug("Counted {Total} activity records", total);
-            return total;
+            if (categories.Contains(OAuthScopes.StepCountRead))
+                pending[OAuthScopes.StepCountRead] = CountOf(_stepCountService.GetStepCountsAsync(
+                    count: int.MaxValue,
+                    skip: 0,
+                    cancellationToken: cancellationToken));
+
+            if (categories.Contains(OAuthScopes.SleepRead))
+                pending[OAuthScopes.SleepRead] = countSleep
+                    ? Widen(_sleepService.CountSessionsAsync(cancellationToken: cancellationToken))
+                    : Task.FromResult(0L);
+
+            await Task.WhenAll(pending.Values);
+
+            var counts = pending.ToDictionary(
+                source => source.Key, source => source.Value.Result, StringComparer.Ordinal);
+
+            _logger.LogDebug("Counted {Total} activity records", counts.Values.Sum());
+            return counts;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error counting activity records");
             throw;
         }
+
+        static async Task<long> CountOf<T>(Task<IEnumerable<T>> source) => (await source).Count();
+
+        static async Task<long> Widen(Task<int> source) => await source;
     }
 }

--- a/src/API/Nocturne.API/Services/Health/ActivityService.cs
+++ b/src/API/Nocturne.API/Services/Health/ActivityService.cs
@@ -592,10 +592,12 @@ public class ActivityService : IActivityService
     {
         try
         {
+            var sanitizedFindForLog = find?.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
             _logger.LogDebug(
                 "Counting activity records in {Categories} with find: {Find}",
                 string.Join(",", categories),
-                find);
+                sanitizedFindForLog);
 
             // Sleep sessions are merged into GetActivitiesAsync only when `find` is
             // empty or a sleep type; the count applies the same gate

--- a/src/Core/Nocturne.Core.Contracts/Health/IActivityService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Health/IActivityService.cs
@@ -106,4 +106,19 @@ public interface IActivityService
         string? find = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Count <see cref="Activity"/> records in each of <paramref name="categories"/>, keyed by the
+    /// same read scope <see cref="V4.IActivityDecomposer.RequiredReadScope"/> returns for records
+    /// from that source. A source not named is not queried at all, and a name this service does not
+    /// recognize yields no entry.
+    /// </summary>
+    /// <param name="categories">The sources to count, named by their read scope.</param>
+    /// <param name="find">Optional MongoDB-style query filter string.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyDictionary<string, long>> CountActivitiesByCategoryAsync(
+        IReadOnlySet<string> categories,
+        string? find = null,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ActivityControllerScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ActivityControllerScopeTests.cs
@@ -1,24 +1,28 @@
+using System.Reflection;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
 using Nocturne.API.Controllers.V4.Health;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.V4;
 using Xunit;
 
 namespace Nocturne.API.Tests.Authorization;
 
 /// <summary>
 /// Asserts that <c>ActivityController</c> actually calls
-/// <see cref="Nocturne.API.Authorization.ActivityWriteScopeGuard"/>. <c>ActivityWriteScopeGuardTests</c>
-/// exercises the guard function in isolation, so removing the call from the handler would leave both
-/// that suite and the attribute sweep in <see cref="V4WriteScopeGatingTests"/> green while the
-/// endpoint became ungated — the activity endpoints are exempted from the sweep precisely because
-/// their gate is a method call.
+/// <see cref="Nocturne.API.Authorization.ActivityWriteScopeGuard"/> and
+/// <see cref="Nocturne.API.Authorization.ActivityReadScopeGuard"/>. The guard suites exercise those
+/// functions in isolation, so removing a call from a handler would leave them and the attribute
+/// sweep in <see cref="V4WriteScopeGatingTests"/> green while the endpoint became ungated — the
+/// activity endpoints are exempted from the sweep precisely because their gate is a method call.
 /// </summary>
 public class ActivityControllerScopeTests
 {
@@ -72,16 +76,185 @@ public class ActivityControllerScopeTests
             .Which.StatusCode.Should().Be(StatusCodes.Status201Created);
     }
 
+    [Fact]
+    public async Task GetActivities_DropsRecordsWhoseCategoryScopeIsMissing()
+    {
+        var (controller, service) = BuildRead(grantedScopes: [OAuthScopes.HeartRateRead]);
+        StubPage(service, OneRecordPerCategory());
+        StubCounts(service);
+
+        var result = await controller.GetActivities();
+
+        Payload(result).Data.Select(a => a.Id).Should().Equal("hr");
+    }
+
+    [Fact]
+    public async Task GetActivities_TotalsOnlyTheCategoriesTheCallerHolds()
+    {
+        var (controller, service) = BuildRead(grantedScopes: [OAuthScopes.HeartRateRead]);
+        StubPage(service, OneRecordPerCategory());
+        StubCounts(service);
+
+        var result = await controller.GetActivities();
+
+        Payload(result).Pagination.Total.Should().Be((int)CategoryCounts[OAuthScopes.HeartRateRead]);
+    }
+
+    [Fact]
+    public async Task GetActivities_TotalsEveryCategoryForACallerHoldingThemAll()
+    {
+        var (controller, service) = BuildRead(grantedScopes: [.. CategoryScopes.Values]);
+        StubPage(service, OneRecordPerCategory());
+        StubCounts(service);
+
+        var result = await controller.GetActivities();
+
+        Payload(result).Pagination.Total.Should().Be((int)CategoryCounts.Values.Sum());
+    }
+
+    [Fact]
+    public async Task GetActivities_AsksTheCountForNoCategoryTheCallerLacks()
+    {
+        var (controller, service) = BuildRead(grantedScopes: [OAuthScopes.HeartRateRead]);
+        StubPage(service, OneRecordPerCategory());
+        StubCounts(service);
+
+        await controller.GetActivities();
+
+        service.Verify(
+            s => s.CountActivitiesByCategoryAsync(
+                It.Is<IReadOnlySet<string>>(asked =>
+                    asked.SetEquals(new[] { OAuthScopes.HeartRateRead })),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// The total counts categories, not the page, so a page carrying nothing the caller may see
+    /// must still report the records waiting on later pages — otherwise a client paging while
+    /// <c>offset &lt; total</c> stops at the first such page.
+    /// </summary>
+    [Fact]
+    public async Task GetActivities_TotalsTheHeldCategoriesEvenWhenThePageShowsNoneOfThem()
+    {
+        var (controller, service) = BuildRead(grantedScopes: [OAuthScopes.HeartRateRead]);
+        StubPage(service, [ActivityWithId("sleep"), ActivityWithId("regular")]);
+        StubCounts(service);
+
+        var result = await controller.GetActivities(offset: 20);
+
+        Payload(result).Data.Should().BeEmpty();
+        Payload(result).Pagination.Total.Should().Be((int)CategoryCounts[OAuthScopes.HeartRateRead]);
+    }
+
+    [Fact]
+    public async Task GetActivity_HidesARecordWhoseCategoryScopeIsMissing()
+    {
+        var (controller, service) = BuildRead(grantedScopes: [OAuthScopes.HeartRateRead]);
+        service.Setup(s => s.GetActivityByIdAsync("sleep", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ActivityWithId("sleep"));
+
+        var result = await controller.GetActivity("sleep");
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetActivity_ReturnsARecordWhoseCategoryScopeIsHeld()
+    {
+        var (controller, service) = BuildRead(grantedScopes: [OAuthScopes.SleepRead]);
+        service.Setup(s => s.GetActivityByIdAsync("sleep", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ActivityWithId("sleep"));
+
+        var result = await controller.GetActivity("sleep");
+
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<Activity>()
+            .Which.Id.Should().Be("sleep");
+    }
+
+    /// <summary>
+    /// The in-handler filter decides what a response may contain, but only the attribute keeps a
+    /// caller holding none of the four categories out — and a controller-level <c>[Authorize]</c>
+    /// alone admits any member.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(ActivityController.GetActivities))]
+    [InlineData(nameof(ActivityController.GetActivity))]
+    public void ReadActions_AdmitOnAnyMergedActivityCategory(string action)
+    {
+        var attribute = typeof(ActivityController).GetMethod(action)!
+            .GetCustomAttribute<RequireScopeAttribute>();
+
+        attribute.Should().NotBeNull($"{action} must be gated on the activity read scopes");
+        attribute!.Scopes.Should().BeEquivalentTo(ActivityReadScopeGuard.AdmissionScopes);
+    }
+
     private static void Denied(object? result) =>
         result.Should().BeOfType<ObjectResult>()
             .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
 
+    private static PaginatedResponse<Activity> Payload(
+        ActionResult<PaginatedResponse<Activity>> result) =>
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<PaginatedResponse<Activity>>().Subject;
+
+    private static void StubPage(Mock<IActivityService> service, IEnumerable<Activity> page) =>
+        service.Setup(s => s.GetActivitiesAsync(
+                It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+    /// <summary>
+    /// Stubs the per-category count with <see cref="CategoryCounts"/>, honouring the contract that
+    /// a category the caller did not ask for is not counted — so a total that includes one is a
+    /// category the controller asked for and should not have.
+    /// </summary>
+    private static void StubCounts(Mock<IActivityService> service) =>
+        service.Setup(s => s.CountActivitiesByCategoryAsync(
+                It.IsAny<IReadOnlySet<string>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlySet<string> asked, string? _, CancellationToken _) =>
+                (IReadOnlyDictionary<string, long>)CategoryCounts
+                    .Where(c => asked.Contains(c.Key))
+                    .ToDictionary(c => c.Key, c => c.Value));
+
+    private static Activity ActivityWithId(string id) => new() { Id = id, Mills = 1 };
+
+    /// <summary>One record per merged category, each identified by its category's key.</summary>
+    private static IEnumerable<Activity> OneRecordPerCategory() =>
+        CategoryScopes.Keys.Select(ActivityWithId).ToList();
+
+    /// <summary>Distinct per-category counts, so a total names the categories that produced it.</summary>
+    private static readonly Dictionary<string, long> CategoryCounts = new()
+    {
+        [OAuthScopes.HeartRateRead] = 71,
+        [OAuthScopes.StepCountRead] = 13,
+        [OAuthScopes.SleepRead] = 5,
+        [OAuthScopes.TreatmentsRead] = 11,
+    };
+
+    private static readonly Dictionary<string, string> CategoryScopes = new()
+    {
+        ["hr"] = OAuthScopes.HeartRateRead,
+        ["sc"] = OAuthScopes.StepCountRead,
+        ["sleep"] = OAuthScopes.SleepRead,
+        ["regular"] = OAuthScopes.TreatmentsRead,
+    };
+
+    private static (ActivityController Controller, Mock<IActivityService> Service) BuildRead(
+        string[] grantedScopes) =>
+        Build(requiredScope: null, grantedScopes, a => CategoryScopes[a.Id!]);
+
     private static (ActivityController Controller, Mock<IActivityService> Service) Build(
-        string? requiredScope, string[] grantedScopes)
+        string? requiredScope,
+        string[] grantedScopes,
+        Func<Activity, string>? requiredReadScope = null)
     {
         var service = new Mock<IActivityService>(MockBehavior.Strict);
         var decomposer = new Mock<IActivityDecomposer>(MockBehavior.Loose);
         decomposer.Setup(d => d.RequiredWriteScope(It.IsAny<Activity>())).Returns(requiredScope);
+        if (requiredReadScope is not null)
+            decomposer.Setup(d => d.RequiredReadScope(It.IsAny<Activity>())).Returns(requiredReadScope);
 
         var httpContext = new DefaultHttpContext();
         httpContext.Items["AuthContext"] = new AuthContext { IsAuthenticated = true };

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/ActivityControllerV4Tests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/ActivityControllerV4Tests.cs
@@ -29,6 +29,10 @@ public class ActivityControllerV4Tests
         {
             ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
         };
+
+        _service.Setup(s => s.CountActivitiesByCategoryAsync(
+                It.IsAny<IReadOnlySet<string>>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, long>());
     }
 
     private void GrantScopes(params string[] scopes) =>

--- a/tests/Unit/Nocturne.API.Tests/Services/Health/ActivityServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Health/ActivityServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Nocturne.API.Authorization;
 using Nocturne.API.Services.Health;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.Legacy;
@@ -9,6 +10,7 @@ using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Sleep;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Xunit;
 using Nocturne.API.Services.Realtime;
 
@@ -833,6 +835,79 @@ public class ActivityServiceTests
         // Assert
         Assert.Equal(6, count);
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CountActivitiesByCategoryAsync_KeysEachSourceByItsReadScope()
+    {
+        _mockStateSpanService
+            .Setup(s => s.GetActivitiesAsync(
+                It.IsAny<string?>(), int.MaxValue, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new Activity { Id = "1", Mills = 1000 }]);
+        _mockHeartRateService
+            .Setup(s => s.GetHeartRatesAsync(int.MaxValue, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new HeartRate(), new HeartRate()]);
+        _mockStepCountService
+            .Setup(s => s.GetStepCountsAsync(int.MaxValue, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new StepCount(), new StepCount(), new StepCount()]);
+        _mockSleepService
+            .Setup(s => s.CountSessionsAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<SleepSessionType?>(),
+                It.IsAny<SleepSource?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(4);
+
+        var counts = await _activityService.CountActivitiesByCategoryAsync(
+            AllCategories, cancellationToken: CancellationToken.None);
+
+        counts.Should().BeEquivalentTo(new Dictionary<string, long>
+        {
+            [OAuthScopes.TreatmentsRead] = 1,
+            [OAuthScopes.HeartRateRead] = 2,
+            [OAuthScopes.StepCountRead] = 3,
+            [OAuthScopes.SleepRead] = 4,
+        });
+    }
+
+    /// <summary>
+    /// Each source is materialized in full to be counted, so a category nobody asked for must not
+    /// be fetched at all.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CountActivitiesByCategoryAsync_DoesNotQueryASourceItWasNotAskedFor()
+    {
+        _mockHeartRateService
+            .Setup(s => s.GetHeartRatesAsync(int.MaxValue, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new HeartRate(), new HeartRate()]);
+
+        var counts = await _activityService.CountActivitiesByCategoryAsync(
+            new HashSet<string> { OAuthScopes.HeartRateRead },
+            cancellationToken: CancellationToken.None);
+
+        counts.Should().BeEquivalentTo(new Dictionary<string, long>
+        {
+            [OAuthScopes.HeartRateRead] = 2,
+        });
+        _mockStateSpanService.Verify(
+            s => s.GetActivitiesAsync(
+                It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockStepCountService.Verify(
+            s => s.GetStepCountsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockSleepService.Verify(
+            s => s.CountSessionsAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<SleepSessionType?>(),
+                It.IsAny<SleepSource?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// The categories the merged read endpoints ask for. Driving the count from the guard's own
+    /// list is what keeps a category the endpoints admit from silently going uncounted.
+    /// </summary>
+    private static readonly IReadOnlySet<string> AllCategories =
+        ActivityReadScopeGuard.AdmissionScopes.ToHashSet();
 
     [Fact]
     [Trait("Category", "Unit")]


### PR DESCRIPTION
## What

`Controllers/V4/Health/ActivityController.cs` served its two GET actions on `[Authorize]` alone. `IActivityService` merges four storages into one response — StateSpans, heart rates, step counts and sleep sessions — each with its own read scope, so any authenticated member read sleep, heart-rate and step data through v4 regardless of what their role or token was granted. Member requests are not category-filtered by RLS; only shares are.

The v1 controller already solved this. This is the same shape applied to v4: the attribute lists the four read scopes as an **OR** for admission, and `ActivityReadScopeGuard` then drops the records whose category the caller doesn't hold. `GetActivity` answers 404 rather than 403 for a record outside the caller's categories, so the response doesn't disclose that the record exists.

Filter-to-granted, not require-all: a follower legitimately holding one category keeps working and simply doesn't see the other lanes. Requiring the union would 403 every narrow caller — the #635 failure class.

## The paginated total

`PaginationInfo.Total` came from `CountActivitiesAsync`, which sums all four categories. Serving that beside a filtered page would disclose how many records exist in categories the filter had just removed.

`CountActivitiesAsync` was never a merged count — it fans out to four independently countable sources and adds them up. So the accurate answer for a partially-scoped caller is the sum over the categories they hold, and that is what the endpoint now returns. New `IActivityService.CountActivitiesByCategoryAsync(categories, …)` returns per-source counts keyed by the same read scope `IActivityDecomposer.RequiredReadScope` reports; `CountActivitiesAsync` is now that method summed over every category, so v1's two call sites are behaviourally unchanged.

A category that isn't asked for is never queried, which follows the "don't query what the caller can't read" pattern #735 established for `CorrelationController`. It's also cheaper: each skipped category skips a `count: int.MaxValue` fetch that materialises every row to call `.Count()`.

No OAuth concept entered `ActivityService` — it takes a set of source names and the controller decides which, so the authorization decision stays beside `Filter`. `ActivityServiceTests` drives the new method from `ActivityReadScopeGuard.AdmissionScopes` itself, so a category the endpoints admit but the service can't count fails a test.

An earlier revision degraded the total to `offset + visible.Count`. That was a functional regression — a caller whose first page held no visible records was told `total == offset` and any well-behaved client stopped paging — and it is not what shipped here.

## Tests

Six new cases in `ActivityControllerScopeTests` plus service coverage. Mutations, each applied → failed → restored → green:

| Mutation | Observed |
|---|---|
| Count all four categories rather than the granted ones | 3 failed |
| `Filter(...)` → `records.ToList()` | 2 failed |
| Delete the `CanRead` check in `GetActivity` | 1 failed |
| Remove both `[RequireScope]` attributes | 2 failed |
| Query the state-span source unconditionally | 1 failed |
| Drop `SleepRead` from the service's countable set | 1 failed (v1 regression caught) |

The "visible categories non-empty but page empty" case is covered explicitly, since that is what the discarded lower-bound approach got wrong.

Targeted authorization + activity suites: 787 passed, 0 failed.

## Residuals

- The count still materialises every row of each queried source before counting it. Unchanged from before and strictly improved for narrow callers, but a real `CountAsync` on the state-span/heart-rate/step-count services is the proper fix.
- `[RequireScope]` admission is asserted by reflection; these are direct controller-method tests, so the MVC filter pipeline doesn't run. The runtime 403 for a caller holding none of the four rests on the generic `RequireScopeAttributeTests`.
- Neither GET action carries `[ResponseCache]`, so per-caller filtering introduces no cross-member cache leak here.
