### PR TITLE
fix(reports): stop future-dated records stretching the Year Overview range

### DIFF
--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
@@ -214,7 +214,16 @@ public class DataOverviewService : IDataOverviewService
                 DateTimeOffset.FromUnixTimeMilliseconds(globalMax.Value),
                 tz
             );
-            years = Enumerable.Range(minLocal.Year, maxLocal.Year - minLocal.Year + 1).ToArray();
+
+            // Some uploaders emit future-dated records, and the range is derived from a
+            // bare MAX() over every table — so one bad row would otherwise stretch the
+            // list to its year and open the report on a century of empty ones. Clamping
+            // both ends keeps the range non-empty when every record is future-dated.
+            var currentYear = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, tz).Year;
+            var minYear = Math.Min(minLocal.Year, currentYear);
+            var maxYear = Math.Min(maxLocal.Year, currentYear);
+
+            years = Enumerable.Range(minYear, maxYear - minYear + 1).ToArray();
         }
 
         return new DataOverviewYearsResponse

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewServiceTests.cs
@@ -34,6 +34,8 @@ public class DataOverviewServiceTests : IDisposable
     private const long Dec31_2024_23h = 1735686000000L;
     // 2025-01-01 01:00:00 UTC = 1735693200000
     private const long Jan1_2025_01h = 1735693200000L;
+    // A far-future timestamp, of the kind buggy uploaders emit.
+    private static readonly DateTime June15_2162_Noon = new(2162, 6, 15, 12, 0, 0, DateTimeKind.Utc);
 
     public DataOverviewServiceTests()
     {
@@ -122,6 +124,51 @@ public class DataOverviewServiceTests : IDisposable
         var result = await _service.GetAvailableYearsAsync();
 
         result.Years.Should().BeEquivalentTo([2023, 2024, 2025]);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetAvailableYearsAsync_FutureDatedRecord_StopsAtCurrentYear()
+    {
+        _dbContext.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(June15_2024_Noon).UtcDateTime,
+            Mgdl = 120.0,
+            DataSource = "dexcom"
+        });
+        _dbContext.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = June15_2162_Noon,
+            Mgdl = 120.0,
+            DataSource = "dexcom"
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetAvailableYearsAsync();
+
+        var currentYear = DateTime.UtcNow.Year;
+        result.Years.Should().BeEquivalentTo(
+            Enumerable.Range(2024, currentYear - 2024 + 1));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetAvailableYearsAsync_OnlyFutureDatedRecords_ReturnsCurrentYearOnly()
+    {
+        _dbContext.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = June15_2162_Noon,
+            Mgdl = 120.0,
+            DataSource = "dexcom"
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetAvailableYearsAsync();
+
+        result.Years.Should().ContainSingle().Which.Should().Be(DateTime.UtcNow.Year);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #607

The Year Overview picker opened on 2162. `DataOverviewService.GetAvailableYearsAsync` built the year list as `Enumerable.Range(minLocal.Year, maxLocal.Year - minLocal.Year + 1)` over a bare `MAX()` across every table, so one future-dated record — MikePlante1 traced theirs to a CGMBLEKit bug in Trio's G6 submodule — generated ~137 years, and the UI sorts descending.

## What changed

Both ends of the range are clamped to the current year in the user's timezone. The min is clamped too, so the range stays non-empty (and `Enumerable.Range` never gets a negative count) when *every* record is future-dated.

## Scope

This fixes the picker only. The junk rows are still in the database and still show up wherever else they land — deleting them is a separate problem, and per the issue thread they come back after deletion while the uploader bug persists.

## Tests

Two added to `DataOverviewServiceTests`: a past record alongside a 2162 one, and a 2162 record alone. Mutation-checked by flipping `Math.Min` to `Math.Max` — 8 of 48 tests fail. 48/48 pass with the fix.