### PR TITLE
fix(auth): make a spent recovery code buy a passkey enrolment instead of a dead end

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -56,6 +56,12 @@ public class PasskeyController : ControllerBase
     private const string RecoveryCookieName = ".Nocturne.RecoverySession";
 
     /// <summary>
+    /// How long a spent recovery code stays redeemable for one passkey enrolment. Bounds both the
+    /// token and the cookie carrying it, so neither outlives the other.
+    /// </summary>
+    private static readonly TimeSpan RecoverySessionLifetime = TimeSpan.FromMinutes(10);
+
+    /// <summary>
     /// Shown for every recovery-mode refusal so the response never distinguishes an unknown
     /// username from an account that still has a working sign-in method.
     /// </summary>
@@ -195,16 +201,38 @@ public class PasskeyController : ControllerBase
     }
 
     /// <summary>
+    /// The attributes the recovery-session cookie is written with. A cookie is keyed by name,
+    /// domain and path, so the write and the expiry that spends it must present the same ones.
+    /// Host-only: the recovery session is redeemed on the host it was issued from, so unlike a
+    /// session cookie it is never widened to sibling tenants.
+    /// </summary>
+    private CookieOptions RecoveryCookieOptions() => new()
+    {
+        HttpOnly = true,
+        Secure = _oidcOptions.Cookie.Secure,
+        SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict,
+        Path = "/",
+        IsEssential = true,
+    };
+
+    /// <summary>
     /// Complete passkey registration with attestation response
     /// </summary>
     /// <remarks>
     /// The challenge must have been issued for the subject the caller's credentials resolve to,
     /// so a challenge minted by another flow cannot be redeemed as an enrolment onto it.
+    /// <para>
+    /// Declares no invalidation, like the other enrolment a recovery session reaches
+    /// (<see cref="RecoveryModeComplete"/>): the generated command would refresh
+    /// <see cref="ListCredentials"/>, which needs a session, and its 401 would surface as a
+    /// failure on an enrolment that in fact succeeded. Callers holding a session refresh their
+    /// own list.
+    /// </para>
     /// </remarks>
     [HttpPost("register/complete")]
     [DenyDemoSubject]
     [AllowAnonymous]
-    [RemoteCommand(Invalidates = ["ListCredentials"])]
+    [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyRegisterCompleteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
@@ -229,6 +257,10 @@ public class PasskeyController : ControllerBase
             var result = await _passkeyService.CompleteRegistrationAsync(
                 request.AttestationResponseJson, request.ChallengeToken, tenantId,
                 expectedSubjectId: subjectId.Value, request.Label);
+
+            // One spent recovery code buys one enrolment: the credential it authorized now exists,
+            // so the session that authorized it is over even though its token has time left.
+            Response.Cookies.Delete(RecoveryCookieName, RecoveryCookieOptions());
 
             return Ok(new PasskeyRegisterCompleteResponse
             {
@@ -614,17 +646,11 @@ public class PasskeyController : ControllerBase
             subjectInfo,
             permissions: ["passkey:manage"],
             roles: [],
-            lifetime: TimeSpan.FromMinutes(10));
+            lifetime: RecoverySessionLifetime);
 
-        Response.Cookies.Append(RecoveryCookieName, recoveryToken, new CookieOptions
-        {
-            HttpOnly = true,
-            Secure = true,
-            SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict,
-            MaxAge = TimeSpan.FromMinutes(10),
-            Path = "/",
-            IsEssential = true,
-        });
+        var cookieOptions = RecoveryCookieOptions();
+        cookieOptions.MaxAge = RecoverySessionLifetime;
+        Response.Cookies.Append(RecoveryCookieName, recoveryToken, cookieOptions);
 
         return Ok(new RecoveryVerifyResponse
         {

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -353,6 +353,7 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
   const refreshToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.refreshToken);
   const guestSessionToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.guestSession);
   const platformAccessToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.platformAccess);
+  const recoverySessionToken = onShareHost ? undefined : event.cookies.get(AUTH_COOKIE_NAMES.recoverySession);
 
   const extraHeaders: Record<string, string> = {
     "X-Forwarded-Proto": getOriginalProto(event.request),
@@ -379,6 +380,7 @@ const apiClientHandle: Handle = async ({ event, resolve }) => {
     refreshToken,
     guestSessionToken,
     platformAccessToken,
+    recoverySessionToken,
     extraHeaders,
     responseCookies: event.cookies,
     rawSetCookies: event.locals.rawSetCookies,

--- a/src/Web/packages/app/src/lib/config/auth-cookies.ts
+++ b/src/Web/packages/app/src/lib/config/auth-cookies.ts
@@ -11,6 +11,7 @@ import {
   COOKIE_REFRESH_TOKEN_NAME,
   COOKIE_PLATFORM_ACCESS_NAME,
   COOKIE_GUEST_SESSION_NAME,
+  COOKIE_RECOVERY_SESSION_NAME,
 } from "./constants";
 
 export function getAccessTokenCookieName(): string {
@@ -26,6 +27,7 @@ export const AUTH_COOKIE_NAMES = {
   refreshToken: COOKIE_REFRESH_TOKEN_NAME,
   platformAccess: COOKIE_PLATFORM_ACCESS_NAME,
   guestSession: COOKIE_GUEST_SESSION_NAME,
+  recoverySession: COOKIE_RECOVERY_SESSION_NAME,
   isAuthenticated: "IsAuthenticated",
 } as const;
 

--- a/src/Web/packages/app/src/lib/config/constants.ts
+++ b/src/Web/packages/app/src/lib/config/constants.ts
@@ -24,6 +24,10 @@ export const COOKIE_PLATFORM_ACCESS_NAME = ".Nocturne.PlatformAccess";
 // Guest-link session, issued by the API. Set by the API (not this app), so the
 // name is fixed by the server side.
 export const COOKIE_GUEST_SESSION_NAME = "nocturne-guest-session";
+// Short-lived proof that a recovery code was spent, issued by the API. Carries no session:
+// the API accepts it for passkey enrolment only, so it has to reach that ceremony and
+// nothing about it makes the visitor signed in.
+export const COOKIE_RECOVERY_SESSION_NAME = ".Nocturne.RecoverySession";
 
 // OpenTelemetry service identity (build-time, not deployment config)
 export const OTEL_SERVICE_NAME = "nocturne-web";

--- a/src/Web/packages/app/src/lib/server/api-client-factory.ts
+++ b/src/Web/packages/app/src/lib/server/api-client-factory.ts
@@ -24,6 +24,7 @@ export interface ServerHttpClientOptions {
   refreshToken?: string;
   guestSessionToken?: string;
   platformAccessToken?: string;
+  recoverySessionToken?: string;
   hashedInstanceKey?: string | null;
   extraHeaders?: Record<string, string>;
   responseCookies?: CookieSetter;
@@ -83,6 +84,11 @@ export function createServerHttpClient(
       if (options?.platformAccessToken) {
         cookies.push(
           `${AUTH_COOKIE_NAMES.platformAccess}=${options.platformAccessToken}`
+        );
+      }
+      if (options?.recoverySessionToken) {
+        cookies.push(
+          `${AUTH_COOKIE_NAMES.recoverySession}=${options.recoverySessionToken}`
         );
       }
       if (cookies.length > 0) {

--- a/src/Web/packages/app/src/lib/server/api-proxy-headers.test.ts
+++ b/src/Web/packages/app/src/lib/server/api-proxy-headers.test.ts
@@ -7,6 +7,7 @@ const JAR: Record<string, string> = {
   [AUTH_COOKIE_NAMES.refreshToken]: "refresh-value",
   [AUTH_COOKIE_NAMES.guestSession]: "guest-value",
   [AUTH_COOKIE_NAMES.platformAccess]: "platform-value",
+  [AUTH_COOKIE_NAMES.recoverySession]: "recovery-value",
 };
 
 const cookies = { get: (name: string) => JAR[name] };
@@ -50,6 +51,9 @@ describe("buildProxyHeaders", () => {
     expect(cookie).toContain(`${AUTH_COOKIE_NAMES.refreshToken}=refresh-value`);
     expect(cookie).toContain(`${AUTH_COOKIE_NAMES.guestSession}=guest-value`);
     expect(cookie).toContain(`${AUTH_COOKIE_NAMES.platformAccess}=platform-value`);
+    // A recovery-code visitor's only credential: unforwarded, the passkey they came to register
+    // cannot be enrolled and the recovery code is spent for nothing.
+    expect(cookie).toContain(`${AUTH_COOKIE_NAMES.recoverySession}=recovery-value`);
   });
 
   it("leaves the incoming Cookie header alone when the jar holds no auth cookies", () => {

--- a/src/Web/packages/app/src/lib/server/api-proxy-headers.ts
+++ b/src/Web/packages/app/src/lib/server/api-proxy-headers.ts
@@ -56,6 +56,7 @@ export function buildProxyHeaders({
     AUTH_COOKIE_NAMES.refreshToken,
     AUTH_COOKIE_NAMES.guestSession,
     AUTH_COOKIE_NAMES.platformAccess,
+    AUTH_COOKIE_NAMES.recoverySession,
   ]
     .map((name) => {
       const value = cookies.get(name);

--- a/src/Web/packages/app/src/lib/server/auth-cookie-propagation.test.ts
+++ b/src/Web/packages/app/src/lib/server/auth-cookie-propagation.test.ts
@@ -140,6 +140,39 @@ describe("propagateAuthCookies", () => {
     });
   });
 
+  it("propagates the recovery session, and the expiry that spends it", () => {
+    // Recovery-code sign-in is a server-side form: dropped here, the visitor never receives the
+    // credential their code bought and cannot register the passkey that gets them back in.
+    const { cookies, calls } = createRecordingCookies();
+
+    propagateAuthCookies(
+      [
+        `${AUTH_COOKIE_NAMES.recoverySession}=recovery-token; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=600`,
+      ],
+      cookies
+    );
+
+    expect(calls[0]).toMatchObject({
+      op: "set",
+      name: AUTH_COOKIE_NAMES.recoverySession,
+      value: "recovery-token",
+      opts: { path: "/", httpOnly: true, sameSite: "strict", maxAge: 600 },
+    });
+
+    const spent = createRecordingCookies();
+    propagateAuthCookies(
+      [
+        `${AUTH_COOKIE_NAMES.recoverySession}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+      ],
+      spent.cookies
+    );
+
+    expect(spent.calls[0]).toMatchObject({
+      op: "delete",
+      name: AUTH_COOKIE_NAMES.recoverySession,
+    });
+  });
+
   it("propagates cookie deletion when the server expires an auth cookie", () => {
     const { cookies, calls } = createRecordingCookies();
 

--- a/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
+++ b/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
@@ -31,6 +31,11 @@ const AUTH_COOKIE_SET: ReadonlySet<string> = new Set([
   // Its deletions matter too: the API clears it once the grant is revoked or
   // expired, which stops the browser resending a dead cookie.
   AUTH_COOKIE_NAMES.guestSession,
+  // Recovery-code sign-in is a server-side form, so the API's Set-Cookie has to be forwarded
+  // or the recovery session never reaches the browser and the passkey the visitor came to
+  // register cannot be enrolled. Its deletion matters too: the API spends the cookie once the
+  // credential exists.
+  AUTH_COOKIE_NAMES.recoverySession,
 ]);
 
 /**

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
@@ -168,6 +168,7 @@
         challengeToken: pendingPasskey.challengeToken,
         label: newPasskeyLabel.trim() || undefined,
       });
+      await credentialsQuery.refresh();
       showLabelDialog = false;
       pendingPasskey = null;
       newPasskeyLabel = "";

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/auth.remote.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/auth.remote.ts
@@ -263,6 +263,11 @@ const authenticatorSchema = z.object({
  * Runs entirely on the server, so it works with JavaScript disabled: the
  * browser posts the form, the handler redirects on success, and a rejected code
  * comes back as a field-level issue on the re-rendered page.
+ *
+ * A spent code buys a recovery session, which authorizes one passkey enrolment and no
+ * session, so the destination is the enrolment page and not the page the visitor asked
+ * for — that one needs a session, which their new passkey gets them. `returnUrl` rides
+ * along so it still decides where they land at the end.
  */
 export const signInWithRecoveryCode = form(
   recoveryCodeSchema,
@@ -289,7 +294,11 @@ export const signInWithRecoveryCode = form(
       invalid(issue.code("That username and recovery code don't match."));
     }
 
-    redirect(303, safeReturnUrl(data.returnUrl));
+    const destination = new URLSearchParams({
+      username: data.username,
+      returnUrl: safeReturnUrl(data.returnUrl),
+    });
+    redirect(303, `/auth/recovery/passkey?${destination}`);
   }
 );
 

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/help/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/help/+page.svelte
@@ -110,6 +110,10 @@
           and one of your remaining codes. Each code can only be used once, so
           cross it off your list after use.
         </p>
+        <p class="mt-2 text-sm leading-relaxed text-muted-foreground">
+          A code doesn't sign you in on its own: it gives you ten minutes to set
+          up a new passkey, and you sign in with that.
+        </p>
       </Card.Content>
     </Card.Root>
 

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery/passkey/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery/passkey/+page.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import * as Card from "$lib/components/ui/card";
+  import { Button } from "$lib/components/ui/button";
+  import { FormError } from "$lib/forms";
+  import { Fingerprint, KeyRound, Loader2, Check } from "lucide-svelte";
+  import {
+    startRegistration,
+    type PublicKeyCredentialCreationOptionsJSON,
+  } from "@simplewebauthn/browser";
+  import {
+    registerOptions,
+    registerComplete,
+  } from "$lib/api/generated/passkeys.generated.remote";
+  import {
+    describePasskeyError,
+    parseCeremonyOptions,
+  } from "$lib/components/auth/passkey-errors";
+  import { page } from "$app/state";
+
+  /**
+   * Where a spent recovery code lands. The account is named by the recovery session the
+   * verify step set, so the username here is only what the new credential is labelled
+   * with; naming someone else changes nothing about which account is enrolled.
+   */
+  const username = $derived(page.url.searchParams.get("username") ?? "");
+  const returnUrl = $derived(page.url.searchParams.get("returnUrl") ?? "/");
+  const loginUrl = $derived(
+    `/auth/login?${new URLSearchParams({ returnUrl })}`
+  );
+
+  let isRegistering = $state(false);
+  let registered = $state(false);
+  let errorMessage = $state<string | null>(null);
+
+  /**
+   * Enrols a replacement passkey against the recovery session. The WebAuthn ceremony runs
+   * in the browser, so this step needs JavaScript.
+   */
+  async function handleRegister() {
+    if (isRegistering) return;
+    isRegistering = true;
+    errorMessage = null;
+
+    try {
+      const response = await registerOptions({ username });
+      const options =
+        parseCeremonyOptions<PublicKeyCredentialCreationOptionsJSON>(
+          response.options
+        );
+
+      const attestation = await startRegistration({ optionsJSON: options });
+
+      await registerComplete({
+        attestationResponseJson: JSON.stringify(attestation),
+        challengeToken: response.challengeToken ?? "",
+        label: username ? `${username}'s passkey` : undefined,
+      });
+
+      registered = true;
+    } catch (err) {
+      console.error("Recovery passkey registration failed:", err);
+      errorMessage = describePasskeyError(
+        err,
+        "register",
+        "We couldn't register a passkey. A recovery code is only good for ten minutes — sign in with another one to try again."
+      );
+    } finally {
+      isRegistering = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Register a Passkey - Nocturne</title>
+</svelte:head>
+
+<div class="flex min-h-screen items-center justify-center p-4">
+  <Card.Root class="w-full max-w-md">
+    <Card.Header class="text-center">
+      <div
+        class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10"
+      >
+        <KeyRound class="h-6 w-6 text-primary" />
+      </div>
+      <Card.Title class="text-xl">Register a passkey</Card.Title>
+      <Card.Description>
+        {#if registered}
+          Your passkey is ready. Sign in with it to finish.
+        {:else}
+          Your recovery code was accepted. It lets you set up a passkey for
+          {username || "your account"} — nothing else — and it expires in ten
+          minutes.
+        {/if}
+      </Card.Description>
+    </Card.Header>
+
+    <Card.Content class="space-y-4">
+      {#if registered}
+        <div
+          class="flex items-start gap-3 rounded-md border border-green-500/20 bg-green-500/5 p-3"
+        >
+          <Check class="mt-0.5 h-4 w-4 shrink-0 text-green-600" />
+          <p class="text-sm text-green-700 dark:text-green-400">
+            Passkey registered. Your recovery code is now used up.
+          </p>
+        </div>
+
+        <Button class="w-full" size="lg" href={loginUrl}>
+          Sign in with your passkey
+        </Button>
+      {:else}
+        <FormError issues={errorMessage} focusOnShow />
+
+        <Button
+          class="w-full"
+          size="lg"
+          onclick={handleRegister}
+          disabled={isRegistering}
+        >
+          {#if isRegistering}
+            <Loader2 class="mr-2 h-5 w-5 animate-spin" />
+            Waiting for passkey...
+          {:else}
+            <Fingerprint class="mr-2 h-5 w-5" />
+            Register passkey
+          {/if}
+        </Button>
+      {/if}
+    </Card.Content>
+
+    <Card.Footer class="justify-center">
+      <a href={loginUrl} class="text-xs text-muted-foreground hover:underline">
+        Back to sign in
+      </a>
+    </Card.Footer>
+  </Card.Root>
+</div>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -376,6 +376,29 @@ public class PasskeyControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task RegisterComplete_WithARecoverySession_SpendsTheCookie()
+    {
+        // One recovery code buys one enrolment: the credential exists now, so the cookie that
+        // authorized it must not authorize a second.
+        var subjectId = await SeedMemberAsync("owner", withPasskey: true);
+        GiveRecoverySession(subjectId, "passkey:manage");
+        _passkeyService
+            .Setup(s => s.CompleteRegistrationAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), subjectId, It.IsAny<string?>()))
+            .ReturnsAsync(new PasskeyCredentialResult(Guid.CreateVersion7(), subjectId));
+
+        await _controller.RegisterComplete(new PasskeyRegisterCompleteRequest
+        {
+            AttestationResponseJson = "{}",
+            ChallengeToken = "token",
+        });
+
+        var setCookie = _controller.ControllerContext.HttpContext.Response.Headers.SetCookie
+            .Single(header => header!.StartsWith(".Nocturne.RecoverySession=", StringComparison.Ordinal));
+        setCookie.Should().Contain("expires=Thu, 01 Jan 1970");
+    }
+
+    [Fact]
     public async Task RegisterComplete_NoChallengeToken_ReturnsBadRequest()
     {
         Authenticate();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyRecoverySessionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyRecoverySessionTests.cs
@@ -1,0 +1,156 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// The recovery-code path over the real pipeline: spending a code has to leave the caller able to
+/// enrol a replacement passkey, and able to do nothing else.
+/// </summary>
+public class PasskeyRecoverySessionTests : IClassFixture<AuthenticationTestFactory>
+{
+    private const string RecoveryCookieName = ".Nocturne.RecoverySession";
+    private const string Username = "test";
+
+    private readonly AuthenticationTestFactory _factory;
+    private readonly HttpClient _client;
+
+    public PasskeyRecoverySessionTests(AuthenticationTestFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task A_spent_recovery_code_yields_a_session_that_can_enrol_a_passkey()
+    {
+        var cookie = await SpendARecoveryCodeAsync();
+
+        var response = await PostAsync("register/options", new { username = Username }, cookie);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("challengeToken").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task The_recovery_cookie_is_http_only_and_time_boxed()
+    {
+        var setCookie = await VerifyRecoveryCodeAsync();
+
+        var attributes = setCookie.ToLowerInvariant();
+
+        attributes.Should().Contain("httponly");
+        // The window a spent code stays redeemable in, and the whole time-boxing of the
+        // credential — widening it silently is the failure this pins.
+        attributes.Should().Contain("max-age=600");
+    }
+
+    [Fact]
+    public async Task An_expired_recovery_session_cannot_enrol_a_passkey()
+    {
+        var response = await PostAsync(
+            "register/options", new { username = Username }, ExpiredRecoveryToken());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task A_forged_recovery_session_cannot_enrol_a_passkey()
+    {
+        var response = await PostAsync(
+            "register/options", new { username = Username }, cookie: "not-a-token");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task No_recovery_session_cannot_enrol_a_passkey()
+    {
+        var response = await PostAsync("register/options", new { username = Username }, cookie: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task A_recovery_session_reaches_nothing_but_enrolment()
+    {
+        var cookie = await SpendARecoveryCodeAsync();
+
+        // Passkey management on the subject's own account, one route over from the enrolment the
+        // recovery session does authorize: it needs a session, which a recovery code never grants.
+        var list = new HttpRequestMessage(HttpMethod.Get, "/api/auth/passkey/credentials");
+        list.Headers.Add("Cookie", $"{RecoveryCookieName}={cookie}");
+        (await _client.SendAsync(list)).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        var regenerate = await PostAsync("recovery/regenerate", new { }, cookie);
+        regenerate.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// A recovery-session token the API signed but whose window has passed. Hand-minted because
+    /// <see cref="IJwtService.GenerateAccessToken"/> stamps <c>nbf</c> at issue time and refuses to
+    /// mint a token that expires before it.
+    /// </summary>
+    private string ExpiredRecoveryToken()
+    {
+        var jwt = _factory.Services.GetRequiredService<IOptions<JwtOptions>>().Value;
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.SecretKey));
+
+        return new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(
+            issuer: jwt.Issuer,
+            audience: jwt.Audience,
+            claims: [new Claim("sub", TestDatabaseSeeder.TestSubjectId.ToString()),
+                     new Claim("permission", "passkey:manage")],
+            notBefore: DateTime.UtcNow.AddMinutes(-20),
+            expires: DateTime.UtcNow.AddMinutes(-10),
+            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256)));
+    }
+
+    /// <summary>Spends a freshly issued recovery code and returns the recovery-session token.</summary>
+    private async Task<string> SpendARecoveryCodeAsync()
+    {
+        var setCookie = await VerifyRecoveryCodeAsync();
+        return setCookie[(setCookie.IndexOf('=') + 1)..setCookie.IndexOf(';')];
+    }
+
+    /// <summary>Spends a freshly issued recovery code and returns the recovery Set-Cookie header.</summary>
+    private async Task<string> VerifyRecoveryCodeAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var recoveryCodes = scope.ServiceProvider.GetRequiredService<IRecoveryCodeService>();
+        var codes = await recoveryCodes.GenerateCodesAsync(TestDatabaseSeeder.TestSubjectId);
+
+        var response = await PostAsync(
+            "recovery/verify", new { username = Username, code = codes[0] }, cookie: null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        return response.Headers.GetValues("Set-Cookie")
+            .Single(header => header.StartsWith(RecoveryCookieName, StringComparison.Ordinal));
+    }
+
+    private Task<HttpResponseMessage> PostAsync(string path, object body, string? cookie)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/api/auth/passkey/{path}")
+        {
+            Content = JsonContent.Create(body),
+        };
+        if (cookie != null)
+        {
+            request.Headers.Add("Cookie", $"{RecoveryCookieName}={cookie}");
+        }
+        return _client.SendAsync(request);
+    }
+}


### PR DESCRIPTION
Fixes #558.

## What

A locked-out user burned a one-time recovery code, got a `.Nocturne.RecoverySession` cookie nothing read, and was redirected to a dashboard they weren't authenticated for. The narrow-credential half already existed (#628 built `ResolveRegistrationSubject` to read the cookie on the two passkey-enrolment endpoints); what was missing was everything around it.

**Decision — narrow recovery credential, not a full session.** A session cookie's ceiling is the member's whole tenant role (`MemberScopeResolver.UnscopedCredentialTypes` — no vocabulary exists for "authenticated only for re-registration"), and minting a session straight from one recovery code would skip the TOTP step-up that `LoginComplete` deliberately enforces, undoing #628. So the recovery session reaches exactly `register/options` + `register/complete`, bound to its own subject; it is not an auth handler, so every session-gated endpoint still 401s (asserted by test).

- One `RecoverySessionLifetime` (10 min) bounds token and cookie together; `register/complete` expires the cookie, so one code buys one enrolment. Codes are still consumed only on successful verify — and the verify now yields a usable credential.
- Cookie `Secure` honours the OIDC cookie options instead of being hardcoded (a plain-HTTP self-host could never hold it before).
- Web: the cookie joins both propagation allowlists; `signInWithRecoveryCode` now lands on a new `/auth/recovery/passkey` page that runs the enrolment ceremony and hands off to login; `/auth/help` gains one sentence.
- `register/complete` drops `Invalidates = ["ListCredentials"]` — the generated invalidation needs a session and its 401 surfaced as failure on an enrolment that succeeded; the rationale is on the action.

## Testing

`PasskeyRecoverySessionTests` (6, real HTTP): real code → cookie → challenge minted; HttpOnly + `max-age=600`; expired/forged/absent → 401; **a recovery session reaches nothing but enrolment**. Plus the cookie-spend test and 24 web tests over the allowlists. Mutation proofs include one that caught a real draft bug (claim name `permission` vs `permissions`), which is what mutation proofs are for. API suite 5710/0; `pnpm check` at the 64-error baseline, none in touched files.

## Noted, pre-existing, not in this diff

`TryReadRecoverySessionSubject` accepts any valid JWT carrying `permission: passkey:manage` with no token-type marker (unlike `SessionCookieHandler.IsGrantShaped`); the only mint site today is `RecoveryVerify`. Being filed as a hardening follow-up.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
