### PR TITLE
fix(connectors): derive data-source ids from a stable hash

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Connectors;
@@ -970,12 +971,7 @@ public class DataSourceService : IDataSourceService
         return deletedCounts;
     }
 
-    private static string GenerateId(string deviceId)
-    {
-        // Create a stable ID from the device identifier
-        var hash = deviceId.GetHashCode();
-        return $"ds-{Math.Abs(hash):x8}";
-    }
+    internal static string GenerateId(string deviceId) => $"ds-{HashUtils.Sha256Hex(deviceId)[..8]}";
 
     private static string CleanDeviceName(string deviceId)
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceGenerateIdTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceGenerateIdTests.cs
@@ -1,0 +1,50 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Nocturne.API.Services.Connectors;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// The delete endpoint resolves a data-source id back to a device by re-listing the active sources,
+/// so an id a client holds must still resolve after the API restarts.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DataSourceServiceGenerateIdTests
+{
+    private const string DeviceId = "xDrip-DexcomG6 Samsung Galaxy S21";
+
+    [Fact]
+    public void GenerateId_IsStableForTheSameDevice()
+    {
+        DataSourceService.GenerateId(DeviceId).Should().Be(DataSourceService.GenerateId(DeviceId));
+    }
+
+    [Theory]
+    [InlineData(DeviceId)]
+    [InlineData("dexcom-connector")]
+    [InlineData("")]
+    public void GenerateId_MatchesTheDataSourceIdFormat(string deviceId)
+    {
+        Regex.IsMatch(DataSourceService.GenerateId(deviceId), "^ds-[0-9a-f]{8}$").Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Pinned so a change of hash algorithm is a deliberate, visible break rather than a silent
+    /// invalidation of every id a client is holding.
+    /// </summary>
+    [Theory]
+    [InlineData(DeviceId, "ds-8ba3c03d")]
+    [InlineData("dexcom-connector", "ds-983acc04")]
+    public void GenerateId_DerivesFromTheDeviceIdentifier(string deviceId, string expected)
+    {
+        DataSourceService.GenerateId(deviceId).Should().Be(expected);
+    }
+
+    [Fact]
+    public void GenerateId_DiffersBetweenDevices()
+    {
+        DataSourceService.GenerateId("dexcom-connector")
+            .Should().NotBe(DataSourceService.GenerateId("nightscout-connector"));
+    }
+}


### PR DESCRIPTION
Fixes #793.

## What

`DataSourceService.GenerateId` derived a "stable" id from `string.GetHashCode()`, which .NET randomises per process — so every data-source id changed on API restart, and a client holding one got a 404 from the delete endpoint (which resolves ids by re-listing active sources). `Math.Abs(int.MinValue)` could also throw for the one deviceId per process hashing to `int.MinValue`. Now: `$"ds-{HashUtils.Sha256Hex(deviceId)[..8]}"` — stable, no sign handling, same `ds-` + 8 lowercase hex format.

## Consumer analysis

Nothing persists a `ds-` id: no DB column, migration, cache key, or SignalR payload stores one. The id round-trips only through `ServicesOverview.ActiveDataSources` → the delete endpoint's fresh re-listing (`DataSourceService.DeleteDataSourceDataAsync`), which also accepts the raw `DeviceId`. Deletion itself is keyed on `DeviceId`, never the hash. The Svelte keyed-each on `source.id` merely re-keyed the DOM each restart.

Visibility widened `private` → `internal` for direct testing, following the existing `InternalsVisibleTo("Nocturne.API.Tests")` pattern (`DirectGrantTokenHandler.ComputeSha256Hex`, `MigrationJobService.MongoSourceIdentifier`).

## Testing

- New `DataSourceServiceGenerateIdTests`: stability across calls, `^ds-[0-9a-f]{8}$` format, two pinned expected values (independently verified as UTF-8 SHA-256 prefixes at review), distinctness across devices.
- Mutation-proven: an uppercase-hex mutant fails 5 of the 7 tests.
- `tests/Unit/Nocturne.API.Tests` — 5703 passed, 0 failed, 5 skipped.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
