### PR TITLE
fix(data): give meter_glucose and calibrations the tenant-scoped unique legacy-id index

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260817064038_AddTenantScopedLegacyIdIndexesToMeterGlucoseAndCalibrations.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260817064038_AddTenantScopedLegacyIdIndexesToMeterGlucoseAndCalibrations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260817064038_AddTenantScopedLegacyIdIndexesToMeterGlucoseAndCalibrations")]
+    partial class AddTenantScopedLegacyIdIndexesToMeterGlucoseAndCalibrations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260817064038_AddTenantScopedLegacyIdIndexesToMeterGlucoseAndCalibrations.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260817064038_AddTenantScopedLegacyIdIndexesToMeterGlucoseAndCalibrations.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantScopedLegacyIdIndexesToMeterGlucoseAndCalibrations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_meter_glucose_legacy_id",
+                table: "meter_glucose");
+
+            migrationBuilder.DropIndex(
+                name: "ix_calibrations_legacy_id",
+                table: "calibrations");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_meter_glucose_tenant_legacy_id",
+                table: "meter_glucose",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_calibrations_tenant_legacy_id",
+                table: "calibrations",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_meter_glucose_tenant_legacy_id",
+                table: "meter_glucose");
+
+            migrationBuilder.DropIndex(
+                name: "ix_calibrations_tenant_legacy_id",
+                table: "calibrations");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_meter_glucose_legacy_id",
+                table: "meter_glucose",
+                column: "legacy_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_calibrations_legacy_id",
+                table: "calibrations",
+                column: "legacy_id");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1636,8 +1636,16 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
         modelBuilder
             .Entity<MeterGlucoseEntity>()
-            .HasIndex(e => e.LegacyId)
-            .HasDatabaseName("ix_meter_glucose_legacy_id");
+            .HasIndex(e => new { e.TenantId, e.LegacyId })
+            .HasDatabaseName("ix_meter_glucose_tenant_legacy_id")
+            .IsUnique()
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+        // Keep the conventional TenantId index (see ApsSnapshot note).
+        modelBuilder
+            .Entity<MeterGlucoseEntity>()
+            .HasIndex(e => e.TenantId)
+            .HasDatabaseName("IX_meter_glucose_tenant_id");
 
         modelBuilder
             .Entity<MeterGlucoseEntity>()
@@ -1653,8 +1661,16 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
         modelBuilder
             .Entity<CalibrationEntity>()
-            .HasIndex(e => e.LegacyId)
-            .HasDatabaseName("ix_calibrations_legacy_id");
+            .HasIndex(e => new { e.TenantId, e.LegacyId })
+            .HasDatabaseName("ix_calibrations_tenant_legacy_id")
+            .IsUnique()
+            .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+        // Keep the conventional TenantId index (see ApsSnapshot note).
+        modelBuilder
+            .Entity<CalibrationEntity>()
+            .HasIndex(e => e.TenantId)
+            .HasDatabaseName("IX_calibrations_tenant_id");
 
         modelBuilder
             .Entity<CalibrationEntity>()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/LegacyIdIndexFilterTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/LegacyIdIndexFilterTests.cs
@@ -1,12 +1,18 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Nocturne.Infrastructure.Data.Entities;
 using Xunit;
 
 namespace Nocturne.Infrastructure.Data.Tests;
 
 /// <summary>
-/// Pins the filter on every <c>(tenant_id, legacy_id)</c> uniqueness index.
+/// Pins the presence and the filter of the <c>(tenant_id, legacy_id)</c> uniqueness index that
+/// backstops every legacy-id-keyed v4 table.
+///
+/// <see cref="Nocturne.Infrastructure.Data.Repositories.V4.V4RepositoryBase{TModel, TEntity}"/>
+/// dedups a bulk create by reading the colliding legacy ids and then inserting the survivors, so
+/// the index is the only thing standing between two overlapping imports and a duplicate row.
 ///
 /// <see cref="Nocturne.Infrastructure.Data.Extensions.SoftDeleteDedupExtensions.GetBlockingLegacyIdsAsync"/>
 /// deliberately lets a legacy id whose row was soft-deleted by a system sweep be re-imported:
@@ -17,31 +23,65 @@ namespace Nocturne.Infrastructure.Data.Tests;
 [Trait("Category", "Unit")]
 public class LegacyIdIndexFilterTests
 {
+    /// <summary>
+    /// Tables whose legacy id is not their dedup key: the snapshot repositories upsert on
+    /// <c>(tenant_id, data_source, sync_identifier)</c>, and that index carries the uniqueness.
+    /// </summary>
+    private static readonly string[] TablesKeyedOnSyncIdentifierInstead =
+        ["aps_snapshots", "pump_snapshots", "uploader_snapshots"];
+
+    [Fact]
+    public void EveryLegacyIdTable_HasATenantScopedUniqueIndex()
+    {
+        using var ctx = CreateContext();
+
+        LegacyIdEntityTypes(ctx)
+            .Where(e => !TablesKeyedOnSyncIdentifierInstead.Contains(e.GetTableName())
+                && !e.GetIndexes().Any(IsTenantLegacyIdUniqueIndex))
+            .Select(e => e.GetTableName())
+            .Should().BeEmpty(
+                "a read-then-insert dedup with no uniqueness index lets two overlapping imports both insert the same legacy id");
+    }
+
     [Fact]
     public void LegacyIdUniqueIndexes_ExcludeSoftDeletedRows()
     {
-        using var ctx = new NocturneDbContext(
-            new DbContextOptionsBuilder<NocturneDbContext>()
-                .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
-                .Options)
-        { TenantId = Guid.NewGuid() };
+        using var ctx = CreateContext();
 
-        var legacyIdIndexes = ctx.Model.GetEntityTypes()
-            .Where(e => typeof(ISoftDeletable).IsAssignableFrom(e.ClrType))
+        LegacyIdEntityTypes(ctx)
             .SelectMany(e => e.GetIndexes())
-            .Where(i => i.IsUnique
-                && i.Properties.Select(p => p.Name).SequenceEqual(
-                    [nameof(ITenantScoped.TenantId), nameof(IV4Entity.LegacyId)]))
-            .ToList();
-
-        // Without this the assertion below passes vacuously the moment the discovery drifts.
-        legacyIdIndexes.Should().HaveCountGreaterThan(10,
-            "the model carries a legacy-id uniqueness index on every soft-deletable v4 table");
-
-        legacyIdIndexes
-            .Where(i => i.GetFilter()?.Contains("deleted_at IS NULL", StringComparison.Ordinal) != true)
+            .Where(i => IsTenantLegacyIdUniqueIndex(i)
+                && i.GetFilter()?.Contains("deleted_at IS NULL", StringComparison.Ordinal) != true)
             .Select(i => i.GetDatabaseName())
             .Should().BeEmpty(
                 "a soft-deleted row must drop out of the index so a system-swept legacy id stays re-importable");
     }
+
+    private static NocturneDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
+            .Options)
+        { TenantId = Guid.NewGuid() };
+
+    /// <summary>
+    /// Both facts pass vacuously if discovery drifts, so the count is asserted here rather than
+    /// in either one.
+    /// </summary>
+    private static IReadOnlyList<IEntityType> LegacyIdEntityTypes(NocturneDbContext ctx)
+    {
+        var entityTypes = ctx.Model.GetEntityTypes()
+            .Where(e => typeof(ISoftDeletable).IsAssignableFrom(e.ClrType)
+                && e.FindProperty(nameof(IV4Entity.LegacyId)) is not null)
+            .ToList();
+
+        entityTypes.Should().HaveCountGreaterThan(10,
+            "the v4 granular model spreads legacy ids across every time-series and schedule table");
+
+        return entityTypes;
+    }
+
+    private static bool IsTenantLegacyIdUniqueIndex(IIndex index) =>
+        index.IsUnique
+        && index.Properties.Select(p => p.Name).SequenceEqual(
+            [nameof(ITenantScoped.TenantId), nameof(IV4Entity.LegacyId)]);
 }


### PR DESCRIPTION
`meter_glucose` and `calibrations` indexed `LegacyId` on its own, where every other
`IV4TimeSeriesEntity` with a `LegacyId` uses `(TenantId, LegacyId)` unique, filtered on
`legacy_id IS NOT NULL AND deleted_at IS NULL`.

Two problems: no uniqueness backstop for the read-then-insert legacy-id dedup in `V4RepositoryBase`
(so two overlapping imports can both pass the read and both insert), and the index led with
`legacy_id`, so the tenant-scoped lookup could not use it as a prefix and scanned across tenants.

Both entities now use the sibling shape verbatim.

## Production pre-flight: clean, safe to deploy

A `CREATE UNIQUE INDEX` over violating rows fails, and migrations run on API startup — so
pre-existing duplicates would put the API into a crash loop rather than log a warning. Unlike every
table the existing precedent covers, these two have never had the constraint, so nothing has been
stopping duplicates accumulating. I checked production before opening this:

```
      tbl      | dup_groups | excess_rows        rows   with_legacy
---------------+------------+-------------      ------  -----------
 meter_glucose |          0 |           0        1553         1417
 calibrations  |          0 |           0         156          140
```

Zero duplicates. No cleanup step is needed and there is no crash-loop risk.

## One thing the issue did not anticipate

The first generated migration also contained `DropIndex("IX_meter_glucose_tenant_id")` and
`DropIndex("IX_calibrations_tenant_id")` — EF treats the auto-created `tenant_id` index as redundant
once another index leads with `tenant_id`, filter or no filter. That is exactly the trap the existing
`ApsSnapshot` comment documents: a *filtered* index cannot serve general tenant-scoped scans, and
unlike `sensor_glucose`/`boluses`, neither of these tables has a `(tenant_id, timestamp)` index to
fall back on. Dropping it would have sent every tenant-scoped read on those tables to a seq scan.

I followed the established remedy (re-declare the plain `TenantId` index with the EF default name)
and regenerated, so the committed migration touches only the two legacy-id indexes and the
`tenant_id` indexes are unchanged in DDL.

## Guard test

`LegacyIdIndexFilterTests` now asserts that every `ISoftDeletable` entity with a `LegacyId` **has**
such an index at all, not merely that existing ones are filtered correctly. Both facts share a
discovery helper carrying the non-vacuity assertion, so neither can pass if discovery drifts. Proven
to fail on the pre-fix model, naming both tables.

`aps_snapshots`, `pump_snapshots` and `uploader_snapshots` are in an explicit exception list because
their dedup key is `sync_identifier`. That reasoning does not fully hold and is tracked in #786 —
which the same production check also shows is duplicate-free across all three (~4.6M legacy-id rows).

614 tests green.

Fixes #774
