### PR TITLE
fix(bot): honour the default chat-identity link the UI already sets

### DIFF
--- a/src/Web/packages/app/src/lib/server/bot/api-client.ts
+++ b/src/Web/packages/app/src/lib/server/bot/api-client.ts
@@ -168,6 +168,7 @@ function mapCandidate(c: {
   nocturneUserId?: string;
   label?: string;
   displayName?: string;
+  isDefault?: boolean;
 }): DirectoryCandidate {
   return {
     id: c.id ?? "",
@@ -176,5 +177,6 @@ function mapCandidate(c: {
     nocturneUserId: c.nocturneUserId ?? "",
     label: c.label ?? "",
     displayName: c.displayName ?? "",
+    isDefault: c.isDefault ?? false,
   };
 }

--- a/src/Web/packages/bot/src/commands/alerts.test.ts
+++ b/src/Web/packages/bot/src/commands/alerts.test.ts
@@ -31,8 +31,14 @@ function candidate(
     nocturneUserId: `nocturne-user-${label}`,
     label,
     displayName: label.toUpperCase(),
+    isDefault: false,
   };
 }
+
+const asDefault = (c: DirectoryCandidate): DirectoryCandidate => ({
+  ...c,
+  isDefault: true,
+});
 
 function createContext(candidates: DirectoryCandidate[] | null) {
   const resolve = vi.fn().mockResolvedValue(candidates);
@@ -162,6 +168,28 @@ describe("ack_alert action", () => {
     );
     expect(ctx.scopedApiFactory).not.toHaveBeenCalled();
     expect(post).not.toHaveBeenCalled();
+  });
+
+  it("uses the tenant on the button over the user's default", async () => {
+    const ctx = createContext([asDefault(HOME), WORK]);
+    const { event, post } = createActionEvent(WORK_TENANT);
+
+    await runWithContext(ctx.context, () => handler(event));
+
+    expect(ctx.scopedApiFactory).toHaveBeenCalledExactlyOnceWith("work-clinic");
+    expect(ctx.acknowledgeBySlug.has("home-clinic")).toBe(false);
+    expect(post).toHaveBeenCalledExactlyOnceWith("All alerts acknowledged.");
+  });
+
+  it("falls back to the default when the button carries no tenant", async () => {
+    const ctx = createContext([HOME, asDefault(WORK)]);
+    const { event, post, postEphemeral } = createActionEvent();
+
+    await runWithContext(ctx.context, () => handler(event));
+
+    expect(ctx.scopedApiFactory).toHaveBeenCalledExactlyOnceWith("work-clinic");
+    expect(postEphemeral).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledExactlyOnceWith("All alerts acknowledged.");
   });
 
   it("asks a multi-link user to choose when the button carries no tenant", async () => {

--- a/src/Web/packages/bot/src/lib/require-link.test.ts
+++ b/src/Web/packages/bot/src/lib/require-link.test.ts
@@ -11,6 +11,7 @@ const HOME: DirectoryCandidate = {
   nocturneUserId: "nocturne-user-home",
   label: "home",
   displayName: "HOME",
+  isDefault: false,
 };
 
 const WORK: DirectoryCandidate = {
@@ -22,6 +23,11 @@ const WORK: DirectoryCandidate = {
   label: "work",
   displayName: "WORK",
 };
+
+const asDefault = (c: DirectoryCandidate): DirectoryCandidate => ({
+  ...c,
+  isDefault: true,
+});
 
 function createContext(candidates: DirectoryCandidate[] | null) {
   const resolve = vi.fn().mockResolvedValue(candidates);
@@ -81,6 +87,30 @@ describe("requireLink", () => {
 
     expect(run.result).toBe("work");
     expect(run.seen).toEqual(["work-clinic"]);
+  });
+
+  it("resolves a multi-link user to their default when no label is given", async () => {
+    const run = await runSlash([HOME, asDefault(WORK)], "");
+
+    expect(run.result).toBe("work");
+    expect(run.seen).toEqual(["work-clinic"]);
+    expect(run.postEphemeral).not.toHaveBeenCalled();
+  });
+
+  it("prefers an explicit label over the default", async () => {
+    const run = await runSlash([HOME, asDefault(WORK)], "home");
+
+    expect(run.result).toBe("home");
+    expect(run.seen).toEqual(["home-clinic"]);
+    expect(run.postEphemeral).not.toHaveBeenCalled();
+  });
+
+  it("stays ambiguous when more than one link claims to be default", async () => {
+    const run = await runSlash([asDefault(HOME), asDefault(WORK)], "");
+
+    expect(run.result).toBeNull();
+    expect(run.seen).toEqual([]);
+    expect(run.postEphemeral).toHaveBeenCalledOnce();
   });
 
   it("lists the choices when a multi-link user gives no label", async () => {

--- a/src/Web/packages/bot/src/lib/require-link.ts
+++ b/src/Web/packages/bot/src/lib/require-link.ts
@@ -43,8 +43,11 @@ interface LinkResolutionInput {
  * - **Multiple candidates + label arg matches exactly one** → invokes
  *   callback with the matched link.
  *
- * - **Multiple candidates + no label arg** → explains the ambiguity, listing
- *   each label and display name, and returns null.
+ * - **Multiple candidates + no label arg + exactly one marked default** →
+ *   invokes callback with the default link.
+ *
+ * - **Multiple candidates + no label arg + no single default** → explains the
+ *   ambiguity, listing each label and display name, and returns null.
  *
  * - **Multiple candidates + label arg does not match any** → explains "no link
  *   named X, try one of: ..." and returns null.
@@ -69,8 +72,13 @@ interface LinkResolutionInput {
  * //   Resolves to the "work" link.
  *
  * @example
+ * // Multi + default:
+ * //   User has "home" and "work", with "work" set as their default.
+ * //   They run `/bg`. Resolves to "work" without asking.
+ *
+ * @example
  * // Multi + ambiguous:
- * //   User has "home" and "work". They run `/bg`.
+ * //   User has "home" and "work", neither set as default. They run `/bg`.
  * //   Ephemeral: "You have multiple linked Nocturne accounts: `home` (Home),
  * //   `work` (Work). Use `/bg <label>` to pick one, or set a default in
  * //   Settings → Integrations → Discord."
@@ -222,7 +230,8 @@ export async function requireLinkForAction<T>(
 }
 
 /**
- * Selects a single DirectoryCandidate from a non-empty list. Returns
+ * Selects a single DirectoryCandidate from a non-empty list, preferring a bound
+ * `tenantId`, then an explicit `labelArg`, then the sole default link. Returns
  * "tenant-not-linked" if `tenantId` names a tenant the user has no link to,
  * "ambiguous" if no disambiguation is possible, or "not-found" if the label arg
  * doesn't match any candidate.
@@ -253,6 +262,10 @@ function pickCandidate(
     return match ?? "not-found";
   }
 
-  // No label and multiple candidates: ambiguous.
+  // ux_directory_user_one_default permits at most one default per platform
+  // user, so more than one here means the invariant broke — don't guess.
+  const defaults = candidates.filter((c) => c.isDefault);
+  if (defaults.length === 1) return defaults[0]!;
+
   return "ambiguous";
 }

--- a/src/Web/packages/bot/src/types.ts
+++ b/src/Web/packages/bot/src/types.ts
@@ -98,6 +98,11 @@ export interface DirectoryCandidate {
   nocturneUserId: string;
   label: string;
   displayName: string;
+  /**
+   * The link a bare, label-less invocation resolves to. At most one of a
+   * platform user's links carries it (`ux_directory_user_one_default`).
+   */
+  isDefault: boolean;
 }
 
 export interface HeartbeatRequest {


### PR DESCRIPTION
Fixes #831.

## What

The bot advertised "set a default in Settings → Integrations → Discord" but could never honour one. Two dropped sites, not one: the bot's `DirectoryCandidate` type omitted `isDefault`, **and** the SvelteKit adapter's `mapCandidate` rebuilds candidates field-by-field, so the value died there even with the type fixed. Both now carry it, and `pickCandidate` resolves the sole default with precedence preserved: bound tenant (button value) → single candidate → explicit label → sole default → ambiguous. Two defaults fall through to ambiguous rather than guessing — the DB makes that state impossible anyway (`ux_directory_user_one_default`, a partial unique index per platform user, with `SetDefaultAsync` clearing the predecessor cross-tenant in a transaction), and the comment cites the index by name.

Verified the advertised settings surface exists and works: the Discord integrations page renders "Set as default" against `POST /chat-identity/links/{id}/set-default`, so the copy is honest now that the bot honours it. The #830-corrected docblock is restored to describe the real branch.

## Testing

5 new tests (slash + action paths): sole default resolves without prompting; label beats default; bound tenant beats default; two defaults → ambiguous; no default unchanged. Mutation-proven: removing the default branch fails exactly the two sole-default tests. `pnpm --filter @nocturne/bot test` 39/39; `tsc` clean.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
