### PR TITLE
refactor(data): drive the snapshot indexes and CorrelationId off the contracts

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4Entity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4Entity.cs
@@ -3,10 +3,14 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// <summary>
 /// Marker for V4 clinical entities that participate in tenant-scoped soft-delete
 /// dedup. Implementations expose <see cref="Id"/>, <see cref="LegacyId"/>,
-/// <see cref="ITenantScoped.TenantId"/>, and <see cref="ISoftDeletable.DeletedAt"/>.
+/// <see cref="CorrelationId"/>, <see cref="ITenantScoped.TenantId"/>, and
+/// <see cref="ISoftDeletable.DeletedAt"/>.
 /// </summary>
 public interface IV4Entity : ITenantScoped, ISoftDeletable
 {
     Guid Id { get; set; }
     string? LegacyId { get; set; }
+
+    /// <summary>Links records decomposed from the same legacy Treatment or DeviceStatus.</summary>
+    Guid? CorrelationId { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -418,6 +418,17 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     }
 
     /// <summary>
+    /// The device-status snapshot tables, whose dedup key is the <see cref="ISyncDedupable"/> one
+    /// rather than their legacy id.
+    /// </summary>
+    internal static readonly Type[] V4SnapshotEntities =
+    [
+        typeof(ApsSnapshotEntity),
+        typeof(PumpSnapshotEntity),
+        typeof(UploaderSnapshotEntity),
+    ];
+
+    /// <summary>
     /// V4 record tables keyed on <see cref="IV4TimeSeriesEntity.Timestamp"/>.
     /// </summary>
     internal static readonly Type[] V4TimeSeriesRecordEntities =
@@ -437,15 +448,16 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         typeof(CarbRatioScheduleEntity),
         typeof(SensitivityScheduleEntity),
         typeof(TargetRangeScheduleEntity),
+        .. V4SnapshotEntities,
     ];
 
     /// <summary>
     /// V4 record tables whose legacy id is the dedup key, adding the span-shaped
-    /// <see cref="TempBasalEntity"/>. The snapshot tables are absent: they dedup on the
-    /// <see cref="ISyncDedupable"/> key, so their legacy id carries a plain lookup index instead.
+    /// <see cref="TempBasalEntity"/>. The snapshot tables drop out: their legacy id carries a plain
+    /// lookup index instead of the tenant-scoped unique one.
     /// </summary>
     internal static readonly Type[] V4LegacyIdRecordEntities =
-        [.. V4TimeSeriesRecordEntities, typeof(TempBasalEntity)];
+        [.. V4TimeSeriesRecordEntities.Except(V4SnapshotEntities), typeof(TempBasalEntity)];
 
     /// <summary>
     /// Profile-decomposition schedule tables, read as (tenant, profile, newest-first).
@@ -479,9 +491,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
         typeof(BasalInjectionEntity),
         typeof(CarbIntakeEntity),
         typeof(TempBasalEntity),
-        typeof(ApsSnapshotEntity),
-        typeof(PumpSnapshotEntity),
-        typeof(UploaderSnapshotEntity),
+        .. V4SnapshotEntities,
     ];
 
     /// <summary>
@@ -507,8 +517,22 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
                 .IsUnique()
                 .HasFilter("legacy_id IS NOT NULL AND deleted_at IS NULL");
 
-            entity.HasIndex(nameof(SensorGlucoseEntity.CorrelationId))
+            entity.HasIndex(nameof(IV4Entity.CorrelationId))
                 .HasDatabaseName($"ix_{table}_correlation_id");
+        }
+
+        foreach (var entity in V4SnapshotEntities.Select(t => modelBuilder.Entity(t)))
+        {
+            var table = entity.Metadata.GetTableName();
+
+            entity.HasIndex(nameof(IV4Entity.LegacyId))
+                .HasDatabaseName($"ix_{table}_legacy_id");
+
+            // The partial sync-id index leads with tenant_id, which makes EF drop the auto-created
+            // tenant index as redundant, but a filtered index can't serve general tenant-scoped
+            // scans (all pre-existing rows have NULL sync_identifier).
+            entity.HasIndex(nameof(ITenantScoped.TenantId))
+                .HasDatabaseName($"IX_{table}_tenant_id");
         }
 
         foreach (var entity in V4ProfileNamedEntities.Select(t => modelBuilder.Entity(t)))
@@ -1435,59 +1459,6 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             .HasIndex(e => new { e.TenantId, e.EventType, e.Timestamp })
             .HasDatabaseName("ix_device_events_tenant_event_type_timestamp")
             .IsDescending(false, false, true);
-
-        modelBuilder
-            .Entity<ApsSnapshotEntity>()
-            .HasIndex(e => e.Timestamp)
-            .HasDatabaseName("ix_aps_snapshots_timestamp")
-            .IsDescending();
-
-        modelBuilder
-            .Entity<ApsSnapshotEntity>()
-            .HasIndex(e => e.LegacyId)
-            .HasDatabaseName("ix_aps_snapshots_legacy_id");
-
-        // Keep the conventional TenantId index: the partial sync-id index starts with tenant_id,
-        // which makes EF drop the auto-created one as redundant, but a filtered index can't serve
-        // general tenant-scoped scans (all pre-existing rows have NULL sync_identifier).
-        modelBuilder
-            .Entity<ApsSnapshotEntity>()
-            .HasIndex(e => e.TenantId)
-            .HasDatabaseName("IX_aps_snapshots_tenant_id");
-
-        modelBuilder
-            .Entity<PumpSnapshotEntity>()
-            .HasIndex(e => e.Timestamp)
-            .HasDatabaseName("ix_pump_snapshots_timestamp")
-            .IsDescending();
-
-        modelBuilder
-            .Entity<PumpSnapshotEntity>()
-            .HasIndex(e => e.LegacyId)
-            .HasDatabaseName("ix_pump_snapshots_legacy_id");
-
-        // Keep the conventional TenantId index (see ApsSnapshot note above).
-        modelBuilder
-            .Entity<PumpSnapshotEntity>()
-            .HasIndex(e => e.TenantId)
-            .HasDatabaseName("IX_pump_snapshots_tenant_id");
-
-        modelBuilder
-            .Entity<UploaderSnapshotEntity>()
-            .HasIndex(e => e.Timestamp)
-            .HasDatabaseName("ix_uploader_snapshots_timestamp")
-            .IsDescending();
-
-        modelBuilder
-            .Entity<UploaderSnapshotEntity>()
-            .HasIndex(e => e.LegacyId)
-            .HasDatabaseName("ix_uploader_snapshots_legacy_id");
-
-        // Keep the conventional TenantId index (see ApsSnapshot note above).
-        modelBuilder
-            .Entity<UploaderSnapshotEntity>()
-            .HasIndex(e => e.TenantId)
-            .HasDatabaseName("IX_uploader_snapshots_tenant_id");
 
         modelBuilder
             .Entity<DeviceStatusExtrasEntity>()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
@@ -61,9 +61,32 @@ public class ModelConventionTests
         AssertFamily(
             NocturneDbContext.V4LegacyIdRecordEntities,
             "_correlation_id",
-            i => Columns(i).SequenceEqual([nameof(SensorGlucoseEntity.CorrelationId)])
+            i => Columns(i).SequenceEqual([nameof(IV4Entity.CorrelationId)])
                 && !i.IsUnique
                 && i.GetFilter() is null);
+
+    [Fact]
+    public void EverySnapshotTable_HasAPlainLegacyIdLookup() =>
+        AssertFamily(
+            NocturneDbContext.V4SnapshotEntities,
+            "_legacy_id",
+            i => Columns(i).SequenceEqual([nameof(IV4Entity.LegacyId)])
+                && !i.IsUnique
+                && i.GetFilter() is null);
+
+    /// <summary>
+    /// EF drops this one as redundant against the partial sync-id index unless it is declared — see
+    /// <see cref="NocturneDbContext.V4SnapshotEntities"/>.
+    /// </summary>
+    [Fact]
+    public void EverySnapshotTable_KeepsTheUnfilteredTenantIndex() =>
+        AssertFamily(
+            NocturneDbContext.V4SnapshotEntities,
+            "_tenant_id",
+            i => Columns(i).SequenceEqual([nameof(ITenantScoped.TenantId)])
+                && !i.IsUnique
+                && i.GetFilter() is null,
+            prefix: "IX_");
 
     [Fact]
     public void EverySyncDedupedTable_HasThePartialUniqueUpsertKey() =>
@@ -97,7 +120,11 @@ public class ModelConventionTests
                 && i.IsDescending is not null
                 && i.IsDescending.SequenceEqual([false, false, true]));
 
-    private static void AssertFamily(IReadOnlyList<Type> entities, string suffix, Func<IIndex, bool> shape)
+    private static void AssertFamily(
+        IReadOnlyList<Type> entities,
+        string suffix,
+        Func<IIndex, bool> shape,
+        string prefix = "ix_")
     {
         entities.Should().NotBeEmpty(
             "a loop over an empty list emits nothing, and every shape assertion would then pass vacuously");
@@ -107,9 +134,10 @@ public class ModelConventionTests
         entities.Select(model.FindEntityType)
             .Where(e => e is null
                 || !e.GetIndexes().Any(i =>
-                    i.GetDatabaseName() == $"ix_{e.GetTableName()}{suffix}" && shape(i)))
+                    i.GetDatabaseName() == $"{prefix}{e.GetTableName()}{suffix}" && shape(i)))
             .Select(e => e?.ShortName() ?? "<unmapped>")
-            .Should().BeEmpty("every listed table needs ix_<table>{0} in the conventional shape", suffix);
+            .Should().BeEmpty(
+                "every listed table needs {0}<table>{1} in the conventional shape", prefix, suffix);
     }
 
     private static IEnumerable<string> Columns(IIndex index) => index.Properties.Select(p => p.Name);


### PR DESCRIPTION
Fixes #797.

## What

Closes both remainders from #779, with the EF model provably unchanged.

**1. `CorrelationId` now has a contract.** The issue's "24 entities" conflated two concepts: four audit tables declare a *string request-trace* `CorrelationId` (a homonym), while the V4 decomposition correlation (`Guid?`) sits on the 18 `IV4TimeSeriesEntity` implementers plus `TempBasalEntity` and `DeviceStatusExtrasEntity`. `IV4TimeSeriesEntity` was the wrong widening target (`TempBasalEntity` is in the correlation-index loop but deliberately doesn't implement it — span-shaped, keys on `StartTimestamp`). `IV4Entity`'s implementer set is exactly the loop's set, so it declares `CorrelationId` and the loop reads `nameof(IV4Entity.CorrelationId)` instead of pointing at `SensorGlucoseEntity`. No new near-synonym interface. `DeviceStatusExtrasEntity` stays out for an independent reason: no `LegacyId` (and a non-nullable `Guid` correlation), so it can't implement `IV4Entity`; its hand-written index stays.

**2. The snapshot tables join the convention loops.** Naive membership in `V4TimeSeriesRecordEntities` would have leaked the tenant-scoped unique legacy-id and correlation indexes onto the snapshots (a real model change), because `V4LegacyIdRecordEntities` spread the whole list. Instead the already-documented exclusion is now executable: a `V4SnapshotEntities` list (a distinct concept — the three device-status snapshot tables, which dedup on the `ISyncDedupable` key) spreads into `V4TimeSeriesRecordEntities` and `SyncDedupedEntities`, and `V4LegacyIdRecordEntities` subtracts it. The snapshots' plain `ix_*_legacy_id` and unfiltered `IX_*_tenant_id` indexes became a loop too, collapsing the triplicated "see ApsSnapshot note above" comment. #786's plain, non-tenant-scoped legacy-id lookup is preserved untouched. Net −29 lines in `NocturneDbContext`.

## Model identity

`dotnet ef migrations has-pending-model-changes` → "No changes have been made to the model since the last migration." (verified twice, including an independent re-run at review). No migration generated.

## Testing

- `ModelConventionTests` gains `EverySnapshotTable_HasAPlainLegacyIdLookup` and `EverySnapshotTable_KeepsTheUnfilteredTenantIndex`; mutation-proven (renaming the emitted index names fails exactly those two).
- `tests/Unit/Nocturne.Infrastructure.Data.Tests` 623 passed; `tests/Unit/Nocturne.API.Tests` 5696 passed / 5 skipped. Zero failures.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
