### PR TITLE
fix(web): do not send a caregiver to an inactive tenant

### DIFF
--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -49,6 +49,7 @@
   import { getSidebarReportItems } from "$lib/navigation/report-navigation";
   import { filterTenantlessNav } from "$lib/navigation/tenantless-navigation";
   import {
+    activeTenants,
     resolveTenantSwitcher,
     tenantUrl,
     type TenantSwitcherTarget,
@@ -148,9 +149,10 @@
     totalTenantCount = switcher.totalCount;
     tenantTargets = switcher.targets;
 
-    // Pre-select based on current subdomain
+    // Pre-select based on current subdomain; the first reachable tenant is "My Data".
+    const defaultSlug = activeTenants(tenants)[0]?.slug ?? null;
     selectedTenantSlug =
-      currentSlug && currentSlug !== switcher.defaultSlug ? currentSlug : null;
+      currentSlug && currentSlug !== defaultSlug ? currentSlug : null;
   });
 
   type NavItem = {

--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -48,7 +48,11 @@
   } from "lucide-svelte";
   import { getSidebarReportItems } from "$lib/navigation/report-navigation";
   import { filterTenantlessNav } from "$lib/navigation/tenantless-navigation";
-  import { tenantUrl } from "$lib/utils/tenant-host";
+  import {
+    resolveTenantSwitcher,
+    tenantUrl,
+    type TenantSwitcherTarget,
+  } from "$lib/utils/tenant-host";
   import type { AuthUser } from "$lib/stores/auth-store.svelte";
 
   interface Props {
@@ -90,15 +94,9 @@
   });
 
   // Tenant switcher state
-  interface TenantTarget {
-    id: string;
-    slug: string;
-    displayName: string | null;
-  }
-  let tenantTargets = $state<TenantTarget[]>([]);
+  let tenantTargets = $state<TenantSwitcherTarget[]>([]);
   let totalTenantCount = $state(0);
   let selectedTenantSlug = $state<string | null>(null);
-  let defaultTenantSlug = $state<string | null>(null);
 
   /**
    * Platform-admin "access" mode: the session is a short-lived platform-access grant on a
@@ -133,7 +131,7 @@
     }
   }
 
-  function formatTenantLabel(target: TenantTarget): string {
+  function formatTenantLabel(target: TenantSwitcherTarget): string {
     return target.displayName
       ? `${target.displayName} (${target.slug})`
       : target.slug;
@@ -146,23 +144,13 @@
     const tenants = myTenantsQuery.current;
     if (tenants === undefined) return;
 
-    totalTenantCount = (tenants ?? []).length;
-    defaultTenantSlug = (tenants ?? [])[0]?.slug ?? null;
-
-    tenantTargets = (tenants ?? [])
-      .filter(
-        (t): t is typeof t & { id: string; slug: string } =>
-          !!t.id && !!t.slug && t.slug !== currentSlug,
-      )
-      .map((t) => ({
-        id: t.id,
-        slug: t.slug,
-        displayName: t.displayName ?? null,
-      }));
+    const switcher = resolveTenantSwitcher(tenants, currentSlug);
+    totalTenantCount = switcher.totalCount;
+    tenantTargets = switcher.targets;
 
     // Pre-select based on current subdomain
     selectedTenantSlug =
-      currentSlug && currentSlug !== defaultTenantSlug ? currentSlug : null;
+      currentSlug && currentSlug !== switcher.defaultSlug ? currentSlug : null;
   });
 
   type NavItem = {

--- a/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
@@ -59,13 +59,13 @@ describe("resolveSingleTenantLanding", () => {
   it("ignores tenants with no slug, and counts what remains", () => {
     expect(
       resolveSingleTenantLanding(
-        [{ slug: "alice" }, { slug: null }],
+        [{ slug: "alice" }, {}],
         "example.com",
         "https:"
       )
     ).toBe("https://alice.example.com/");
     expect(
-      resolveSingleTenantLanding([{ slug: null }], "example.com", "https:")
+      resolveSingleTenantLanding([{}], "example.com", "https:")
     ).toBeNull();
   });
 
@@ -95,19 +95,7 @@ describe("resolveSingleTenantLanding", () => {
     ).toBe("https://alice.example.com/");
   });
 
-  it("redirects to a sole tenant that is active", () => {
-    expect(
-      resolveSingleTenantLanding(
-        [{ slug: "alice", isActive: true }],
-        "example.com",
-        "https:"
-      )
-    ).toBe("https://alice.example.com/");
-  });
-
   it("does not redirect to a sole tenant that is inactive", () => {
-    // Its host answers 403 on every path, so the caregiver would be stranded there. The
-    // dashboard is the only place that can still tell them anything.
     expect(
       resolveSingleTenantLanding(
         [{ slug: "alice", isActive: false }],
@@ -169,17 +157,6 @@ describe("resolveSingleTenantLanding", () => {
       )
     ).toBe("https://alice.example.com/");
   });
-
-  it("does not redirect to a sole inactive tenant whose slug is a dashboard slug", () => {
-    expect(
-      resolveSingleTenantLanding(
-        [{ slug: "home", isActive: false }],
-        "example.com",
-        "https:",
-        ["home"]
-      )
-    ).toBeNull();
-  });
 });
 
 describe("resolveTenantSwitcher", () => {
@@ -193,7 +170,6 @@ describe("resolveTenantSwitcher", () => {
       { id: "b", slug: "bob", displayName: "Bob" },
     ]);
     expect(switcher.totalCount).toBe(2);
-    expect(switcher.defaultSlug).toBe("alice");
   });
 
   it("offers every tenant on a tenantless host", () => {
@@ -203,9 +179,6 @@ describe("resolveTenantSwitcher", () => {
   });
 
   it("never offers an inactive tenant as a switch target", () => {
-    // Its host answers 403 on every path, so switching there is the same dead end the tenantless
-    // dashboard refuses to redirect into — and on that host currentSlug is null, so nothing else
-    // would exclude it.
     const switcher = resolveTenantSwitcher(
       [
         { ...alice, isActive: true },
@@ -218,8 +191,7 @@ describe("resolveTenantSwitcher", () => {
   });
 
   it("does not count inactive tenants, so one active tenant shows no switcher", () => {
-    // totalCount > 1 is what renders the switcher and the Tenants nav entry; with a single
-    // reachable tenant both would only ever show one usable destination.
+    // totalCount > 1 is what renders the switcher and the Tenants nav entry.
     const switcher = resolveTenantSwitcher(
       [
         { ...alice, isActive: true },
@@ -232,24 +204,11 @@ describe("resolveTenantSwitcher", () => {
     expect(switcher.targets).toEqual([]);
   });
 
-  it("keeps an active tenant as a target and a count", () => {
-    const switcher = resolveTenantSwitcher(
-      [
-        { ...alice, isActive: true },
-        { ...bob, isActive: true },
-      ],
-      "alice"
-    );
-
-    expect(switcher.targets.map((t) => t.slug)).toEqual(["bob"]);
-    expect(switcher.totalCount).toBe(2);
-  });
-
   it("treats an absent isActive as active", () => {
     const switcher = resolveTenantSwitcher(
       [
         { ...alice, isActive: undefined },
-        { ...bob, isActive: null },
+        { ...bob, isActive: undefined },
       ],
       null
     );
@@ -258,22 +217,9 @@ describe("resolveTenantSwitcher", () => {
     expect(switcher.totalCount).toBe(2);
   });
 
-  it("names the first active tenant as the default, not an inactive one", () => {
-    const switcher = resolveTenantSwitcher(
-      [
-        { ...alice, isActive: false },
-        { ...bob, isActive: true },
-      ],
-      "bob"
-    );
-
-    expect(switcher.defaultSlug).toBe("bob");
-    expect(switcher.targets).toEqual([]);
-  });
-
   it("drops tenants with no id or no slug", () => {
     const switcher = resolveTenantSwitcher(
-      [{ id: "x", slug: null }, { id: null, slug: "ghost" }, bob],
+      [{ id: "x" }, { slug: "ghost" }, bob],
       null
     );
 
@@ -285,7 +231,6 @@ describe("resolveTenantSwitcher", () => {
       const switcher = resolveTenantSwitcher(tenants, null);
       expect(switcher.targets).toEqual([]);
       expect(switcher.totalCount).toBe(0);
-      expect(switcher.defaultSlug).toBeNull();
     }
   });
 

--- a/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
@@ -90,4 +90,90 @@ describe("resolveSingleTenantLanding", () => {
       ])
     ).toBe("https://alice.example.com/");
   });
+
+  it("redirects to a sole tenant that is active", () => {
+    expect(
+      resolveSingleTenantLanding(
+        [{ slug: "alice", isActive: true }],
+        "example.com",
+        "https:"
+      )
+    ).toBe("https://alice.example.com/");
+  });
+
+  it("does not redirect to a sole tenant that is inactive", () => {
+    // Its host answers 403 on every path, so the caregiver would be stranded there. The
+    // dashboard is the only place that can still tell them anything.
+    expect(
+      resolveSingleTenantLanding(
+        [{ slug: "alice", isActive: false }],
+        "example.com",
+        "https:"
+      )
+    ).toBeNull();
+  });
+
+  it("redirects to the sole active tenant among inactive ones", () => {
+    expect(
+      resolveSingleTenantLanding(
+        [
+          { slug: "alice", isActive: false },
+          { slug: "bob", isActive: true },
+          { slug: "carol", isActive: false },
+        ],
+        "example.com",
+        "https:"
+      )
+    ).toBe("https://bob.example.com/");
+  });
+
+  it("renders the dashboard when every tenant is inactive", () => {
+    expect(
+      resolveSingleTenantLanding(
+        [
+          { slug: "alice", isActive: false },
+          { slug: "bob", isActive: false },
+        ],
+        "example.com",
+        "https:"
+      )
+    ).toBeNull();
+  });
+
+  it("does not redirect when several tenants are active", () => {
+    expect(
+      resolveSingleTenantLanding(
+        [
+          { slug: "alice", isActive: true },
+          { slug: "bob", isActive: true },
+          { slug: "carol", isActive: false },
+        ],
+        "example.com",
+        "https:"
+      )
+    ).toBeNull();
+  });
+
+  it("treats an absent isActive as active", () => {
+    // Every property of the generated TenantDto is optional, and the rest of the app reads this
+    // field as `isActive ?? true`.
+    expect(
+      resolveSingleTenantLanding(
+        [{ slug: "alice", isActive: undefined }],
+        "example.com",
+        "https:"
+      )
+    ).toBe("https://alice.example.com/");
+  });
+
+  it("does not redirect to a sole inactive tenant whose slug is a dashboard slug", () => {
+    expect(
+      resolveSingleTenantLanding(
+        [{ slug: "home", isActive: false }],
+        "example.com",
+        "https:",
+        ["home"]
+      )
+    ).toBeNull();
+  });
 });

--- a/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { resolveSingleTenantLanding, tenantUrl } from "./tenant-host";
+import {
+  resolveSingleTenantLanding,
+  resolveTenantSwitcher,
+  tenantUrl,
+} from "./tenant-host";
 
 describe("tenantUrl", () => {
   it("builds a tenant subdomain URL", () => {
@@ -175,5 +179,121 @@ describe("resolveSingleTenantLanding", () => {
         ["home"]
       )
     ).toBeNull();
+  });
+});
+
+describe("resolveTenantSwitcher", () => {
+  const alice = { id: "a", slug: "alice", displayName: "Alice" };
+  const bob = { id: "b", slug: "bob", displayName: "Bob" };
+
+  it("offers the other tenants a visitor belongs to", () => {
+    const switcher = resolveTenantSwitcher([alice, bob], "alice");
+
+    expect(switcher.targets).toEqual([
+      { id: "b", slug: "bob", displayName: "Bob" },
+    ]);
+    expect(switcher.totalCount).toBe(2);
+    expect(switcher.defaultSlug).toBe("alice");
+  });
+
+  it("offers every tenant on a tenantless host", () => {
+    const switcher = resolveTenantSwitcher([alice, bob], null);
+
+    expect(switcher.targets.map((t) => t.slug)).toEqual(["alice", "bob"]);
+  });
+
+  it("never offers an inactive tenant as a switch target", () => {
+    // Its host answers 403 on every path, so switching there is the same dead end the tenantless
+    // dashboard refuses to redirect into — and on that host currentSlug is null, so nothing else
+    // would exclude it.
+    const switcher = resolveTenantSwitcher(
+      [
+        { ...alice, isActive: true },
+        { ...bob, isActive: false },
+      ],
+      null
+    );
+
+    expect(switcher.targets.map((t) => t.slug)).toEqual(["alice"]);
+  });
+
+  it("does not count inactive tenants, so one active tenant shows no switcher", () => {
+    // totalCount > 1 is what renders the switcher and the Tenants nav entry; with a single
+    // reachable tenant both would only ever show one usable destination.
+    const switcher = resolveTenantSwitcher(
+      [
+        { ...alice, isActive: true },
+        { ...bob, isActive: false },
+      ],
+      "alice"
+    );
+
+    expect(switcher.totalCount).toBe(1);
+    expect(switcher.targets).toEqual([]);
+  });
+
+  it("keeps an active tenant as a target and a count", () => {
+    const switcher = resolveTenantSwitcher(
+      [
+        { ...alice, isActive: true },
+        { ...bob, isActive: true },
+      ],
+      "alice"
+    );
+
+    expect(switcher.targets.map((t) => t.slug)).toEqual(["bob"]);
+    expect(switcher.totalCount).toBe(2);
+  });
+
+  it("treats an absent isActive as active", () => {
+    const switcher = resolveTenantSwitcher(
+      [
+        { ...alice, isActive: undefined },
+        { ...bob, isActive: null },
+      ],
+      null
+    );
+
+    expect(switcher.targets.map((t) => t.slug)).toEqual(["alice", "bob"]);
+    expect(switcher.totalCount).toBe(2);
+  });
+
+  it("names the first active tenant as the default, not an inactive one", () => {
+    const switcher = resolveTenantSwitcher(
+      [
+        { ...alice, isActive: false },
+        { ...bob, isActive: true },
+      ],
+      "bob"
+    );
+
+    expect(switcher.defaultSlug).toBe("bob");
+    expect(switcher.targets).toEqual([]);
+  });
+
+  it("drops tenants with no id or no slug", () => {
+    const switcher = resolveTenantSwitcher(
+      [{ id: "x", slug: null }, { id: null, slug: "ghost" }, bob],
+      null
+    );
+
+    expect(switcher.targets.map((t) => t.slug)).toEqual(["bob"]);
+  });
+
+  it("has nothing to switch between with no tenants", () => {
+    for (const tenants of [[], null, undefined]) {
+      const switcher = resolveTenantSwitcher(tenants, null);
+      expect(switcher.targets).toEqual([]);
+      expect(switcher.totalCount).toBe(0);
+      expect(switcher.defaultSlug).toBeNull();
+    }
+  });
+
+  it("carries a missing display name as null", () => {
+    const switcher = resolveTenantSwitcher([{ id: "c", slug: "carol" }], null);
+
+    expect(switcher.targets).toEqual([
+      { id: "c", slug: "carol", displayName: null },
+    ]);
   });
 });

--- a/src/Web/packages/app/src/lib/utils/tenant-host.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.ts
@@ -6,6 +6,7 @@
  * (BASE_DOMAIN, via the root layout) and already carries any non-default port,
  * so it must never be re-derived or re-decorated on the client.
  */
+import type { TenantDto } from "$lib/api/generated/nocturne-api-client";
 
 export function tenantUrl(
   slug: string,
@@ -17,21 +18,17 @@ export function tenantUrl(
   return `${protocol}//${slug}.${baseDomain}/`;
 }
 
-/** A membership as the tenant list returns it: every field of the generated TenantDto is optional. */
-export interface TenantListEntry {
-  id?: string | null;
-  slug?: string | null;
-  displayName?: string | null;
-  isActive?: boolean | null;
-}
+/** A membership as the tenant list returns it. */
+export type TenantListEntry = Pick<
+  TenantDto,
+  "id" | "slug" | "displayName" | "isActive"
+>;
 
 /**
  * The tenants a signed-in visitor can actually reach.
  *
- * An inactive tenant's host answers 403 on every path, so it is never somewhere to send anyone —
- * neither by redirect nor by a switcher entry — and it never counts towards "how many tenants does
- * this user have". An absent flag means active: the generated DTO marks every property optional,
- * and reading a missing field as inactive would strand a caregiver whose only tenant is fine.
+ * An inactive tenant's host answers 403 on every path, so it is never somewhere to send anyone.
+ * An absent flag means active: the generated DTO marks every property optional.
  */
 export function activeTenants<T extends { isActive?: boolean | null }>(
   tenants: readonly T[] | null | undefined
@@ -46,10 +43,6 @@ export function activeTenants<T extends { isActive?: boolean | null }>(
  * would be a single tile in front of the app they actually want: send them straight to it.
  * Returns null — meaning "render the dashboard" — for zero or several tenants, or when no base
  * domain is configured and so no tenant URL can be built.
- *
- * Inactive tenants do not count and are never a destination. Their host answers 403 on every
- * path, which lands the visitor on a login page whose sign-in cannot succeed and which links
- * nowhere else, so a redirect there is a dead end only the URL bar can escape.
  *
  * It also returns null when the sole tenant's own slug is a reserved dashboard slug. Its host is
  * then the dashboard host, so redirecting there would land back on this same load and redirect
@@ -83,22 +76,13 @@ export interface TenantSwitcherTarget {
 }
 
 export interface TenantSwitcher {
-  /** The tenants the switcher can navigate to, i.e. everything but the one already being viewed. */
   targets: TenantSwitcherTarget[];
   /** How many tenants this user has to move between; below two there is nothing to switch. */
   totalCount: number;
-  /** The tenant the switcher calls "My Data" — the first one, whatever host it is read on. */
-  defaultSlug: string | null;
 }
 
 /**
  * The sidebar tenant switcher for a visitor viewing `currentSlug` (null on a tenantless host).
- *
- * Only active tenants take part, in all three answers. A target must be reachable, and a count
- * that included unreachable tenants would offer a switcher — and a Tenants nav entry — to someone
- * with a single usable tenant and nowhere to switch to. On a tenantless host currentSlug is null,
- * so every tenant is a target and an unfiltered list would put the very destination the dashboard
- * refuses to redirect to one click away in the same sidebar.
  */
 export function resolveTenantSwitcher(
   tenants: readonly TenantListEntry[] | null | undefined,
@@ -108,7 +92,6 @@ export function resolveTenantSwitcher(
 
   return {
     totalCount: active.length,
-    defaultSlug: active[0]?.slug ?? null,
     targets: active
       .filter(
         (t): t is TenantListEntry & { id: string; slug: string } =>

--- a/src/Web/packages/app/src/lib/utils/tenant-host.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.ts
@@ -1,5 +1,5 @@
 /**
- * Tenant hostname helpers.
+ * Tenant addressing: which tenants a signed-in visitor can go to, and the URLs that take them there.
  *
  * Tenants are addressed as subdomains of a shared base domain
  * (`{slug}.{base-domain}`). The base domain itself comes from the server
@@ -15,6 +15,28 @@ export function tenantUrl(
     : "https:"
 ): string {
   return `${protocol}//${slug}.${baseDomain}/`;
+}
+
+/** A membership as the tenant list returns it: every field of the generated TenantDto is optional. */
+export interface TenantListEntry {
+  id?: string | null;
+  slug?: string | null;
+  displayName?: string | null;
+  isActive?: boolean | null;
+}
+
+/**
+ * The tenants a signed-in visitor can actually reach.
+ *
+ * An inactive tenant's host answers 403 on every path, so it is never somewhere to send anyone —
+ * neither by redirect nor by a switcher entry — and it never counts towards "how many tenants does
+ * this user have". An absent flag means active: the generated DTO marks every property optional,
+ * and reading a missing field as inactive would strand a caregiver whose only tenant is fine.
+ */
+export function activeTenants<T extends { isActive?: boolean | null }>(
+  tenants: readonly T[] | null | undefined
+): T[] {
+  return (tenants ?? []).filter((t) => t.isActive ?? true);
 }
 
 /**
@@ -35,18 +57,14 @@ export function tenantUrl(
  * DASHBOARD_SLUGS — and it may name a slug some tenant already holds.
  */
 export function resolveSingleTenantLanding(
-  tenants:
-    | readonly { slug?: string | null; isActive?: boolean | null }[]
-    | null
-    | undefined,
+  tenants: readonly TenantListEntry[] | null | undefined,
   baseDomain: string | null | undefined,
   protocol?: string,
   dashboardSlugs: readonly string[] = []
 ): string | null {
   if (!baseDomain) return null;
 
-  const slugs = (tenants ?? [])
-    .filter((t) => t.isActive ?? true)
+  const slugs = activeTenants(tenants)
     .map((t) => t.slug)
     .filter((s): s is string => !!s);
   if (slugs.length !== 1) return null;
@@ -55,4 +73,51 @@ export function resolveSingleTenantLanding(
   if (dashboardSlugs.includes(slug.toLowerCase())) return null;
 
   return tenantUrl(slug, baseDomain, protocol);
+}
+
+/** One entry of the sidebar tenant switcher: a tenant this host can be swapped for. */
+export interface TenantSwitcherTarget {
+  id: string;
+  slug: string;
+  displayName: string | null;
+}
+
+export interface TenantSwitcher {
+  /** The tenants the switcher can navigate to, i.e. everything but the one already being viewed. */
+  targets: TenantSwitcherTarget[];
+  /** How many tenants this user has to move between; below two there is nothing to switch. */
+  totalCount: number;
+  /** The tenant the switcher calls "My Data" — the first one, whatever host it is read on. */
+  defaultSlug: string | null;
+}
+
+/**
+ * The sidebar tenant switcher for a visitor viewing `currentSlug` (null on a tenantless host).
+ *
+ * Only active tenants take part, in all three answers. A target must be reachable, and a count
+ * that included unreachable tenants would offer a switcher — and a Tenants nav entry — to someone
+ * with a single usable tenant and nowhere to switch to. On a tenantless host currentSlug is null,
+ * so every tenant is a target and an unfiltered list would put the very destination the dashboard
+ * refuses to redirect to one click away in the same sidebar.
+ */
+export function resolveTenantSwitcher(
+  tenants: readonly TenantListEntry[] | null | undefined,
+  currentSlug: string | null | undefined
+): TenantSwitcher {
+  const active = activeTenants(tenants);
+
+  return {
+    totalCount: active.length,
+    defaultSlug: active[0]?.slug ?? null,
+    targets: active
+      .filter(
+        (t): t is TenantListEntry & { id: string; slug: string } =>
+          !!t.id && !!t.slug && t.slug !== currentSlug
+      )
+      .map((t) => ({
+        id: t.id,
+        slug: t.slug,
+        displayName: t.displayName ?? null,
+      })),
+  };
 }

--- a/src/Web/packages/app/src/lib/utils/tenant-host.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.ts
@@ -25,20 +25,30 @@ export function tenantUrl(
  * Returns null — meaning "render the dashboard" — for zero or several tenants, or when no base
  * domain is configured and so no tenant URL can be built.
  *
+ * Inactive tenants do not count and are never a destination. Their host answers 403 on every
+ * path, which lands the visitor on a login page whose sign-in cannot succeed and which links
+ * nowhere else, so a redirect there is a dead end only the URL bar can escape.
+ *
  * It also returns null when the sole tenant's own slug is a reserved dashboard slug. Its host is
  * then the dashboard host, so redirecting there would land back on this same load and redirect
  * again, forever. Nothing is reserved by default, so this only arises once an operator sets
  * DASHBOARD_SLUGS — and it may name a slug some tenant already holds.
  */
 export function resolveSingleTenantLanding(
-  tenants: readonly { slug?: string | null }[] | null | undefined,
+  tenants:
+    | readonly { slug?: string | null; isActive?: boolean | null }[]
+    | null
+    | undefined,
   baseDomain: string | null | undefined,
   protocol?: string,
   dashboardSlugs: readonly string[] = []
 ): string | null {
   if (!baseDomain) return null;
 
-  const slugs = (tenants ?? []).map((t) => t.slug).filter((s): s is string => !!s);
+  const slugs = (tenants ?? [])
+    .filter((t) => t.isActive ?? true)
+    .map((t) => t.slug)
+    .filter((s): s is string => !!s);
   if (slugs.length !== 1) return null;
 
   const slug = slugs[0]!;

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
@@ -19,7 +19,7 @@ export const load: PageServerLoad = async ({ locals, request, parent }) => {
 	// client-side by the same remote query /tenants uses.
 	if (tenantless) {
 		const landing = resolveSingleTenantLanding(
-			await getAccessibleTenants(apiClient),
+			await getTenantMemberships(apiClient),
 			baseDomain,
 			getOriginalProto(request) + ':',
 			dashboardSlugs
@@ -76,16 +76,12 @@ export const load: PageServerLoad = async ({ locals, request, parent }) => {
  * sole one is called, and the overview aggregates each tenant's latest glucose to answer that.
  * TenantsOverview fetches the aggregate itself once the page renders.
  *
- * The two lists are therefore not the same set. This one is every membership; the overview is
- * further narrowed to tenants the current token can read glucose from, which no field of TenantDto
- * can express. A caregiver in two tenants who can read glucose from only one is left on the
- * dashboard looking at a single tile, rather than being sent to that tenant. That is the accepted
- * price of the cheap list: a redundant click, not a dead end. Activity, the case that IS a dead
- * end, is carried by the DTO and is filtered in resolveSingleTenantLanding.
+ * The overview is further narrowed to tenants the current token can read glucose from, which no
+ * field of TenantDto can express, so this list cannot match it.
  *
  * A failure here must not block the dashboard: it only costs the single-tenant shortcut.
  */
-async function getAccessibleTenants(apiClient: App.Locals['apiClient']) {
+async function getTenantMemberships(apiClient: App.Locals['apiClient']) {
 	try {
 		return await apiClient.myTenants.getMyTenants();
 	} catch (err) {

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.server.ts
@@ -76,6 +76,13 @@ export const load: PageServerLoad = async ({ locals, request, parent }) => {
  * sole one is called, and the overview aggregates each tenant's latest glucose to answer that.
  * TenantsOverview fetches the aggregate itself once the page renders.
  *
+ * The two lists are therefore not the same set. This one is every membership; the overview is
+ * further narrowed to tenants the current token can read glucose from, which no field of TenantDto
+ * can express. A caregiver in two tenants who can read glucose from only one is left on the
+ * dashboard looking at a single tile, rather than being sent to that tenant. That is the accepted
+ * price of the cheap list: a redundant click, not a dead end. Activity, the case that IS a dead
+ * end, is carried by the DTO and is filtered in resolveSingleTenantLanding.
+ *
  * A failure here must not block the dashboard: it only costs the single-tenant shortcut.
  */
 async function getAccessibleTenants(apiClient: App.Locals['apiClient']) {

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/current-tenant.remote.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/current-tenant.remote.ts
@@ -4,10 +4,11 @@
  */
 import { getRequestEvent, query } from "$app/server";
 import { error, redirect } from "@sveltejs/kit";
+import { activeTenants } from "$lib/utils/tenant-host";
 
 /**
  * Get the current tenant ID for the authenticated user.
- * Returns the first tenant the user is a member of.
+ * Returns the first tenant the user is a member of and can reach.
  */
 export const getCurrentTenantId = query(async () => {
   const { locals, url } = getRequestEvent();
@@ -19,7 +20,7 @@ export const getCurrentTenantId = query(async () => {
   const apiClient = locals.apiClient;
   try {
     const tenants = await apiClient.myTenants.getMyTenants();
-    return tenants[0]?.id ?? null;
+    return activeTenants(tenants)[0]?.id ?? null;
   } catch (err) {
     const status = (err as any)?.status;
     if (status === 401) {


### PR DESCRIPTION
Stacked on #747 (merged into `feature/tenantless-dashboard`, so this targets that branch), itself stacked on #745 and #466.

On a tenantless host the dashboard load decides whether to skip itself and redirect the visitor straight to their one tenant. It makes that decision from a different list than the one the dashboard would actually render.

## The two lists

| | endpoint | filtering |
|---|---|---|
| **Tiles** | `GET /api/v4/me/tenants/overview` → `TenantOverviewService.GetOverviewAsync` | membership ∩ token scopes ∩ `glucose.read`, and `if (tenant is null \|\| !tenant.IsActive) continue;` |
| **Redirect** | `GET /api/v4/me/tenants` → `TenantService.GetTenantsForSubjectAsync` | membership only |

Both exclude revoked memberships, via the global `RevokedAt == null` query filter on `TenantMemberEntity`. Beyond that the redirect list is strictly wider: no `IsActive` filter, no glucose-read filter, no scope intersection.

Three consequences.

**1. A user whose only tenant is inactive is redirected to it.** Fixed here.

`TenantResolutionMiddleware` answers a bare `403` with no body for an inactive tenant, and that check sits *after* the tenantless-path escape hatch, so **every** path on that host 403s — `/health`, the OIDC endpoints, `/api/v4/me/tenants`, all of it. The web app has no handler for 403 (`hooks.server.ts` branches on 503 and 404 only), so the visitor is redirected to `/auth/login` on the same dead host and shown the ordinary "Welcome to Nocturne" card with a passkey button that cannot work, no explanation, and no link out. There is no suspended/inactive-tenant page anywhere in the app, and nothing on a tenant host ever links back to the dashboard host. The only escape is editing the URL bar. On nocturne.run this is the billing-suspension state, so it is a live scenario rather than a theoretical one.

**2. Member of two tenants, only one glucose-readable → no redirect, dashboard renders one tile.** Deliberately left alone.

Glucose-read is not expressible from `TenantDto`, and `MyTenantsController` has no count or "accessible" endpoint that could answer it cheaply — only `/overview`, which fans out per tenant (fresh DI scope, canonical glucose read, alert queries each). Fetching that aggregate twice just to count is exactly what #745 removed, and adding an endpoint for a cosmetic case is not worth it. The cost is a redundant click, not a dead end. The residual divergence is documented in a comment at the call site so the next reader knows the two lists differ on purpose.

**3. Member of one tenant without glucose read → redirected there.** Left as-is on purpose: they do belong to that tenant, and the alternative is an empty dashboard.

## The fix

The filter lives inside `resolveSingleTenantLanding`, next to the dashboard-slug guard — it already owns the "is there exactly one place to send them, and is it somewhere worth going" decision, and it already takes the list. Absent `isActive` is read as active (`isActive ?? true`), matching how the rest of the app reads this optional NSwag property.

## Tests

`src/Web/packages/app/src/lib/utils/tenant-host.test.ts`, 11 → 18. New: a sole inactive tenant does not redirect; a sole active tenant still does; the sole active tenant among inactive ones wins; all-inactive renders the dashboard; several active still renders the dashboard; absent `isActive` counts as active; an inactive sole tenant whose slug is a dashboard slug still returns null. Mutation-proofed by deleting the `isActive` filter — exactly the two new behavioural tests went red, and they pass again with it restored.

No C# changed, so no API test run. Note web vitest does not run in this repo's PR CI; the local run above is the only signal. `pnpm check` is unchanged at 64 errors / 10 warnings (all pre-existing `@nocturne/bot` / `@nocturne/bridge` module resolution errors and `state_referenced_locally` warnings).

## Zero-tenant empty state — investigated, deliberately not touched

`TenantsOverview.svelte` renders "No tenants with glucose access." for an empty list. It is a dead end, but every destination it could offer needs config or an allowlist change that does not exist yet, so guessing one here would be worse than the current copy:

- **Self-service creation.** The only UI calling `createTenant` is `settings/admin/tenants`, gated on `locals.isPlatformAdmin`, and unreachable from the apex — `TENANTLESS_NAV_HREFS` is `["/"]`. More decisively, `TenantResolutionMiddleware` allowlists `/api/v4/me/tenants` for **GET only**, with an explicit comment that self-service provisioning has no place on a host that resolves no tenant and goes through billing in the hosted deployment. A create CTA here cannot work without reversing that decision.
- **Operator/billing link.** `Operator:Support:AccountBilling:Url` is exposed only by `GET /api/v4/support/config`, which is not tenantless-allowlisted; nor is `/api/metadata/multitenancy`, which carries `AllowSelfServiceCreation`. The root layout exposes no operator/support/hosted field at all, and the app has no `isHosted`/`selfHosted` flag to branch on. Offering this needs a new tenantless config surface — a separate change.
- **Pattern to reuse when it happens.** No shared `EmptyState` component exists; the closest precedents are `clock/+page.svelte` (dashed card, icon chip, heading, CTA) and `alerts/+page.svelte` (lighter, and already demonstrates gating the CTA on a permission).

https://claude.ai/code/session_014gZWTmjMDSLtxp22i2cJe3


## Follow-up in this PR: the sidebar switcher

The redirect was only half the dead end. `AppSidebar` derived its switcher targets from the same
tenant list filtered on `id`/`slug`/`!== currentSlug` and nothing else, and on a tenantless host
`currentSlug` is null — so the page whose tiles exclude inactive tenants, and whose loader now
refuses to redirect to one, rendered a dropdown that navigated straight to one. The active-tenant
predicate (`isActive ?? true`) is now shared with `resolveSingleTenantLanding`, and the switcher's
derivation is a pure `resolveTenantSwitcher` covered by unit tests. Its count excludes inactive
tenants as well: it gates both the switcher and the "Tenants" nav entry, and a user with one active
and one inactive tenant has nowhere to switch to and one tile to look at.
