### PR TITLE
fix(data): back the snapshot legacy-id insert path with a unique index

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots")]
+    partial class AddTenantScopedLegacyIdIndexesToSnapshots
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots.cs
@@ -1,0 +1,141 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantScopedLegacyIdIndexesToSnapshots : Migration
+    {
+        private static readonly string[] SnapshotTables =
+            ["aps_snapshots", "pump_snapshots", "uploader_snapshots"];
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // The unique index below fails on any legacy id these tables already hold twice, and a
+            // failed migration crash-loops the API. Soft-delete every loser (newest insert wins) so
+            // the survivor keeps serving reads; the delete carries no auth context, so
+            // SoftDeleteDedupExtensions.GetBlockingLegacyIdsAsync leaves the id re-importable.
+            // FORCE ROW LEVEL SECURITY binds the migrator too, hence the per-tenant GUC.
+            foreach (var table in SnapshotTables)
+            {
+                migrationBuilder.Sql($"""
+                    DO $$
+                    DECLARE
+                        t RECORD;
+                    BEGIN
+                        FOR t IN SELECT id FROM tenants LOOP
+                            PERFORM set_config('app.current_tenant_id', t.id::text, true);
+
+                            UPDATE {table}
+                            SET deleted_at = now()
+                            WHERE id IN (
+                                SELECT id
+                                FROM (
+                                    SELECT id,
+                                           row_number() OVER (
+                                               PARTITION BY tenant_id, legacy_id
+                                               ORDER BY sys_created_at DESC, id DESC) AS rn
+                                    FROM {table}
+                                    WHERE legacy_id IS NOT NULL AND deleted_at IS NULL
+                                ) ranked
+                                WHERE ranked.rn > 1);
+                        END LOOP;
+                    END $$;
+                    """);
+            }
+
+            migrationBuilder.DropIndex(
+                name: "ix_uploader_snapshots_legacy_id",
+                table: "uploader_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "ix_pump_snapshots_legacy_id",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "ix_aps_snapshots_legacy_id",
+                table: "aps_snapshots");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_uploader_snapshots_correlation_id",
+                table: "uploader_snapshots",
+                column: "correlation_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_uploader_snapshots_tenant_legacy_id",
+                table: "uploader_snapshots",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pump_snapshots_correlation_id",
+                table: "pump_snapshots",
+                column: "correlation_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pump_snapshots_tenant_legacy_id",
+                table: "pump_snapshots",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_aps_snapshots_correlation_id",
+                table: "aps_snapshots",
+                column: "correlation_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_aps_snapshots_tenant_legacy_id",
+                table: "aps_snapshots",
+                columns: new[] { "tenant_id", "legacy_id" },
+                unique: true,
+                filter: "legacy_id IS NOT NULL AND deleted_at IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_uploader_snapshots_correlation_id",
+                table: "uploader_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "ix_uploader_snapshots_tenant_legacy_id",
+                table: "uploader_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "ix_pump_snapshots_correlation_id",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "ix_pump_snapshots_tenant_legacy_id",
+                table: "pump_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "ix_aps_snapshots_correlation_id",
+                table: "aps_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "ix_aps_snapshots_tenant_legacy_id",
+                table: "aps_snapshots");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_uploader_snapshots_legacy_id",
+                table: "uploader_snapshots",
+                column: "legacy_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pump_snapshots_legacy_id",
+                table: "pump_snapshots",
+                column: "legacy_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_aps_snapshots_legacy_id",
+                table: "aps_snapshots",
+                column: "legacy_id");
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -418,8 +418,7 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     }
 
     /// <summary>
-    /// The device-status snapshot tables, whose dedup key is the <see cref="ISyncDedupable"/> one
-    /// rather than their legacy id.
+    /// The device-status snapshot tables, upserted on the <see cref="ISyncDedupable"/> key.
     /// </summary>
     internal static readonly Type[] V4SnapshotEntities =
     [
@@ -452,12 +451,12 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     ];
 
     /// <summary>
-    /// V4 record tables whose legacy id is the dedup key, adding the span-shaped
-    /// <see cref="TempBasalEntity"/>. The snapshot tables drop out: their legacy id carries a plain
-    /// lookup index instead of the tenant-scoped unique one.
+    /// V4 record tables whose legacy id is an insert-only dedup key, adding the span-shaped
+    /// <see cref="TempBasalEntity"/>. The snapshots belong here too: their sync-identifier
+    /// uniqueness is filtered on a non-null identifier, which a legacy import never carries.
     /// </summary>
     internal static readonly Type[] V4LegacyIdRecordEntities =
-        [.. V4TimeSeriesRecordEntities.Except(V4SnapshotEntities), typeof(TempBasalEntity)];
+        [.. V4TimeSeriesRecordEntities, typeof(TempBasalEntity)];
 
     /// <summary>
     /// Profile-decomposition schedule tables, read as (tenant, profile, newest-first).
@@ -521,18 +520,13 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
                 .HasDatabaseName($"ix_{table}_correlation_id");
         }
 
+        // The partial sync-id and legacy-id indexes lead with tenant_id, which makes EF drop the
+        // auto-created tenant index as redundant, but a filtered index can't serve general
+        // tenant-scoped scans (all pre-existing rows have NULL sync_identifier).
         foreach (var entity in V4SnapshotEntities.Select(t => modelBuilder.Entity(t)))
         {
-            var table = entity.Metadata.GetTableName();
-
-            entity.HasIndex(nameof(IV4Entity.LegacyId))
-                .HasDatabaseName($"ix_{table}_legacy_id");
-
-            // The partial sync-id index leads with tenant_id, which makes EF drop the auto-created
-            // tenant index as redundant, but a filtered index can't serve general tenant-scoped
-            // scans (all pre-existing rows have NULL sync_identifier).
             entity.HasIndex(nameof(ITenantScoped.TenantId))
-                .HasDatabaseName($"IX_{table}_tenant_id");
+                .HasDatabaseName($"IX_{entity.Metadata.GetTableName()}_tenant_id");
         }
 
         foreach (var entity in V4ProfileNamedEntities.Select(t => modelBuilder.Entity(t)))

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/LegacyIdIndexFilterTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/LegacyIdIndexFilterTests.cs
@@ -23,21 +23,13 @@ namespace Nocturne.Infrastructure.Data.Tests;
 [Trait("Category", "Unit")]
 public class LegacyIdIndexFilterTests
 {
-    /// <summary>
-    /// Tables whose legacy id is not their dedup key: the snapshot repositories upsert on
-    /// <c>(tenant_id, data_source, sync_identifier)</c>, and that index carries the uniqueness.
-    /// </summary>
-    private static readonly string[] TablesKeyedOnSyncIdentifierInstead =
-        ["aps_snapshots", "pump_snapshots", "uploader_snapshots"];
-
     [Fact]
     public void EveryLegacyIdTable_HasATenantScopedUniqueIndex()
     {
         using var ctx = CreateContext();
 
         LegacyIdEntityTypes(ctx)
-            .Where(e => !TablesKeyedOnSyncIdentifierInstead.Contains(e.GetTableName())
-                && !e.GetIndexes().Any(IsTenantLegacyIdUniqueIndex))
+            .Where(e => !e.GetIndexes().Any(IsTenantLegacyIdUniqueIndex))
             .Select(e => e.GetTableName())
             .Should().BeEmpty(
                 "a read-then-insert dedup with no uniqueness index lets two overlapping imports both insert the same legacy id");

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
@@ -65,18 +65,9 @@ public class ModelConventionTests
                 && !i.IsUnique
                 && i.GetFilter() is null);
 
-    [Fact]
-    public void EverySnapshotTable_HasAPlainLegacyIdLookup() =>
-        AssertFamily(
-            NocturneDbContext.V4SnapshotEntities,
-            "_legacy_id",
-            i => Columns(i).SequenceEqual([nameof(IV4Entity.LegacyId)])
-                && !i.IsUnique
-                && i.GetFilter() is null);
-
     /// <summary>
-    /// EF drops this one as redundant against the partial sync-id index unless it is declared — see
-    /// <see cref="NocturneDbContext.V4SnapshotEntities"/>.
+    /// EF drops this one as redundant against the tenant-leading partial indexes unless it is
+    /// declared — see <see cref="NocturneDbContext.V4SnapshotEntities"/>.
     /// </summary>
     [Fact]
     public void EverySnapshotTable_KeepsTheUnfilteredTenantIndex() =>


### PR DESCRIPTION
Fixes #786.

## What

`aps_snapshots`, `pump_snapshots` and `uploader_snapshots` only enforced uniqueness on `(tenant_id, data_source, sync_identifier)` — filtered on a non-null sync identifier, which a legacy import never carries. Those rows fall through to `V4RepositoryBase`'s read-then-insert legacy-id dedup with no index behind it, so two overlapping imports both insert. Their plain `legacy_id` index also wasn't tenant-leading.

The snapshots now fold into `V4LegacyIdRecordEntities` (the `.Except(V4SnapshotEntities)` carve-out from #813 is deleted), picking up the family's tenant-scoped partial unique index. The correlation index the family emits is justified, not incidental: `GetByCorrelationIdsAsync` filters on `correlation_id` alone (called by `DeviceStatusProjectionService` on every v1/v3 devicestatus page) and was previously unindexed. The plain `ix_*_legacy_id` drops — `GetBlockingLegacyIdsAsync` queries `(tenant_id, legacy_id)` under `IgnoreQueryFilters`, which the unfiltered `IX_*_tenant_id` serves, matching the other 18 legacy-id tables.

## The migration

Generated (not hand-written), with a data-fixing step ahead of the `CREATE UNIQUE INDEX` so pre-existing duplicates can't crash-loop the API on boot: per tenant (RLS-aware `set_config` loop, following the `BackfillTrackerPublicVisibilityToPrivate` precedent), losers per `(tenant_id, legacy_id)` are soft-deleted, newest insert winning (`sys_created_at DESC, id DESC` — deterministic tie-break). Losers keep `deleted_by_user = false`, so the dedup treats them as system-swept and re-importable. `PARTITION BY tenant_id` keeps the ranking correct even under a BYPASSRLS role.

**The SQL was proven empirically, not just reasoned about**: a throwaway `postgres:18.3` container with `FORCE ROW LEVEL SECURITY`, the real `tenant_isolation` policy and a `NOSUPERUSER NOBYPASSRLS` role, seeded with 3-way/2-way duplicates across two tenants plus null-legacy-id and already-deleted rows — correct survivors, untouched bystanders, index created clean.

## Tests

- `LegacyIdIndexFilterTests.EveryLegacyIdTable_HasATenantScopedUniqueIndex` — the `TablesKeyedOnSyncIdentifierInstead` exception list is **deleted**, so the fact is now a completeness proof over every legacy-id table. Mutation-proven: restoring the `.Except(...)` carve-out fails exactly this test.
- `dotnet ef migrations has-pending-model-changes` → no changes (verified twice, including an independent re-run at review).
- Infrastructure.Data 622 passed; API 5696 passed / 5 skipped.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
