### PR TITLE
fix(auth): persist and enforce direct grant expiry

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/DirectGrantController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/DirectGrantController.cs
@@ -68,7 +68,7 @@ public class DirectGrantController : ControllerBase
         }
 
         var result = await _directGrantService.CreateAsync(
-            _dbContext, auth.SubjectId.Value, request.Label, request.Scopes,
+            _dbContext, auth.SubjectId.Value, request.Label, request.Scopes, request.ExpiresAt,
             HttpContext.Connection.RemoteIpAddress?.ToString(),
             Request.Headers.UserAgent.ToString(),
             ct: HttpContext.RequestAborted);
@@ -159,6 +159,7 @@ public class CreateDirectGrantResponse
     public string Label { get; set; } = string.Empty;
     public List<string> Scopes { get; set; } = new();
     public DateTime CreatedAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }
 }
 
 /// <summary>
@@ -171,6 +172,12 @@ public class DirectGrantDto
     public string Label { get; set; } = string.Empty;
     public List<string> Scopes { get; set; } = new();
     public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// When the grant stops authenticating. Null means it never does.
+    /// </summary>
+    public DateTime? ExpiresAt { get; set; }
+
     public DateTime? LastUsedAt { get; set; }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantDirectGrantController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/TenantDirectGrantController.cs
@@ -71,7 +71,7 @@ public class TenantDirectGrantController : ControllerBase
         await using var dbContext = await _dbContextFactory.CreateTenantPinnedContextAsync(tenantId, ct);
 
         var result = await _directGrantService.CreateAsync(
-            dbContext, request.SubjectId, request.Label, request.Scopes,
+            dbContext, request.SubjectId, request.Label, request.Scopes, request.ExpiresAt,
             HttpContext.Connection.RemoteIpAddress?.ToString(),
             Request.Headers.UserAgent.ToString(),
             actor: CallerDescription(),

--- a/src/API/Nocturne.API/Middleware/Handlers/ApiKeyHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/ApiKeyHandler.cs
@@ -21,13 +21,16 @@ public class ApiKeyHandler : IAuthHandler
     public string Name => "ApiKeyHandler";
 
     private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<ApiKeyHandler> _logger;
 
     public ApiKeyHandler(
         IDbContextFactory<NocturneDbContext> dbContextFactory,
+        TimeProvider timeProvider,
         ILogger<ApiKeyHandler> logger)
     {
         _dbContextFactory = dbContextFactory;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
@@ -79,30 +82,14 @@ public class ApiKeyHandler : IAuthHandler
         await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
         dbContext.TenantId = tenantCtx.TenantId;
 
-        OAuthGrantEntity? grant;
+        var activeGrants = DirectGrantTokenHandler.ActiveDirectGrants(
+            dbContext.OAuthGrants.AsNoTracking(),
+            tenantCtx.TenantId,
+            _timeProvider.GetUtcNow().UtcDateTime);
 
-        if (tokenHash != null)
-        {
-            grant = await dbContext.OAuthGrants
-                .AsNoTracking()
-                .IgnoreQueryFilters()
-                .Where(g => g.TokenHash == tokenHash
-                         && g.TenantId == tenantCtx.TenantId
-                         && g.GrantType == OAuthGrantTypes.Direct
-                         && g.RevokedAt == null)
-                .FirstOrDefaultAsync();
-        }
-        else
-        {
-            grant = await dbContext.OAuthGrants
-                .AsNoTracking()
-                .IgnoreQueryFilters()
-                .Where(g => g.LegacySecretHash == legacySecretHash
-                         && g.TenantId == tenantCtx.TenantId
-                         && g.GrantType == OAuthGrantTypes.Direct
-                         && g.RevokedAt == null)
-                .FirstOrDefaultAsync();
-        }
+        var grant = tokenHash != null
+            ? await activeGrants.FirstOrDefaultAsync(g => g.TokenHash == tokenHash)
+            : await activeGrants.FirstOrDefaultAsync(g => g.LegacySecretHash == legacySecretHash);
 
         if (grant == null)
         {

--- a/src/API/Nocturne.API/Middleware/Handlers/DirectGrantTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/DirectGrantTokenHandler.cs
@@ -33,6 +33,7 @@ public class DirectGrantTokenHandler : IAuthHandler
     public string Name => "DirectGrantTokenHandler";
 
     private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<DirectGrantTokenHandler> _logger;
 
     /// <summary>
@@ -40,9 +41,11 @@ public class DirectGrantTokenHandler : IAuthHandler
     /// </summary>
     public DirectGrantTokenHandler(
         IDbContextFactory<NocturneDbContext> dbContextFactory,
+        TimeProvider timeProvider,
         ILogger<DirectGrantTokenHandler> logger)
     {
         _dbContextFactory = dbContextFactory;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
@@ -68,7 +71,8 @@ public class DirectGrantTokenHandler : IAuthHandler
             return AuthResult.Skip();
         }
 
-        var grant = await FindActiveGrantAsync(_dbContextFactory, token, tenantCtx.TenantId);
+        var grant = await FindActiveGrantAsync(
+            _dbContextFactory, token, tenantCtx.TenantId, _timeProvider.GetUtcNow().UtcDateTime);
 
         if (grant == null)
         {
@@ -109,11 +113,13 @@ public class DirectGrantTokenHandler : IAuthHandler
     /// <param name="dbContextFactory">Factory for the tenant-pinned context.</param>
     /// <param name="token">The presented token, <c>noc_</c>-prefixed.</param>
     /// <param name="tenantId">The tenant the grant must belong to.</param>
+    /// <param name="now">The instant the grant must be active at.</param>
     /// <param name="ct">Cancellation token.</param>
     internal static async Task<OAuthGrantEntity?> FindActiveGrantAsync(
         IDbContextFactory<NocturneDbContext> dbContextFactory,
         string token,
         Guid tenantId,
+        DateTime now,
         CancellationToken ct = default)
     {
         var tokenHash = ComputeSha256Hex(token);
@@ -121,14 +127,28 @@ public class DirectGrantTokenHandler : IAuthHandler
         await using var dbContext = await dbContextFactory.CreateDbContextAsync(ct);
         dbContext.TenantId = tenantId;
 
-        return await dbContext.OAuthGrants
-            .AsNoTracking()
+        return await ActiveDirectGrants(dbContext.OAuthGrants.AsNoTracking(), tenantId, now)
+            .FirstOrDefaultAsync(g => g.TokenHash == tokenHash, ct);
+    }
+
+    /// <summary>
+    /// Narrows <paramref name="grants"/> to the direct grants on <paramref name="tenantId"/> that
+    /// authenticate at <paramref name="now"/>: not revoked, and either open-ended or short of their
+    /// <c>ExpiresAt</c>. The expiry instant itself does not authenticate, matching
+    /// <see cref="Services.Auth.GuestLinkService"/>.
+    /// </summary>
+    /// <remarks>
+    /// Query filters are ignored here for the reason given on <see cref="FindActiveGrantAsync"/>.
+    /// </remarks>
+    internal static IQueryable<OAuthGrantEntity> ActiveDirectGrants(
+        IQueryable<OAuthGrantEntity> grants, Guid tenantId, DateTime now)
+    {
+        return grants
             .IgnoreQueryFilters()
-            .Where(g => g.TokenHash == tokenHash
-                     && g.TenantId == tenantId
+            .Where(g => g.TenantId == tenantId
                      && g.GrantType == OAuthGrantTypes.Direct
-                     && g.RevokedAt == null)
-            .FirstOrDefaultAsync(ct);
+                     && g.RevokedAt == null
+                     && (g.ExpiresAt == null || g.ExpiresAt > now));
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Auth/DirectGrantService.cs
+++ b/src/API/Nocturne.API/Services/Auth/DirectGrantService.cs
@@ -32,6 +32,10 @@ public interface IDirectGrantService
     /// <param name="subjectId">The subject the grant is issued to.</param>
     /// <param name="label">The human-readable label.</param>
     /// <param name="scopes">The requested scopes; normalized before storage.</param>
+    /// <param name="expiresAt">
+    /// When the grant stops authenticating; null issues an open-ended grant. Rejected when it is
+    /// not in the future — see <see cref="Validators.Auth.CreateDirectGrantRequestValidator"/>.
+    /// </param>
     /// <param name="ipAddress">The caller's IP address, for the audit trail.</param>
     /// <param name="userAgent">The caller's user agent, for the audit trail.</param>
     /// <param name="actor">
@@ -46,6 +50,7 @@ public interface IDirectGrantService
         Guid subjectId,
         string label,
         IReadOnlyCollection<string>? scopes,
+        DateTime? expiresAt,
         string? ipAddress,
         string? userAgent,
         string? actor = null,
@@ -119,6 +124,7 @@ public class DirectGrantService : IDirectGrantService
         Guid subjectId,
         string label,
         IReadOnlyCollection<string>? scopes,
+        DateTime? expiresAt,
         string? ipAddress,
         string? userAgent,
         string? actor = null,
@@ -157,6 +163,7 @@ public class DirectGrantService : IDirectGrantService
             // api-secret protocol (Loop, AAPS, Trio, iAPS) — which pre-hash the value with SHA-1
             // before sending — authenticate with this same token via ApiKeyHandler's legacy path.
             LegacySecretHash = HashUtils.Sha1Hex(plaintextToken),
+            ExpiresAt = expiresAt,
             CreatedAt = DateTime.UtcNow,
         };
 
@@ -180,6 +187,7 @@ public class DirectGrantService : IDirectGrantService
             Label = entity.Label!,
             Scopes = normalizedScopes,
             CreatedAt = entity.CreatedAt,
+            ExpiresAt = entity.ExpiresAt,
         });
     }
 
@@ -200,6 +208,7 @@ public class DirectGrantService : IDirectGrantService
                 Label = g.Label ?? string.Empty,
                 Scopes = g.Scopes,
                 CreatedAt = g.CreatedAt,
+                ExpiresAt = g.ExpiresAt,
                 LastUsedAt = g.LastUsedAt,
                 IsLegacy = g.IsMigrated,
             })

--- a/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
+++ b/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
@@ -62,6 +62,7 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
     private readonly IAuthorizationService _authorizationService;
     private readonly ITenantMemberService _memberService;
     private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
+    private readonly TimeProvider _timeProvider;
     private readonly IConfiguration _configuration;
     private readonly ILogger<HubTokenAuthorizer> _logger;
 
@@ -72,6 +73,7 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
         IAuthorizationService authorizationService,
         ITenantMemberService memberService,
         IDbContextFactory<NocturneDbContext> dbContextFactory,
+        TimeProvider timeProvider,
         IConfiguration configuration,
         ILogger<HubTokenAuthorizer> logger)
     {
@@ -81,6 +83,7 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
         _authorizationService = authorizationService;
         _memberService = memberService;
         _dbContextFactory = dbContextFactory;
+        _timeProvider = timeProvider;
         _configuration = configuration;
         _logger = logger;
     }
@@ -239,7 +242,7 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
         string token, Guid connectionTenantId, string requiredScope)
     {
         var grant = await DirectGrantTokenHandler.FindActiveGrantAsync(
-            _dbContextFactory, token, connectionTenantId);
+            _dbContextFactory, token, connectionTenantId, _timeProvider.GetUtcNow().UtcDateTime);
 
         if (grant is null)
         {

--- a/src/API/Nocturne.API/Validators/Admin/AdminCreateDirectGrantRequestValidator.cs
+++ b/src/API/Nocturne.API/Validators/Admin/AdminCreateDirectGrantRequestValidator.cs
@@ -11,11 +11,8 @@ namespace Nocturne.API.Validators.Admin;
 /// <remarks>
 /// <list type="bullet">
 /// <item><description>SubjectId is required.</description></item>
-/// <item><description>Label and scope rules are shared with the self-service endpoint via
-/// <see cref="CreateDirectGrantRequestValidator"/>.</description></item>
-/// <item><description>ExpiresAt must not be set: direct grants do not expire, and the
-/// self-service endpoint's silent-ignore of the field must not carry over to a surface whose
-/// callers are SDKs that would trust a requested expiry.</description></item>
+/// <item><description>Label, scope, and expiry rules are shared with the self-service endpoint
+/// via <see cref="CreateDirectGrantRequestValidator"/>.</description></item>
 /// </list>
 /// </remarks>
 /// <seealso cref="AdminCreateDirectGrantRequest"/>
@@ -30,7 +27,5 @@ public class AdminCreateDirectGrantRequestValidator : AbstractValidator<AdminCre
     {
         Include(new CreateDirectGrantRequestValidator());
         RuleFor(x => x.SubjectId).NotEmpty();
-        RuleFor(x => x.ExpiresAt).Null()
-            .WithMessage("Direct grants do not expire; ExpiresAt must not be set");
     }
 }

--- a/src/API/Nocturne.API/Validators/Auth/CreateDirectGrantRequestValidator.cs
+++ b/src/API/Nocturne.API/Validators/Auth/CreateDirectGrantRequestValidator.cs
@@ -12,6 +12,8 @@ namespace Nocturne.API.Validators.Auth;
 /// <item><description>Label is required and capped at 200 characters.</description></item>
 /// <item><description>At least one scope is required.</description></item>
 /// <item><description>Each scope must be a value recognized by <see cref="OAuthScopes.IsValid"/>.</description></item>
+/// <item><description>ExpiresAt is optional, and when set must be in the future: a grant issued
+/// at or past its expiry authenticates nothing.</description></item>
 /// </list>
 /// </remarks>
 /// <seealso cref="CreateDirectGrantRequest"/>
@@ -28,5 +30,8 @@ public class CreateDirectGrantRequestValidator : AbstractValidator<CreateDirectG
         RuleFor(x => x.Scopes).NotEmpty().WithMessage("At least one scope is required");
         RuleForEach(x => x.Scopes).Must(OAuthScopes.IsValid)
             .WithMessage(scope => $"Invalid scope: {scope}");
+        RuleFor(x => x.ExpiresAt).Must(expiresAt => expiresAt > DateTime.UtcNow)
+            .When(x => x.ExpiresAt.HasValue)
+            .WithMessage("ExpiresAt must be in the future");
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthGrantEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/OAuthGrantEntity.cs
@@ -99,7 +99,8 @@ public class OAuthGrantEntity : ITenantScoped, IAuditable, IEntityCreated
     public DateTime? DismissedAt { get; set; }
 
     /// <summary>
-    /// When this grant expires. Only used for guest grants (creation + 48h).
+    /// When this grant expires; null means it never does. Guest grants are always given one
+    /// (creation + 48h); direct grants carry one only when the caller asked for it.
     /// </summary>
     [Column("expires_at")]
     public DateTime? ExpiresAt { get; set; }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/DirectGrantControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/DirectGrantControllerTests.cs
@@ -125,6 +125,51 @@ public class DirectGrantControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task Create_RequestedExpiry_IsPersistedAndReturned()
+    {
+        var expiresAt = new DateTime(2027, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        var request = new CreateDirectGrantRequest
+        {
+            Label = "Short-lived Token",
+            Scopes = ["glucose.read"],
+            ExpiresAt = expiresAt,
+        };
+
+        var result = await _controller.Create(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<CreateDirectGrantResponse>(okResult.Value);
+        Assert.Equal(expiresAt, response.ExpiresAt);
+
+        var grant = await _dbContext.OAuthGrants.FirstOrDefaultAsync(g => g.Id == response.Id);
+        Assert.Equal(expiresAt, grant!.ExpiresAt);
+
+        var listResult = await _controller.List();
+        var listed = Assert.IsType<List<DirectGrantDto>>(
+            Assert.IsType<OkObjectResult>(listResult.Result).Value);
+        Assert.Equal(expiresAt, Assert.Single(listed, g => g.Id == response.Id).ExpiresAt);
+    }
+
+    [Fact]
+    public async Task Create_NoExpiry_StoresOpenEndedGrant()
+    {
+        var request = new CreateDirectGrantRequest
+        {
+            Label = "Open-ended Token",
+            Scopes = ["glucose.read"],
+        };
+
+        var result = await _controller.Create(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<CreateDirectGrantResponse>(okResult.Value);
+        Assert.Null(response.ExpiresAt);
+
+        var grant = await _dbContext.OAuthGrants.FirstOrDefaultAsync(g => g.Id == response.Id);
+        Assert.Null(grant!.ExpiresAt);
+    }
+
+    [Fact]
     public async Task Create_EmptyLabel_ReturnsBadRequest()
     {
         var request = new CreateDirectGrantRequest

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/ApiKeyHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/ApiKeyHandlerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Microsoft.Data.Sqlite;
 using Moq;
 using Nocturne.API.Middleware.Handlers;
@@ -26,6 +27,9 @@ public class ApiKeyHandlerTests : IDisposable
 
     private readonly Guid _testTenantId = Guid.CreateVersion7();
     private readonly Guid _subjectId = Guid.CreateVersion7();
+
+    private static readonly DateTime Now = new(2026, 8, 17, 12, 0, 0, DateTimeKind.Utc);
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(Now, TimeSpan.Zero));
 
     public ApiKeyHandlerTests()
     {
@@ -63,7 +67,7 @@ public class ApiKeyHandlerTests : IDisposable
             .ReturnsAsync(() => new NocturneDbContext(_dbOptions) { TenantId = _testTenantId });
 
         var logger = new Mock<ILogger<ApiKeyHandler>>();
-        _handler = new ApiKeyHandler(_dbContextFactory.Object, logger.Object);
+        _handler = new ApiKeyHandler(_dbContextFactory.Object, _clock, logger.Object);
     }
 
     public void Dispose()
@@ -373,6 +377,109 @@ public class ApiKeyHandlerTests : IDisposable
         Assert.NotNull(result.AuthContext);
         Assert.Equal(AuthType.ApiKey, result.AuthContext!.AuthType);
         Assert.Equal(_subjectId, result.AuthContext.SubjectId);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_GrantExpiringOneTickFromNow_ReturnsSuccess()
+    {
+        var token = await SeedTokenGrantAsync("noc_expiringkey001", Now.AddTicks(1));
+
+        var result = await _handler.AuthenticateAsync(ApiSecretContext(token));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_GrantExpiringExactlyNow_ReturnsFailure()
+    {
+        var token = await SeedTokenGrantAsync("noc_expiringkey002", Now);
+
+        var result = await _handler.AuthenticateAsync(ApiSecretContext(token));
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.ShouldSkip);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_GrantExpiredOneTickAgo_ReturnsFailure()
+    {
+        var token = await SeedTokenGrantAsync("noc_expiringkey003", Now.AddTicks(-1));
+
+        var result = await _handler.AuthenticateAsync(ApiSecretContext(token));
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.ShouldSkip);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_LegacySecretGrantExpiredOneTickAgo_ReturnsFailure()
+    {
+        var sha1Hash = HashUtils.Sha1Hex("expiredlegacysecret");
+        await SeedGrantAsync(tokenHash: null, legacySecretHash: sha1Hash, expiresAt: Now.AddTicks(-1));
+
+        var result = await _handler.AuthenticateAsync(ApiSecretContext(sha1Hash));
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.ShouldSkip);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_LegacySecretGrantExpiringOneTickFromNow_ReturnsSuccess()
+    {
+        var sha1Hash = HashUtils.Sha1Hex("livelegacysecret");
+        await SeedGrantAsync(tokenHash: null, legacySecretHash: sha1Hash, expiresAt: Now.AddTicks(1));
+
+        var result = await _handler.AuthenticateAsync(ApiSecretContext(sha1Hash));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_GrantWithNoExpiry_ReturnsSuccessYearsAfterCreation()
+    {
+        var token = await SeedTokenGrantAsync(
+            "noc_openendedkey001", expiresAt: null, createdAt: Now.AddYears(-5));
+
+        var result = await _handler.AuthenticateAsync(ApiSecretContext(token));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+    }
+
+    private async Task<string> SeedTokenGrantAsync(
+        string token, DateTime? expiresAt, DateTime? createdAt = null)
+    {
+        await SeedGrantAsync(
+            DirectGrantTokenHandler.ComputeSha256Hex(token), null, expiresAt, createdAt);
+        return token;
+    }
+
+    private async Task SeedGrantAsync(
+        string? tokenHash, string? legacySecretHash, DateTime? expiresAt, DateTime? createdAt = null)
+    {
+        await using var ctx = new NocturneDbContext(_dbOptions) { TenantId = _testTenantId };
+        ctx.OAuthGrants.Add(new OAuthGrantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = _subjectId,
+            TenantId = _testTenantId,
+            GrantType = OAuthGrantTypes.Direct,
+            TokenHash = tokenHash,
+            LegacySecretHash = legacySecretHash,
+            Scopes = ["glucose.read"],
+            CreatedAt = createdAt ?? Now,
+            ExpiresAt = expiresAt,
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private DefaultHttpContext ApiSecretContext(string apiSecret)
+    {
+        var context = CreateHttpContext();
+        context.Request.Headers["api-secret"] = apiSecret;
+        return context;
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/DirectGrantTokenHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/DirectGrantTokenHandlerTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Time.Testing;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Data.Sqlite;
@@ -22,6 +23,9 @@ public class DirectGrantTokenHandlerTests : IDisposable
 
     private readonly Guid _testTenantId = Guid.CreateVersion7();
     private readonly Guid _subjectId = Guid.CreateVersion7();
+
+    private static readonly DateTime Now = new(2026, 8, 17, 12, 0, 0, DateTimeKind.Utc);
+    private readonly FakeTimeProvider _clock = new(new DateTimeOffset(Now, TimeSpan.Zero));
 
     public DirectGrantTokenHandlerTests()
     {
@@ -60,7 +64,7 @@ public class DirectGrantTokenHandlerTests : IDisposable
             .ReturnsAsync(() => new NocturneDbContext(_dbOptions) { TenantId = _testTenantId });
 
         var logger = new Mock<ILogger<DirectGrantTokenHandler>>();
-        _handler = new DirectGrantTokenHandler(_dbContextFactory.Object, logger.Object);
+        _handler = new DirectGrantTokenHandler(_dbContextFactory.Object, _clock, logger.Object);
     }
 
     public void Dispose()
@@ -257,6 +261,75 @@ public class DirectGrantTokenHandlerTests : IDisposable
 
         Assert.True(result.ShouldSkip);
         Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_GrantExpiringOneTickFromNow_ReturnsSuccess()
+    {
+        var token = await SeedGrantAsync("noc_expiringtoken001", Now.AddTicks(1));
+
+        var result = await _handler.AuthenticateAsync(BearerContext(token));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_GrantExpiringExactlyNow_ReturnsSkip()
+    {
+        var token = await SeedGrantAsync("noc_expiringtoken002", Now);
+
+        var result = await _handler.AuthenticateAsync(BearerContext(token));
+
+        Assert.True(result.ShouldSkip);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_GrantExpiredOneTickAgo_ReturnsSkip()
+    {
+        var token = await SeedGrantAsync("noc_expiringtoken003", Now.AddTicks(-1));
+
+        var result = await _handler.AuthenticateAsync(BearerContext(token));
+
+        Assert.True(result.ShouldSkip);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_GrantWithNoExpiry_ReturnsSuccessYearsAfterCreation()
+    {
+        var token = await SeedGrantAsync("noc_openendedtoken01", expiresAt: null, createdAt: Now.AddYears(-5));
+
+        var result = await _handler.AuthenticateAsync(BearerContext(token));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(_subjectId, result.AuthContext!.SubjectId);
+    }
+
+    private async Task<string> SeedGrantAsync(string token, DateTime? expiresAt, DateTime? createdAt = null)
+    {
+        await using var ctx = new NocturneDbContext(_dbOptions) { TenantId = _testTenantId };
+        ctx.OAuthGrants.Add(new OAuthGrantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = _subjectId,
+            TenantId = _testTenantId,
+            GrantType = OAuthGrantTypes.Direct,
+            TokenHash = DirectGrantTokenHandler.ComputeSha256Hex(token),
+            Scopes = ["glucose.read"],
+            CreatedAt = createdAt ?? Now,
+            ExpiresAt = expiresAt,
+        });
+        await ctx.SaveChangesAsync();
+        return token;
+    }
+
+    private DefaultHttpContext BearerContext(string token)
+    {
+        var context = CreateHttpContext();
+        context.Request.Headers.Authorization = $"Bearer {token}";
+        return context;
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
@@ -59,6 +59,7 @@ public class HubTokenAuthorizerTests
         _authorizationService.Object,
         _memberService.Object,
         _dbContextFactory,
+        TimeProvider.System,
         configuration ?? new ConfigurationBuilder().Build(),
         NullLogger<HubTokenAuthorizer>.Instance);
 

--- a/tests/Unit/Nocturne.API.Tests/Validators/Admin/AdminCreateDirectGrantRequestValidatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Validators/Admin/AdminCreateDirectGrantRequestValidatorTests.cs
@@ -43,10 +43,19 @@ public class AdminCreateDirectGrantRequestValidatorTests
     }
 
     [Fact]
-    public void Set_expiry_fails()
+    public void Future_expiry_passes()
     {
         var request = ValidRequest();
         request.ExpiresAt = DateTime.UtcNow.AddDays(1);
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Past_expiry_fails_via_shared_rules()
+    {
+        var request = ValidRequest();
+        request.ExpiresAt = DateTime.UtcNow.AddMinutes(-1);
         var result = _validator.TestValidate(request);
         result.ShouldHaveValidationErrorFor(x => x.ExpiresAt);
     }

--- a/tests/Unit/Nocturne.API.Tests/Validators/Auth/CreateDirectGrantRequestValidatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Validators/Auth/CreateDirectGrantRequestValidatorTests.cs
@@ -23,6 +23,33 @@ public class CreateDirectGrantRequestValidatorTests
         result.ShouldNotHaveAnyValidationErrors();
     }
 
+    [Fact]
+    public void Future_expiry_passes()
+    {
+        var request = ValidRequest();
+        request.ExpiresAt = DateTime.UtcNow.AddHours(1);
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Past_expiry_fails()
+    {
+        var request = ValidRequest();
+        request.ExpiresAt = DateTime.UtcNow.AddMinutes(-1);
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.ExpiresAt);
+    }
+
+    [Fact]
+    public void Absent_expiry_passes()
+    {
+        var request = ValidRequest();
+        request.ExpiresAt = null;
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]


### PR DESCRIPTION
`POST /api/auth/direct-grants` accepted an `ExpiresAt` and dropped it, so a caller asking for a
short-lived credential got a permanent one with no way to tell. `OAuthGrantEntity.ExpiresAt` already
existed but nothing wrote it, and neither authentication path read it.

Persisting alone would have been **worse** than the silent ignore, because the expiry would then look
real while still authenticating past it. So all read paths are gated together.

## Three read paths, not two

The issue names two. There is a third: `HubTokenAuthorizer` calls
`DirectGrantTokenHandler.FindActiveGrantAsync` for SignalR hub tokens, so without it an expired grant
could still open a realtime connection. All three now share one `ActiveDirectGrants` predicate rather
than three copies of the filter:

- `DirectGrantTokenHandler` — bearer / `?token=`
- `ApiKeyHandler` — legacy `api-secret`
- `HubTokenAuthorizer` — SignalR

## Semantics

The expiry instant itself does not authenticate (`ExpiresAt > now`), matching `GuestLinkService`, which
uses the same strict comparison. A null `ExpiresAt` still authenticates indefinitely, so existing
grants are unaffected. Creation rejects a non-future `ExpiresAt`, since a grant born expired
authenticates nothing.

Clock reads go through `TimeProvider`, so the boundary is pinned at tick granularity in tests rather
than raced.

## Two-surface inconsistency resolved

`AdminCreateDirectGrantRequestValidator` (added in #730) rejected a non-null `ExpiresAt` outright,
precisely so the silent-ignore did not carry over to a new SDK-facing endpoint. Now that the field
works, that rejection is the thing that would be inconsistent, so it is dropped and both surfaces share
the same rule.

## Tests

Boundary pinned at tick granularity on **both** handlers — one tick before expiry authenticates,
exactly at expiry does not, one tick after does not — plus the legacy-secret path specifically, since
covering only the bearer handler would leave `api-secret` unprotected, which is the bug.

Mutation-proved twice, independently:
- Flipping `>` to `>=` in the shared predicate fails `GrantExpiringExactlyNow` in **both** handler test
  classes (2 failures).
- Dropping the predicate from `ApiKeyHandler` alone fails 3 tests, all in `ApiKeyHandlerTests`, across
  the token *and* legacy-secret paths, while `DirectGrantTokenHandlerTests` stays green — proving the
  handlers are independently gated.

5699/5700 in `Nocturne.API.Tests`; the one failure is an unrelated document-processing memory
benchmark that passes in isolation (load-sensitive).

No schema change: the column already existed.

Fixes #764
