### PR TITLE
refactor: converge the remaining non-C# mmol factors on one constant per boundary

### DIFF
--- a/src/Taskbar/mod.wh.cpp
+++ b/src/Taskbar/mod.wh.cpp
@@ -284,11 +284,16 @@ static int64_t NowMsEpoch() {
     return (int64_t)((u.QuadPart - 116444736000000000ULL) / 10000ULL);
 }
 
+// A standalone Windhawk mod can't link the shared constant, so the factor is copied here. It
+// MUST equal GlucoseConstants.MgdlPerMmol, or the taskbar and the server disagree about which
+// side of a rounding boundary a reading falls on.
+constexpr double kMgdlPerMmol = 18.0182;
+
 // Convert a canonical mg/dL value to the configured display unit. mmol/L is
 // rounded to 1 dp; mg/dL to a whole number.
 static double ToDisplayUnit(double mgdl) {
     if (g_settings.unit == L"mg/dL") return std::round(mgdl);
-    return std::round(mgdl / 18.0182 * 10.0) / 10.0;
+    return std::round(mgdl / kMgdlPerMmol * 10.0) / 10.0;
 }
 
 static std::string Narrow(const std::wstring& w) {

--- a/src/Web/packages/bot/package.json
+++ b/src/Web/packages/bot/package.json
@@ -16,6 +16,7 @@
   "author": "Nocturne Project",
   "license": "AGPL-3.0-only",
   "dependencies": {
+    "@nocturne/ui": "workspace:*",
     "chat": "4.29.0",
     "@chat-adapter/discord": "4.29.0",
     "@chat-adapter/slack": "4.29.0",

--- a/src/Web/packages/bot/src/lib/format.ts
+++ b/src/Web/packages/bot/src/lib/format.ts
@@ -1,3 +1,5 @@
+import { MGDL_PER_MMOL } from "@nocturne/ui/glucose";
+
 export const TREND_ARROWS: Record<string, string> = {
   DoubleUp: "^^",
   SingleUp: "^",
@@ -11,7 +13,7 @@ export const TREND_ARROWS: Record<string, string> = {
 };
 
 export function formatGlucose(mgdl: number, unit: "mg/dL" | "mmol/L"): string {
-  if (unit === "mmol/L") return `${(mgdl / 18.0182).toFixed(1)} mmol/L`;
+  if (unit === "mmol/L") return `${(mgdl / MGDL_PER_MMOL).toFixed(1)} mmol/L`;
   return `${mgdl} mg/dL`;
 }
 

--- a/src/Web/packages/desktop/src-tauri/src/glucose_poll.rs
+++ b/src/Web/packages/desktop/src-tauri/src/glucose_poll.rs
@@ -13,6 +13,11 @@ use serde::Deserialize;
 // has no prediction engine — the field just comes back empty.
 const SUMMARY_HOURS: u32 = 3;
 
+/// Milligrams per decilitre in one millimole per litre of glucose, for consumers rendering a
+/// display unit. Must equal `GlucoseConstants.MgdlPerMmol`, or the companion and the server
+/// disagree about which side of a rounding boundary a reading falls on.
+pub const MGDL_PER_MMOL: f64 = 18.0182;
+
 /// The latest reading, parsed from the summary for the tray icon and the readout. `sgv`/`delta`
 /// are mg/dL; display-unit conversion is the consumer's job.
 #[derive(Clone, Debug, serde::Serialize)]

--- a/src/Web/packages/desktop/src-tauri/src/toast.rs
+++ b/src/Web/packages/desktop/src-tauri/src/toast.rs
@@ -14,6 +14,7 @@
 //! so a fresh token is resolved when the button is clicked.
 
 use crate::client_devices::DeviceActionIntent;
+use crate::glucose_poll::MGDL_PER_MMOL;
 use crate::signalr::InAppNotification;
 use tauri_winrt_notification::{Duration, Scenario, Toast};
 
@@ -23,7 +24,6 @@ const APP_ID: &str = Toast::POWERSHELL_APP_ID;
 
 /// Button action argument recognised by the activation handler.
 const ACK_ACTION: &str = "acknowledge";
-const MMOL_PER_MGDL: f64 = 18.0182;
 
 /// Who an ack from this toast is attributed to server-side (`acknowledgedBy`).
 const ACK_BY: &str = "desktop-companion";
@@ -159,7 +159,7 @@ fn body_line(intent: &DeviceActionIntent) -> String {
         _ => "Alert",
     };
     match intent.glucose_value {
-        Some(mgdl) => format!("{severity} \u{00b7} {:.1} mmol/L", mgdl / MMOL_PER_MGDL),
+        Some(mgdl) => format!("{severity} \u{00b7} {:.1} mmol/L", mgdl / MGDL_PER_MMOL),
         None => severity.to_string(),
     }
 }

--- a/src/Web/packages/desktop/src-tauri/src/tray.rs
+++ b/src/Web/packages/desktop/src-tauri/src/tray.rs
@@ -9,7 +9,7 @@
 //! ownership is coordinated with the glucose poll via shared state so the two don't fight over the
 //! icon and the normal tile is restored when the last flashing excursion clears.
 
-use crate::glucose_poll::CurrentBg;
+use crate::glucose_poll::{CurrentBg, MGDL_PER_MMOL};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -29,7 +29,6 @@ const FLASH_INTERVAL_MS: u64 = 600;
 
 /// Display unit. mmol/L is the default (1 dp); switch to "mg/dL" (0 dp) by changing this constant.
 const TRAY_UNIT: &str = "mmol/L";
-const MMOL_PER_MGDL: f64 = 18.0182;
 
 /// Segoe UI Bold — present on every Win11 install. Read at runtime; never bundled/committed.
 const FONT_PATH: &str = r"C:\Windows\Fonts\segoeuib.ttf";
@@ -107,7 +106,7 @@ fn to_display(sgv_mgdl: f64) -> String {
     if TRAY_UNIT == "mg/dL" {
         format!("{:.0}", sgv_mgdl.round())
     } else {
-        format!("{:.1}", sgv_mgdl / MMOL_PER_MGDL)
+        format!("{:.1}", sgv_mgdl / MGDL_PER_MMOL)
     }
 }
 

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
       '@chat-adapter/whatsapp':
         specifier: 4.29.0
         version: 4.29.0(zod@4.4.3)
+      '@nocturne/ui':
+        specifier: workspace:*
+        version: link:../ui
       '@resend/chat-sdk-adapter':
         specifier: ^0.2.2
         version: 0.2.2(@chat-adapter/shared@4.29.0(zod@4.4.3))(@react-email/render@2.0.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(chat@4.29.0(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/tests/Unit/Nocturne.Core.Constants.Tests/GlucoseConversionFactorMirrorTests.cs
+++ b/tests/Unit/Nocturne.Core.Constants.Tests/GlucoseConversionFactorMirrorTests.cs
@@ -6,24 +6,38 @@ using Xunit;
 namespace Nocturne.Core.Constants.Tests;
 
 /// <summary>
-/// The frontend converts glucose for display with its own copy of the factor, so a backend-only
-/// change leaves the two disagreeing by about 1 part in 7,000 — enough to move a rounded mmol
-/// reading. This reads the TypeScript source and fails on the difference.
+/// TypeScript, Rust and the Windhawk mod cannot link <see cref="GlucoseConstants.MgdlPerMmol"/>, so
+/// each declares its own copy of the factor. A backend-only change leaves them disagreeing by about
+/// 1 part in 7,000 — enough to move a rounded mmol reading. This reads each source and fails on the
+/// difference.
 /// </summary>
 public class GlucoseConversionFactorMirrorTests
 {
-    private static readonly Regex Declaration =
-        new(@"export const MGDL_PER_MMOL = ([0-9.]+);", RegexOptions.Compiled);
-
-    [Fact]
-    public void TypeScriptUsesTheSameFactorAsTheBackend()
+    public static TheoryData<string, string> Declarations() => new()
     {
-        var path = Path.Combine(RepositoryRoot(), "src", "Web", "packages", "ui", "src", "lib",
-            "glucose.ts");
-        var match = Declaration.Match(File.ReadAllText(path));
+        {
+            Path.Combine("src", "Web", "packages", "ui", "src", "lib", "glucose.ts"),
+            @"export const MGDL_PER_MMOL = ([0-9.]+);"
+        },
+        {
+            Path.Combine("src", "Web", "packages", "desktop", "src-tauri", "src", "glucose_poll.rs"),
+            @"pub const MGDL_PER_MMOL: f64 = ([0-9.]+);"
+        },
+        {
+            Path.Combine("src", "Taskbar", "mod.wh.cpp"),
+            @"constexpr double kMgdlPerMmol = ([0-9.]+);"
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(Declarations))]
+    public void MirroredFactorMatchesTheBackend(string relativePath, string pattern)
+    {
+        var path = Path.Combine(RepositoryRoot(), relativePath);
+        var match = Regex.Match(File.ReadAllText(path), pattern);
 
         if (!match.Success)
-            throw new InvalidOperationException($"No MGDL_PER_MMOL declaration in {path}.");
+            throw new InvalidOperationException($"No declaration matching /{pattern}/ in {path}.");
 
         double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture)
             .Should().Be(GlucoseConstants.MgdlPerMmol);


### PR DESCRIPTION
Fixes #782.

## What

#802 landed most of #782 (TS rename to `MGDL_PER_MMOL = 18.0182`, ScheduleView import, C++ literal already on 18.0182), so this is the remainder: eliminating the last hand-copied factors and the backwards Rust name. **No numeric value changes anywhere** — every site was already on 18.0182.

- **Bot**: `format.ts` imports `MGDL_PER_MMOL` from `@nocturne/ui/glucose` instead of inlining the literal; `@nocturne/bot` gains the `workspace:*` dependency on `@nocturne/ui` that #802 deferred. Safe for the Docker runtime stage: `app` and `portal` already declare the same prod dependency and go through the same `pnpm install --frozen-lockfile --prod` with `packages/ui` absent.
- **Rust**: `MMOL_PER_MGDL` was named for the reciprocal of what it held (both sites divide by it). One `pub const MGDL_PER_MMOL` now lives in `glucose_poll` (the module owning the canonical mg/dL reading), imported by `tray` and `toast`.
- **C++**: the standalone Windhawk mod can't link anything, so its literal becomes a named `constexpr kMgdlPerMmol` carrying the constraint. The shared `TaskbarWidgetHost` protocol block (lines 563–630) is untouched.
- **Drift guard**: `GlucoseConversionFactorMirrorTests` becomes a theory over all three mirrored declarations (TS, Rust, C++). Mutation-proven: setting either new literal to 18.01559 fails exactly the corresponding theory case.

## Testing

- `cargo check --all-targets` clean; `cargo test tray::` 16 passed, `toast::` 8 passed.
- `pnpm --filter @nocturne/bot build` + vitest (18 passed); runtime resolution of `@nocturne/ui/glucose` verified under Node.
- `dotnet test tests/Unit/Nocturne.Core.Constants.Tests` — 19 passed (2 new theory cases).
- `pnpm check` error count unchanged before/after (1061, from the absent generated NSwag client).

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
