### PR TITLE
fix(connectors): surface CareLink and MyLife publish failures in SyncResult

### DIFF
--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -130,7 +130,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
         // Seed the tenant timezone timeline from the pump's reported zone (idempotent; first sync only).
         await ConfigureCareLinkTimezoneAsync(data, cancellationToken);
 
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
+        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
         var isStale = IsDataStale(data);
 
         await PublishSensorGlucoseStepAsync(data, config, enabledTypes, isStale, result, cancellationToken);
@@ -241,7 +241,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     private async Task PublishSensorGlucoseStepAsync(
         CareLinkData data,
         CareLinkConnectorConfiguration config,
-        List<SyncDataType> enabledTypes,
+        HashSet<SyncDataType> enabledTypes,
         bool isStale,
         SyncResult result,
         CancellationToken cancellationToken)
@@ -297,7 +297,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     private async Task PublishDeviceStatusStepAsync(
         CareLinkData data,
         CareLinkConnectorConfiguration config,
-        List<SyncDataType> enabledTypes,
+        HashSet<SyncDataType> enabledTypes,
         SyncResult result,
         CancellationToken cancellationToken)
     {
@@ -335,8 +335,9 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     }
 
     /// <summary>
-    ///     Publishes the latest alarm as a SystemEvent, deduped by datetime+code. Alarm failures
-    ///     are logged but never fail the sync.
+    ///     Publishes the latest alarm as a SystemEvent, deduped by datetime+code. A rejected publish
+    ///     fails the sync and leaves the dedup key behind so the next cycle retries the same alarm;
+    ///     a transport exception is only logged, matching the pre-existing policy for this step.
     /// </summary>
     private async Task PublishAlarmStepAsync(
         CareLinkData data,
@@ -357,12 +358,16 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
                 var systemEvent = CareLinkSystemEventMapper.Map(data.LastAlarm, pumpOffsetMs, data.CurrentServerTime);
                 if (systemEvent != null)
                 {
-                    var success = await PublishSystemEventDataAsync([systemEvent], config, cancellationToken);
-                    if (success)
+                    if (await PublishSystemEventDataAsync([systemEvent], config, cancellationToken))
                     {
                         _lastAlarmKey = alarmKey;
                         _logger.LogInformation("[{ConnectorSource}] Published alarm event {Code}",
                             ConnectorSource, data.LastAlarm.Code);
+                    }
+                    else
+                    {
+                        result.Success = false;
+                        result.Errors.Add("Alarm event publish failed");
                     }
                 }
             }
@@ -386,7 +391,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     private async Task PublishTreatmentsStepAsync(
         CareLinkData data,
         CareLinkConnectorConfiguration config,
-        List<SyncDataType> enabledTypes,
+        HashSet<SyncDataType> enabledTypes,
         SyncResult result,
         CancellationToken cancellationToken)
     {
@@ -395,39 +400,32 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
             var pumpOffsetMs = Utilities.CareLinkTimestampParser.CalculatePumpOffsetMs(
                 data.MedicalDeviceTime ?? "", data.CurrentServerTime);
 
-            if (enabledTypes.Contains(SyncDataType.Boluses))
-            {
-                var boluses = CareLinkTreatmentMapper.MapBoluses(data, pumpOffsetMs);
-                if (boluses.Count > 0 && await PublishBolusDataAsync(boluses, config, cancellationToken))
-                {
-                    result.ItemsSynced[SyncDataType.Boluses] = boluses.Count;
-                    _logger.LogInformation("[{ConnectorSource}] Synced {Count} Bolus records", ConnectorSource, boluses.Count);
-                }
-            }
+            await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabledTypes,
+                CareLinkTreatmentMapper.MapBoluses(data, pumpOffsetMs), PublishBolusDataAsync,
+                config, cancellationToken);
 
-            if (enabledTypes.Contains(SyncDataType.CarbIntake))
-            {
-                var carbs = CareLinkTreatmentMapper.MapCarbIntakes(data, pumpOffsetMs);
-                if (carbs.Count > 0 && await PublishCarbIntakeDataAsync(carbs, config, cancellationToken))
-                {
-                    result.ItemsSynced[SyncDataType.CarbIntake] = carbs.Count;
-                    _logger.LogInformation("[{ConnectorSource}] Synced {Count} CarbIntake records", ConnectorSource, carbs.Count);
-                }
-            }
+            await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabledTypes,
+                CareLinkTreatmentMapper.MapCarbIntakes(data, pumpOffsetMs), PublishCarbIntakeDataAsync,
+                config, cancellationToken);
 
-            if (enabledTypes.Contains(SyncDataType.TempBasals))
-            {
-                var tempBasals = CareLinkTreatmentMapper.MapTempBasals(data, pumpOffsetMs);
-                if (tempBasals.Count > 0 && await PublishTempBasalDataAsync(tempBasals, config, cancellationToken))
-                {
-                    result.ItemsSynced[SyncDataType.TempBasals] = tempBasals.Count;
-                    _logger.LogInformation("[{ConnectorSource}] Synced {Count} TempBasal records", ConnectorSource, tempBasals.Count);
-                }
-            }
+            await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabledTypes,
+                CareLinkTreatmentMapper.MapTempBasals(data, pumpOffsetMs), PublishTempBasalDataAsync,
+                config, cancellationToken);
 
+            // Not routed through PublishRecordTypeAsync: system events would have to be gated and
+            // counted under DeviceEvents, which CareLink does not declare supported, so the helper
+            // would suppress them outright.
             var notifications = CareLinkSystemEventMapper.MapNotifications(data.NotificationHistory, pumpOffsetMs);
-            if (notifications.Count > 0 && await PublishSystemEventDataAsync(notifications, config, cancellationToken))
-                _logger.LogInformation("[{ConnectorSource}] Synced {Count} notification events", ConnectorSource, notifications.Count);
+            if (notifications.Count > 0)
+            {
+                if (await PublishSystemEventDataAsync(notifications, config, cancellationToken))
+                    _logger.LogInformation("[{ConnectorSource}] Synced {Count} notification events", ConnectorSource, notifications.Count);
+                else
+                {
+                    result.Success = false;
+                    result.Errors.Add("Notification events publish failed");
+                }
+            }
         }
         catch (OperationCanceledException) { throw; }
         catch (HttpRequestException ex)

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -266,13 +266,8 @@ public class MyLifeConnectorService(
                     profiles, PublishProfileDataAsync, config, cancellationToken);
 
                 var profileStateSpans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource);
-                if (profileStateSpans.Count > 0)
-                {
-                    await PublishStateSpanDataAsync(profileStateSpans, config, cancellationToken);
-                    _logger.LogInformation(
-                        "Published {Count} profile state spans from pump settings",
-                        profileStateSpans.Count);
-                }
+                await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
+                    profileStateSpans, PublishStateSpanDataAsync, config, cancellationToken, "pump settings");
             }
         }
         catch (Exception ex)

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeSyncService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeSyncService.cs
@@ -71,7 +71,7 @@ public class MyLifeSyncService(MyLifeSoapClient soapClient, ILogger<MyLifeSyncSe
         }
     }
 
-    public async Task<IReadOnlyList<MyLifePumpSettingsReadout>> FetchPumpSettingsAsync(
+    public virtual async Task<IReadOnlyList<MyLifePumpSettingsReadout>> FetchPumpSettingsAsync(
         string serviceUrl,
         string authToken,
         string patientId,

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
@@ -35,18 +35,113 @@ public class CareLinkConnectorServiceTests
         result.Errors.Should().ContainMatch("*No data returned from any CareLink endpoint*");
     }
 
+    /// <summary>
+    /// A rejected treatment publish must fail the sync. The bolus publish used to gate only the
+    /// <c>ItemsSynced</c> counter, so a connector that reached CareLink but could not write to the
+    /// tenant still reported a green sync with the treatments missing.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenBolusPublishIsRejected_ReportsFailure()
+    {
+        var handler = new CareLinkFakeHandler
+        {
+            MonitorDataJson = """
+                {
+                  "currentServerTime": 1767261600000,
+                  "lastSG": {},
+                  "markers": [
+                    {
+                      "type": "INSULIN",
+                      "dateTime": "2026-01-01T10:00:00",
+                      "id": 1,
+                      "bolusType": "NORMAL",
+                      "programmedFastAmount": 2.5,
+                      "deliveredFastAmount": 2.5
+                    }
+                  ]
+                }
+                """
+        };
+        // Boluses alone, so the assertion cannot be satisfied by another step's failure. No
+        // publisher is wired, so every publish is rejected.
+        var fixture = new ServiceFixture(handler, new CareLinkConnectorConfiguration
+        {
+            Username = "user@example.com",
+            Server = "EU",
+            SyncGlucose = false,
+            SyncDeviceStatus = false,
+            SyncCarbIntake = false,
+            SyncTempBasals = false,
+        });
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Boluses] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeFalse("a bolus batch that never reached the tenant is not a successful sync");
+        result.Errors.Should().Contain("Boluses publish failed");
+    }
+
+    /// <summary>
+    /// A rejected alarm publish must fail the sync and leave the dedup key unadvanced, so the next
+    /// cycle retries the same alarm instead of treating it as delivered.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAlarmPublishIsRejected_ReportsFailureAndRetriesNextSync()
+    {
+        var handler = new CareLinkFakeHandler
+        {
+            MonitorDataJson = """
+                {
+                  "currentServerTime": 1767261600000,
+                  "lastSG": {},
+                  "lastAlarm": {
+                    "type": "PUMP_SUSPEND",
+                    "code": 816,
+                    "flash": true,
+                    "datetime": "2026-01-01T10:00:00"
+                  }
+                }
+                """
+        };
+        var fixture = new ServiceFixture(handler, AlarmOnlyConfiguration());
+
+        var first = await fixture.Service.SyncDataAsync(
+            new SyncRequest(), fixture.Config, CancellationToken.None);
+        var second = await fixture.Service.SyncDataAsync(
+            new SyncRequest(), fixture.Config, CancellationToken.None);
+
+        first.Success.Should().BeFalse("an alarm that never reached the tenant is not a successful sync");
+        first.Errors.Should().Contain("Alarm event publish failed");
+        second.Errors.Should().Contain("Alarm event publish failed",
+            "the dedup key must not advance past an alarm that was never published");
+    }
+
+    /// <summary>Leaves only the alarm step able to publish, so its failure cannot be confused for another step's.</summary>
+    private static CareLinkConnectorConfiguration AlarmOnlyConfiguration() => new()
+    {
+        Username = "user@example.com",
+        Server = "EU",
+        SyncGlucose = false,
+        SyncDeviceStatus = false,
+        SyncBoluses = false,
+        SyncCarbIntake = false,
+        SyncTempBasals = false,
+    };
+
     /// <summary>Wires the connector service and a real token provider onto one fake handler.</summary>
     private sealed class ServiceFixture
     {
         internal CareLinkConnectorService Service { get; }
-        internal CareLinkConnectorConfiguration Config { get; } = new()
-        {
-            Username = "user@example.com",
-            Server = "EU",
-        };
+        internal CareLinkConnectorConfiguration Config { get; }
 
-        internal ServiceFixture(CareLinkFakeHandler handler)
+        internal ServiceFixture(CareLinkFakeHandler handler, CareLinkConnectorConfiguration? config = null)
         {
+            Config = config ?? new CareLinkConnectorConfiguration
+            {
+                Username = "user@example.com",
+                Server = "EU",
+            };
+
             var tenantAccessor = new Mock<ITenantAccessor>();
             tenantAccessor.Setup(t => t.IsResolved).Returns(true);
             tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkFakeHandler.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkFakeHandler.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using Nocturne.Connectors.CareLink.Configurations;
 
 namespace Nocturne.Connectors.CareLink.Tests.Services;
 
@@ -21,6 +22,9 @@ internal sealed class CareLinkFakeHandler : HttpMessageHandler
 
     internal string TokenResponseJson { get; init; } =
         """{"access_token":"new-access-token","refresh_token":"rotated-refresh-token"}""";
+
+    /// <summary>Body for the monitor endpoint; when null that endpoint 404s like the others.</summary>
+    internal string? MonitorDataJson { get; init; }
 
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)
@@ -57,6 +61,10 @@ internal sealed class CareLinkFakeHandler : HttpMessageHandler
 
         if (url == TokenUrl)
             return Json(TokenResponseJson);
+
+        if (MonitorDataJson is not null
+            && url.EndsWith(CareLinkConstants.Endpoints.MonitorData, StringComparison.Ordinal))
+            return Json(MonitorDataJson);
 
         return new HttpResponseMessage(HttpStatusCode.NotFound);
     }

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceTests.cs
@@ -7,6 +7,7 @@ using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.MyLife.Configurations;
 using Nocturne.Connectors.MyLife.Mappers;
+using Nocturne.Connectors.MyLife.Models;
 using Nocturne.Connectors.MyLife.Services;
 using Nocturne.Core.Contracts.Multitenancy;
 using Xunit;
@@ -71,8 +72,47 @@ public class MyLifeConnectorServiceTests
         sessionCache.Get(tenantId).Should().BeNull("no session must be cached when login fails");
     }
 
+    /// <summary>
+    /// A rejected state-span publish must fail the sync. The profile-derived spans used to discard
+    /// the publish result outright, so a sync that wrote nothing still reported success.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenProfileStateSpanPublishIsRejected_ReportsFailure()
+    {
+        var tenantId = Guid.NewGuid();
+        using var http = new HttpClient(new SoapStubHandler(loginSucceeds: true));
+
+        // No basal programs, so only the state spans are mapped and the assertion cannot be
+        // satisfied by the profile publish. No publisher is wired, so every publish is rejected.
+        var readouts = new List<MyLifePumpSettingsReadout>
+        {
+            new()
+            {
+                Id = "readout-1",
+                DeviceSerialNumber = "SN-1",
+                ActiveBasalProgramName = "Day",
+                UploadDateTime = 1767261600000L * 10_000
+            }
+        };
+        var (service, _) = BuildService(http, tenantId,
+            soapClient => new StubPumpSettingsSyncService(soapClient, readouts));
+
+        var config = new MyLifeConnectorConfiguration
+        {
+            Username = "user@example.com",
+            Password = "secret",
+            PatientId = "patient-1"
+        };
+        var request = new SyncRequest { DataTypes = [SyncDataType.Profiles, SyncDataType.StateSpans] };
+
+        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        result.Success.Should().BeFalse("state spans that never reached the tenant are not a successful sync");
+        result.Errors.Should().Contain("StateSpans publish failed");
+    }
+
     private static (MyLifeConnectorService Service, IMyLifeSessionCache SessionCache) BuildService(
-        HttpClient http, Guid tenantId)
+        HttpClient http, Guid tenantId, Func<MyLifeSoapClient, MyLifeSyncService>? syncServiceFactory = null)
     {
         var resolver = new ConnectorServerResolver<MyLifeConnectorConfiguration>(null, null, null);
 
@@ -90,7 +130,8 @@ public class MyLifeConnectorServiceTests
             soapClient,
             sessionCache,
             NullLogger<MyLifeAuthTokenProvider>.Instance);
-        var syncService = new MyLifeSyncService(soapClient, NullLogger<MyLifeSyncService>.Instance);
+        var syncService = syncServiceFactory?.Invoke(soapClient)
+            ?? new MyLifeSyncService(soapClient, NullLogger<MyLifeSyncService>.Instance);
 
         var service = new MyLifeConnectorService(
             http,
@@ -104,6 +145,18 @@ public class MyLifeConnectorServiceTests
             publisher: null);
 
         return (service, sessionCache);
+    }
+
+    /// <summary>
+    /// Returns fixed pump-settings readouts, bypassing the encrypted-archive fetch.
+    /// </summary>
+    private sealed class StubPumpSettingsSyncService(
+        MyLifeSoapClient soapClient, IReadOnlyList<MyLifePumpSettingsReadout> readouts)
+        : MyLifeSyncService(soapClient, NullLogger<MyLifeSyncService>.Instance)
+    {
+        public override Task<IReadOnlyList<MyLifePumpSettingsReadout>> FetchPumpSettingsAsync(
+            string serviceUrl, string authToken, string patientId, CancellationToken cancellationToken)
+            => Task.FromResult(readouts);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #784.

## What

CareLink's bolus/carb/temp-basal publishes gated only `ItemsSynced`, its two SystemEvent publishes gated only a log line and the alarm dedup key, and MyLife's profile-derived state-span publish discarded its result — so a rejected publish reported a green sync with the data missing.

- The three CareLink treatment types route through `PublishRecordTypeAsync`; the enclosing `enabledTypes.Contains(...)` checks collapse into the helper's identical gate (no gating delta — verified per site).
- CareLink's two SystemEvent sites stay hand-inlined **deliberately**: the helper would gate and count them under `DeviceEvents`, which CareLink does not declare in `SupportedDataTypes`, so routing them would suppress alarms and notifications outright. They now propagate failure into `SyncResult` inline; the alarm dedup key still advances only on success, so the next cycle retries. (The missing `DeviceEvents` declaration is the real fix for routing these — follow-up below.)
- MyLife's profile state spans route through the helper with one deliberate delta, flagged here: they are now gated on the `StateSpans` toggle (previously they published whenever `Profiles` was active). That matches the temp-basal state spans earlier in the same method and the connector's own `needStateSpans` check.
- Glooko untouched — its remaining publishes are #803's, and its profile block is deferred by #784 itself.

## Testing

Three new tests, each mutation-proven (reverting the fix makes them fail):
- CareLink: rejected bolus publish → `Success=false` + `"Boluses publish failed"` (Boluses-only config so no other step can satisfy the assertion).
- CareLink: rejected alarm publish → failure on BOTH of two consecutive syncs, proving the dedup key did not advance.
- MyLife: rejected profile state-span publish → failure (readout crafted so only the span publish can fail).

CareLink 81, MyLife 32, Connectors.Core 105, Glooko 73, Tandem 58 — all passing; full solution builds.

## Follow-up worth filing

CareLink publishes SystemEvents but doesn't declare `DeviceEvents` supported, so the events are un-gateable, invisible in `ItemsSynced`, and hidden from the sync-toggle schema (`ConnectorConfigurationService` skips toggles for undeclared types). Declaring it is the prerequisite for routing those two sites through the shared helper.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
