### PR TITLE
fix(api): key the per-client rate limits on the end user, not the SSR hop

### DIFF
--- a/src/API/Nocturne.API/Authorization/InstanceKeyDigest.cs
+++ b/src/API/Nocturne.API/Authorization/InstanceKeyDigest.cs
@@ -21,11 +21,18 @@ public static class InstanceKeyDigest
     /// </summary>
     public static string Resolve(IConfiguration configuration)
     {
-        var instanceKey =
-            configuration[$"Parameters:{ServiceNames.Parameters.InstanceKey}"]
-            ?? configuration[ServiceNames.ConfigKeys.InstanceKey]
-            ?? "";
+        var instanceKey = ResolveKey(configuration);
 
         return !string.IsNullOrEmpty(instanceKey) ? HashUtils.Sha256Hex(instanceKey) : "";
     }
+
+    /// <summary>
+    /// Returns the configured instance key itself, or an empty string when none is configured.
+    /// For the callers that need the key as signing material rather than as a credential to
+    /// compare (see <see cref="RateLimiting.ClientRateLimitKey"/>).
+    /// </summary>
+    public static string ResolveKey(IConfiguration configuration) =>
+        configuration[$"Parameters:{ServiceNames.Parameters.InstanceKey}"]
+        ?? configuration[ServiceNames.ConfigKeys.InstanceKey]
+        ?? "";
 }

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -5,6 +5,7 @@ using Nocturne.API.Configuration;
 using Nocturne.API.Services;
 using Nocturne.API.Middleware.Handlers;
 using Nocturne.API.Multitenancy;
+using Nocturne.API.RateLimiting;
 using Nocturne.API.Services.AidDetection;
 using Nocturne.API.Services.Alerts;
 using Nocturne.API.Services.Alerts.Evaluators;
@@ -90,6 +91,34 @@ public static class ServiceRegistrationExtensions
     /// controller actions and so cannot carry the attribute.
     /// </summary>
     public const string DocsRateLimitPolicy = "docs";
+
+    /// <summary>
+    /// The rate-limiting policies partitioned on the calling client, with the ceiling and window
+    /// each applies. Held as one table so all of them resolve their partition through
+    /// <see cref="ClientRateLimitKey"/> and the trust decision behind a forwarded address is taken
+    /// in exactly one place.
+    /// </summary>
+    internal static readonly (string Policy, int PermitLimit, TimeSpan Window)[] ClientAddressPolicies =
+    [
+        ("oauth-token", 30, TimeSpan.FromMinutes(1)),
+        ("oauth-device", 10, TimeSpan.FromMinutes(1)),
+        // RFC 7591 Dynamic Client Registration.
+        ("oauth-register", 10, TimeSpan.FromHours(1)),
+        ("oauth-device-approve", 20, TimeSpan.FromMinutes(1)),
+        ("totp-login", 10, TimeSpan.FromMinutes(1)),
+        ("guest-activate", 5, TimeSpan.FromMinutes(10)),
+        // Friction against naive abuse only — this does NOT bound the refresh_tokens table. The
+        // real ceiling is DemoSessionLimits.MaxLiveSessions, enforced on the subject id.
+        ("demo-session", 10, TimeSpan.FromMinutes(5)),
+        ("support-issues", 5, TimeSpan.FromHours(1)),
+        // The documentation surface (/scalar, /openapi) runs before tenant resolution and
+        // authentication, and the reference reads the tenants table and may write that tenant's
+        // OAuth client, so it is the one unauthenticated path that reaches the database that
+        // early. What bounds the damage is elsewhere: the row holds at most
+        // ScalarAuthProvider.MaxRedirectUris entries, and both the tenant resolution and the
+        // client id are cached, so a flood mostly costs the page render.
+        (DocsRateLimitPolicy, 30, TimeSpan.FromMinutes(1)),
+    ];
 
     /// <summary>
     /// Rate-limiting policy for the statistics actions that compute over a caller-supplied body.
@@ -314,157 +343,33 @@ public static class ServiceRegistrationExtensions
             ConnectCallback = new PinnedConnector(OutboundAddressPolicy.NotLinkLocal).ConnectAsync,
         });
 
+        var clientRateLimitKey = new ClientRateLimitKey(configuration);
+
         services.AddRateLimiter(options =>
         {
-            options.AddPolicy(
-                "oauth-token",
-                context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = 30,
-                            Window = TimeSpan.FromMinutes(1),
-                            QueueLimit = 0,
-                        }
-                    )
-            );
-
-            options.AddPolicy(
-                "oauth-device",
-                context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = 10,
-                            Window = TimeSpan.FromMinutes(1),
-                            QueueLimit = 0,
-                        }
-                    )
-            );
-
-            // RFC 7591 Dynamic Client Registration: 10 registrations per IP per hour.
-            options.AddPolicy(
-                "oauth-register",
-                context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = 10,
-                            Window = TimeSpan.FromHours(1),
-                            QueueLimit = 0,
-                        }
-                    )
-            );
-
-            options.AddPolicy(
-                "oauth-device-approve",
-                context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = 20,
-                            Window = TimeSpan.FromMinutes(1),
-                            QueueLimit = 0,
-                        }
-                    )
-            );
-
-            options.AddPolicy(
-                "totp-login",
-                context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = 10,
-                            Window = TimeSpan.FromMinutes(1),
-                            QueueLimit = 0,
-                        }
-                    )
-            );
-
-            // Guest link activation: 5 attempts per IP per 10 minutes.
-            options.AddPolicy(
-                "guest-activate",
-                context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = 5,
-                            Window = TimeSpan.FromMinutes(10),
-                            QueueLimit = 0,
-                        }
-                    )
-            );
-
-            // Demo sign-in: 10 sessions per IP per 5 minutes. Friction against naive abuse
-            // only — this does NOT bound the refresh_tokens table. The partition key comes from
-            // Connection.RemoteIpAddress, which UseForwardedHeaders sets from X-Forwarded-For
-            // with no trusted-proxy list, and the gateway does not strip that header, so a
-            // caller rotating it gets a fresh partition every request. The real ceiling is
-            // DemoSessionLimits.MaxLiveSessions, enforced on the subject id.
-            options.AddPolicy(
-                "demo-session",
-                context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = 10,
-                            Window = TimeSpan.FromMinutes(5),
-                            QueueLimit = 0,
-                        }
-                    )
-            );
-
-            // Support issue creation: 5 issues per IP per hour.
-            options.AddPolicy(
-                "support-issues",
-                context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = 5,
-                            Window = TimeSpan.FromHours(1),
-                            QueueLimit = 0,
-                        }
-                    )
-            );
-
-            // Documentation surface (/scalar, /openapi): 30 per IP per minute. These endpoints run
-            // before tenant resolution and authentication, and the reference reads the tenants
-            // table and may write that tenant's OAuth client, so they are the one unauthenticated
-            // path that reaches the database that early. As with demo-session the partition key is
-            // no hard ceiling — it comes from X-Forwarded-For. What bounds the damage is elsewhere:
-            // the row holds at most ScalarAuthProvider.MaxRedirectUris entries, and both the tenant
-            // resolution and the client id are cached, so a flood mostly costs the page render.
-            options.AddPolicy(
-                DocsRateLimitPolicy,
-                context =>
-                    RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                        factory: _ => new FixedWindowRateLimiterOptions
-                        {
-                            PermitLimit = 30,
-                            Window = TimeSpan.FromMinutes(1),
-                            QueueLimit = 0,
-                        }
-                    )
-            );
+            foreach (var (policy, permitLimit, window) in ClientAddressPolicies)
+            {
+                options.AddPolicy(
+                    policy,
+                    context =>
+                        RateLimitPartition.GetFixedWindowLimiter(
+                            partitionKey: clientRateLimitKey.Resolve(context),
+                            factory: _ => new FixedWindowRateLimiterOptions
+                            {
+                                PermitLimit = permitLimit,
+                                Window = window,
+                                QueueLimit = 0,
+                            }
+                        )
+                );
+            }
 
             // Statistics compute POSTs: 60 per tenant host per minute. These actions compute over a
             // caller-supplied body rather than over stored data, and reports.read — the scope
             // gating them — is held by every public share link, so an anonymous viewer can post
-            // them. The partition is the Host rather than the IP because the limiter runs before
-            // tenant resolution, the tenant (or share token) is the subdomain, and the browser does
-            // not reach these actions directly: the SvelteKit server calls them, so every tenant's
-            // traffic arrives from one address.
+            // them. The partition is the Host rather than the client because what this bounds is one
+            // tenant's compute across all of its viewers, and the limiter runs before tenant
+            // resolution while the tenant (or share token) is already the subdomain.
             options.AddPolicy(
                 StatisticsComputeRateLimitPolicy,
                 context =>

--- a/src/API/Nocturne.API/RateLimiting/ClientRateLimitKey.cs
+++ b/src/API/Nocturne.API/RateLimiting/ClientRateLimitKey.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using Nocturne.API.Authorization;
+using Nocturne.Core.Constants;
+
+namespace Nocturne.API.RateLimiting;
+
+/// <summary>
+/// Resolves the calling client that the address-keyed rate-limit policies partition on.
+/// </summary>
+/// <remarks>
+/// The browser's address does not always reach the API: a page rendered by the SvelteKit server
+/// calls the API from its own container, so an endpoint reached through a remote function (guest
+/// code activation, TOTP sign-in) sees one address for every user of the deployment, and one
+/// person's five mistyped attempts spend everyone else's window. The address is therefore carried
+/// in <see cref="ServiceNames.Headers.ClientIp"/> and honoured only when
+/// <see cref="ServiceNames.Headers.ClientIpSignature"/> shows the sender holds the instance key:
+/// the header alone is writable by anyone the gateway admits, and the peer address is no evidence
+/// either, since browser traffic and SSR traffic arrive over the same internal network. Signing the
+/// address rather than presenting the key's digest keeps a reusable credential off user-originated
+/// requests — a captured signature buckets its own address and nothing else.
+/// <para>
+/// This settles who shares a partition, not what a partition may spend: an unsigned request still
+/// partitions on <c>Connection.RemoteIpAddress</c>, which <c>UseForwardedHeaders</c> takes from
+/// <c>X-Forwarded-For</c> with no trusted-proxy list, so a caller rotating that header still gets
+/// a fresh window. The ceilings that do bound abuse are named on the policies themselves in
+/// <see cref="Extensions.ServiceRegistrationExtensions"/>.
+/// </para>
+/// </remarks>
+public sealed class ClientRateLimitKey
+{
+    private const string Unknown = "unknown";
+
+    private readonly byte[] _signingKey;
+
+    public ClientRateLimitKey(IConfiguration configuration)
+    {
+        _signingKey = Encoding.UTF8.GetBytes(InstanceKeyDigest.ResolveKey(configuration));
+    }
+
+    /// <summary>
+    /// The partition key for this request: the signed end-user address when one is presented,
+    /// otherwise the address the connection came from.
+    /// </summary>
+    public string Resolve(HttpContext context) =>
+        SignedClientAddress(context.Request)
+        ?? context.Connection.RemoteIpAddress?.ToString()
+        ?? Unknown;
+
+    private string? SignedClientAddress(HttpRequest request)
+    {
+        if (_signingKey.Length == 0)
+            return null;
+
+        var presented = request.Headers[ServiceNames.Headers.ClientIp].FirstOrDefault()?.Trim();
+        if (string.IsNullOrEmpty(presented))
+            return null;
+
+        var signature = request.Headers[ServiceNames.Headers.ClientIpSignature].FirstOrDefault()?.Trim();
+        if (string.IsNullOrEmpty(signature))
+            return null;
+
+        if (!IPAddress.TryParse(presented, out var address))
+            return null;
+
+        var expected = Convert.ToHexStringLower(
+            HMACSHA256.HashData(_signingKey, Encoding.UTF8.GetBytes(presented)));
+
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(signature.ToLowerInvariant()),
+            Encoding.UTF8.GetBytes(expected))
+            ? address.ToString()
+            : null;
+    }
+}

--- a/src/Core/Nocturne.Core.Constants/ServiceNames.cs
+++ b/src/Core/Nocturne.Core.Constants/ServiceNames.cs
@@ -188,6 +188,18 @@ public static class ServiceNames
         /// that request to admin and bypass per-tenant public-access controls.
         /// </summary>
         public const string InstanceService = "X-Instance-Service";
+
+        /// <summary>
+        /// Header carrying the address of the end user a service call is being made on behalf of,
+        /// for a caller (the SSR server) the API cannot see the browser behind.
+        /// </summary>
+        public const string ClientIp = "X-Nocturne-Client-Ip";
+
+        /// <summary>
+        /// Header carrying the HMAC-SHA256 of <see cref="ClientIp"/>, keyed on the shared instance
+        /// key. Without it the address is ignored, since any caller can write the address header.
+        /// </summary>
+        public const string ClientIpSignature = "X-Nocturne-Client-Ip-Signature";
     }
 
     /// <summary>

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -19,6 +19,7 @@ import { sequence } from "@sveltejs/kit/hooks";
 import type { AuthUser } from "./app.d";
 import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
 import { buildProxyHeaders } from "$lib/server/api-proxy-headers";
+import { clientAddressHeaders } from "$lib/server/client-address";
 import { getOriginalProto, getEffectiveHost, getOriginalHost, isShareHost } from "$lib/server/request-host";
 import { STATIC_ASSET_PREFIXES, isPublicRoute } from "$lib/server/public-routes";
 import {
@@ -356,6 +357,7 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
 
   const extraHeaders: Record<string, string> = {
     "X-Forwarded-Proto": getOriginalProto(event.request),
+    ...clientAddressHeaders(event),
   };
 
   // Forward the original Host for tenant resolution behind reverse proxies.

--- a/src/Web/packages/app/src/lib/server/api-proxy-headers.test.ts
+++ b/src/Web/packages/app/src/lib/server/api-proxy-headers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
 import { buildProxyHeaders } from "./api-proxy-headers";
+import {
+  CLIENT_IP_HEADER,
+  CLIENT_IP_SIGNATURE_HEADER,
+} from "./client-address";
 
 const JAR: Record<string, string> = {
   [AUTH_COOKIE_NAMES.accessToken]: "access-value",
@@ -80,6 +84,27 @@ describe("buildProxyHeaders", () => {
 
       expect(headers.has("X-Instance-Key")).toBe(false);
       expect(headers.has("X-Instance-Service")).toBe(false);
+    }
+  });
+
+  it("strips a client-written client address on every host", () => {
+    for (const isShareHost of [true, false]) {
+      const headers = buildProxyHeaders({
+        requestHeaders: new Headers({
+          [CLIENT_IP_HEADER]: "198.51.100.9",
+          [CLIENT_IP_SIGNATURE_HEADER]: "forged",
+          "X-Forwarded-For": "203.0.113.4",
+        }),
+        effectiveHost: "acme.nocturne.run",
+        proto: "https",
+        isShareHost,
+        cookies: emptyCookies,
+      });
+
+      expect(headers.has(CLIENT_IP_HEADER)).toBe(false);
+      expect(headers.has(CLIENT_IP_SIGNATURE_HEADER)).toBe(false);
+      // The address the gateway saw still travels — it is what the API partitions on here.
+      expect(headers.get("X-Forwarded-For")).toBe("203.0.113.4");
     }
   });
 

--- a/src/Web/packages/app/src/lib/server/api-proxy-headers.ts
+++ b/src/Web/packages/app/src/lib/server/api-proxy-headers.ts
@@ -1,4 +1,8 @@
 import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
+import {
+  CLIENT_IP_HEADER,
+  CLIENT_IP_SIGNATURE_HEADER,
+} from "$lib/server/client-address";
 
 /** The subset of SvelteKit's Cookies the proxy reads. */
 export interface ProxyCookieReader {
@@ -45,6 +49,12 @@ export function buildProxyHeaders({
 
   headers.delete("X-Instance-Key");
   headers.delete("X-Instance-Service");
+
+  // On this path the address the API partitions on is the X-Forwarded-For entry the gateway left,
+  // forwarded on with the rest of the incoming headers. A client-written pair is unsigned and so
+  // ignored, but it has no business travelling either.
+  headers.delete(CLIENT_IP_HEADER);
+  headers.delete(CLIENT_IP_SIGNATURE_HEADER);
 
   if (isShareHost) {
     headers.delete("Cookie");

--- a/src/Web/packages/app/src/lib/server/client-address.test.ts
+++ b/src/Web/packages/app/src/lib/server/client-address.test.ts
@@ -1,0 +1,69 @@
+import { createHmac } from "crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  CLIENT_IP_HEADER,
+  CLIENT_IP_SIGNATURE_HEADER,
+  clientAddressHeaders,
+  getClientAddress,
+} from "./client-address";
+
+const INSTANCE_KEY = "s3cret-instance-key";
+const SOCKET_ADDRESS = "10.0.1.7";
+
+function event(headers: Record<string, string> = {}) {
+  return {
+    request: new Request("http://web.internal/guest", { headers }),
+    getClientAddress: () => SOCKET_ADDRESS,
+  };
+}
+
+describe("clientAddressHeaders", () => {
+  const previous = process.env.INSTANCE_KEY;
+
+  beforeEach(() => {
+    process.env.INSTANCE_KEY = INSTANCE_KEY;
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.INSTANCE_KEY;
+    else process.env.INSTANCE_KEY = previous;
+  });
+
+  it("names the browser the gateway forwarded, signed with the instance key", () => {
+    const headers = clientAddressHeaders(
+      event({ "X-Forwarded-For": "203.0.113.4" }),
+    );
+
+    expect(headers[CLIENT_IP_HEADER]).toBe("203.0.113.4");
+    expect(headers[CLIENT_IP_SIGNATURE_HEADER]).toBe(
+      createHmac("sha256", INSTANCE_KEY).update("203.0.113.4").digest("hex"),
+    );
+  });
+
+  it("takes the client from the head of a proxy chain", () => {
+    expect(
+      getClientAddress(event({ "X-Forwarded-For": "203.0.113.4, 172.16.0.2" })),
+    ).toBe("203.0.113.4");
+  });
+
+  it("falls back to the connection's peer", () => {
+    expect(clientAddressHeaders(event())[CLIENT_IP_HEADER]).toBe(SOCKET_ADDRESS);
+  });
+
+  it("sends nothing it cannot sign", () => {
+    delete process.env.INSTANCE_KEY;
+
+    expect(clientAddressHeaders(event({ "X-Forwarded-For": "203.0.113.4" }))).toEqual({});
+  });
+
+  it("sends nothing when there is no client, as while prerendering", () => {
+    const prerender = {
+      request: new Request("http://web.internal/guest"),
+      getClientAddress: () => {
+        throw new Error("Cannot read clientAddress on a prerendered page");
+      },
+    };
+
+    expect(clientAddressHeaders(prerender)).toEqual({});
+  });
+});

--- a/src/Web/packages/app/src/lib/server/client-address.ts
+++ b/src/Web/packages/app/src/lib/server/client-address.ts
@@ -1,0 +1,60 @@
+import { createHmac } from "crypto";
+import { env } from "$env/dynamic/private";
+
+/**
+ * Carriage of the end user's address across the SSR hop to the API.
+ *
+ * Calls made for a page or remote function leave this container, not the browser, so without this
+ * the API sees one address for every user and keys its per-client rate limits on it. The signature
+ * is what makes the address believable — see `ClientRateLimitKey` on the API for the trust rule.
+ */
+
+/** Must stay in sync with `ServiceNames.Headers.ClientIp` on the API. */
+export const CLIENT_IP_HEADER = "X-Nocturne-Client-Ip";
+
+/** Must stay in sync with `ServiceNames.Headers.ClientIpSignature` on the API. */
+export const CLIENT_IP_SIGNATURE_HEADER = "X-Nocturne-Client-Ip-Signature";
+
+/** The part of SvelteKit's RequestEvent the address is read from. */
+export interface ClientAddressSource {
+  request: Request;
+  getClientAddress(): string;
+}
+
+/**
+ * The address of the browser this request came from: the first X-Forwarded-For entry the gateway
+ * left, else the peer of the connection this container accepted.
+ */
+export function getClientAddress(event: ClientAddressSource): string | null {
+  const forwarded = event.request.headers.get("x-forwarded-for");
+  const client = forwarded?.split(",")[0]?.trim();
+  if (client) return client;
+
+  try {
+    return event.getClientAddress() || null;
+  } catch {
+    // Throws while prerendering, where there is no client to name.
+    return null;
+  }
+}
+
+/**
+ * Headers naming the end user of an onward API call, signed with the instance key.
+ *
+ * Empty when there is no address or no instance key to sign with: the API then partitions on the
+ * connection it sees, which is this container — the pre-existing shared bucket.
+ */
+export function clientAddressHeaders(
+  event: ClientAddressSource,
+): Record<string, string> {
+  const instanceKey = env.INSTANCE_KEY;
+  const clientAddress = getClientAddress(event);
+  if (!instanceKey || !clientAddress) return {};
+
+  return {
+    [CLIENT_IP_HEADER]: clientAddress,
+    [CLIENT_IP_SIGNATURE_HEADER]: createHmac("sha256", instanceKey)
+      .update(clientAddress)
+      .digest("hex"),
+  };
+}

--- a/tests/Unit/Nocturne.API.Tests/RateLimiting/ClientAddressPolicyCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/RateLimiting/ClientAddressPolicyCoverageTests.cs
@@ -1,0 +1,68 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Nocturne.API.Extensions;
+using Xunit;
+
+namespace Nocturne.API.Tests.RateLimiting;
+
+/// <summary>
+/// Pins the rate-limit policies applied to controller actions against the one table that resolves
+/// its partition through <see cref="Nocturne.API.RateLimiting.ClientRateLimitKey"/>.
+/// </summary>
+/// <remarks>
+/// A policy registered on its own with a partition key of its own would key on the connection —
+/// which, for anything a remote function reaches, is the SvelteKit container shared by every user.
+/// </remarks>
+public class ClientAddressPolicyCoverageTests
+{
+    [Fact]
+    public void EveryPolicyOnAnAction_PartitionsOnTheClientOrTheTenantHost()
+    {
+        var applied = AppliedPolicies();
+
+        // A scan that discovered nothing would pass while guarding nothing.
+        applied.Should().HaveCountGreaterThan(5,
+            "the scan should discover the rate-limited actions");
+
+        var tableAndHostKeyed = ClientAddressPolicyNames()
+            .Append(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)
+            .ToList();
+
+        applied.Except(tableAndHostKeyed).Should().BeEmpty(
+            "a policy outside the table keys on the connection, so every user behind the SSR "
+            + "server would share its window");
+    }
+
+    [Fact]
+    public void EveryClientAddressPolicy_IsAppliedSomewhere()
+    {
+        var applied = AppliedPolicies();
+
+        ClientAddressPolicyNames()
+            // The documentation surface is mapped rather than a controller action, so it carries
+            // its policy through RequireRateLimiting in Program.cs.
+            .Where(policy => policy != ServiceRegistrationExtensions.DocsRateLimitPolicy)
+            .Except(applied)
+            .Should().BeEmpty("a policy nothing applies is dead configuration");
+    }
+
+    private static List<string> ClientAddressPolicyNames() =>
+        ServiceRegistrationExtensions.ClientAddressPolicies.Select(p => p.Policy).ToList();
+
+    private static List<string> AppliedPolicies() =>
+        typeof(ServiceRegistrationExtensions).Assembly
+            .GetTypes()
+            .Where(t => typeof(ControllerBase).IsAssignableFrom(t))
+            .SelectMany(t => t
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Cast<MemberInfo>()
+                .Append(t))
+            .SelectMany(m => m.GetCustomAttributes<EnableRateLimitingAttribute>())
+            .Select(a => a.PolicyName)
+            .Where(name => name is not null)
+            .Select(name => name!)
+            .Distinct()
+            .ToList();
+}

--- a/tests/Unit/Nocturne.API.Tests/RateLimiting/ClientRateLimitKeyTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/RateLimiting/ClientRateLimitKeyTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Nocturne.API.RateLimiting;
+using Nocturne.Core.Constants;
+using Xunit;
+
+namespace Nocturne.API.Tests.RateLimiting;
+
+/// <summary>
+/// Guards the partition the address-keyed rate-limit policies count against.
+/// </summary>
+/// <remarks>
+/// A call made for a page or remote function arrives from the SvelteKit container, so the address
+/// has to be carried in a header for these limits to bound one user rather than the deployment.
+/// A header is writable by anyone the gateway admits, which is what the signature settles.
+/// </remarks>
+public class ClientRateLimitKeyTests
+{
+    private const string InstanceKey = "s3cret-instance-key";
+    private const string GatewayAddress = "10.0.1.7";
+
+    [Fact]
+    public void ASignedAddress_PartitionsPerEndUser()
+    {
+        var key = KeyFor();
+
+        var first = key.Resolve(Context("203.0.113.4"));
+        var second = key.Resolve(Context("198.51.100.9"));
+
+        first.Should().Be("203.0.113.4");
+        second.Should().Be("198.51.100.9");
+        first.Should().NotBe(second,
+            "two users of the same SvelteKit container must not share one window");
+    }
+
+    [Fact]
+    public void AnAddressWithNoSignature_IsIgnored()
+    {
+        var context = Context("203.0.113.4");
+        context.Request.Headers.Remove(ServiceNames.Headers.ClientIpSignature);
+
+        KeyFor().Resolve(context).Should().Be(GatewayAddress,
+            "any caller the gateway admits can write the address header");
+    }
+
+    [Fact]
+    public void AnAddressSignedWithAnotherKey_IsIgnored()
+    {
+        var context = Context("203.0.113.4", signWith: "not-the-instance-key");
+
+        KeyFor().Resolve(context).Should().Be(GatewayAddress);
+    }
+
+    [Fact]
+    public void ASignatureLiftedFromAnotherAddress_IsIgnored()
+    {
+        var context = Context("203.0.113.4");
+        context.Request.Headers[ServiceNames.Headers.ClientIp] = "198.51.100.9";
+
+        KeyFor().Resolve(context).Should().Be(GatewayAddress,
+            "a captured signature must not be replayable onto a victim's address");
+    }
+
+    [Fact]
+    public void AValueThatIsNotAnAddress_IsIgnored()
+    {
+        var context = Context("not-an-address");
+
+        KeyFor().Resolve(context).Should().Be(GatewayAddress,
+            "the partition key is an address, so a signed caller cannot mint arbitrary ones");
+    }
+
+    [Fact]
+    public void WithNoInstanceKeyConfigured_TheAddressIsIgnored()
+    {
+        var context = Context("203.0.113.4");
+
+        KeyFor(instanceKey: null).Resolve(context).Should().Be(GatewayAddress,
+            "nothing can be verified without the key, so the header is not honoured");
+    }
+
+    [Fact]
+    public void WithNoAddressPresented_ThePartitionIsTheConnection()
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse(GatewayAddress);
+
+        KeyFor().Resolve(context).Should().Be(GatewayAddress);
+    }
+
+    [Fact]
+    public void WithNeitherAnAddressNorAConnection_ThePartitionIsShared()
+    {
+        KeyFor().Resolve(new DefaultHttpContext()).Should().Be("unknown");
+    }
+
+    [Fact]
+    public void ASignedIPv6Address_IsCanonicalized()
+    {
+        var context = Context("2001:DB8::1");
+
+        KeyFor().Resolve(context).Should().Be("2001:db8::1",
+            "one address written two ways must not buy two windows");
+    }
+
+    private static ClientRateLimitKey KeyFor(string? instanceKey = InstanceKey) =>
+        new(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [ServiceNames.ConfigKeys.InstanceKey] = instanceKey,
+            })
+            .Build());
+
+    /// <summary>A request as the SSR server makes it: the gateway's peer address plus a signed client.</summary>
+    private static HttpContext Context(string clientAddress, string signWith = InstanceKey)
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse(GatewayAddress);
+        context.Request.Headers[ServiceNames.Headers.ClientIp] = clientAddress;
+        context.Request.Headers[ServiceNames.Headers.ClientIpSignature] = Sign(clientAddress, signWith);
+        return context;
+    }
+
+    private static string Sign(string value, string instanceKey) =>
+        Convert.ToHexStringLower(HMACSHA256.HashData(
+            Encoding.UTF8.GetBytes(instanceKey),
+            Encoding.UTF8.GetBytes(value)));
+}


### PR DESCRIPTION
Fixes #566.

## What

Guest-code activation (and eight sibling policies) partitioned rate limits on `Connection.RemoteIpAddress`. Reached through a SvelteKit remote function, that address is the web container for every user, so one person's five mistyped guest codes locked out the whole deployment.

**The design the codebase forced:** the obvious anchors don't exist — the SSR client deliberately carries no instance key (forwarding it once elevated anonymous visitors to admin), the rate limiter runs before authentication, and "internal peer" means nothing because browser and SSR traffic arrive over the same docker network. So the web server now names the end user on onward calls (`X-Nocturne-Client-Ip`) and proves it with an HMAC-SHA256 over the address, keyed on the instance key both containers already hold (no deployment change). The API honours the address only when the signature verifies (constant-time compare); otherwise it falls back to the connection address. Signing the address rather than presenting a key digest keeps a reusable credential off user-originated requests — a captured signature buckets its own address and nothing else. The web proxy strips inbound copies of both headers.

**One trust decision, one site:** all nine formerly address-keyed policies (`oauth-token`, `oauth-device`, `oauth-register`, `oauth-device-approve`, `totp-login`, `guest-activate`, `demo-session`, `support-issues`, `docs`) now live in one table resolved through `ClientRateLimitKey`. Limits and windows are unchanged; `statistics-compute` stays host-keyed on purpose.

**Honest limit, stated in the helper's docs:** this settles *who shares* a partition, not the ceiling — the unsigned fallback is still `X-Forwarded-For`-derived because `UseForwardedHeaders` clears the trusted-proxy lists, so a header-rotating caller still gets fresh windows. That pre-existing property is being filed separately; it is not made worse here.

Out of scope, still in the issue: distinguishing expired/used/mistyped guest codes.

## Testing

- `ClientRateLimitKeyTests` (9): signed address honoured; missing/garbled signature ignored; **spoof tests** — an address signed with another key, and a signature lifted from another address, are both ignored (mutation-proven: disabling the compare fails exactly those two); keyless config falls back.
- `ClientAddressPolicyCoverageTests` (2): scans every `[EnableRateLimiting]` in the API and fails if a policy is registered outside the table, with a discovery floor so zero matches can't pass vacuously.
- Web: 12 tests over the header builder and proxy stripping. API suite 5714/0.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
