### PR TITLE
refactor(connectors): make PerformSyncInternalAsync abstract and drop Tandem's publish copy

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -373,164 +373,18 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     protected static DateTime DefaultInitialSyncFloor() => DateTime.UtcNow.AddMonths(-6);
 
     /// <summary>
-    ///     Core synchronization logic that processes data types sequentially.
-    ///     Shared between manual and background sync flows.
+    ///     Core synchronization logic: fetches and publishes every data type the tenant has enabled,
+    ///     honouring <see cref="BaseConnectorConfiguration.GetEnabledDataTypes"/> over
+    ///     <see cref="SupportedDataTypes"/>. Shared between the manual and background sync flows.
+    ///     There is deliberately no default implementation: a connector that advertises data types it
+    ///     does not sync would fail silently, so the omission is a compile error instead.
     /// </summary>
-    protected virtual async Task<SyncResult> PerformSyncInternalAsync(
+    protected abstract Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TConfig config,
         CancellationToken cancellationToken,
         ISyncProgressReporter? progressReporter = null
-    )
-    {
-        var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
-
-        if (!request.DataTypes.Any())
-            request.DataTypes = SupportedDataTypes;
-
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
-        var disabledTypes = SupportedDataTypes.Except(enabledTypes).ToList();
-        if (disabledTypes.Count > 0)
-            _logger.LogInformation(
-                "Skipping disabled data types for {Connector}: {DisabledTypes}",
-                ConnectorSource,
-                string.Join(", ", disabledTypes));
-
-        var typesToSync = request.DataTypes.Where(type => enabledTypes.Contains(type)).ToList();
-        var completedTypes = new List<SyncDataType>();
-        var itemsSoFar = new Dictionary<SyncDataType, int>();
-
-        foreach (var type in typesToSync)
-        {
-            if (progressReporter != null)
-            {
-                await progressReporter.ReportProgressAsync(new SyncProgressEvent
-                {
-                    ConnectorId = ConnectorSource,
-                    ConnectorName = ServiceName,
-                    Phase = SyncPhase.Syncing,
-                    CurrentDataType = type,
-                    CompletedDataTypes = [.. completedTypes],
-                    TotalDataTypes = typesToSync.Count,
-                    ItemsSyncedSoFar = new(itemsSoFar),
-                    MessageType = SyncMessageType.FetchingDataType,
-                    MessageParams = new() { ["dataType"] = type.ToString() },
-                }, cancellationToken);
-            }
-
-            try
-            {
-                var count = 0;
-                DateTime? lastTime = null;
-                var publishSuccess = true;
-
-                switch (type)
-                {
-                    case SyncDataType.Glucose:
-                        var entries = await FetchGlucoseDataRangeAsync(
-                            request.From,
-                            request.To
-                        );
-                        var entryList = entries.ToList();
-                        count = entryList.Count;
-                        if (count > 0)
-                            lastTime = entryList.Max(e => e.Date);
-                        publishSuccess = await PublishGlucoseDataInBatchesAsync(
-                            entryList,
-                            config,
-                            cancellationToken
-                        );
-                        break;
-
-                    case SyncDataType.Profiles:
-                        var profiles = await FetchProfilesAsync();
-                        var profileList = profiles.ToList();
-                        count = profileList.Count;
-                        if (count > 0)
-                            lastTime = profileList
-                                .Where(p => p.Mills > 0)
-                                .Select(p => DateTimeOffset.FromUnixTimeMilliseconds(p.Mills).UtcDateTime)
-                                .DefaultIfEmpty()
-                                .Max();
-                        publishSuccess = await PublishProfileDataAsync(
-                            profileList,
-                            config,
-                            cancellationToken
-                        );
-                        break;
-
-                    default:
-                        _logger.LogDebug(
-                            "Data type {DataType} not supported by this connector",
-                            type
-                        );
-                        break;
-                }
-
-                result.ItemsSynced[type] = count;
-                result.LastEntryTimes[type] = lastTime;
-                if (!publishSuccess)
-                {
-                    result.Success = false;
-                    result.Errors.Add($"{type} publish failed");
-                }
-
-                if (progressReporter != null && count > 0)
-                {
-                    await progressReporter.ReportProgressAsync(new SyncProgressEvent
-                    {
-                        ConnectorId = ConnectorSource,
-                        ConnectorName = ServiceName,
-                        Phase = SyncPhase.Syncing,
-                        CurrentDataType = type,
-                        CompletedDataTypes = [.. completedTypes],
-                        TotalDataTypes = typesToSync.Count,
-                        ItemsSyncedSoFar = new(itemsSoFar) { [type] = count },
-                        MessageType = SyncMessageType.PublishingDataType,
-                        MessageParams = new() { ["dataType"] = type.ToString(), ["count"] = count.ToString() },
-                    }, cancellationToken);
-                }
-
-                completedTypes.Add(type);
-                itemsSoFar[type] = count;
-            }
-            catch (Exception ex)
-            {
-                result.Success = false;
-                result.Errors.Add($"Failed to sync {type}: {ex.Message}");
-
-                _logger.LogError(
-                    ex,
-                    "Failed to sync {DataType} for {Connector}",
-                    type,
-                    ConnectorSource
-                );
-
-                completedTypes.Add(type);
-                itemsSoFar[type] = 0;
-            }
-        }
-
-        result.EndTime = DateTimeOffset.UtcNow;
-
-        if (progressReporter != null)
-        {
-            await progressReporter.ReportProgressAsync(new SyncProgressEvent
-            {
-                ConnectorId = ConnectorSource,
-                ConnectorName = ServiceName,
-                Phase = result.Success ? SyncPhase.Completed : SyncPhase.Failed,
-                CurrentDataType = null,
-                CompletedDataTypes = [.. completedTypes],
-                TotalDataTypes = typesToSync.Count,
-                ItemsSyncedSoFar = new(itemsSoFar),
-                ErrorMessage = result.Success ? null : string.Join("; ", result.Errors),
-                MessageType = result.Success ? SyncMessageType.SyncComplete : SyncMessageType.SyncFailed,
-            }, cancellationToken);
-        }
-
-        return result;
-    }
+    );
 
     protected virtual Task<IEnumerable<Entry>> FetchGlucoseDataRangeAsync(
         DateTime? from,

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -104,8 +104,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
             var time = new TandemTimeResolver(config.TimezoneOffset);
 
-            if (enabled.Contains(SyncDataType.Profiles))
-                await SyncProfilesAsync(device, time, result, config, cancellationToken);
+            await SyncProfilesAsync(device, enabled, result, config, cancellationToken);
 
             await SyncEventsAsync(region, pumperId, device, enabled, time, result, config, cancellationToken);
         }
@@ -126,20 +125,16 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     }
 
     private async Task SyncProfilesAsync(
-        TandemBffPump device, TandemTimeResolver time, SyncResult result,
+        TandemBffPump device, HashSet<SyncDataType> enabled, SyncResult result,
         TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var profile = new TandemProfileMapper(_logger).Map(device.Settings?.Details);
         if (profile == null)
             return;
 
-        var success = await PublishProfileDataAsync([profile], config, cancellationToken);
-        result.ItemsSynced[SyncDataType.Profiles] = 1;
-        if (!success)
-        {
-            result.Success = false;
-            result.Errors.Add("Profile publish failed");
-        }
+        await PublishRecordTypeAsync<Nocturne.Core.Models.Profile>(
+            result, SyncDataType.Profiles, enabled, [profile],
+            PublishProfileDataAsync, config, cancellationToken);
     }
 
     private async Task SyncEventsAsync(
@@ -212,62 +207,44 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         TandemUserModeMapper userMode, TandemDeviceStatusMapper deviceStatus,
         SyncResult result, TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        if (enabled.Contains(SyncDataType.Glucose) && groups.TryGetValue(TandemEventClass.CgmReading, out var cgmEvents))
-            await PublishAsync(SyncDataType.Glucose, cgm.Map(cgmEvents), PublishSensorGlucoseDataAsync, result, config, cancellationToken);
+        if (groups.TryGetValue(TandemEventClass.CgmReading, out var cgmEvents))
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabled,
+                cgm.Map(cgmEvents), PublishSensorGlucoseDataAsync, config, cancellationToken);
 
         if (groups.TryGetValue(TandemEventClass.Bolus, out var bolusEvents))
         {
             var decomposed = bolus.Map(bolusEvents);
-            if (enabled.Contains(SyncDataType.Boluses))
-                await PublishAsync(SyncDataType.Boluses, decomposed.Boluses, PublishBolusDataAsync, result, config, cancellationToken);
-            if (enabled.Contains(SyncDataType.CarbIntake))
-                await PublishAsync(SyncDataType.CarbIntake, decomposed.CarbIntakes, PublishCarbIntakeDataAsync, result, config, cancellationToken);
-            if (enabled.Contains(SyncDataType.BolusCalculations))
-                await PublishAsync(SyncDataType.BolusCalculations, decomposed.BolusCalculations, PublishBolusCalculationDataAsync, result, config, cancellationToken);
+            await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabled,
+                decomposed.Boluses, PublishBolusDataAsync, config, cancellationToken);
+            await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabled,
+                decomposed.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken);
+            await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, enabled,
+                decomposed.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken);
         }
 
-        if (enabled.Contains(SyncDataType.TempBasals) && groups.TryGetValue(TandemEventClass.Basal, out var basalEvents))
-            await PublishAsync(SyncDataType.TempBasals, basal.Map(basalEvents, windowEnd, config.IgnoreZeroUnitBasal), PublishTempBasalDataAsync, result, config, cancellationToken);
+        if (groups.TryGetValue(TandemEventClass.Basal, out var basalEvents))
+            await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabled,
+                basal.Map(basalEvents, windowEnd, config.IgnoreZeroUnitBasal), PublishTempBasalDataAsync,
+                config, cancellationToken);
 
-        if (enabled.Contains(SyncDataType.DeviceEvents))
-        {
-            var devEvents = Concat(groups, TandemEventClass.Cartridge, TandemEventClass.CgmStartJoinStop,
-                TandemEventClass.BasalSuspension, TandemEventClass.BasalResume);
-            if (devEvents.Count > 0)
-                await PublishAsync(SyncDataType.DeviceEvents, deviceEvents.Map(devEvents), PublishDeviceEventDataAsync, result, config, cancellationToken);
+        var devEvents = Concat(groups, TandemEventClass.Cartridge, TandemEventClass.CgmStartJoinStop,
+            TandemEventClass.BasalSuspension, TandemEventClass.BasalResume);
+        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabled,
+            deviceEvents.Map(devEvents), PublishDeviceEventDataAsync, config, cancellationToken);
 
-            var sysEvents = Concat(groups, TandemEventClass.Alarm, TandemEventClass.CgmAlert);
-            if (sysEvents.Count > 0)
-                // System events (alarms / CGM alerts) are gated and accounted under DeviceEvents —
-                // there is no dedicated SyncDataType for them — so a publish failure flips Success.
-                await PublishAsync(SyncDataType.DeviceEvents, systemEvents.Map(sysEvents),
-                    PublishSystemEventDataAsync, result, config, cancellationToken);
-        }
+        // Alarms and CGM alerts are gated and accounted under DeviceEvents — there is no dedicated
+        // SyncDataType for them — so a publish failure flips Success.
+        var sysEvents = Concat(groups, TandemEventClass.Alarm, TandemEventClass.CgmAlert);
+        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabled,
+            systemEvents.Map(sysEvents), PublishSystemEventDataAsync, config, cancellationToken);
 
-        if (enabled.Contains(SyncDataType.StateSpans) && groups.TryGetValue(TandemEventClass.UserMode, out var userModeEvents))
-            await PublishAsync(SyncDataType.StateSpans, userMode.Map(userModeEvents), PublishStateSpanDataAsync, result, config, cancellationToken);
+        if (groups.TryGetValue(TandemEventClass.UserMode, out var userModeEvents))
+            await PublishRecordTypeAsync(result, SyncDataType.StateSpans, enabled,
+                userMode.Map(userModeEvents), PublishStateSpanDataAsync, config, cancellationToken);
 
-        if (enabled.Contains(SyncDataType.DeviceStatus) && groups.TryGetValue(TandemEventClass.DeviceStatus, out var dailyBasal))
-            await PublishAsync(SyncDataType.DeviceStatus, deviceStatus.Map(dailyBasal), PublishDeviceStatusAsync, result, config, cancellationToken);
-    }
-
-    private async Task PublishAsync<T>(
-        SyncDataType type, List<T> records,
-        Func<IEnumerable<T>, TandemConnectorConfiguration, CancellationToken, Task<bool>> publish,
-        SyncResult result, TandemConnectorConfiguration config, CancellationToken cancellationToken)
-        where T : class
-    {
-        if (records.Count == 0)
-            return;
-
-        var success = await publish(records, config, cancellationToken);
-        result.ItemsSynced.TryGetValue(type, out var prev);
-        result.ItemsSynced[type] = prev + records.Count;
-        if (!success)
-        {
-            result.Success = false;
-            result.Errors.Add($"{type} publish failed");
-        }
+        if (groups.TryGetValue(TandemEventClass.DeviceStatus, out var dailyBasal))
+            await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, enabled,
+                deviceStatus.Map(dailyBasal), PublishDeviceStatusAsync, config, cancellationToken);
     }
 
     private async Task<TandemPumpLogsResponse?> FetchWindowAsync(

--- a/tests/Integration/Nocturne.Connectors.Tests/BaseConnectorServiceTests.cs
+++ b/tests/Integration/Nocturne.Connectors.Tests/BaseConnectorServiceTests.cs
@@ -132,6 +132,14 @@ public class TestConnectorService : BaseConnectorService<TestConnectorConfigurat
         return Task.FromResult<IEnumerable<Entry>>(entries);
     }
 
+    // This double only exercises the publish path, never a sync run.
+    protected override Task<SyncResult> PerformSyncInternalAsync(
+        SyncRequest request,
+        TestConnectorConfiguration config,
+        CancellationToken cancellationToken,
+        ISyncProgressReporter? progressReporter = null)
+        => throw new NotSupportedException();
+
     // Public wrapper for testing protected method
     public Task<bool> PublishGlucoseDataAsyncPublic(
         IEnumerable<Entry> entries,

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
@@ -31,6 +31,14 @@ public class BaseConnectorServiceTests
         public override Task<IEnumerable<Nocturne.Core.Models.Entry>> FetchGlucoseDataAsync(DateTime? since = null)
             => Task.FromResult(Enumerable.Empty<Nocturne.Core.Models.Entry>());
 
+        // These tests exercise the base helpers directly, never a sync run.
+        protected override Task<SyncResult> PerformSyncInternalAsync(
+            SyncRequest request,
+            TestConfig config,
+            CancellationToken cancellationToken,
+            ISyncProgressReporter? progressReporter = null)
+            => throw new NotSupportedException();
+
         // Exposes the protected retry helper so its attempt-count behaviour can be tested directly.
         public Task<string?> InvokeExecuteWithRetryAsync(
             Func<Task<string?>> operation,

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SupportedDataTypesFromRegistrationTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SupportedDataTypesFromRegistrationTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Core.Models;
@@ -29,6 +30,14 @@ public class SupportedDataTypesFromRegistrationTests
         protected override string ConnectorSource => "test";
         public override string ServiceName => "Test";
         public override Task<bool> AuthenticateAsync() => Task.FromResult(true);
+
+        // These tests only read SupportedDataTypes, never run a sync.
+        protected override Task<SyncResult> PerformSyncInternalAsync(
+            SyncRequest request,
+            TConfig config,
+            CancellationToken cancellationToken,
+            ISyncProgressReporter? progressReporter = null)
+            => throw new NotSupportedException();
     }
 
     private static Service<TConfig> Build<TConfig>() where TConfig : BaseConnectorConfiguration =>


### PR DESCRIPTION
Fixes #785.

## What

**1. `BaseConnectorService.PerformSyncInternalAsync` is now abstract.** The default body handled only Glucose and Profiles. All twelve production connectors override it and nothing chains to `base.`, so it was unreachable — and a trap: a new connector that forgot to override would compile and then silently sync a subset of the data types it advertises via `ConnectorRegistrationAttribute`. The omission is now a compile error. The three test doubles that derive from the base without ever running a sync get minimal throwing overrides.

**2. Tandem's private `PublishAsync<T>` is deleted.** It was a near-copy of the base's `PublishRecordTypeAsync`, differing only in dropping the `activeTypes` gate (which every call site then re-implemented with its own `enabled.Contains` check) and the success log. Call sites now use the base helper with `enabled` passed in, collapsing the duplicated gates. Tandem's profile sync hand-rolled the same publish/count/error shape and goes through the helper too; its provably-unused `TandemTimeResolver` parameter is dropped.

## Behaviour notes

- The base helper's gate + empty-skip + accumulate + `$"{type} publish failed"` semantics are identical to the deleted copy; the only deltas are an added success log per published type, mapper calls now running for disabled types (pure functions, output discarded by the gate), and the profile failure message becoming the consistent `"Profiles publish failed"`.
- Two `SyncMessageType` values (`FetchingDataType`, `PublishingDataType`) lose their only producer with the deleted default body; frontend translations for them still exist. Tracked separately rather than expanding this diff.

## Testing

- Full solution builds (`-p:GenerateNSwagClient=false`), 0 errors.
- All 11 `tests/Unit/Nocturne.Connectors.*` projects pass (518 tests total), plus `tests/Integration/Nocturne.Connectors.Tests` with integration/performance categories excluded.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
