### PR TITLE
fix(twiist): stop the trend table throwing on every sync

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Twiist/Mappers/TwiistGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Mappers/TwiistGlucoseMapper.cs
@@ -25,8 +25,8 @@ public class TwiistGlucoseMapper(ILogger logger)
         { "FortyFiveDown", GlucoseDirection.FortyFiveDown },
         { "NotComputable", GlucoseDirection.NotComputable },
         { "RateOutOfRange", GlucoseDirection.RateOutOfRange },
-        // Twiist also uses arrow Unicode names
-        { "FLAT", GlucoseDirection.Flat },
+        // Twiist also uses arrow Unicode names. The lookup is OrdinalIgnoreCase, so a name that
+        // differs from one above only in case is the same key and must not be repeated here.
         { "UP", GlucoseDirection.SingleUp },
         { "DOWN", GlucoseDirection.SingleDown },
         { "DOUBLE_UP", GlucoseDirection.DoubleUp },

--- a/tests/Unit/Nocturne.Connectors.Twiist.Tests/Mappers/TwiistGlucoseMapperTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Twiist.Tests/Mappers/TwiistGlucoseMapperTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Nocturne.Connectors.Twiist.Mappers;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Connectors.Twiist.Tests.Mappers;
+
+public class TwiistGlucoseMapperTests
+{
+    [Theory]
+    [InlineData("Flat", GlucoseDirection.Flat)]
+    [InlineData("SingleUp", GlucoseDirection.SingleUp)]
+    [InlineData("FortyFiveDown", GlucoseDirection.FortyFiveDown)]
+    [InlineData("RateOutOfRange", GlucoseDirection.RateOutOfRange)]
+    public void ParseTrend_ReadsTheSummaryTrendNames(string trend, GlucoseDirection expected)
+    {
+        TwiistGlucoseMapper.ParseTrend(trend).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("UP", GlucoseDirection.SingleUp)]
+    [InlineData("DOWN", GlucoseDirection.SingleDown)]
+    [InlineData("DOUBLE_UP", GlucoseDirection.DoubleUp)]
+    [InlineData("FORTY_FIVE_DOWN", GlucoseDirection.FortyFiveDown)]
+    public void ParseTrend_ReadsTheArrowNames(string trend, GlucoseDirection expected)
+    {
+        TwiistGlucoseMapper.ParseTrend(trend).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("flat", GlucoseDirection.Flat)]
+    [InlineData("FLAT", GlucoseDirection.Flat)]
+    [InlineData("fOrTyFiVeUp", GlucoseDirection.FortyFiveUp)]
+    public void ParseTrend_IsCaseInsensitive(string trend, GlucoseDirection expected)
+    {
+        // The lookup uses OrdinalIgnoreCase, so a name that differs only in case is the same key —
+        // listing both spellings as separate entries would throw when the table is built.
+        TwiistGlucoseMapper.ParseTrend(trend).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null, GlucoseDirection.None)]
+    [InlineData("", GlucoseDirection.None)]
+    public void ParseTrend_ReportsNoDirectionWhenTheSummaryCarriesNoTrend(string? trend, GlucoseDirection expected)
+    {
+        TwiistGlucoseMapper.ParseTrend(trend).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseTrend_ReportsNotComputableForAnUnrecognisedName()
+    {
+        TwiistGlucoseMapper.ParseTrend("sideways").Should().Be(GlucoseDirection.NotComputable);
+    }
+}


### PR DESCRIPTION
The Twiist connector cannot sync at all. `TrendDirections` is keyed
`StringComparer.OrdinalIgnoreCase` and lists both `"Flat"` and `"FLAT"` — the same key under that
comparer. A collection initializer compiles to `Add`, which throws on a duplicate, so the static
initializer fails:

```
System.TypeInitializationException : The type initializer for
'Nocturne.Connectors.Twiist.Mappers.TwiistGlucoseMapper' threw an exception.
---- System.ArgumentException : An item with the same key has already been added. Key: FLAT
```

`TwiistConnectorService` calls `ParseTrend` whenever the pump summary carries a trend, which is the
ordinary case, and does so before publishing glucose. The throw unwinds to the sync-wide catch, so
the cycle publishes no glucose, boluses, carbs or temp basals — it surfaces only as
`Sync error: The type initializer ... threw an exception`.

Removing the redundant `"FLAT"` entry is the whole fix. The remaining arrow names
(`UP`, `DOWN`, `DOUBLE_UP`, `FORTY_FIVE_DOWN`, …) differ from the summary names by more than case,
so they are distinct keys and stay.

`ParseTrend` had no test, which is how a mapper that could never be constructed went unnoticed.
The new tests cover both name sets, case-insensitivity (the property that made the duplicate a
fault), the null/empty trend, and the unrecognised-name fallback. They fail on the parent commit
with the exception above.
