### PR TITLE
fix(api): stop serving stale therapy and glucose reads from the shared cache

### DIFF
--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -64,9 +64,15 @@ public class EntriesController : ControllerBase
     /// </summary>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The most recent glucose entry, or empty array if no entries exist</returns>
+    /// <remarks>
+    /// Never cached, per <see cref="V4.Profiles.ProfileController.GetProfileSummary"/>: the current
+    /// reading is the most staleness-sensitive value the API serves. The <c>Last-Modified</c> /
+    /// <c>If-Modified-Since</c> handling below still answers a conditional poll with a 304, so
+    /// revalidating callers pay no body.
+    /// </remarks>
     [HttpGet("current")]
     [NightscoutEndpoint("/api/v1/entries/current")]
-    [ResponseCache(Duration = 60, VaryByHeader = "If-Modified-Since")]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(typeof(Entry[]), 304)] // Not Modified response
     [RequireScope(OAuthScopes.GlucoseRead)]
@@ -297,9 +303,15 @@ public class EntriesController : ControllerBase
     /// <param name="dateString">ISO date string for date filtering</param>
     /// <param name="format">Output format (json, csv, tsv, txt)</param>
     /// <returns>Array of entries matching the criteria</returns>
+    /// <remarks>
+    /// Never cached, per <see cref="V4.Profiles.ProfileController.GetProfileSummary"/>: a reading or
+    /// correction that has just landed must not be missing from the next poll. The
+    /// <c>Last-Modified</c> / <c>If-Modified-Since</c> handling below still answers a conditional
+    /// poll with a 304, so revalidating callers pay no body.
+    /// </remarks>
     [HttpGet]
     [NightscoutEndpoint("/api/v1/entries")]
-    [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" }, VaryByHeader = "If-Modified-Since")]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(typeof(Entry[]), 304)] // Not Modified response
     [RequireScope(OAuthScopes.GlucoseRead)]

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
@@ -25,9 +25,8 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 /// <c>/illness</c>, <c>/travel</c>, <c>/activities</c>) are thin wrappers that pre-filter
 /// <see cref="IStateSpanService.GetStateSpansAsync"/> by <see cref="StateSpanCategory"/>.
 ///
-/// The main <c>GET /</c> endpoint is annotated with <c>RemoteQueryAttribute</c>
-/// and cached for 120 seconds. Create, update, and delete use
-/// <c>RemoteCommandAttribute</c> with cache invalidation hints.
+/// The main <c>GET /</c> endpoint is annotated with <c>RemoteQueryAttribute</c>. Create, update,
+/// and delete use <c>RemoteCommandAttribute</c> with cache invalidation hints.
 /// </remarks>
 /// <seealso cref="IStateSpanService"/>
 /// <seealso cref="StateSpan"/>
@@ -58,9 +57,15 @@ public class StateSpansController : ControllerBase
     /// <summary>
     /// Query all state spans with optional filtering
     /// </summary>
+    /// <remarks>
+    /// Never cached, per <see cref="Profiles.ProfileController.GetProfileSummary"/>: a temporary
+    /// target, override, or data-exclusion window the caller just set must not be invisible until a
+    /// cached list body expires — and an exclusion window decides whether readings count towards
+    /// analytics, so a stale one silently changes reported statistics.
+    /// </remarks>
     [HttpGet]
     [RemoteQuery]
-    [ResponseCache(Duration = 120, VaryByQueryKeys = new[] { "*" })]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     [ProducesResponseType(typeof(PaginatedResponse<StateSpan>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<PaginatedResponse<StateSpan>>> GetStateSpans(

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/CalibrationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/CalibrationController.cs
@@ -16,8 +16,6 @@ namespace Nocturne.API.Controllers.V4.Glucose;
 /// <remarks>
 /// Inherits standard list, get-by-ID, create, update, and delete operations from
 /// <see cref="V4CrudControllerBase{TModel,TCreateRequest,TUpdateRequest,TRepository}"/>.
-/// The <c>GetAll</c> response is cached for 120 seconds with vary-by-query-keys to minimise
-/// database pressure when the dashboard polls for calibration data.
 /// </remarks>
 /// <seealso cref="ICalibrationRepository"/>
 /// <seealso cref="Calibration"/>
@@ -36,8 +34,11 @@ public class CalibrationController(ICalibrationRepository repo)
     public override string WriteScope => OAuthScopes.GlucoseReadWrite;
 
     /// <inheritdoc/>
-    /// <remarks>Response is cached for 120 seconds, varied by all query parameters.</remarks>
-    [ResponseCache(Duration = 120, VaryByQueryKeys = new[] { "*" })]
+    /// <remarks>
+    /// Never cached, per <see cref="Profiles.ProfileController.GetProfileSummary"/>: a calibration the
+    /// patient just entered must not be invisible until a cached list body expires.
+    /// </remarks>
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     public override Task<ActionResult<PaginatedResponse<Calibration>>> GetAll(
         [FromQuery] DateTime? from, [FromQuery] DateTime? to,
         [FromQuery] int limit = 100, [FromQuery] int offset = 0,

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
@@ -19,7 +19,6 @@ namespace Nocturne.API.Controllers.V4.Glucose;
 /// <remarks>
 /// Inherits standard list, get-by-ID, create, update, and delete operations from
 /// <see cref="V4CrudControllerBase{TModel,TCreateRequest,TUpdateRequest,TRepository}"/>.
-/// The <c>GetAll</c> response is cached for 120 seconds with vary-by-query-keys.
 /// </remarks>
 /// <seealso cref="IMeterGlucoseRepository"/>
 /// <seealso cref="MeterGlucose"/>
@@ -42,8 +41,11 @@ public class MeterGlucoseController(
     public override string WriteScope => OAuthScopes.GlucoseReadWrite;
 
     /// <inheritdoc/>
-    /// <remarks>Response is cached for 120 seconds, varied by all query parameters.</remarks>
-    [ResponseCache(Duration = 120, VaryByQueryKeys = new[] { "*" })]
+    /// <remarks>
+    /// Never cached, per <see cref="Profiles.ProfileController.GetProfileSummary"/>: a fingerstick the
+    /// patient just entered must not be invisible until a cached list body expires.
+    /// </remarks>
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     public override Task<ActionResult<PaginatedResponse<MeterGlucose>>> GetAll(
         [FromQuery] DateTime? from, [FromQuery] DateTime? to,
         [FromQuery] int limit = 100, [FromQuery] int offset = 0,

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -55,8 +55,12 @@ public class SensorGlucoseController(
     /// The <c>patientDeviceId</c> query parameter is read directly from the request because the base list
     /// signature (shared by every V4 read controller) has no device-attribution concept — binding it here keeps
     /// a single <c>GET</c> action while adding the sensor-glucose-only filter.
+    /// <para>
+    /// Never cached, per <see cref="Profiles.ProfileController.GetProfileSummary"/>: a newly arrived or
+    /// corrected reading must not be invisible until a cached list body expires.
+    /// </para>
     /// </remarks>
-    [ResponseCache(Duration = 90, VaryByQueryKeys = new[] { "*" })]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     public override async Task<ActionResult<PaginatedResponse<SensorGlucose>>> GetAll(
         [FromQuery] DateTime? from, [FromQuery] DateTime? to,
         [FromQuery] int limit = 100, [FromQuery] int offset = 0,

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/ProfileController.cs
@@ -78,10 +78,12 @@ public class ProfileController : ControllerBase, IWriteScopedController
     /// </summary>
     [HttpGet("summary")]
     [RemoteQuery]
-    // Never cached: profile mutations invalidate the client-side query, but a
-    // cached body could answer the refetch with therapy settings up to the cache
-    // duration old, so edited target ranges and the active-profile badge would
-    // read as unchanged. Matches PredictionController.GetProfileSnapshot.
+    // Never cached: UseResponseCaching keys only on host + query + Cookie, so a mutation that
+    // correctly invalidates its client-side query can still have the refetch answered from a body
+    // up to the cache duration old — an edited target range, the active-profile badge, or a
+    // just-entered record reads as unchanged. Every per-user therapy and glucose read that a
+    // caller can mutate carries this attribute for that reason.
+    // Matches PredictionController.GetProfileSnapshot.
     [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     [ProducesResponseType(typeof(ProfileSummary), StatusCodes.Status200OK)]
     public async Task<ActionResult<ProfileSummary>> GetProfileSummary(

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -16,8 +16,6 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 /// Exposes standard V4 CRUD operations via <see cref="V4CrudControllerBase{TModel,TCreateRequest,TUpdateRequest,TRepository}"/>.
 /// </summary>
 /// <remarks>
-/// The <c>GET /</c> list endpoint is cached for 90 seconds (varying by all query string parameters).
-///
 /// On update, immutable fields (<see cref="Bolus.BolusType"/>, <see cref="Bolus.Kind"/>,
 /// <see cref="Bolus.LegacyId"/>, <see cref="Bolus.CreatedAt"/>, <see cref="Bolus.PumpRecordId"/>,
 /// <see cref="Bolus.DeviceId"/>, and <see cref="Bolus.AdditionalProperties"/>) are preserved from the
@@ -46,8 +44,11 @@ public class BolusController(
     public override string WriteScope => OAuthScopes.TreatmentsReadWrite;
 
     /// <inheritdoc/>
-    /// <remarks>Response is cached for 90 seconds, varying by all query parameters.</remarks>
-    [ResponseCache(Duration = 90, VaryByQueryKeys = new[] { "*" })]
+    /// <remarks>
+    /// Never cached, per <see cref="Profiles.ProfileController.GetProfileSummary"/>: a just-entered
+    /// bolus must not be invisible until a cached list body expires.
+    /// </remarks>
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     public override Task<ActionResult<PaginatedResponse<Bolus>>> GetAll(
         [FromQuery] DateTime? from, [FromQuery] DateTime? to,
         [FromQuery] int limit = 100, [FromQuery] int offset = 0,

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
@@ -36,9 +36,13 @@ public class TempBasalController(
     /// <summary>
     /// Lists temp basal spans, newest-first by default.
     /// </summary>
+    /// <remarks>
+    /// Never cached, per <see cref="Profiles.ProfileController.GetProfileSummary"/>: a just-started
+    /// or just-cancelled span must not be invisible until a cached list body expires.
+    /// </remarks>
     [HttpGet]
     [RequireScope(OAuthScopes.TreatmentsRead)]
-    [ResponseCache(Duration = 90, VaryByQueryKeys = new[] { "*" })]
+    [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     [ProducesResponseType(typeof(PaginatedResponse<TempBasal>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<PaginatedResponse<TempBasal>>> GetAll(

--- a/tests/Unit/Nocturne.API.Tests/Authorization/AnalyticsReadScopeGuardTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/AnalyticsReadScopeGuardTests.cs
@@ -220,22 +220,6 @@ public class AnalyticsReadScopeGuardTests
             .RequiredScopes.Should().Equal(OAuthScopes.TreatmentsRead);
     }
 
-    /// <summary>
-    /// Per-scope redaction makes the body depend on the caller's credential, so a redacted
-    /// response must not sit in the shared response cache, whose key is host + query + Cookie: a
-    /// credential presenting neither a cookie nor an <c>Authorization</c> header (the legacy
-    /// <c>api-secret</c> header) would otherwise be served another caller's unredacted body.
-    /// </summary>
-    [Theory]
-    [InlineData(typeof(ChartDataController), nameof(ChartDataController.GetDashboardChartData))]
-    [InlineData(typeof(ActogramController), nameof(ActogramController.GetActogram))]
-    public void RedactedResponses_AreNotSharedCacheable(Type controller, string action)
-    {
-        var cache = controller.GetMethod(action)!.GetCustomAttribute<ResponseCacheAttribute>();
-
-        cache!.Location.Should().Be(ResponseCacheLocation.Client);
-    }
-
     [Fact]
     public async Task ChartData_Handler_RedactsTheCategoriesTheCallerLacks()
     {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/ResponseCachePolicyTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/ResponseCachePolicyTests.cs
@@ -1,0 +1,82 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Controllers.V4.Analytics;
+using Nocturne.API.Controllers.V4.Glucose;
+using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.API.Controllers.V4.Treatments;
+using V1EntriesController = Nocturne.API.Controllers.V1.EntriesController;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// Pins the <see cref="ResponseCacheAttribute"/> posture of every cache-annotated read, so a
+/// duration cannot be reintroduced on an endpoint that must not carry one.
+/// </summary>
+public class ResponseCachePolicyTests
+{
+    private static ResponseCacheAttribute CacheOn(Type controller, string action)
+    {
+        var attribute = controller.GetMethod(action)!.GetCustomAttribute<ResponseCacheAttribute>();
+        attribute.Should().NotBeNull($"{controller.Name}.{action} declares a cache posture");
+        return attribute!;
+    }
+
+    /// <summary>
+    /// Per-user therapy and glucose reads the caller can mutate. Rationale at
+    /// <see cref="ProfileController.GetProfileSummary"/>.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(BolusController), nameof(BolusController.GetAll))]
+    [InlineData(typeof(TempBasalController), nameof(TempBasalController.GetAll))]
+    [InlineData(typeof(SensorGlucoseController), nameof(SensorGlucoseController.GetAll))]
+    [InlineData(typeof(MeterGlucoseController), nameof(MeterGlucoseController.GetAll))]
+    [InlineData(typeof(CalibrationController), nameof(CalibrationController.GetAll))]
+    [InlineData(typeof(StateSpansController), nameof(StateSpansController.GetStateSpans))]
+    [InlineData(typeof(V1EntriesController), nameof(V1EntriesController.GetCurrentEntry))]
+    [InlineData(typeof(V1EntriesController), nameof(V1EntriesController.GetEntries))]
+    [InlineData(typeof(ProfileController), nameof(ProfileController.GetProfileSummary))]
+    [InlineData(typeof(PredictionController), nameof(PredictionController.GetProfileSnapshot))]
+    public void MutableReads_AreNeverStored(Type controller, string action)
+    {
+        var cache = CacheOn(controller, action);
+
+        cache.NoStore.Should().BeTrue();
+        cache.Location.Should().Be(ResponseCacheLocation.None);
+        cache.Duration.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Per-scope redaction makes the body depend on the caller's credential, so a redacted
+    /// response must not sit in the shared response cache, whose key is host + query + Cookie: a
+    /// credential presenting neither a cookie nor an <c>Authorization</c> header (the legacy
+    /// <c>api-secret</c> header) would otherwise be served another caller's unredacted body.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(ChartDataController), nameof(ChartDataController.GetDashboardChartData))]
+    [InlineData(typeof(ActogramController), nameof(ActogramController.GetActogram))]
+    public void RedactedResponses_AreNotSharedCacheable(Type controller, string action)
+    {
+        CacheOn(controller, action).Location.Should().Be(ResponseCacheLocation.Client);
+    }
+
+    /// <summary>
+    /// Aggregates over a window, gated all-or-nothing by <c>reports.read</c> and narrowed no
+    /// further per caller scope, so the shared cache is safe and its staleness window is a
+    /// deliberate trade-off against recompute cost.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(DataOverviewController), nameof(DataOverviewController.GetAvailableYears), 300)]
+    [InlineData(typeof(DataOverviewController), nameof(DataOverviewController.GetDailySummary), 180)]
+    [InlineData(typeof(DataOverviewController), nameof(DataOverviewController.GetGriTimeline), 300)]
+    [InlineData(typeof(StatisticsController), nameof(StatisticsController.GetRangeAnalytics), 60)]
+    [InlineData(typeof(SensorIntegrityController), nameof(SensorIntegrityController.Analyze), 60)]
+    [InlineData(typeof(ChartDataController), nameof(ChartDataController.GetBasalSeries), 60)]
+    public void AggregateReads_KeepTheirSharedCacheWindow(Type controller, string action, int seconds)
+    {
+        var cache = CacheOn(controller, action);
+
+        cache.NoStore.Should().BeFalse();
+        cache.Location.Should().Be(ResponseCacheLocation.Any);
+        cache.Duration.Should().Be(seconds);
+    }
+}


### PR DESCRIPTION
Fixes #562.

## What

Matches #554's `ProfileController.GetProfileSummary` remedy — `[ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]` — on the remaining per-user therapy/glucose reads, with the rationale living at that one action and every new site referencing it by `<see cref>`. Full per-endpoint decision table in the commit message; the shape:

- **Un-cached now:** Bolus, TempBasal, SensorGlucose, MeterGlucose, Calibration `GetAll`; StateSpans (a stale data-exclusion window silently changes reported statistics); both v1 entries routes (a follower's poll must not miss a just-landed reading — the `Last-Modified`/304 path still spares revalidating callers the body, though expect more DB reads on those two routes after deploy).
- **Deliberately unchanged:** DataOverview/Statistics/SensorIntegrity aggregates (`reports.read` all-or-nothing, no per-caller narrowing, expensive to recompute), Actogram (already `Client` — it redacts per scope), ChartData (documented share-link trade-off).
- An audit of every scope-redacting controller confirms none of the endpoints left cached narrows per caller scope, so no shared-cache leak hides in the kept set.

## Testing

New `ResponseCachePolicyTests` pins the posture of every cache-annotated read in three theories (never-stored, client-only for redacted, pinned durations for aggregates), and **absorbs** the pre-existing duplicate redaction assertion from `AnalyticsReadScopeGuardTests` so the invariant lives at one site. Triple mutation proof: reintroducing a 90s duration on Bolus, stripping `Client` from Actogram, and shifting a DataOverview duration each fail exactly their theory. API suite: 5719 passed, 0 failed.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
