### PR TITLE
docs(eversense): correct the trend-table provenance comment

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Eversense/Mappers/EversenseSensorGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Mappers/EversenseSensorGlucoseMapper.cs
@@ -8,8 +8,9 @@ namespace Nocturne.Connectors.Eversense.Mappers;
 public class EversenseSensorGlucoseMapper(ILogger logger)
 {
     /// <summary>
-    /// Eversense trend values mapped to GlucoseDirection.
-    /// Mapping verified via LoopKit GlucoseTrend enum and the EversenseNowClient trendmap.
+    /// Eversense trend values mapped to GlucoseDirection. The wire value is the ordinal of the
+    /// Eversense app's own ARROW_TYPE enum, which runs falling-to-rising — the inverse of LoopKit's
+    /// GlucoseTrend, so this table reads as reversed if checked against LoopKit.
     /// </summary>
     private static readonly Dictionary<int, GlucoseDirection> TrendDirections = new()
     {


### PR DESCRIPTION
#778 flagged that the Eversense trend table might be fully inverted, because a comment claimed the
mapping was verified against LoopKit's `GlucoseTrend` enum — and LoopKit orders `1 = upUpUp` through
`7 = downDownDown`, the reverse of our table. If true, every Eversense trend arrow would be inverted,
which is the most dangerous possible direction for this bug.

**The table is correct. The comment was wrong.** No mapping values change here; this replaces the
misleading provenance comment with Eversense's own.

## Why the table is right

Eversense's Android app defines `Utils$ARROW_TYPE` with ordinals `0 = STALE, 1 = FALLING_FAST` …
`5 = RISING_FAST` — falling at the low end, rising at the high end, the exact inverse of LoopKit's
polarity. `StateModelUploadUtility.fetchStateModelCurrentValueInfo()` writes
`getGlucoseTrendDirection().ordinal()` into the field serialised as `"GlucoseTrend"`, which is
precisely the field `EversensePatientDatum.GlucoseTrend` deserialises — so the wire value is that
ordinal end to end. Corroborated by a second independent decompile of a different APK build, and the
sign of every value agrees with `EversenseNowClient`, `jaslo/esiphone` and
`alexanderkyte/eversense-companion`.

## Confirmed against production data

Rather than rely on decompiled evidence alone, I measured the actual rate of change per direction
label on the live Eversense tenant (353 readings, 2026-06-17 → 2026-08-17), using consecutive
readings 5 minutes apart:

```
   direction   |  n  | min_rate | avg_rate | max_rate    (mg/dL per minute)
---------------+-----+----------+----------+----------
 FortyFiveDown |  16 |    -2.40 |    -1.26 |     0.40
 Flat          | 288 |    -2.40 |    -0.07 |     1.60
 FortyFiveUp   |  15 |     0.40 |     1.33 |     2.20
```

Rows we label `FortyFiveUp` have genuinely **rising** glucose (avg +1.33 mg/dL/min); rows we label
`FortyFiveDown` are genuinely **falling** (avg −1.26). Under an inverted table these would be
reversed. The direction mapping is confirmed by live patient data, not just by reverse engineering.

## Tests

`EversenseSensorGlucoseMapperTests.Map_TrendValues_MapsToCorrectDirection` already pins all eight
values with a separate fact for an out-of-range input, so the mapping is regression-protected and I
added nothing. #778's claim that no vendor trend mapper has a test is stale for Eversense.

## Left open deliberately

Values `6` and `7` never appear in production (they map to our double arrows), and no `SingleDown`
reading had a usable neighbour to rate-check. Whether wire values `1` and `5` should be double rather
than single arrows — a magnitude question, never a direction one — is tracked separately in #787,
along with why the rate-based approach above cannot settle it.

Closes #778
