### PR TITLE
feat: serve the subject's own settings on a tenantless host

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -139,7 +139,6 @@ public class PasskeyController : ControllerBase
             return Problem(detail: "Username is required", statusCode: 400, title: "Bad Request");
         }
 
-        var tenantId = _tenantAccessor.TenantId;
         var result = await _passkeyService.GenerateRegistrationOptionsAsync(
             subjectId.Value, request.Username);
 
@@ -650,7 +649,6 @@ public class PasskeyController : ControllerBase
             return Problem(detail: "Authentication required", statusCode: 401, title: "Unauthorized");
         }
 
-        var tenantId = _tenantAccessor.TenantId;
         var credentials = await _passkeyService.GetCredentialsAsync(auth.SubjectId.Value);
         var primaryFactorCount = await _subjectService.CountPrimaryAuthFactorsAsync(auth.SubjectId.Value);
 

--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -120,6 +120,7 @@ public class PasskeyController : ControllerBase
     /// subject id would let anyone enrol their own authenticator onto another account.
     /// </remarks>
     [HttpPost("register/options")]
+    [DenyDemoSubject]
     [AllowAnonymous]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
@@ -140,7 +141,7 @@ public class PasskeyController : ControllerBase
 
         var tenantId = _tenantAccessor.TenantId;
         var result = await _passkeyService.GenerateRegistrationOptionsAsync(
-            subjectId.Value, request.Username, tenantId);
+            subjectId.Value, request.Username);
 
         return Ok(new PasskeyOptionsResponse
         {
@@ -202,6 +203,7 @@ public class PasskeyController : ControllerBase
     /// so a challenge minted by another flow cannot be redeemed as an enrolment onto it.
     /// </remarks>
     [HttpPost("register/complete")]
+    [DenyDemoSubject]
     [AllowAnonymous]
     [RemoteCommand(Invalidates = ["ListCredentials"])]
     [ProducesResponseType(typeof(PasskeyRegisterCompleteResponse), StatusCodes.Status200OK)]
@@ -267,7 +269,7 @@ public class PasskeyController : ControllerBase
         }
 
         var result = await _passkeyService.GenerateRegistrationOptionsAsync(
-            subject.Id, subject.Username ?? subject.Name, _tenantAccessor.TenantId);
+            subject.Id, subject.Username ?? subject.Name);
 
         return Ok(new PasskeyOptionsResponse
         {
@@ -636,6 +638,7 @@ public class PasskeyController : ControllerBase
     /// List all passkey credentials for the authenticated user
     /// </summary>
     [HttpGet("credentials")]
+    [DenyDemoSubject]
     [RemoteQuery]
     [ProducesResponseType(typeof(PasskeyCredentialListResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -648,7 +651,7 @@ public class PasskeyController : ControllerBase
         }
 
         var tenantId = _tenantAccessor.TenantId;
-        var credentials = await _passkeyService.GetCredentialsAsync(auth.SubjectId.Value, tenantId);
+        var credentials = await _passkeyService.GetCredentialsAsync(auth.SubjectId.Value);
         var primaryFactorCount = await _subjectService.CountPrimaryAuthFactorsAsync(auth.SubjectId.Value);
 
         return Ok(new PasskeyCredentialListResponse
@@ -668,6 +671,7 @@ public class PasskeyController : ControllerBase
     /// Remove a passkey credential. Cannot remove the last credential if user has no OIDC link.
     /// </summary>
     [HttpDelete("credentials/{id:guid}")]
+    [DenyDemoSubject]
     [RemoteCommand(Invalidates = ["ListCredentials"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -702,6 +706,7 @@ public class PasskeyController : ControllerBase
     /// Regenerate recovery codes for the authenticated user. Invalidates all existing codes.
     /// </summary>
     [HttpPost("recovery/regenerate")]
+    [DenyDemoSubject]
     [RemoteCommand(Invalidates = ["GetRecoveryStatus"])]
     [ProducesResponseType(typeof(RecoveryRegenerateResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -725,6 +730,7 @@ public class PasskeyController : ControllerBase
     /// Get the count of remaining recovery codes for the authenticated user
     /// </summary>
     [HttpGet("recovery/status")]
+    [DenyDemoSubject]
     [RemoteQuery]
     [ProducesResponseType(typeof(RecoveryStatusResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -914,7 +920,7 @@ public class PasskeyController : ControllerBase
         await _dbContext.SaveChangesAsync();
 
         var result = await _passkeyService.GenerateRegistrationOptionsAsync(
-            subjectId.Value, username, tenant.Id);
+            subjectId.Value, username);
 
         return Ok(new PasskeyOptionsResponse
         {
@@ -1081,7 +1087,7 @@ public class PasskeyController : ControllerBase
 
         // Generate passkey registration options
         var result = await _passkeyService.GenerateRegistrationOptionsAsync(
-            subjectId.Value, username, tenantId);
+            subjectId.Value, username);
 
         return Ok(new PasskeyOptionsResponse
         {

--- a/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
@@ -93,6 +93,7 @@ public class TotpController : ControllerBase
     /// <response code="400">No primary factor configured, or user account not found.</response>
     /// <response code="401">Not authenticated.</response>
     [HttpPost("setup")]
+    [DenyDemoSubject]
     [RemoteCommand]
     [ProducesResponseType(typeof(TotpSetupResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -138,6 +139,7 @@ public class TotpController : ControllerBase
     /// <response code="400">Invalid code or challenge token.</response>
     /// <response code="401">Not authenticated.</response>
     [HttpPost("verify-setup")]
+    [DenyDemoSubject]
     [RemoteCommand(Invalidates = ["ListCredentials"])]
     [ProducesResponseType(typeof(TotpVerifySetupResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -171,6 +173,7 @@ public class TotpController : ControllerBase
     /// <response code="200">List of TOTP credentials.</response>
     /// <response code="401">Not authenticated.</response>
     [HttpGet]
+    [DenyDemoSubject]
     [RemoteQuery]
     [ProducesResponseType(typeof(List<TotpCredentialDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -203,6 +206,7 @@ public class TotpController : ControllerBase
     /// <response code="204">Credential removed.</response>
     /// <response code="401">Not authenticated.</response>
     [HttpDelete("{id:guid}")]
+    [DenyDemoSubject]
     [RemoteCommand(Invalidates = ["ListCredentials"])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/API/Nocturne.API/Controllers/V4/Account/AvatarController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Account/AvatarController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.Core.Contracts.Storage;
 using SixLabors.ImageSharp;
@@ -26,6 +27,7 @@ public class AvatarController(IAvatarStore avatarStore, ILogger<AvatarController
     /// Upload or replace the current subject's avatar. Image is resized to 256x256 WebP.
     /// </summary>
     [HttpPost]
+    [DenyDemoSubject]
     [RemoteCommand]
     [RequestSizeLimit(MaxUploadBytes)]
     [ProducesResponseType(typeof(AvatarUploadResponse), StatusCodes.Status200OK)]
@@ -89,6 +91,7 @@ public class AvatarController(IAvatarStore avatarStore, ILogger<AvatarController
     /// Delete the current subject's avatar.
     /// </summary>
     [HttpDelete]
+    [DenyDemoSubject]
     [RemoteCommand]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> Delete(CancellationToken ct)

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantController.cs
@@ -180,7 +180,7 @@ public class TenantController : ControllerBase
         if (!await IsCallerTenantOwnerAsync(id, ct))
             return Forbid();
 
-        var passkeys = await passkeyService.GetCredentialsAsync(subjectId, id);
+        var passkeys = await passkeyService.GetCredentialsAsync(subjectId);
         var oidcIdentities = await subjectService.GetLinkedOidcIdentitiesAsync(subjectId);
 
         return Ok(new SubjectCredentialsDto(

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UserPreferencesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UserPreferencesController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
+using Nocturne.API.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
@@ -78,6 +79,7 @@ public class UserPreferencesController : ControllerBase
     /// <param name="request">The preferences to update</param>
     /// <returns>Updated preferences</returns>
     [HttpPatch]
+    [DenyDemoSubject]
     [RemoteCommand(Invalidates = ["GetPreferences"])]
     [ProducesResponseType(typeof(UserPreferencesResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -200,7 +200,7 @@ public partial class SetupController : ControllerBase
             tenant!, request.DisplayName.Trim(), normalizedUsername, ct);
 
         var result = await _passkeyService.GenerateRegistrationOptionsAsync(
-            subjectId, normalizedUsername, tenant!.Id);
+            subjectId, normalizedUsername);
 
         return Ok(new SetupOwnerOptionsResponse
         {

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -149,12 +149,22 @@ public class TenantResolutionMiddleware
         new TenantlessPath("/api/auth/totp/setup", HttpMethods.Post),
         new TenantlessPath("/api/auth/totp/verify-setup", HttpMethods.Post),
         new TenantlessPath("/api/auth/totp", HttpMethods.Get),
-        // Revoking one authenticator, whose route carries its id. Narrowed to DELETE so the
-        // sibling POST /login, which gates on membership of the resolved tenant, stays out.
+        // Revoking one authenticator, whose route carries its id. Narrowed to DELETE so the sibling
+        // /login, which gates on membership of the resolved tenant, is not admitted under the POST
+        // it is served on. Asked without a method this prefix answers for its own DELETE, so a
+        // coverage sweep sees /login as reachable; routing has no DELETE there to reach.
         new TenantlessPath("/api/auth/totp/", HttpMethods.Delete, Prefix: true),
         // GET the list and DELETE one by id; nothing else is routed beneath either.
         new TenantlessPath("/api/auth/passkey/credentials", Prefix: true),
         new TenantlessPath("/api/auth/oidc/link/identities", Prefix: true),
+        // Linking an identity is a full-page navigation, so a 404 loses the page rather than
+        // failing one control. It reads its tenant slug as a nullable off HttpContext.Items purely
+        // to route the callback home, which on a tenantless host is where the caller already is —
+        // the same shape as the login/callback pair above.
+        new TenantlessPath("/api/auth/oidc/link", HttpMethods.Get),
+        new TenantlessPath("/api/auth/oidc/link/callback", HttpMethods.Get),
+        // GET is [AllowAnonymous] and serves any subject's picture by id on every tenant host
+        // already; it is admitted here because the page renders through it.
         "/api/v4/me/avatar",
 
         // Cross-tenant by design: these operate on arbitrary tenants by id and so cannot rely on

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -83,6 +83,11 @@ public class TenantResolutionMiddleware
         // carries — empty for an ordinary subject, non-empty for one holding global roles.
         // Caller-scoped either way, so nothing about a tenant is exposed.
         "/api/v4/me/permissions",
+        // Units, time format, region, colour theme, chart style, language — stored on the subject
+        // (subjects.preferences / subjects.preferred_language) and read by SubjectId alone. Not
+        // only presentation: the dashboard tiles render glucose in the units held here, so a 404
+        // shows an mmol/L user their children's readings in mg/dL.
+        "/api/v4/user/preferences",
         "/api/v4/admin/tenants/validate-slug",
         "/api/metadata",
         "/api/v4/chat-identity/directory/resolve",

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -37,18 +37,25 @@ public class TenantResolutionMiddleware
     /// <summary>
     /// A path served without a resolved tenant, optionally narrowed to a single HTTP method.
     /// </summary>
-    /// <param name="Path">The exact path, matched case-insensitively.</param>
+    /// <param name="Path">The path, matched case-insensitively.</param>
     /// <param name="Method">
     /// The only method admitted tenantlessly, or null to admit every method. Naming a method
     /// matters where a path carries both a cross-tenant read and a tenant-affecting write.
     /// </param>
-    private readonly record struct TenantlessPath(string Path, string? Method = null)
+    /// <param name="Prefix">
+    /// Whether <paramref name="Path"/> admits everything beneath it. Needed by controllers whose
+    /// routes carry an id segment; prefer an exact entry, which cannot admit a route added later.
+    /// </param>
+    private readonly record struct TenantlessPath(
+        string Path, string? Method = null, bool Prefix = false)
     {
         /// <summary>Admit every method on a path, which is the case for most of the list.</summary>
         public static implicit operator TenantlessPath(string path) => new(path);
 
         public bool Matches(string path, string? method) =>
-            Path.Equals(path, StringComparison.OrdinalIgnoreCase) &&
+            (Prefix
+                ? path.StartsWith(Path, StringComparison.OrdinalIgnoreCase)
+                : Path.Equals(path, StringComparison.OrdinalIgnoreCase)) &&
             (Method is null || method is null ||
              Method.Equals(method, StringComparison.OrdinalIgnoreCase));
     }
@@ -125,29 +132,47 @@ public class TenantResolutionMiddleware
         // tenant pin, so it can confer no tenant-scoped authority. POST only, matching the
         // only verb the endpoint serves.
         new TenantlessPath("/api/auth/oidc/refresh", HttpMethods.Post),
-    ];
+        // The subject's own sign-in factors and linked identities, as /settings/account manages
+        // them. Each is keyed on the caller's SubjectId, and the tables behind them
+        // (passkey_credentials, recovery_codes, totp_credentials, subject_oidc_identities,
+        // subject_avatars) carry no tenant column — one person's credential is the same credential
+        // in every tenant they belong to, so managing it from a tenant subdomain was arbitrary.
+        //
+        // The sign-in ceremonies are deliberately absent. TotpController.Login gates on membership
+        // of the resolved tenant and the passkey login/* paths likewise, so authenticating on a
+        // tenantless host remains identity-provider-only; these enrol and revoke factors for a
+        // caller who is already authenticated.
+        new TenantlessPath("/api/auth/passkey/register/options", HttpMethods.Post),
+        new TenantlessPath("/api/auth/passkey/register/complete", HttpMethods.Post),
+        new TenantlessPath("/api/auth/passkey/recovery/status", HttpMethods.Get),
+        new TenantlessPath("/api/auth/passkey/recovery/regenerate", HttpMethods.Post),
+        new TenantlessPath("/api/auth/totp/setup", HttpMethods.Post),
+        new TenantlessPath("/api/auth/totp/verify-setup", HttpMethods.Post),
+        new TenantlessPath("/api/auth/totp", HttpMethods.Get),
+        // Revoking one authenticator, whose route carries its id. Narrowed to DELETE so the
+        // sibling POST /login, which gates on membership of the resolved tenant, stays out.
+        new TenantlessPath("/api/auth/totp/", HttpMethods.Delete, Prefix: true),
+        // GET the list and DELETE one by id; nothing else is routed beneath either.
+        new TenantlessPath("/api/auth/passkey/credentials", Prefix: true),
+        new TenantlessPath("/api/auth/oidc/link/identities", Prefix: true),
+        "/api/v4/me/avatar",
 
-    /// <summary>
-    /// Prefixes that are cross-tenant by design and must never be gated on
-    /// a resolved tenant. Admin tenant management (create, provision, member
-    /// management) operates on arbitrary tenants by ID and cannot rely on
-    /// subdomain resolution.
-    /// </summary>
-    private static readonly string[] TenantlessAllowedPrefixes =
-    [
-        // Platform-admin tenant-access grant: minted at the apex (operator is not on
-        // any tenant subdomain yet); the target tenant is resolved from the query string.
-        "/api/auth/platform-access",
-        "/api/v4/admin/demo/",
-        "/api/v4/admin/platform-settings",
-        "/api/v4/admin/tenants",
-        "/api/v4/dev-only/",
-        "/api/v4/platform/",
-        "/api/v4/setup/",
+        // Cross-tenant by design: these operate on arbitrary tenants by id and so cannot rely on
+        // subdomain resolution at all.
+        //
+        // Platform-admin tenant-access grant: minted at the apex (the operator is not on any
+        // tenant subdomain yet); the target tenant is resolved from the query string.
+        new TenantlessPath("/api/auth/platform-access", Prefix: true),
+        new TenantlessPath("/api/v4/admin/demo/", Prefix: true),
+        new TenantlessPath("/api/v4/admin/platform-settings", Prefix: true),
+        new TenantlessPath("/api/v4/admin/tenants", Prefix: true),
+        new TenantlessPath("/api/v4/dev-only/", Prefix: true),
+        new TenantlessPath("/api/v4/platform/", Prefix: true),
+        new TenantlessPath("/api/v4/setup/", Prefix: true),
         // Cross-tenant overview hub: authorizes a subject in-band and joins per-tenant groups
         // itself, so the connection is negotiated from the apex with no tenant. Prefix, not
         // exact path: SignalR appends /negotiate to the hub path.
-        "/hubs/overview",
+        new TenantlessPath("/hubs/overview", Prefix: true),
     ];
 
     /// <summary>
@@ -160,8 +185,7 @@ public class TenantResolutionMiddleware
     /// method, which is what a coverage sweep over the whole surface wants.
     /// </param>
     public static bool IsTenantlessAllowed(string path, string? method = null) =>
-        TenantlessAllowedPaths.Any(p => p.Matches(path, method)) ||
-        TenantlessAllowedPrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase));
+        TenantlessAllowedPaths.Any(p => p.Matches(path, method));
 
     public async Task InvokeAsync(HttpContext context)
     {

--- a/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
@@ -100,7 +100,7 @@ public class PasskeyService : IPasskeyService
     }
 
     public async Task<PasskeyRegistrationOptions> GenerateRegistrationOptionsAsync(
-        Guid subjectId, string username, Guid tenantId)
+        Guid subjectId, string username)
     {
         var existingCredentials = await _dbContext.PasskeyCredentials
             .Where(c => c.SubjectId == subjectId)
@@ -299,7 +299,7 @@ public class PasskeyService : IPasskeyService
         return new PasskeyAssertionResult(subject.Id, subject.Username ?? subject.Name, subject.Name);
     }
 
-    public async Task<List<PasskeyCredentialInfo>> GetCredentialsAsync(Guid subjectId, Guid tenantId)
+    public async Task<List<PasskeyCredentialInfo>> GetCredentialsAsync(Guid subjectId)
     {
         return await _dbContext.PasskeyCredentials
             .Where(c => c.SubjectId == subjectId)

--- a/src/Core/Nocturne.Core.Contracts/Auth/IPasskeyService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IPasskeyService.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Core.Contracts.Auth;
 public interface IPasskeyService
 {
     /// <summary>Generates registration options for creating a new passkey credential.</summary>
-    Task<PasskeyRegistrationOptions> GenerateRegistrationOptionsAsync(Guid subjectId, string username, Guid tenantId);
+    Task<PasskeyRegistrationOptions> GenerateRegistrationOptionsAsync(Guid subjectId, string username);
 
     /// <summary>Validates the attestation response and stores the new passkey credential.</summary>
     /// <param name="expectedSubjectId">
@@ -32,7 +32,7 @@ public interface IPasskeyService
     Task<PasskeyAssertionResult> CompleteAssertionAsync(string assertionResponseJson, string challengeToken, Guid tenantId);
 
     /// <summary>Returns all registered passkey credentials for the specified subject.</summary>
-    Task<List<PasskeyCredentialInfo>> GetCredentialsAsync(Guid subjectId, Guid tenantId);
+    Task<List<PasskeyCredentialInfo>> GetCredentialsAsync(Guid subjectId);
 
     /// <summary>Removes a passkey credential from the specified subject.</summary>
     Task RemoveCredentialAsync(Guid credentialId, Guid subjectId, Guid tenantId);

--- a/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.test.ts
+++ b/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.test.ts
@@ -7,9 +7,12 @@ describe("paletteItemsFor", () => {
     expect(paletteItemsFor(false)).toEqual(items);
   });
 
-  it("offers only the dashboard on a tenantless host", () => {
+  it("offers only the subject-scoped destinations on a tenantless host", () => {
     // Everything else bounces back to "/" via the route guard, so Cmd-K must not advertise it.
-    expect(paletteItemsFor(true).map((item) => item.id)).toEqual(["page-dashboard"]);
+    expect(paletteItemsFor(true).map((item) => item.id)).toEqual([
+      "page-dashboard",
+      "settings-appearance",
+    ]);
   });
 
   it("keeps no entry whose destination needs a resolved tenant", () => {
@@ -29,6 +32,6 @@ describe("paletteItemsFor", () => {
     expect(groups).toContain("actions");
 
     const tenantlessGroups = new Set(paletteItemsFor(true).map((item) => item.group));
-    expect(tenantlessGroups).toEqual(new Set(["pages"]));
+    expect(tenantlessGroups).toEqual(new Set(["pages", "settings"]));
   });
 });

--- a/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.test.ts
+++ b/src/Web/packages/app/src/lib/components/command-palette/command-palette-items.test.ts
@@ -11,6 +11,7 @@ describe("paletteItemsFor", () => {
     // Everything else bounces back to "/" via the route guard, so Cmd-K must not advertise it.
     expect(paletteItemsFor(true).map((item) => item.id)).toEqual([
       "page-dashboard",
+      "settings-account",
       "settings-appearance",
     ]);
   });

--- a/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/AppSidebar.svelte
@@ -532,11 +532,8 @@
     <Sidebar.Menu>
       {#if !langPrefKnown}
         <Sidebar.MenuItem class="group-data-[collapsible=icon]:hidden">
-          <!-- The language choice still applies to this page; only persisting it needs a tenant
-               (the preferences write is tenant-scoped), so a tenantless host keeps the selector
-               and drops the write rather than losing the control entirely. -->
           <LanguageSelector
-            onLanguageChange={user && !tenantless
+            onLanguageChange={user
               ? (locale: string) =>
                   updateLanguagePreference({ preferredLanguage: locale })
               : undefined}

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
@@ -13,10 +13,10 @@ describe("filterTenantlessNav", () => {
     expect(filterTenantlessNav(items)).toEqual([{ title: "Dashboard", href: "/" }]);
   });
 
-  it("drops the settings group, whose pages all need a resolved tenant", () => {
-    // Account and appearance look subject-scoped but call /api/auth/passkey/*, /api/v4/totp/*,
-    // and /api/v4/settings, none of which the API serves without a tenant. Listing them would
-    // put entries in the sidebar that 404 when opened.
+  it("keeps only the subject-scoped page in the settings group", () => {
+    // Appearance carries the subject's own units/formats/theme. Account looks subject-scoped and
+    // its data is, but /api/auth/passkey/* and /api/auth/totp/* are not served off a tenant, so
+    // listing it would put an entry in the sidebar that 404s when opened.
     const items = [
       {
         title: "Settings",
@@ -30,7 +30,30 @@ describe("filterTenantlessNav", () => {
       },
     ];
 
-    expect(filterTenantlessNav(items)).toEqual([]);
+    expect(filterTenantlessNav(items)).toEqual([
+      {
+        title: "Settings",
+        children: [{ title: "Appearance", href: "/settings/appearance" }],
+      },
+    ]);
+  });
+
+  it("admits the subject's own appearance page as a route", () => {
+    expect(isTenantlessRoute("/settings/appearance")).toBe(true);
+  });
+
+  it("keeps the rest of settings off a tenantless host", () => {
+    // The tenant-scoped pages would render a shell and then 404, and account needs auth
+    // endpoints the API does not serve without a tenant.
+    for (const href of [
+      "/settings",
+      "/settings/account",
+      "/settings/members",
+      "/settings/profile",
+      "/settings/trackers",
+    ]) {
+      expect(isTenantlessRoute(href)).toBe(false);
+    }
   });
 
   it("drops a group whose children are all tenant-scoped, leaving no empty heading", () => {
@@ -70,7 +93,6 @@ describe("isTenantlessRoute", () => {
     expect(isTenantlessRoute("/tenants")).toBe(false);
     expect(isTenantlessRoute("/settings/members")).toBe(false);
     expect(isTenantlessRoute("/settings/account")).toBe(false);
-    expect(isTenantlessRoute("/settings/appearance")).toBe(false);
   });
 
   it("matches whole paths, not prefixes", () => {

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.test.ts
@@ -13,10 +13,7 @@ describe("filterTenantlessNav", () => {
     expect(filterTenantlessNav(items)).toEqual([{ title: "Dashboard", href: "/" }]);
   });
 
-  it("keeps only the subject-scoped page in the settings group", () => {
-    // Appearance carries the subject's own units/formats/theme. Account looks subject-scoped and
-    // its data is, but /api/auth/passkey/* and /api/auth/totp/* are not served off a tenant, so
-    // listing it would put an entry in the sidebar that 404s when opened.
+  it("keeps only the subject-scoped pages in the settings group", () => {
     const items = [
       {
         title: "Settings",
@@ -33,21 +30,22 @@ describe("filterTenantlessNav", () => {
     expect(filterTenantlessNav(items)).toEqual([
       {
         title: "Settings",
-        children: [{ title: "Appearance", href: "/settings/appearance" }],
+        children: [
+          { title: "Account", href: "/settings/account" },
+          { title: "Appearance", href: "/settings/appearance" },
+        ],
       },
     ]);
   });
 
-  it("admits the subject's own appearance page as a route", () => {
+  it("admits the subject's own settings pages as routes", () => {
     expect(isTenantlessRoute("/settings/appearance")).toBe(true);
+    expect(isTenantlessRoute("/settings/account")).toBe(true);
   });
 
   it("keeps the rest of settings off a tenantless host", () => {
-    // The tenant-scoped pages would render a shell and then 404, and account needs auth
-    // endpoints the API does not serve without a tenant.
     for (const href of [
       "/settings",
-      "/settings/account",
       "/settings/members",
       "/settings/profile",
       "/settings/trackers",
@@ -92,7 +90,6 @@ describe("isTenantlessRoute", () => {
     expect(isTenantlessRoute("/calendar")).toBe(false);
     expect(isTenantlessRoute("/tenants")).toBe(false);
     expect(isTenantlessRoute("/settings/members")).toBe(false);
-    expect(isTenantlessRoute("/settings/account")).toBe(false);
   });
 
   it("matches whole paths, not prefixes", () => {

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
@@ -6,11 +6,10 @@
  * tenantless surface is therefore whatever the API admits without a tenant, which today is the
  * cross-tenant overview and nothing else.
  *
- * The account and appearance settings pages look subject-scoped and are not: they call
- * /api/auth/passkey/*, /api/v4/totp/*, and /api/v4/settings, none of which the API serves off a
- * tenant. Listing them would put two entries in the sidebar that 404 when opened. Widening the
- * auth endpoints to tenantless hosts is a security-relevant change, and /api/v4/settings is
- * genuinely tenant-scoped, so they stay off the list until the API surface catches up.
+ * The account settings page stays off the list. It looks subject-scoped and its data is —
+ * passkeys, TOTP authenticators and linked identities are all keyed on the subject with no tenant
+ * column — but /api/auth/passkey/* and /api/auth/totp/* are not served off a tenant, and widening
+ * authentication endpoints is a security-relevant change that deserves its own review.
  */
 
 /**
@@ -23,6 +22,9 @@
  */
 export const TENANTLESS_NAV_HREFS: readonly string[] = [
   "/", // the cross-tenant overview
+  // Subject-scoped half only (subjects.preferences / subjects.preferred_language); the page hides
+  // its tenant-scoped half here.
+  "/settings/appearance",
 ];
 
 interface NavLike {

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
@@ -6,10 +6,6 @@
  * tenantless surface is therefore whatever the API admits without a tenant, which today is the
  * cross-tenant overview and nothing else.
  *
- * The account settings page stays off the list. It looks subject-scoped and its data is —
- * passkeys, TOTP authenticators and linked identities are all keyed on the subject with no tenant
- * column — but /api/auth/passkey/* and /api/auth/totp/* are not served off a tenant, and widening
- * authentication endpoints is a security-relevant change that deserves its own review.
  */
 
 /**
@@ -25,6 +21,10 @@ export const TENANTLESS_NAV_HREFS: readonly string[] = [
   // Subject-scoped half only (subjects.preferences / subjects.preferred_language); the page hides
   // its tenant-scoped half here.
   "/settings/appearance",
+  // Passkeys, authenticators, linked identities, sessions and avatar — all keyed on the subject,
+  // none carrying a tenant column. The sign-in ceremonies that prove a factor stay tenant-gated,
+  // so this manages factors for a caller who is already authenticated.
+  "/settings/account",
 ];
 
 interface NavLike {

--- a/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
+++ b/src/Web/packages/app/src/lib/navigation/tenantless-navigation.ts
@@ -3,18 +3,14 @@
  *
  * Almost every page in the app reads or writes one tenant's data, and on a tenantless host there
  * is no tenant for the API to resolve — those pages would render a shell and then 404. The
- * tenantless surface is therefore whatever the API admits without a tenant, which today is the
- * cross-tenant overview and nothing else.
- *
+ * tenantless surface is therefore whatever the API admits without a tenant.
  */
 
 /**
  * Hrefs that are meaningful without a resolved tenant.
  *
- * The API's tenantless surface (TenantResolutionMiddleware.TenantlessAllowedPaths) admits the
- * cross-tenant overview and the session/auth endpoints, and nothing else that a page renders
- * from. Anything added here has to have its endpoints admitted there first, or the nav gains an
- * entry that 404s.
+ * Anything added here needs every endpoint the page renders from admitted in
+ * TenantResolutionMiddleware.TenantlessAllowedPaths first, or the nav gains an entry that 404s.
  */
 export const TENANTLESS_NAV_HREFS: readonly string[] = [
   "/", // the cross-tenant overview
@@ -22,8 +18,7 @@ export const TENANTLESS_NAV_HREFS: readonly string[] = [
   // its tenant-scoped half here.
   "/settings/appearance",
   // Passkeys, authenticators, linked identities, sessions and avatar — all keyed on the subject,
-  // none carrying a tenant column. The sign-in ceremonies that prove a factor stay tenant-gated,
-  // so this manages factors for a caller who is already authenticated.
+  // none carrying a tenant column.
   "/settings/account",
 ];
 

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -128,19 +128,12 @@ export function registerPreferencesWriteThrough(
   writeThrough = fn;
 }
 
-/**
- * The `Domain` attribute preference cookies are written with, or null for host-only cookies.
- * Injected rather than derived because BASE_DOMAIN reaches the browser only through layout data.
- */
+/** Injected rather than derived: BASE_DOMAIN reaches the browser only through layout data. */
 let preferenceCookieDomain: string | null = null;
 
 /**
- * Tell the store which domain to scope preference cookies to, and migrate the cookies this
- * document already wrote at the narrower scope.
- *
- * The base domain is not knowable at module load, but the cookies are written there — that is the
- * point of them, hydrating before first paint. So the first write of every document is necessarily
- * host-scoped, and this widens it as soon as the layout supplies the answer.
+ * Scope preference cookies to the base domain, and rewrite the ones this document already wrote
+ * host-scoped: cookies are written at module load, before the layout can supply the domain.
  */
 export function registerPreferenceCookieDomain(
   baseDomain: string | null | undefined
@@ -676,18 +669,12 @@ function hasAnyLocalPreference(): boolean {
 // ==========================================
 
 /**
- * The `document.cookie` assignments that store one preference cookie, in the order they must be
- * made. Pure so the scoping rules below are testable without a DOM.
+ * The `document.cookie` assignments storing one preference cookie, in the order they must be made.
+ * Pure so the scoping rules are testable without a DOM.
  *
- * Preferences belong to the subject, not to a tenant, so their cookies are widened to the base
- * domain exactly as the session cookies are — otherwise a user who set mmol/L and a 24-hour clock
- * on their tenant's subdomain gets the defaults on the dashboard host until the server round-trip
- * lands, which is the pre-paint hydration these cookies exist to provide.
- *
- * A browser that stored the host-scoped cookie before the widening presents both variants under one
- * `Cookie` header with no way to tell them apart, so the host-scoped one is expired ahead of every
- * widened write and clients converge on a single cookie. With no domain to widen to there is only
- * ever one cookie, and expiring it first would be deleting the value about to be written.
+ * A browser that stored the cookie before it was widened presents both variants under one `Cookie`
+ * header with no way to tell them apart, so a widened write expires the host-scoped one first.
+ * Unwidened there is only one cookie, and that expiry would delete the value being written.
  */
 export function preferenceCookieWrites(
   name: string,

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -717,13 +717,27 @@ export function parsePrefsCookie(
   }
 }
 
-function readPrefsCookie(): UserDisplayPreferences | null {
-  if (!browser) return null;
-  const match = document.cookie
+/**
+ * The value of a named cookie in a `document.cookie` header, taking the LAST of same-name rows.
+ *
+ * Through the widening transition a browser can hold both a host-scoped and a base-domain variant,
+ * indistinguishable in the header. RFC 6265 orders equal-path cookies oldest first, so the last is
+ * the newer of the two — taking the first would let a stale value win and then be written back as
+ * the widened one.
+ */
+export function readCookieFrom(header: string, name: string): string | null {
+  const match = header
     .split("; ")
-    .find((row) => row.startsWith(`${PREFS_COOKIE_NAME}=`));
-  if (!match) return null;
-  return parsePrefsCookie(match.slice(PREFS_COOKIE_NAME.length + 1));
+    .findLast((row) => row.startsWith(`${name}=`));
+  return match ? match.slice(name.length + 1) : null;
+}
+
+function readCookie(name: string): string | null {
+  return browser ? readCookieFrom(document.cookie, name) : null;
+}
+
+function readPrefsCookie(): UserDisplayPreferences | null {
+  return parsePrefsCookie(readCookie(PREFS_COOKIE_NAME));
 }
 
 // Hydrate synchronously from the cookie on load (before first paint) so a known
@@ -812,6 +826,22 @@ export function hasLanguagePreference(): boolean {
  */
 function syncLanguageCookie(locale: SupportedLocale): void {
   writePreferenceCookie(LANGUAGE_COOKIE_NAME, locale, LANGUAGE_COOKIE_MAX_AGE);
+}
+
+/**
+ * The language to start from, given what this origin stored and what the shared cookie carries.
+ *
+ * localStorage is per-origin while the cookie spans the base domain, so a first visit to a sibling
+ * subdomain has no stored value and must adopt the cookie's. Writing the default back instead
+ * would destroy the choice on every host, not merely fail to honour it on this one. A stored value
+ * is this device's own answer and wins; an unrecognised cookie is ignored.
+ */
+export function resolveInitialLanguage(
+  stored: string | null,
+  cookie: string | null
+): SupportedLocale | null {
+  if (stored !== null) return null;
+  return cookie && isSupportedLocale(cookie) ? cookie : null;
 }
 
 /**
@@ -913,7 +943,13 @@ export function getLanguage(): SupportedLocale {
   return preferredLanguage.current;
 }
 
-// Sync cookie on initial load in browser
 if (browser) {
+  // Hydrate before writing back, as the display preferences do.
+  const adopted = resolveInitialLanguage(
+    localStorage.getItem(LANGUAGE_COOKIE_NAME),
+    readCookie(LANGUAGE_COOKIE_NAME)
+  );
+  if (adopted) preferredLanguage.current = adopted;
+
   syncLanguageCookie(preferredLanguage.current);
 }

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -30,6 +30,7 @@ import supportedLocales from "../../../../../supportedLocales.json";
 import { WidgetId } from "../api/generated/nocturne-api-client";
 import type { UserDisplayPreferences } from "$lib/api";
 import { weekStartName } from "../components/calendar/calendar-date";
+import { resolveCookieDomain } from "../utils/tenant-host";
 
 // ==========================================
 // Type Definitions
@@ -125,6 +126,34 @@ export function registerPreferencesWriteThrough(
   fn: (prefs: UserDisplayPreferences) => unknown
 ): void {
   writeThrough = fn;
+}
+
+/**
+ * The `Domain` attribute preference cookies are written with, or null for host-only cookies.
+ * Injected rather than derived because BASE_DOMAIN reaches the browser only through layout data.
+ */
+let preferenceCookieDomain: string | null = null;
+
+/**
+ * Tell the store which domain to scope preference cookies to, and migrate the cookies this
+ * document already wrote at the narrower scope.
+ *
+ * The base domain is not knowable at module load, but the cookies are written there — that is the
+ * point of them, hydrating before first paint. So the first write of every document is necessarily
+ * host-scoped, and this widens it as soon as the layout supplies the answer.
+ */
+export function registerPreferenceCookieDomain(
+  baseDomain: string | null | undefined
+): void {
+  if (!browser) return;
+
+  const domain = resolveCookieDomain(baseDomain);
+  if (domain === preferenceCookieDomain) return;
+  preferenceCookieDomain = domain;
+
+  const prefs = readPrefsCookie();
+  if (prefs) writePrefsCookie(prefs);
+  syncLanguageCookie(preferredLanguage.current);
 }
 
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -646,10 +675,46 @@ function hasAnyLocalPreference(): boolean {
 // Preference cookie helpers
 // ==========================================
 
-function writePrefsCookie(prefs: UserDisplayPreferences): void {
+/**
+ * The `document.cookie` assignments that store one preference cookie, in the order they must be
+ * made. Pure so the scoping rules below are testable without a DOM.
+ *
+ * Preferences belong to the subject, not to a tenant, so their cookies are widened to the base
+ * domain exactly as the session cookies are — otherwise a user who set mmol/L and a 24-hour clock
+ * on their tenant's subdomain gets the defaults on the dashboard host until the server round-trip
+ * lands, which is the pre-paint hydration these cookies exist to provide.
+ *
+ * A browser that stored the host-scoped cookie before the widening presents both variants under one
+ * `Cookie` header with no way to tell them apart, so the host-scoped one is expired ahead of every
+ * widened write and clients converge on a single cookie. With no domain to widen to there is only
+ * ever one cookie, and expiring it first would be deleting the value about to be written.
+ */
+export function preferenceCookieWrites(
+  name: string,
+  value: string,
+  maxAge: number,
+  domain: string | null
+): string[] {
+  const write = `${name}=${value};path=/;max-age=${maxAge};SameSite=Lax`;
+  if (!domain) return [write];
+
+  return [`${name}=;path=/;max-age=0;SameSite=Lax`, `${write};domain=${domain}`];
+}
+
+/** The one writer for every preference cookie, so a scope can never drift between them. */
+function writePreferenceCookie(name: string, value: string, maxAge: number): void {
   if (!browser) return;
-  const value = encodeURIComponent(JSON.stringify(prefs));
-  document.cookie = `${PREFS_COOKIE_NAME}=${value};path=/;max-age=${PREFS_COOKIE_MAX_AGE};SameSite=Lax`;
+  for (const assignment of preferenceCookieWrites(name, value, maxAge, preferenceCookieDomain)) {
+    document.cookie = assignment;
+  }
+}
+
+function writePrefsCookie(prefs: UserDisplayPreferences): void {
+  writePreferenceCookie(
+    PREFS_COOKIE_NAME,
+    encodeURIComponent(JSON.stringify(prefs)),
+    PREFS_COOKIE_MAX_AGE
+  );
 }
 
 /** Decode a raw `nocturne-prefs` cookie value; also used server-side by the root layout load. */
@@ -730,6 +795,8 @@ export const preferredLanguage = new LanguagePref();
 /** Cookie name for language preference - used by SSR */
 export const LANGUAGE_COOKIE_NAME = "nocturne-language";
 
+const LANGUAGE_COOKIE_MAX_AGE = 31536000; // 1 year
+
 /**
  * The language the browser will settle on, from the same sources in the same order:
  * a saved subject preference outranks the cookie that mirrors localStorage. SSR
@@ -757,8 +824,7 @@ export function hasLanguagePreference(): boolean {
  * Sync language preference to cookie for server-side access
  */
 function syncLanguageCookie(locale: SupportedLocale): void {
-  if (!browser) return;
-  document.cookie = `${LANGUAGE_COOKIE_NAME}=${locale};path=/;max-age=31536000;SameSite=Lax`;
+  writePreferenceCookie(LANGUAGE_COOKIE_NAME, locale, LANGUAGE_COOKIE_MAX_AGE);
 }
 
 /**

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -944,7 +944,6 @@ export function getLanguage(): SupportedLocale {
 }
 
 if (browser) {
-  // Hydrate before writing back, as the display preferences do.
   const adopted = resolveInitialLanguage(
     localStorage.getItem(LANGUAGE_COOKIE_NAME),
     readCookie(LANGUAGE_COOKIE_NAME)

--- a/src/Web/packages/app/src/lib/stores/appearance-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.test.ts
@@ -23,6 +23,7 @@ const {
   applyPreferences,
   collectPreferences,
   hasStoredPreferences,
+  preferenceCookieWrites,
 } = await import("./appearance-store.svelte");
 
 describe("appearance-store preference sync", () => {
@@ -109,5 +110,45 @@ describe("appearance-store preference sync", () => {
       expect(hasStoredPreferences({ glucoseUnits: "mmol" })).toBe(true);
       expect(hasStoredPreferences({ prediction: { minutes: 30 } })).toBe(true);
     });
+  });
+});
+
+describe("preferenceCookieWrites", () => {
+  it("writes one host-scoped cookie when there is no domain to widen to", () => {
+    expect(preferenceCookieWrites("nocturne-prefs", "v", 60, null)).toEqual([
+      "nocturne-prefs=v;path=/;max-age=60;SameSite=Lax",
+    ]);
+  });
+
+  it("scopes the cookie to the base domain so it crosses tenant subdomains", () => {
+    expect(preferenceCookieWrites("nocturne-prefs", "v", 60, ".example.com")).toEqual([
+      "nocturne-prefs=;path=/;max-age=0;SameSite=Lax",
+      "nocturne-prefs=v;path=/;max-age=60;SameSite=Lax;domain=.example.com",
+    ]);
+  });
+
+  it("expires the host-scoped cookie before writing the widened one", () => {
+    // Both variants are presented under one Cookie header with no way to tell them apart, so a
+    // browser that stored the narrow cookie first must be converged onto the wide one.
+    const [first, second] = preferenceCookieWrites("nocturne-language", "en", 60, ".example.com");
+
+    expect(first).not.toContain("domain=");
+    expect(first).toContain("max-age=0");
+    expect(second).toContain("domain=.example.com");
+    expect(second).toContain("max-age=60");
+  });
+
+  it("never expires the cookie it is about to write when host-scoped", () => {
+    // Without a domain the two variants are the same cookie, so a leading expiry would delete it.
+    const writes = preferenceCookieWrites("nocturne-language", "en", 60, null);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).not.toContain("max-age=0");
+  });
+
+  it("carries the name, value and lifetime it was given", () => {
+    expect(preferenceCookieWrites("nocturne-language", "fr", 31536000, null)).toEqual([
+      "nocturne-language=fr;path=/;max-age=31536000;SameSite=Lax",
+    ]);
   });
 });

--- a/src/Web/packages/app/src/lib/stores/appearance-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.test.ts
@@ -24,6 +24,8 @@ const {
   collectPreferences,
   hasStoredPreferences,
   preferenceCookieWrites,
+  readCookieFrom,
+  resolveInitialLanguage,
 } = await import("./appearance-store.svelte");
 
 describe("appearance-store preference sync", () => {
@@ -150,5 +152,56 @@ describe("preferenceCookieWrites", () => {
     expect(preferenceCookieWrites("nocturne-language", "fr", 31536000, null)).toEqual([
       "nocturne-language=fr;path=/;max-age=31536000;SameSite=Lax",
     ]);
+  });
+});
+
+describe("readCookieFrom", () => {
+  it("reads a cookie out of the header", () => {
+    expect(readCookieFrom("a=1; nocturne-prefs=x; b=2", "nocturne-prefs")).toBe("x");
+  });
+
+  it("takes the newer of two same-name cookies, not the first", () => {
+    // A browser mid-widening holds a host-scoped and a base-domain variant with no way to tell
+    // them apart; RFC 6265 orders equal-path cookies oldest first.
+    expect(readCookieFrom("nocturne-prefs=stale; nocturne-prefs=fresh", "nocturne-prefs"))
+      .toBe("fresh");
+  });
+
+  it("does not match a cookie whose name merely starts the same", () => {
+    expect(readCookieFrom("nocturne-prefs-old=x", "nocturne-prefs")).toBeNull();
+  });
+
+  it("reads an empty value as empty rather than absent", () => {
+    expect(readCookieFrom("nocturne-prefs=", "nocturne-prefs")).toBe("");
+  });
+
+  it("finds nothing in an empty or unrelated header", () => {
+    expect(readCookieFrom("", "nocturne-prefs")).toBeNull();
+    expect(readCookieFrom("other=1", "nocturne-prefs")).toBeNull();
+  });
+});
+
+describe("resolveInitialLanguage", () => {
+  it("adopts the shared cookie when this origin stored nothing", () => {
+    // The destructive case: localStorage is per-origin, so a first visit to a sibling subdomain
+    // reads nothing and would otherwise write the default over the whole base domain.
+    expect(resolveInitialLanguage(null, "de")).toBe("de");
+  });
+
+  it("keeps this origin's stored language over the cookie", () => {
+    expect(resolveInitialLanguage(JSON.stringify("fr"), "de")).toBeNull();
+  });
+
+  it("keeps a stored language even when it matches the cookie", () => {
+    expect(resolveInitialLanguage(JSON.stringify("de"), "de")).toBeNull();
+  });
+
+  it("ignores a cookie naming a locale that is not supported", () => {
+    expect(resolveInitialLanguage(null, "klingon")).toBeNull();
+  });
+
+  it("adopts nothing when there is no cookie either", () => {
+    expect(resolveInitialLanguage(null, null)).toBeNull();
+    expect(resolveInitialLanguage(null, "")).toBeNull();
   });
 });

--- a/src/Web/packages/app/src/lib/stores/appearance-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.test.ts
@@ -130,8 +130,6 @@ describe("preferenceCookieWrites", () => {
   });
 
   it("expires the host-scoped cookie before writing the widened one", () => {
-    // Both variants are presented under one Cookie header with no way to tell them apart, so a
-    // browser that stored the narrow cookie first must be converged onto the wide one.
     const [first, second] = preferenceCookieWrites("nocturne-language", "en", 60, ".example.com");
 
     expect(first).not.toContain("domain=");
@@ -141,7 +139,6 @@ describe("preferenceCookieWrites", () => {
   });
 
   it("never expires the cookie it is about to write when host-scoped", () => {
-    // Without a domain the two variants are the same cookie, so a leading expiry would delete it.
     const writes = preferenceCookieWrites("nocturne-language", "en", 60, null);
 
     expect(writes).toHaveLength(1);
@@ -161,8 +158,6 @@ describe("readCookieFrom", () => {
   });
 
   it("takes the newer of two same-name cookies, not the first", () => {
-    // A browser mid-widening holds a host-scoped and a base-domain variant with no way to tell
-    // them apart; RFC 6265 orders equal-path cookies oldest first.
     expect(readCookieFrom("nocturne-prefs=stale; nocturne-prefs=fresh", "nocturne-prefs"))
       .toBe("fresh");
   });
@@ -183,8 +178,6 @@ describe("readCookieFrom", () => {
 
 describe("resolveInitialLanguage", () => {
   it("adopts the shared cookie when this origin stored nothing", () => {
-    // The destructive case: localStorage is per-origin, so a first visit to a sibling subdomain
-    // reads nothing and would otherwise write the default over the whole base domain.
     expect(resolveInitialLanguage(null, "de")).toBe("de");
   });
 

--- a/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  resolveCookieDomain,
   resolveSingleTenantLanding,
   resolveTenantSwitcher,
   tenantUrl,
@@ -240,5 +241,48 @@ describe("resolveTenantSwitcher", () => {
     expect(switcher.targets).toEqual([
       { id: "c", slug: "carol", displayName: null },
     ]);
+  });
+});
+
+describe("resolveCookieDomain", () => {
+  it("widens to every host under the base domain", () => {
+    expect(resolveCookieDomain("example.com")).toBe(".example.com");
+  });
+
+  it("widens a multi-label base domain to itself, not to its parent", () => {
+    // nocturne.example.com is as valid a base domain as example.com; widening to .example.com
+    // would hand the cookie to hosts of an unrelated deployment.
+    expect(resolveCookieDomain("nocturne.example.com")).toBe(".nocturne.example.com");
+  });
+
+  it("drops the port, which a Domain attribute cannot carry", () => {
+    expect(resolveCookieDomain("example.com:1612")).toBe(".example.com");
+  });
+
+  it("keeps a single-label host cookie host-only", () => {
+    // Browsers reject a Domain attribute on "localhost" outright.
+    expect(resolveCookieDomain("localhost")).toBeNull();
+    expect(resolveCookieDomain("localhost:1612")).toBeNull();
+  });
+
+  it("keeps a .localhost host cookie host-only", () => {
+    // Chromium does not reliably scope cookies across *.localhost names.
+    expect(resolveCookieDomain("nocturne.localhost")).toBeNull();
+    expect(resolveCookieDomain("nocturne.localhost:1612")).toBeNull();
+    expect(resolveCookieDomain("NOCTURNE.LOCALHOST")).toBeNull();
+  });
+
+  it("keeps an IP-literal host cookie host-only", () => {
+    // A browser discards any cookie whose Domain is set on an IP host, losing the value.
+    expect(resolveCookieDomain("192.168.1.10")).toBeNull();
+    expect(resolveCookieDomain("192.168.1.10:1612")).toBeNull();
+    expect(resolveCookieDomain("[::1]:1612")).toBeNull();
+  });
+
+  it("has no domain to widen to without a base domain", () => {
+    expect(resolveCookieDomain(null)).toBeNull();
+    expect(resolveCookieDomain(undefined)).toBeNull();
+    expect(resolveCookieDomain("")).toBeNull();
+    expect(resolveCookieDomain(":1612")).toBeNull();
   });
 });

--- a/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.test.ts
@@ -260,20 +260,17 @@ describe("resolveCookieDomain", () => {
   });
 
   it("keeps a single-label host cookie host-only", () => {
-    // Browsers reject a Domain attribute on "localhost" outright.
     expect(resolveCookieDomain("localhost")).toBeNull();
     expect(resolveCookieDomain("localhost:1612")).toBeNull();
   });
 
   it("keeps a .localhost host cookie host-only", () => {
-    // Chromium does not reliably scope cookies across *.localhost names.
     expect(resolveCookieDomain("nocturne.localhost")).toBeNull();
     expect(resolveCookieDomain("nocturne.localhost:1612")).toBeNull();
     expect(resolveCookieDomain("NOCTURNE.LOCALHOST")).toBeNull();
   });
 
   it("keeps an IP-literal host cookie host-only", () => {
-    // A browser discards any cookie whose Domain is set on an IP host, losing the value.
     expect(resolveCookieDomain("192.168.1.10")).toBeNull();
     expect(resolveCookieDomain("192.168.1.10:1612")).toBeNull();
     expect(resolveCookieDomain("[::1]:1612")).toBeNull();

--- a/src/Web/packages/app/src/lib/utils/tenant-host.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.ts
@@ -18,6 +18,28 @@ export function tenantUrl(
   return `${protocol}//${slug}.${baseDomain}/`;
 }
 
+/**
+ * The `Domain` attribute that scopes a cookie to every host sharing the base domain, or null when
+ * widening is unsafe and the cookie must stay host-only.
+ *
+ * Mirrors the API's `SessionCookieExtensions.ResolveCookieDomain`, which does this for the session
+ * cookies; the two must agree or a browser holds preferences at one scope and its session at
+ * another. Three cases yield null: a single-label host ("localhost") cannot carry a Domain
+ * attribute at all, Chromium does not reliably scope cookies across `*.localhost` names, and an IP
+ * literal has no domain hierarchy to widen into — a browser discards any cookie whose Domain is set
+ * on an IP host, which would lose the value rather than narrow it.
+ */
+export function resolveCookieDomain(baseDomain: string | null | undefined): string | null {
+  // A Domain attribute is a bare hostname; a value carrying a port is discarded wholesale.
+  const host = (baseDomain ?? "").split(":")[0]!;
+  if (!host) return null;
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return null;
+  if (!host.includes(".")) return null;
+  if (host.toLowerCase().endsWith(".localhost")) return null;
+
+  return `.${host}`;
+}
+
 /** A membership as the tenant list returns it. */
 export type TenantListEntry = Pick<
   TenantDto,

--- a/src/Web/packages/app/src/lib/utils/tenant-host.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.ts
@@ -30,7 +30,9 @@ export function resolveCookieDomain(baseDomain: string | null | undefined): stri
   // A value carrying a port is discarded wholesale.
   const host = (baseDomain ?? "").split(":")[0]!;
   if (!host) return null;
-  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return null;
+  // Any all-numeric dotted form, not just four octets: the API uses IPAddress.TryParse, which
+  // also accepts shorthand such as "10.0.1".
+  if (/^\d+(\.\d+)*$/.test(host)) return null;
   if (!host.includes(".")) return null;
   if (host.toLowerCase().endsWith(".localhost")) return null;
 

--- a/src/Web/packages/app/src/lib/utils/tenant-host.ts
+++ b/src/Web/packages/app/src/lib/utils/tenant-host.ts
@@ -19,18 +19,15 @@ export function tenantUrl(
 }
 
 /**
- * The `Domain` attribute that scopes a cookie to every host sharing the base domain, or null when
- * widening is unsafe and the cookie must stay host-only.
+ * The `Domain` attribute scoping a cookie to every host under the base domain, or null where a
+ * browser would reject or discard it: a single-label host, an IP literal, or a `*.localhost` name
+ * (Chromium does not reliably scope cookies across those).
  *
- * Mirrors the API's `SessionCookieExtensions.ResolveCookieDomain`, which does this for the session
- * cookies; the two must agree or a browser holds preferences at one scope and its session at
- * another. Three cases yield null: a single-label host ("localhost") cannot carry a Domain
- * attribute at all, Chromium does not reliably scope cookies across `*.localhost` names, and an IP
- * literal has no domain hierarchy to widen into — a browser discards any cookie whose Domain is set
- * on an IP host, which would lose the value rather than narrow it.
+ * Mirrors the API's `SessionCookieExtensions.ResolveCookieDomain`. The two must agree, or a
+ * browser holds its preferences at one scope and its session at another.
  */
 export function resolveCookieDomain(baseDomain: string | null | undefined): string | null {
-  // A Domain attribute is a bare hostname; a value carrying a port is discarded wholesale.
+  // A value carrying a port is discarded wholesale.
   const host = (baseDomain ?? "").split(":")[0]!;
   if (!host) return null;
   if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return null;

--- a/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
@@ -162,10 +162,20 @@ describe("(authenticated) layout load — where each host situation lands", () =
     await expect(
       redirectLocation({
         host: BASE,
-        pathname: "/settings/account",
+        pathname: "/settings/members",
         ...populatedTenantless,
       })
     ).resolves.toBe("/");
+  });
+
+  it("leaves a subject-scoped route alone on a tenantless host", async () => {
+    await expect(
+      redirectLocation({
+        host: BASE,
+        pathname: "/settings/account",
+        ...populatedTenantless,
+      })
+    ).resolves.toBeNull();
   });
 
   it("sends a signed-out visitor to login before the tenantless route guard runs", async () => {

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -136,16 +136,24 @@
     })
   );
 
+  /**
+   * This page carries two scopes: units, formats, theme, chart style, widgets and language live on
+   * the subject, while chart range, glucose processing and tracker pills are the tenant's. The
+   * endpoints behind the tenant half are not served on a host that resolves none, so its queries
+   * are never created rather than left to 404.
+   */
+  const tenantless = page.data.tenantless === true;
+
   // Glucose processing settings
-  const preferenceQuery = getPreference();
-  const sourceDefaultsQuery = getSourceDefaults();
+  const preferenceQuery = tenantless ? null : getPreference();
+  const sourceDefaultsQuery = tenantless ? null : getSourceDefaults();
   let glucoseProcessingPreference: string | null = $derived(
-    preferenceQuery.current?.preferredGlucoseProcessing ?? null,
+    preferenceQuery?.current?.preferredGlucoseProcessing ?? null,
   );
   let sourceDefaults: Array<{ match: string; field: string; processing: string }> =
     $derived(
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- zod types the rule fields as optional, but the API always returns them populated
-      (sourceDefaultsQuery.current?.rules ?? []) as Array<{
+      (sourceDefaultsQuery?.current?.rules ?? []) as Array<{
         match: string;
         field: string;
         processing: string;
@@ -156,8 +164,8 @@
   // Chart range and tracker pills persist server-side. They used to only mutate
   // the in-memory settings store, which nothing ever saved, so the dashboard
   // picked the change up live and then lost it on reload.
-  const uiSettingsQuery = getUiSettings();
-  const featureSettings = $derived(uiSettingsQuery.current?.features);
+  const uiSettingsQuery = tenantless ? null : getUiSettings();
+  const featureSettings = $derived(uiSettingsQuery?.current?.features);
   const focusHours = $derived(featureSettings?.display?.focusHours ?? 12);
   const trackerPillsEnabled = $derived(featureSettings?.trackerPills?.enabled ?? true);
 
@@ -175,7 +183,7 @@
       await store.reload();
     } catch {
       toast.error("Could not save. Check your connection and try again.");
-      await uiSettingsQuery.refresh();
+      await uiSettingsQuery?.refresh();
     }
   }
 </script>
@@ -644,31 +652,33 @@
         <CardDescription>Configure chart display preferences</CardDescription>
       </CardHeader>
       <CardContent>
-        <div class="grid gap-4 @sm:grid-cols-2">
-          <div class="space-y-2">
-            <FormLabel>Default chart range</FormLabel>
-            <Select
-              type="single"
-              value={String(focusHours)}
-              onValueChange={(value: string) =>
-                saveFeatures({ display: { focusHours: parseInt(value) } })}
-            >
-              <SelectTrigger>
-                <span>{focusHours} hours</span>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="2">2 hours</SelectItem>
-                <SelectItem value="3">3 hours</SelectItem>
-                <SelectItem value="4">4 hours</SelectItem>
-                <SelectItem value="6">6 hours</SelectItem>
-                <SelectItem value="12">12 hours</SelectItem>
-                <SelectItem value="24">24 hours</SelectItem>
-              </SelectContent>
-            </Select>
+        {#if !tenantless}
+          <div class="grid gap-4 @sm:grid-cols-2">
+            <div class="space-y-2">
+              <FormLabel>Default chart range</FormLabel>
+              <Select
+                type="single"
+                value={String(focusHours)}
+                onValueChange={(value: string) =>
+                  saveFeatures({ display: { focusHours: parseInt(value) } })}
+              >
+                <SelectTrigger>
+                  <span>{focusHours} hours</span>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="2">2 hours</SelectItem>
+                  <SelectItem value="3">3 hours</SelectItem>
+                  <SelectItem value="4">4 hours</SelectItem>
+                  <SelectItem value="6">6 hours</SelectItem>
+                  <SelectItem value="12">12 hours</SelectItem>
+                  <SelectItem value="24">24 hours</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           </div>
-        </div>
 
-        <Separator class="my-4" />
+          <Separator class="my-4" />
+        {/if}
 
         <!-- Glucose line visual style -->
         <div class="grid gap-4 @sm:grid-cols-2">
@@ -848,6 +858,7 @@
     </div>
 
 
+    {#if !tenantless}
     <!-- Glucose Processing -->
     <Card>
       <CardHeader>
@@ -961,6 +972,7 @@
         </p>
       </CardContent>
     </Card>
+    {/if}
 
     <!-- Browser Tab Settings (Favicon) -->
     <TitleFaviconSettings />

--- a/src/Web/packages/app/src/routes/+layout.ts
+++ b/src/Web/packages/app/src/routes/+layout.ts
@@ -5,8 +5,10 @@ import { browser } from '$app/environment'
 import {
     preferredLanguage,
     isSupportedLocale,
+    registerPreferenceCookieDomain,
     registerPreferencesWriteThrough,
     reconcilePreferences,
+    setLanguage,
     type SupportedLocale,
 } from '$lib/stores/appearance-store.svelte'
 import { updateDisplayPreferences } from '$lib/api/user-preferences.remote'
@@ -23,6 +25,14 @@ export const load: LayoutLoad = async ({ url, data }) => {
     // Determine the locale to use
     let locale: SupportedLocale = 'en'
 
+    // Wire up per-user display-preference sync (units, time format, theme, chart style).
+    // Registering the backend write-through here keeps the store free of server-remote imports,
+    // and the cookie domain must be registered before anything below writes a cookie.
+    if (browser) {
+        registerPreferenceCookieDomain(data?.baseDomain)
+        registerPreferencesWriteThrough((prefs) => updateDisplayPreferences(prefs))
+    }
+
     if (queryLocale && isSupportedLocale(queryLocale)) {
         // 1. Query param override
         locale = queryLocale
@@ -34,21 +44,14 @@ export const load: LayoutLoad = async ({ url, data }) => {
         // sync localStorage to match (handles new device case)
         const userPreference = data?.user?.preferredLanguage
         if (userPreference && isSupportedLocale(userPreference) && userPreference !== preferredLanguage.current) {
-            preferredLanguage.current = userPreference
+            await setLanguage(userPreference)
             locale = userPreference
-            // Also update the cookie
-            document.cookie = `nocturne-language=${userPreference};path=/;max-age=31536000;SameSite=Lax`
         }
     }
 
-    // Wire up per-user display-preference sync (units, time format, theme, chart style).
-    // Registering the backend write-through here keeps the store free of server-remote imports.
-    if (browser) {
-        registerPreferencesWriteThrough((prefs) => updateDisplayPreferences(prefs))
-        if (data?.isAuthenticated) {
-            // Server preferences win across devices; an empty server blob seeds from local once.
-            reconcilePreferences(data?.user?.preferences)
-        }
+    if (browser && data?.isAuthenticated) {
+        // Server preferences win across devices; an empty server blob seeds from local once.
+        reconcilePreferences(data?.user?.preferences)
     }
 
     // WUCHALE-DISABLED: wuchale temporarily disabled — locale dynamic load skipped.

--- a/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
@@ -4,6 +4,7 @@ using Nocturne.API.Authorization;
 using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Controllers.V2;
 using Nocturne.API.Controllers.V4;
+using Nocturne.API.Controllers.V4.Account;
 using Nocturne.API.Controllers.V4.Connectors;
 using Nocturne.API.Controllers.V4.Identity;
 using Nocturne.API.Controllers.V4.Profiles;
@@ -92,6 +93,27 @@ public class DemoSubjectGatedEndpointsTests
         // Units, formats and theme persist on the shared subject, so one visitor's choice
         // follows every later one. The read stays open, as with the session list above.
         { typeof(UserPreferencesController), nameof(UserPreferencesController.UpdatePreferences) },
+
+        // Sign-in factors on the shared subject. Enrolling binds a visitor's own authenticator to
+        // the account every other visitor uses; listing shows them each other's credential labels;
+        // revoking and regenerating destroy factors and recovery codes they did not create. The
+        // enrolment pair is [AllowAnonymous] for the recovery flow, so the coverage sweep — which
+        // reads bare [Authorize] as the surface — cannot see it; these entries are the only guard.
+        { typeof(PasskeyController), nameof(PasskeyController.RegisterOptions) },
+        { typeof(PasskeyController), nameof(PasskeyController.RegisterComplete) },
+        { typeof(PasskeyController), nameof(PasskeyController.ListCredentials) },
+        { typeof(PasskeyController), nameof(PasskeyController.RemoveCredential) },
+        { typeof(PasskeyController), nameof(PasskeyController.RegenerateRecoveryCodes) },
+        { typeof(PasskeyController), nameof(PasskeyController.GetRecoveryStatus) },
+        { typeof(TotpController), nameof(TotpController.Setup) },
+        { typeof(TotpController), nameof(TotpController.VerifySetup) },
+        { typeof(TotpController), nameof(TotpController.ListCredentials) },
+        { typeof(TotpController), nameof(TotpController.RemoveCredential) },
+
+        // The avatar every later visitor is shown. The read stays open — it is the demo account's
+        // own picture, and the tiles render it.
+        { typeof(AvatarController), nameof(AvatarController.Upload) },
+        { typeof(AvatarController), nameof(AvatarController.Delete) },
     };
 
     [Theory]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
@@ -6,6 +6,7 @@ using Nocturne.API.Controllers.V2;
 using Nocturne.API.Controllers.V4;
 using Nocturne.API.Controllers.V4.Connectors;
 using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.API.Controllers.V4.Profiles;
 using Xunit;
 
 namespace Nocturne.API.Tests.Authorization;
@@ -87,6 +88,10 @@ public class DemoSubjectGatedEndpointsTests
         // caller's. List stays open — see TheSessionListStaysOpenWhileRevocationDoesNot.
         { typeof(SessionsController), nameof(SessionsController.Revoke) },
         { typeof(SessionsController), nameof(SessionsController.RevokeOthers) },
+
+        // Units, formats and theme persist on the shared subject, so one visitor's choice
+        // follows every later one. The read stays open, as with the session list above.
+        { typeof(UserPreferencesController), nameof(UserPreferencesController.UpdatePreferences) },
     };
 
     [Theory]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
@@ -53,6 +53,10 @@ public class TenantlessDemoSubjectCoverageTests
             ["MyPermissionsController.GetMyPermissions"] = "returns the caller's own global subject-role scopes; tenant-derived scopes are not applied off a tenant",
 
             ["PlatformController.GetTransitionStatus"] = "reports the deployment's multitenancy configuration, not subject state",
+
+            // The write is [DenyDemoSubject]: every demo visitor authenticates as the one shared
+            // demo subject, so a persisted change would follow every other visitor.
+            ["UserPreferencesController.GetPreferences"] = "returns the caller's own units and formats, which for the demo subject are the demo account's public display defaults",
         };
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
@@ -54,8 +54,6 @@ public class TenantlessDemoSubjectCoverageTests
 
             ["PlatformController.GetTransitionStatus"] = "reports the deployment's multitenancy configuration, not subject state",
 
-            // The write is [DenyDemoSubject]: every demo visitor authenticates as the one shared
-            // demo subject, so a persisted change would follow every other visitor.
             ["UserPreferencesController.GetPreferences"] = "returns the caller's own units and formats, which for the demo subject are the demo account's public display defaults",
         };
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -206,7 +206,7 @@ public class PasskeyControllerTests : IDisposable
 
     private void StubRegistrationOptions(Guid subjectId, string username) =>
         _passkeyService
-            .Setup(s => s.GenerateRegistrationOptionsAsync(subjectId, username, _tenantId))
+            .Setup(s => s.GenerateRegistrationOptionsAsync(subjectId, username))
             .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
 
     #region Passkey enrolment is bound to the caller
@@ -219,7 +219,7 @@ public class PasskeyControllerTests : IDisposable
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         objectResult.StatusCode.Should().Be(401);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()),
             Times.Never,
             "an anonymous caller must not be able to start an enrolment ceremony");
     }
@@ -247,7 +247,7 @@ public class PasskeyControllerTests : IDisposable
     {
         Authenticate();
         _passkeyService
-            .Setup(s => s.GenerateRegistrationOptionsAsync(_subjectId, "testuser", _tenantId))
+            .Setup(s => s.GenerateRegistrationOptionsAsync(_subjectId, "testuser"))
             .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
 
         var result = await _controller.RegisterOptions(new PasskeyRegisterOptionsRequest { Username = "testuser" });
@@ -257,7 +257,7 @@ public class PasskeyControllerTests : IDisposable
         response.Options.Should().Contain("challenge");
         response.ChallengeToken.Should().Be("token-data");
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(_subjectId, "testuser", _tenantId),
+            s => s.GenerateRegistrationOptionsAsync(_subjectId, "testuser"),
             Times.Once);
     }
 
@@ -315,9 +315,9 @@ public class PasskeyControllerTests : IDisposable
 
         Assert.IsType<OkObjectResult>(result.Result);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(callerId, "victim", _tenantId), Times.Once);
+            s => s.GenerateRegistrationOptionsAsync(callerId, "victim"), Times.Once);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(victimId, It.IsAny<string>(), It.IsAny<Guid>()), Times.Never);
+            s => s.GenerateRegistrationOptionsAsync(victimId, It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -334,7 +334,7 @@ public class PasskeyControllerTests : IDisposable
 
         Assert.IsType<OkObjectResult>(result.Result);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(subjectId, "owner", _tenantId), Times.Once);
+            s => s.GenerateRegistrationOptionsAsync(subjectId, "owner"), Times.Once);
     }
 
     [Fact]
@@ -348,7 +348,7 @@ public class PasskeyControllerTests : IDisposable
 
         Assert.Equal(401, Assert.IsType<ObjectResult>(result.Result).StatusCode);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()),
             Times.Never);
     }
 
@@ -407,7 +407,7 @@ public class PasskeyControllerTests : IDisposable
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         objectResult.StatusCode.Should().Be(400);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()),
             Times.Never);
     }
 
@@ -426,7 +426,7 @@ public class PasskeyControllerTests : IDisposable
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         objectResult.StatusCode.Should().Be(400);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()),
             Times.Never,
             "an account that can still sign in must not be enrollable without a session");
     }
@@ -440,14 +440,14 @@ public class PasskeyControllerTests : IDisposable
             .Setup(s => s.CountPrimaryAuthFactorsAsync(orphanId))
             .ReturnsAsync(0);
         _passkeyService
-            .Setup(s => s.GenerateRegistrationOptionsAsync(orphanId, "orphan", _tenantId))
+            .Setup(s => s.GenerateRegistrationOptionsAsync(orphanId, "orphan"))
             .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
 
         var result = await _controller.RecoveryModeOptions(new PasskeyLoginOptionsRequest { Username = "orphan" });
 
         Assert.IsType<OkObjectResult>(result.Result);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(orphanId, "orphan", _tenantId),
+            s => s.GenerateRegistrationOptionsAsync(orphanId, "orphan"),
             Times.Once,
             "the subject comes from the server's lookup, not from the request");
     }
@@ -466,7 +466,7 @@ public class PasskeyControllerTests : IDisposable
 
         Assert.Equal(400, Assert.IsType<ObjectResult>(result.Result).StatusCode);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(elsewhereId, It.IsAny<string>(), It.IsAny<Guid>()),
+            s => s.GenerateRegistrationOptionsAsync(elsewhereId, It.IsAny<string>()),
             Times.Never);
     }
 
@@ -617,7 +617,7 @@ public class PasskeyControllerTests : IDisposable
         var elsewhereId = await SeedMemberAsync("elsewhere", tenantId: Guid.CreateVersion7());
         var inviteService = StubValidInvite();
         _passkeyService
-            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), "elsewhere", _tenantId))
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), "elsewhere"))
             .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
 
         var result = await _controller.InviteOptions(
@@ -628,7 +628,7 @@ public class PasskeyControllerTests : IDisposable
         var victim = await _dbContext.Subjects.AsNoTracking().FirstAsync(s => s.Id == elsewhereId);
         victim.Name.Should().Be("elsewhere", "another tenant's member must not be renamed by an invite here");
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(elsewhereId, It.IsAny<string>(), It.IsAny<Guid>()),
+            s => s.GenerateRegistrationOptionsAsync(elsewhereId, It.IsAny<string>()),
             Times.Never,
             "the ceremony must not be bound to another tenant's member");
         var subjects = await _dbContext.Subjects.AsNoTracking()
@@ -809,7 +809,7 @@ public class PasskeyControllerTests : IDisposable
     {
         var inviteService = StubValidInvite();
         _passkeyService
-            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), "invitee", _tenantId))
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), "invitee"))
             .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
 
         Assert.IsType<OkObjectResult>((await _controller.InviteOptions(
@@ -855,7 +855,7 @@ public class PasskeyControllerTests : IDisposable
     {
         await AllowAccessRequestsAsync();
         _passkeyService
-            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), "sam-smith", _tenantId))
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), "sam-smith"))
             .ReturnsAsync(new PasskeyRegistrationOptions("{\"challenge\":\"abc\"}", "token-data"));
 
         Assert.IsType<OkObjectResult>((await _controller.AccessRequestOptions(
@@ -906,7 +906,7 @@ public class PasskeyControllerTests : IDisposable
 
         Assert.IsType<ConflictObjectResult>(result.Result);
         _passkeyService.Verify(
-            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()),
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()),
             Times.Never);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
@@ -432,7 +432,7 @@ public class SetupControllerTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         _passkeyService
-            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()))
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()))
             .ReturnsAsync(new PasskeyRegistrationOptions("{}", "challenge-token"));
 
         // Act
@@ -665,7 +665,7 @@ public class SetupControllerTests : IDisposable
         // and lock the instance out permanently.
         var (_, subjectId) = await SeedSoleTenantWithOwnerRoleAsync();
         _passkeyService
-            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>()))
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()))
             .ReturnsAsync(new PasskeyRegistrationOptions("{}", "challenge-token"));
 
         await _controller.OwnerOptions(

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
@@ -28,6 +28,9 @@ public sealed class TenantlessDashboardPathsTests
     [InlineData("/api/v4/me/permissions")]
     // The login page's provider buttons — the only sign-in affordance on a tenantless host.
     [InlineData("/api/auth/oidc/providers")]
+    // The caller's own units/format/theme, stored on the subject. The tiles render glucose in
+    // the units held here, so a 404 is a wrong reading, not a cosmetic default.
+    [InlineData("/api/v4/user/preferences")]
     public void The_tenantless_dashboard_paths_are_allowed(string path)
     {
         TenantResolutionMiddleware.IsTenantlessAllowed(path).Should().BeTrue();
@@ -40,6 +43,10 @@ public sealed class TenantlessDashboardPathsTests
     [InlineData("/api/v4/chart-data/dashboard")]
     [InlineData("/api/v4/me/tenants/overview/extra")]
     [InlineData("/api/v4/me/permissions/grant")]
+    // The tenant's own display configuration, which is a different endpoint to the subject's
+    // preferences and must not be reachable off a tenant.
+    [InlineData("/api/v4/ui-settings")]
+    [InlineData("/api/v4/settings/glucose-processing")]
     public void Tenant_scoped_paths_stay_gated(string path)
     {
         TenantResolutionMiddleware.IsTenantlessAllowed(path).Should().BeFalse();

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
@@ -31,6 +31,17 @@ public sealed class TenantlessDashboardPathsTests
     // The caller's own units/format/theme, stored on the subject. The tiles render glucose in
     // the units held here, so a 404 is a wrong reading, not a cosmetic default.
     [InlineData("/api/v4/user/preferences")]
+    // The caller's own sign-in factors and linked identities, all keyed on SubjectId.
+    [InlineData("/api/auth/passkey/credentials")]
+    [InlineData("/api/auth/passkey/register/options")]
+    [InlineData("/api/auth/passkey/register/complete")]
+    [InlineData("/api/auth/passkey/recovery/status")]
+    [InlineData("/api/auth/passkey/recovery/regenerate")]
+    [InlineData("/api/auth/totp")]
+    [InlineData("/api/auth/totp/setup")]
+    [InlineData("/api/auth/totp/verify-setup")]
+    [InlineData("/api/auth/oidc/link/identities")]
+    [InlineData("/api/v4/me/avatar")]
     public void The_tenantless_dashboard_paths_are_allowed(string path)
     {
         TenantResolutionMiddleware.IsTenantlessAllowed(path).Should().BeTrue();
@@ -50,6 +61,56 @@ public sealed class TenantlessDashboardPathsTests
     public void Tenant_scoped_paths_stay_gated(string path)
     {
         TenantResolutionMiddleware.IsTenantlessAllowed(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void The_sign_in_ceremonies_stay_gated()
+    {
+        // Enrolling a factor for an already-authenticated caller is subject-scoped; proving one to
+        // obtain a session is not. TotpController.Login gates on membership of the resolved
+        // tenant, and the passkey login paths likewise, so sign-in on a tenantless host stays
+        // identity-provider-only.
+        // Asserted against POST, the only method each is served under: the DELETE that revokes an
+        // authenticator is matched as a prefix, so asking "under any method" would answer for that
+        // instead. Routing has no DELETE here to reach.
+        foreach (var path in new[]
+                 {
+                     "/api/auth/totp/login",
+                     "/api/auth/passkey/login/options",
+                     "/api/auth/passkey/login/complete",
+                     "/api/auth/passkey/login/discoverable/options",
+                 })
+        {
+            TenantResolutionMiddleware.IsTenantlessAllowed(path, HttpMethods.Post)
+                .Should().BeFalse(path);
+        }
+    }
+
+    [Fact]
+    public void Revoking_an_authenticator_is_admitted_without_admitting_its_sibling_login()
+    {
+        // The revoke route carries the credential's id, so it can only be matched as a prefix —
+        // which the login path sits under. The method is what separates them.
+        var totpCredential = "/api/auth/totp/0198f4a0-0000-7000-8000-000000000000";
+
+        TenantResolutionMiddleware.IsTenantlessAllowed(totpCredential, HttpMethods.Delete)
+            .Should().BeTrue();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/totp/login", HttpMethods.Post)
+            .Should().BeFalse();
+        TenantResolutionMiddleware.IsTenantlessAllowed(totpCredential, HttpMethods.Post)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Passkey_credentials_admit_the_id_route_and_nothing_outside_them()
+    {
+        TenantResolutionMiddleware
+            .IsTenantlessAllowed("/api/auth/passkey/credentials/0198f4a0-0000-7000-8000-000000000000")
+            .Should().BeTrue();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/passkey/recovery/verify")
+            .Should().BeFalse();
+        TenantResolutionMiddleware.IsTenantlessAllowed("/api/auth/passkey/onboarding/complete")
+            .Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
@@ -41,6 +41,9 @@ public sealed class TenantlessDashboardPathsTests
     [InlineData("/api/auth/totp/setup")]
     [InlineData("/api/auth/totp/verify-setup")]
     [InlineData("/api/auth/oidc/link/identities")]
+    // Linking is a full-page navigation, so a 404 loses the page rather than one control.
+    [InlineData("/api/auth/oidc/link")]
+    [InlineData("/api/auth/oidc/link/callback")]
     [InlineData("/api/v4/me/avatar")]
     public void The_tenantless_dashboard_paths_are_allowed(string path)
     {

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessDashboardPathsTests.cs
@@ -28,8 +28,6 @@ public sealed class TenantlessDashboardPathsTests
     [InlineData("/api/v4/me/permissions")]
     // The login page's provider buttons — the only sign-in affordance on a tenantless host.
     [InlineData("/api/auth/oidc/providers")]
-    // The caller's own units/format/theme, stored on the subject. The tiles render glucose in
-    // the units held here, so a 404 is a wrong reading, not a cosmetic default.
     [InlineData("/api/v4/user/preferences")]
     // The caller's own sign-in factors and linked identities, all keyed on SubjectId.
     [InlineData("/api/auth/passkey/credentials")]
@@ -41,7 +39,6 @@ public sealed class TenantlessDashboardPathsTests
     [InlineData("/api/auth/totp/setup")]
     [InlineData("/api/auth/totp/verify-setup")]
     [InlineData("/api/auth/oidc/link/identities")]
-    // Linking is a full-page navigation, so a 404 loses the page rather than one control.
     [InlineData("/api/auth/oidc/link")]
     [InlineData("/api/auth/oidc/link/callback")]
     [InlineData("/api/v4/me/avatar")]
@@ -57,8 +54,7 @@ public sealed class TenantlessDashboardPathsTests
     [InlineData("/api/v4/chart-data/dashboard")]
     [InlineData("/api/v4/me/tenants/overview/extra")]
     [InlineData("/api/v4/me/permissions/grant")]
-    // The tenant's own display configuration, which is a different endpoint to the subject's
-    // preferences and must not be reachable off a tenant.
+    // The tenant's display configuration, a different endpoint to the subject's preferences.
     [InlineData("/api/v4/ui-settings")]
     [InlineData("/api/v4/settings/glucose-processing")]
     public void Tenant_scoped_paths_stay_gated(string path)
@@ -69,13 +65,9 @@ public sealed class TenantlessDashboardPathsTests
     [Fact]
     public void The_sign_in_ceremonies_stay_gated()
     {
-        // Enrolling a factor for an already-authenticated caller is subject-scoped; proving one to
-        // obtain a session is not. TotpController.Login gates on membership of the resolved
-        // tenant, and the passkey login paths likewise, so sign-in on a tenantless host stays
-        // identity-provider-only.
         // Asserted against POST, the only method each is served under: the DELETE that revokes an
         // authenticator is matched as a prefix, so asking "under any method" would answer for that
-        // instead. Routing has no DELETE here to reach.
+        // instead.
         foreach (var path in new[]
                  {
                      "/api/auth/totp/login",
@@ -92,8 +84,6 @@ public sealed class TenantlessDashboardPathsTests
     [Fact]
     public void Revoking_an_authenticator_is_admitted_without_admitting_its_sibling_login()
     {
-        // The revoke route carries the credential's id, so it can only be matched as a prefix —
-        // which the login path sits under. The method is what separates them.
         var totpCredential = "/api/auth/totp/0198f4a0-0000-7000-8000-000000000000";
 
         TenantResolutionMiddleware.IsTenantlessAllowed(totpCredential, HttpMethods.Delete)

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/PasskeyServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/PasskeyServiceTests.cs
@@ -50,7 +50,7 @@ public class PasskeyServiceTests
         var service = CreateService();
 
         // Act
-        var credentials = await service.GetCredentialsAsync(_subjectId, _tenantId);
+        var credentials = await service.GetCredentialsAsync(_subjectId);
 
         // Assert - only returns credentials for the specified subject
         credentials.Should().HaveCount(2);
@@ -63,7 +63,7 @@ public class PasskeyServiceTests
     {
         var service = CreateService();
 
-        var credentials = await service.GetCredentialsAsync(_subjectId, _tenantId);
+        var credentials = await service.GetCredentialsAsync(_subjectId);
 
         credentials.Should().BeEmpty();
     }
@@ -82,7 +82,7 @@ public class PasskeyServiceTests
         await _dbContext.SaveChangesAsync();
 
         var service = CreateService();
-        var credentials = await service.GetCredentialsAsync(_subjectId, _tenantId);
+        var credentials = await service.GetCredentialsAsync(_subjectId);
 
         credentials.Should().HaveCount(2);
         credentials[0].Label.Should().Be("Newer");
@@ -329,7 +329,7 @@ public class PasskeyServiceTests
         var victimSubjectId = Guid.CreateVersion7();
 
         // A challenge minted for the victim — as the old caller-supplied subjectId allowed.
-        var options = await service.GenerateRegistrationOptionsAsync(victimSubjectId, "victim", _tenantId);
+        var options = await service.GenerateRegistrationOptionsAsync(victimSubjectId, "victim");
 
         var act = () => service.CompleteRegistrationAsync(
             "{}", options.ChallengeToken, _tenantId, expectedSubjectId: _subjectId);
@@ -364,7 +364,7 @@ public class PasskeyServiceTests
     {
         var service = CreateService();
 
-        var registration = await service.GenerateRegistrationOptionsAsync(_subjectId, "testuser", _tenantId);
+        var registration = await service.GenerateRegistrationOptionsAsync(_subjectId, "testuser");
 
         var act = () => service.CompleteAssertionAsync("{}", registration.ChallengeToken, _tenantId);
 


### PR DESCRIPTION
Stacked on #752 (`feature/tenantless-redirect-scope`), itself on #745 and #466.

The tenantless dashboard trims itself to the cross-tenant overview and nothing else, on the stated grounds that `/settings/account` and `/settings/appearance` "look subject-scoped and are not". Half of that is wrong, and the half that is right is right for a different reason than the comment gives.

## What is actually scoped to what

The data model already answers this; the pages do not follow it.

| Concern | Storage | Endpoint | Scope |
|---|---|---|---|
| Units, time/region format, colour theme, chart style, widgets | `subjects.preferences` (jsonb) | `/api/v4/user/preferences` | **subject** |
| Language | `subjects.preferred_language` | same | **subject** |
| Passkeys, TOTP, linked identities, recovery codes, avatar | `passkey_credentials`, `totp_credentials`, `subject_oidc_identities`, `recovery_codes`, `subject_avatars` — none carrying a tenant column | `/api/auth/passkey/*`, `/api/auth/totp/*`, `/api/auth/oidc/link/*`, `/api/v4/me/avatar` | **subject** |
| Chart range, tracker pills, glucose processing | `settings` (`ITenantScoped`) | `/api/v4/ui-settings`, `/api/v4/settings/glucose-processing` | **tenant** |

`/settings/appearance` straddles the last two rows, and the straddle is *within a card* — the Chart Options card holds the tenant's default range next to the subject's line-colour mode. So page-level allowlisting can never be right for it, which is why the original comment had to reject the page wholesale.

## The commits

**1. `nocturne-prefs` / `nocturne-language` carried across subdomains.** #745 widened the session cookie to `Domain=.{base-domain}`; these two stayed host-scoped, so the pre-paint hydration they exist to provide did not happen on the dashboard host. Not cosmetic: the tiles render glucose through `bg()`, which reads the units held here. `resolveCookieDomain` mirrors `SessionCookieExtensions.ResolveCookieDomain` including all three host-only cases. The base domain reaches the browser only through layout data, so the module-load write is necessarily narrow and `registerPreferenceCookieDomain` widens it; each widened write expires the host-scoped variant first, since both arrive under one `Cookie` header indistinguishably. Three cookie writers became one — the root layout had its own inline copy of the language-cookie assignment, which is how the `Domain` drifted in the first place.

**2. Display preferences on the tenantless host.** `/api/v4/user/preferences` allowlisted; `/settings/appearance` no longer creates its three tenant-scoped queries there and hides their controls individually; the sidebar stops dropping its language persist callback, which was never tenant-scoped.

**3. Sign-in factors on the tenantless host.** The tenant coupling that made this look risky was not real: `PasskeyService` took a `tenantId` for both `GetCredentialsAsync` and `GenerateRegistrationOptionsAsync` and used **neither**, and the TOTP setup/verify/list actions never mention a tenant. Both dead parameters are gone, so the subject-keying is structural rather than incidental. `TenantController` was passing a tenant id into `GetCredentialsAsync` as if it filtered a member's passkeys; it never did.

Sign-in itself stays tenant-gated — `TotpController.Login` checks membership of the resolved tenant and the passkey `login/*` paths likewise, so authenticating on a tenantless host remains identity-provider-only. These endpoints enrol and revoke factors for a caller who already holds a session.

**4. Review fixes** (see below).

## The two allowlists became one

They differed only in exact-vs-prefix matching, which left prefixes method-blind — and `DELETE /api/auth/totp/{id}` can only be matched as a prefix, one that `POST /api/auth/totp/login` sits under. `TenantlessPath` now carries a `Prefix` flag so the method separates them. Every pre-existing prefix carried over unchanged. One honest caveat, documented at the site: asked *without* a method, that prefix answers for its own DELETE, so a coverage sweep sees `/api/auth/totp/login` as reachable — routing has no DELETE there to reach, and the middleware always passes the real method.

## Demo-subject gating was the larger half, twice

Every demo visitor authenticates as **one shared `subjects` row** (`DemoTenantService.EnsureDemoMemberAsync` creates it once), so anything persisted follows every later visitor.

`TenantlessDemoSubjectCoverageTests` caught the preference write immediately, and the avatar writes in the third commit. It structurally **cannot** see the passkey enrolment pair: its predicate is "endpoints whose only gate is bare `[Authorize]`", and `register/options` / `register/complete` are `[AllowAnonymous]` (for the recovery flow) while still resolving a subject from the session. A demo visitor could therefore bind their own authenticator to the shared account, read other visitors' credential labels, and revoke factors they did not create — all of it already reachable on the demo tenant's own host, so this closes it there too, not just on the apex. Thirteen endpoints gated across the two commits; the reads that expose only the demo account's own public presentation stay open. The pinning entries in `DemoSubjectGatedEndpointsTests` are the **only** guard on the enrolment pair.

`DenyDemoSubjectAttribute` no-ops when there is no auth context, so the recovery-cookie path through `register/options` is unaffected, and first-run setup enrols through its own ungated `/api/v4/setup/owner/options`.

## Review round

A review agent over the first three commits found a bug in the cookie fix worse than the one it fixed, plus four smaller ones. All in commit 4.

- **Language cookie clobber.** Display preferences hydrate from their cookie at module load; language never did — it is a `PersistedState` over localStorage, which is per-origin. Host-scoped, that asymmetry was invisible. Widened, a first visit to a sibling subdomain read no stored language, defaulted to `"en"`, and wrote that over the base-domain cookie — destroying the choice on **every** host. Repaired after a flash for a signed-in user; permanent otherwise. Language now adopts the shared cookie when this origin stored nothing.
- **Stale-cookie read.** `readPrefsCookie` took the *first* same-name row; RFC 6265 orders equal-path cookies oldest first, so mid-transition the stale value won and was written back as the widened one. Now takes the last.
- **OIDC linking 404'd.** `/settings/account` went onto the tenantless surface with the identity list and unlink admitted but not the initiate/callback pair, and linking is a full-page navigation, so the visitor lost the page rather than one control. Both are subject-scoped and read their tenant slug as a nullable purely to route the callback home — the same shape as the already-allowlisted login/callback pair.
- IP-literal guard widened to any all-numeric dotted host, since the C# it mirrors uses `IPAddress.TryParse`, which accepts `"10.0.1"`; two locals left dead by the parameter removal; the TOTP prefix comment no longer claims more than the two-argument overload gives.

**Two findings did not hold and were verified rather than taken.** The demo gate keys on `EffectiveSubjectId`, which looked bypassable if it were a non-demo owner while `SubjectId` was the demo subject — but `ActingAsSubjectId` is only ever set by `GuestSessionHandler`, which sets `SubjectId = null` in the same object, so that state cannot exist. And the gated preference write surfaces no unhandled rejection to a demo visitor: `updateDisplayPreferences` catches server-side and returns null.

## Tests

`Nocturne.API.Tests`: **5585 passed, 0 failed, 5 skipped.** New coverage pins the account surface and the four sign-in ceremonies in `TenantlessDashboardPathsTests` — including that DELETE on a credential id is admitted while the POST `/login` beneath the same prefix is not — plus thirteen entries in `DemoSubjectGatedEndpointsTests` and the tenant-scoped display endpoints asserted still gated.

Web vitest: **775 passed, 1 skipped.** `resolveCookieDomain`, `preferenceCookieWrites`, `readCookieFrom` and `resolveInitialLanguage` are pure so the cookie rules are testable without a DOM — the `@vitest-environment` docblock is silently not honoured under this repo's vitest config, which is worth knowing before reaching for it. Mutation-checked in both rounds: deleting the host-scoped expiry, the `*.localhost` guard, `findLast`, and the stored-value precedence each turned exactly the tests asserting them red.

`pnpm check`: **64 errors / 10 warnings, matching baseline exactly.**

## Deliberately not here

Instance administration on a tenantless host — filed as #756. None of the four platform-admin pages is a clean move: `/settings/admin` and `/settings/access-requests` assign *tenant* roles from an *instance* surface, `/settings/admin/tenants` despite its name manages one tenant via `tenants[0]` with no `ORDER BY` behind it, and `/settings/admin/connector-cursors` is genuinely cross-tenant but its only inbound link is from a tenant-scoped page. The real blocker is that there is no tenantless entry point at all, which wants the scope-tagged navigation catalogue described in that issue.

Also not here: `/settings/access` splits the same way (`refresh_tokens` is subject-keyed while guest links, connected apps and public-docs are not), and the coverage sweep's `[AllowAnonymous]` blind spot deserves its own fix rather than a growing pin list.
