### PR TITLE
chore(connectors): remove the dead FetchTreatmentsAsync hook and its Nightscout override

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -394,14 +394,6 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         return FetchGlucoseDataAsync(from);
     }
 
-    protected virtual Task<IEnumerable<Treatment>> FetchTreatmentsAsync(
-        DateTime? from,
-        DateTime? to
-    )
-    {
-        return Task.FromResult(Enumerable.Empty<Treatment>());
-    }
-
     protected virtual Task<IEnumerable<Profile>> FetchProfilesAsync()
     {
         return Task.FromResult(Enumerable.Empty<Profile>());

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -757,21 +757,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         return allEntries;
     }
 
-    protected override async Task<IEnumerable<Treatment>> FetchTreatmentsAsync(
-        DateTime? from, DateTime? to)
-    {
-        var allTreatments = new List<Treatment>();
-        await foreach (var page in FetchTreatmentPagesAsync(from, to))
-            allTreatments.AddRange(page);
-
-        _logger.LogInformation(
-            "[{ConnectorSource}] Retrieved {Count} treatments from Nightscout",
-            ConnectorSource,
-            allTreatments.Count);
-
-        return allTreatments;
-    }
-
     protected override async Task<IEnumerable<Profile>> FetchProfilesAsync()
     {
         var profiles = await FetchDataAsync<Profile[]>(


### PR DESCRIPTION
Fixes #817.

Zero call sites repo-wide for either member (verified pre- and post-deletion); nothing became transitively dead — the override's one helper, `FetchTreatmentPagesAsync`, has a live caller inside `PerformSyncInternalAsync`.

The safety evidence, not just the hygiene: Nightscout treatments flow through the streaming crawl path (`CrawlAndPublishAsync("Treatments", …)` with its own cursor), and the deleted override was a stale duplicate of the superseded whole-range-accumulation design that the file's own comment (lines 186–193) rejects for having caused OOM on multi-year backfills. Deleting it removes a latent footgun a future caller could have innocently reintroduced. The three treatment-pagination tests exercise the live path and stay green.

All 11 connector unit suites pass (521/0) plus the 21 NightscoutConnector API tests.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup