### PR TITLE
chore(web): upgrade layerchart 2.0.1 -> 2.2.0

### DIFF
--- a/src/Web/packages/app/package.json
+++ b/src/Web/packages/app/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-svelte": "^3.17.1",
     "globals": "^17.6.0",
     "happy-dom": "^20.9.0",
-    "layerchart": "2.0.1",
+    "layerchart": "2.2.0",
     "mode-watcher": "^1.1.0",
     "openapi-remote-codegen": "0.2.0",
     "paneforge": "^1.0.2",

--- a/src/Web/packages/glucose-chart/package.json
+++ b/src/Web/packages/glucose-chart/package.json
@@ -32,6 +32,7 @@
     "@types/d3-scale": "^4.0.9",
     "d3": "^7.9.0",
     "d3-scale": "^4.0.2",
+    "layerchart": "2.2.0",
     "svelte": "^5.54.0",
     "typescript": "^5.9.3",
     "svelte-check": "^4.4.2"

--- a/src/Web/packages/ui/package.json
+++ b/src/Web/packages/ui/package.json
@@ -22,7 +22,7 @@
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tailwindcss/typography": "^0.5.19",
     "bits-ui": "^2.15.5",
-    "layerchart": "2.0.1",
+    "layerchart": "2.2.0",
     "clsx": "^2.1.1",
     "mode-watcher": "^1.1.0",
     "paneforge": "^1.0.2",

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -222,8 +222,8 @@ importers:
         specifier: ^20.9.0
         version: 20.9.0
       layerchart:
-        specifier: 2.0.1
-        version: 2.0.1(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3)
+        specifier: 2.2.0
+        version: 2.2.0(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3)
       mode-watcher:
         specifier: ^1.1.0
         version: 1.1.0(svelte@5.55.5(@typescript-eslint/types@8.59.3))
@@ -573,9 +573,6 @@ importers:
       '@lucide/svelte':
         specifier: '>=0.400.0'
         version: 0.563.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))
-      layerchart:
-        specifier: '>=2.0.0'
-        version: 2.0.1(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3)
       tailwindcss:
         specifier: '>=4.0.0'
         version: 4.1.18
@@ -595,6 +592,9 @@ importers:
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
+      layerchart:
+        specifier: 2.2.0
+        version: 2.2.0(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3)
       svelte:
         specifier: 5.55.5
         version: 5.55.5(@typescript-eslint/types@8.59.3)
@@ -714,8 +714,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       layerchart:
-        specifier: 2.0.1
-        version: 2.0.1(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3)
+        specifier: 2.2.0
+        version: 2.2.0(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3)
       mode-watcher:
         specifier: ^1.1.0
         version: 1.1.0(svelte@5.55.5(@typescript-eslint/types@8.59.3))
@@ -1347,6 +1347,9 @@ packages:
 
   '@layerstack/utils@2.0.0-next.18':
     resolution: {integrity: sha512-EYILHpfBRYMMEahajInu9C2AXQom5IcAEdtCeucD3QIl/fdDgRbtzn6/8QW9ewumfyNZetdUvitOksmI1+gZYQ==}
+
+  '@layerstack/utils@2.0.0-next.19':
+    resolution: {integrity: sha512-HyXCEz9pge4rFWklrSgFr3YIwdE1gP8WM6GPetmnKPDfYLF1/oetRFKI9FqiE+dw4brnULGPKJsVhjM3vQfD4A==}
 
   '@lucide/svelte@0.555.0':
     resolution: {integrity: sha512-aqTOMjBjf/HNwrhggRdb83T0QslZdpJTyTwr/chtXTGw7u4Hcu4zQb/5uA+csF0KKawKWVnsNI1MdHEHeEXTcQ==}
@@ -4708,8 +4711,8 @@ packages:
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
-  layerchart@2.0.1:
-    resolution: {integrity: sha512-ss19hUjjZawMni60dgYsm+ZT/Fq/HYh8YSQt6D9xhN+Dc9HB6TH77FOeOl1avf7Wlpc2MG7X16SFuMGh8nR+Eg==}
+  layerchart@2.2.0:
+    resolution: {integrity: sha512-IarOANUPAqv+P9UESpQhzlkiM36oQhUACZuE3T9wbFHoD8FtSBdr/UNRC4Aks2UBN/OEy/dE+xBypZ6RFoFLMg==}
     peerDependencies:
       svelte: 5.55.5
 
@@ -7369,6 +7372,12 @@ snapshots:
       tailwind-merge: 3.6.0
 
   '@layerstack/utils@2.0.0-next.18':
+    dependencies:
+      d3-array: 3.2.4
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  '@layerstack/utils@2.0.0-next.19':
     dependencies:
       d3-array: 3.2.4
       d3-time: 3.1.0
@@ -11074,13 +11083,13 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  layerchart@2.0.1(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3):
+  layerchart@2.2.0(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@6.4.1(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3):
     dependencies:
       '@dagrejs/dagre': 2.0.4
       '@layerstack/svelte-actions': 1.0.1-next.18
       '@layerstack/svelte-state': 0.1.0-next.23
       '@layerstack/tailwind': 2.0.0-next.21
-      '@layerstack/utils': 2.0.0-next.18
+      '@layerstack/utils': 2.0.0-next.19
       '@types/d3-contour': 3.0.6
       d3-array: 3.2.4
       d3-chord: 3.0.1
@@ -11095,6 +11104,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-interpolate-path: 2.3.0
       d3-path: 3.1.0
+      d3-polygon: 3.0.1
       d3-quadtree: 3.0.1
       d3-random: 3.0.1
       d3-sankey: 0.12.3
@@ -11110,13 +11120,13 @@ snapshots:
       - '@sveltejs/kit'
       - zod
 
-  layerchart@2.0.1(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3):
+  layerchart@2.2.0(@sveltejs/kit@2.59.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(typescript@5.9.3)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))(svelte@5.55.5(@typescript-eslint/types@8.59.3))(zod@4.4.3):
     dependencies:
       '@dagrejs/dagre': 2.0.4
       '@layerstack/svelte-actions': 1.0.1-next.18
       '@layerstack/svelte-state': 0.1.0-next.23
       '@layerstack/tailwind': 2.0.0-next.21
-      '@layerstack/utils': 2.0.0-next.18
+      '@layerstack/utils': 2.0.0-next.19
       '@types/d3-contour': 3.0.6
       d3-array: 3.2.4
       d3-chord: 3.0.1
@@ -11131,6 +11141,7 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-interpolate-path: 2.3.0
       d3-path: 3.1.0
+      d3-polygon: 3.0.1
       d3-quadtree: 3.0.1
       d3-random: 3.0.1
       d3-sankey: 0.12.3


### PR DESCRIPTION
## What

Moves the three workspace packages that use layerchart from 2.0.1 to 2.2.0.

## Why now, and what it does *not* fix

Checked against the workarounds in #498/#499/#503/#698/#721/#739 before upgrading.

2.1.1's `perf(Chart): Remove quadratic domain recalculation on mount` sounds like the O(N^2) mark-registration problem those PRs work around, but it isn't. It memoizes the per-series value collection inside `resolveDomain`; the commit's own comment confirms the mechanism is unchanged — `resolveDomain` still re-runs on **every** mark registration, because each mounting mark bumps `_markInfosVersion`. It reduces the cost per re-run for `series`-based charts (which this repo mostly doesn't use), not the number of re-runs. Nothing since the 2.0 rework touches `registerComponent`, so its O(N^2) teardown (indexOf + splice per sibling on every data change) is also untouched.

`<Text>` still has no children snippet, and `AnnotationRange` still destructures without `...rest`. So every native-SVG conversion and every `value`-prop label fix stays necessary.

What we do get: the `<Spline>` fix (path data was tweened even without `motion` — ~20x less memory growth while streaming) is directly relevant, since `Spline`/`Area`/`Axis` are the O(1)-per-track components we kept. Plus prop memoization and single-pass stacked domains. 2.2.0 adds touch pinch-zoom on `TransformContext` and UTC-scale axis ticks; neither is used here.

## Note on the peer-only package

`@nightscout/glucose-chart` declared layerchart only as a peer, so pnpm kept resolving it to 2.0.1 while the app moved to 2.2.0 — meaning its `check`, which is the CI gate, would have typechecked against a version we no longer ship. It now carries a pinned devDependency alongside the peer range, matching what `packages/ui` already does.

## Verification

- `@nightscout/glucose-chart` `check` (the CI gate) — 0 errors / 0 warnings.
- `@nocturne/ui` `check` — 0 errors / 0 warnings.
- `@nocturne/app` `check` — 64 errors / 10 warnings / 31 files, **byte-identical to the 2.0.1 baseline measured on the same worktree**. The remaining errors are pre-existing (unbuilt `@nocturne/bot`/`@nocturne/bridge` workspace deps, generated-client noise, and a `SwimLaneTrack` `ChartSpanKind` narrowing) and were confirmed present on 2.0.1.
- 14 chart browser tests pass, including `mark-registration.svelte.test.ts` — registrations stay flat at 27, so 2.2.0 doesn't regress the conversions.
- Lockfile diff is layerchart-only (an earlier `pnpm update -r` pulled in unrelated bumps to vitest/bits-ui/runed/lightningcss; that was reverted and redone as a plain install).
