### PR TITLE
fix(data): stop freezing update timestamps and let swept basal injections re-import

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260817042048_RestoreUpdateTimestampWritesAndBasalInjectionSoftDeleteIndex.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260817042048_RestoreUpdateTimestampWritesAndBasalInjectionSoftDeleteIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260817042048_RestoreUpdateTimestampWritesAndBasalInjectionSoftDeleteIndex")]
+    partial class RestoreUpdateTimestampWritesAndBasalInjectionSoftDeleteIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260817042048_RestoreUpdateTimestampWritesAndBasalInjectionSoftDeleteIndex.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260817042048_RestoreUpdateTimestampWritesAndBasalInjectionSoftDeleteIndex.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RestoreUpdateTimestampWritesAndBasalInjectionSoftDeleteIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_basal_injections_tenant_legacy_id",
+                table: "basal_injections");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_basal_injections_tenant_legacy_id",
+                table: "basal_injections",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_basal_injections_tenant_legacy_id",
+                table: "basal_injections");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_basal_injections_tenant_legacy_id",
+                table: "basal_injections",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1719,7 +1719,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasIndex(e => new { e.TenantId, e.LegacyId })
             .HasDatabaseName("ix_basal_injections_tenant_legacy_id")
             .IsUnique()
-            .HasFilter("legacy_id IS NOT NULL");
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
         modelBuilder
             .Entity<BasalInjectionEntity>()
@@ -2651,8 +2651,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<FoodEntity>()
             .Property(f => f.SysUpdatedAt)
-            .HasDefaultValueSql("CURRENT_TIMESTAMP")
-            .ValueGeneratedOnAddOrUpdate();
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
         modelBuilder
             .Entity<ConnectorFoodEntryEntity>()
@@ -2662,8 +2661,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<ConnectorFoodEntryEntity>()
             .Property(e => e.SysUpdatedAt)
-            .HasDefaultValueSql("CURRENT_TIMESTAMP")
-            .ValueGeneratedOnAddOrUpdate();
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
         modelBuilder
             .Entity<ConnectorFoodEntryEntity>()
@@ -2673,8 +2671,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<TreatmentFoodEntity>()
             .Property(tf => tf.SysUpdatedAt)
-            .HasDefaultValueSql("CURRENT_TIMESTAMP")
-            .ValueGeneratedOnAddOrUpdate();
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
         modelBuilder
             .Entity<UserFoodFavoriteEntity>()
@@ -2684,20 +2681,17 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<SettingsEntity>()
             .Property(s => s.SysUpdatedAt)
-            .HasDefaultValueSql("CURRENT_TIMESTAMP")
-            .ValueGeneratedOnAddOrUpdate();
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
         modelBuilder
             .Entity<StepCountEntity>()
             .Property(s => s.SysUpdatedAt)
-            .HasDefaultValueSql("CURRENT_TIMESTAMP")
-            .ValueGeneratedOnAddOrUpdate();
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
         modelBuilder
             .Entity<HeartRateEntity>()
             .Property(h => h.SysUpdatedAt)
-            .HasDefaultValueSql("CURRENT_TIMESTAMP")
-            .ValueGeneratedOnAddOrUpdate();
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
         // Configure required fields and defaults
         modelBuilder.Entity<FoodEntity>().Property(f => f.Type).HasDefaultValue("food");
@@ -2748,10 +2742,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         modelBuilder.Entity<RefreshTokenEntity>(entity =>
         {
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
-            entity
-                .Property(e => e.UpdatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .ValueGeneratedOnAddOrUpdate();
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
 
             entity
                 .HasOne(e => e.Subject)
@@ -2765,10 +2756,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         {
             entity.Property(e => e.IsActive).HasDefaultValue(true);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
-            entity
-                .Property(e => e.UpdatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .ValueGeneratedOnAddOrUpdate();
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
 
             // Per-user display preferences stored as a JSONB blob (semantic comparison is
             // applied by the relational jsonb-string value-comparer configured above).
@@ -2789,10 +2777,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         {
             entity.Property(e => e.IsSystemRole).HasDefaultValue(false);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
-            entity
-                .Property(e => e.UpdatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .ValueGeneratedOnAddOrUpdate();
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
         });
 
         // Configure SubjectRole (many-to-many) relationships
@@ -2828,10 +2813,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             entity.Property(e => e.IsEnabled).HasDefaultValue(true);
             entity.Property(e => e.DisplayOrder).HasDefaultValue(0);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
-            entity
-                .Property(e => e.UpdatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .ValueGeneratedOnAddOrUpdate();
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
         });
 
         // Configure Auth Audit Log entity relationships and defaults
@@ -2947,10 +2929,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             entity.Property(e => e.RedirectUris).HasDefaultValue("[]");
             entity.Property(e => e.IsKnown).HasDefaultValue(false);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
-            entity
-                .Property(e => e.UpdatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .ValueGeneratedOnAddOrUpdate();
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
         });
 
         // Configure OAuth Grant entity
@@ -3072,15 +3051,9 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             entity.Property(e => e.Id).HasValueGenerator<GuidV7ValueGenerator>();
             entity.Property(e => e.ConfigJson).HasDefaultValue("{}");
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
-            entity
-                .Property(e => e.UpdatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .ValueGeneratedOnAddOrUpdate();
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
             entity.Property(e => e.SysCreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
-            entity
-                .Property(e => e.SysUpdatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP")
-                .ValueGeneratedOnAddOrUpdate();
+            entity.Property(e => e.SysUpdatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
         });
 
         // Configure TenantMember relationships

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/LegacyIdIndexFilterTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/LegacyIdIndexFilterTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// Pins the filter on every <c>(tenant_id, legacy_id)</c> uniqueness index.
+///
+/// <see cref="Nocturne.Infrastructure.Data.Extensions.SoftDeleteDedupExtensions.GetBlockingLegacyIdsAsync"/>
+/// deliberately lets a legacy id whose row was soft-deleted by a system sweep be re-imported:
+/// resync inserts a fresh row and leaves the old one for audit. That only works if the old row
+/// has dropped out of the uniqueness index, so an index that filters on <c>legacy_id IS NOT NULL</c>
+/// alone turns the very next resync into a 23505 on that table.
+/// </summary>
+[Trait("Category", "Unit")]
+public class LegacyIdIndexFilterTests
+{
+    [Fact]
+    public void LegacyIdUniqueIndexes_ExcludeSoftDeletedRows()
+    {
+        using var ctx = new NocturneDbContext(
+            new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
+                .Options)
+        { TenantId = Guid.NewGuid() };
+
+        var legacyIdIndexes = ctx.Model.GetEntityTypes()
+            .Where(e => typeof(ISoftDeletable).IsAssignableFrom(e.ClrType))
+            .SelectMany(e => e.GetIndexes())
+            .Where(i => i.IsUnique
+                && i.Properties.Select(p => p.Name).SequenceEqual(
+                    [nameof(ITenantScoped.TenantId), nameof(IV4Entity.LegacyId)]))
+            .ToList();
+
+        // Without this the assertion below passes vacuously the moment the discovery drifts.
+        legacyIdIndexes.Should().HaveCountGreaterThan(10,
+            "the model carries a legacy-id uniqueness index on every soft-deletable v4 table");
+
+        legacyIdIndexes
+            .Where(i => i.GetFilter()?.Contains("deleted_at IS NULL", StringComparison.Ordinal) != true)
+            .Select(i => i.GetDatabaseName())
+            .Should().BeEmpty(
+                "a soft-deleted row must drop out of the index so a system-swept legacy id stays re-importable");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
@@ -1,6 +1,7 @@
+using System.Data.Common;
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Nocturne.Infrastructure.Data.Entities;
 using Xunit;
 
@@ -11,19 +12,24 @@ namespace Nocturne.Infrastructure.Data.Tests;
 /// <c>NocturneDbContext.UpdateTimestamps</c>, driven by the timestamp marker interfaces
 /// (<see cref="ISystemTimestamped"/>, <see cref="ISystemCreated"/>,
 /// <see cref="IEntityTimestamped"/>, <see cref="IEntityCreated"/>) plus a small set of
-/// entity-specific columns. EF InMemory runs the SaveChanges override, so timestamp
-/// stamping is exercised end to end.
+/// entity-specific columns.
+///
+/// The store is in-memory SQLite, not EF InMemory: only a relational provider honours
+/// <c>HasDefaultValueSql</c> and store-generated value configuration, so a column that
+/// SaveChanges stamps but the provider then discards from the UPDATE is visible here.
 /// </summary>
-public class UpdateTimestampsTests
+public class UpdateTimestampsTests : IDisposable
 {
     // A clearly-stale sentinel so a freshly-stamped utcNow value is unambiguously newer.
     private static readonly DateTime Stale = new(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
+    private readonly List<DbConnection> _connections = [];
+
     [Fact]
     public async Task SystemTimestamped_StampsBothOnInsert_AndBumpsUpdatedOnModify()
     {
-        var options = NewStore();
         var tenantId = Guid.NewGuid();
+        var options = NewStore(tenantId);
         var id = Guid.CreateVersion7();
         var before = DateTime.UtcNow;
 
@@ -57,8 +63,8 @@ public class UpdateTimestampsTests
     [Fact]
     public async Task SystemTimestamped_UnchangedTrackedRow_IsNotBumpedByAnotherRowsSave()
     {
-        var options = NewStore();
         var tenantId = Guid.NewGuid();
+        var options = NewStore(tenantId);
         var idA = Guid.CreateVersion7();
         var idB = Guid.CreateVersion7();
 
@@ -86,8 +92,8 @@ public class UpdateTimestampsTests
     [Fact]
     public async Task SystemTimestamped_TimestampOnlyModification_KeepsTheAssignedValue()
     {
-        var options = NewStore();
         var tenantId = Guid.NewGuid();
+        var options = NewStore(tenantId);
         var id = Guid.CreateVersion7();
 
         await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
@@ -115,13 +121,20 @@ public class UpdateTimestampsTests
     [Fact]
     public async Task SystemCreated_StampsCreatedOnInsertOnly()
     {
-        var options = NewStore();
         var tenantId = Guid.NewGuid();
+        var options = NewStore(tenantId);
+        var foodId = Guid.CreateVersion7();
         var before = DateTime.UtcNow;
 
         await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
         {
-            ctx.UserFoodFavorites.Add(new UserFoodFavoriteEntity { Id = Guid.CreateVersion7(), SysCreatedAt = Stale });
+            ctx.Foods.Add(new FoodEntity { Id = foodId });
+            ctx.UserFoodFavorites.Add(new UserFoodFavoriteEntity
+            {
+                Id = Guid.CreateVersion7(),
+                FoodId = foodId,
+                SysCreatedAt = Stale,
+            });
             await ctx.SaveChangesAsync();
         }
 
@@ -155,8 +168,8 @@ public class UpdateTimestampsTests
     [Fact]
     public async Task ClockFace_StampsAllFourConventions()
     {
-        var options = NewStore();
         var tenantId = Guid.NewGuid();
+        var options = NewStore(tenantId);
         var before = DateTime.UtcNow;
 
         await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
@@ -186,8 +199,8 @@ public class UpdateTimestampsTests
     [Fact]
     public async Task ConnectorConfiguration_StampsLastModifiedOnInsert()
     {
-        var options = NewStore();
         var tenantId = Guid.NewGuid();
+        var options = NewStore(tenantId);
         var before = DateTimeOffset.UtcNow;
 
         await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
@@ -223,13 +236,22 @@ public class UpdateTimestampsTests
     [Fact]
     public async Task OAuthRefreshToken_StampsIssuedAtOnInsert()
     {
-        var options = NewStore();
         var tenantId = Guid.NewGuid();
+        var options = NewStore(tenantId);
+        var subjectId = Guid.CreateVersion7();
+        var grantId = Guid.CreateVersion7();
         var before = DateTime.UtcNow;
 
         await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
         {
-            ctx.OAuthRefreshTokens.Add(new OAuthRefreshTokenEntity { Id = Guid.CreateVersion7(), IssuedAt = Stale });
+            ctx.Subjects.Add(new SubjectEntity { Id = subjectId });
+            ctx.OAuthGrants.Add(new OAuthGrantEntity { Id = grantId, TenantId = tenantId, SubjectId = subjectId });
+            ctx.OAuthRefreshTokens.Add(new OAuthRefreshTokenEntity
+            {
+                Id = Guid.CreateVersion7(),
+                GrantId = grantId,
+                IssuedAt = Stale,
+            });
             await ctx.SaveChangesAsync();
         }
 
@@ -256,8 +278,8 @@ public class UpdateTimestampsTests
     [Fact]
     public async Task TenantScoped_InheritsTenantFromContextOnInsert()
     {
-        var options = NewStore();
         var tenantId = Guid.NewGuid();
+        var options = NewStore(tenantId);
 
         await using (var ctx = new NocturneDbContext(options) { TenantId = tenantId })
         {
@@ -288,9 +310,9 @@ public class UpdateTimestampsTests
     [Fact]
     public async Task TenantScoped_CrossTenantModify_Throws()
     {
-        var options = NewStore();
         var ownerTenant = Guid.NewGuid();
         var otherTenant = Guid.NewGuid();
+        var options = NewStore(ownerTenant, otherTenant);
         var id = Guid.CreateVersion7();
 
         await using (var ctx = new NocturneDbContext(options) { TenantId = ownerTenant })
@@ -309,9 +331,39 @@ public class UpdateTimestampsTests
             "modifying a row owned by another tenant must fail closed");
     }
 
-    private static DbContextOptions<NocturneDbContext> NewStore() =>
-        new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseInMemoryDatabase($"update_timestamps_{Guid.NewGuid()}")
-            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+    /// <summary>
+    /// Creates an isolated SQLite store with the schema applied and the supplied tenants
+    /// seeded (every ITenantScoped table carries an FK to <c>tenants</c>, which a relational
+    /// provider actually enforces).
+    /// </summary>
+    private DbContextOptions<NocturneDbContext> NewStore(params Guid[] tenantIds)
+    {
+        var connection = new SqliteConnection("Filename=:memory:");
+        connection.Open();
+        _connections.Add(connection);
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(connection)
+            .EnableSensitiveDataLogging()
             .Options;
+
+        using var seed = new NocturneDbContext(options);
+        seed.Database.EnsureCreated();
+        foreach (var tenantId in tenantIds)
+        {
+            seed.Tenants.Add(new TenantEntity { Id = tenantId, Slug = $"t{tenantId:N}"[..12] });
+        }
+        seed.SaveChanges();
+
+        return options;
+    }
+
+    public void Dispose()
+    {
+        foreach (var connection in _connections)
+        {
+            connection.Dispose();
+        }
+        GC.SuppressFinalize(this);
+    }
 }


### PR DESCRIPTION
Two drift bugs in `NocturneDbContext`, both found by comparing near-identical entity configuration
blocks against each other. One migration covers both.

## `basal_injections` could not re-import after a system sweep

Thirteen entities filter their `(TenantId, LegacyId)` unique index with
`legacy_id IS NOT NULL AND deleted_at IS NULL`. `basal_injections` alone filtered on
`legacy_id IS NOT NULL`.

That filter is what makes the soft-delete contract work. `GetBlockingLegacyIdsAsync` deliberately
does **not** block re-import of a row whose delete was a system sweep (`deleted_by_user = false`) —
resync inserts a fresh row and leaves the old one for audit continuity. On every sibling the swept
row drops out of the unique index so the insert succeeds. On `basal_injections` it stayed in, so the
insert violated the constraint (23505).

The git history shows how it happened: PR #214 mechanically added `AND deleted_at IS NULL` to
thirteen indexes, and PR #215 branched off it and introduced this index with the pre-#214 shape. The
comment nine lines below the defective index even states the rule — they applied it to the
`sync_identifier` index and missed the `legacy_id` one directly above.

A model guard test now asserts that **every** unique `(TenantId, LegacyId)` index on an
`ISoftDeletable` entity carries the filter, with a discovery floor so it cannot pass vacuously.
Reverting only this line makes it fail, naming `ix_basal_injections_tenant_legacy_id`.

## Twelve tables never recorded an update time

Thirteen properties were configured `.HasDefaultValueSql("CURRENT_TIMESTAMP").ValueGeneratedOnAddOrUpdate()`.
`OnAddOrUpdate` makes EF treat the column as store-owned and omit it from writes; `HasDefaultValueSql`
fires only on INSERT; and there is no update trigger anywhere in the tree. Meanwhile
`UpdateTimestamps()` assigns `SysUpdatedAt`/`UpdatedAt` on every save for every entity — and EF
discarded that assignment on exactly these thirteen.

Affected: `SysUpdatedAt` on Food, ConnectorFoodEntry, TreatmentFood, Settings, StepCount, HeartRate,
ClockFace; `UpdatedAt` on RefreshToken, Subject, Role, OidcProvider, OAuthClient, ClockFace. The
other ~35 timestamped entities configure nothing and behave correctly.

`HasDefaultValueSql` is kept: it matches the shape the correctly-configured siblings already use, it
is inert once `OnAddOrUpdate` is gone, it remains the backstop for non-EF inserts, and dropping it
would have emitted thirteen pointless `AlterColumn` operations against production. The generated
migration confirms this — no column DDL at all.

**Why no test caught it:** `UpdateTimestampsTests` asserted exactly this behaviour, on `FoodEntity`,
and passed — because it used `UseInMemoryDatabase`, and the InMemory provider ignores both
`HasDefaultValueSql` and `ValueGeneratedOnAddOrUpdate`. It is now re-pointed at in-memory SQLite,
which also meant seeding parent rows that InMemory had been silently ignoring FKs for. On the parent
commit the re-pointed test fails 4 of 11; here it passes.

**Measured on production.** Across the twelve tables, ten have never recorded a single update:

| table | rows | rows ever bumped | max gap between created and updated |
|---|---|---|---|
| `heart_rates` | 48,685 | 0 | 144 ms |
| `step_counts` | 23,515 | 0 | 65 ms |
| `treatment_foods` | 9,172 | 0 | 31 ms |
| `oauth_clients` | 753 | 0 | — |
| `foods`, `settings`, `roles`, `clock_faces`, `connector_food_entries`, `oidc_providers` | small | 0 | — |
| `boluses` *(control)* | 486,374 | 113,464 | 33 days |
| `sensor_glucose` *(control)* | 4,825,666 | 618,177 | — |

The sub-150 ms maxima are the insert transaction itself, so on those tables the column has never moved
after the row was written, while the correctly-configured controls bump 13-23% of rows.

`subjects` (48 of 131) and `refresh_tokens` (6,623 of 7,823) *do* bump, but not through this
configuration: `SubjectService` and `EfFirstPartyTokenRepository` update them with
`ExecuteUpdateAsync(... SetProperty(e => e.UpdatedAt, ...))`, which emits raw SQL and bypasses the
property-level suppression entirely. Any tracked-entity save on those two tables still discards the
stamp; only the explicit `SetProperty` paths survive.

## Migration

`20260817042048_RestoreUpdateTimestampWritesAndBasalInjectionSoftDeleteIndex` — generated, not
hand-written. `Up()` contains only the drop and recreate of the one index. The snapshot diff is
exactly thirteen `ValueGeneratedOnAddOrUpdate` → `ValueGeneratedOnAdd` lines plus the one filter.

