### PR TITLE
fix(entries): emit the legacy Nightscout direction spelling on v1/v3

### DIFF
--- a/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/ChartDataService.cs
@@ -146,7 +146,7 @@ public class ChartDataService : IChartDataService
             {
                 Time = r.Mills,
                 Sgv = r.Mgdl,
-                Direction = r.Direction?.ToString(),
+                Direction = r.Direction?.ToWireString(),
                 DataSource = r.DataSource ?? r.Device,
             })
             .ToList(); // Already sorted

--- a/src/API/Nocturne.API/Services/Glucose/DirectionService.cs
+++ b/src/API/Nocturne.API/Services/Glucose/DirectionService.cs
@@ -56,8 +56,7 @@ public static class DirectionService
         if (entry == null)
             return result;
 
-        // Parse direction from string to enum
-        var direction = ParseDirection(entry.Direction);
+        var direction = DirectionExtensions.Parse(entry.Direction);
         result.Value = direction;
         result.Label = DirectionToChar(direction);
         result.Entity = CharToEntity(result.Label);
@@ -164,33 +163,6 @@ public static class DirectionService
             return string.Empty;
 
         return $"&#{(int)character[0]};";
-    }
-
-    /// <summary>
-    /// Parse direction string to enum - handles legacy string values
-    /// </summary>
-    private static Direction ParseDirection(string? directionString)
-    {
-        if (string.IsNullOrEmpty(directionString))
-            return Direction.NONE;
-
-        return directionString switch
-        {
-            "NONE" => Direction.NONE,
-            "TripleUp" => Direction.TripleUp,
-            "DoubleUp" => Direction.DoubleUp,
-            "SingleUp" => Direction.SingleUp,
-            "FortyFiveUp" => Direction.FortyFiveUp,
-            "Flat" => Direction.Flat,
-            "FortyFiveDown" => Direction.FortyFiveDown,
-            "SingleDown" => Direction.SingleDown,
-            "DoubleDown" => Direction.DoubleDown,
-            "TripleDown" => Direction.TripleDown,
-            "NOT COMPUTABLE" => Direction.NotComputable,
-            "RATE OUT OF RANGE" => Direction.RateOutOfRange,
-            "CGM ERROR" => Direction.CgmError,
-            _ => Direction.NONE,
-        };
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Glucose/SensorGlucoseToEntryMapper.cs
+++ b/src/API/Nocturne.API/Services/Glucose/SensorGlucoseToEntryMapper.cs
@@ -31,7 +31,7 @@ public static class SensorGlucoseToEntryMapper
             Mgdl = sg.Mgdl,
             Mmol = sg.Mmol,
             Mbg = 0,
-            Direction = sg.Direction?.ToString(),
+            Direction = sg.Direction?.ToWireString(),
             Trend = sg.Trend.HasValue ? (int?)sg.Trend.Value : null,
             TrendRate = sg.TrendRate,
             Noise = sg.Noise,

--- a/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
@@ -419,32 +419,13 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     }
 
     /// <summary>
-    /// Converts a Nightscout direction string (e.g. <c>"SingleUp"</c>, <c>"Flat"</c>) to the typed
-    /// <see cref="GlucoseDirection"/> enum. Returns <see langword="null"/> for unknown or empty values.
+    /// Converts a Nightscout direction string (e.g. <c>"SingleUp"</c>, <c>"NOT COMPUTABLE"</c>) to the
+    /// typed <see cref="GlucoseDirection"/> enum. Returns <see langword="null"/> for unknown or empty
+    /// values, and for legacy values V4 does not model (triple arrows, CGM error).
     /// </summary>
     /// <param name="direction">The raw direction string from the legacy entry.</param>
     /// <returns>The corresponding <see cref="GlucoseDirection"/> value, or <see langword="null"/> if unrecognised.</returns>
-    internal static GlucoseDirection? MapDirection(string? direction)
-    {
-        if (string.IsNullOrEmpty(direction))
-            return null;
-
-        return direction switch
-        {
-            "NONE" => GlucoseDirection.None,
-            "DoubleUp" => GlucoseDirection.DoubleUp,
-            "SingleUp" => GlucoseDirection.SingleUp,
-            "FortyFiveUp" => GlucoseDirection.FortyFiveUp,
-            "Flat" => GlucoseDirection.Flat,
-            "FortyFiveDown" => GlucoseDirection.FortyFiveDown,
-            "SingleDown" => GlucoseDirection.SingleDown,
-            "DoubleDown" => GlucoseDirection.DoubleDown,
-            "NOT COMPUTABLE" => GlucoseDirection.NotComputable,
-            "RATE OUT OF RANGE" => GlucoseDirection.RateOutOfRange,
-            _ => Enum.TryParse<GlucoseDirection>(direction, ignoreCase: true, out var parsed)
-                ? parsed
-                : null
-        };
-    }
+    internal static GlucoseDirection? MapDirection(string? direction) =>
+        DirectionExtensions.TryParse(direction, out var parsed) ? parsed.ToGlucoseDirection() : null;
 
 }

--- a/src/Core/Nocturne.Core.Models/Direction.cs
+++ b/src/Core/Nocturne.Core.Models/Direction.cs
@@ -7,6 +7,12 @@ namespace Nocturne.Core.Models;
 /// These values indicate the rate and direction of glucose change.
 /// 1:1 Legacy JavaScript compatibility with ClientApp/lib/plugins/direction.js
 /// </summary>
+/// <remarks>
+/// Three of the legacy wire spellings contain spaces and so cannot be member names. The wire form of
+/// every value is <see cref="DirectionExtensions.ToWireString(Direction)"/>; <see cref="JsonStringEnumConverter"/>
+/// ignores per-member naming attributes, so member names — not wire spellings — are what this enum
+/// serialises as on its own.
+/// </remarks>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum Direction
 {
@@ -63,19 +69,16 @@ public enum Direction
     /// <summary>
     /// CGM cannot determine direction due to insufficient data
     /// </summary>
-    [JsonPropertyName("NOT COMPUTABLE")]
     NotComputable,
 
     /// <summary>
     /// Rate of change is outside measurable range
     /// </summary>
-    [JsonPropertyName("RATE OUT OF RANGE")]
     RateOutOfRange,
 
     /// <summary>
     /// CGM sensor error or malfunction
     /// </summary>
-    [JsonPropertyName("CGM ERROR")]
     CgmError,
 }
 
@@ -84,6 +87,75 @@ public enum Direction
 /// </summary>
 public static class DirectionExtensions
 {
+    /// <summary>
+    /// The legacy Nightscout wire spelling of each <see cref="Direction"/>, from
+    /// <c>ClientApp/lib/plugins/direction.js</c>. Sole source of truth for the string form: v1/v3
+    /// responses, the <c>entries</c> SignalR broadcast and the CSV/TSV export all read it, and
+    /// <see cref="TryParse"/> indexes it.
+    /// </summary>
+    private static readonly Dictionary<Direction, string> WireNames = new()
+    {
+        { Direction.NONE, "NONE" },
+        { Direction.TripleUp, nameof(Direction.TripleUp) },
+        { Direction.DoubleUp, nameof(Direction.DoubleUp) },
+        { Direction.SingleUp, nameof(Direction.SingleUp) },
+        { Direction.FortyFiveUp, nameof(Direction.FortyFiveUp) },
+        { Direction.Flat, nameof(Direction.Flat) },
+        { Direction.FortyFiveDown, nameof(Direction.FortyFiveDown) },
+        { Direction.SingleDown, nameof(Direction.SingleDown) },
+        { Direction.DoubleDown, nameof(Direction.DoubleDown) },
+        { Direction.TripleDown, nameof(Direction.TripleDown) },
+        { Direction.NotComputable, "NOT COMPUTABLE" },
+        { Direction.RateOutOfRange, "RATE OUT OF RANGE" },
+        { Direction.CgmError, "CGM ERROR" },
+    };
+
+    private static readonly Dictionary<string, Direction> ByName = BuildNameIndex();
+
+    /// <summary>
+    /// Gets the legacy Nightscout wire spelling of a direction — <c>"NOT COMPUTABLE"</c> rather than
+    /// the member name <c>NotComputable</c>. Use this wherever a direction crosses the v1/v2/v3
+    /// surface; <c>ToString()</c> emits the member name, which Nightscout clients do not recognise.
+    /// </summary>
+    public static string ToWireString(this Direction direction) =>
+        WireNames.TryGetValue(direction, out var name) ? name : WireNames[Direction.NONE];
+
+    /// <summary>
+    /// Parses a direction string, accepting both the legacy wire spelling
+    /// (<c>"NOT COMPUTABLE"</c>) and the member name (<c>"NotComputable"</c>), case-insensitively.
+    /// </summary>
+    /// <returns><see langword="true"/> when <paramref name="value"/> names a direction.</returns>
+    public static bool TryParse(string? value, out Direction direction)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            direction = Direction.NONE;
+            return false;
+        }
+
+        return ByName.TryGetValue(value, out direction);
+    }
+
+    /// <summary>
+    /// Parses a direction string as <see cref="TryParse"/> does, falling back to
+    /// <see cref="Direction.NONE"/> for null, empty and unrecognised values.
+    /// </summary>
+    public static Direction Parse(string? value) =>
+        TryParse(value, out var direction) ? direction : Direction.NONE;
+
+    private static Dictionary<string, Direction> BuildNameIndex()
+    {
+        var index = new Dictionary<string, Direction>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var direction in Enum.GetValues<Direction>())
+        {
+            index[direction.ToString()] = direction;
+            index[direction.ToWireString()] = direction;
+        }
+
+        return index;
+    }
+
     /// <summary>
     /// Converts a <see cref="Direction"/> enum value to the Nightscout/Dexcom trend number (0-9).
     /// Used by the pebble endpoint and other legacy integrations.
@@ -117,29 +189,10 @@ public static class DirectionExtensions
 
     /// <summary>
     /// Parses a direction string to the corresponding Dexcom trend number (0-9).
-    /// Handles both <see cref="Direction"/> enum names and legacy space-separated string formats
-    /// (e.g., "NOT COMPUTABLE", "RATE OUT OF RANGE").
+    /// Accepts both spellings via <see cref="TryParse"/>.
     /// </summary>
     /// <param name="direction">Direction string to parse; null or empty returns 8 (NotComputable)</param>
     /// <returns>Dexcom trend number (0-9); returns 8 (NotComputable) for any unrecognized input</returns>
-    public static int ParseToTrendNumber(string? direction)
-    {
-        if (string.IsNullOrEmpty(direction))
-            return 8; // NOT COMPUTABLE
-
-        // Try to parse as enum first
-        if (Enum.TryParse<Direction>(direction, ignoreCase: true, out var parsed))
-        {
-            return parsed.ToTrendNumber();
-        }
-
-        // Handle legacy string formats
-        return direction.ToUpperInvariant() switch
-        {
-            "NOT COMPUTABLE" => 8,
-            "RATE OUT OF RANGE" => 9,
-            "CGM ERROR" => 8,
-            _ => 8
-        };
-    }
+    public static int ParseToTrendNumber(string? direction) =>
+        TryParse(direction, out var parsed) ? parsed.ToTrendNumber() : 8;
 }

--- a/src/Core/Nocturne.Core.Models/Entry.cs
+++ b/src/Core/Nocturne.Core.Models/Entry.cs
@@ -207,34 +207,7 @@ public class Entry : ProcessableDocumentBase
     /// Gets the direction as a strongly-typed enum value
     /// </summary>
     [JsonIgnore]
-    public Models.Direction DirectionEnum => ParseDirection(Direction);
-
-    /// <summary>
-    /// Parse direction string to enum - handles legacy string values
-    /// </summary>
-    private static Models.Direction ParseDirection(string? directionString)
-    {
-        if (string.IsNullOrEmpty(directionString))
-            return Models.Direction.NONE;
-
-        return directionString switch
-        {
-            "NONE" => Models.Direction.NONE,
-            "TripleUp" => Models.Direction.TripleUp,
-            "DoubleUp" => Models.Direction.DoubleUp,
-            "SingleUp" => Models.Direction.SingleUp,
-            "FortyFiveUp" => Models.Direction.FortyFiveUp,
-            "Flat" => Models.Direction.Flat,
-            "FortyFiveDown" => Models.Direction.FortyFiveDown,
-            "SingleDown" => Models.Direction.SingleDown,
-            "DoubleDown" => Models.Direction.DoubleDown,
-            "TripleDown" => Models.Direction.TripleDown,
-            "NOT COMPUTABLE" => Models.Direction.NotComputable,
-            "RATE OUT OF RANGE" => Models.Direction.RateOutOfRange,
-            "CGM ERROR" => Models.Direction.CgmError,
-            _ => Models.Direction.NONE,
-        };
-    }
+    public Models.Direction DirectionEnum => DirectionExtensions.Parse(Direction);
 
     /// <summary>
     /// Gets or sets the entry type (e.g., "sgv", "cal", "mbg")

--- a/src/Core/Nocturne.Core.Models/Projections/EntryProjection.cs
+++ b/src/Core/Nocturne.Core.Models/Projections/EntryProjection.cs
@@ -21,7 +21,7 @@ public static class EntryProjection
         entry.Mgdl = sg.Mgdl;
         entry.Sgv = sg.Mgdl;
         entry.Mmol = sg.Mmol;
-        entry.Direction = sg.Direction?.ToString();
+        entry.Direction = sg.Direction?.ToWireString();
         entry.Trend = sg.Trend.HasValue ? (int)sg.Trend.Value : null;
         entry.TrendRate = sg.TrendRate;
         entry.Noise = sg.Noise;

--- a/src/Core/Nocturne.Core.Models/Serializers/FlexibleDirectionConverter.cs
+++ b/src/Core/Nocturne.Core.Models/Serializers/FlexibleDirectionConverter.cs
@@ -15,17 +15,17 @@ namespace Nocturne.Core.Models.Serializers;
 /// <seealso cref="Entry"/>
 public class FlexibleDirectionConverter : JsonConverter<string?>
 {
-    private static readonly Dictionary<int, string> NumericDirectionMap = new()
+    private static readonly Dictionary<int, Direction> NumericDirectionMap = new()
     {
-        [1] = "DoubleUp",
-        [2] = "SingleUp",
-        [3] = "FortyFiveUp",
-        [4] = "Flat",
-        [5] = "FortyFiveDown",
-        [6] = "SingleDown",
-        [7] = "DoubleDown",
-        [8] = "NOT COMPUTABLE",
-        [9] = "RATE OUT OF RANGE",
+        [1] = Direction.DoubleUp,
+        [2] = Direction.SingleUp,
+        [3] = Direction.FortyFiveUp,
+        [4] = Direction.Flat,
+        [5] = Direction.FortyFiveDown,
+        [6] = Direction.SingleDown,
+        [7] = Direction.DoubleDown,
+        [8] = Direction.NotComputable,
+        [9] = Direction.RateOutOfRange,
     };
 
     public override string? Read(
@@ -43,7 +43,7 @@ public class FlexibleDirectionConverter : JsonConverter<string?>
                 if (reader.TryGetInt32(out var intValue))
                 {
                     return NumericDirectionMap.TryGetValue(intValue, out var direction)
-                        ? direction
+                        ? direction.ToWireString()
                         : intValue.ToString();
                 }
                 return null;

--- a/src/Core/Nocturne.Core.Models/V4/GlucoseDirection.cs
+++ b/src/Core/Nocturne.Core.Models/V4/GlucoseDirection.cs
@@ -45,3 +45,59 @@ public enum GlucoseDirection
     /// <summary>Rate of change is outside the computable range.</summary>
     RateOutOfRange
 }
+
+/// <summary>
+/// Bridges <see cref="GlucoseDirection"/> to the legacy <see cref="Direction"/>, which owns the
+/// Nightscout wire spellings.
+/// </summary>
+public static class GlucoseDirectionExtensions
+{
+    /// <summary>
+    /// Gets the equivalent legacy <see cref="Direction"/>. <see cref="GlucoseDirection"/> is a subset:
+    /// it has no triple arrows and no CGM-error value.
+    /// </summary>
+    public static Direction ToDirection(this GlucoseDirection direction) =>
+        direction switch
+        {
+            GlucoseDirection.None => Direction.NONE,
+            GlucoseDirection.DoubleUp => Direction.DoubleUp,
+            GlucoseDirection.SingleUp => Direction.SingleUp,
+            GlucoseDirection.FortyFiveUp => Direction.FortyFiveUp,
+            GlucoseDirection.Flat => Direction.Flat,
+            GlucoseDirection.FortyFiveDown => Direction.FortyFiveDown,
+            GlucoseDirection.SingleDown => Direction.SingleDown,
+            GlucoseDirection.DoubleDown => Direction.DoubleDown,
+            GlucoseDirection.NotComputable => Direction.NotComputable,
+            GlucoseDirection.RateOutOfRange => Direction.RateOutOfRange,
+            _ => Direction.NONE,
+        };
+
+    /// <summary>
+    /// Gets the equivalent <see cref="GlucoseDirection"/>, or <see langword="null"/> for the legacy
+    /// values this enum does not model.
+    /// </summary>
+    public static GlucoseDirection? ToGlucoseDirection(this Direction direction) =>
+        direction switch
+        {
+            Direction.NONE => GlucoseDirection.None,
+            Direction.DoubleUp => GlucoseDirection.DoubleUp,
+            Direction.SingleUp => GlucoseDirection.SingleUp,
+            Direction.FortyFiveUp => GlucoseDirection.FortyFiveUp,
+            Direction.Flat => GlucoseDirection.Flat,
+            Direction.FortyFiveDown => GlucoseDirection.FortyFiveDown,
+            Direction.SingleDown => GlucoseDirection.SingleDown,
+            Direction.DoubleDown => GlucoseDirection.DoubleDown,
+            Direction.NotComputable => GlucoseDirection.NotComputable,
+            Direction.RateOutOfRange => GlucoseDirection.RateOutOfRange,
+            _ => null,
+        };
+
+    /// <summary>
+    /// Gets the legacy Nightscout wire spelling — see
+    /// <see cref="DirectionExtensions.ToWireString(Direction)"/>. Required wherever a V4 direction is
+    /// projected onto the v1/v2/v3 surface, where <c>ToString()</c> would emit an unrecognised
+    /// PascalCase name.
+    /// </summary>
+    public static string ToWireString(this GlucoseDirection direction) =>
+        direction.ToDirection().ToWireString();
+}

--- a/src/Web/packages/app/src/lib/utils/direction-info.test.ts
+++ b/src/Web/packages/app/src/lib/utils/direction-info.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getDirectionInfo } from "./index";
+
+describe("getDirectionInfo", () => {
+	it.each([
+		["NOT COMPUTABLE", "unknown"],
+		["NotComputable", "unknown"],
+		["RATE OUT OF RANGE", "out of range"],
+		["RateOutOfRange", "out of range"],
+		["Flat", "stable"],
+		["DoubleDown", "falling very fast"],
+	])("resolves %s to %s", (direction, label) => {
+		expect(getDirectionInfo(direction).label).toBe(label);
+	});
+
+	it("falls back to stable for unrecognised and absent values", () => {
+		expect(getDirectionInfo("Bogus").label).toBe("stable");
+		expect(getDirectionInfo(undefined).label).toBe("stable");
+	});
+});

--- a/src/Web/packages/app/src/lib/utils/index.ts
+++ b/src/Web/packages/app/src/lib/utils/index.ts
@@ -16,57 +16,69 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SvelteComponent = any;
 
+const directionInfo: Partial<Record<
+  Direction,
+  { label: string; icon: SvelteComponent; css: string }
+>> = {
+  [Direction.DoubleUp]: {
+    label: "rising very fast",
+    icon: ArrowUp,
+    css: "text-red-500",
+  },
+  [Direction.SingleUp]: {
+    label: "rising",
+    icon: ArrowUpRight,
+    css: "text-orange-500",
+  },
+  [Direction.FortyFiveUp]: {
+    label: "rising slowly",
+    icon: ArrowUpRight,
+    css: "text-yellow-500",
+  },
+  [Direction.Flat]: { label: "stable", icon: ArrowRight, css: "text-green-500" },
+  [Direction.FortyFiveDown]: {
+    label: "falling slowly",
+    icon: ArrowDownRight,
+    css: "text-yellow-500",
+  },
+  [Direction.SingleDown]: {
+    label: "falling",
+    icon: ArrowDownRight,
+    css: "text-orange-500",
+  },
+  [Direction.DoubleDown]: {
+    label: "falling very fast",
+    icon: ArrowDown,
+    css: "text-red-500",
+  },
+  [Direction.NotComputable]: {
+    label: "unknown",
+    icon: HelpCircle,
+    css: "text-gray-500",
+  },
+  [Direction.RateOutOfRange]: {
+    label: "out of range",
+    icon: AlertTriangle,
+    css: "text-gray-500",
+  },
+};
+
+/**
+ * v1/v3 responses carry the space-separated Nightscout spellings ("NOT COMPUTABLE"); v4 carries the
+ * enum member names. Both resolve to the same entry.
+ */
+const normaliseDirection = (direction: string) => direction.replace(/\s/g, "").toUpperCase();
+
+const directionsByName = new Map(
+  Object.keys(directionInfo).map((name) => [normaliseDirection(name), name as Direction])
+);
+
 /** Get BG trend direction information */
 export function getDirectionInfo(direction?: Direction | string) {
-  const directions: Partial<Record<
-    Direction,
-    { label: string; icon: SvelteComponent; css: string }
-  >> = {
-    [Direction.DoubleUp]: {
-      label: "rising very fast",
-      icon: ArrowUp,
-      css: "text-red-500",
-    },
-    [Direction.SingleUp]: {
-      label: "rising",
-      icon: ArrowUpRight,
-      css: "text-orange-500",
-    },
-    [Direction.FortyFiveUp]: {
-      label: "rising slowly",
-      icon: ArrowUpRight,
-      css: "text-yellow-500",
-    },
-    [Direction.Flat]: { label: "stable", icon: ArrowRight, css: "text-green-500" },
-    [Direction.FortyFiveDown]: {
-      label: "falling slowly",
-      icon: ArrowDownRight,
-      css: "text-yellow-500",
-    },
-    [Direction.SingleDown]: {
-      label: "falling",
-      icon: ArrowDownRight,
-      css: "text-orange-500",
-    },
-    [Direction.DoubleDown]: {
-      label: "falling very fast",
-      icon: ArrowDown,
-      css: "text-red-500",
-    },
-    [Direction.NotComputable]: {
-      label: "unknown",
-      icon: HelpCircle,
-      css: "text-gray-500",
-    },
-    [Direction.RateOutOfRange]: {
-      label: "out of range",
-      icon: AlertTriangle,
-      css: "text-gray-500",
-    },
-  };
-
-  const dirValue = typeof direction === 'string' ? direction as Direction : direction;
-  return directions[dirValue || Direction.Flat] || directions[Direction.Flat]!;
+  const name = direction
+    ? directionsByName.get(normaliseDirection(direction))
+    : undefined;
+  return directionInfo[name ?? Direction.Flat] || directionInfo[Direction.Flat]!;
 }
 
 /** Enhanced relative time formatting with internationalization support */

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/ChartDataServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/ChartDataServiceTests.cs
@@ -56,6 +56,24 @@ public class ChartDataServiceTests
         }
 
         [Fact]
+        public void NotComputableDirection_UsesLegacyWireSpelling()
+        {
+            var readings = new List<SensorGlucose>
+            {
+                new()
+                {
+                    Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(TestMills).UtcDateTime,
+                    Mgdl = 120.0,
+                    Direction = GlucoseDirection.NotComputable,
+                },
+            };
+
+            var (data, _) = ChartDataService.BuildGlucoseData(readings);
+
+            data[0].Direction.Should().Be("NOT COMPUTABLE");
+        }
+
+        [Fact]
         public void AllReadingsIncluded()
         {
             var readings = new List<SensorGlucose>

--- a/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryProjectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Entries/EntryProjectionTests.cs
@@ -81,6 +81,23 @@ public class EntryProjectionTests
         entry.Direction.Should().Be("FortyFiveUp");
     }
 
+    [Theory]
+    [InlineData(GlucoseDirection.None, "NONE")]
+    [InlineData(GlucoseDirection.NotComputable, "NOT COMPUTABLE")]
+    [InlineData(GlucoseDirection.RateOutOfRange, "RATE OUT OF RANGE")]
+    public void FromSensorGlucose_MapsDirectionToLegacyWireSpelling(
+        GlucoseDirection direction,
+        string expected
+    )
+    {
+        var sg = CreateSensorGlucose();
+        sg.Direction = direction;
+
+        var entry = EntryProjection.FromSensorGlucose(sg);
+
+        entry.Direction.Should().Be(expected);
+    }
+
     [Fact]
     public void FromSensorGlucose_NullDirection_MapsToNull()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/Glucose/DirectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Glucose/DirectionServiceTests.cs
@@ -90,6 +90,28 @@ public class DirectionServiceTests
         }
     }
 
+    [Theory]
+    [InlineData("NotComputable", "-", "&#45;")]
+    [InlineData("RateOutOfRange", "⇕", "&#8661;")]
+    [InlineData("None", "⇼", "&#8700;")]
+    public void GetDirectionInfo_ShouldAcceptEnumMemberSpelling(
+        string direction,
+        string expectedLabel,
+        string expectedEntity
+    )
+    {
+        var entry = new Entry
+        {
+            Direction = direction,
+            Mills = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        };
+
+        var result = DirectionService.GetDirectionInfo(entry);
+
+        Assert.Equal(expectedLabel, result.Label);
+        Assert.Equal(expectedEntity, result.Entity);
+    }
+
     [Fact]
     public void GetDirectionInfo_ShouldReturnNullDisplayForNullEntry()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
@@ -657,23 +657,21 @@ public class EntryDecomposerTests : IDisposable
 
     #endregion
 
-    #region Direction Fallback via TryParse
+    #region Direction Parsing
 
     [Theory]
     [InlineData("flat", GlucoseDirection.Flat)]
     [InlineData("FLAT", GlucoseDirection.Flat)]
     [InlineData("singleup", GlucoseDirection.SingleUp)]
     [InlineData("SINGLEDOWN", GlucoseDirection.SingleDown)]
-    public void MapDirection_CaseInsensitiveFallback_MapsCorrectly(string input, GlucoseDirection expected)
+    public void MapDirection_CaseInsensitive_MapsCorrectly(string input, GlucoseDirection expected)
     {
-        // The switch cases are exact-match; non-matching falls to Enum.TryParse with ignoreCase
         EntryDecomposer.MapDirection(input).Should().Be(expected);
     }
 
     [Fact]
     public void MapDirection_WhitespaceOnly_ReturnsNull()
     {
-        // String.IsNullOrEmpty returns false for whitespace, so it goes to switch
         EntryDecomposer.MapDirection("   ").Should().BeNull();
     }
 
@@ -804,9 +802,21 @@ public class EntryDecomposerTests : IDisposable
     [InlineData("NOT COMPUTABLE", GlucoseDirection.NotComputable)]
     [InlineData("RATE OUT OF RANGE", GlucoseDirection.RateOutOfRange)]
     [InlineData("NONE", GlucoseDirection.None)]
+    [InlineData("NotComputable", GlucoseDirection.NotComputable)]
+    [InlineData("RateOutOfRange", GlucoseDirection.RateOutOfRange)]
+    [InlineData("None", GlucoseDirection.None)]
     public void MapDirection_KnownValues_MapsCorrectly(string input, GlucoseDirection expected)
     {
         EntryDecomposer.MapDirection(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("TripleUp")]
+    [InlineData("TripleDown")]
+    [InlineData("CGM ERROR")]
+    public void MapDirection_LegacyOnlyValues_ReturnNull(string input)
+    {
+        EntryDecomposer.MapDirection(input).Should().BeNull();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Core.Models.Tests/DirectionWireFormatTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/DirectionWireFormatTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using Nocturne.Core.Models.Projections;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests;
+
+public class DirectionWireFormatTests
+{
+    [Theory]
+    [InlineData(Direction.NONE, "NONE")]
+    [InlineData(Direction.TripleUp, "TripleUp")]
+    [InlineData(Direction.DoubleUp, "DoubleUp")]
+    [InlineData(Direction.SingleUp, "SingleUp")]
+    [InlineData(Direction.FortyFiveUp, "FortyFiveUp")]
+    [InlineData(Direction.Flat, "Flat")]
+    [InlineData(Direction.FortyFiveDown, "FortyFiveDown")]
+    [InlineData(Direction.SingleDown, "SingleDown")]
+    [InlineData(Direction.DoubleDown, "DoubleDown")]
+    [InlineData(Direction.TripleDown, "TripleDown")]
+    [InlineData(Direction.NotComputable, "NOT COMPUTABLE")]
+    [InlineData(Direction.RateOutOfRange, "RATE OUT OF RANGE")]
+    [InlineData(Direction.CgmError, "CGM ERROR")]
+    public void ToWireString_UsesLegacyNightscoutSpelling(Direction direction, string expected)
+    {
+        direction.ToWireString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void Parse_RoundTripsEveryWireString()
+    {
+        foreach (var direction in Enum.GetValues<Direction>())
+        {
+            DirectionExtensions.Parse(direction.ToWireString()).Should().Be(direction);
+        }
+    }
+
+    [Theory]
+    [InlineData("NOT COMPUTABLE", Direction.NotComputable)]
+    [InlineData("NotComputable", Direction.NotComputable)]
+    [InlineData("not computable", Direction.NotComputable)]
+    [InlineData("notcomputable", Direction.NotComputable)]
+    [InlineData("RATE OUT OF RANGE", Direction.RateOutOfRange)]
+    [InlineData("RateOutOfRange", Direction.RateOutOfRange)]
+    [InlineData("CGM ERROR", Direction.CgmError)]
+    [InlineData("CgmError", Direction.CgmError)]
+    [InlineData("NONE", Direction.NONE)]
+    [InlineData("None", Direction.NONE)]
+    [InlineData("Flat", Direction.Flat)]
+    [InlineData("flat", Direction.Flat)]
+    [InlineData("FORTYFIVEUP", Direction.FortyFiveUp)]
+    public void Parse_AcceptsBothSpellings(string value, Direction expected)
+    {
+        DirectionExtensions.Parse(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("sideways")]
+    [InlineData("NOTCOMPUTABLE!")]
+    public void TryParse_RejectsUnknownValues(string? value)
+    {
+        DirectionExtensions.TryParse(value, out var direction).Should().BeFalse();
+        direction.Should().Be(Direction.NONE);
+        DirectionExtensions.Parse(value).Should().Be(Direction.NONE);
+    }
+
+    [Fact]
+    public void ParseToTrendNumber_UnknownAndEmptyValuesReportNotComputable()
+    {
+        DirectionExtensions.ParseToTrendNumber(null).Should().Be(8);
+        DirectionExtensions.ParseToTrendNumber("").Should().Be(8);
+        DirectionExtensions.ParseToTrendNumber("sideways").Should().Be(8);
+    }
+
+    [Theory]
+    [InlineData("NOT COMPUTABLE", 8)]
+    [InlineData("NotComputable", 8)]
+    [InlineData("RATE OUT OF RANGE", 9)]
+    [InlineData("RateOutOfRange", 9)]
+    [InlineData("NONE", 0)]
+    [InlineData("Flat", 4)]
+    public void ParseToTrendNumber_AcceptsBothSpellings(string value, int expected)
+    {
+        DirectionExtensions.ParseToTrendNumber(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(GlucoseDirection.None, Direction.NONE)]
+    [InlineData(GlucoseDirection.DoubleUp, Direction.DoubleUp)]
+    [InlineData(GlucoseDirection.SingleUp, Direction.SingleUp)]
+    [InlineData(GlucoseDirection.FortyFiveUp, Direction.FortyFiveUp)]
+    [InlineData(GlucoseDirection.Flat, Direction.Flat)]
+    [InlineData(GlucoseDirection.FortyFiveDown, Direction.FortyFiveDown)]
+    [InlineData(GlucoseDirection.SingleDown, Direction.SingleDown)]
+    [InlineData(GlucoseDirection.DoubleDown, Direction.DoubleDown)]
+    [InlineData(GlucoseDirection.NotComputable, Direction.NotComputable)]
+    [InlineData(GlucoseDirection.RateOutOfRange, Direction.RateOutOfRange)]
+    public void ToDirection_MapsEveryV4Value(GlucoseDirection direction, Direction expected)
+    {
+        direction.ToDirection().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(Direction.TripleUp)]
+    [InlineData(Direction.TripleDown)]
+    [InlineData(Direction.CgmError)]
+    public void ToGlucoseDirection_IsNullForValuesV4DoesNotModel(Direction direction)
+    {
+        direction.ToGlucoseDirection().Should().BeNull();
+    }
+
+    [Fact]
+    public void SensorGlucoseProjection_RoundTripsEveryDirection()
+    {
+        foreach (var direction in Enum.GetValues<GlucoseDirection>())
+        {
+            var entry = EntryProjection.FromSensorGlucose(
+                new SensorGlucose { Mgdl = 120, Direction = direction }
+            );
+
+            entry.Direction.Should().Be(direction.ToWireString());
+            entry.DirectionEnum.ToGlucoseDirection().Should().Be(direction);
+        }
+    }
+
+    [Fact]
+    public void SensorGlucoseProjection_EmitsLegacySpellingForSpaceSeparatedValues()
+    {
+        var entry = EntryProjection.FromSensorGlucose(
+            new SensorGlucose { Mgdl = 120, Direction = GlucoseDirection.NotComputable }
+        );
+
+        entry.Direction.Should().Be("NOT COMPUTABLE");
+        entry.DirectionEnum.Should().Be(Direction.NotComputable);
+    }
+}


### PR DESCRIPTION
Fixes #781.

## What

v1/v3 projections stringified the V4 `GlucoseDirection`, so `/api/v1/entries`, `/api/v3/entries`, the CSV/TSV export and the `entries` SignalR broadcast emitted `NotComputable`/`RateOutOfRange`/`None` — spellings the legacy parsers didn't know, so a round-tripped "not computable" fell to `Direction.NONE` and rendered as the NONE glyph.

**One home for the mapping:** `DirectionExtensions` owns a `Direction → wire-spelling` table (from legacy `direction.js`) plus `TryParse`/`Parse` indexing **both** spellings case-insensitively. The three verbatim copies of the 13-arm switch (`Entry.DirectionEnum`, `DirectionService`, `EntryDecomposer.MapDirection`) collapse onto it; `GlucoseDirectionExtensions` bridges the V4 enum.

**Wire-format decision — projection seam, not enum attributes.** Two findings overrode the issue's suggested `[JsonPropertyName]` route:
1. It never worked: `JsonStringEnumConverter` ignores per-member naming attributes (proved with a scratch serializer run — `Direction.NotComputable` serialized as `"NotComputable"` and `"NOT COMPUTABLE"` failed to parse), so the three attributes `Direction` carried were dead code and are removed.
2. `GlucoseDirection`'s PascalCase form is a published v4 contract (NSwag TS enum, Zod schemas, frontend bindings) **and** the storage format (`SensorGlucoseMapper` persists the member name). Renaming its members would break every v4 consumer to fix a v1/v3 bug.

So `EntryProjection`, `SensorGlucoseToEntryMapper` and `ChartDataService` call `ToWireString()` at the seam. Only `NOT COMPUTABLE`/`RATE OUT OF RANGE`/`NONE` actually change on the wire; **all v1/v3 goldens are untouched** (they only contain `Flat`/`FortyFiveUp`, identical in both spellings), so Loop/AAPS payloads for normal trends are byte-identical.

**Frontend:** `getDirectionInfo` resolves both spellings (hoisted to module scope), so a `"NOT COMPUTABLE"` reading renders "unknown" instead of falling into the green "stable" arrow — without this the wire change would have regressed `RecentEntriesCard`. Verified at review with a generated client and a new pinned test (7 cases) added on the branch.

## Testing

- New `DirectionWireFormatTests` (54 cases): per-value spellings, full round-trip over every `Direction`, both-spelling parse, the issue's regression (`GlucoseDirection` → v1 string → parse → same value). Two mutation proofs (dropping the wire-name index arm fails 8 tests; breaking one spelling fails 4).
- API 5716 / Core.Models 672 / Infrastructure.Data 623 / six connector suites — all passing. (The only solution-build failure is the pre-existing `Nocturne.Desktop.Tray` MSIX packaging error, reproduced on pristine main.)

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
