### PR TITLE
fix(auth): derive the platform-access cookie domain from the base domain

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -237,8 +237,8 @@ public static class ServiceRegistrationExtensions
             opts.BaseDomain = configuration[BaseDomainOptions.ConfigKey] ?? ""
         );
 
-        // Derive the session- and state-cookie Domain attributes from the base domain, in one
-        // place, so every writer and deleter of those cookies agrees on their scope.
+        // Derive the session-, state-, and platform-access cookie Domain attributes from the base
+        // domain, in one place, so every writer and deleter of those cookies agrees on their scope.
         services.PostConfigure<OidcOptions>(opts =>
             SessionCookieExtensions.ApplyCookieDomainDefaults(opts, baseDomain)
         );

--- a/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
@@ -53,20 +53,27 @@ public static class SessionCookieExtensions
     }
 
     /// <summary>
-    /// Fill in the cookie <c>Domain</c> attributes that are derived from the base domain rather
-    /// than configured. Applied as a post-configure so explicit configuration still wins.
+    /// Fill in the cookie <c>Domain</c> attributes, all three of which are derived from the base
+    /// domain rather than configured. Applied as a post-configure so explicit configuration
+    /// still wins.
     /// </summary>
     /// <remarks>
-    /// Two independent scopes, for two different reasons. Session cookies widen so one sign-in
-    /// carries across tenant subdomains and the apex dashboard. State cookies widen so a login
-    /// begun on any host can be completed at the apex callback, which is the registered
-    /// redirect_uri; an operator who already set <see cref="CookieSettings.Domain"/> made that
-    /// choice explicitly, so it is inherited rather than overridden.
+    /// Three scopes, one source. Session cookies widen so one sign-in carries across tenant
+    /// subdomains and the apex dashboard. The platform-access grant widens because it is minted
+    /// on the apex and redeemed on the tenant subdomain it is pinned to. State cookies widen so a
+    /// login begun on any host can be completed at the apex callback, which is the registered
+    /// redirect_uri.
+    /// <para>
+    /// <see cref="CookieSettings.Domain"/> is defaulted before <see cref="CookieSettings.StateDomain"/>
+    /// reads it, so an operator override moves both together while the derived value reaches both
+    /// as well.
+    /// </para>
     /// </remarks>
     public static void ApplyCookieDomainDefaults(OidcOptions options, string? baseDomain)
     {
         options.Cookie.SessionDomain ??= ResolveCookieDomain(baseDomain);
-        options.Cookie.StateDomain ??= options.Cookie.Domain ?? ResolveCookieDomain(baseDomain);
+        options.Cookie.Domain ??= ResolveCookieDomain(baseDomain);
+        options.Cookie.StateDomain ??= options.Cookie.Domain;
     }
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
@@ -79,7 +79,11 @@ public class CookieSettings
     /// host-only cookie is never sent to that second host, so an underived value silently breaks
     /// platform access altogether; anything wider than the base domain broadcasts a superuser
     /// credential past the app. Tenants are always reached at a subdomain of the base domain, so
-    /// no deployment topology makes a third value correct.
+    /// no deployment topology makes a third value correct. Within it the grant is sent to every
+    /// host, including the <c>{token}.share.{base-domain}</c> names served to untrusted share
+    /// recipients, which is safe: the cookie is HttpOnly and Secure, and
+    /// <c>PlatformAccessCookieHandler</c> skips it unless the resolved tenant is the one it is
+    /// pinned to, so it confers nothing on a host belonging to any other tenant.
     /// <para>
     /// Retained as an override for an operator with a reason to narrow or move it. Setting it also
     /// moves <see cref="StateDomain"/>, which defaults from this value.

--- a/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/OidcOptions.cs
@@ -70,9 +70,21 @@ public class CookieSettings
     public string LinkStateCookieName { get; set; } = ".Nocturne.OidcLinkState";
 
     /// <summary>
-    /// Cookie domain for the platform-access grant, and the operator's override for
-    /// <see cref="StateDomain"/> (null = current domain).
+    /// Domain attribute for the platform-access grant cookie, and the operator's override for
+    /// <see cref="StateDomain"/>. Defaults, like the other two domains, to ".{base-domain}".
     /// </summary>
+    /// <remarks>
+    /// Derived rather than left unset because the grant is minted on the apex — where the platform
+    /// admin signs in — and redeemed on the <c>{slug}.{base-domain}</c> host it is pinned to. A
+    /// host-only cookie is never sent to that second host, so an underived value silently breaks
+    /// platform access altogether; anything wider than the base domain broadcasts a superuser
+    /// credential past the app. Tenants are always reached at a subdomain of the base domain, so
+    /// no deployment topology makes a third value correct.
+    /// <para>
+    /// Retained as an override for an operator with a reason to narrow or move it. Setting it also
+    /// moves <see cref="StateDomain"/>, which defaults from this value.
+    /// </para>
+    /// </remarks>
     public string? Domain { get; set; }
 
     /// <summary>
@@ -81,18 +93,17 @@ public class CookieSettings
     /// also presented at the apex dashboard and at sibling tenants the subject belongs to.
     /// </summary>
     /// <remarks>
-    /// Derived from the base domain and deliberately independent of <see cref="Domain"/>, which is
-    /// an operator-set option scoping the platform-access grant. That one is left to the operator:
-    /// it is minted on the apex, where the operator still is, and redeemed on the tenant subdomain
-    /// it is pinned to, so its scope is a deployment decision rather than something the session
-    /// widening should decide for them. The OIDC state cookies take <see cref="StateDomain"/>.
+    /// Derived from the base domain, as <see cref="Domain"/> and <see cref="StateDomain"/> are.
+    /// Kept a separate knob from those so an operator can narrow one scope without dragging the
+    /// others with it: this one carries the ordinary session, <see cref="Domain"/> the
+    /// platform-access grant, and <see cref="StateDomain"/> the OIDC state cookies.
     /// </remarks>
     public string? SessionDomain { get; set; }
 
     /// <summary>
     /// Domain attribute for the short-lived OIDC state cookies (login state, link state, and the
-    /// setup flow's reuse of the login-state cookie name). Defaults to <see cref="Domain"/> when
-    /// the operator set it, and otherwise to ".{base-domain}".
+    /// setup flow's reuse of the login-state cookie name). Defaults to <see cref="Domain"/>, which
+    /// is itself ".{base-domain}" unless the operator overrode it.
     /// </summary>
     /// <remarks>
     /// The registered redirect_uri is the apex callback, so a login begun on any other host has to

--- a/src/Web/packages/app/src/lib/stores/auth-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/auth-store.svelte.ts
@@ -14,7 +14,6 @@ import { browser } from "$app/environment";
 import { goto } from "$app/navigation";
 import {
   getSessionInfo,
-  getProvidersInfo,
   refreshSession as refreshSessionRemote,
   logoutSession as logoutSessionRemote,
 } from "../../routes/(unauthenticated)/auth/auth.remote";
@@ -32,16 +31,6 @@ export interface AuthUser {
   permissions: string[];
   expiresAt?: Date;
   avatarUrl?: string;
-}
-
-/**
- * OIDC Provider information for login UI
- */
-export interface OidcProvider {
-  id: string;
-  name: string;
-  icon?: string;
-  buttonColor?: string;
 }
 
 /**
@@ -68,7 +57,6 @@ export class AuthStore {
   private _state = $state<AuthState>("idle");
   private _user = $state<AuthUser | null>(null);
   private _error = $state<string | null>(null);
-  private _providers = $state<OidcProvider[]>([]);
 
   // Login dialog state
   private _loginDialogOpen = $state(false);
@@ -77,7 +65,6 @@ export class AuthStore {
   state = $derived(this._state);
   user = $derived(this._user);
   error = $derived(this._error);
-  providers = $derived(this._providers);
   loginDialogOpen = $derived(this._loginDialogOpen);
 
   isAuthenticated = $derived(this._state === "authenticated" && this._user !== null);
@@ -208,48 +195,6 @@ export class AuthStore {
       this._user = null;
       this._expiresAt = null;
     }
-  }
-
-  /**
-   * Load available OIDC providers
-   */
-  async loadProviders(): Promise<OidcProvider[]> {
-    if (!browser) return [];
-
-    try {
-      const result = await getProvidersInfo().run();
-      this._providers = result.providers.map((p) => ({
-        id: p.id ?? "",
-        name: p.name ?? "",
-        icon: p.icon,
-        buttonColor: p.buttonColor,
-      }));
-
-      return this._providers;
-    } catch (e) {
-      console.error("Failed to load providers:", e);
-      return [];
-    }
-  }
-
-  /**
-   * Initiate OIDC login flow
-   * @param providerId - Optional provider ID (uses default if not specified)
-   * @param returnUrl - URL to return to after login
-   */
-  login(providerId?: string, returnUrl?: string): void {
-    if (!browser) return;
-
-    const params = new URLSearchParams();
-    if (providerId) {
-      params.set("provider", providerId);
-    }
-    if (returnUrl) {
-      params.set("returnUrl", returnUrl);
-    }
-
-    const loginUrl = `/api/auth/login${params.toString() ? `?${params.toString()}` : ""}`;
-    window.location.href = loginUrl;
   }
 
   /**

--- a/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
@@ -7,9 +7,9 @@ using Xunit;
 namespace Nocturne.API.Tests.Extensions;
 
 /// <summary>
-/// Covers the session-cookie Domain widening: the value derived from the base domain, that every
-/// writer and the deleter agree on it, and that the pre-widening host-scoped cookies are expired
-/// so a browser holding both converges on one.
+/// Covers the cookie Domain widening — session, state, and platform-access grant: the value
+/// derived from the base domain, that every writer and the deleter agree on it, and that the
+/// pre-widening host-scoped cookies are expired so a browser holding both converges on one.
 /// </summary>
 [Trait("Category", "Unit")]
 public sealed class SessionCookieExtensionsTests
@@ -177,7 +177,7 @@ public sealed class SessionCookieExtensionsTests
     }
 
     [Fact]
-    public void ApplyCookieDomainDefaults_widens_both_scopes_from_the_base_domain()
+    public void ApplyCookieDomainDefaults_widens_all_three_scopes_from_the_base_domain()
     {
         var options = new OidcOptions();
 
@@ -187,6 +187,30 @@ public sealed class SessionCookieExtensionsTests
         options.Cookie.StateDomain.Should().Be(".nocturne.run",
             "a login begun on a reserved dashboard slug has no slug in its state to be bounced " +
             "back by, so its state cookie has to be readable at the apex callback");
+        options.Cookie.Domain.Should().Be(".nocturne.run",
+            "the platform-access grant is minted on the apex and redeemed on the tenant " +
+            "subdomain it is pinned to, so a host-only grant never arrives");
+    }
+
+    [Theory]
+    // Single-label hosts, *.localhost, and IP literals cannot carry a Domain attribute; the
+    // platform-access grant stays host-only there for the same reasons the session cookies do.
+    [InlineData("localhost")]
+    [InlineData("nocturne.localhost:1612")]
+    [InlineData("192.168.1.10")]
+    [InlineData("[2001:db8::1]")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ApplyCookieDomainDefaults_leaves_every_scope_host_scoped_where_widening_is_unsafe(
+        string? baseDomain)
+    {
+        var options = new OidcOptions();
+
+        SessionCookieExtensions.ApplyCookieDomainDefaults(options, baseDomain);
+
+        options.Cookie.SessionDomain.Should().BeNull();
+        options.Cookie.StateDomain.Should().BeNull();
+        options.Cookie.Domain.Should().BeNull();
     }
 
     [Fact]
@@ -199,6 +223,8 @@ public sealed class SessionCookieExtensionsTests
 
         SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.run");
 
+        options.Cookie.Domain.Should().Be(".ops.example.com",
+            "the derived default must not overwrite an operator's explicit scope");
         options.Cookie.StateDomain.Should().Be(".ops.example.com",
             "an operator who set Cookie.Domain already scoped the state cookies deliberately");
         options.Cookie.SessionDomain.Should().Be(".nocturne.run",
@@ -206,28 +232,23 @@ public sealed class SessionCookieExtensionsTests
     }
 
     [Fact]
-    public void ApplyCookieDomainDefaults_leaves_both_host_scoped_where_widening_is_unsafe()
-    {
-        var options = new OidcOptions();
-
-        SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.localhost:1612");
-
-        options.Cookie.SessionDomain.Should().BeNull();
-        options.Cookie.StateDomain.Should().BeNull();
-    }
-
-    [Fact]
     public void ApplyCookieDomainDefaults_never_overwrites_an_explicit_value()
     {
         var options = new OidcOptions
         {
-            Cookie = new CookieSettings { SessionDomain = ".a.example", StateDomain = ".b.example" },
+            Cookie = new CookieSettings
+            {
+                SessionDomain = ".a.example",
+                StateDomain = ".b.example",
+                Domain = ".c.example",
+            },
         };
 
         SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.run");
 
         options.Cookie.SessionDomain.Should().Be(".a.example");
         options.Cookie.StateDomain.Should().Be(".b.example");
+        options.Cookie.Domain.Should().Be(".c.example");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
@@ -236,19 +236,16 @@ public sealed class SessionCookieExtensionsTests
     {
         var options = new OidcOptions
         {
-            Cookie = new CookieSettings
-            {
-                SessionDomain = ".a.example",
-                StateDomain = ".b.example",
-                Domain = ".c.example",
-            },
+            Cookie = new CookieSettings { SessionDomain = ".a.example", StateDomain = ".b.example" },
         };
 
         SessionCookieExtensions.ApplyCookieDomainDefaults(options, "nocturne.run");
 
         options.Cookie.SessionDomain.Should().Be(".a.example");
-        options.Cookie.StateDomain.Should().Be(".b.example");
-        options.Cookie.Domain.Should().Be(".c.example");
+        options.Cookie.StateDomain.Should().Be(".b.example",
+            "an explicit state scope survives the derivation of Cookie.Domain, which it would " +
+            "otherwise have defaulted from");
+        options.Cookie.Domain.Should().Be(".nocturne.run");
     }
 
     [Fact]


### PR DESCRIPTION
`Oidc:Cookie:Domain` has exactly one correct value, and its default is not that value.

After #745 the option scopes exactly one thing — the platform-access grant cookie in `PlatformAccessController` — plus acting as the operator override for `StateDomain`.

## The one-correct-value argument

That grant is **minted on the apex** (`PlatformAccessController` writes the cookie, then redirects) and **redeemed on `{slug}.{base-domain}`** (`PlatformAccessCookieHandler` matches the grant's pinned tenant against the subdomain-resolved tenant). So:

- **null / host-only** — the cookie is never sent to the redemption host, so platform access simply does not work. This is today's default, which means it is **silently broken out of the box for every self-hoster who has not set the option**. Nobody notices because the failure looks like "platform access just doesn't do anything".
- **wider than the base domain** — broadcasts a superuser credential to hosts outside the app.
- **`.{base-domain}`** — the only value that works.

And there is no per-tenant custom-domain support anywhere: tenants are always `{slug}.{base-domain}` and shares always `{token}.share.{base-domain}` (`SubdomainParser`, and the tenant record carries only a slug). So no deployment topology makes a different value correct.

## The change

`Domain` is now defaulted in `SessionCookieExtensions.ApplyCookieDomainDefaults`, the same treatment `SessionDomain` and `StateDomain` already get:

```csharp
options.Cookie.SessionDomain ??= ResolveCookieDomain(baseDomain);
options.Cookie.Domain ??= ResolveCookieDomain(baseDomain);
options.Cookie.StateDomain ??= options.Cookie.Domain;
```

`Domain` is defaulted **before** `StateDomain` reads it, so an operator override still moves the state cookies with it, and the derived value reaches both when no override is set. `StateDomain`'s old `?? ResolveCookieDomain(baseDomain)` fallback is now redundant and is gone.

**The property is not removed.** It remains settable as an operator escape hatch — this is about the default, not the knob. The XML docs on all three domain properties are rewritten to describe the new reality, including *why* `Domain` is derived (the apex-mint / subdomain-redeem handoff).

`ResolveCookieDomain` also brings the safety cases with it: single-label hosts, `*.localhost`, IP literals, and port-carrying values all still yield null (host-only), so local dev and LAN installs are unaffected.

## Port safety

A related reason to derive rather than hand-roll: nocturne-cloud sets this env var to a hand-built `$".{baseDomain}"` with no `SplitHostPort`. A base domain carrying a port produces `.example.com:1612`, which a browser discards wholesale — taking the grant with it. `ResolveCookieDomain` strips the port.

## Follow-up for nocturne-cloud

nocturne-cloud's `Oidc__Cookie__Domain` env var becomes redundant once this ships and **should be deleted in a follow-up** — but only **after a deployed image contains this change**. Deleting it before then would leave `Domain` null in production and break platform access there.

## Second commit — dead code

`authStore.login()` and `authStore.loadProviders()` are unreferenced across `src/Web`; `login()` navigated to `/api/auth/login`, a route no controller serves. Deleting `loadProviders` also orphans the `_providers` field, the `providers` derived, and the `OidcProvider` interface (all verified unreferenced). The `getProvidersInfo` remote query itself is **kept** — `LinkedOidcIdentities.svelte` uses it.

## Tests

`SessionCookieExtensionsTests` extended: `Domain` derives from the base domain when unset; an operator-set `Domain` is preserved and still drives `StateDomain`; and a new theory covers the null-yielding cases (single-label, `.localhost`, IPv4, bracketed IPv6, empty, null) across all three scopes. No existing test asserted `Domain` stayed null by default, so nothing was weakened.

Full `Nocturne.API.Tests`: **5441 passed, 0 failed, 5 skipped**. Web vitest 728 passed and `pnpm check` unchanged from baseline (64 pre-existing errors either way).

Mutation-proofed: removing the new `??=` fails `ApplyCookieDomainDefaults_widens_all_three_scopes_from_the_base_domain`.

https://claude.ai/code/session_014gZWTmjMDSLtxp22i2cJe3
