### PR TITLE
fix(treatments): attribute and audit the v1 bulk delete so resyncs cannot resurrect it

### DIFF
--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -14,6 +14,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.API.Services.Audit;
 
 using V4Models = Nocturne.Core.Models.V4;
@@ -1594,73 +1595,53 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             ? DateTimeOffset.FromUnixTimeMilliseconds(toMills.Value).UtcDateTime
             : null;
 
+        var scope = $"timestamp={from:O}..{to:O}";
+
         long total = 0;
-        total += await DeleteEntitiesByTimeRange(_dbContext.Boluses, from, to, ct);
-        total += await DeleteEntitiesByTimeRange(_dbContext.CarbIntakes, from, to, ct);
-        total += await DeleteEntitiesByTimeRange(_dbContext.BGChecks, from, to, ct);
-        total += await DeleteEntitiesByTimeRange(_dbContext.Notes, from, to, ct);
-        total += await DeleteEntitiesByTimeRange(_dbContext.DeviceEvents, from, to, ct);
-        total += await DeleteEntitiesByTimeRange(_dbContext.BolusCalculations, from, to, ct);
-        total += await DeleteEntitiesByTimeRange(_dbContext.TempBasals, from, to, ct);
+        total += await DeleteEntitiesByTimeRange(_dbContext.Boluses, from, to, scope, ct);
+        total += await DeleteEntitiesByTimeRange(_dbContext.CarbIntakes, from, to, scope, ct);
+        total += await DeleteEntitiesByTimeRange(_dbContext.BGChecks, from, to, scope, ct);
+        total += await DeleteEntitiesByTimeRange(_dbContext.Notes, from, to, scope, ct);
+        total += await DeleteEntitiesByTimeRange(_dbContext.DeviceEvents, from, to, scope, ct);
+        total += await DeleteEntitiesByTimeRange(_dbContext.BolusCalculations, from, to, scope, ct);
+        total += await DeleteSpansByTimeRange(from, to, scope, ct);
 
         _logger.LogInformation("BulkDelete: removed {Total} v4 treatment records for find={Find}", total, findForLog);
         return total;
     }
 
-    private static async Task<int> DeleteEntitiesByTimeRange<T>(
-        Microsoft.EntityFrameworkCore.DbSet<T> dbSet, DateTime? from, DateTime? to, CancellationToken ct)
-        where T : class, ISoftDeletable
+    /// <summary>
+    /// Soft-deletes the point-in-time records in the window through the audited bulk-delete path, so a
+    /// user-issued delete is attributed and a later connector resync cannot re-create it
+    /// (<see cref="SoftDeleteDedupExtensions"/>).
+    /// </summary>
+    private Task<int> DeleteEntitiesByTimeRange<T>(
+        DbSet<T> dbSet, DateTime? from, DateTime? to, string scope, CancellationToken ct)
+        where T : class, IV4TimeSeriesEntity, IAuditable
     {
         var query = dbSet.AsQueryable();
 
-        // All V4 entity types have a Timestamp column (point-in-time) or StartTimestamp (span-based).
-        // Use the dynamic interface approach: filter via the entity's timestamp property.
-        if (from.HasValue || to.HasValue)
-        {
-            // Use ExecuteDeleteAsync with raw filtering — entities all have Timestamp or StartTimestamp
-            // mapped as the primary time column. We filter through the queryable.
-            if (typeof(T).GetProperty("Timestamp") != null)
-            {
-                var param = System.Linq.Expressions.Expression.Parameter(typeof(T), "e");
-                var timestampProp = System.Linq.Expressions.Expression.Property(param, "Timestamp");
+        if (from.HasValue)
+            query = query.Where(e => e.Timestamp >= from.Value);
+        if (to.HasValue)
+            query = query.Where(e => e.Timestamp <= to.Value);
 
-                if (from.HasValue)
-                {
-                    var fromExpr = System.Linq.Expressions.Expression.Constant(from.Value, typeof(DateTime));
-                    var gte = System.Linq.Expressions.Expression.GreaterThanOrEqual(timestampProp, fromExpr);
-                    var lambda = System.Linq.Expressions.Expression.Lambda<Func<T, bool>>(gte, param);
-                    query = query.Where(lambda);
-                }
-                if (to.HasValue)
-                {
-                    var toExpr = System.Linq.Expressions.Expression.Constant(to.Value, typeof(DateTime));
-                    var lte = System.Linq.Expressions.Expression.LessThanOrEqual(timestampProp, toExpr);
-                    var lambda = System.Linq.Expressions.Expression.Lambda<Func<T, bool>>(lte, param);
-                    query = query.Where(lambda);
-                }
-            }
-            else if (typeof(T).GetProperty("StartTimestamp") != null)
-            {
-                var param = System.Linq.Expressions.Expression.Parameter(typeof(T), "e");
-                var timestampProp = System.Linq.Expressions.Expression.Property(param, "StartTimestamp");
+        return _dbContext.AuditedSoftDeleteAsync(query, _auditContext, scope, ct);
+    }
 
-                if (from.HasValue)
-                {
-                    var fromExpr = System.Linq.Expressions.Expression.Constant(from.Value, typeof(DateTime));
-                    var gte = System.Linq.Expressions.Expression.GreaterThanOrEqual(timestampProp, fromExpr);
-                    var lambda = System.Linq.Expressions.Expression.Lambda<Func<T, bool>>(gte, param);
-                    query = query.Where(lambda);
-                }
-                if (to.HasValue)
-                {
-                    var toExpr = System.Linq.Expressions.Expression.Constant(to.Value, typeof(DateTime));
-                    var lte = System.Linq.Expressions.Expression.LessThanOrEqual(timestampProp, toExpr);
-                    var lambda = System.Linq.Expressions.Expression.Lambda<Func<T, bool>>(lte, param);
-                    query = query.Where(lambda);
-                }
-            }
-        }
+    /// <summary>
+    /// <see cref="DeleteEntitiesByTimeRange{T}"/> for temp basals, which key on
+    /// <see cref="TempBasalEntity.StartTimestamp"/> and so stay off <see cref="IV4TimeSeriesEntity"/>.
+    /// </summary>
+    private Task<int> DeleteSpansByTimeRange(DateTime? from, DateTime? to, string scope, CancellationToken ct)
+    {
+        var query = _dbContext.TempBasals.AsQueryable();
 
-        return await query.ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+        if (from.HasValue)
+            query = query.Where(e => e.StartTimestamp >= from.Value);
+        if (to.HasValue)
+            query = query.Where(e => e.StartTimestamp <= to.Value);
+
+        return _dbContext.AuditedSoftDeleteAsync(query, _auditContext, scope, ct);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBulkDeleteTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBulkDeleteTests.cs
@@ -1,0 +1,241 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Audit;
+using Nocturne.API.Services.V4;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Contracts.Treatments;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.V4;
+
+/// <summary>
+/// Covers the legacy v1 bulk delete (<c>DELETE /api/v1/treatments?find[created_at][…]</c>) reaching
+/// <see cref="TreatmentDecomposer.BulkDeleteAsync"/>: every record type in the window must be
+/// soft-deleted through the audited path so the delete is attributed and
+/// <see cref="SoftDeleteDedupExtensions"/> stops a connector resync re-creating what the user removed.
+/// </summary>
+[Trait("Category", "Unit")]
+public class TreatmentDecomposerBulkDeleteTests : IDisposable
+{
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private const string AuthType = "SessionCookie";
+
+    /// <summary>Every seeded record sits inside this window; the find query below brackets it.</summary>
+    private static readonly DateTime Inside = new(2023, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Outside = new(2024, 6, 1, 10, 0, 0, DateTimeKind.Utc);
+
+    private const string Find =
+        "find[created_at][$gte]=2023-01-01T00:00:00.000Z&find[created_at][$lte]=2023-01-02T00:00:00.000Z";
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+
+    private readonly AuditContext _userAuditContext = new()
+    {
+        SubjectId = Guid.Parse("00000000-0000-0000-0000-0000000000aa"),
+        SubjectName = "owner@example.com",
+        AuthType = AuthType,
+        Endpoint = "DELETE /api/v1/treatments"
+    };
+
+    public TreatmentDecomposerBulkDeleteTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        db.Tenants.Add(new TenantEntity { Id = TenantId, Slug = "test" });
+        db.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private NocturneDbContext NewContext() => new(_dbOptions) { TenantId = TenantId };
+
+    private TreatmentDecomposer CreateDecomposer(NocturneDbContext context, IAuditContext auditContext) => new(
+        context,
+        Mock.Of<IBolusRepository>(),
+        Mock.Of<ITempBasalRepository>(),
+        Mock.Of<ICarbIntakeRepository>(),
+        Mock.Of<IBGCheckRepository>(),
+        Mock.Of<INoteRepository>(),
+        Mock.Of<IDeviceEventRepository>(),
+        Mock.Of<IBolusCalculationRepository>(),
+        Mock.Of<IStateSpanService>(),
+        Mock.Of<ITreatmentFoodService>(),
+        Mock.Of<IDeviceService>(),
+        Mock.Of<IPatientDeviceStamper>(),
+        Mock.Of<IProfileDecomposer>(),
+        Mock.Of<IActiveProfileResolver>(),
+        Mock.Of<IPatientInsulinRepository>(),
+        auditContext,
+        NullLogger<TreatmentDecomposer>.Instance);
+
+    /// <summary>One record of every type the sweep covers, plus a bolus outside the window.</summary>
+    private void SeedOneOfEachType()
+    {
+        using var db = NewContext();
+
+        db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "bolus-1",
+            Timestamp = Inside,
+            Insulin = 1.5
+        });
+        db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "bolus-outside",
+            Timestamp = Outside,
+            Insulin = 2.5
+        });
+        db.CarbIntakes.Add(new CarbIntakeEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "carb-1",
+            Timestamp = Inside,
+            Carbs = 20
+        });
+        db.BGChecks.Add(new BGCheckEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "bgcheck-1",
+            Timestamp = Inside,
+            Glucose = 100
+        });
+        db.Notes.Add(new NoteEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "note-1",
+            Timestamp = Inside,
+            Text = "hello"
+        });
+        db.DeviceEvents.Add(new DeviceEventEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "devevent-1",
+            Timestamp = Inside,
+            EventType = "Site Change"
+        });
+        db.BolusCalculations.Add(new BolusCalculationEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "boluscalc-1",
+            Timestamp = Inside
+        });
+        db.TempBasals.Add(new TempBasalEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "tempbasal-1",
+            StartTimestamp = Inside,
+            Rate = 0.8,
+            Origin = "Algorithm"
+        });
+
+        db.SaveChanges();
+    }
+
+    private async Task<long> BulkDeleteAsync(IAuditContext auditContext)
+    {
+        await using var ctx = NewContext();
+        return await CreateDecomposer(ctx, auditContext).BulkDeleteAsync(Find, WriteOrigin.Live);
+    }
+
+    [Fact]
+    public async Task BulkDelete_UserContext_BlocksConnectorResyncFromRecreatingEveryType()
+    {
+        SeedOneOfEachType();
+
+        (await BulkDeleteAsync(_userAuditContext)).Should().Be(7);
+
+        await using var assertCtx = NewContext();
+
+        (await assertCtx.GetBlockingLegacyIdsAsync<BolusEntity>(["bolus-1"])).Should().Contain("bolus-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<CarbIntakeEntity>(["carb-1"])).Should().Contain("carb-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<BGCheckEntity>(["bgcheck-1"])).Should().Contain("bgcheck-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<NoteEntity>(["note-1"])).Should().Contain("note-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<DeviceEventEntity>(["devevent-1"])).Should().Contain("devevent-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<BolusCalculationEntity>(["boluscalc-1"])).Should().Contain("boluscalc-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<TempBasalEntity>(["tempbasal-1"])).Should().Contain("tempbasal-1");
+    }
+
+    [Fact]
+    public async Task BulkDelete_UserContext_LeavesRecordsOutsideTheWindowUntouched()
+    {
+        SeedOneOfEachType();
+
+        await BulkDeleteAsync(_userAuditContext);
+
+        await using var assertCtx = NewContext();
+        var outside = await assertCtx.Boluses.IgnoreQueryFilters()
+            .SingleAsync(b => b.LegacyId == "bolus-outside");
+        outside.DeletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BulkDelete_UserContext_WritesOneSummaryRowPerTypeScopedToTheWindow()
+    {
+        SeedOneOfEachType();
+
+        await BulkDeleteAsync(_userAuditContext);
+
+        await using var assertCtx = NewContext();
+        var summaries = await assertCtx.MutationAuditLog.Where(a => a.Action == "bulk_delete").ToListAsync();
+
+        summaries.Select(s => s.EntityType).Should().BeEquivalentTo(
+            new[] { "Bolus", "CarbIntake", "BGCheck", "Note", "DeviceEvent", "BolusCalculation", "TempBasal" });
+        summaries.Should().OnlyContain(s => s.EntityId == null && s.AuthType == AuthType);
+        summaries.Should().OnlyContain(s => s.ChangesJson!.Contains(
+            "timestamp=2023-01-01T00:00:00.0000000Z..2023-01-02T00:00:00.0000000Z"));
+    }
+
+    [Fact]
+    public async Task BulkDelete_SystemContext_LeavesRecordsRecreatableAndUnaudited()
+    {
+        SeedOneOfEachType();
+
+        (await BulkDeleteAsync(SystemAuditContext.ForService("connector:nightscout"))).Should().Be(7);
+
+        await using var assertCtx = NewContext();
+        var bolus = await assertCtx.Boluses.IgnoreQueryFilters().SingleAsync(b => b.LegacyId == "bolus-1");
+        bolus.DeletedAt.Should().NotBeNull();
+
+        (await assertCtx.GetBlockingLegacyIdsAsync<BolusEntity>(["bolus-1"])).Should().BeEmpty();
+        (await assertCtx.GetBlockingLegacyIdsAsync<TempBasalEntity>(["tempbasal-1"])).Should().BeEmpty();
+        (await assertCtx.MutationAuditLog.AnyAsync()).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Fixes #844.

## What

The legacy v1 bulk delete (`DELETE /api/v1/treatments?find[created_at][...]`) soft-deleted seven treatment tables with a bare `ExecuteUpdateAsync(SetProperty(DeletedAt, now))` — never stamping `deleted_by_user` and writing no audit — so `SoftDeleteDedupExtensions` treated these user deletions as system sweeps and the next connector sync re-created everything the user deleted.

All seven tables now route through #847's `AuditedSoftDeleteAsync` (every one is `IAuditable, ISoftDeletable` on current main — the issue's historical caveat about BGChecks/Notes no longer holds), stamping the dedup flag and writing one `bulk_delete` summary row per type with scope `timestamp={from:O}..{to:O}` (matching the `SensorGlucoseRepository` precedent). The 50 lines of hand-rolled `Expression` reflection over `"Timestamp"`/`"StartTimestamp"` collapse onto the typed contracts: `IV4TimeSeriesEntity.Timestamp` for the six point-in-time types, one explicit span variant for temp basals. Filter semantics preserved exactly (inclusive both ends, as before).

**Attribution verified, not assumed**: the chain `TreatmentsController → TreatmentService → TreatmentDecomposer` carries the request's `IAuditContext`, which is user-attributed unless inside `SystemAuditScope` — and a test pins both directions rather than trusting the reading.

## Testing

Four new SQLite-backed tests: the regression that matters (delete then assert `GetBlockingLegacyIdsAsync` blocks re-import of all seven legacy ids), window boundaries, the seven summary rows with exact scope, and system-context semantics staying re-creatable/unaudited. Mutation-proven: reverting to the bare update fails exactly the two attribution-dependent tests. API 5764/0, Infrastructure.Data 633/0.

## Same bug, two more sites (being filed)

The single-treatment v1/v3 delete (`DeleteByLegacyIdAsync`, same file) and `DataSourceService`'s BGChecks/Notes purge (routed through the unattributed helper under a now-stale "not auditable" comment) carry the identical defect.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
