### PR TITLE
test(agp): align the mmol expectations with the converged conversion factor

### DIFF
--- a/src/Web/packages/app/src/lib/components/ambulatory-glucose-profile/agp-utils.test.ts
+++ b/src/Web/packages/app/src/lib/components/ambulatory-glucose-profile/agp-utils.test.ts
@@ -108,9 +108,9 @@ describe("transformStats", () => {
 
 		expect(result[0].median).toBe(10.0);
 		expect(result[0].percentiles!.p10).toBe(3.9);
-		expect(result[0].percentiles!.p25).toBe(5.6);
+		expect(result[0].percentiles!.p25).toBe(5.5);
 		expect(result[0].percentiles!.p75).toBe(11.1);
-		expect(result[0].percentiles!.p90).toBe(16.7);
+		expect(result[0].percentiles!.p90).toBe(16.6);
 	});
 
 	it("defaults missing median to 0", () => {


### PR DESCRIPTION
Two assertions in agp-utils.test.ts still pinned the retired 18.01559 divisor: 100 mg/dL is 5.5 (not 5.6) and 300 mg/dL is 16.6 (not 16.7) under the converged `MGDL_PER_MMOL = 18.0182`. The case's other three values round identically under both divisors, so these were the only two left. Failing on main today; 16/16 pass after. CI runs no web vitest, which is how they stayed green — the display change itself is the intended outcome of the #776/#782 convergence.

Found while reviewing the fix for #780.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup