### PR TITLE
docs: correct comments that misstate the code they sit above

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -313,7 +313,6 @@ public static class ServiceRegistrationExtensions
             ConnectCallback = new PinnedConnector(OutboundAddressPolicy.NotLinkLocal).ConnectAsync,
         });
 
-        // Rate limiting for OAuth endpoints
         services.AddRateLimiter(options =>
         {
             options.AddPolicy(
@@ -505,7 +504,6 @@ public static class ServiceRegistrationExtensions
         // Demo mode
         services.AddSingleton<IDemoModeService, DemoModeService>();
 
-        // V4 projection (must be registered before EntryService/TreatmentService)
         services.AddScoped<IV4ToLegacyProjectionService, V4ToLegacyProjectionService>();
 
         // Collection effect descriptors (resolved by WriteSideEffectsService)
@@ -653,12 +651,12 @@ public static class ServiceRegistrationExtensions
         // Basal series builder (used by chart data pipeline and reports endpoint)
         services.AddScoped<IBasalSeriesBuilder, BasalSeriesBuilder>();
 
-        // Chart data pipeline stages (order matters!)
         services.AddScoped<ProfileLoadStage>();
         services.AddScoped<DataFetchStage>();
         services.AddScoped<IobCobComputeStage>();
         services.AddScoped<DtoMappingStage>();
 
+        // The stages run in the order of this array, not the order they were registered in.
         services.AddScoped<IEnumerable<IChartDataStage>>(sp => new IChartDataStage[]
         {
             sp.GetRequiredService<ProfileLoadStage>(),

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -128,7 +128,7 @@ builder.Services.AddDataProtection()
 // Add compatibility proxy services
 builder.Services.AddCompatibilityProxyServices(builder.Configuration);
 
-// Use in-memory cache for single-user deployments
+// In-process, so each replica caches independently and entries are lost on restart.
 builder.Services.AddNocturneMemoryCache();
 
 builder.Logging.ClearProviders();
@@ -151,9 +151,6 @@ builder.Services.AddHostedService<SoftDeleteCleanupService>();
 // controller's seed-extras endpoint (demo container, all environments).
 builder.Services.AddScoped<SampleDataSeeder>();
 
-// Add native API services for strangler pattern
-// Note: NightscoutJsonFilter is added globally to apply null-omission and
-// NocturneOnly field exclusion to v1-v3 API responses only
 builder.Services.AddScoped<ReadAccessAuditFilter>();
 builder.Services.AddControllers(options =>
 {
@@ -338,9 +335,8 @@ app.UseResponseCaching();
 // UseRouting so the rewritten path is what the router sees.
 app.UseMiddleware<JsonExtensionMiddleware>();
 
-// Explicit UseRouting so TenantSetupMiddleware can read endpoint metadata
-// (e.g. [AllowDuringSetup]). Minimal hosting would insert this automatically
-// but we make it explicit for clarity.
+// Routing must run here, not where minimal hosting would insert it, so that
+// TenantSetupMiddleware below can read endpoint metadata such as [AllowDuringSetup].
 app.UseRouting();
 
 // Ahead of the documentation branch below, which jumps straight to its endpoint and would

--- a/src/Aspire/Nocturne.Aspire.Host/Program.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Program.cs
@@ -92,9 +92,9 @@ class Program
                 "PostgreSQL bootstrap password",
                 "Used only at first container start to create runtime roles");
 
-            // Non-bootstrap role passwords. The Postgres container's init
-            // script reads them via env vars and creates nocturne_migrator
-            // and nocturne_app at first container start.
+            // Non-bootstrap role passwords. The Postgres container's init script reads them via
+            // env vars and creates nocturne_migrator, nocturne_app and nocturne_web at first
+            // container start.
             postgresMigratorPassword = builder.AddParameter(
                 ServiceNames.Parameters.PostgresMigratorPassword,
                 secret: true
@@ -230,8 +230,9 @@ class Program
         var discordClientSecret = builder.AddParameter("discord-client-secret", "", secret: true);
 
         // Platform base domain — the single hostname all services derive URLs from.
-        // Production should set this to e.g. "nocturne.run" via user-secrets.
-        // Injected as "BaseDomain" into both the API and SvelteKit.
+        // Production should set this to e.g. "nocturne.run" via user-secrets. Reaches the API and
+        // SvelteKit as BASE_DOMAIN in publish mode only; run mode overrides it further down with a
+        // value derived from the live gateway endpoint.
         var baseDomain = builder.AddParameter("base-domain", "")
             .WithPublishMetadata(
                 "Base domain",


### PR DESCRIPTION
First slice of a comment pass over the composition roots. This one is only the comments that are
**factually wrong** — each asserts something a maintainer would act on, and each is untrue. The bulk
narration sweep is separate.

| Site | Claim | Reality |
|---|---|---|
| `ServiceRegistrationExtensions.cs` | V4 projection "must be registered before EntryService/TreatmentService" | `AddScoped` resolution does not depend on registration order, and the service's only consumer is `TreatmentReadService` |
| `ServiceRegistrationExtensions.cs` | "Chart data pipeline stages (order matters!)" | Sat above four order-independent registrations; the order that matters is the array six lines below, which now carries the note |
| `ServiceRegistrationExtensions.cs` | "Rate limiting for OAuth endpoints" | Also defines `totp-login`, `guest-activate`, `demo-session`, `support-issues`, `docs`, `statistics-compute` |
| `API/Program.cs` | "in-memory cache for single-user deployments" | Multi-tenant service; what matters is that the cache is in-process per replica |
| `API/Program.cs` | "native API services for strangler pattern" | No longer heads a strangler; the `NightscoutJsonFilter` note beneath repeated the filter's own `///` |
| `API/Program.cs` | explicit `UseRouting` is "for clarity" | Contradicts the sentence above it — it is there so `TenantSetupMiddleware` can read endpoint metadata, and removing it would break that |
| `Aspire.Host/Program.cs` | init script creates two roles | It creates three (`nocturne_web` landed later) |
| `Aspire.Host/Program.cs` | base domain reaches API and web | Publish mode only; run mode overrides it from the live gateway endpoint |

The two ordering claims are the ones worth reviewing closely: both assert a constraint that does not
exist, so someone reorganising this file would preserve a non-constraint and could conclude a real
dependency edge exists where it doesn't.

Comments only — no behaviour change.
