### PR TITLE
fix(alerts): stop alarm-profile and webhook settings writes reporting false success

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/WebhookSettingsController.cs
@@ -11,12 +11,11 @@ using Nocturne.Core.Models.Configuration;
 namespace Nocturne.API.Controllers.V4.Connectors;
 
 /// <summary>
-/// Controller for managing outbound webhook notification settings (URL, headers, test dispatch).
+/// Controller for testing outbound webhook delivery.
 /// </summary>
 /// <remarks>
-/// Webhook settings are persisted per-tenant and allow administrators to configure an external
-/// HTTP endpoint that receives alert notifications. The <c>POST /test</c> endpoint sends a test
-/// payload via <see cref="WebhookRequestSender"/> to verify connectivity before saving.
+/// The <c>POST /test</c> endpoint sends a test payload via <see cref="WebhookRequestSender"/>.
+/// The GET/PUT pair has no storage behind it — see <see cref="NoStorageDetail"/>.
 /// </remarks>
 /// <seealso cref="WebhookRequestSender"/>
 /// <seealso cref="WebhookNotificationSettings"/>
@@ -25,49 +24,45 @@ namespace Nocturne.API.Controllers.V4.Connectors;
 [Route("api/v4/ui-settings/notifications/webhooks")]
 [Authorize]
 // Choosing where a tenant's alerts are delivered, and dispatching from the server to a
-// caller-named host, are tenant administration. The GET is left on [Authorize] alone: it returns a
-// fixed disabled stub rather than anything the tenant configured.
+// caller-named host, are tenant administration. The GET is left on [Authorize] alone: it exposes
+// no tenant state.
 public class WebhookSettingsController(
     WebhookRequestSender requestSender,
     ILogger<WebhookSettingsController> logger)
     : ControllerBase
 {
+    /// <summary>
+    /// Why the GET/PUT pair reports 501 instead of persisting. The alert engine addresses
+    /// webhooks per rule — an <c>alert_rule_channels</c> row with
+    /// <see cref="Core.Models.Alerts.ChannelType.Webhook"/> whose destination holds the URLs —
+    /// so there is no tenant-wide record to read or write, and no field for a signing secret
+    /// (<see cref="Services.Alerts.Providers.WebhookProvider"/> signs with none). A 200 here
+    /// reported a save that never happened, on the alerting path.
+    /// </summary>
+    private const string NoStorageDetail =
+        "Tenant-wide webhook settings are not stored. Webhook destinations belong to individual "
+        + "alert rules: attach a webhook channel to a rule via /api/v4/alert-rules instead.";
+
     /// <summary>Gets the webhook notification settings for the current tenant.</summary>
     [HttpGet]
     [ProducesResponseType(typeof(WebhookNotificationSettings), 200)]
-    [ProducesResponseType(500)]
-    public Task<ActionResult<WebhookNotificationSettings>> GetWebhookSettings(
-        CancellationToken cancellationToken = default
-    )
-    {
-        // Not wired to the current alert engine's storage, so this reports disabled
-        // regardless of what the tenant configured.
-        return Task.FromResult<ActionResult<WebhookNotificationSettings>>(Ok(
-            new WebhookNotificationSettings
-            {
-                Enabled = false,
-                Urls = new List<string>(),
-                HasSecret = false,
-                Secret = null,
-                SignatureVersion = "v1",
-            }
-        ));
-    }
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status501NotImplemented)]
+    public ActionResult<WebhookNotificationSettings> GetWebhookSettings() => NotStored();
 
     /// <summary>Saves webhook notification settings.</summary>
     [HttpPut]
     [RequireScope(TenantPermissions.TenantSettings)]
     [ProducesResponseType(typeof(WebhookNotificationSettings), 200)]
-    [ProducesResponseType(400)]
-    [ProducesResponseType(500)]
-    public Task<ActionResult<WebhookNotificationSettings>> SaveWebhookSettings(
-        [FromBody] WebhookNotificationSettings settings,
-        CancellationToken cancellationToken = default
-    )
-    {
-        logger.LogWarning("Webhook settings save is a no-op until new alert engine is implemented");
-        return Task.FromResult<ActionResult<WebhookNotificationSettings>>(Ok(settings));
-    }
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status501NotImplemented)]
+    public ActionResult<WebhookNotificationSettings> SaveWebhookSettings(
+        [FromBody] WebhookNotificationSettings settings
+    ) => NotStored();
+
+    private ObjectResult NotStored() => Problem(
+        detail: NoStorageDetail,
+        statusCode: StatusCodes.Status501NotImplemented,
+        title: "Not Implemented"
+    );
 
     /// <summary>Tests webhook settings by sending test payloads to configured URLs.</summary>
     /// <remarks>

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -367,9 +367,31 @@ public class UISettingsController : ControllerBase, IWriteScopedController
                 );
             }
 
-            // The profile is discarded: this is not wired to the current alert engine's
-            // storage.
-            return await GetAlarmConfiguration(cancellationToken);
+            var config =
+                await _settingsService.GetAlarmConfigurationAsync(cancellationToken)
+                ?? GenerateDefaultAlarmConfiguration();
+            config.Profiles ??= [];
+
+            // A blank id would match every other blank-id profile on the next upsert, so the
+            // list could never hold more than one of them.
+            if (string.IsNullOrWhiteSpace(profile.Id))
+            {
+                profile.Id = Guid.CreateVersion7().ToString();
+            }
+
+            var existing = config.Profiles.FindIndex(p => p.Id == profile.Id);
+            if (existing >= 0)
+            {
+                config.Profiles[existing] = profile;
+            }
+            else
+            {
+                config.Profiles.Add(profile);
+            }
+
+            return Ok(
+                await _settingsService.SaveAlarmConfigurationAsync(config, cancellationToken)
+            );
         }
         catch (Exception ex)
         {
@@ -406,9 +428,23 @@ public class UISettingsController : ControllerBase, IWriteScopedController
                 );
             }
 
-            // The profile id is discarded: this is not wired to the current alert engine's
-            // storage.
-            return await GetAlarmConfiguration(cancellationToken);
+            var config =
+                await _settingsService.GetAlarmConfigurationAsync(cancellationToken)
+                ?? GenerateDefaultAlarmConfiguration();
+            config.Profiles ??= [];
+
+            if (config.Profiles.RemoveAll(p => p.Id == profileId) == 0)
+            {
+                return Problem(
+                    detail: $"Alarm profile not found: {profileId}",
+                    statusCode: 404,
+                    title: "Not Found"
+                );
+            }
+
+            return Ok(
+                await _settingsService.SaveAlarmConfigurationAsync(config, cancellationToken)
+            );
         }
         catch (Exception ex)
         {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Connectors/WebhookSettingsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Connectors/WebhookSettingsControllerTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V4.Connectors;
+using Nocturne.API.Services.Alerts.Webhooks;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Connectors;
+
+/// <summary>
+/// Unit coverage for <see cref="WebhookSettingsController"/>'s settings pair. The tenant-wide
+/// webhook record the GET/PUT shape describes has no storage in the current alert engine, so both
+/// must fail visibly rather than echo a save back.
+/// </summary>
+[Trait("Category", "Unit")]
+public class WebhookSettingsControllerTests
+{
+    [Fact]
+    public void GetWebhookSettings_reports501_ratherThanAStubbedDisabledConfig()
+    {
+        var result = NewController().GetWebhookSettings();
+
+        var problem = ProblemOf(result);
+        problem.StatusCode.Should().Be(StatusCodes.Status501NotImplemented);
+        problem.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Contain("alert rules");
+    }
+
+    [Fact]
+    public void SaveWebhookSettings_reports501_ratherThanEchoingTheBody()
+    {
+        var result = NewController().SaveWebhookSettings(new WebhookNotificationSettings
+        {
+            Enabled = true,
+            Urls = ["https://example.invalid/hook"],
+            Secret = "s3cret",
+        });
+
+        ProblemOf(result).StatusCode.Should().Be(StatusCodes.Status501NotImplemented);
+    }
+
+    private static ObjectResult ProblemOf(ActionResult<WebhookNotificationSettings> result) =>
+        result.Result.Should().BeOfType<ObjectResult>().Subject;
+
+    private static WebhookSettingsController NewController()
+    {
+        var services = new ServiceCollection();
+        services.AddControllers();
+
+        return new WebhookSettingsController(
+            new WebhookRequestSender(
+                Mock.Of<IHttpClientFactory>(),
+                NullLogger<WebhookRequestSender>.Instance),
+            NullLogger<WebhookSettingsController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    RequestServices = services.BuildServiceProvider(),
+                },
+            },
+        };
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerAlarmProfileTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerAlarmProfileTests.cs
@@ -1,0 +1,152 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.API.Services.Profiles;
+using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Profiles;
+
+/// <summary>
+/// Unit coverage for the per-profile alarm routes on <see cref="UISettingsController"/>. Each write
+/// is asserted through the matching read: the profile list these routes edit is the same
+/// <see cref="UserAlarmConfiguration"/> blob <c>GET notifications/alarms</c> returns.
+/// </summary>
+[Trait("Category", "Unit")]
+public class UISettingsControllerAlarmProfileTests
+{
+    private static readonly Guid TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public async Task AddOrUpdateAlarmProfile_isVisibleToGetAlarmConfiguration()
+    {
+        var controller = NewController();
+
+        await controller.AddOrUpdateAlarmProfile(new AlarmProfileConfiguration
+        {
+            Id = "night-high",
+            Name = "Nighttime High",
+            AlarmType = AlarmTriggerType.High,
+            Threshold = 220,
+        });
+
+        var profiles = AlarmConfigOf(await controller.GetAlarmConfiguration()).Profiles;
+        profiles.Should().ContainSingle(p => p.Id == "night-high")
+            .Which.Threshold.Should().Be(220);
+    }
+
+    [Fact]
+    public async Task AddOrUpdateAlarmProfile_replacesAnExistingProfileInPlace()
+    {
+        var controller = NewController();
+
+        await controller.AddOrUpdateAlarmProfile(new AlarmProfileConfiguration
+        {
+            Id = "night-high",
+            Name = "Nighttime High",
+            Threshold = 220,
+        });
+        await controller.AddOrUpdateAlarmProfile(new AlarmProfileConfiguration
+        {
+            Id = "night-high",
+            Name = "Nighttime High",
+            Threshold = 190,
+        });
+
+        var profiles = AlarmConfigOf(await controller.GetAlarmConfiguration()).Profiles;
+        profiles.Should().ContainSingle().Which.Threshold.Should().Be(190);
+    }
+
+    [Fact]
+    public async Task AddOrUpdateAlarmProfile_assignsAnId_soBlankIdProfilesDoNotCollide()
+    {
+        var controller = NewController();
+
+        await controller.AddOrUpdateAlarmProfile(new AlarmProfileConfiguration
+        {
+            Id = string.Empty,
+            Name = "First",
+        });
+        await controller.AddOrUpdateAlarmProfile(new AlarmProfileConfiguration
+        {
+            Id = string.Empty,
+            Name = "Second",
+        });
+
+        var profiles = AlarmConfigOf(await controller.GetAlarmConfiguration()).Profiles;
+        profiles.Should().HaveCount(2);
+        profiles.Select(p => p.Id).Should().OnlyHaveUniqueItems().And.NotContain(string.Empty);
+    }
+
+    [Fact]
+    public async Task DeleteAlarmProfile_removesItFromGetAlarmConfiguration()
+    {
+        var controller = NewController();
+
+        await controller.AddOrUpdateAlarmProfile(new AlarmProfileConfiguration { Id = "keep" });
+        await controller.AddOrUpdateAlarmProfile(new AlarmProfileConfiguration { Id = "drop" });
+
+        await controller.DeleteAlarmProfile("drop");
+
+        AlarmConfigOf(await controller.GetAlarmConfiguration()).Profiles
+            .Select(p => p.Id).Should().Equal("keep");
+    }
+
+    [Fact]
+    public async Task DeleteAlarmProfile_reports404_forAnUnknownProfile()
+    {
+        var controller = NewController();
+
+        var result = await controller.DeleteAlarmProfile("never-existed");
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    // ----- helpers -----
+
+    private static UserAlarmConfiguration AlarmConfigOf(
+        ActionResult<UserAlarmConfiguration> result)
+    {
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        return ok.Value.Should().BeAssignableTo<UserAlarmConfiguration>().Subject;
+    }
+
+    private static UISettingsController NewController()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        var dbContext = new NocturneDbContext(options) { TenantId = TenantId };
+        var configuration = new ConfigurationBuilder().Build();
+
+        var services = new ServiceCollection();
+        services.AddControllers();
+
+        return new UISettingsController(
+            NullLogger<UISettingsController>.Instance,
+            configuration,
+            Mock.Of<IHttpClientFactory>(),
+            new UISettingsService(
+                dbContext,
+                NullLogger<UISettingsService>.Instance,
+                configuration))
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    RequestServices = services.BuildServiceProvider(),
+                },
+            },
+        };
+    }
+}


### PR DESCRIPTION
Fixes #652.

## What

All four endpoints stop reporting false success:

- **`AddOrUpdateAlarmProfile` / `DeleteAlarmProfile` — wired.** The storage already existed: `IUISettingsService.Get/SaveAlarmConfigurationAsync` persist the `UserAlarmConfiguration` blob, and the sibling `PUT notifications/alarms` was already using it — only the per-profile POST/DELETE discarded their input. They now upsert/remove the named profile and write back. A delete matching nothing returns the already-declared 404 instead of echoing unchanged state, and a blank-id profile is assigned a UUIDv7 (blank ids would collide on the next upsert). No schema change, no migration.
- **Webhook GET/PUT — honest 501**, the issue's endorsed remedy for a surface that isn't ready. There is genuinely no storage: the alert engine addresses webhooks per rule (`alert_rule_channels` with `ChannelType.Webhook`), `TenantAlertSettingsEntity` has no webhook columns, and the DTO's intended storage layer never landed (`WebhookConfigurationParser`/`WebhookSecretGenerator` have zero callers). The 501 body says so and points at `/api/v4/alert-rules`. `POST /test` is untouched. The declared 200 type is kept so the generated client retains its shape — NSwag surfaces the 501 as a thrown error.

## Testing

New read-back tests: profile upsert/replace/delete observable through `GetAlarmConfiguration` (real `UISettingsService` over in-memory context), delete-miss 404, both webhook 501s. Mutation-proven: reverting the upsert to the old echo fails 4 of 5 alarm tests. API suite 5710 passed / 0 failed.

## Worth knowing (not in this diff)

- Alarm profiles now persist honestly but **nothing evaluates them** — the engine runs on managed rules; that's the #584/#585 gap, tracked there.
- The webhook settings UI is orphaned (nothing imports `WebhookChannelRow`), and the alarm-profile routes have no frontend callers — the 501 breaks no live UI.
- Real alert webhooks are sent unsigned while the test button signs — filed separately.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
