### PR TITLE
fix(sleep): resolve session timezones through the shared helper

### DIFF
--- a/src/API/Nocturne.API/Services/Sleep/SleepReportCalculator.cs
+++ b/src/API/Nocturne.API/Services/Sleep/SleepReportCalculator.cs
@@ -370,22 +370,13 @@ internal static class SleepReportCalculator
     {
         var localStart = session.StartTime;
 
-        if (!string.IsNullOrWhiteSpace(session.Timezone))
+        // Resolve through the shared helper rather than FindSystemTimeZoneById: it
+        // recovers the mis-cased ids connectors emit, and it does not throw on the
+        // ones it cannot resolve — an unresolvable id keys on UTC.
+        if (TimeZoneHelper.TryGetTimeZoneInfoFromId(session.Timezone, out var tz))
         {
-            try
-            {
-                var tz = TimeZoneInfo.FindSystemTimeZoneById(session.Timezone);
-                localStart = TimeZoneInfo.ConvertTimeFromUtc(
-                    DateTime.SpecifyKind(session.StartTime, DateTimeKind.Utc), tz);
-            }
-            catch (TimeZoneNotFoundException)
-            {
-                // Unresolvable timezone id — key on UTC.
-            }
-            catch (InvalidTimeZoneException)
-            {
-                // Corrupt timezone data — key on UTC.
-            }
+            localStart = TimeZoneInfo.ConvertTimeFromUtc(
+                DateTime.SpecifyKind(session.StartTime, DateTimeKind.Utc), tz);
         }
 
         return localStart.AddHours(-12).Date;

--- a/tests/Unit/Nocturne.API.Tests/Services/Sleep/SleepReportCalculatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Sleep/SleepReportCalculatorTests.cs
@@ -674,6 +674,28 @@ public class SleepReportCalculatorTests
         summary.DisplayDate.Should().Be("2026-01-15");
     }
 
+    [Fact]
+    public void ComputeNightSummary_DisplayDate_ResolvesMisCasedTimezoneId()
+    {
+        // ETC/GMT-11 is UTC+11, the same offset as Sydney in January, mis-cased the
+        // way connectors store it. Linux looks up /usr/share/zoneinfo/<id> literally,
+        // so an exact lookup misses (and throws) where the shared resolver recovers
+        // the intended zone; falling back to UTC would key this night to Jan 14.
+        var session = new SleepSession
+        {
+            Id           = Guid.NewGuid().ToString(),
+            StartTime    = new DateTime(2026, 1, 15, 11, 0, 0, DateTimeKind.Utc),
+            EndTime      = new DateTime(2026, 1, 15, 19, 0, 0, DateTimeKind.Utc),
+            Timezone     = "ETC/GMT-11",
+            TotalSleepMs = 480L * 60_000,
+            Source       = SleepSource.Oura,
+        };
+
+        var summary = API.Services.Sleep.SleepReportCalculator.ComputeNightSummary(session, [], _thresholds);
+
+        summary.DisplayDate.Should().Be("2026-01-15");
+    }
+
     // ── Weekly Summaries ──────────────────────────────────────────────────
 
     // 2026-05-04, -11, -18 are Mondays.


### PR DESCRIPTION
Closes #300

`SleepReportCalculator.NightKey` was the last call site still calling `TimeZoneInfo.FindSystemTimeZoneById` directly — every other site listed in the issue has since moved to `TimeZoneHelper`.

It caught `TimeZoneNotFoundException` and `InvalidTimeZoneException`, but neither is what Linux throws for a mis-cased id: the zoneinfo lookup is literal, so `ETC/GMT-2` fails as `DirectoryNotFoundException` and escaped the catch. And the ids connectors emit are exactly that shape — the issue notes ~240 prod rows carrying `ETC/GMT-2`.

## What changed

Resolve via `TimeZoneHelper.TryGetTimeZoneInfoFromId`, which recovers mis-cased ids (including the `Etc/*` family that `GetSystemTimeZones()` doesn't enumerate) and never throws. A session with a mis-cased zone now buckets to its intended night instead of throwing or silently keying on UTC.

## Tests

Added a mis-cased-id case next to the existing `UsesSessionTimezone_NotUtc` test, using `ETC/GMT-11` (UTC+11, Sydney's January offset). It fails with `2026-01-14` when the zone isn't resolved and passes with `2026-01-15` when it is — I confirmed that failure before the fix landed.

Note the test deliberately uses an `Etc/*` id rather than `AUSTRALIA/SYDNEY`: the helper's case-insensitive recovery scans `GetSystemTimeZones()`, which returns IANA ids on Linux but Windows ids on Windows, so a mis-cased regional id only recovers on Linux. The `Etc/*` normalisation path works on both. Worth knowing that the helper's recovery is platform-dependent for regional ids — separate from this fix, but a sharp edge.

66/66 `Services.Sleep` tests pass.