### PR TITLE
fix(migration): give imported Nightscout subjects a tenant membership

### DIFF
--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -8,6 +8,7 @@ using Nocturne.API.Helpers;
 using Nocturne.API.Services.Audit;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4;
@@ -1624,15 +1625,14 @@ internal class MigrationJob
             UpdateCollectionProgress(collectionName, subjects.Length, 0, 0, false);
             UpdateOverallProgress();
 
-            // 3. Pre-load existing token hashes for duplicate detection
-            var existingHashes = await dbContext.Subjects
+            // 3. Pre-load existing subjects by token hash for duplicate detection
+            var existingSubjectIds = await dbContext.Subjects
                 .Where(s => s.AccessTokenHash != null)
-                .Select(s => s.AccessTokenHash!)
-                .ToHashSetAsync(ct);
+                .ToDictionaryAsync(s => s.AccessTokenHash!, s => s.Id, ct);
 
             // 4. Pre-load existing Nocturne roles by name
             var nocturneRoles = await dbContext.Roles
-                .ToDictionaryAsync(r => r.Name, r => r.Id, ct);
+                .ToDictionaryAsync(r => r.Name, r => r, ct);
 
             // Nightscout derives each subject's token from digest = sha1(sha1(api_secret) + _id).
             // HashApiSecret yields exactly that inner sha1(api_secret), so with the mongo _id we
@@ -1654,9 +1654,16 @@ internal class MigrationJob
                     }
 
                     var tokenHash = HashAccessToken(subject.AccessToken);
+                    var roles = await ResolveRolesAsync(dbContext, nocturneRoles, rolePermissions, subject.Roles, ct);
 
-                    if (existingHashes.Contains(tokenHash))
+                    if (existingSubjectIds.TryGetValue(tokenHash, out var existingSubjectId))
                     {
+                        // Re-importing repairs a subject that landed before memberships were
+                        // written, and is how an already-broken tenant recovers. The subject row
+                        // itself is left alone.
+                        await EnsureTenantMembershipAsync(dbContext, existingSubjectId, roles, ct);
+                        await dbContext.SaveChangesAsync(ct);
+
                         totalSkipped++;
                         continue;
                     }
@@ -1685,43 +1692,20 @@ internal class MigrationJob
                     dbContext.Subjects.Add(entity);
                     await dbContext.SaveChangesAsync(ct);
 
-                    // Assign roles
-                    foreach (var roleName in subject.Roles ?? [])
+                    foreach (var role in roles)
                     {
-                        if (roleName == "denied")
-                            continue;
-
-                        if (!nocturneRoles.TryGetValue(roleName, out var roleId))
-                        {
-                            // Custom Nightscout role: create it with fetched permissions
-                            var permissions = rolePermissions.GetValueOrDefault(roleName, []);
-                            var roleEntity = new RoleEntity
-                            {
-                                Id = Guid.CreateVersion7(),
-                                Name = roleName,
-                                Description = "Migrated from Nightscout",
-                                Permissions = permissions,
-                                IsSystemRole = false,
-                                CreatedAt = DateTime.UtcNow,
-                                UpdatedAt = DateTime.UtcNow,
-                            };
-                            dbContext.Roles.Add(roleEntity);
-                            await dbContext.SaveChangesAsync(ct);
-                            roleId = roleEntity.Id;
-                            nocturneRoles[roleName] = roleId;
-                        }
-
                         dbContext.SubjectRoles.Add(new SubjectRoleEntity
                         {
                             SubjectId = entity.Id,
-                            RoleId = roleId,
+                            RoleId = role.Id,
                             AssignedAt = DateTime.UtcNow,
                         });
                     }
 
+                    await EnsureTenantMembershipAsync(dbContext, entity.Id, roles, ct);
                     await dbContext.SaveChangesAsync(ct);
 
-                    existingHashes.Add(tokenHash);
+                    existingSubjectIds[tokenHash] = entity.Id;
                     totalMigrated++;
                     UpdateCollectionProgress(collectionName, subjects.Length, totalMigrated, totalFailed, false);
                     UpdateOverallProgress();
@@ -1745,6 +1729,96 @@ internal class MigrationJob
         _logger.LogInformation(
             "Subject migration complete: {Migrated} migrated, {Skipped} skipped, {Failed} failed",
             totalMigrated, totalSkipped, totalFailed);
+    }
+
+    /// <summary>
+    /// Resolves a Nightscout subject's role names to Nocturne roles, creating any the instance does
+    /// not already have from the permissions fetched off the source. The <paramref name="knownRoles"/>
+    /// lookup is updated so each custom role is created once per run.
+    /// </summary>
+    /// <remarks>
+    /// "denied" is dropped: it is Nightscout's way of spelling "no access", carried instead by
+    /// <see cref="SubjectEntity.IsActive"/>, and a role row for it would grant nothing anyway.
+    /// </remarks>
+    private static async Task<List<RoleEntity>> ResolveRolesAsync(
+        NocturneDbContext dbContext,
+        Dictionary<string, RoleEntity> knownRoles,
+        Dictionary<string, List<string>> sourcePermissions,
+        List<string>? roleNames,
+        CancellationToken ct)
+    {
+        var resolved = new List<RoleEntity>();
+
+        foreach (var roleName in roleNames ?? [])
+        {
+            if (roleName == "denied")
+                continue;
+
+            if (!knownRoles.TryGetValue(roleName, out var role))
+            {
+                role = new RoleEntity
+                {
+                    Id = Guid.CreateVersion7(),
+                    Name = roleName,
+                    Description = "Migrated from Nightscout",
+                    Permissions = sourcePermissions.GetValueOrDefault(roleName, []),
+                    IsSystemRole = false,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow,
+                };
+                dbContext.Roles.Add(role);
+                await dbContext.SaveChangesAsync(ct);
+                knownRoles[roleName] = role;
+            }
+
+            resolved.Add(role);
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// Gives an imported subject a membership of the tenant being migrated into, if it has none.
+    /// Without it the subject authenticates and is then dropped to unauthenticated:
+    /// <c>AuthenticationMiddleware</c> requires a membership row for every credential type it does
+    /// not exempt, and a legacy access token is not exempt.
+    /// </summary>
+    /// <remarks>
+    /// The imported roles are carried as direct permissions rather than mapped onto the seed tenant
+    /// roles, which do not line up with Nightscout's — Viewer is narrower than <c>readable</c>,
+    /// Caretaker wider than <c>careportal</c> — and which have no answer at all for a custom
+    /// Nightscout role. <see cref="ScopeTranslator"/> drops anything it cannot translate, so a
+    /// permission with no Nocturne equivalent grants nothing.
+    /// </remarks>
+    private async Task EnsureTenantMembershipAsync(
+        NocturneDbContext dbContext,
+        Guid subjectId,
+        List<RoleEntity> roles,
+        CancellationToken ct)
+    {
+        var alreadyMember = await dbContext.TenantMembers
+            .AnyAsync(tm => tm.TenantId == _tenantId && tm.SubjectId == subjectId, ct);
+
+        if (alreadyMember)
+            return;
+
+        var scopes = ScopeTranslator.FromPermissions(roles.SelectMany(r => r.Permissions));
+
+        // A "*" grant is stored as the single superuser atom: NormalizeMemberPermissions expands it
+        // back to every scope, so spelling out the expansion would only bake today's scope list in.
+        List<string> permissions = scopes.Contains(TenantPermissions.Superuser)
+            ? [TenantPermissions.Superuser]
+            : [.. scopes];
+
+        dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            SubjectId = subjectId,
+            DirectPermissions = permissions,
+            SysCreatedAt = DateTime.UtcNow,
+            SysUpdatedAt = DateTime.UtcNow,
+        });
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -1625,10 +1625,11 @@ internal class MigrationJob
             UpdateCollectionProgress(collectionName, subjects.Length, 0, 0, false);
             UpdateOverallProgress();
 
-            // 3. Pre-load existing subjects by token hash for duplicate detection
-            var existingSubjectIds = await dbContext.Subjects
+            // 3. Pre-load existing token hashes for duplicate detection
+            var existingHashes = await dbContext.Subjects
                 .Where(s => s.AccessTokenHash != null)
-                .ToDictionaryAsync(s => s.AccessTokenHash!, s => s.Id, ct);
+                .Select(s => s.AccessTokenHash!)
+                .ToHashSetAsync(ct);
 
             // 4. Pre-load existing Nocturne roles by name
             var nocturneRoles = await dbContext.Roles
@@ -1654,19 +1655,14 @@ internal class MigrationJob
                     }
 
                     var tokenHash = HashAccessToken(subject.AccessToken);
-                    var roles = await ResolveRolesAsync(dbContext, nocturneRoles, rolePermissions, subject.Roles, ct);
 
-                    if (existingSubjectIds.TryGetValue(tokenHash, out var existingSubjectId))
+                    if (existingHashes.Contains(tokenHash))
                     {
-                        // Re-importing repairs a subject that landed before memberships were
-                        // written, and is how an already-broken tenant recovers. The subject row
-                        // itself is left alone.
-                        await EnsureTenantMembershipAsync(dbContext, existingSubjectId, roles, ct);
-                        await dbContext.SaveChangesAsync(ct);
-
                         totalSkipped++;
                         continue;
                     }
+
+                    var roles = await ResolveRolesAsync(dbContext, nocturneRoles, rolePermissions, subject.Roles, ct);
 
                     // Determine if subject should be inactive ("denied" is only role)
                     var isDenied = subject.Roles is ["denied"];
@@ -1702,10 +1698,10 @@ internal class MigrationJob
                         });
                     }
 
-                    await EnsureTenantMembershipAsync(dbContext, entity.Id, roles, ct);
+                    AddTenantMembership(dbContext, entity.Id, GrantedPermissions(roles, rolePermissions));
                     await dbContext.SaveChangesAsync(ct);
 
-                    existingSubjectIds[tokenHash] = entity.Id;
+                    existingHashes.Add(tokenHash);
                     totalMigrated++;
                     UpdateCollectionProgress(collectionName, subjects.Length, totalMigrated, totalFailed, false);
                     UpdateOverallProgress();
@@ -1778,31 +1774,39 @@ internal class MigrationJob
     }
 
     /// <summary>
-    /// Gives an imported subject a membership of the tenant being migrated into, if it has none.
-    /// Without it the subject authenticates and is then dropped to unauthenticated:
+    /// The legacy permissions a subject's roles grant it on the source instance. The source's own
+    /// definition wins over the same-named Nocturne role, which may be a wider seeded role that
+    /// merely shares a name (a hand-written Nightscout role called <c>admin</c> need not mean
+    /// <c>*</c>). The local definition is the fallback for a source whose roles endpoint was
+    /// inaccessible.
+    /// </summary>
+    private static IEnumerable<string> GrantedPermissions(
+        List<RoleEntity> roles, Dictionary<string, List<string>> sourcePermissions) =>
+        roles.SelectMany(role => sourcePermissions.TryGetValue(role.Name, out var fromSource)
+            ? fromSource
+            : role.Permissions);
+
+    /// <summary>
+    /// Makes an imported subject a member of the tenant being migrated into. Without the membership
+    /// the subject authenticates and is then dropped straight back to unauthenticated:
     /// <c>AuthenticationMiddleware</c> requires a membership row for every credential type it does
     /// not exempt, and a legacy access token is not exempt.
     /// </summary>
     /// <remarks>
-    /// The imported roles are carried as direct permissions rather than mapped onto the seed tenant
-    /// roles, which do not line up with Nightscout's — Viewer is narrower than <c>readable</c>,
-    /// Caretaker wider than <c>careportal</c> — and which have no answer at all for a custom
-    /// Nightscout role. <see cref="ScopeTranslator"/> drops anything it cannot translate, so a
-    /// permission with no Nocturne equivalent grants nothing.
+    /// The imported permissions are carried directly rather than mapped onto the seed tenant roles,
+    /// which do not line up with Nightscout's — Viewer is narrower than <c>readable</c>, Caretaker
+    /// wider than <c>careportal</c> — and which have no answer at all for a custom Nightscout role.
+    /// <see cref="ScopeTranslator"/> drops anything it cannot translate, so a permission with no
+    /// Nocturne equivalent grants nothing, and a subject left with nothing gets no membership at
+    /// all rather than an entry on the member list that cannot do anything.
     /// </remarks>
-    private async Task EnsureTenantMembershipAsync(
-        NocturneDbContext dbContext,
-        Guid subjectId,
-        List<RoleEntity> roles,
-        CancellationToken ct)
+    private void AddTenantMembership(
+        NocturneDbContext dbContext, Guid subjectId, IEnumerable<string> legacyPermissions)
     {
-        var alreadyMember = await dbContext.TenantMembers
-            .AnyAsync(tm => tm.TenantId == _tenantId && tm.SubjectId == subjectId, ct);
+        var scopes = ScopeTranslator.FromPermissions(legacyPermissions);
 
-        if (alreadyMember)
+        if (scopes.Count == 0)
             return;
-
-        var scopes = ScopeTranslator.FromPermissions(roles.SelectMany(r => r.Permissions));
 
         // A "*" grant is stored as the single superuser atom: NormalizeMemberPermissions expands it
         // back to every scope, so spelling out the expansion would only bake today's scope list in.

--- a/src/Core/Nocturne.Core.Models/Authorization/ScopeTranslator.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/ScopeTranslator.cs
@@ -11,6 +11,32 @@ namespace Nocturne.Core.Models.Authorization;
 /// <seealso cref="Role"/>
 public static class ScopeTranslator
 {
+    private static readonly string[] ReadEverything =
+    [
+        OAuthScopes.GlucoseRead,
+        OAuthScopes.TreatmentsRead,
+        OAuthScopes.DevicesRead,
+        OAuthScopes.TherapyRead,
+        OAuthScopes.FoodRead,
+        OAuthScopes.AlertsRead,
+        OAuthScopes.ReportsRead,
+        OAuthScopes.IdentityRead,
+        OAuthScopes.HeartRateRead,
+        OAuthScopes.StepCountRead,
+        OAuthScopes.SleepRead,
+    ];
+
+    private static readonly string[] WriteEverything =
+    [
+        OAuthScopes.GlucoseReadWrite,
+        OAuthScopes.TreatmentsReadWrite,
+        OAuthScopes.DevicesReadWrite,
+        OAuthScopes.TherapyReadWrite,
+        OAuthScopes.FoodReadWrite,
+        OAuthScopes.AlertsReadWrite,
+        OAuthScopes.SharingReadWrite,
+    ];
+
     /// <summary>
     /// Maps legacy trie permission strings to their equivalent OAuth scopes.
     /// Collapsing create/update into readwrite is intentional. The only lossy case:
@@ -60,40 +86,28 @@ public static class ScopeTranslator
         ["api:profile:update"] = [OAuthScopes.TherapyReadWrite],
         ["api:profile:delete"] = [OAuthScopes.FullAccess],
 
-        // Wildcard reads
-        ["api:*:read"] = [
-            OAuthScopes.GlucoseRead,
-            OAuthScopes.TreatmentsRead,
-            OAuthScopes.DevicesRead,
-            OAuthScopes.TherapyRead,
-            OAuthScopes.FoodRead,
-            OAuthScopes.AlertsRead,
-            OAuthScopes.ReportsRead,
-            OAuthScopes.IdentityRead,
-            OAuthScopes.HeartRateRead,
-            OAuthScopes.StepCountRead,
-            OAuthScopes.SleepRead,
+        // Verb wildcards. Nightscout's own default roles are written this way ("api:activity:*" on
+        // activity, "api:treatments:*" on the seeded careportal role), so a subject holding one had
+        // no scope at all until these were mapped. Collapsed to readwrite on the same basis as
+        // create/update above: delete stays gated behind "*".
+        ["api:entries:*"] = [OAuthScopes.GlucoseReadWrite],
+        ["api:treatments:*"] = [OAuthScopes.TreatmentsReadWrite],
+        ["api:devicestatus:*"] = [OAuthScopes.DevicesReadWrite],
+        ["api:food:*"] = [OAuthScopes.FoodReadWrite],
+        ["api:profile:*"] = [OAuthScopes.TherapyReadWrite],
+        ["api:activity:*"] = [
+            OAuthScopes.HeartRateReadWrite,
+            OAuthScopes.StepCountReadWrite,
+            OAuthScopes.SleepReadWrite,
         ],
 
+        // Wildcard reads. "*:*:read" is how Nightscout's own seeded "readable" role spells it.
+        ["api:*:read"] = ReadEverything,
+        ["*:*:read"] = ReadEverything,
+
         // Wildcard writes
-        ["api:*:create"] = [
-            OAuthScopes.GlucoseReadWrite,
-            OAuthScopes.TreatmentsReadWrite,
-            OAuthScopes.DevicesReadWrite,
-            OAuthScopes.TherapyReadWrite,
-            OAuthScopes.FoodReadWrite,
-            OAuthScopes.AlertsReadWrite,
-            OAuthScopes.SharingReadWrite,
-        ],
-        ["api:*:update"] = [
-            OAuthScopes.GlucoseReadWrite,
-            OAuthScopes.TreatmentsReadWrite,
-            OAuthScopes.DevicesReadWrite,
-            OAuthScopes.TherapyReadWrite,
-            OAuthScopes.FoodReadWrite,
-            OAuthScopes.AlertsReadWrite,
-            OAuthScopes.SharingReadWrite,
-        ],
+        ["api:*:create"] = WriteEverything,
+        ["api:*:update"] = WriteEverything,
         ["api:*:delete"] = [OAuthScopes.FullAccess],
 
         // Full wildcards
@@ -102,19 +116,7 @@ public static class ScopeTranslator
 
         // Named roles
         ["admin"] = [OAuthScopes.FullAccess],
-        ["readable"] = [
-            OAuthScopes.GlucoseRead,
-            OAuthScopes.TreatmentsRead,
-            OAuthScopes.DevicesRead,
-            OAuthScopes.TherapyRead,
-            OAuthScopes.FoodRead,
-            OAuthScopes.AlertsRead,
-            OAuthScopes.ReportsRead,
-            OAuthScopes.IdentityRead,
-            OAuthScopes.HeartRateRead,
-            OAuthScopes.StepCountRead,
-            OAuthScopes.SleepRead,
-        ],
+        ["readable"] = ReadEverything,
     };
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/Authorization/ScopeTranslator.cs
+++ b/src/Core/Nocturne.Core.Models/Authorization/ScopeTranslator.cs
@@ -86,10 +86,9 @@ public static class ScopeTranslator
         ["api:profile:update"] = [OAuthScopes.TherapyReadWrite],
         ["api:profile:delete"] = [OAuthScopes.FullAccess],
 
-        // Verb wildcards. Nightscout's own default roles are written this way ("api:activity:*" on
-        // activity, "api:treatments:*" on the seeded careportal role), so a subject holding one had
-        // no scope at all until these were mapped. Collapsed to readwrite on the same basis as
-        // create/update above: delete stays gated behind "*".
+        // Verb wildcards, which is how Nightscout's own seeded roles are written ("api:activity:*"
+        // on activity, "api:treatments:*" on careportal). Collapsed to readwrite on the same basis
+        // as create/update above: delete stays gated behind "*".
         ["api:entries:*"] = [OAuthScopes.GlucoseReadWrite],
         ["api:treatments:*"] = [OAuthScopes.TreatmentsReadWrite],
         ["api:devicestatus:*"] = [OAuthScopes.DevicesReadWrite],

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ScopeTranslatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ScopeTranslatorTests.cs
@@ -45,6 +45,34 @@ public class ScopeTranslatorTests
         Assert.Contains(OAuthScopes.GlucoseReadWrite, scopes);
     }
 
+    [Theory]
+    [InlineData("api:entries:*", OAuthScopes.GlucoseReadWrite)]
+    [InlineData("api:treatments:*", OAuthScopes.TreatmentsReadWrite)]
+    [InlineData("api:devicestatus:*", OAuthScopes.DevicesReadWrite)]
+    [InlineData("api:food:*", OAuthScopes.FoodReadWrite)]
+    [InlineData("api:profile:*", OAuthScopes.TherapyReadWrite)]
+    [InlineData("api:activity:*", OAuthScopes.SleepReadWrite)]
+    public void FromPermissions_VerbWildcard_MapsToReadWrite(string permission, string expected)
+    {
+        // Nightscout's own roles are written with verb wildcards, so a subject migrated off one
+        // holds these and nothing else.
+        var scopes = ScopeTranslator.FromPermissions([permission]);
+
+        Assert.Contains(expected, scopes);
+        Assert.DoesNotContain(OAuthScopes.FullAccess, scopes);
+    }
+
+    [Fact]
+    public void FromPermissions_NightscoutReadableWildcard_MapsToAllReadScopes()
+    {
+        // "*:*:read" is the permission on Nightscout's seeded "readable" role.
+        var scopes = ScopeTranslator.FromPermissions(["*:*:read"]);
+
+        Assert.Contains(OAuthScopes.GlucoseRead, scopes);
+        Assert.Contains(OAuthScopes.TreatmentsRead, scopes);
+        Assert.DoesNotContain(OAuthScopes.GlucoseReadWrite, scopes);
+    }
+
     [Fact]
     public void FromPermissions_EntriesDelete_MapsToFullAccess()
     {

--- a/tests/Unit/Nocturne.API.Tests/Migration/MigrationSubjectMembershipTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Migration/MigrationSubjectMembershipTests.cs
@@ -1,0 +1,231 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Services.Audit;
+using Nocturne.API.Services.Migration;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.API.Tests.Migration;
+
+/// <summary>
+/// A subject imported from a classic Nightscout instance must come out of the migration as a member
+/// of the tenant it was imported into. Without the membership row it authenticates on its access
+/// token and is then dropped straight back to unauthenticated by the membership check in
+/// <c>AuthenticationMiddleware</c>, so every migrated <c>?token=</c> client 401s.
+/// </summary>
+public class MigrationSubjectMembershipTests
+{
+    private const string ReadableToken = "reader-a1b2c3d4e5f6a7b8";
+    private const string AdminToken = "boss-1111222233334444";
+
+    /// <summary>
+    /// Stands in for the source Nightscout instance, serving its two authorization endpoints.
+    /// Everything else answers 404, which the migration treats as "collection unavailable".
+    /// </summary>
+    private sealed class NightscoutStub : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.RequestUri!.AbsolutePath switch
+            {
+                "/api/v2/authorization/roles" => """
+                    [
+                      { "name": "readable", "permissions": ["*:*:read"] },
+                      { "name": "admin", "permissions": ["*"] },
+                      { "name": "logger", "permissions": ["api:treatments:*"] }
+                    ]
+                    """,
+                "/api/v2/authorization/subjects" => $$"""
+                    [
+                      {
+                        "_id": "5f1a00000000000000000001",
+                        "name": "Reader",
+                        "roles": ["readable", "logger"],
+                        "accessToken": "{{ReadableToken}}"
+                      },
+                      {
+                        "_id": "5f1a00000000000000000002",
+                        "name": "Boss",
+                        "roles": ["admin"],
+                        "accessToken": "{{AdminToken}}"
+                      }
+                    ]
+                    """,
+                _ => null,
+            };
+
+            var response = body is null
+                ? new HttpResponseMessage(HttpStatusCode.NotFound)
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json"),
+                };
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class StubHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(new NightscoutStub());
+    }
+
+    private sealed class FixedTenantAccessor : ITenantAccessor
+    {
+        public TenantContext? Context { get; private set; }
+
+        public bool IsResolved => Context is not null;
+
+        public Guid TenantId => Context?.TenantId ?? Guid.Empty;
+
+        public void SetTenant(TenantContext? tenant) => Context = tenant;
+    }
+
+    private static ServiceProvider BuildProvider(string databaseName) =>
+        new ServiceCollection()
+            .AddDbContext<NocturneDbContext>(o => o.UseInMemoryDatabase(databaseName))
+            .AddScoped<ITenantAccessor, FixedTenantAccessor>()
+            .AddScoped<IAuditContext, AuditContext>()
+            .AddSingleton<IHttpClientFactory, StubHttpClientFactory>()
+            .BuildServiceProvider();
+
+    /// <summary>
+    /// Runs a subjects-only API migration to completion against <see cref="NightscoutStub"/> and
+    /// returns the tenant it imported into.
+    /// </summary>
+    private static async Task<Guid> RunSubjectMigrationAsync(IServiceProvider provider)
+    {
+        var tenant = new TenantContext(
+            Guid.CreateVersion7(), "migrated", "Migrated Tenant", true, IsDemo: false);
+
+        var request = new StartMigrationRequest
+        {
+            Mode = MigrationMode.Api,
+            NightscoutUrl = "https://example-nightscout.invalid",
+            Collections = ["subjects"],
+        };
+
+        var job = new MigrationJob(
+            Guid.CreateVersion7(),
+            tenant.TenantId,
+            request,
+            new MigrationJobInfo
+            {
+                Id = Guid.CreateVersion7(),
+                Mode = MigrationMode.Api,
+                CreatedAt = DateTime.UtcNow,
+            },
+            tenant,
+            NullLogger.Instance,
+            provider);
+
+        await job.ExecuteAsync(CancellationToken.None);
+        job.GetStatus().State.Should().Be(MigrationJobState.Completed);
+
+        return tenant.TenantId;
+    }
+
+    private static async Task<TenantMemberEntity> MemberForAsync(
+        NocturneDbContext db, Guid tenantId, string accessTokenName)
+    {
+        var subject = await db.Subjects.SingleAsync(s => s.Name == accessTokenName);
+        return await db.TenantMembers.SingleAsync(
+            tm => tm.TenantId == tenantId && tm.SubjectId == subject.Id);
+    }
+
+    [Fact]
+    public async Task Imported_subject_becomes_a_member_holding_its_Nightscout_permissions()
+    {
+        await using var provider = BuildProvider($"migration-membership-{Guid.NewGuid():N}");
+        var tenantId = await RunSubjectMigrationAsync(provider);
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+
+        var member = await MemberForAsync(db, tenantId, "Reader");
+
+        // "readable" carries the read scopes; the custom "logger" role's "api:treatments:*" is what
+        // lets it write treatments back.
+        member.DirectPermissions.Should().Contain(
+            [TenantPermissions.GlucoseRead, TenantPermissions.TreatmentsReadWrite]);
+    }
+
+    [Fact]
+    public async Task Imported_membership_grants_scopes_on_the_legacy_access_token()
+    {
+        await using var provider = BuildProvider($"migration-membership-{Guid.NewGuid():N}");
+        var tenantId = await RunSubjectMigrationAsync(provider);
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+
+        // The other half of the round trip: what MemberScopeMiddleware makes of the membership when
+        // the imported token authenticates. An empty result is the 401 this migration used to cause.
+        var resolved = MemberScopeResolver.Resolve(
+            (await MemberForAsync(db, tenantId, "Reader")).DirectPermissions!.ToHashSet(),
+            AuthType.LegacyAccessToken,
+            new HashSet<string>());
+
+        resolved.Should().Contain(OAuthScopes.GlucoseRead);
+    }
+
+    [Fact]
+    public async Task A_Nightscout_admin_is_imported_as_a_superuser_member()
+    {
+        await using var provider = BuildProvider($"migration-membership-{Guid.NewGuid():N}");
+        var tenantId = await RunSubjectMigrationAsync(provider);
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+
+        var member = await MemberForAsync(db, tenantId, "Boss");
+
+        // Stored as the bare atom rather than the expansion, so the grant tracks the scope list.
+        member.DirectPermissions.Should().Equal(TenantPermissions.Superuser);
+    }
+
+    [Fact]
+    public async Task Re_importing_repairs_a_subject_that_has_no_membership()
+    {
+        await using var provider = BuildProvider($"migration-membership-{Guid.NewGuid():N}");
+
+        // A subject as an earlier migration left it: imported, with the matching token hash, and
+        // with no membership of the tenant it was imported into.
+        var strandedId = Guid.CreateVersion7();
+        using (var seedScope = provider.CreateScope())
+        {
+            var seed = seedScope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+            seed.Subjects.Add(new SubjectEntity
+            {
+                Id = strandedId,
+                Name = "Reader",
+                AccessTokenHash = Sha256Hex(ReadableToken),
+                IsActive = true,
+                ApprovalStatus = "Approved",
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        var tenantId = await RunSubjectMigrationAsync(provider);
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+
+        // Repaired in place: the duplicate token must not produce a second subject.
+        db.Subjects.Should().ContainSingle(s => s.Name == "Reader");
+        var member = await db.TenantMembers.SingleAsync(
+            tm => tm.TenantId == tenantId && tm.SubjectId == strandedId);
+        member.DirectPermissions.Should().Contain(TenantPermissions.GlucoseRead);
+    }
+
+    private static string Sha256Hex(string value) => Convert.ToHexStringLower(
+        System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+}

--- a/tests/Unit/Nocturne.API.Tests/Migration/MigrationSubjectMembershipTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Migration/MigrationSubjectMembershipTests.cs
@@ -22,8 +22,9 @@ namespace Nocturne.API.Tests.Migration;
 /// </summary>
 public class MigrationSubjectMembershipTests
 {
-    private const string ReadableToken = "reader-a1b2c3d4e5f6a7b8";
+    private const string ReaderToken = "reader-a1b2c3d4e5f6a7b8";
     private const string AdminToken = "boss-1111222233334444";
+    private const string DeniedToken = "gone-9999888877776666";
 
     /// <summary>
     /// Stands in for the source Nightscout instance, serving its two authorization endpoints.
@@ -49,13 +50,19 @@ public class MigrationSubjectMembershipTests
                         "_id": "5f1a00000000000000000001",
                         "name": "Reader",
                         "roles": ["readable", "logger"],
-                        "accessToken": "{{ReadableToken}}"
+                        "accessToken": "{{ReaderToken}}"
                       },
                       {
                         "_id": "5f1a00000000000000000002",
                         "name": "Boss",
                         "roles": ["admin"],
                         "accessToken": "{{AdminToken}}"
+                      },
+                      {
+                        "_id": "5f1a00000000000000000003",
+                        "name": "Gone",
+                        "roles": ["denied"],
+                        "accessToken": "{{DeniedToken}}"
                       }
                     ]
                     """,
@@ -89,13 +96,19 @@ public class MigrationSubjectMembershipTests
         public void SetTenant(TenantContext? tenant) => Context = tenant;
     }
 
-    private static ServiceProvider BuildProvider(string databaseName) =>
-        new ServiceCollection()
-            .AddDbContext<NocturneDbContext>(o => o.UseInMemoryDatabase(databaseName))
+    private static ServiceProvider BuildProvider()
+    {
+        // Named once, outside the options lambda: the lambda runs per context, so generating the
+        // name there would give every context its own store.
+        var database = $"migration-membership-{Guid.NewGuid():N}";
+
+        return new ServiceCollection()
+            .AddDbContext<NocturneDbContext>(o => o.UseInMemoryDatabase(database))
             .AddScoped<ITenantAccessor, FixedTenantAccessor>()
             .AddScoped<IAuditContext, AuditContext>()
             .AddSingleton<IHttpClientFactory, StubHttpClientFactory>()
             .BuildServiceProvider();
+    }
 
     /// <summary>
     /// Runs a subjects-only API migration to completion against <see cref="NightscoutStub"/> and
@@ -133,18 +146,18 @@ public class MigrationSubjectMembershipTests
         return tenant.TenantId;
     }
 
-    private static async Task<TenantMemberEntity> MemberForAsync(
-        NocturneDbContext db, Guid tenantId, string accessTokenName)
+    private static async Task<TenantMemberEntity?> MemberForAsync(
+        NocturneDbContext db, Guid tenantId, string subjectName)
     {
-        var subject = await db.Subjects.SingleAsync(s => s.Name == accessTokenName);
-        return await db.TenantMembers.SingleAsync(
+        var subject = await db.Subjects.SingleAsync(s => s.Name == subjectName);
+        return await db.TenantMembers.SingleOrDefaultAsync(
             tm => tm.TenantId == tenantId && tm.SubjectId == subject.Id);
     }
 
     [Fact]
-    public async Task Imported_subject_becomes_a_member_holding_its_Nightscout_permissions()
+    public async Task Imported_subject_becomes_a_member_holding_exactly_its_Nightscout_permissions()
     {
-        await using var provider = BuildProvider($"migration-membership-{Guid.NewGuid():N}");
+        await using var provider = BuildProvider();
         var tenantId = await RunSubjectMigrationAsync(provider);
 
         using var scope = provider.CreateScope();
@@ -152,16 +165,29 @@ public class MigrationSubjectMembershipTests
 
         var member = await MemberForAsync(db, tenantId, "Reader");
 
-        // "readable" carries the read scopes; the custom "logger" role's "api:treatments:*" is what
-        // lets it write treatments back.
-        member.DirectPermissions.Should().Contain(
-            [TenantPermissions.GlucoseRead, TenantPermissions.TreatmentsReadWrite]);
+        // "readable" ("*:*:read") carries the reads; the custom "logger" role's "api:treatments:*"
+        // is what lets it write treatments back. Asserted exclusively: the risk in translating a
+        // legacy grant is granting more than the source did, which a containment check would miss.
+        member!.DirectPermissions.Should().BeEquivalentTo([
+            TenantPermissions.GlucoseRead,
+            TenantPermissions.TreatmentsRead,
+            TenantPermissions.TreatmentsReadWrite,
+            TenantPermissions.DevicesRead,
+            TenantPermissions.TherapyRead,
+            TenantPermissions.FoodRead,
+            TenantPermissions.AlertsRead,
+            TenantPermissions.ReportsRead,
+            TenantPermissions.IdentityRead,
+            TenantPermissions.HeartRateRead,
+            TenantPermissions.StepCountRead,
+            TenantPermissions.SleepRead,
+        ]);
     }
 
     [Fact]
     public async Task Imported_membership_grants_scopes_on_the_legacy_access_token()
     {
-        await using var provider = BuildProvider($"migration-membership-{Guid.NewGuid():N}");
+        await using var provider = BuildProvider();
         var tenantId = await RunSubjectMigrationAsync(provider);
 
         using var scope = provider.CreateScope();
@@ -169,18 +195,21 @@ public class MigrationSubjectMembershipTests
 
         // The other half of the round trip: what MemberScopeMiddleware makes of the membership when
         // the imported token authenticates. An empty result is the 401 this migration used to cause.
+        var member = await MemberForAsync(db, tenantId, "Reader");
         var resolved = MemberScopeResolver.Resolve(
-            (await MemberForAsync(db, tenantId, "Reader")).DirectPermissions!.ToHashSet(),
+            member!.DirectPermissions!.ToHashSet(),
             AuthType.LegacyAccessToken,
             new HashSet<string>());
 
-        resolved.Should().Contain(OAuthScopes.GlucoseRead);
+        resolved.Should().Contain([OAuthScopes.GlucoseRead, OAuthScopes.TreatmentsReadWrite]);
+        resolved.Should().NotContain([
+            OAuthScopes.FullAccess, TenantPermissions.MembersManage, TenantPermissions.SharingManage]);
     }
 
     [Fact]
     public async Task A_Nightscout_admin_is_imported_as_a_superuser_member()
     {
-        await using var provider = BuildProvider($"migration-membership-{Guid.NewGuid():N}");
+        await using var provider = BuildProvider();
         var tenantId = await RunSubjectMigrationAsync(provider);
 
         using var scope = provider.CreateScope();
@@ -189,16 +218,63 @@ public class MigrationSubjectMembershipTests
         var member = await MemberForAsync(db, tenantId, "Boss");
 
         // Stored as the bare atom rather than the expansion, so the grant tracks the scope list.
-        member.DirectPermissions.Should().Equal(TenantPermissions.Superuser);
+        member!.DirectPermissions.Should().Equal(TenantPermissions.Superuser);
     }
 
     [Fact]
-    public async Task Re_importing_repairs_a_subject_that_has_no_membership()
+    public async Task A_denied_subject_gets_no_membership()
     {
-        await using var provider = BuildProvider($"migration-membership-{Guid.NewGuid():N}");
+        await using var provider = BuildProvider();
+        var tenantId = await RunSubjectMigrationAsync(provider);
 
-        // A subject as an earlier migration left it: imported, with the matching token hash, and
-        // with no membership of the tenant it was imported into.
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+
+        // Nightscout's "denied" grants nothing, so a membership would only put a member on the
+        // tenant's member list who cannot do anything.
+        (await MemberForAsync(db, tenantId, "Gone")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_source_role_does_not_inherit_a_same_named_local_roles_permissions()
+    {
+        await using var provider = BuildProvider();
+
+        // The instance already has a role called "logger" that grants everything. The source's
+        // "logger" is a narrow custom role; the name collision must not widen the import.
+        using (var seedScope = provider.CreateScope())
+        {
+            var seed = seedScope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+            seed.Roles.Add(new RoleEntity
+            {
+                Id = Guid.CreateVersion7(),
+                Name = "logger",
+                Description = "Local role that happens to share the name",
+                Permissions = ["*"],
+                IsSystemRole = false,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        var tenantId = await RunSubjectMigrationAsync(provider);
+
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
+
+        var member = await MemberForAsync(db, tenantId, "Reader");
+
+        member!.DirectPermissions.Should().NotContain(TenantPermissions.Superuser);
+        member.DirectPermissions.Should().Contain(TenantPermissions.TreatmentsReadWrite);
+    }
+
+    [Fact]
+    public async Task A_subject_whose_token_is_already_known_is_left_untouched()
+    {
+        await using var provider = BuildProvider();
+
+        // Subjects are global and carry no tenant, so a token hash can match a subject another
+        // tenant imported. Duplicate detection stays a plain skip: granting on a hash match would
+        // let one tenant's migration attach a subject it does not own.
         var strandedId = Guid.CreateVersion7();
         using (var seedScope = provider.CreateScope())
         {
@@ -207,7 +283,7 @@ public class MigrationSubjectMembershipTests
             {
                 Id = strandedId,
                 Name = "Reader",
-                AccessTokenHash = Sha256Hex(ReadableToken),
+                AccessTokenHash = Sha256Hex(ReaderToken),
                 IsActive = true,
                 ApprovalStatus = "Approved",
             });
@@ -219,11 +295,9 @@ public class MigrationSubjectMembershipTests
         using var scope = provider.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
 
-        // Repaired in place: the duplicate token must not produce a second subject.
         db.Subjects.Should().ContainSingle(s => s.Name == "Reader");
-        var member = await db.TenantMembers.SingleAsync(
-            tm => tm.TenantId == tenantId && tm.SubjectId == strandedId);
-        member.DirectPermissions.Should().Contain(TenantPermissions.GlucoseRead);
+        (await db.TenantMembers.AnyAsync(
+            tm => tm.TenantId == tenantId && tm.SubjectId == strandedId)).Should().BeFalse();
     }
 
     private static string Sha256Hex(string value) => Convert.ToHexStringLower(

--- a/tests/Unit/Nocturne.Core.Models.Tests/Authorization/OAuthScopeVocabularyTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Authorization/OAuthScopeVocabularyTests.cs
@@ -109,6 +109,8 @@ public class OAuthScopeVocabularyTests
             "api:*:read", "api:*:create", "api:*:update", "api:*:delete",
             "api:entries:read", "api:entries:create", "api:treatments:update",
             "api:devicestatus:create", "api:food:update", "api:profile:create",
+            "api:entries:*", "api:treatments:*", "api:devicestatus:*", "api:food:*",
+            "api:profile:*", "api:activity:*", "*:*:read",
             "readable",
         ];
 


### PR DESCRIPTION
Fixes #545.

## The bug

A subject imported from a classic Nightscout instance authenticated on its access token and was then dropped straight back to unauthenticated. `MigrationJobService` wrote the `subjects` row and its global `subject_roles`, but never a `tenant_members` row, and `AuthenticationMiddleware` re-checks membership after the credential chain has already succeeded. `AuthType.LegacyAccessToken` is not in that check's exemption list, so every migrated `?token=` client 401d — the log line is `Subject {SubjectId} is not a member of tenant {TenantId}`.

The membership check is doing its job here, so the fix is on the migration side rather than exempting the credential: a subject with no membership genuinely should not read a tenant's data.

## The membership grant

The imported permissions are carried as `DirectPermissions` rather than mapped onto a seed tenant role. The seed roles do not line up with Nightscout's in either direction — Viewer is narrower than `readable`, Caretaker wider than `careportal` — and they have no answer at all for a custom Nightscout role. `ScopeTranslator` drops anything it cannot translate, so a permission with no Nocturne equivalent grants nothing.

Two details worth a look in review:

- The source instance's own definition of a role wins over a same-named local role, so a hand-written Nightscout role called `admin` does not inherit the seeded `*`.
- A subject whose roles translate to nothing (Nightscout's `denied`) gets no membership, rather than an entry on the member list that cannot do anything.

## ScopeTranslator

Nightscout's own seeded roles are written with verb wildcards (`api:treatments:*` on careportal, `api:activity:*` on activity) and `*:*:read` on `readable`. None of those were mapped, so the membership row alone would not have fixed anything — a migrated `careportal` or `readable` subject translated to zero scopes. Added those keys, collapsed to readwrite on the same basis as the existing create/update entries (delete stays gated behind `*`), and deduplicated the two repeated scope lists into `ReadEverything`/`WriteEverything`.

`OAuthScopeVocabularyTests.ScopeTranslator_MapsNoLegacyPermissionToAnAdministrationAtom` is extended to cover the new keys.

## Deliberately not included

An earlier draft also repaired subjects imported before this, by granting a membership when duplicate detection hit an existing token hash. That is out, on review: `SubjectEntity` is global and carries no tenant, so a hash match can be a subject **another** tenant imported — and two Nightscout instances forked from one deployment emit identical tokens, so that happens without an attacker. Answering "does this subject belong to anyone else?" needs a cross-tenant read that the tenant-pinned migration context cannot do. Duplicate detection stays a plain skip, and `A_subject_whose_token_is_already_known_is_left_untouched` pins that.

Tenants already migrated therefore are not repaired by re-importing.

## Note on a Nightscout `admin`

Its `*` maps to `TenantPermissions.Superuser`, which through the `FullAccess` shortcut in `SatisfiesScope` also satisfies the tenant-administration atoms (`members.manage`, `sharing.manage`, `audit.read`). That is the documented behaviour of a `*` grant — `OAuthScopeVocabularyTests.FullAccessExpansion_DoesNotEnumerateAdministrationAtoms` asserts it — and narrowing it here would mean losing DELETE, which is gated on `RequireScope(FullAccess)`. Flagging it because the credential is a token that travels in query strings, so if the wider view is that a migrated legacy token should never reach tenant administration, that is a change to what `*` means rather than to this migration.

## Tests

`MigrationSubjectMembershipTests` drives a subjects-only migration against a stub Nightscout and asserts the membership row, its exact permission set, the superuser collapse, the denied and name-collision cases, and the duplicate skip. One test runs the stored permissions back through `MemberScopeResolver` on a `LegacyAccessToken`, covering the authenticate-after-import half.

Assertions are exclusive rather than containment checks: the risk in translating a legacy grant is granting more than the source did, which `Should().Contain(...)` would miss.

Mutation-checked — removing the membership write fails 4 of the 6 (the two asserting absence correctly still pass); reverting to local-role-first and dropping the empty-grant skip fails 2.

API unit suite 5614 passed / 0 failed, Core.Models 618 passed / 0 failed.
