### PR TITLE
fix(connectors): derive supported data types from the registration attribute

### DIFF
--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -50,15 +50,6 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
 
     protected override string ConnectorSource => DataSources.CareLinkConnector;
     public override string ServiceName => ServiceNames.CareLinkConnector;
-    public override List<SyncDataType> SupportedDataTypes =>
-    [
-        SyncDataType.Glucose,
-        SyncDataType.DeviceStatus,
-        SyncDataType.Boluses,
-        SyncDataType.CarbIntake,
-        SyncDataType.TempBasals,
-        SyncDataType.StateSpans,
-    ];
 
     /// <inheritdoc />
     public override Task<bool> AuthenticateAsync()

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Utilities;
@@ -60,8 +62,17 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
     public abstract string ServiceName { get; }
 
-    /// <inheritdoc />
-    public virtual List<SyncDataType> SupportedDataTypes => [SyncDataType.Glucose];
+    /// <summary>
+    /// The data types this connector fetches, read from the <see cref="ConnectorRegistrationAttribute"/>
+    /// on <typeparamref name="TConfig"/>. The attribute drives the tenant-facing toggle schema and
+    /// this property drives the sync loop, so stating them separately lets a connector advertise a
+    /// toggle it never acts on, or act on data the tenant has no way to turn off.
+    /// </summary>
+    public virtual List<SyncDataType> SupportedDataTypes => [.. RegisteredDataTypes];
+
+    private static readonly SyncDataType[] RegisteredDataTypes =
+        typeof(TConfig).GetCustomAttribute<ConnectorRegistrationAttribute>()?.SupportedDataTypes
+        ?? [SyncDataType.Glucose];
 
     public abstract Task<bool> AuthenticateAsync();
 

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
@@ -46,7 +46,6 @@ public class DexcomConnectorService : BaseConnectorService<DexcomConnectorConfig
 
     protected override string ConnectorSource => DataSources.DexcomConnector;
     public override string ServiceName => "Dexcom Share";
-    public override List<SyncDataType> SupportedDataTypes => [SyncDataType.Glucose];
 
     public override async Task<bool> AuthenticateAsync()
     {

--- a/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
@@ -41,7 +41,6 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
 
     protected override string ConnectorSource => DataSources.EversenseConnector;
     public override string ServiceName => "Eversense Now";
-    public override List<SyncDataType> SupportedDataTypes => [SyncDataType.Glucose];
 
     public override async Task<bool> AuthenticateAsync()
     {

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
@@ -71,7 +71,6 @@ public class LibreConnectorService(
 
     public override string ServiceName => "LibreLinkUp";
     protected override string ConnectorSource => DataSources.LibreConnector;
-    public override List<SyncDataType> SupportedDataTypes => [SyncDataType.Glucose];
 
     public override bool IsHealthy => base.IsHealthy && !_tokenProvider.IsTokenExpired;
 

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
@@ -23,9 +23,11 @@ namespace Nocturne.Connectors.Glooko.Configurations;
     DefaultStaleThresholdMinutes = 360,
     SupportedDataTypes = [
         SyncDataType.Glucose,
+        SyncDataType.ManualBG,
         SyncDataType.Boluses,
         SyncDataType.BasalInjections,
         SyncDataType.CarbIntake,
+        SyncDataType.TempBasals,
         SyncDataType.StateSpans,
         SyncDataType.DeviceEvents,
         SyncDataType.Profiles

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -58,18 +58,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     public override string ServiceName => "Glooko";
     protected override string ConnectorSource => DataSources.GlookoConnector;
 
-    public override List<SyncDataType> SupportedDataTypes =>
-    [
-        SyncDataType.Glucose,
-        SyncDataType.ManualBG,
-        SyncDataType.Boluses,
-        SyncDataType.BasalInjections,
-        SyncDataType.CarbIntake,
-        SyncDataType.StateSpans,
-        SyncDataType.TempBasals,
-        SyncDataType.DeviceEvents,
-        SyncDataType.Profiles
-    ];
 
     // ── Authentication ──────────────────────────────────────────────────
 

--- a/src/Connectors/Nocturne.Connectors.Gluroo/Services/GlurooConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/Services/GlurooConnectorService.cs
@@ -22,13 +22,4 @@ public class GlurooConnectorService : NightscoutConnectorServiceBase<GlurooConne
     protected override string ConnectorSource => DataSources.GlurooConnector;
     public override string ServiceName => "Gluroo Global Connect";
 
-    public override List<SyncDataType> SupportedDataTypes =>
-    [
-        SyncDataType.Glucose,
-        SyncDataType.ManualBG,
-        SyncDataType.Boluses,
-        SyncDataType.CarbIntake,
-        SyncDataType.Notes,
-        SyncDataType.Profiles
-    ];
 }

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
@@ -55,7 +55,6 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
 
     protected override string ConnectorSource => DataSources.MyFitnessPalConnector;
     public override string ServiceName => "MyFitnessPal";
-    public override List<SyncDataType> SupportedDataTypes => [SyncDataType.Food];
 
     /// <inheritdoc />
     public override Task<bool> AuthenticateAsync()

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -34,18 +34,6 @@ public class MyLifeConnectorService(
     public override string ServiceName => "MyLife";
     protected override string ConnectorSource => DataSources.MyLifeConnector;
 
-    public override List<SyncDataType> SupportedDataTypes =>
-    [
-        SyncDataType.Glucose,
-        SyncDataType.ManualBG,
-        SyncDataType.Boluses,
-        SyncDataType.CarbIntake,
-        SyncDataType.BolusCalculations,
-        SyncDataType.Notes,
-        SyncDataType.DeviceEvents,
-        SyncDataType.StateSpans,
-        SyncDataType.Profiles
-    ];
 
     public override bool IsHealthy =>
         FailedRequestCount < MaxFailedRequestsBeforeUnhealthy && !tokenProvider.IsTokenExpired;

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -48,20 +48,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     // would silently drop older records. Catch-up syncs still resume from each type's own cursor.
     protected override DateTime? InitialSyncFloor => null;
 
-    public override List<SyncDataType> SupportedDataTypes =>
-    [
-        SyncDataType.Glucose,
-        SyncDataType.ManualBG,
-        SyncDataType.Boluses,
-        SyncDataType.CarbIntake,
-        SyncDataType.BolusCalculations,
-        SyncDataType.Notes,
-        SyncDataType.DeviceEvents,
-        SyncDataType.Profiles,
-        SyncDataType.DeviceStatus,
-        SyncDataType.Food,
-        SyncDataType.Activity
-    ];
 
     public override async Task<bool> AuthenticateAsync()
     {

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -34,21 +34,6 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     protected override string ConnectorSource => DataSources.NocturneRemoteConnector;
     public override string ServiceName => "Nocturne Remote";
 
-    public override List<SyncDataType> SupportedDataTypes =>
-    [
-        SyncDataType.Glucose,
-        SyncDataType.ManualBG,
-        SyncDataType.Boluses,
-        SyncDataType.CarbIntake,
-        SyncDataType.BolusCalculations,
-        SyncDataType.Notes,
-        SyncDataType.DeviceEvents,
-        SyncDataType.StateSpans,
-        SyncDataType.Profiles,
-        SyncDataType.DeviceStatus,
-        SyncDataType.Activity,
-        SyncDataType.Food
-    ];
 
     public override async Task<bool> AuthenticateAsync()
     {

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -44,18 +44,6 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     protected override string ConnectorSource => DataSources.TConnectSyncConnector;
     public override string ServiceName => "Tandem Source";
 
-    public override List<SyncDataType> SupportedDataTypes =>
-    [
-        SyncDataType.Glucose,
-        SyncDataType.Boluses,
-        SyncDataType.CarbIntake,
-        SyncDataType.BolusCalculations,
-        SyncDataType.TempBasals,
-        SyncDataType.DeviceEvents,
-        SyncDataType.StateSpans,
-        SyncDataType.DeviceStatus,
-        SyncDataType.Profiles,
-    ];
 
     public override Task<bool> AuthenticateAsync()
     {

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Configurations/TidepoolConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Configurations/TidepoolConnectorConfiguration.cs
@@ -22,8 +22,7 @@ namespace Nocturne.Connectors.Tidepool.Configurations;
     SupportedDataTypes = [
         SyncDataType.Glucose,
         SyncDataType.Boluses,
-        SyncDataType.CarbIntake,
-        SyncDataType.Activity
+        SyncDataType.CarbIntake
     ]
 )]
 public class TidepoolConnectorConfiguration : BaseConnectorConfiguration

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -45,12 +45,6 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
 
     protected override string ConnectorSource => DataSources.TidepoolConnector;
     public override string ServiceName => "Tidepool";
-    public override List<SyncDataType> SupportedDataTypes =>
-    [
-        SyncDataType.Glucose,
-        SyncDataType.Boluses,
-        SyncDataType.CarbIntake
-    ];
 
     public override Task<bool> AuthenticateAsync()
     {

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -48,8 +48,6 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     protected override string ConnectorSource => DataSources.TwiistConnector;
     public override string ServiceName => "Twiist Insight";
 
-    public override List<SyncDataType> SupportedDataTypes =>
-        [SyncDataType.Glucose, SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.TempBasals];
 
     public override Task<bool> AuthenticateAsync()
     {

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SupportedDataTypesFromRegistrationTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SupportedDataTypesFromRegistrationTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Services;
+
+public class SupportedDataTypesFromRegistrationTests
+{
+    [ConnectorRegistration(
+        "registered-test",
+        "Registered test connector",
+        "RegisteredTest",
+        "REGISTERED_TEST",
+        "registered-test",
+        "registered-test",
+        SupportedDataTypes = [SyncDataType.Glucose, SyncDataType.Boluses, SyncDataType.TempBasals])]
+    public class RegisteredConfig : BaseConnectorConfiguration;
+
+    public class UnregisteredConfig : BaseConnectorConfiguration;
+
+    private class Service<TConfig>(ConnectorServerResolver<TConfig> resolver)
+        : BaseConnectorService<TConfig>(new HttpClient(), resolver, NullLogger.Instance)
+        where TConfig : BaseConnectorConfiguration
+    {
+        protected override string ConnectorSource => "test";
+        public override string ServiceName => "Test";
+        public override Task<bool> AuthenticateAsync() => Task.FromResult(true);
+    }
+
+    private static Service<TConfig> Build<TConfig>() where TConfig : BaseConnectorConfiguration =>
+        new(new ConnectorServerResolver<TConfig>(null, null, null));
+
+    [Fact]
+    public void SupportedDataTypes_ComesFromTheRegistrationAttribute()
+    {
+        // The attribute drives the tenant's toggle schema. Reading the sync loop's list from the
+        // same place is what stops a connector advertising a toggle it never acts on, or syncing
+        // data the tenant cannot turn off.
+        Build<RegisteredConfig>().SupportedDataTypes.Should().BeEquivalentTo(
+            [SyncDataType.Glucose, SyncDataType.Boluses, SyncDataType.TempBasals]);
+    }
+
+    [Fact]
+    public void SupportedDataTypes_FallsBackToGlucoseWithoutARegistration()
+    {
+        Build<UnregisteredConfig>().SupportedDataTypes.Should().BeEquivalentTo([SyncDataType.Glucose]);
+    }
+
+    [Fact]
+    public void SupportedDataTypes_HandsOutACopy()
+    {
+        // The list is materialised once per connector type; callers assign it onto SyncRequest,
+        // so returning the shared instance would let one run's mutation reach every later run.
+        var service = Build<RegisteredConfig>();
+
+        service.SupportedDataTypes.Add(SyncDataType.Profiles);
+
+        service.SupportedDataTypes.Should().NotContain(SyncDataType.Profiles);
+    }
+}


### PR DESCRIPTION
Every connector stated its supported data types twice — once in the `[ConnectorRegistration]`
attribute that drives the tenant-facing toggle schema, and again as a `SupportedDataTypes` override
that drives the sync loop. Twelve of fourteen agreed. Both mismatches were visible to tenants, and
they cut in opposite directions.

**Tidepool advertised a capability that does not exist.** The attribute listed `Activity`; the
service did not. Nothing fetches Tidepool activity — `TidepoolPhysicalActivity` has no references
anywhere in the tree. Tenants were offered a "Sync Activity" toggle that could never do anything.

**Glooko synced data the tenant could not turn off.** The service listed `ManualBG` and `TempBasals`
and genuinely publishes both; the attribute listed neither, so no toggle was generated. A Glooko
tenant had no way to stop manual-BG sync short of editing raw config JSON.

Rather than add a guard test to police the duplication, the base now reads the attribute and the
fourteen overrides are gone — the two lists can no longer disagree. Glooko's attribute gains the two
types it already syncs, Tidepool's loses the one it never did, and the other twelve are unchanged.

The property hands out a copy rather than the shared instance. The list is now materialised once per
closed generic type instead of rebuilt per access, and callers assign it onto
`SyncRequest.DataTypes`, so returning the instance would let one run's mutation reach every later
run. The previous per-connector collection expressions allocated fresh each time and so did not have
that hazard; this preserves it.

Tests cover the attribute being read, the no-attribute fallback to `Glucose`, and the copy
semantics. All ten connector test projects pass.
