### PR TITLE
fix(data): purge soft-deleted rows instead of skipping them

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
@@ -10,6 +10,7 @@ using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Controllers.V4.Admin;
 
@@ -177,9 +178,9 @@ public class DemoAdminController : ControllerBase
         db.TenantId = tenant.Id;
 
         var deleted = 0L;
-        deleted += await db.SensorGlucose.Where(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
-        deleted += await db.MeterGlucose.Where(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
-        deleted += await db.Calibrations.Where(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
+        deleted += await db.SensorGlucose.PurgeAsync(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService), ct);
+        deleted += await db.MeterGlucose.PurgeAsync(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService), ct);
+        deleted += await db.Calibrations.PurgeAsync(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService), ct);
 
         return Ok(new DemoDeleteResultDto(deleted));
     }
@@ -201,15 +202,15 @@ public class DemoAdminController : ControllerBase
         db.TenantId = tenant.Id;
 
         var deleted = 0L;
-        deleted += await db.Boluses.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
-        deleted += await db.CarbIntakes.Where(c => c.DataSource == DataSources.DemoService || (c.DataSource == null && c.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
-        deleted += await db.BGChecks.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
-        deleted += await db.Notes.Where(n => n.DataSource == DataSources.DemoService || (n.DataSource == null && n.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
-        deleted += await db.DeviceEvents.Where(de => de.DataSource == DataSources.DemoService || (de.DataSource == null && de.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
-        deleted += await db.BolusCalculations.Where(bc => bc.DataSource == DataSources.DemoService || (bc.DataSource == null && bc.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
-        deleted += await db.TempBasals.Where(t => t.DataSource == DataSources.DemoService || (t.DataSource == null && t.Device == DataSources.DemoService)).ExecuteDeleteAsync(ct);
-        deleted += await db.StateSpans.Where(s => s.Source == DataSources.DemoService).ExecuteDeleteAsync(ct);
-        deleted += await db.ApsSnapshots.Where(a => a.Device == DataSources.DemoService).ExecuteDeleteAsync(ct);
+        deleted += await db.Boluses.PurgeAsync(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService), ct);
+        deleted += await db.CarbIntakes.PurgeAsync(c => c.DataSource == DataSources.DemoService || (c.DataSource == null && c.Device == DataSources.DemoService), ct);
+        deleted += await db.BGChecks.PurgeAsync(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService), ct);
+        deleted += await db.Notes.PurgeAsync(n => n.DataSource == DataSources.DemoService || (n.DataSource == null && n.Device == DataSources.DemoService), ct);
+        deleted += await db.DeviceEvents.PurgeAsync(de => de.DataSource == DataSources.DemoService || (de.DataSource == null && de.Device == DataSources.DemoService), ct);
+        deleted += await db.BolusCalculations.PurgeAsync(bc => bc.DataSource == DataSources.DemoService || (bc.DataSource == null && bc.Device == DataSources.DemoService), ct);
+        deleted += await db.TempBasals.PurgeAsync(t => t.DataSource == DataSources.DemoService || (t.DataSource == null && t.Device == DataSources.DemoService), ct);
+        deleted += await db.StateSpans.PurgeAsync(s => s.Source == DataSources.DemoService, ct);
+        deleted += await db.ApsSnapshots.PurgeAsync(a => a.Device == DataSources.DemoService, ct);
 
         return Ok(new DemoDeleteResultDto(deleted));
     }

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -1073,19 +1073,17 @@ public class DataSourceService : IDataSourceService
             );
 
             // Delete V4 treatment records by data source
-            var treatmentsDeleted = await _context.Boluses.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.CarbIntakes.Where(c => c.DataSource == DataSources.DemoService || (c.DataSource == null && c.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.BGChecks.Where(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.Notes.Where(n => n.DataSource == DataSources.DemoService || (n.DataSource == null && n.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.DeviceEvents.Where(de => de.DataSource == DataSources.DemoService || (de.DataSource == null && de.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.BolusCalculations.Where(bc => bc.DataSource == DataSources.DemoService || (bc.DataSource == null && bc.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.TempBasals.Where(t => t.DataSource == DataSources.DemoService || (t.DataSource == null && t.Device == DataSources.DemoService)).ExecuteDeleteAsync(cancellationToken);
-            treatmentsDeleted += await _context.StateSpans.Where(s => s.Source == DataSources.DemoService).ExecuteDeleteAsync(cancellationToken);
+            var treatmentsDeleted = await _context.Boluses.PurgeAsync(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.CarbIntakes.PurgeAsync(c => c.DataSource == DataSources.DemoService || (c.DataSource == null && c.Device == DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.BGChecks.PurgeAsync(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.Notes.PurgeAsync(n => n.DataSource == DataSources.DemoService || (n.DataSource == null && n.Device == DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.DeviceEvents.PurgeAsync(de => de.DataSource == DataSources.DemoService || (de.DataSource == null && de.Device == DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.BolusCalculations.PurgeAsync(bc => bc.DataSource == DataSources.DemoService || (bc.DataSource == null && bc.Device == DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.TempBasals.PurgeAsync(t => t.DataSource == DataSources.DemoService || (t.DataSource == null && t.Device == DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.StateSpans.PurgeAsync(s => s.Source == DataSources.DemoService, cancellationToken);
 
             // Delete APS snapshots - demo data uses the demo-service device
-            var deviceStatusDeleted = await _context
-                .ApsSnapshots.Where(ds => ds.Device == DataSources.DemoService)
-                .ExecuteDeleteAsync(cancellationToken);
+            var deviceStatusDeleted = await _context.ApsSnapshots.PurgeAsync(ds => ds.Device == DataSources.DemoService, cancellationToken);
 
             var deletedCounts = new Dictionary<string, long>();
             if (glucoseDeleted > 0) deletedCounts[nameof(SyncDataType.Glucose)] = glucoseDeleted;

--- a/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
+++ b/src/API/Nocturne.API/Services/Seeding/SampleDataSeeder.cs
@@ -15,6 +15,7 @@ using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Abstractions;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Services.Demo.Configuration;
 using Nocturne.Services.Demo.Services;
 
@@ -466,9 +467,7 @@ public class SampleDataSeeder
             }
 
             // Rebuild instances from the schedule (idempotent re-seed).
-            await _db.TrackerInstances
-                .Where(i => i.DefinitionId == definition.Id)
-                .ExecuteDeleteAsync(ct);
+            await _db.TrackerInstances.PurgeAsync(i => i.DefinitionId == definition.Id, ct);
 
             var changes = schedule
                 .Where(e => e.EventType == spec.TriggerEventType)
@@ -548,12 +547,9 @@ public class SampleDataSeeder
 
         // Rebuild alarm history for the seeded rules (idempotent re-seed).
         var seededRuleIds = rulesByName.Values.Select(r => r.Id).ToList();
-        await _db.AlertInstances
-            .Where(i => i.AlertExcursion != null && seededRuleIds.Contains(i.AlertExcursion.AlertRuleId))
-            .ExecuteDeleteAsync(ct);
-        await _db.AlertExcursions
-            .Where(e => seededRuleIds.Contains(e.AlertRuleId))
-            .ExecuteDeleteAsync(ct);
+        await _db.AlertInstances.PurgeAsync(
+            i => i.AlertExcursion != null && seededRuleIds.Contains(i.AlertExcursion.AlertRuleId), ct);
+        await _db.AlertExcursions.PurgeAsync(e => seededRuleIds.Contains(e.AlertRuleId), ct);
 
         var excursionsCreated = 0;
         foreach (var episode in episodes.OrderByDescending(e => e.StartUtc).Take(MaxAlarmEpisodes))
@@ -673,9 +669,7 @@ public class SampleDataSeeder
                 .Select(c => new { c.Id, c.Timestamp, c.Carbs })
                 .ToListAsync(ct);
             var linkedIntakeIds = intakes.Select(i => i.Id).ToList();
-            await _db.TreatmentFoods
-                .Where(tf => linkedIntakeIds.Contains(tf.CarbIntakeId))
-                .ExecuteDeleteAsync(ct);
+            await _db.TreatmentFoods.PurgeAsync(tf => linkedIntakeIds.Contains(tf.CarbIntakeId), ct);
 
             foreach (var (time, mealName) in mealCarbLinks)
             {
@@ -720,9 +714,7 @@ public class SampleDataSeeder
     private async Task<int> SeedStateSpansAsync(
         DateTime localToday, int days, string dataSource, CancellationToken ct)
     {
-        await _db.StateSpans
-            .Where(s => s.Source == dataSource)
-            .ExecuteDeleteAsync(ct);
+        await _db.StateSpans.PurgeAsync(s => s.Source == dataSource, ct);
 
         var spans = DemoLifestyleSeeds.BuildSpans(localToday, days);
         foreach (var seed in spans)
@@ -959,9 +951,7 @@ public class SampleDataSeeder
             return 0;
 
         var userId = owner.ToString();
-        await _db.InAppNotifications
-            .Where(n => n.UserId == userId && n.Source == "sample-seed")
-            .ExecuteDeleteAsync(ct);
+        await _db.InAppNotifications.PurgeAsync(n => n.UserId == userId && n.Source == "sample-seed", ct);
 
         var created = 0;
         foreach (var episode in episodes.OrderByDescending(e => e.StartUtc).Take(MaxAlarmNotifications))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/PurgeExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/PurgeExtensions.cs
@@ -1,0 +1,41 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// Hard-delete helper for the paths whose job is to empty a table — demo resets, idempotent
+/// re-seeds, test fixtures — rather than to retire a record a user can still see.
+/// </summary>
+public static class PurgeExtensions
+{
+    /// <summary>
+    /// Hard-deletes every row of the set matching <paramref name="predicate"/>, soft-deleted rows
+    /// included, within the tenant the context is pinned to.
+    /// </summary>
+    /// <remarks>
+    /// <c>ExecuteDeleteAsync</c> honours the global query filters, so a purge left under
+    /// <see cref="NocturneDbContext.SoftDeleteFilterKey"/> skips rows that are already soft-deleted
+    /// — leaving them invisible to reads and immune to the purge meant to remove them. Only that
+    /// filter is lifted: parameterless <c>IgnoreQueryFilters()</c> would drop
+    /// <see cref="NocturneDbContext.TenantFilterKey"/> with it and widen the delete across tenants.
+    ///
+    /// Unaudited, as the purge paths this serves have always been. Retiring a live record belongs on
+    /// the audited soft-delete path (<see cref="AuditedBulkDeleteExtensions"/>) instead.
+    /// </remarks>
+    /// <param name="rows">The set to purge from.</param>
+    /// <param name="predicate">Row filter, or <c>null</c> for the tenant's whole table.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The number of rows deleted.</returns>
+    public static Task<int> PurgeAsync<TEntity>(
+        this DbSet<TEntity> rows,
+        Expression<Func<TEntity, bool>>? predicate = null,
+        CancellationToken ct = default)
+        where TEntity : class, ITenantScoped
+    {
+        var purgeable = rows.IgnoreQueryFilters([NocturneDbContext.SoftDeleteFilterKey]);
+
+        return (predicate is null ? purgeable : purgeable.Where(predicate)).ExecuteDeleteAsync(ct);
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -21,6 +21,19 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     private readonly DbContextOptions<NocturneDbContext> _options;
 
     /// <summary>
+    /// Key of the global query filter restricting every <see cref="ITenantScoped"/> entity to
+    /// <see cref="TenantId"/>.
+    /// </summary>
+    public const string TenantFilterKey = "tenant_isolation";
+
+    /// <summary>
+    /// Key of the global query filter hiding soft-deleted rows of every <see cref="ISoftDeletable"/>
+    /// entity. Named separately from <see cref="TenantFilterKey"/> so a purge can lift it alone —
+    /// see <see cref="Extensions.PurgeExtensions"/>.
+    /// </summary>
+    public const string SoftDeleteFilterKey = "soft_delete";
+
+    /// <summary>
     /// Initializes a new instance of the NocturneDbContext class
     /// </summary>
     /// <param name="options">The options for this context</param>
@@ -2515,7 +2528,8 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     }
 
     /// <summary>
-    /// Applies global query filters for tenant isolation on all ITenantScoped entities.
+    /// Applies the global query filters carried by every ITenantScoped entity: tenant isolation,
+    /// plus the soft-delete predicate on the ISoftDeletable ones.
     /// Filters reference this.TenantId which is set per-request.
     /// EF Core parameterizes the value, so pooled contexts work correctly.
     /// </summary>
@@ -2529,26 +2543,31 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             var parameter = Expression.Parameter(entityType.ClrType, "e");
             var tenantIdProperty = Expression.Property(parameter, nameof(ITenantScoped.TenantId));
             var currentTenantId = Expression.Property(Expression.Constant(this), nameof(TenantId));
-            Expression body = Expression.Equal(tenantIdProperty, currentTenantId);
+            var entityBuilder = modelBuilder.Entity(entityType.ClrType);
 
-            if (typeof(ISoftDeletable).IsAssignableFrom(entityType.ClrType))
-            {
-                var deletedAtProperty = Expression.Property(parameter, nameof(ISoftDeletable.DeletedAt));
-                var nullValue = Expression.Constant(null, typeof(DateTime?));
-                var isNotDeleted = Expression.Equal(deletedAtProperty, nullValue);
-                body = Expression.AndAlso(body, isNotDeleted);
+            // Keyed rather than anonymous filters: a hard purge has to lift the soft-delete
+            // predicate without lifting tenant isolation with it (PurgeExtensions).
+            entityBuilder.HasQueryFilter(
+                TenantFilterKey,
+                Expression.Lambda(Expression.Equal(tenantIdProperty, currentTenantId), parameter));
 
-                // Records whether the latest soft-delete was user-initiated. The soft-delete
-                // dedup discriminator (SoftDeleteDedupExtensions) blocks connector resync from
-                // re-creating a user-deleted row, while a system-sweep delete stays re-creatable.
-                // A shadow property so it lands on every soft-deletable table without a per-entity edit.
-                modelBuilder.Entity(entityType.ClrType)
-                    .Property<bool>("DeletedByUser")
-                    .HasColumnName("deleted_by_user")
-                    .HasDefaultValue(false);
-            }
+            if (!typeof(ISoftDeletable).IsAssignableFrom(entityType.ClrType))
+                continue;
 
-            modelBuilder.Entity(entityType.ClrType).HasQueryFilter(Expression.Lambda(body, parameter));
+            var deletedAtProperty = Expression.Property(parameter, nameof(ISoftDeletable.DeletedAt));
+            var nullValue = Expression.Constant(null, typeof(DateTime?));
+            entityBuilder.HasQueryFilter(
+                SoftDeleteFilterKey,
+                Expression.Lambda(Expression.Equal(deletedAtProperty, nullValue), parameter));
+
+            // Records whether the latest soft-delete was user-initiated. The soft-delete
+            // dedup discriminator (SoftDeleteDedupExtensions) blocks connector resync from
+            // re-creating a user-deleted row, while a system-sweep delete stays re-creatable.
+            // A shadow property so it lands on every soft-deletable table without a per-entity edit.
+            entityBuilder
+                .Property<bool>("DeletedByUser")
+                .HasColumnName("deleted_by_user")
+                .HasDefaultValue(false);
         }
     }
 

--- a/tests/Integration/Nocturne.API.Tests/Infrastructure/ParityTestFixture.cs
+++ b/tests/Integration/Nocturne.API.Tests/Infrastructure/ParityTestFixture.cs
@@ -93,18 +93,18 @@ public class ParityTestFixture : IAsyncLifetime
     {
         if (_sharedState == null) return;
 
-        // Clean Nocturne (PostgreSQL) first using ExecuteDeleteAsync for bulk deletion
-        // This is more reliable than RemoveRange as it bypasses the change tracker
+        // Clean Nocturne (PostgreSQL) first with a bulk purge: more reliable than RemoveRange as it
+        // bypasses the change tracker, and unlike ExecuteDeleteAsync it empties the table rather than
+        // leaving soft-deleted rows to leak into the next test.
         var db = _sharedState.DbContext;
 
         // Clear change tracker to ensure no stale entities
         db.ChangeTracker.Clear();
 
-        // Use ExecuteDeleteAsync for efficient bulk deletion that bypasses EF tracking
-        await db.ApsSnapshots.ExecuteDeleteAsync(cancellationToken);
-        await db.Foods.ExecuteDeleteAsync(cancellationToken);
-        await db.Settings.ExecuteDeleteAsync(cancellationToken);
-        await db.StateSpans.ExecuteDeleteAsync(cancellationToken);
+        await db.ApsSnapshots.PurgeAsync(ct: cancellationToken);
+        await db.Foods.PurgeAsync(ct: cancellationToken);
+        await db.Settings.PurgeAsync(ct: cancellationToken);
+        await db.StateSpans.PurgeAsync(ct: cancellationToken);
         // Clean Nightscout (network calls - may have latency)
         await _sharedState.NightscoutContainer.CleanupDataAsync(cancellationToken);
     }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Admin/DemoAdminPurgeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Admin/DemoAdminPurgeTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V4.Admin;
+using Nocturne.API.Services.Demo;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Cache.Abstractions;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Admin;
+
+/// <summary>
+/// The demo delete endpoints are what the demo service calls to empty the tenant before a
+/// regenerate, so they have to reach records a visitor deleted — those are soft-deleted rows, which
+/// the global filter hid from the purge.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DemoAdminPurgeTests : IDisposable
+{
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-0000000000de");
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+
+    public DemoAdminPurgeTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        db.Tenants.Add(new TenantEntity { Id = TenantId, Slug = "demo", IsDemo = true, IsActive = true });
+        db.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private NocturneDbContext NewContext() => new(_dbOptions) { TenantId = TenantId };
+
+    private DemoAdminController BuildController()
+    {
+        var dbFactory = new Mock<IDbContextFactory<NocturneDbContext>>();
+        dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new NocturneDbContext(_dbOptions));
+
+        var tenantService = new Mock<ITenantService>();
+        var demoTenantService = new DemoTenantService(
+            dbFactory.Object,
+            tenantService.Object,
+            TestPublicAccessCache.Create(),
+            new Mock<ICacheService>().Object,
+            new Mock<ILogger<DemoTenantService>>().Object);
+
+        return new DemoAdminController(tenantService.Object, demoTenantService, dbFactory.Object);
+    }
+
+    [Fact]
+    public async Task DeleteEntries_PurgesSoftDeletedGlucose()
+    {
+        var deletedAt = DateTime.UtcNow;
+        await using (var seed = NewContext())
+        {
+            seed.SensorGlucose.Add(new SensorGlucoseEntity
+            {
+                Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+                Timestamp = DateTime.UtcNow, Mgdl = 120, DeletedAt = deletedAt,
+            });
+            seed.MeterGlucose.Add(new MeterGlucoseEntity
+            {
+                Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+                Timestamp = DateTime.UtcNow, Mgdl = 110, DeletedAt = deletedAt,
+            });
+            seed.Calibrations.Add(new CalibrationEntity
+            {
+                Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+                Timestamp = DateTime.UtcNow, DeletedAt = deletedAt,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        await BuildController().DeleteEntries(CancellationToken.None);
+
+        await using var assert = NewContext();
+        (await assert.SensorGlucose.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.MeterGlucose.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.Calibrations.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DeleteTreatments_PurgesSoftDeletedTreatments()
+    {
+        var deletedAt = DateTime.UtcNow;
+        await using (var seed = NewContext())
+        {
+            seed.Boluses.Add(new BolusEntity
+            {
+                Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+                Timestamp = DateTime.UtcNow, Insulin = 1, DeletedAt = deletedAt,
+            });
+            seed.CarbIntakes.Add(new CarbIntakeEntity
+            {
+                Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+                Timestamp = DateTime.UtcNow, Carbs = 30, DeletedAt = deletedAt,
+            });
+            seed.ApsSnapshots.Add(new ApsSnapshotEntity
+            {
+                Id = Guid.CreateVersion7(), TenantId = TenantId, Device = DataSources.DemoService,
+                Timestamp = DateTime.UtcNow, AidAlgorithm = "Loop", DeletedAt = deletedAt,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        await BuildController().DeleteTreatments(CancellationToken.None);
+
+        await using var assert = NewContext();
+        (await assert.Boluses.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.CarbIntakes.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.ApsSnapshots.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteDemoDataTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteDemoDataTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// A demo reset has to leave the tables empty. The purge used to run under the soft-delete query
+/// filter, so any record a visitor had deleted survived the reset and could then be neither read nor
+/// purged.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DataSourceServiceDeleteDemoDataTests : IDisposable
+{
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+
+    private readonly Mock<ISensorGlucoseRepository> _sensorGlucose = new();
+    private readonly Mock<IMeterGlucoseRepository> _meterGlucose = new();
+    private readonly Mock<ICalibrationRepository> _calibrations = new();
+    private readonly Mock<IConnectorConfigurationService> _connectorConfig = new();
+
+    public DataSourceServiceDeleteDemoDataTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        db.Tenants.Add(new TenantEntity { Id = TenantId, Slug = "demo" });
+        db.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private NocturneDbContext NewContext() => new(_dbOptions) { TenantId = TenantId };
+
+    private DataSourceService CreateService(NocturneDbContext context) => new(
+        context,
+        _sensorGlucose.Object,
+        _meterGlucose.Object,
+        _calibrations.Object,
+        Mock.Of<IAuditContext>(),
+        _connectorConfig.Object,
+        NullLogger<DataSourceService>.Instance);
+
+    /// <summary>One already-soft-deleted demo record of every type the purge covers.</summary>
+    private void SeedSoftDeletedDemoData()
+    {
+        var deletedAt = DateTime.UtcNow;
+        var timestamp = DateTime.UtcNow;
+
+        using var db = NewContext();
+        db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Insulin = 1, DeletedAt = deletedAt,
+        });
+        db.CarbIntakes.Add(new CarbIntakeEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Carbs = 20, DeletedAt = deletedAt,
+        });
+        db.BGChecks.Add(new BGCheckEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Glucose = 100, DeletedAt = deletedAt,
+        });
+        db.Notes.Add(new NoteEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Text = "note", DeletedAt = deletedAt,
+        });
+        db.DeviceEvents.Add(new DeviceEventEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, EventType = "SiteChange", DeletedAt = deletedAt,
+        });
+        db.BolusCalculations.Add(new BolusCalculationEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, DeletedAt = deletedAt,
+        });
+        db.TempBasals.Add(new TempBasalEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            StartTimestamp = timestamp, Rate = 0.5, Origin = "pump", DeletedAt = deletedAt,
+        });
+        db.ApsSnapshots.Add(new ApsSnapshotEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, Device = DataSources.DemoService,
+            Timestamp = timestamp, AidAlgorithm = "Loop", DeletedAt = deletedAt,
+        });
+        db.StateSpans.Add(new StateSpanEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, Source = DataSources.DemoService,
+            Category = "PumpMode", State = "Automatic", StartTimestamp = timestamp,
+        });
+        db.SaveChanges();
+    }
+
+    [Fact]
+    public async Task DeleteDemoData_PurgesSoftDeletedRecords()
+    {
+        SeedSoftDeletedDemoData();
+
+        await using (var ctx = NewContext())
+        {
+            var result = await CreateService(ctx).DeleteDemoDataAsync();
+
+            result.Success.Should().BeTrue();
+            result.DeletedCounts.Should().Contain(new KeyValuePair<string, long>("Treatments", 8));
+            result.DeletedCounts.Should().Contain(new KeyValuePair<string, long>("DeviceStatus", 1));
+        }
+
+        await using var assert = NewContext();
+        (await assert.Boluses.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.CarbIntakes.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.BGChecks.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.Notes.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.DeviceEvents.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.BolusCalculations.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.TempBasals.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.ApsSnapshots.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+        (await assert.StateSpans.IgnoreQueryFilters().CountAsync()).Should().Be(0);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/PurgeExtensionsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/PurgeExtensionsTests.cs
@@ -1,0 +1,135 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
+
+namespace Nocturne.Infrastructure.Data.Tests.Extensions;
+
+/// <summary>
+/// A purge exists to empty a table, so it has to reach rows the soft-delete filter hides — and it
+/// has to stop at the context's tenant, which the parameterless <c>IgnoreQueryFilters()</c> would
+/// not.
+/// </summary>
+[Trait("Category", "Unit")]
+public class PurgeExtensionsTests : IDisposable
+{
+    private const string Source = "demo-service";
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _options;
+    private readonly Guid _tenantA = Guid.CreateVersion7();
+    private readonly Guid _tenantB = Guid.CreateVersion7();
+
+    public PurgeExtensionsTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var db = new NocturneDbContext(_options);
+        db.Database.EnsureCreated();
+        db.Tenants.Add(new TenantEntity { Id = _tenantA, Slug = "a" });
+        db.Tenants.Add(new TenantEntity { Id = _tenantB, Slug = "b" });
+        db.SaveChanges();
+
+        SeedBoluses(_tenantA);
+        SeedBoluses(_tenantB);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private NocturneDbContext NewContext(Guid tenantId) => new(_options) { TenantId = tenantId };
+
+    /// <summary>One live and one already-soft-deleted bolus, both carrying <see cref="Source"/>.</summary>
+    private void SeedBoluses(Guid tenantId)
+    {
+        using var db = NewContext(tenantId);
+        db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            DataSource = Source,
+            Timestamp = DateTime.UtcNow,
+            Insulin = 1,
+        });
+        db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            DataSource = Source,
+            Timestamp = DateTime.UtcNow,
+            Insulin = 2,
+            DeletedAt = DateTime.UtcNow,
+        });
+        db.SaveChanges();
+    }
+
+    private async Task<int> CountAllAsync(Guid tenantId)
+    {
+        await using var db = NewContext(tenantId);
+        return await db.Boluses.IgnoreQueryFilters().CountAsync(b => b.TenantId == tenantId);
+    }
+
+    [Fact]
+    public async Task PurgeAsync_RemovesSoftDeletedRowsToo()
+    {
+        await using var db = NewContext(_tenantA);
+
+        var purged = await db.Boluses.PurgeAsync(b => b.DataSource == Source);
+
+        purged.Should().Be(2, "the soft-deleted row is exactly what the purge exists to remove");
+        (await CountAllAsync(_tenantA)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PurgeAsync_LeavesOtherTenantsRowsAlone()
+    {
+        await using var db = NewContext(_tenantA);
+
+        await db.Boluses.PurgeAsync(b => b.DataSource == Source);
+
+        (await CountAllAsync(_tenantB)).Should().Be(2, "lifting the tenant filter would take these too");
+    }
+
+    [Fact]
+    public async Task PurgeAsync_WithoutPredicate_EmptiesOnlyTheContextTenantsRows()
+    {
+        await using var db = NewContext(_tenantA);
+
+        var purged = await db.Boluses.PurgeAsync();
+
+        purged.Should().Be(2);
+        (await CountAllAsync(_tenantA)).Should().Be(0);
+        (await CountAllAsync(_tenantB)).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task PurgeAsync_DeletesFromASetWithNoSoftDeleteFilter()
+    {
+        await using (var seed = NewContext(_tenantA))
+        {
+            seed.StateSpans.Add(new StateSpanEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _tenantA,
+                Source = Source,
+                Category = "PumpMode",
+                State = "Automatic",
+                StartTimestamp = DateTime.UtcNow,
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        await using var db = NewContext(_tenantA);
+
+        (await db.StateSpans.PurgeAsync(s => s.Source == Source)).Should().Be(1);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/MutationAuditInterceptorTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Interceptors/MutationAuditInterceptorTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Common;
-using System.Linq.Expressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -77,19 +76,13 @@ public class TestNocturneDbContext : NocturneDbContext
         // (set_config / current_setting) which don't work with SQLite.
         modelBuilder.Entity<TestAuditableEntity>(e =>
         {
-            e.HasQueryFilter(null as LambdaExpression);
+            e.ClearQueryFilters();
             e.Property(x => x.DeletedAt).IsRequired(false);
         });
 
-        modelBuilder.Entity<TestSensorGlucoseEntity>(e =>
-        {
-            e.HasQueryFilter(null as LambdaExpression);
-        });
+        modelBuilder.Entity<TestSensorGlucoseEntity>(e => e.ClearQueryFilters());
 
-        modelBuilder.Entity<TestNonAuditableEntity>(e =>
-        {
-            e.HasQueryFilter(null as LambdaExpression);
-        });
+        modelBuilder.Entity<TestNonAuditableEntity>(e => e.ClearQueryFilters());
     }
 }
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
@@ -120,6 +120,29 @@ public class ModelConventionTests
                 && i.IsDescending is not null
                 && i.IsDescending.SequenceEqual([false, false, true]));
 
+    /// <summary>
+    /// <see cref="Nocturne.Infrastructure.Data.Extensions.PurgeExtensions"/> lifts the soft-delete
+    /// filter by key, and <c>IgnoreQueryFilters</c> ignores a key the entity does not declare — so
+    /// folding the two predicates back into one filter would silently restore the purge skip.
+    /// </summary>
+    [Fact]
+    public void EverySoftDeletableEntity_DeclaresTheTenantAndSoftDeleteFiltersSeparately()
+    {
+        var softDeletable = Model().GetEntityTypes()
+            .Where(e => typeof(ISoftDeletable).IsAssignableFrom(e.ClrType)
+                     && typeof(ITenantScoped).IsAssignableFrom(e.ClrType))
+            .ToList();
+
+        softDeletable.Should().HaveCountGreaterThan(20,
+            "an empty set would let every assertion below pass vacuously");
+
+        softDeletable
+            .Where(e => e.FindDeclaredQueryFilter(NocturneDbContext.SoftDeleteFilterKey) is null
+                     || e.FindDeclaredQueryFilter(NocturneDbContext.TenantFilterKey) is null)
+            .Select(e => e.ShortName())
+            .Should().BeEmpty("a purge has to lift the soft-delete filter without lifting tenant isolation");
+    }
+
     private static void AssertFamily(
         IReadOnlyList<Type> entities,
         string suffix,

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/QueryFilterTestExtensions.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/QueryFilterTestExtensions.cs
@@ -1,0 +1,29 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// SQLite-backed tests assert on rows the production filters hide (other tenants',
+/// soft-deleted ones), so their contexts drop every global filter the model declares.
+/// </summary>
+internal static class QueryFilterTestExtensions
+{
+    /// <summary>
+    /// Removes every global query filter declared on the entity type. <see cref="NocturneDbContext"/>
+    /// registers keyed filters, which <c>HasQueryFilter(null)</c> does not touch — that clears only an
+    /// anonymous filter.
+    /// </summary>
+    internal static EntityTypeBuilder ClearQueryFilters(this EntityTypeBuilder builder)
+    {
+        foreach (var filter in builder.Metadata.GetDeclaredQueryFilters().ToList())
+        {
+            if (filter.IsAnonymous)
+                builder.HasQueryFilter(null as LambdaExpression);
+            else
+                builder.HasQueryFilter(filter.Key, null);
+        }
+
+        return builder;
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/TenantAuditConfigCacheTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/TenantAuditConfigCacheTests.cs
@@ -151,8 +151,7 @@ public class TenantAuditConfigCacheTests : IDisposable
                 if (entityType.IsOwned())
                     continue;
 
-                modelBuilder.Entity(entityType.ClrType)
-                    .HasQueryFilter(null as System.Linq.Expressions.LambdaExpression);
+                modelBuilder.Entity(entityType.ClrType).ClearQueryFilters();
             }
         }
     }


### PR DESCRIPTION
Fixes #792.

## What

`ExecuteDeleteAsync` runs under the global query filters, so every purge path silently skipped rows already soft-deleted — invisible to reads, immune to the purge that exists to remove them. Demo resets weren't resets; idempotent re-seeds could collide with survivors they could neither see nor delete.

**The fix the issue warned about, avoided structurally:** parameterless `IgnoreQueryFilters()` lifts the tenant predicate too. EF Core 10 ships named query filters (verified against the pinned package, not from memory), so the combined tenant+soft-delete filter is now two keyed filters (`tenant_isolation`, `soft_delete`), and the new `PurgeAsync` DbSet extension lifts **only** the soft-delete key — tenant isolation stays in force and no call site can forget to re-apply it. One helper, 22 call sites converted across `DataSourceService` (demo purge), both `DemoAdminController` delete endpoints (the `/entries` one wasn't in the issue but is the same defect three lines up), `SampleDataSeeder`, and `ParityTestFixture` (whose `ApsSnapshots` wipe was leaking soft-deleted rows between integration runs).

Purges stay unaudited, as they were. Two EF behaviours discovered en route are covered by tests: an unknown filter key is silently ignored (so one helper serves non-soft-deletable sets), and `HasQueryFilter(null)` clears only anonymous filters (three test contexts needed a key-agnostic `ClearQueryFilters()` helper).

## Testing

- `PurgeExtensionsTests` (SQLite, real context): soft-deleted rows removed; **another tenant's live and soft-deleted rows survive** (the trap test); no-predicate form empties only the pinned tenant.
- Per-site tests for the demo purge and both admin endpoints (seeded soft-deleted rows now counted and gone under `IgnoreQueryFilters()`).
- New model guard: `EverySoftDeletableEntity_DeclaresTheTenantAndSoftDeleteFiltersSeparately` — folding the filters back into one would make `PurgeAsync` a silent no-op; this fails first.
- Five mutation proofs (no lifting; parameterless lift → cross-tenant trap test fails; two site reverts; filter-registration removal).
- Full solution unit matrix run because the filter split touches every entity: 21 suites, 0 failures. `has-pending-model-changes` → none (query filters aren't in the snapshot; independently re-verified at review).

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
