### PR TITLE
fix(glooko): stop reporting an unknown glucose trend as Flat

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
@@ -254,7 +254,7 @@ public class GlookoSensorGlucoseMapper
 
     private static GlucoseDirection ParseTrendToDirection(string? trend)
     {
-        if (string.IsNullOrWhiteSpace(trend)) return GlucoseDirection.Flat;
+        if (string.IsNullOrWhiteSpace(trend)) return GlucoseDirection.None;
 
         return trend.ToUpperInvariant() switch
         {
@@ -267,7 +267,7 @@ public class GlookoSensorGlucoseMapper
             "DOUBLEDOWN" or "DOUBLE_DOWN" => GlucoseDirection.DoubleDown,
             "NOT COMPUTABLE" or "NOTCOMPUTABLE" => GlucoseDirection.NotComputable,
             "RATE OUT OF RANGE" or "RATEOUTOFRANGE" => GlucoseDirection.RateOutOfRange,
-            _ => GlucoseDirection.Flat
+            _ => GlucoseDirection.NotComputable
         };
     }
 

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoSensorGlucoseTrendTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoSensorGlucoseTrendTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Mappers;
+using Nocturne.Connectors.Glooko.Models;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Mappers;
+
+public class GlookoSensorGlucoseTrendTests
+{
+    private const string ConnectorSource = "glooko_test";
+
+    private static GlucoseDirection? DirectionFor(string? trend)
+    {
+        var config = new GlookoConnectorConfiguration { TimezoneOffset = 0 };
+        var mapper = new GlookoSensorGlucoseMapper(
+            config, ConnectorSource, new GlookoTimeMapper(config, NullLogger.Instance), NullLogger.Instance);
+
+        var batch = new GlookoBatchData
+        {
+            Readings =
+            [
+                new GlookoCgmReading { Timestamp = "2026-03-09T07:00:00.000Z", Value = 12000, Trend = trend },
+            ],
+        };
+
+        return mapper.TransformBatchDataToSensorGlucose(batch).Single().Direction;
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoTrendSupplied_IsNone(string? trend) =>
+        DirectionFor(trend).Should().Be(GlucoseDirection.None);
+
+    [Theory]
+    [InlineData("SIDEWAYS")]
+    [InlineData("42")]
+    public void UnrecognisedTrend_IsNotComputable(string trend) =>
+        DirectionFor(trend).Should().Be(GlucoseDirection.NotComputable);
+
+    [Theory]
+    [InlineData("FLAT", GlucoseDirection.Flat)]
+    [InlineData("flat", GlucoseDirection.Flat)]
+    [InlineData("DOUBLEUP", GlucoseDirection.DoubleUp)]
+    [InlineData("DOUBLE_UP", GlucoseDirection.DoubleUp)]
+    [InlineData("SINGLEUP", GlucoseDirection.SingleUp)]
+    [InlineData("FORTYFIVEUP", GlucoseDirection.FortyFiveUp)]
+    [InlineData("FORTY_FIVE_DOWN", GlucoseDirection.FortyFiveDown)]
+    [InlineData("SINGLEDOWN", GlucoseDirection.SingleDown)]
+    [InlineData("DOUBLE_DOWN", GlucoseDirection.DoubleDown)]
+    [InlineData("NOT COMPUTABLE", GlucoseDirection.NotComputable)]
+    [InlineData("RATEOUTOFRANGE", GlucoseDirection.RateOutOfRange)]
+    public void RecognisedTrend_MapsToItsDirection(string trend, GlucoseDirection expected) =>
+        DirectionFor(trend).Should().Be(expected);
+}


### PR DESCRIPTION
`GlookoSensorGlucoseMapper.ParseTrendToDirection` returned `GlucoseDirection.Flat` both when Glooko
sent no trend and when it sent a token we don't recognise. `Flat` renders a horizontal arrow — a
positive clinical claim that glucose is stable — so a reading with no vendor trend was
indistinguishable from a genuine `FLAT` one.

Absent trends now map to `None` and unrecognised ones to `NotComputable`, matching
`TwiistGlucoseMapper.ParseTrend`.

## This is 100% of Glooko data, not an edge case

I checked production before merging. Every Glooko CGM reading we have ever stored is `Flat`:

```
 data_source      | direction | count  |   first    |    last
------------------+-----------+--------+------------+------------
 glooko-connector | Flat      | 409517 | 2025-05-12 | 2026-08-16
```

409,517 readings over 15 months, one distinct direction. Glooko is evidently not supplying a trend
token we recognise on *any* reading, so every Glooko trend arrow in production today is a fabricated
stability claim. For comparison, `dexcom-connector` is 80% `Flat` and `nightscout-connector` 73%,
which is what a real distribution looks like.

## Sequencing: this wants #780 alongside it

Because it is 100% of Glooko readings rather than a rare fallback, this fix immediately routes
409k+ readings onto the `None` path — and #780 documents that `None` currently renders as either a
flat arrow (the clock face defaults to 90°, which points right) or the literal string `NotComputable`
(the bot). Merged alone, Glooko users either see the same false flat arrow or raw enum text.

The fix here is still correct on its own — it stops the API asserting something untrue — but the
user-visible win needs #780.

## Tests

`GlookoSensorGlucoseTrendTests` covers null, empty, whitespace, two unrecognised tokens, and eleven
recognised tokens so the real mapping stays pinned. Mutation-proved: restoring either `Flat` fallback
fails 5 of the new tests. Full project 73/73 green.

Fixes #772
