### PR TITLE
refactor: one mmol/mg-dL conversion factor across C# and TypeScript

### DIFF
--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Nocturne.API.Services.Profiles.Resolvers;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Analytics;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
@@ -2578,7 +2579,7 @@ public class StatisticsService : IStatisticsService
     /// <returns>Glucose value in mmol/L</returns>
     public double MgdlToMMOL(double mgdl)
     {
-        return Math.Round((mgdl / 18.01559) * 10) / 10;
+        return Math.Round((mgdl / GlucoseConstants.MgdlPerMmol) * 10) / 10;
     }
 
     /// <summary>
@@ -2588,7 +2589,7 @@ public class StatisticsService : IStatisticsService
     /// <returns>Glucose value in mg/dL</returns>
     public double MmolToMGDL(double mmol)
     {
-        return Math.Round(mmol * 18.01559);
+        return Math.Round(mmol * GlucoseConstants.MgdlPerMmol);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Legacy/DDataService.cs
+++ b/src/API/Nocturne.API/Services/Legacy/DDataService.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Entries;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.Legacy;
@@ -36,9 +37,6 @@ public class DDataService : IDDataService
         "loop",
         "xdripjs",
     };
-
-    // Constant for mmol/L to mg/dL conversion
-    private const double MMOL_TO_MGDL = 18.0182;
 
     public DDataService(
         IEntryStore store,
@@ -378,9 +376,9 @@ public class DDataService : IDDataService
             if (!string.IsNullOrEmpty(treatment.Units) && treatment.Units == "mmol")
             {
                 if (treatment.TargetTop.HasValue)
-                    treatment.TargetTop = treatment.TargetTop * MMOL_TO_MGDL;
+                    treatment.TargetTop = treatment.TargetTop * GlucoseConstants.MgdlPerMmol;
                 if (treatment.TargetBottom.HasValue)
-                    treatment.TargetBottom = treatment.TargetBottom * MMOL_TO_MGDL;
+                    treatment.TargetBottom = treatment.TargetBottom * GlucoseConstants.MgdlPerMmol;
                 treatment.Units = "mg/dl";
                 converted = true;
             }
@@ -395,9 +393,9 @@ public class DDataService : IDDataService
             )
             {
                 if (treatment.TargetTop.HasValue)
-                    treatment.TargetTop = treatment.TargetTop * MMOL_TO_MGDL;
+                    treatment.TargetTop = treatment.TargetTop * GlucoseConstants.MgdlPerMmol;
                 if (treatment.TargetBottom.HasValue)
-                    treatment.TargetBottom = treatment.TargetBottom * MMOL_TO_MGDL;
+                    treatment.TargetBottom = treatment.TargetBottom * GlucoseConstants.MgdlPerMmol;
                 treatment.Units = "mg/dl";
             }
         }

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -368,7 +369,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
     internal static List<V4Models.ScheduleEntry> ConvertSensitivityValues(List<TimeValue> timeValues, string? units)
     {
         var toMgdl = IsMmol(units)
-            ? (Func<double, double>)(value => Math.Round(value * MgdlPerMmol))
+            ? (Func<double, double>)(value => Math.Round(value * GlucoseConstants.MgdlPerMmol))
             : value => value;
 
         return timeValues.Select(tv =>
@@ -382,11 +383,6 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
             };
         }).ToList();
     }
-
-    /// <summary>
-    /// mg/dL per mmol/L. Matches the factor the V4 glucose models use (<see cref="V4Models.SensorGlucose"/> et al.).
-    /// </summary>
-    private const double MgdlPerMmol = 18.0182;
 
     /// <summary>
     /// Merges separate low- and high-target <see cref="TimeValue"/> lists into a single list of
@@ -406,7 +402,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
     internal static List<V4Models.TargetRangeEntry> MergeTargets(List<TimeValue> lows, List<TimeValue> highs, string? units)
     {
         var toMgdl = IsMmol(units)
-            ? (Func<double, double>)(value => Math.Round(value * MgdlPerMmol))
+            ? (Func<double, double>)(value => Math.Round(value * GlucoseConstants.MgdlPerMmol))
             : value => value;
         var highLookup = highs.ToDictionary(h => h.Time, h => h.Value);
 

--- a/src/Connectors/Nocturne.Connectors.Eversense/Mappers/EversenseSensorGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Mappers/EversenseSensorGlucoseMapper.cs
@@ -23,8 +23,6 @@ public class EversenseSensorGlucoseMapper(ILogger logger)
         { 7, GlucoseDirection.DoubleUp },
     };
 
-    private const double MmolToMgdlFactor = 18.0182;
-
     private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     public SensorGlucose? Map(EversensePatientDatum patient)
@@ -38,7 +36,7 @@ public class EversenseSensorGlucoseMapper(ILogger logger)
             }
 
             var mgdl = patient.Units == 1
-                ? patient.CurrentGlucose * MmolToMgdlFactor
+                ? patient.CurrentGlucose * GlucoseConstants.MgdlPerMmol
                 : (double)patient.CurrentGlucose;
 
             var direction = TrendDirections.GetValueOrDefault(patient.GlucoseTrend, GlucoseDirection.None);

--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSensorGlucoseMapper.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Glooko.Configurations;
 using Nocturne.Connectors.Glooko.Models;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.Connectors.Glooko.Mappers;
@@ -272,5 +273,5 @@ public class GlookoSensorGlucoseMapper
     }
 
     private static double ConvertToMgdl(double value, string? meterUnits) =>
-        meterUnits?.ToLowerInvariant() == "mmoll" ? value * 18.0182 : value;
+        meterUnits?.ToLowerInvariant() == "mmoll" ? value * GlucoseConstants.MgdlPerMmol : value;
 }

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Configurations/TidepoolConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Configurations/TidepoolConstants.cs
@@ -2,11 +2,6 @@ namespace Nocturne.Connectors.Tidepool.Configurations;
 
 public static class TidepoolConstants
 {
-    /// <summary>
-    ///     Conversion factor for mmol/L to mg/dL (molar mass of glucose / 10)
-    /// </summary>
-    public const double MmolToMgdlFactor = 18.01559;
-
     public static class Servers
     {
         public const string Us = "api.tidepool.org";

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Mappers/TidepoolSensorGlucoseMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Mappers/TidepoolSensorGlucoseMapper.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Tidepool.Models;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Models.V4;
 
 namespace Nocturne.Connectors.Tidepool.Mappers;
@@ -56,7 +57,7 @@ public class TidepoolSensorGlucoseMapper(ILogger logger, string connectorSource)
         if (string.IsNullOrEmpty(units)) return value;
         return units.ToLowerInvariant() switch
         {
-            "mmol/l" or "mmol" => value * 18.0182,
+            "mmol/l" or "mmol" => value * GlucoseConstants.MgdlPerMmol,
             "mg/dl" => value,
             _ => value
         };

--- a/src/Core/Nocturne.Core.Constants/GlucoseConstants.cs
+++ b/src/Core/Nocturne.Core.Constants/GlucoseConstants.cs
@@ -1,0 +1,13 @@
+namespace Nocturne.Core.Constants;
+
+/// <summary>
+/// Glucose unit conversion constants shared by models, connectors, analytics, and widgets.
+/// </summary>
+public static class GlucoseConstants
+{
+    /// <summary>
+    /// Milligrams per decilitre in one millimole per litre of glucose: the conventional CGM-ecosystem
+    /// factor, about 1 part in 7,000 above the 180.156 g/mol molar mass divided by 10.
+    /// </summary>
+    public const double MgdlPerMmol = 18.0182;
+}

--- a/src/Core/Nocturne.Core.Models/V4/BGCheck.cs
+++ b/src/Core/Nocturne.Core.Models/V4/BGCheck.cs
@@ -1,3 +1,5 @@
+using Nocturne.Core.Constants;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -11,10 +13,9 @@ namespace Nocturne.Core.Models.V4;
 /// computed properties that normalize to both unit systems.
 /// </para>
 /// <para>
-/// <see cref="Mgdl"/> is computed as: if <see cref="Units"/> is <see cref="GlucoseUnit.Mmol"/>,
-/// then <c>Glucose * 18.0182</c>; otherwise <c>Glucose</c> as-is.
-/// <see cref="Mmol"/> is the inverse: if already mmol/L, returns <c>Glucose</c>; otherwise
-/// <c>Glucose / 18.0182</c>.
+/// <see cref="Mgdl"/> and <see cref="Mmol"/> convert through
+/// <see cref="GlucoseConstants.MgdlPerMmol"/> when <see cref="Units"/> is not already the
+/// requested unit.
 /// </para>
 /// </remarks>
 /// <seealso cref="Treatment"/>
@@ -98,18 +99,14 @@ public class BGCheck : IV4Record
     /// <summary>
     /// Glucose in mg/dL, computed from <see cref="Glucose"/> and <see cref="Units"/>.
     /// </summary>
-    /// <remarks>
-    /// Computed as <c>Units == GlucoseUnit.Mmol ? Glucose * 18.0182 : Glucose</c>.
-    /// </remarks>
-    public double Mgdl => Units == GlucoseUnit.Mmol ? Glucose * 18.0182 : Glucose;
+    public double Mgdl =>
+        Units == GlucoseUnit.Mmol ? Glucose * GlucoseConstants.MgdlPerMmol : Glucose;
 
     /// <summary>
     /// Glucose in mmol/L, computed from <see cref="Glucose"/> and <see cref="Units"/>.
     /// </summary>
-    /// <remarks>
-    /// Computed as <c>Units == GlucoseUnit.Mmol ? Glucose : Glucose / 18.0182</c>.
-    /// </remarks>
-    public double Mmol => Units == GlucoseUnit.Mmol ? Glucose : Glucose / 18.0182;
+    public double Mmol =>
+        Units == GlucoseUnit.Mmol ? Glucose : Glucose / GlucoseConstants.MgdlPerMmol;
 
     /// <summary>
     /// APS system sync/deduplication identifier (used by Loop and AAPS)

--- a/src/Core/Nocturne.Core.Models/V4/MeterGlucose.cs
+++ b/src/Core/Nocturne.Core.Models/V4/MeterGlucose.cs
@@ -1,3 +1,5 @@
+using Nocturne.Core.Constants;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -10,8 +12,8 @@ namespace Nocturne.Core.Models.V4;
 /// is sourced directly from the meter via upload (e.g., through a connector or xDrip).
 /// </para>
 /// <para>
-/// <see cref="Mmol"/> is computed from <see cref="Mgdl"/> using the standard conversion factor
-/// (18.0182). <see cref="Mgdl"/> is always the source of truth.
+/// <see cref="Mmol"/> is computed from <see cref="Mgdl"/> using
+/// <see cref="GlucoseConstants.MgdlPerMmol"/>. <see cref="Mgdl"/> is always the source of truth.
 /// </para>
 /// </remarks>
 /// <seealso cref="Entry"/>
@@ -89,9 +91,9 @@ public class MeterGlucose : IV4Record, IDeviceAttributed
     /// Glucose value in mmol/L, computed from <see cref="Mgdl"/>.
     /// </summary>
     /// <remarks>
-    /// Computed as <c>Mgdl / 18.0182</c>. The mg/dL value is the source of truth.
+    /// The mg/dL value is the source of truth.
     /// </remarks>
-    public double Mmol => Mgdl / 18.0182;
+    public double Mmol => Mgdl / GlucoseConstants.MgdlPerMmol;
 
     /// <summary>
     /// Catch-all for fields not mapped to dedicated columns

--- a/src/Core/Nocturne.Core.Models/V4/SensorGlucose.cs
+++ b/src/Core/Nocturne.Core.Models/V4/SensorGlucose.cs
@@ -1,3 +1,5 @@
+using Nocturne.Core.Constants;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -9,9 +11,10 @@ namespace Nocturne.Core.Models.V4;
 /// stored as its own record rather than being multiplexed through the entries collection.
 /// </para>
 /// <para>
-/// <see cref="Mmol"/> is computed from <see cref="Mgdl"/> using the standard conversion factor
-/// (18.0182). <see cref="Trend"/> is computed by casting <see cref="Direction"/> to its integer
-/// equivalent, providing a 1:1 mapping between <see cref="GlucoseDirection"/> and <see cref="GlucoseTrend"/>.
+/// <see cref="Mmol"/> is computed from <see cref="Mgdl"/> using
+/// <see cref="GlucoseConstants.MgdlPerMmol"/>. <see cref="Trend"/> is computed by casting
+/// <see cref="Direction"/> to its integer equivalent, providing a 1:1 mapping between
+/// <see cref="GlucoseDirection"/> and <see cref="GlucoseTrend"/>.
 /// </para>
 /// </remarks>
 /// <seealso cref="Entry"/>
@@ -98,9 +101,9 @@ public class SensorGlucose : IV4Record, IDeviceAttributed
     /// Glucose value in mmol/L (computed from <see cref="Mgdl"/>).
     /// </summary>
     /// <remarks>
-    /// Computed as <c>Mgdl / 18.0182</c>. The mg/dL value is the source of truth.
+    /// The mg/dL value is the source of truth.
     /// </remarks>
-    public double Mmol => Mgdl / 18.0182;
+    public double Mmol => Mgdl / GlucoseConstants.MgdlPerMmol;
 
     /// <summary>
     /// CGM trend arrow direction.
@@ -158,7 +161,8 @@ public class SensorGlucose : IV4Record, IDeviceAttributed
     /// <summary>
     /// Smoothed glucose value in mmol/L (computed from <see cref="SmoothedMgdl"/>).
     /// </summary>
-    public double? SmoothedMmol => SmoothedMgdl.HasValue ? SmoothedMgdl.Value / 18.0182 : null;
+    public double? SmoothedMmol =>
+        SmoothedMgdl.HasValue ? SmoothedMgdl.Value / GlucoseConstants.MgdlPerMmol : null;
 
     /// <summary>
     /// Unsmoothed (raw) glucose value in mg/dL, when known.
@@ -168,7 +172,8 @@ public class SensorGlucose : IV4Record, IDeviceAttributed
     /// <summary>
     /// Unsmoothed glucose value in mmol/L (computed from <see cref="UnsmoothedMgdl"/>).
     /// </summary>
-    public double? UnsmoothedMmol => UnsmoothedMgdl.HasValue ? UnsmoothedMgdl.Value / 18.0182 : null;
+    public double? UnsmoothedMmol =>
+        UnsmoothedMgdl.HasValue ? UnsmoothedMgdl.Value / GlucoseConstants.MgdlPerMmol : null;
 
     /// <summary>
     /// Catch-all for fields not mapped to dedicated columns

--- a/src/Desktop/Nocturne.Desktop.Tray/Helpers/GlucoseRangeHelper.cs
+++ b/src/Desktop/Nocturne.Desktop.Tray/Helpers/GlucoseRangeHelper.cs
@@ -11,12 +11,6 @@ namespace Nocturne.Desktop.Tray.Helpers;
 /// </summary>
 public static class GlucoseRangeHelper
 {
-    /// <summary>
-    /// Standard conversion factor from mg/dL to mmol/L.
-    /// Provided here for backward compatibility; prefer <see cref="GlucoseFormatHelper.MgdlToMmolFactor"/>.
-    /// </summary>
-    public const double MgdlToMmolFactor = GlucoseFormatHelper.MgdlToMmolFactor;
-
     public static readonly Color UrgentColor = Color.FromArgb(255, 200, 30, 30);
     public static readonly Color WarningColor = Color.FromArgb(255, 230, 160, 30);
     public static readonly Color InRangeColor = Color.FromArgb(255, 60, 180, 75);

--- a/src/Web/packages/app/src/lib/components/schedule/ScheduleView.svelte
+++ b/src/Web/packages/app/src/lib/components/schedule/ScheduleView.svelte
@@ -13,8 +13,7 @@
   import { Input } from "$lib/components/ui/input";
   import { Plus, Trash2 } from "lucide-svelte";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
-
-  const MGDL_TO_MMOL = 18.01559;
+  import { MGDL_PER_MMOL } from "@nocturne/ui/glucose";
 
   interface ScheduleEntry {
     time?: string;
@@ -90,11 +89,11 @@
     }
 
     if (src === "mgdl" && dst === "mmol") {
-      return Math.round((value / MGDL_TO_MMOL) * 10) / 10;
+      return Math.round((value / MGDL_PER_MMOL) * 10) / 10;
     }
 
     if (src === "mmol" && dst === "mgdl") {
-      return Math.round(value * MGDL_TO_MMOL);
+      return Math.round(value * MGDL_PER_MMOL);
     }
 
     return value;

--- a/src/Web/packages/ui/src/lib/glucose.ts
+++ b/src/Web/packages/ui/src/lib/glucose.ts
@@ -8,13 +8,16 @@
 /** Display unit preference. */
 export type GlucoseUnits = "mg/dl" | "mmol";
 
-/** Conversion factor from mg/dL to mmol/L. */
-const MGDL_TO_MMOL = 18.01559;
+/**
+ * Milligrams per decilitre in one millimole per litre of glucose. Must equal
+ * `GlucoseConstants.MgdlPerMmol`; `GlucoseConversionFactorMirrorTests` fails if it does not.
+ */
+export const MGDL_PER_MMOL = 18.0182;
 
 /** Convert a glucose value from mg/dL to the given display units. */
 export function convertToDisplayUnits(mgdl: number, units: GlucoseUnits): number {
   if (units === "mmol") {
-    return Math.round((mgdl / MGDL_TO_MMOL) * 10) / 10;
+    return Math.round((mgdl / MGDL_PER_MMOL) * 10) / 10;
   }
   return Math.round(mgdl);
 }
@@ -22,7 +25,7 @@ export function convertToDisplayUnits(mgdl: number, units: GlucoseUnits): number
 /** Convert a glucose value from display units back to mg/dL. */
 export function convertFromDisplayUnits(value: number, units: GlucoseUnits): number {
   if (units === "mmol") {
-    return Math.round(value * MGDL_TO_MMOL);
+    return Math.round(value * MGDL_PER_MMOL);
   }
   return Math.round(value);
 }

--- a/src/Widgets/Nocturne.Widget.Contracts/Helpers/GlucoseFormatHelper.cs
+++ b/src/Widgets/Nocturne.Widget.Contracts/Helpers/GlucoseFormatHelper.cs
@@ -1,3 +1,5 @@
+using Nocturne.Core.Constants;
+
 namespace Nocturne.Widget.Contracts.Helpers;
 
 /// <summary>
@@ -5,11 +7,6 @@ namespace Nocturne.Widget.Contracts.Helpers;
 /// </summary>
 public static class GlucoseFormatHelper
 {
-    /// <summary>
-    /// Standard conversion factor from mg/dL to mmol/L (molecular weight of glucose / 10).
-    /// </summary>
-    public const double MgdlToMmolFactor = 18.01559;
-
     /// <summary>
     /// Formats a glucose value in mg/dL to the appropriate display string for the given unit.
     /// </summary>
@@ -20,7 +17,7 @@ public static class GlucoseFormatHelper
     {
         return unit switch
         {
-            GlucoseUnit.MmolL => (mgdl / MgdlToMmolFactor).ToString("F1"),
+            GlucoseUnit.MmolL => (mgdl / GlucoseConstants.MgdlPerMmol).ToString("F1"),
             _ => ((int)mgdl).ToString(),
         };
     }
@@ -28,12 +25,12 @@ public static class GlucoseFormatHelper
     /// <summary>
     /// Converts a glucose value from mg/dL to mmol/L.
     /// </summary>
-    public static double ToMmol(double mgdl) => mgdl / MgdlToMmolFactor;
+    public static double ToMmol(double mgdl) => mgdl / GlucoseConstants.MgdlPerMmol;
 
     /// <summary>
     /// Converts a glucose value from mmol/L to mg/dL.
     /// </summary>
-    public static double ToMgdl(double mmol) => mmol * MgdlToMmolFactor;
+    public static double ToMgdl(double mmol) => mmol * GlucoseConstants.MgdlPerMmol;
 
     /// <summary>
     /// Formats a glucose delta value with sign prefix for the given unit.
@@ -45,7 +42,8 @@ public static class GlucoseFormatHelper
     {
         if (delta is null)
             return "";
-        var value = unit == GlucoseUnit.MmolL ? delta.Value / MgdlToMmolFactor : delta.Value;
+        var value =
+            unit == GlucoseUnit.MmolL ? delta.Value / GlucoseConstants.MgdlPerMmol : delta.Value;
         var formatted =
             unit == GlucoseUnit.MmolL ? value.ToString("+0.0;-0.0;0.0") : value.ToString("+0;-0;0");
         return formatted;

--- a/tests/Unit/Nocturne.API.Tests/Services/Treatments/BolusWizardServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Treatments/BolusWizardServiceTests.cs
@@ -1,5 +1,6 @@
 using Moq;
 using Nocturne.API.Services.Treatments;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Xunit;
@@ -347,7 +348,10 @@ public class BolusWizardServiceTests
         // Create concrete Entry object instead of mocking
         var entry = new Entry
         {
-            Mgdl = (int)Math.Round(currentBG * (profileData.Units == "mmol" ? 18.01559 : 1)),
+            Mgdl = (int)
+                Math.Round(
+                    currentBG * (profileData.Units == "mmol" ? GlucoseConstants.MgdlPerMmol : 1)
+                ),
             Mills = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
 

--- a/tests/Unit/Nocturne.Core.Constants.Tests/GlucoseConstantsTests.cs
+++ b/tests/Unit/Nocturne.Core.Constants.Tests/GlucoseConstantsTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Nocturne.Core.Constants.Tests;
+
+public class GlucoseConstantsTests
+{
+    [Theory]
+    [InlineData(40)]
+    [InlineData(70)]
+    [InlineData(100)]
+    [InlineData(180)]
+    [InlineData(400)]
+    public void ConvertingToMmolAndBack_ReturnsTheOriginalMgdl(double mgdl)
+    {
+        var mmol = mgdl / GlucoseConstants.MgdlPerMmol;
+        var roundTripped = mmol * GlucoseConstants.MgdlPerMmol;
+
+        roundTripped.Should().BeApproximately(mgdl, 1e-9);
+    }
+
+    [Theory]
+    [InlineData(5.5, 99)]
+    [InlineData(4.0, 72)]
+    [InlineData(10.0, 180)]
+    public void MmolConvertsToTheExpectedRoundedMgdl(double mmol, double expectedMgdl)
+    {
+        Math.Round(mmol * GlucoseConstants.MgdlPerMmol).Should().Be(expectedMgdl);
+    }
+
+    [Theory]
+    [InlineData(72, 4.0)]
+    [InlineData(180, 10.0)]
+    [InlineData(400, 22.2)]
+    public void MgdlConvertsToTheExpectedRoundedMmol(double mgdl, double expectedMmol)
+    {
+        Math.Round(mgdl / GlucoseConstants.MgdlPerMmol, 1).Should().Be(expectedMmol);
+    }
+
+    /// <summary>
+    /// 100 mg/dL sits either side of the 5.55 mmol/L rounding boundary depending on which of the two
+    /// factors historically present in the tree is used, so it pins which one survived.
+    /// </summary>
+    [Fact]
+    public void OneHundredMgdlDisplaysAsFivePointFiveMmol()
+    {
+        Math.Round(100 / GlucoseConstants.MgdlPerMmol, 1).Should().Be(5.5);
+        Math.Round(100 / 18.01559, 1).Should().Be(5.6);
+    }
+}

--- a/tests/Unit/Nocturne.Core.Constants.Tests/GlucoseConversionFactorMirrorTests.cs
+++ b/tests/Unit/Nocturne.Core.Constants.Tests/GlucoseConversionFactorMirrorTests.cs
@@ -1,0 +1,46 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace Nocturne.Core.Constants.Tests;
+
+/// <summary>
+/// The frontend converts glucose for display with its own copy of the factor, so a backend-only
+/// change leaves the two disagreeing by about 1 part in 7,000 — enough to move a rounded mmol
+/// reading. This reads the TypeScript source and fails on the difference.
+/// </summary>
+public class GlucoseConversionFactorMirrorTests
+{
+    private static readonly Regex Declaration =
+        new(@"export const MGDL_PER_MMOL = ([0-9.]+);", RegexOptions.Compiled);
+
+    [Fact]
+    public void TypeScriptUsesTheSameFactorAsTheBackend()
+    {
+        var path = Path.Combine(RepositoryRoot(), "src", "Web", "packages", "ui", "src", "lib",
+            "glucose.ts");
+        var match = Declaration.Match(File.ReadAllText(path));
+
+        if (!match.Success)
+            throw new InvalidOperationException($"No MGDL_PER_MMOL declaration in {path}.");
+
+        double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture)
+            .Should().Be(GlucoseConstants.MgdlPerMmol);
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (Directory.Exists(Path.Combine(directory.FullName, "src", "Web")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"No src/Web directory above {AppContext.BaseDirectory}.");
+    }
+}


### PR DESCRIPTION
The mmol/L ↔ mg/dL factor was written as a literal across the tree with two different values —
`18.0182` at 19 sites (all the ingestion mappers and the V4 model properties) and `18.01559` at 4
(statistics, the widget helper, and an unused `TidepoolConstants` member). Both are defensible
roundings, so a reading converted on one path and displayed on another could disagree in the last
digit and nobody could tell which was intended.

There is now one `GlucoseConstants.MgdlPerMmol` in `Nocturne.Core.Constants`, used by all 23 C# sites
and both TypeScript display paths.

## Which value, and why

**A correction to the issue's premise:** 180.156 g/mol ÷ 10 is 18.0156, so `18.01559` is the
IUPAC-accurate value and `18.0182` is the *ecosystem* convention (AAPS, xDrip), about 1 part in 6,900
above the true molar mass. The issue had these the wrong way round.

`18.0182` still wins, for the blast-radius reason — which survives the correction intact:

- It holds the 19 majority sites, including every ingestion mapper (Tidepool, Glooko, Eversense) and
  the V4 model computed properties. Changing those would move stored and derived readings.
- `18.01559` was only ever on read-side paths, so moving those moves display and statistics rounding
  only, nothing persisted.
- The tree already disagreed with itself: `SensorGlucose.Mmol` (18.0182) and
  `StatisticsService.MgdlToMMOL` (18.01559) gave different answers for 100 mg/dL. Unifying on
  18.0182 makes the display agree with the model rather than the other way round.
- It is what the DIY ecosystem we interoperate with uses.

## This changes a displayed value — please sanity-check

100 mg/dL sits almost exactly on the rounding boundary between the two factors:

- `100 / 18.0182 = 5.5499…` → **5.5**
- `100 / 18.01559 = 5.5507…` → **5.6**

So the statistics endpoints, the widget/tray, and now the web app display **5.5** where the read-side
paths previously showed 5.6. Also affected: 300 → 16.6 (was 16.7) and 500 → 27.7 (was 27.8); other
integers below 500 are unchanged. Nothing persisted changes. This brings every surface into line with
what `SensorGlucose.Mmol` has been producing all along, but it does mean the display no longer matches
the folk value "100 mg/dL = 5.6 mmol/L".

## TypeScript included

`glucose.ts` and `ScheduleView.svelte` both held their own `18.01559`. Left split, the web app would
have shown 5.6 while the tray and widget showed 5.5 — a worse state than before, since those surfaces
previously agreed. `glucose.ts` is already documented as the single source of truth for glucose
presentation, so the constant is exported from there and `ScheduleView` imports it rather than
redeclaring it. Renamed to `MGDL_PER_MMOL`: the old `MGDL_TO_MMOL` named the reciprocal of what it
held, the same trap the issue describes for `TidepoolConstants.MmolToMgdlFactor`.

`GlucoseConversionFactorMirrorTests` reads `glucose.ts` and fails if the two sides diverge — a
hand-copied mirror cannot detect its own drift, which is how the split arose. Proven to fail both on a
value change and on the file going missing.

## Traps removed

- `TidepoolConstants.MmolToMgdlFactor` (18.01559) was declared and **never referenced**, while its own
  mapper hardcoded 18.0182 two files away. Deleted, so it cannot be "tidied up" into use later — a
  change that would look like pure cleanup and silently shift every Tidepool mmol reading.
- `GlucoseFormatHelper.MgdlToMmolFactor` and Eversense's private const of the same name (bound to the
  *other* value) are both gone.
- A dead `GlucoseRangeHelper.MgdlToMmolFactor` re-export was removed.

## Tests

No existing expectation needed loosening. One fixture that *synthesised* input from `18.01559` now
uses the shared constant (numerically identical for its cases). New tests cover round-trip stability
and clinical values, plus a canary pinning which factor survived. Mutation-proved. 634 C# tests green,
solution builds clean.

The bot's inline `18.0182` is untouched — it already agrees numerically, and deduplicating it needs a
workspace dependency on `@nocturne/ui`. Remaining Rust/C++ copies stay in #782.

Fixes #776
