### PR TITLE
fix(theme): make the TDD widget's auto-delivery colour distinguishable

### DIFF
--- a/src/Web/packages/glucose-chart/src/themes/nocturne.css
+++ b/src/Web/packages/glucose-chart/src/themes/nocturne.css
@@ -38,7 +38,7 @@
   /* IOB (Insulin on Board) - for charts - should be more prominent than basal */
   --iob-basal: rgba(30, 150, 252, 0.7);
   --iob-bolus: rgba(30, 150, 252, 1);
-  --iob-temporary: rgba(80, 170, 255, 0.8);
+  --iob-temporary: rgba(45, 190, 175, 0.85);
 
   /* Pump Mode States */
   --pump-mode-automatic: oklch(0.6 0.118 184.704); /* Green - full automation */
@@ -89,7 +89,7 @@
   /* IOB - Dark Mode - more saturated for contrast */
   --iob-basal: rgba(60, 160, 255, 0.8);
   --iob-bolus: rgba(30, 150, 252, 1);
-  --iob-temporary: rgba(100, 180, 255, 0.85);
+  --iob-temporary: rgba(60, 215, 200, 0.9);
 
   /* Data Exclusion - Dark Mode - slightly higher opacity for visibility on dark backgrounds */
   --data-exclusion-compression-low: rgba(255, 165, 0, 0.2);

--- a/src/Web/packages/ui/src/styles/classic-theme.css
+++ b/src/Web/packages/ui/src/styles/classic-theme.css
@@ -62,7 +62,7 @@
   /* IOB */
   --iob-basal: rgba(0, 153, 255, 0.5);
   --iob-bolus: rgba(0, 153, 255, 1.0);
-  --iob-temporary: rgba(0, 153, 255, 0.6);
+  --iob-temporary: rgba(0, 190, 170, 0.75);
 
   /* Pump Mode States */
   --pump-mode-automatic: oklch(0.8 0.35 142);
@@ -160,7 +160,7 @@
 
   /* IOB - Dark Mode */
   --iob-basal: rgba(0, 153, 255, 0.6);
-  --iob-temporary: rgba(0, 153, 255, 0.7);
+  --iob-temporary: rgba(0, 210, 190, 0.8);
 
   /* Data Exclusion - Dark Mode */
   --data-exclusion-compression-low: rgba(255, 165, 0, 0.2);

--- a/src/Web/packages/ui/src/styles/nocturne-theme.css
+++ b/src/Web/packages/ui/src/styles/nocturne-theme.css
@@ -70,7 +70,7 @@
   /* IOB (Insulin on Board) - for charts - should be more prominent than basal */
   --iob-basal: rgba(30, 150, 252, 0.7);
   --iob-bolus: rgba(30, 150, 252, 1);
-  --iob-temporary: rgba(80, 170, 255, 0.8);
+  --iob-temporary: rgba(45, 190, 175, 0.85);
 
   /* Pump Mode States */
   --pump-mode-automatic: oklch(0.6 0.118 184.704); /* Green - full automation */
@@ -121,7 +121,7 @@
   /* IOB - Dark Mode - more saturated for contrast */
   --iob-basal: rgba(60, 160, 255, 0.8);
   --iob-bolus: rgba(30, 150, 252, 1);
-  --iob-temporary: rgba(100, 180, 255, 0.85);
+  --iob-temporary: rgba(60, 215, 200, 0.9);
 
   /* Data Exclusion - Dark Mode - slightly higher opacity for visibility on dark backgrounds */
   --data-exclusion-compression-low: rgba(255, 165, 0, 0.2);


### PR DESCRIPTION
Closes #489

> small issue: blue color for basal and auto too similiar to distinguish

Confirmed. In the nocturne theme `--iob-basal` is `rgba(30, 150, 252, 0.7)` and `--iob-temporary` is `rgba(80, 170, 255, 0.8)`. The classic theme is worse — the *same* RGB at 0.6 alpha against basal's 0.5.

## What changed

`--iob-temporary` is repointed to a teal in the nocturne and classic themes, light and dark. Basal and bolus stay on the insulin blue.

`--iob-temporary` has exactly one consumer in the repo — the "Auto" segment and legend swatch of `TddWidget.svelte` — so this is contained to the widget in the screenshot; no chart surface moves. `--iob-basal` is used by the glucose chart and is untouched.

The glucose-chart package carries its own copy of the nocturne theme (it publishes to npm separately), so both copies are updated together to keep them identical.

## Left alone

- **trio** — its `--iob-temporary` is a distinctly lighter blue that mirrors Trio's own UI, and it reads fine.
- **aaps** — already teal.

## Verification

Colour values only; no behaviour. The teal is a judgement call, so if you'd rather have a different hue it's a four-line change.