### PR TITLE
chore(deps): clear NuGet vulnerability advisories across the solution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,8 +61,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
     <!-- Infrastructure packages -->
     <!-- MongoDB packages kept for migration tool only -->
-    <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />
-    <PackageVersion Include="MongoDB.Bson" Version="3.5.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
+    <PackageVersion Include="MongoDB.Bson" Version="3.9.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="SocketIOClient" Version="4.0.4" />
     <PackageVersion Include="StackExchange.Redis" Version="2.9.32" />
@@ -91,9 +91,9 @@
     <!-- WASM Runtime packages -->
     <PackageVersion Include="Wasmtime" Version="34.0.2" />
     <!-- Testcontainers packages -->
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.8.1" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <!-- Keep MongoDB testcontainer for migration testing only -->
-    <PackageVersion Include="Testcontainers.MongoDb" Version="4.8.1" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="4.14.0" />
     <!-- Performance testing packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
@@ -102,12 +102,12 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Spectre.Console" Version="0.53.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.53.0" />
-    <PackageVersion Include="WireMock.Net" Version="1.15.0" />
+    <PackageVersion Include="WireMock.Net" Version="2.12.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.72" />
     <PackageVersion Include="RestSharp" Version="111.4.1" />
     <PackageVersion Include="QRCoder" Version="1.6.0" />
-    <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
+    <PackageVersion Include="HtmlSanitizer" Version="9.1.973" />
     <PackageVersion Include="DotNetEnv" Version="3.1.1" />
     <PackageVersion Include="EfToMermaid" Version="1.1.0" />
     <PackageVersion Include="Alexa.NET" Version="1.22.0" />
@@ -117,12 +117,16 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />
     <!-- Security fix: pin transitive dependency to patch CVE-2026-26127 (Base64Url DoS) -->
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.14" />
+    <!-- Security fix: pin StreamJsonRpc's transitive MessagePack (GHSA-hv8m-jj95-wg3x, GHSA-vh6j-jc39-fggf) -->
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
+    <!-- Security fix: pin EF Core Sqlite's transitive SQLite native bundle (GHSA-2m69-gcr7-jv3q) -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.13" />
     <!-- Cryptography packages -->
     <PackageVersion Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
     <!-- ASP.NET Core additional packages -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.HttpsPolicy" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.6.3" />
     <PackageVersion Include="OpenApiRemoteCodegen.Attributes" Version="0.1.0" />
@@ -150,6 +154,6 @@
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <!-- Packages with security patches -->
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/src/Aspire/Nocturne.Aspire.Hosting/Nocturne.Aspire.Hosting.csproj
+++ b/src/Aspire/Nocturne.Aspire.Hosting/Nocturne.Aspire.Hosting.csproj
@@ -8,5 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
+    <PackageReference Include="MessagePack" />
   </ItemGroup>
 </Project>

--- a/tests/Integration/Nocturne.API.Tests/Infrastructure/NightscoutContainer.cs
+++ b/tests/Integration/Nocturne.API.Tests/Infrastructure/NightscoutContainer.cs
@@ -55,8 +55,7 @@ public class NightscoutContainer : IAsyncDisposable
 
         // Start MongoDB first (Nightscout's backend)
         // Use plain mongo container without authentication (MongoDbBuilder adds auth which breaks Nightscout)
-        _mongoContainer = new ContainerBuilder()
-            .WithImage("mongo:7")
+        _mongoContainer = new ContainerBuilder("mongo:7")
             .WithNetwork(_network)
             .WithNetworkAliases(MongoNetworkAlias)
             .WithPortBinding(27017, true)
@@ -76,8 +75,7 @@ public class NightscoutContainer : IAsyncDisposable
         var internalMongoUri = $"mongodb://{MongoNetworkAlias}:27017/nightscout";
 
         // Start Nightscout connected to MongoDB via internal network
-        _nightscoutContainer = new ContainerBuilder()
-            .WithImage(NightscoutImage)
+        _nightscoutContainer = new ContainerBuilder(NightscoutImage)
             .WithNetwork(_network)
             .WithPortBinding(NightscoutPort, true)
             .WithEnvironment("MONGODB_URI", internalMongoUri)

--- a/tests/Integration/Nocturne.API.Tests/Infrastructure/ParityTestFixture.cs
+++ b/tests/Integration/Nocturne.API.Tests/Infrastructure/ParityTestFixture.cs
@@ -146,8 +146,7 @@ public class ParityTestFixture : IAsyncLifetime
             }
 
             // Start PostgreSQL for Nocturne
-            _postgresContainer = new PostgreSqlBuilder()
-                .WithImage("postgres:16")
+            _postgresContainer = new PostgreSqlBuilder("postgres:16")
                 .WithDatabase("nocturne_parity")
                 .WithUsername("test")
                 .WithPassword("test")

--- a/tests/Integration/Nocturne.API.Tests/Migration/MigrationTestFixture.cs
+++ b/tests/Integration/Nocturne.API.Tests/Migration/MigrationTestFixture.cs
@@ -51,8 +51,7 @@ public class MigrationTestFixture : IAsyncLifetime
 
     public MigrationTestFixture()
     {
-        _mongoContainer = new MongoDbBuilder()
-            .WithImage("mongo:7")
+        _mongoContainer = new MongoDbBuilder("mongo:7")
             .Build();
     }
 

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
@@ -37,8 +37,7 @@ public class RlsCompletenessFixture : IAsyncLifetime
     {
         var initScriptPath = ResolveInitScriptPath();
 
-        _container = new PostgreSqlBuilder()
-            .WithImage("postgres:17.6")
+        _container = new PostgreSqlBuilder("postgres:17.6")
             .WithDatabase(DbName)
             .WithUsername(BootstrapUser)
             .WithPassword(BootstrapPassword)

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
@@ -42,8 +42,7 @@ public class V4GoldenFixture : IAsyncLifetime
     {
         var initScriptPath = ResolveInitScriptPath();
 
-        _container = new PostgreSqlBuilder()
-            .WithImage("postgres:17.6")
+        _container = new PostgreSqlBuilder("postgres:17.6")
             .WithDatabase(DbName)
             .WithUsername(BootstrapUser)
             .WithPassword(BootstrapPassword)

--- a/tests/Performance/Nocturne.Infrastructure.Data.Performance.Tests/Infrastructure/PostgresFixture.cs
+++ b/tests/Performance/Nocturne.Infrastructure.Data.Performance.Tests/Infrastructure/PostgresFixture.cs
@@ -13,8 +13,7 @@ public class PostgresFixture : IAsyncDisposable
 
     public PostgresFixture()
     {
-        _container = new PostgreSqlBuilder()
-            .WithImage("postgres:17.6")
+        _container = new PostgreSqlBuilder("postgres:17.6")
             .WithDatabase("nocturne_perf")
             .WithUsername("test")
             .WithPassword("test")

--- a/tests/Shared/Nocturne.Tests.Shared/Infrastructure/SharedTestContainerFixture.cs
+++ b/tests/Shared/Nocturne.Tests.Shared/Infrastructure/SharedTestContainerFixture.cs
@@ -18,8 +18,7 @@ public class SharedTestContainerFixture : IAsyncLifetime
     public async Task InitializeAsync()
     {
         // Start PostgreSQL container
-        _postgreSqlContainer = new PostgreSqlBuilder()
-            .WithImage("postgres:16")
+        _postgreSqlContainer = new PostgreSqlBuilder("postgres:16")
             .WithDatabase("nocturne_test")
             .WithUsername("postgres")
             .WithPassword("password")

--- a/tests/Unit/Nocturne.API.Tests/Nocturne.API.Tests.csproj
+++ b/tests/Unit/Nocturne.API.Tests/Nocturne.API.Tests.csproj
@@ -29,6 +29,7 @@
         <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="Microsoft.Data.Sqlite" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <!-- The central 4.8.0 pin is for the source generators, which must load in Visual Studio's
              Roslyn. Here the parser only reads test sources, and EF Core's design-time package
              already pulls 5.0.0 in transitively, so anything older is a version conflict. -->

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Nocturne.Infrastructure.Data.Tests.csproj
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Nocturne.Infrastructure.Data.Tests.csproj
@@ -21,6 +21,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
         <PackageReference Include="Testcontainers.PostgreSql"/>
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
Fixes #796.

## What

Triage found **nine** advisory'd packages, not the issue's five (four more appeared since filing, all test/AppHost-only). All nine are cleared; `dotnet restore` and `dotnet list package --vulnerable --include-transitive` now report zero advisories solution-wide (independently re-verified at review).

Where the flagged package was transitive, the parent was bumped in preference to pinning; where no parent bump reached a fixed version, a central `PackageVersion` plus an explicit `PackageReference` on the pulling project follows the existing `Microsoft.Bcl.Memory` convention. `CentralPackageTransitivePinningEnabled` was deliberately not flipped.

| Package | Old → New | Via | Severity | Reachability |
|---|---|---|---|---|
| AngleSharp | 0.17.1 → 1.6.0 | HtmlSanitizer 9.0.892 → 9.1.973 | moderate (mXSS) | **Production** — `DocumentProcessingService` sanitizes legacy free-text |
| Snappier | 1.0.0 → 1.3.1 | MongoDB.Driver 3.5.0 → 3.9.0 | high | Low — only if Mongo negotiates snappy during migration |
| SharpCompress | 0.30.1 → 0.48.1 | same MongoDB.Driver bump | moderate (zip-slip) | Not reachable — nothing extracts archives |
| Microsoft.OpenApi | 2.0.0 → 2.7.5 | Microsoft.AspNetCore.OpenApi 10.0.8 → 10.0.11 | high | Production — the API serves an OpenAPI doc |
| System.Security.Cryptography.Xml | 10.0.8 → 10.0.10 | direct | 5× high | No SignedXml/xmldsig use; reached via Data Protection key-ring XML |
| SSH.NET | 2024.2.0 → 2026.0.0 | Testcontainers.* 4.8.1 → 4.14.0 | high | Test-only |
| Scriban.Signed | 5.5.0 → 7.2.5 | WireMock.Net 1.15.0 → 2.12.0 | critical (sandbox escape) | Test-only (E2E templating) |
| MessagePack | 2.5.192 → 2.5.302 | pinned under StreamJsonRpc ← Aspire.Hosting | high | Aspire orchestration RPC only |
| SQLitePCLRaw.lib.e_sqlite3 | 2.1.11 → 2.1.13 | pinned via bundle_e_sqlite3 under EF Core Sqlite | high | Test-only; advisory declares no patched version, so this moves off the vulnerable range |

Testcontainers 4.14.0 obsoletes the parameterless builder constructors; the eight fixture call sites pass the image to the constructor now, exactly as the deprecation prescribes.

## Deliberately not included

Promoting NU1902/NU1903 to errors: there is no existing `WarningsAsErrors` pattern to extend (only `NoWarn` suppressions), and hard-failing CI on advisories published against pinned versions would fail builds on days nobody touched the repo. Recommended as a separate decision, paired with a scheduled audit job.

## Testing

- `dotnet build nocturne.sln -p:GenerateNSwagClient=false --no-incremental` — 0 errors, NU19xx count 0 (204 pre-existing doc/nullability warnings).
- All 18 `tests/Unit/*` projects pass (Infrastructure.Data 621, API 5696/5 skipped, etc.). Zero failures.
- Integration/E2E suites compile but weren't executed locally (Docker + Aspire); CI's integration jobs will exercise Testcontainers 4.14.0 and WireMock.Net 2.12.0 on this PR.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
