### PR TITLE
perf(data): summary-row soft deletes, paged hard deletes, capped broadcasts

### DIFF
--- a/src/API/Nocturne.API/Models/Responses/MutationAuditDto.cs
+++ b/src/API/Nocturne.API/Models/Responses/MutationAuditDto.cs
@@ -5,7 +5,7 @@ public class MutationAuditDto
     public Guid Id { get; set; }
     public DateTime CreatedAt { get; set; }
     public string EntityType { get; set; } = null!;
-    public Guid EntityId { get; set; }
+    public Guid? EntityId { get; set; }
     public string Action { get; set; } = null!;
     public string? Changes { get; set; }
     public Guid? SubjectId { get; set; }

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -916,8 +916,8 @@ public class DataSourceService : IDataSourceService
     /// Capability matrix (entity interfaces decide the path):
     /// <list type="bullet">
     /// <item>Glucose and the auditable+soft-deletable treatments (Bolus, CarbIntake, BolusCalculation,
-    ///   DeviceEvent) take the audited soft-delete path. The audit row's non-null AuthType is what makes
-    ///   the soft-delete dedup block re-import (<see cref="SoftDeleteDedupExtensions"/>).</item>
+    ///   DeviceEvent) take the audited soft-delete path, which stamps the <c>deleted_by_user</c> flag the
+    ///   soft-delete dedup reads to block re-import (<see cref="SoftDeleteDedupExtensions"/>).</item>
     /// <item>StateSpan is auditable but not soft-deletable, so it takes the audited hard-delete path.</item>
     /// <item>BGChecks, Notes and device status are soft-deletable but not auditable, so they soft-delete
     ///   without an audit row; with the connector disabled they do not re-import.</item>
@@ -934,14 +934,15 @@ public class DataSourceService : IDataSourceService
         var calibrationsDeleted = await _calibrations.DeleteBySourceAsync(deviceId, cancellationToken);
 
         // Auditable + soft-deletable treatments: audited soft-delete, user-attributed.
+        var scope = $"data_source={deviceId}";
         var bolusesDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.Boluses.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId)), _auditContext, cancellationToken);
+            _context.Boluses.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId)), _auditContext, scope, cancellationToken);
         var carbIntakesDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.CarbIntakes.Where(c => c.DataSource == deviceId || (c.DataSource == null && c.Device == deviceId)), _auditContext, cancellationToken);
+            _context.CarbIntakes.Where(c => c.DataSource == deviceId || (c.DataSource == null && c.Device == deviceId)), _auditContext, scope, cancellationToken);
         var bolusCalcsDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.BolusCalculations.Where(bc => bc.DataSource == deviceId || (bc.DataSource == null && bc.Device == deviceId)), _auditContext, cancellationToken);
+            _context.BolusCalculations.Where(bc => bc.DataSource == deviceId || (bc.DataSource == null && bc.Device == deviceId)), _auditContext, scope, cancellationToken);
         var deviceEventsDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.DeviceEvents.Where(de => de.DataSource == deviceId || (de.DataSource == null && de.Device == deviceId)), _auditContext, cancellationToken);
+            _context.DeviceEvents.Where(de => de.DataSource == deviceId || (de.DataSource == null && de.Device == deviceId)), _auditContext, scope, cancellationToken);
 
         // StateSpan is auditable but not soft-deletable: audited hard delete.
         var stateSpansDeleted = await _context.AuditedExecuteDeleteAsync(

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/MutationAuditLogEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/MutationAuditLogEntity.cs
@@ -25,17 +25,23 @@ public class MutationAuditLogEntity : ITenantScoped
     [MaxLength(100)]
     public string EntityType { get; set; } = null!;
 
-    /// <summary>Primary key of the mutated entity.</summary>
+    /// <summary>
+    /// Primary key of the mutated entity; null for a <c>bulk_delete</c>, which describes a set of rows
+    /// rather than one record.
+    /// </summary>
     [Column("entity_id")]
-    public Guid EntityId { get; set; }
+    public Guid? EntityId { get; set; }
 
-    /// <summary>Mutation kind: create, update, delete, or restore.</summary>
+    /// <summary>Mutation kind: create, update, delete, restore, or bulk_delete.</summary>
     [Required]
     [Column("action")]
-    [MaxLength(10)]
+    [MaxLength(20)]
     public string Action { get; set; } = null!;
 
-    /// <summary>JSONB diff for updates, full snapshot for deletes; null for creates.</summary>
+    /// <summary>
+    /// JSONB diff for updates, full snapshot for deletes, <c>{count, scope}</c> for a bulk_delete;
+    /// null for creates.
+    /// </summary>
     [Column("changes", TypeName = "jsonb")]
     public string? ChangesJson { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
@@ -7,98 +8,135 @@ using Nocturne.Infrastructure.Data.Entities;
 namespace Nocturne.Infrastructure.Data.Extensions;
 
 /// <summary>
-/// Extensions for executing bulk deletes that write per-row audit log entries before removal.
+/// The outcome of an audited soft delete: how many rows were soft-deleted, and the entities
+/// materialized for the caller's realtime broadcast.
 /// </summary>
+/// <param name="Count">Rows soft-deleted by the operation.</param>
+/// <param name="Entities">
+/// The soft-deleted entities, detached but still holding their loaded values — empty when the match
+/// set exceeded <see cref="AuditedBulkDeleteExtensions.BroadcastMaterializationCap"/>.
+/// </param>
+public readonly record struct AuditedSoftDeleteResult<T>(int Count, List<T> Entities)
+{
+    /// <summary>
+    /// True when the match set was too large to materialize: <see cref="Entities"/> is empty and the
+    /// caller must fall back to a coarse collection-level invalidation instead of per-record events.
+    /// </summary>
+    public bool Collapsed => Count > 0 && Entities.Count == 0;
+}
+
+/// <summary>
+/// Extensions for executing bulk deletes that record them in <c>mutation_audit_log</c>.
+/// </summary>
+/// <remarks>
+/// A soft delete leaves the row in place, so a per-row snapshot would be a verbatim copy of data that
+/// is still readable and the dedup discriminator lives on the row itself
+/// (<see cref="SoftDeleteDedupExtensions"/>) — soft deletes therefore record one <c>bulk_delete</c>
+/// summary row naming the scope they were issued against. A hard delete destroys the row, so its
+/// per-row snapshots are the only surviving copy and are kept.
+/// </remarks>
 public static class AuditedBulkDeleteExtensions
 {
+    /// <summary>
+    /// Rows an audited hard delete snapshots per page. Sized so one page's JSON snapshots are a bounded
+    /// working set while the statement count stays proportional to rows/1000 rather than to rows.
+    /// </summary>
+    private const int HardDeletePageSize = 1000;
+
+    /// <summary>
+    /// Upper bound on the entities an audited soft delete materializes for its caller's realtime
+    /// broadcast. A per-record event stream longer than this is worse for subscribers than one coarse
+    /// invalidation, and materializing a source's whole history is what this cap exists to prevent.
+    /// </summary>
+    public const int BroadcastMaterializationCap = 500;
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = false,
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
     };
 
+    /// <summary>What a <c>bulk_delete</c> summary row records in place of per-row snapshots.</summary>
+    private readonly record struct BulkDeleteSummary(int Count, string Scope);
+
     /// <summary>
-    /// Executes a bulk delete with audit trail. Queries affected records,
-    /// writes audit entries, then executes the delete — all in one transaction.
+    /// Executes a bulk hard delete, snapshotting every removed row into <c>mutation_audit_log</c>.
     /// </summary>
+    /// <remarks>
+    /// Runs a page at a time: each page's snapshots and its delete share a transaction, but the
+    /// operation as a whole is NOT atomic — a failure part-way leaves earlier pages deleted (and
+    /// audited). Re-running the same call resumes, because the deleted rows no longer match.
+    /// Unattributed/system deletes skip the snapshots entirely and issue a single delete statement.
+    /// </remarks>
     public static async Task<int> AuditedExecuteDeleteAsync<T>(
         this NocturneDbContext context,
         IQueryable<T> query,
         IAuditContext? auditContext,
         CancellationToken ct = default) where T : class, IAuditable
     {
+        if (auditContext.IsSystemMutation())
+            return await query.ExecuteDeleteAsync(ct);
+
         var strategy = context.Database.CreateExecutionStrategy();
+        var total = 0;
+        int page;
 
-        return await strategy.ExecuteAsync(async () =>
+        do
         {
-            await using var transaction = await context.Database.BeginTransactionAsync(ct);
-
-            // Query affected records for audit snapshot
-            var affectedRecords = await query.ToListAsync(ct);
-
-            if (affectedRecords.Count == 0)
+            page = await strategy.ExecuteAsync(async () =>
             {
-                await transaction.CommitAsync(ct);
-                return 0;
-            }
+                await using var transaction = await context.Database.BeginTransactionAsync(ct);
 
-            var auditEntries = BuildDeleteAuditEntries(context, affectedRecords, auditContext);
+                var records = await query.Take(HardDeletePageSize).ToListAsync(ct);
+                if (records.Count == 0)
+                {
+                    await transaction.CommitAsync(ct);
+                    return 0;
+                }
 
-            // Detach the loaded entities so they don't interfere with the bulk delete
-            foreach (var record in affectedRecords)
-                context.Entry(record).State = EntityState.Detached;
+                var auditEntries = BuildDeleteAuditEntries(context, records, auditContext);
+                var ids = records.Select(IdOf).ToList();
 
-            // Write audit entries
-            if (auditEntries.Count > 0)
-            {
+                // Detach the loaded entities so they don't interfere with the bulk delete
+                foreach (var record in records)
+                    context.Entry(record).State = EntityState.Detached;
+
                 context.Set<MutationAuditLogEntity>().AddRange(auditEntries);
                 await context.SaveChangesAsync(ct);
-            }
 
-            // Execute bulk delete
-            var deletedCount = await query.ExecuteDeleteAsync(ct);
+                var deleted = await query
+                    .Where(e => ids.Contains(EF.Property<Guid>(e, "Id")))
+                    .ExecuteDeleteAsync(ct);
 
-            await transaction.CommitAsync(ct);
-            return deletedCount;
-        });
+                await transaction.CommitAsync(ct);
+                return deleted;
+            });
+
+            total += page;
+        }
+        while (page == HardDeletePageSize);
+
+        return total;
     }
 
     /// <summary>
-    /// Executes a bulk soft delete with audit trail. Queries affected records,
-    /// writes audit entries, then sets <c>DeletedAt</c> — all in one transaction.
+    /// Executes a bulk soft delete, recording it as one <c>bulk_delete</c> summary row for
+    /// <paramref name="scope"/>. No rows are materialized.
     /// </summary>
+    /// <param name="context">The tenant-scoped context the audit row is written on.</param>
+    /// <param name="query">The rows to soft-delete.</param>
+    /// <param name="auditContext">Actor/request metadata; system or null writes no audit row.</param>
+    /// <param name="scope">
+    /// The key the delete was issued against (e.g. <c>data_source=dexcom-connector</c>), recorded on
+    /// the summary row — without it the row cannot say which records it covered.
+    /// </param>
+    /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of records soft-deleted.</returns>
     public static async Task<int> AuditedSoftDeleteAsync<T>(
         this NocturneDbContext context,
         IQueryable<T> query,
         IAuditContext? auditContext,
-        CancellationToken ct = default) where T : class, IAuditable, ISoftDeletable
-        => (await context.AuditedSoftDeleteWithEntitiesAsync(query, auditContext, ct)).Count;
-
-    /// <summary>
-    /// As <see cref="AuditedSoftDeleteAsync{T}"/>, but returns the ids of the soft-deleted records so the
-    /// caller can broadcast per-record delete events. The records are already materialized for the audit
-    /// snapshot, so surfacing their ids costs no extra query.
-    /// </summary>
-    public static async Task<List<Guid>> AuditedSoftDeleteWithIdsAsync<T>(
-        this NocturneDbContext context,
-        IQueryable<T> query,
-        IAuditContext? auditContext,
-        CancellationToken ct = default) where T : class, IAuditable, ISoftDeletable
-        => (await context.AuditedSoftDeleteWithEntitiesAsync(query, auditContext, ct))
-            .Select(e => (Guid)typeof(T).GetProperty("Id")!.GetValue(e)!)
-            .ToList();
-
-    /// <summary>
-    /// As <see cref="AuditedSoftDeleteAsync{T}"/>, but returns the soft-deleted entities so the caller can
-    /// project them (e.g. to the legacy <c>Entry</c> shape) and broadcast per-record delete events. The
-    /// records are already materialized for the audit snapshot, so surfacing them costs no extra query.
-    /// They are detached after the snapshot but still hold their loaded values.
-    /// </summary>
-    public static async Task<List<T>> AuditedSoftDeleteWithEntitiesAsync<T>(
-        this NocturneDbContext context,
-        IQueryable<T> query,
-        IAuditContext? auditContext,
+        string scope,
         CancellationToken ct = default) where T : class, IAuditable, ISoftDeletable
     {
         var strategy = context.Database.CreateExecutionStrategy();
@@ -107,42 +145,148 @@ public static class AuditedBulkDeleteExtensions
         {
             await using var transaction = await context.Database.BeginTransactionAsync(ct);
 
-            // Query affected records for audit snapshot
-            var affectedRecords = await query.ToListAsync(ct);
+            var count = await SoftDeleteRowsAsync(query, auditContext, ct);
+            await WriteBulkDeleteSummaryAsync<T>(context, count, scope, auditContext, ct);
 
-            if (affectedRecords.Count == 0)
-            {
-                await transaction.CommitAsync(ct);
-                return [];
-            }
+            await transaction.CommitAsync(ct);
+            return count;
+        });
+    }
 
-            var now = DateTime.UtcNow;
-            var auditEntries = BuildDeleteAuditEntries(context, affectedRecords, auditContext);
+    /// <summary>
+    /// As <see cref="AuditedSoftDeleteAsync{T}"/>, but returns the ids of the soft-deleted records so the
+    /// caller can broadcast per-record delete events.
+    /// </summary>
+    public static async Task<AuditedSoftDeleteResult<Guid>> AuditedSoftDeleteWithIdsAsync<T>(
+        this NocturneDbContext context,
+        IQueryable<T> query,
+        IAuditContext? auditContext,
+        string scope,
+        CancellationToken ct = default) where T : class, IAuditable, ISoftDeletable
+    {
+        var result = await context.AuditedSoftDeleteWithEntitiesAsync(query, auditContext, scope, ct);
+        return new AuditedSoftDeleteResult<Guid>(
+            result.Count, result.Entities.Select(IdOf).ToList());
+    }
+
+    /// <summary>
+    /// As <see cref="AuditedSoftDeleteAsync{T}"/>, but returns the soft-deleted entities so the caller can
+    /// project them (e.g. to the legacy <c>Entry</c> shape) and broadcast per-record delete events.
+    /// </summary>
+    /// <remarks>
+    /// Materializes at most <see cref="BroadcastMaterializationCap"/> entities. Under the cap the
+    /// entities are loaded anyway, so each gets its own <c>delete</c> audit row; over it nothing is
+    /// returned and the operation records a single <c>bulk_delete</c> summary row for
+    /// <paramref name="scope"/>, as <see cref="AuditedSoftDeleteAsync{T}"/> does.
+    /// </remarks>
+    public static async Task<AuditedSoftDeleteResult<T>> AuditedSoftDeleteWithEntitiesAsync<T>(
+        this NocturneDbContext context,
+        IQueryable<T> query,
+        IAuditContext? auditContext,
+        string scope,
+        CancellationToken ct = default) where T : class, IAuditable, ISoftDeletable
+    {
+        var strategy = context.Database.CreateExecutionStrategy();
+
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await context.Database.BeginTransactionAsync(ct);
+
+            // One row past the cap is all it takes to know the match set exceeds it.
+            var records = await query.Take(BroadcastMaterializationCap + 1).ToListAsync(ct);
+            var collapsed = records.Count > BroadcastMaterializationCap;
+
+            List<MutationAuditLogEntity> auditEntries =
+                collapsed ? [] : BuildDeleteAuditEntries(context, records, auditContext);
 
             // Detach the loaded entities so they don't interfere with the bulk update
-            foreach (var record in affectedRecords)
+            foreach (var record in records)
                 context.Entry(record).State = EntityState.Detached;
 
-            // Write audit entries
+            if (collapsed)
+                records.Clear();
+
             if (auditEntries.Count > 0)
             {
                 context.Set<MutationAuditLogEntity>().AddRange(auditEntries);
                 await context.SaveChangesAsync(ct);
             }
 
-            // Execute bulk soft delete, carrying the dedup attribution flag in the same
-            // update: a user-initiated delete blocks resync re-creation, a system sweep
-            // (no auth context) leaves the row re-creatable. This runs whether or not audit
-            // rows were written.
-            var isUserDelete = !auditContext.IsSystemMutation();
-            await query.ExecuteUpdateAsync(
-                s => s
-                    .SetProperty(e => e.DeletedAt, now)
-                    .SetProperty(e => EF.Property<bool>(e, "DeletedByUser"), isUserDelete), ct);
+            var count = await SoftDeleteRowsAsync(query, auditContext, ct);
+
+            if (collapsed)
+                await WriteBulkDeleteSummaryAsync<T>(context, count, scope, auditContext, ct);
 
             await transaction.CommitAsync(ct);
-            return affectedRecords;
+            return new AuditedSoftDeleteResult<T>(count, records);
         });
+    }
+
+    /// <summary>
+    /// Executes a bulk soft delete without audit trail by setting <c>DeletedAt</c> on all matching rows.
+    /// </summary>
+    public static async Task<int> SoftDeleteAsync<T>(
+        this NocturneDbContext context,
+        IQueryable<T> query,
+        CancellationToken ct = default) where T : class, ISoftDeletable
+    {
+        return await query.ExecuteUpdateAsync(
+            s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+    }
+
+    /// <summary>
+    /// Stamps <c>DeletedAt</c> and the dedup attribution flag in one update: a user-initiated delete
+    /// blocks resync re-creation, a system sweep leaves the row re-creatable
+    /// (<see cref="SoftDeleteDedupExtensions"/>). Runs whether or not an audit row is written.
+    /// </summary>
+    private static Task<int> SoftDeleteRowsAsync<T>(
+        IQueryable<T> query,
+        IAuditContext? auditContext,
+        CancellationToken ct) where T : class, ISoftDeletable
+    {
+        var now = DateTime.UtcNow;
+        var isUserDelete = !auditContext.IsSystemMutation();
+
+        return query.ExecuteUpdateAsync(
+            s => s
+                .SetProperty(e => e.DeletedAt, now)
+                .SetProperty(e => EF.Property<bool>(e, "DeletedByUser"), isUserDelete), ct);
+    }
+
+    /// <summary>
+    /// Appends the one summary row a bulk soft delete records: the entity type, how many rows it
+    /// covered, the scope it was issued against, and the actor. <c>EntityId</c> is null — the row
+    /// describes a set, not a record.
+    /// </summary>
+    private static async Task WriteBulkDeleteSummaryAsync<T>(
+        NocturneDbContext context,
+        int count,
+        string scope,
+        IAuditContext? auditContext,
+        CancellationToken ct)
+    {
+        if (count == 0 || auditContext.IsSystemMutation())
+            return;
+
+        context.Set<MutationAuditLogEntity>().Add(new MutationAuditLogEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = context.TenantId,
+            EntityType = AuditEntityTypeName<T>(),
+            EntityId = null,
+            Action = "bulk_delete",
+            ChangesJson = JsonSerializer.Serialize(new BulkDeleteSummary(count, scope), JsonOptions),
+            SubjectId = auditContext?.SubjectId,
+            SubjectName = auditContext?.SubjectName,
+            AuthType = auditContext?.AuthType,
+            IpAddress = auditContext?.IpAddress,
+            TokenId = auditContext?.TokenId,
+            CorrelationId = auditContext?.CorrelationId,
+            Endpoint = auditContext?.Endpoint,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        await context.SaveChangesAsync(ct);
     }
 
     /// <summary>
@@ -161,7 +305,7 @@ public static class AuditedBulkDeleteExtensions
             return [];
 
         var now = DateTime.UtcNow;
-        var entityTypeName = typeof(T).Name.Replace("Entity", "");
+        var entityTypeName = AuditEntityTypeName<T>();
 
         return affectedRecords.Select(record =>
         {
@@ -192,6 +336,7 @@ public static class AuditedBulkDeleteExtensions
                 Action = "delete",
                 ChangesJson = JsonSerializer.Serialize(snapshot, JsonOptions),
                 SubjectId = auditContext?.SubjectId,
+                SubjectName = auditContext?.SubjectName,
                 AuthType = auditContext?.AuthType,
                 IpAddress = auditContext?.IpAddress,
                 TokenId = auditContext?.TokenId,
@@ -202,15 +347,10 @@ public static class AuditedBulkDeleteExtensions
         }).ToList();
     }
 
-    /// <summary>
-    /// Executes a bulk soft delete without audit trail by setting <c>DeletedAt</c> on all matching rows.
-    /// </summary>
-    public static async Task<int> SoftDeleteAsync<T>(
-        this NocturneDbContext context,
-        IQueryable<T> query,
-        CancellationToken ct = default) where T : class, ISoftDeletable
-    {
-        return await query.ExecuteUpdateAsync(
-            s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
+    private static string AuditEntityTypeName<T>() => typeof(T).Name.Replace("Entity", "");
+
+    private static readonly ConcurrentDictionary<Type, PropertyInfo> IdProperties = new();
+
+    private static Guid IdOf<T>(T entity) where T : class
+        => (Guid)IdProperties.GetOrAdd(typeof(T), t => t.GetProperty("Id")!).GetValue(entity)!;
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260818112100_NullableAuditEntityIdForBulkDelete.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260818112100_NullableAuditEntityIdForBulkDelete.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260818112100_NullableAuditEntityIdForBulkDelete")]
+    partial class NullableAuditEntityIdForBulkDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260818112100_NullableAuditEntityIdForBulkDelete.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260818112100_NullableAuditEntityIdForBulkDelete.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class NullableAuditEntityIdForBulkDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "entity_id",
+                table: "mutation_audit_log",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "action",
+                table: "mutation_audit_log",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(10)",
+                oldMaxLength: 10);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "entity_id",
+                table: "mutation_audit_log",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "action",
+                table: "mutation_audit_log",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(20)",
+                oldMaxLength: 20);
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalScheduleRepository.cs
@@ -93,7 +93,7 @@ public class BasalScheduleRepository : V4RepositoryBase<BasalSchedule, BasalSche
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.BasalSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix)),
-            AuditContext, ct);
+            AuditContext, $"legacy_id_prefix={prefix}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -197,7 +197,7 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.Boluses.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            AuditContext, ct);
+            AuditContext, $"sync_identifier={dataSource}/{syncIdentifier}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -215,7 +215,7 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.CarbIntakes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            AuditContext, ct);
+            AuditContext, $"sync_identifier={dataSource}/{syncIdentifier}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -155,7 +155,7 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.DeviceEvents.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            AuditContext, ct);
+            AuditContext, $"sync_identifier={dataSource}/{syncIdentifier}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -467,7 +467,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
             ctx.SensorGlucose.Where(e => e.DataSource == source || (e.DataSource == null && e.Device == source)),
-            AuditContext, ct);
+            AuditContext, $"data_source={source}", ct);
     }
 
     /// <inheritdoc />
@@ -526,6 +526,6 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         if (to.HasValue)
             query = query.Where(e => e.Timestamp < to.Value);
 
-        return await ctx.AuditedSoftDeleteAsync(query, AuditContext, ct);
+        return await ctx.AuditedSoftDeleteAsync(query, AuditContext, $"timestamp={from:O}..{to:O}", ct);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -306,13 +306,18 @@ public class TempBasalRepository : ITempBasalRepository
     /// <param name="legacyId">The legacy identifier.</param>
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The number of deleted records.</returns>
+    /// <remarks>
+    /// Above <see cref="AuditedBulkDeleteExtensions.BroadcastMaterializationCap"/> the ids are not
+    /// materialized and no delete event fires: temp basals ride only the native V4 port, which has no
+    /// coarse collection-level signal to fall back to (unlike the glucose family's entries sink).
+    /// </remarks>
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var deletedIds = await ctx.AuditedSoftDeleteWithIdsAsync(
-            ctx.TempBasals.Where(e => e.LegacyId == legacyId), _auditContext, ct);
-        await RaiseBroadcastAsync([], [], deletedIds, origin, ct);
-        return deletedIds.Count;
+        var result = await ctx.AuditedSoftDeleteWithIdsAsync(
+            ctx.TempBasals.Where(e => e.LegacyId == legacyId), _auditContext, $"legacy_id={legacyId}", ct);
+        await RaiseBroadcastAsync([], [], result.Entities, origin, ct);
+        return result.Count;
     }
 
     /// <summary>
@@ -446,7 +451,7 @@ public class TempBasalRepository : ITempBasalRepository
             ctx.TempBasals.Where(e => e.DataSource == source
                 && e.StartTimestamp >= from && e.StartTimestamp <= to
                 && (e.LegacyId == null || !keepLegacyIds.Contains(e.LegacyId))),
-            _auditContext, ct);
+            _auditContext, $"data_source={source}", ct);
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -102,6 +102,21 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <summary>
+    /// The coarse substitute for per-record delete events when a delete matched more rows than
+    /// <see cref="AuditedBulkDeleteExtensions.BroadcastMaterializationCap"/>: the legacy entries sink's
+    /// collection-level bulk-delete signal (cache invalidation plus a count-only storage-delete
+    /// broadcast). The native V4 port has no coarse form — <see cref="IV4RecordBroadcaster{TModel}"/>
+    /// carries record ids only — so V4 subscribers see no delete event and converge on their next read.
+    /// </summary>
+    private async Task RaiseBulkDeleteBroadcastAsync(int deletedCount, WriteOrigin origin, CancellationToken ct)
+    {
+        if (origin != WriteOrigin.Live || _entrySink is null || deletedCount <= 0)
+            return;
+
+        await _entrySink.OnBulkDeletedAsync(deletedCount, ct);
+    }
+
+    /// <summary>
     /// Projects glucose-family writes to the legacy <see cref="Entry"/> shape and fires the legacy entry
     /// sink — gated to <see cref="WriteOrigin.Live"/>, and a no-op when no sink is wired or the type has no
     /// projection (<see cref="ProjectToLegacyEntry"/> returns null).
@@ -328,11 +343,15 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     public virtual async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        var entities = await ctx.AuditedSoftDeleteWithEntitiesAsync(
-            ctx.Set<TEntity>().Where(e => e.LegacyId == legacyId), AuditContext, ct);
-        var models = entities.Select(ToDomain).ToList();
-        await RaiseBroadcastAsync([], [], models, origin, ct);
-        return models.Count;
+        var result = await ctx.AuditedSoftDeleteWithEntitiesAsync(
+            ctx.Set<TEntity>().Where(e => e.LegacyId == legacyId), AuditContext, $"legacy_id={legacyId}", ct);
+
+        if (result.Collapsed)
+            await RaiseBulkDeleteBroadcastAsync(result.Count, origin, ct);
+        else
+            await RaiseBroadcastAsync([], [], result.Entities.Select(ToDomain).ToList(), origin, ct);
+
+        return result.Count;
     }
 
     /// <summary>Latest stored record timestamp, optionally scoped to a data source (connector watermark).</summary>

--- a/src/Web/packages/app/src/lib/components/audit/AuditMutationsTable.svelte
+++ b/src/Web/packages/app/src/lib/components/audit/AuditMutationsTable.svelte
@@ -61,6 +61,7 @@
     { value: "Create", label: "Create" },
     { value: "Update", label: "Update" },
     { value: "Delete", label: "Delete" },
+    { value: "bulk_delete", label: "Bulk delete" },
     { value: "Restore", label: "Restore" },
   ];
 
@@ -95,11 +96,34 @@
   function getActionBadgeVariant(action: string | undefined): "default" | "secondary" | "destructive" {
     switch (action?.toLowerCase()) {
       case "delete":
+      case "bulk_delete":
         return "destructive";
       case "create":
         return "default";
       default:
         return "secondary";
+    }
+  }
+
+  function formatAction(action: string | undefined): string {
+    if (!action) return "—";
+    return action.toLowerCase() === "bulk_delete" ? "Bulk delete" : action;
+  }
+
+  /**
+   * A bulk_delete row describes a set of records rather than one, so it carries a count and the key
+   * the delete was scoped to instead of a field-level diff.
+   */
+  function parseBulkDeleteSummary(
+    changes: string | undefined
+  ): { count: number; scope: string } | null {
+    if (!changes) return null;
+    try {
+      const parsed = JSON.parse(changes);
+      if (typeof parsed?.count !== "number") return null;
+      return { count: parsed.count, scope: String(parsed.scope ?? "") };
+    } catch {
+      return null;
     }
   }
 
@@ -370,7 +394,7 @@
 
 {#snippet actionBadgeSnippet({ action }: { action: string | undefined })}
   <Badge variant={getActionBadgeVariant(action)}>
-    {action ?? "\u2014"}
+    {formatAction(action)}
   </Badge>
 {/snippet}
 
@@ -494,7 +518,19 @@
                       <span class="ml-2 font-mono text-xs">{row.original.entityId}</span>
                     </div>
                   {/if}
-                  {#if row.original.changes}
+                  {#if row.original.action?.toLowerCase() === "bulk_delete"}
+                    {@const summary = parseBulkDeleteSummary(row.original.changes)}
+                    {#if summary}
+                      <div>
+                        <span class="font-medium text-muted-foreground">Records deleted:</span>
+                        <span class="ml-2">{summary.count}</span>
+                      </div>
+                      <div>
+                        <span class="font-medium text-muted-foreground">Scope:</span>
+                        <span class="ml-2 font-mono text-xs">{summary.scope}</span>
+                      </div>
+                    {/if}
+                  {:else if row.original.changes}
                     {@const diffs = parseChanges(row.original.changes)}
                     {#if diffs.length > 0}
                       <div>

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
@@ -163,10 +163,12 @@ public class DataSourceServiceDeleteConnectorDataTests : IDisposable
             .SingleAsync(b => b.LegacyId == "bolus-1");
         bolus.DeletedAt.Should().NotBeNull();
 
-        // ...and carry a user-attributed delete audit row.
-        (await assertCtx.MutationAuditLog.SingleAsync(a =>
-            a.EntityType == "Bolus" && a.EntityId == bolus.Id && a.Action == "delete"))
-            .AuthType.Should().Be(AuthType);
+        // ...and are covered by one user-attributed bulk_delete summary row naming the purged source.
+        var bolusSummary = await assertCtx.MutationAuditLog.SingleAsync(a =>
+            a.EntityType == "Bolus" && a.Action == "bulk_delete");
+        bolusSummary.AuthType.Should().Be(AuthType);
+        bolusSummary.EntityId.Should().BeNull();
+        bolusSummary.ChangesJson.Should().Contain($"data_source={_deviceId}");
 
         // StateSpan is hard-deleted but still leaves a user-attributed delete audit row.
         (await assertCtx.StateSpans.IgnoreQueryFilters().AnyAsync(s => s.Source == _deviceId))

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/AuditedBulkDeleteExtensionsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/AuditedBulkDeleteExtensionsTests.cs
@@ -1,5 +1,7 @@
 using System.Data.Common;
+using System.Text.Json;
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Tests.Interceptors;
@@ -15,19 +17,15 @@ namespace Nocturne.Infrastructure.Data.Tests.Extensions;
 [Trait("Category", "Unit")]
 public class AuditedBulkDeleteExtensionsTests : IDisposable
 {
+    private const string Scope = "data_source=test-connector";
+
     private readonly DbConnection _connection;
-    private readonly DbContextOptions<NocturneDbContext> _contextOptions;
     private readonly Guid _tenantId = Guid.CreateVersion7();
 
     public AuditedBulkDeleteExtensionsTests()
     {
         _connection = new SqliteConnection("Filename=:memory:");
         _connection.Open();
-
-        _contextOptions = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseSqlite(_connection)
-            .EnableSensitiveDataLogging()
-            .Options;
 
         using var context = CreateContext();
         context.Database.EnsureCreated();
@@ -41,9 +39,16 @@ public class AuditedBulkDeleteExtensionsTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private TestNocturneDbContext CreateContext()
+    private TestNocturneDbContext CreateContext(StatementRecorder? recorder = null)
     {
-        var context = new TestNocturneDbContext(_contextOptions);
+        var builder = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging();
+
+        if (recorder is not null)
+            builder.AddInterceptors(recorder);
+
+        var context = new TestNocturneDbContext(builder.Options);
         context.TenantId = _tenantId;
         return context;
     }
@@ -63,6 +68,22 @@ public class AuditedBulkDeleteExtensionsTests : IDisposable
         return entity.Id;
     }
 
+    private async Task SeedManyAsync(int count)
+    {
+        await using var context = CreateContext();
+        for (var i = 0; i < count; i++)
+        {
+            context.TestAuditables.Add(new TestAuditableEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _tenantId,
+                Name = "SweepMe",
+                Value = i
+            });
+        }
+        await context.SaveChangesAsync();
+    }
+
     private sealed class UserAuditContext : IAuditContext
     {
         public Guid? SubjectId => Guid.Empty;
@@ -75,6 +96,73 @@ public class AuditedBulkDeleteExtensionsTests : IDisposable
         public bool IsSystem => false;
     }
 
+    /// <summary>
+    /// Records every statement the context issues, so a test can assert that a path materialized
+    /// nothing (no SELECT) or paged its work (more than one DELETE) — properties the row counts alone
+    /// cannot distinguish.
+    /// </summary>
+    private sealed class StatementRecorder : DbCommandInterceptor
+    {
+        private readonly List<string> _statements = [];
+
+        public int SelectCount => _statements.Count(s => s.StartsWith("SELECT", StringComparison.OrdinalIgnoreCase));
+        public int DeleteCount => _statements.Count(s => s.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase));
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Record(command);
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Record(command);
+            return ValueTask.FromResult(result);
+        }
+
+        public override InterceptionResult<int> NonQueryExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            Record(command);
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            Record(command);
+            return ValueTask.FromResult(result);
+        }
+
+        public override InterceptionResult<object> ScalarExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<object> result)
+        {
+            Record(command);
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<object>> ScalarExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<object> result,
+            CancellationToken cancellationToken = default)
+        {
+            Record(command);
+            return ValueTask.FromResult(result);
+        }
+
+        private void Record(DbCommand command) => _statements.Add(command.CommandText.TrimStart());
+    }
+
+    private static (int Count, string Scope) ReadSummary(string? changesJson)
+    {
+        using var doc = JsonDocument.Parse(changesJson!);
+        return (doc.RootElement.GetProperty("count").GetInt32(),
+            doc.RootElement.GetProperty("scope").GetString()!);
+    }
+
     [Fact]
     public async Task AuditedSoftDelete_SystemAuditContext_SoftDeletesWithoutAuditRows()
     {
@@ -83,7 +171,8 @@ public class AuditedBulkDeleteExtensionsTests : IDisposable
         await using var context = CreateContext();
         var deleted = await context.AuditedSoftDeleteAsync(
             context.TestAuditables.Where(e => e.Id == id),
-            SystemAuditContext.ForService("connector:nightscout"));
+            SystemAuditContext.ForService("connector:nightscout"),
+            Scope);
 
         deleted.Should().Be(1);
 
@@ -95,6 +184,22 @@ public class AuditedBulkDeleteExtensionsTests : IDisposable
     }
 
     [Fact]
+    public async Task AuditedSoftDelete_SystemAuditContext_MaterializesNothing()
+    {
+        await SeedManyAsync(5);
+        var recorder = new StatementRecorder();
+
+        await using var context = CreateContext(recorder);
+        var deleted = await context.AuditedSoftDeleteAsync(
+            context.TestAuditables.Where(e => e.Name == "SweepMe"),
+            SystemAuditContext.ForService("connector:nightscout"),
+            Scope);
+
+        deleted.Should().Be(5);
+        recorder.SelectCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task AuditedSoftDelete_NullAuditContext_SoftDeletesWithoutAuditRows()
     {
         var id = await SeedAsync();
@@ -102,7 +207,8 @@ public class AuditedBulkDeleteExtensionsTests : IDisposable
         await using var context = CreateContext();
         var deleted = await context.AuditedSoftDeleteAsync(
             context.TestAuditables.Where(e => e.Id == id),
-            auditContext: null);
+            auditContext: null,
+            Scope);
 
         deleted.Should().Be(1);
 
@@ -113,26 +219,87 @@ public class AuditedBulkDeleteExtensionsTests : IDisposable
     }
 
     [Fact]
-    public async Task AuditedSoftDelete_UserAuditContext_WritesAuditRowAndFlagsDeletedByUser()
+    public async Task AuditedSoftDelete_UserAuditContext_WritesOneSummaryRowAndFlagsDeletedByUser()
     {
-        var id = await SeedAsync();
+        await SeedManyAsync(3);
 
         await using var context = CreateContext();
         var deleted = await context.AuditedSoftDeleteAsync(
-            context.TestAuditables.Where(e => e.Id == id),
-            new UserAuditContext());
+            context.TestAuditables.Where(e => e.Name == "SweepMe"),
+            new UserAuditContext(),
+            Scope);
 
-        deleted.Should().Be(1);
+        deleted.Should().Be(3);
 
         await using var verify = CreateContext();
-        var row = await verify.TestAuditables.SingleAsync(e => e.Id == id);
-        verify.Entry(row).Property("DeletedByUser").CurrentValue.Should().Be(true);
+        foreach (var row in await verify.TestAuditables.ToListAsync())
+            verify.Entry(row).Property("DeletedByUser").CurrentValue.Should().Be(true);
 
         var log = await verify.Set<MutationAuditLogEntity>().SingleAsync();
-        log.Action.Should().Be("delete");
-        log.EntityId.Should().Be(id);
+        log.Action.Should().Be("bulk_delete");
+        log.EntityId.Should().BeNull();
         log.EntityType.Should().Be("TestAuditable");
         log.AuthType.Should().Be("SessionCookie");
+        log.SubjectName.Should().Be("tester");
+        ReadSummary(log.ChangesJson).Should().Be((3, Scope));
+    }
+
+    [Fact]
+    public async Task AuditedSoftDelete_MatchesNothing_WritesNoAuditRow()
+    {
+        await using var context = CreateContext();
+        var deleted = await context.AuditedSoftDeleteAsync(
+            context.TestAuditables.Where(e => e.Name == "Absent"),
+            new UserAuditContext(),
+            Scope);
+
+        deleted.Should().Be(0);
+        (await context.Set<MutationAuditLogEntity>().CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AuditedSoftDeleteWithEntities_UnderCap_ReturnsEntitiesWithPerRowAuditRows()
+    {
+        await SeedManyAsync(AuditedBulkDeleteExtensions.BroadcastMaterializationCap);
+
+        await using var context = CreateContext();
+        var result = await context.AuditedSoftDeleteWithEntitiesAsync(
+            context.TestAuditables.Where(e => e.Name == "SweepMe"),
+            new UserAuditContext(),
+            Scope);
+
+        result.Count.Should().Be(AuditedBulkDeleteExtensions.BroadcastMaterializationCap);
+        result.Entities.Should().HaveCount(AuditedBulkDeleteExtensions.BroadcastMaterializationCap);
+        result.Collapsed.Should().BeFalse();
+
+        await using var verify = CreateContext();
+        var logs = await verify.Set<MutationAuditLogEntity>().ToListAsync();
+        logs.Should().HaveCount(AuditedBulkDeleteExtensions.BroadcastMaterializationCap);
+        logs.Should().OnlyContain(l => l.Action == "delete" && l.EntityId != null);
+    }
+
+    [Fact]
+    public async Task AuditedSoftDeleteWithEntities_OverCap_CollapsesToOneSummaryRow()
+    {
+        var total = AuditedBulkDeleteExtensions.BroadcastMaterializationCap + 1;
+        await SeedManyAsync(total);
+
+        await using var context = CreateContext();
+        var result = await context.AuditedSoftDeleteWithEntitiesAsync(
+            context.TestAuditables.Where(e => e.Name == "SweepMe"),
+            new UserAuditContext(),
+            Scope);
+
+        result.Count.Should().Be(total);
+        result.Entities.Should().BeEmpty();
+        result.Collapsed.Should().BeTrue();
+
+        await using var verify = CreateContext();
+        var log = await verify.Set<MutationAuditLogEntity>().SingleAsync();
+        log.Action.Should().Be("bulk_delete");
+        log.EntityId.Should().BeNull();
+        ReadSummary(log.ChangesJson).Should().Be((total, Scope));
+        (await verify.TestAuditables.CountAsync(e => e.DeletedAt != null)).Should().Be(total);
     }
 
     [Fact]
@@ -153,6 +320,22 @@ public class AuditedBulkDeleteExtensionsTests : IDisposable
     }
 
     [Fact]
+    public async Task AuditedExecuteDelete_SystemAuditContext_MaterializesNothing()
+    {
+        await SeedManyAsync(5);
+        var recorder = new StatementRecorder();
+
+        await using var context = CreateContext(recorder);
+        var deleted = await context.AuditedExecuteDeleteAsync(
+            context.TestAuditables.Where(e => e.Name == "SweepMe"),
+            SystemAuditContext.ForService("connector:nightscout"));
+
+        deleted.Should().Be(5);
+        recorder.SelectCount.Should().Be(0);
+        recorder.DeleteCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task AuditedExecuteDelete_UserAuditContext_WritesAuditRow()
     {
         var id = await SeedAsync();
@@ -167,5 +350,25 @@ public class AuditedBulkDeleteExtensionsTests : IDisposable
         log.Action.Should().Be("delete");
         log.EntityId.Should().Be(id);
         log.AuthType.Should().Be("SessionCookie");
+    }
+
+    [Fact]
+    public async Task AuditedExecuteDelete_MoreRowsThanOnePage_PagesAndSnapshotsEveryRow()
+    {
+        const int total = 1500;
+        await SeedManyAsync(total);
+        var recorder = new StatementRecorder();
+
+        await using var context = CreateContext(recorder);
+        var deleted = await context.AuditedExecuteDeleteAsync(
+            context.TestAuditables.Where(e => e.Name == "SweepMe"),
+            new UserAuditContext());
+
+        deleted.Should().Be(total);
+        recorder.DeleteCount.Should().Be(2);
+
+        await using var verify = CreateContext();
+        (await verify.TestAuditables.CountAsync()).Should().Be(0);
+        (await verify.Set<MutationAuditLogEntity>().CountAsync(l => l.Action == "delete")).Should().Be(total);
     }
 }


### PR DESCRIPTION
Fixes #646.

## What

`AuditedSoftDeleteAsync` materialized every matched row to snapshot it and wrote one audit row each, in one transaction — a full CGM history's deletion meant hundreds of thousands of heap entities plus as many JSON rows in one commit (the 24GB audit table shape). All four parts of the issue's proposal, with two argued deviations:

1. **Soft deletes record one `bulk_delete` summary row** (entity type, count, scope, actor) and become a single `ExecuteUpdateAsync` — the per-row snapshot was a verbatim copy of a row that still exists, and the dedup discriminator lives on the row (`deleted_by_user`). *Deviation:* the extension can't know "the key it was scoped to" from an `IQueryable`, so `scope` is a new **required** parameter (placed before `ct` so every positional call site became a compile error), threaded through all 15 call sites. `entity_id` becomes nullable and `action` widens to 20 chars (`bulk_delete` is 11) — generated migration, schema-only.
2. **Hard deletes keep per-row snapshots but page at 1000**, each page's snapshots + delete in its own transaction; resumable after partial failure (stated in the docs). *Deviation:* pages delete by the loaded id set rather than `Take(n).ExecuteDelete` — portable, and makes "snapshotted ⟺ deleted" exact per page.
3. **System mutations early-out** to a single delete statement (previously loaded every row to build zero audit entries).
4. **Broadcast cap at 500**: over it, `WithEntities/WithIds` return `Collapsed` and callers fall back to the legacy entries sink's existing coarse bulk-delete signal (`OnBulkDeletedAsync` — reused, not invented). Documented honestly: the native V4 broadcaster has no coarse form, so V4 subscribers converge on their next read; temp basals have no fallback at all.

The audit view renders the new shape (`bulk_delete` filter option, badge, count/scope panel). Also fixed in scope: bulk-delete audit rows never set `SubjectName`, so the UI showed a truncated subject id.

## Testing

11 rewritten extension tests including a `DbCommandInterceptor` statement recorder, so "materialized nothing" and "actually paged" are asserted on statement counts. Five simultaneous mutations each caught by exactly its intended test (cap boundary at exactly 500, paging loop, summary-row dedup, system guards). Infrastructure.Data 628/0, API 5703/0, `pnpm check` at the documented 64-error baseline with zero in touched files. `has-pending-model-changes` clean (independently re-verified at review).

Unblocks #643.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
