### PR TITLE
refactor(connectors): give the sync-toggle mapping one owner and guard the TS mirror

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
@@ -42,23 +42,6 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
         WriteIndented = false
     };
 
-    private static readonly Dictionary<string, SyncDataType> SyncPropertyToDataType =
-        new(StringComparer.OrdinalIgnoreCase)
-        {
-            ["SyncGlucose"] = SyncDataType.Glucose,
-            ["SyncManualBG"] = SyncDataType.ManualBG,
-            ["SyncBoluses"] = SyncDataType.Boluses,
-            ["SyncCarbIntake"] = SyncDataType.CarbIntake,
-            ["SyncBolusCalculations"] = SyncDataType.BolusCalculations,
-            ["SyncNotes"] = SyncDataType.Notes,
-            ["SyncDeviceEvents"] = SyncDataType.DeviceEvents,
-            ["SyncStateSpans"] = SyncDataType.StateSpans,
-            ["SyncProfiles"] = SyncDataType.Profiles,
-            ["SyncDeviceStatus"] = SyncDataType.DeviceStatus,
-            ["SyncActivity"] = SyncDataType.Activity,
-            ["SyncFood"] = SyncDataType.Food,
-        };
-
     public ConnectorConfigurationService(
         NocturneDbContext context,
         ISecretEncryptionService encryptionService,
@@ -655,11 +638,9 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
                 continue;
 
             // Skip sync toggle properties for data types this connector doesn't support
-            if (SyncPropertyToDataType.TryGetValue(property.Name, out var requiredDataType))
-            {
-                if (!supportedDataTypes.Contains(requiredDataType))
-                    continue;
-            }
+            if (ConnectorSyncToggles.ByPropertyKey.TryGetValue(connectorPropAttr.Key, out var gatedDataType)
+                && !supportedDataTypes.Contains(gatedDataType))
+                continue;
 
             var propName = ToCamelCase(connectorPropAttr.GetKeyName());
 
@@ -760,11 +741,9 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
                 continue;
 
             // Skip sync toggle properties for data types this connector doesn't support
-            if (SyncPropertyToDataType.TryGetValue(property.Name, out var requiredDataType))
-            {
-                if (!supportedDataTypes.Contains(requiredDataType))
-                    continue;
-            }
+            if (ConnectorSyncToggles.ByPropertyKey.TryGetValue(connectorPropAttr.Key, out var gatedDataType)
+                && !supportedDataTypes.Contains(gatedDataType))
+                continue;
 
             object? value = null;
             try

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorSyncToggles.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorSyncToggles.cs
@@ -1,0 +1,38 @@
+using Nocturne.Connectors.Core.Models;
+
+namespace Nocturne.Connectors.Core.Extensions;
+
+/// <summary>
+///     The per-data-type sync toggles, resolved from the two enums that already name them: the
+///     <see cref="ConnectorPropertyKey"/> called <c>Sync{X}</c> is the toggle for the
+///     <see cref="SyncDataType"/> called <c>X</c>. Anything else beginning with <c>Sync</c> —
+///     <see cref="ConnectorPropertyKey.SyncIntervalMinutes"/> — names no data type and is not a
+///     toggle.
+/// </summary>
+public static class ConnectorSyncToggles
+{
+    private const string TogglePrefix = "Sync";
+
+    /// <summary>
+    ///     Every sync toggle property key, mapped to the data type it gates.
+    /// </summary>
+    public static IReadOnlyDictionary<ConnectorPropertyKey, SyncDataType> ByPropertyKey { get; } = Build();
+
+    private static Dictionary<ConnectorPropertyKey, SyncDataType> Build()
+    {
+        var toggles = new Dictionary<ConnectorPropertyKey, SyncDataType>();
+
+        foreach (var key in Enum.GetValues<ConnectorPropertyKey>())
+        {
+            var name = key.ToString();
+            if (!name.StartsWith(TogglePrefix, StringComparison.Ordinal))
+                continue;
+
+            if (Enum.TryParse<SyncDataType>(name[TogglePrefix.Length..], out var dataType)
+                && Enum.IsDefined(dataType))
+                toggles[key] = dataType;
+        }
+
+        return toggles;
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Nocturne.Connectors.Core.Extensions;
@@ -11,6 +12,9 @@ namespace Nocturne.Connectors.Core.Models;
 /// </summary>
 public abstract class BaseConnectorConfiguration : IConnectorConfiguration
 {
+    private static readonly ConcurrentDictionary<Type, Dictionary<SyncDataType, PropertyInfo>>
+        SyncTogglePropertyCache = new();
+
     /// <summary>
     ///     Gets the connector name from the ConnectorRegistration attribute.
     ///     Used for error messages and logging.
@@ -104,26 +108,37 @@ public abstract class BaseConnectorConfiguration : IConnectorConfiguration
     [ConnectorProperty(ConnectorPropertyKey.StaleThresholdMinutes)]
     public int StaleThresholdMinutes { get; set; } = 0;
 
-    public bool IsDataTypeEnabled(SyncDataType type) => type switch
-    {
-        SyncDataType.Glucose => SyncGlucose,
-        SyncDataType.ManualBG => SyncManualBG,
-        SyncDataType.Boluses => SyncBoluses,
-        SyncDataType.CarbIntake => SyncCarbIntake,
-        SyncDataType.BolusCalculations => SyncBolusCalculations,
-        SyncDataType.Notes => SyncNotes,
-        SyncDataType.DeviceEvents => SyncDeviceEvents,
-        SyncDataType.StateSpans => SyncStateSpans,
-        SyncDataType.TempBasals => SyncTempBasals,
-        SyncDataType.Profiles => SyncProfiles,
-        SyncDataType.DeviceStatus => SyncDeviceStatus,
-        SyncDataType.Activity => SyncActivity,
-        SyncDataType.Food => SyncFood,
-        _ => true
-    };
+    /// <summary>
+    ///     Whether this configuration has <paramref name="type"/> switched on. A data type with no
+    ///     sync toggle property — Calibrations, BasalInjections and BGChecks — has nothing to switch
+    ///     it off, so it syncs whenever the connector declares it supported.
+    /// </summary>
+    public bool IsDataTypeEnabled(SyncDataType type)
+        => !SyncToggleProperties(GetType()).TryGetValue(type, out var toggle)
+           || (bool)toggle.GetValue(this)!;
 
     public List<SyncDataType> GetEnabledDataTypes(List<SyncDataType> supportedTypes)
         => supportedTypes.Where(IsDataTypeEnabled).ToList();
+
+    /// <summary>
+    ///     The bool properties carrying a sync toggle key on a concrete configuration type, indexed
+    ///     by the data type each one gates.
+    /// </summary>
+    private static Dictionary<SyncDataType, PropertyInfo> SyncToggleProperties(Type configurationType)
+        => SyncTogglePropertyCache.GetOrAdd(configurationType, static type =>
+        {
+            var toggles = new Dictionary<SyncDataType, PropertyInfo>();
+
+            foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                var key = property.GetCustomAttribute<ConnectorPropertyAttribute>()?.Key;
+
+                if (key is not null && ConnectorSyncToggles.ByPropertyKey.TryGetValue(key.Value, out var dataType))
+                    toggles[dataType] = property;
+            }
+
+            return toggles;
+        });
 
     public virtual void Validate()
     {

--- a/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
+++ b/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
@@ -3,57 +3,6 @@
  * Maps backend ConnectorPropertyKey enum values to localized labels, descriptions, and categories.
  */
 
-// Local type definition for connector property keys
-export enum ConnectorPropertyKey {
-  TimezoneOffset = "TimezoneOffset",
-  Enabled = "Enabled",
-  MaxRetryAttempts = "MaxRetryAttempts",
-  BatchSize = "BatchSize",
-  SyncIntervalMinutes = "SyncIntervalMinutes",
-  SyncGlucose = "SyncGlucose",
-  SyncManualBG = "SyncManualBG",
-  SyncBoluses = "SyncBoluses",
-  SyncCarbIntake = "SyncCarbIntake",
-  SyncBolusCalculations = "SyncBolusCalculations",
-  SyncNotes = "SyncNotes",
-  SyncDeviceEvents = "SyncDeviceEvents",
-  SyncStateSpans = "SyncStateSpans",
-  SyncProfiles = "SyncProfiles",
-  SyncDeviceStatus = "SyncDeviceStatus",
-  SyncActivity = "SyncActivity",
-  SyncFood = "SyncFood",
-  Username = "Username",
-  Password = "Password",
-  Email = "Email",
-  Server = "Server",
-  Region = "Region",
-  PatientId = "PatientId",
-  UserId = "UserId",
-  Url = "Url",
-  ApiSecret = "ApiSecret",
-  MaxCount = "MaxCount",
-  UseV3Api = "UseV3Api",
-  V3IncludeCgmBackfill = "V3IncludeCgmBackfill",
-  ServiceUrl = "ServiceUrl",
-  EnableMealCarbConsolidation = "EnableMealCarbConsolidation",
-  EnableTempBasalConsolidation = "EnableTempBasalConsolidation",
-  TempBasalConsolidationWindowMinutes = "TempBasalConsolidationWindowMinutes",
-  AppPlatform = "AppPlatform",
-  AppVersion = "AppVersion",
-  LookbackDays = "LookbackDays",
-  AccessToken = "AccessToken",
-  WebhookEnabled = "WebhookEnabled",
-  WebhookSecret = "WebhookSecret",
-  ActiveThresholdMinutes = "ActiveThresholdMinutes",
-  StaleThresholdMinutes = "StaleThresholdMinutes",
-  WriteBackEnabled = "WriteBackEnabled",
-  WriteBackBatchSize = "WriteBackBatchSize",
-  GlucoseProcessing = "GlucoseProcessing",
-}
-
-/** String key names derived from the generated enum */
-type ConnectorPropertyKeyName = keyof typeof ConnectorPropertyKey;
-
 export type PropertyCategory = 'General' | 'Credentials' | 'Sync' | 'Advanced';
 
 export type PropertyMeta = {
@@ -62,7 +11,11 @@ export type PropertyMeta = {
   category: PropertyCategory;
 };
 
-export const connectorPropertyMeta: Record<ConnectorPropertyKeyName, PropertyMeta> = {
+/**
+ * One entry per backend ConnectorPropertyKey; ConnectorPropertyMetaMirrorTests reads this file and
+ * that enum and fails if the two sets differ.
+ */
+export const connectorPropertyMeta = {
   // Base configuration
   TimezoneOffset: {
     label: 'Timezone Offset',
@@ -131,6 +84,11 @@ export const connectorPropertyMeta: Record<ConnectorPropertyKeyName, PropertyMet
     description: 'Sync device state periods like suspend, resume, and mode changes',
     category: 'Sync',
   },
+  SyncTempBasals: {
+    label: 'Sync Temp Basals',
+    description: 'Sync temporary basal rate adjustments',
+    category: 'Sync',
+  },
   SyncProfiles: {
     label: 'Sync Profiles',
     description: 'Sync basal rate profiles and settings',
@@ -190,6 +148,16 @@ export const connectorPropertyMeta: Record<ConnectorPropertyKeyName, PropertyMet
   UserId: {
     label: 'User ID',
     description: 'User identifier for the account',
+    category: 'Credentials',
+  },
+  PatientUsername: {
+    label: 'Patient Username',
+    description: 'Username of the patient to follow when the account follows more than one',
+    category: 'Credentials',
+  },
+  RefreshToken: {
+    label: 'Refresh Token',
+    description: 'Long-lived token used in place of the password once issued',
     category: 'Credentials',
   },
 
@@ -260,6 +228,40 @@ export const connectorPropertyMeta: Record<ConnectorPropertyKeyName, PropertyMet
     description: 'Number of days of historical data to retrieve',
     category: 'Sync',
   },
+  LastFullWalkAt: {
+    label: 'Last Full Walk',
+    description: 'When the diary was last read back to its first entry',
+    category: 'Advanced',
+  },
+
+  // CareLink-specific
+  CountryCode: {
+    label: 'Country Code',
+    description: 'Two-letter country code of the CareLink account',
+    category: 'General',
+  },
+  LanguageCode: {
+    label: 'Language Code',
+    description: 'Two-letter language code of the CareLink account',
+    category: 'General',
+  },
+
+  // Tandem-specific
+  PumpSerialNumber: {
+    label: 'Pump Serial Number',
+    description: 'Serial number of the pump to follow when the account has more than one',
+    category: 'General',
+  },
+  FetchAllEventTypes: {
+    label: 'Fetch All Event Types',
+    description: 'Read every pump history event type rather than the default filtered set',
+    category: 'Advanced',
+  },
+  IgnoreZeroUnitBasal: {
+    label: 'Ignore Zero-Unit Basal',
+    description: 'Skip basal entries that resolve to a near-zero rate',
+    category: 'Advanced',
+  },
   // OAuth and Webhooks
   AccessToken: {
     label: 'Access Token',
@@ -303,7 +305,10 @@ export const connectorPropertyMeta: Record<ConnectorPropertyKeyName, PropertyMet
     description: 'How the connector labels its glucose readings (smoothed or unsmoothed)',
     category: 'General',
   },
-};
+} satisfies Record<string, PropertyMeta>;
+
+/** String key names, taken from the entries above. */
+export type ConnectorPropertyKeyName = keyof typeof connectorPropertyMeta;
 
 /**
  * Convert PascalCase/camelCase to Title Case with spaces.

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorSchemaSyncToggleTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorSchemaSyncToggleTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Connectors;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Dexcom.Configurations;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// The configuration form is rendered from this schema, so a toggle in it is a toggle a user can
+/// switch — for a data type the connector has no way of producing, that is a control that does
+/// nothing.
+/// </summary>
+public class ConnectorSchemaSyncToggleTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly NocturneDbContext _dbContext;
+
+    public ConnectorSchemaSyncToggleTests()
+    {
+        // Force-load the Dexcom connector assembly so the service's reflection-based type lookup
+        // (AppDomain scan for [ConnectorRegistration]) can resolve "Dexcom".
+        _ = typeof(DexcomConnectorConfiguration);
+
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        _dbContext = new NocturneDbContext(dbOptions) { TenantId = Guid.CreateVersion7() };
+        _dbContext.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task GlucoseOnlyConnectorSchemaOffersNoTempBasalToggle()
+    {
+        // Dexcom Share reports glucose and nothing else: SupportedDataTypes is [Glucose].
+        var schema = await CreateService().GetSchemaAsync("Dexcom");
+
+        var properties = schema.RootElement.GetProperty("properties");
+
+        properties.TryGetProperty("syncGlucose", out _).Should().BeTrue(
+            "the connector supports glucose, so its toggle belongs in the form");
+        properties.TryGetProperty("syncTempBasals", out _).Should().BeFalse();
+        properties.TryGetProperty("syncBoluses", out _).Should().BeFalse();
+    }
+
+    private ConnectorConfigurationService CreateService() =>
+        new(
+            _dbContext,
+            Mock.Of<ISecretEncryptionService>(),
+            Mock.Of<ISignalRBroadcastService>(),
+            Mock.Of<IAuditContext>(),
+            new ConfigurationBuilder().Build(),
+            Mock.Of<IHostEnvironment>(),
+            Enumerable.Empty<IConnectorCacheInvalidator>(),
+            NullLogger<ConnectorConfigurationService>.Instance);
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorPropertyMetaMirrorTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorPropertyMetaMirrorTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Nocturne.Connectors.Core.Extensions;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Extensions;
+
+/// <summary>
+/// The frontend labels every connector property from a hand-written table, and derives its own key
+/// type from that table's keys — so TypeScript cannot notice a key the backend has and the table
+/// does not. This reads both sides and fails on the difference; without it a new property key
+/// renders with no description under the wrong heading.
+/// </summary>
+public class ConnectorPropertyMetaMirrorTests
+{
+    private static readonly Regex MetaEntry = new(@"^  (\w+): \{$", RegexOptions.Compiled);
+
+    [Fact]
+    public void TypeScriptTableCoversExactlyTheConnectorPropertyKeys()
+    {
+        var described = PropertyKeysDescribedInTypeScript();
+
+        described.Should().BeEquivalentTo(Enum.GetNames<ConnectorPropertyKey>());
+    }
+
+    private static IReadOnlyList<string> PropertyKeysDescribedInTypeScript()
+    {
+        var path = Path.Combine(RepositoryTree.Root(), "src", "Web", "packages", "app", "src", "lib",
+            "config", "connectorPropertyMeta.ts");
+        var lines = File.ReadAllLines(path);
+
+        var start = Array.FindIndex(lines,
+            line => line.StartsWith("export const connectorPropertyMeta", StringComparison.Ordinal));
+        if (start < 0)
+            throw new InvalidOperationException($"No connectorPropertyMeta declaration in {path}.");
+
+        var end = Array.FindIndex(lines, start + 1,
+            line => line.StartsWith("}", StringComparison.Ordinal));
+        if (end < 0)
+            throw new InvalidOperationException($"connectorPropertyMeta is never closed in {path}.");
+
+        return [.. lines[(start + 1)..end]
+            .Select(line => MetaEntry.Match(line))
+            .Where(match => match.Success)
+            .Select(match => match.Groups[1].Value)];
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorSyncToggleTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorSyncToggleTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Tests.Unit;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Extensions;
+
+/// <summary>
+/// The sync toggles are resolved from the names of <see cref="ConnectorPropertyKey"/> and
+/// <see cref="SyncDataType"/> members rather than listed anywhere, so these tests hold the naming
+/// convention that resolution depends on: a toggle that stops resolving would silently sync data a
+/// user switched off, or offer a toggle for a data type the connector cannot produce.
+/// </summary>
+public class ConnectorSyncToggleTests
+{
+    [Fact]
+    public void EverySyncToggleOnTheConfigurationResolvesToADataType()
+    {
+        var toggleKeys = SyncToggleProperties()
+            .Select(property => property.GetCustomAttribute<ConnectorPropertyAttribute>()!.Key)
+            .ToList();
+
+        toggleKeys.Should().NotBeEmpty("the configuration declares sync toggle properties");
+        toggleKeys.Should().OnlyContain(key => ConnectorSyncToggles.ByPropertyKey.ContainsKey(key),
+            "an unresolved toggle is never matched against the connector's supported data types");
+    }
+
+    [Fact]
+    public void EveryResolvedToggleIsABoolPropertyOnTheConfiguration()
+    {
+        var declared = SyncToggleProperties()
+            .Select(property => property.GetCustomAttribute<ConnectorPropertyAttribute>()!.Key);
+
+        ConnectorSyncToggles.ByPropertyKey.Keys.Should().BeEquivalentTo(declared);
+    }
+
+    [Fact]
+    public void SyncIntervalIsNotAToggle()
+    {
+        ConnectorSyncToggles.ByPropertyKey.Should()
+            .NotContainKey(ConnectorPropertyKey.SyncIntervalMinutes);
+    }
+
+    [Fact]
+    public void EachToggleGatesOnlyItsOwnDataType()
+    {
+        foreach (var (key, dataType) in ConnectorSyncToggles.ByPropertyKey)
+        {
+            var configuration = new TestConnectorConfiguration();
+            PropertyFor(key).SetValue(configuration, false);
+
+            configuration.IsDataTypeEnabled(dataType).Should().BeFalse(
+                "{0} is switched off", key);
+
+            var others = ConnectorSyncToggles.ByPropertyKey.Values.Where(other => other != dataType);
+            others.Should().OnlyContain(other => configuration.IsDataTypeEnabled(other),
+                $"only {key} was switched off");
+        }
+    }
+
+    [Fact]
+    public void DataTypesWithNoToggleAreAlwaysEnabled()
+    {
+        var untoggled = Enum.GetValues<SyncDataType>()
+            .Except(ConnectorSyncToggles.ByPropertyKey.Values)
+            .ToList();
+
+        untoggled.Should().Contain(
+            [SyncDataType.Calibrations, SyncDataType.BasalInjections, SyncDataType.BGChecks]);
+
+        var allTogglesOff = new TestConnectorConfiguration();
+        foreach (var key in ConnectorSyncToggles.ByPropertyKey.Keys)
+            PropertyFor(key).SetValue(allTogglesOff, false);
+
+        untoggled.Should().OnlyContain(dataType => allTogglesOff.IsDataTypeEnabled(dataType));
+    }
+
+    private static PropertyInfo PropertyFor(ConnectorPropertyKey key) =>
+        SyncToggleProperties()
+            .Single(property => property.GetCustomAttribute<ConnectorPropertyAttribute>()!.Key == key);
+
+    private static IEnumerable<PropertyInfo> SyncToggleProperties() =>
+        typeof(TestConnectorConfiguration)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.PropertyType == typeof(bool)
+                               && property.GetCustomAttribute<ConnectorPropertyAttribute>() is { } attribute
+                               && attribute.GetKeyName().StartsWith("Sync", StringComparison.Ordinal));
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/RepositoryTree.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/RepositoryTree.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+
+namespace Nocturne.Connectors.Core.Tests;
+
+/// <summary>
+/// Locates the working tree for tests that assert over source files rather than compiled output.
+/// </summary>
+internal static class RepositoryTree
+{
+    /// <summary>
+    ///     The repository root, found by walking up from the test binaries.
+    /// </summary>
+    public static string Root()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (Directory.Exists(Path.Combine(directory.FullName, "src", "Connectors")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"No src/Connectors directory above {AppContext.BaseDirectory}.");
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorHttpClientConstructionTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorHttpClientConstructionTests.cs
@@ -67,26 +67,10 @@ public partial class ConnectorHttpClientConstructionTests
 
     private static List<string> ConnectorSources()
     {
-        var connectors = Path.Combine(RepositoryRoot(), "src", "Connectors");
+        var connectors = Path.Combine(RepositoryTree.Root(), "src", "Connectors");
 
         return [.. Directory.EnumerateFiles(connectors, "*.cs", SearchOption.AllDirectories)
             .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
                            && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))];
-    }
-
-    private static string RepositoryRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-
-        while (directory is not null)
-        {
-            if (Directory.Exists(Path.Combine(directory.FullName, "src", "Connectors")))
-                return directory.FullName;
-
-            directory = directory.Parent;
-        }
-
-        throw new DirectoryNotFoundException(
-            $"No src/Connectors directory above {AppContext.BaseDirectory}.");
     }
 }


### PR DESCRIPTION
The set of per-connector sync toggles was written out by hand in five places and two had drifted.
`SyncPropertyToDataType` in `ConnectorConfigurationService` was missing `SyncTempBasals`, so the lookup
that skips toggles for unsupported data types returned false and the skip never happened — a temp-basal
toggle was emitted into **every** connector's schema, including glucose-only Dexcom, Libre and
Eversense, and food-only MyFitnessPal.

The mapping now has one owner. `ConnectorSyncToggles.ByPropertyKey` derives it from the two enums that
already name it: the `ConnectorPropertyKey` called `Sync{X}` is the toggle for the `SyncDataType` called
`X`. `SyncIntervalMinutes` is excluded because `IntervalMinutes` names no data type.

## Places enumerating the mapping: 3 in C# + 1 in TS to 1, with the mirror guarded

- The hand-written dictionary is deleted. The issue **undercounted** its use: it was consulted at *two*
  call sites, `GenerateSchemaFromType` **and** `GetEffectiveConfiguration`, so the drift leaked into the
  effective-configuration read as well as the form schema. Both now key off the enum rather than
  `property.Name`.
- `IsDataTypeEnabled`'s 13-arm switch is gone, replaced by a per-type cached lookup built from the
  `[ConnectorProperty]` keys. The `_ => true` default for untoggled types is preserved and now
  documented rather than implicit.
- The `bool SyncX` properties remain one per toggle — unavoidable without source generation, since they
  are the serialised configuration surface — but they no longer restate the mapping.

## The TypeScript mirror was the harder half

`connectorPropertyMeta.ts` derived its own key type from its own contents, so TypeScript could never
notice a key the backend had and the table did not. The duplicated `export enum ConnectorPropertyKey`
is deleted (nothing imported it) and `ConnectorPropertyKeyName` is now
`keyof typeof connectorPropertyMeta`, making the entries the only list.

`ConnectorPropertyMetaMirrorTests` reads both the `.ts` file and the C# enum and fails on any
difference. It cannot pass silently: a missing file throws `FileNotFoundException`, a renamed
declaration or unclosed literal throws, and zero parsed keys fails the equality assertion. Proven to
fail on a member removed from one side only, on an extra key on one side only (the guard is symmetric),
and — verified independently — on the file being absent.

The table was missing **nine** keys, not one. Eight were non-sync properties (CareLink, Tandem,
Eversense, MyFitnessPal) rendering with an empty description under `General` instead of their real
category. Their labels and descriptions are new wording taken from the C# doc comments and are worth a
skim, particularly `PumpSerialNumber` and `CountryCode`/`LanguageCode`, which are filed under `General`
rather than `Credentials`.

## Tests

Pre-fix proof: `GlucoseOnlyConnectorSchemaOffersNoTempBasalToggle` fails against the unmodified service
with `Expected properties.TryGetProperty("syncTempBasals", out _) to be False, but found True` — the bug
reproduced, Dexcom's form schema carrying a temp-basal toggle. The resolver tests assert every bool
`Sync*` `[ConnectorProperty]` resolves to a data type, and assert the collection is non-empty first so
they cannot pass by finding nothing.

105 + 251 green. `RepositoryTree` is a repo-root locator extracted from an identical private copy that
already existed in `ConnectorHttpClientConstructionTests`, so two source-reading tests share one locator
rather than gaining a second.

## Judgement calls

**The Connect CLI switch (site 5) is left alone.** Its `null` fallthrough means ten connectors cannot be
run by the dev CLI — a clean refusal at startup, not a partial sync, so no data-integrity consequence.
Completing it is not mechanical: the switch reads per-connector credential fields off
`ConnectConfiguration`, which only has them for four connectors, so it means ~30 new configuration
properties plus env-var and validation wiring. It is also not part of the toggle set.

**`BasalInjections` is a real gap, filed as #788.** Of the three data types with no toggle,
`Calibrations` and `BGChecks` are declared supported by no connector, so their `true` default is
unreachable. `BasalInjections` *is* declared supported by Glooko and published gated on that default, so
Glooko always syncs it with no way to switch it off. Not fixed here; after this refactor adding it is a
one-line enum change.

Fixes #773
