### PR TITLE
fix(glucose): stop the stores and remaining surfaces defaulting an unknown trend to Flat

### DIFF
--- a/src/Desktop/Nocturne.Desktop.Tray/Helpers/TrendHelper.cs
+++ b/src/Desktop/Nocturne.Desktop.Tray/Helpers/TrendHelper.cs
@@ -9,6 +9,15 @@ namespace Nocturne.Desktop.Tray.Helpers;
 /// </summary>
 public static class TrendHelper
 {
+    /// <summary>Segoe Fluent Icons upward arrow, the glyph <see cref="GetArrowRotation"/> rotates.</summary>
+    public const string ArrowUpGlyph = "\uE74A";
+
+    /// <summary>
+    /// Segoe Fluent Icons glyph for a direction no arrow can express. Rendered unrotated:
+    /// a rotated glyph would report a trend the CGM never sent, and 90 degrees reads as stable.
+    /// </summary>
+    public const string UnknownGlyph = "\uE9CE";
+
     /// <summary>
     /// Returns a Segoe Fluent Icons glyph for the given direction.
     /// Windows-specific: uses Segoe Fluent Icon font codepoints.
@@ -17,24 +26,25 @@ public static class TrendHelper
     {
         return direction switch
         {
-            "TripleUp" => "\uE74A",
-            "DoubleUp" => "\uE74A",
-            "SingleUp" => "\uE74A",
+            "TripleUp" => ArrowUpGlyph,
+            "DoubleUp" => ArrowUpGlyph,
+            "SingleUp" => ArrowUpGlyph,
             "FortyFiveUp" => "\uE76C",
             "Flat" => "\uE76C",
             "FortyFiveDown" => "\uE76C",
             "SingleDown" => "\uE74B",
             "DoubleDown" => "\uE74B",
             "TripleDown" => "\uE74B",
-            _ => "\uE9CE",
+            _ => UnknownGlyph,
         };
     }
 
     /// <summary>
-    /// Returns the rotation angle for a Segoe Fluent Icons arrow glyph.
+    /// Returns the rotation angle for <see cref="ArrowUpGlyph"/>, or <c>null</c> when no arrow
+    /// can express the direction. Callers must then render <see cref="UnknownGlyph"/> unrotated.
     /// Windows-specific: used with WinUI RotateTransform.
     /// </summary>
-    public static double GetArrowRotation(string? direction)
+    public static double? GetArrowRotation(string? direction)
     {
         return direction switch
         {
@@ -47,7 +57,7 @@ public static class TrendHelper
             "SingleDown" => 180,
             "DoubleDown" => 180,
             "TripleDown" => 180,
-            _ => 90,
+            _ => null,
         };
     }
 

--- a/src/Desktop/Nocturne.Desktop.Tray/Views/GlucoseCard.xaml.cs
+++ b/src/Desktop/Nocturne.Desktop.Tray/Views/GlucoseCard.xaml.cs
@@ -43,9 +43,13 @@ public sealed partial class GlucoseCard : UserControl
         BgValueText.Text = GlucoseRangeHelper.FormatValue(reading.Sgv, settings.Unit);
         BgValueText.Foreground = brush;
 
-        TrendArrowText.Text = "\uE74A";
+        var direction = reading.Direction.ToString();
+        var rotation = TrendHelper.GetArrowRotation(direction);
+        TrendArrowText.Text = rotation is null
+            ? TrendHelper.GetArrowGlyph(direction)
+            : TrendHelper.ArrowUpGlyph;
         TrendArrowText.Foreground = brush;
-        TrendArrowRotation.Angle = TrendHelper.GetArrowRotation(reading.Direction.ToString());
+        TrendArrowRotation.Angle = rotation ?? 0;
 
         var delta = GlucoseRangeHelper.FormatDelta(reading.Delta, settings.Unit);
         DeltaText.Text = delta;

--- a/src/Web/packages/app/src/lib/components/layout/MobileHeader.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/MobileHeader.svelte
@@ -21,7 +21,7 @@
   let scrollThreshold = 10; // Minimum scroll amount to trigger hide/show
 
   // Get direction info for arrow display
-  const directionInfo = $derived(getDirectionInfo(realtimeStore?.direction ?? "NONE"));
+  const directionInfo = $derived(getDirectionInfo(realtimeStore?.direction));
 
   // This header is the only glucose surface on a phone — CurrentBGDisplay hides
   // itself below @md — so it carries the same stale/disconnected states.

--- a/src/Web/packages/app/src/lib/components/layout/SidebarGlucoseWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/SidebarGlucoseWidget.svelte
@@ -74,7 +74,7 @@
 
   // Trend metadata
   const bgDelta = $derived(realtimeStore?.bgDelta ?? 0);
-  const direction = $derived(realtimeStore?.direction ?? "Flat");
+  const direction = $derived(realtimeStore?.direction ?? "");
   const timeSinceReading = $derived(realtimeStore?.timeSinceReading ?? "");
   const displayDelta = $derived(formatGlucoseDelta(bgDelta, units));
   const hasData = $derived(!isLoading && rawCurrentBG > 0);

--- a/src/Web/packages/app/src/lib/components/tenants/TenantOverviewTile.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/tenants/TenantOverviewTile.svelte.test.ts
@@ -188,6 +188,25 @@ describe("TenantOverviewTile", () => {
       .toHaveClass(/text-muted-foreground/);
   });
 
+  it("labels a reading with no trend as unknown rather than stable", async () => {
+    render(TenantOverviewTile, {
+      props: {
+        tenant: makeTenant({
+          latest: {
+            mgdl: 120,
+            delta: 4,
+            direction: GlucoseDirection.None,
+            timestamp: new Date(),
+          },
+        }),
+        baseDomain: "example.com",
+      },
+    });
+
+    await expect.element(page.getByLabelText("unknown")).toBeVisible();
+    expect(page.getByLabelText("stable").elements()).toHaveLength(0);
+  });
+
   it("renders an em-dash when latest exists but has no mgdl value", async () => {
     render(TenantOverviewTile, {
       props: {

--- a/src/Web/packages/app/src/lib/stores/public-clock-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/public-clock-store.svelte.ts
@@ -27,7 +27,7 @@ export class PublicClockStore implements ClockGlucoseSource {
   }
 
   currentBG = $derived(this.readings[0]?.mgdl ?? 0);
-  direction = $derived(this.readings[0]?.direction ?? "Flat");
+  direction = $derived(this.readings[0]?.direction ?? "");
   lastUpdated = $derived(this.readings[0]?.mills ?? Date.now());
   demoMode = $derived(this.readings.some((r) => r.dataSource === "demo-service"));
 

--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -185,8 +185,12 @@ export class RealtimeStore {
     return this.currentBG - this.previousBG;
   });
 
-  /** Direction and trend */
-  direction = $derived(this.currentEntry?.direction || "Flat");
+  /**
+   * Trend direction exactly as the reading carried it, empty when it carried none.
+   * Consumers render the unknown state; substituting a drawable direction here would
+   * report a trend the CGM never sent.
+   */
+  direction = $derived(this.currentEntry?.direction ?? "");
 
   /** Time since last update */
   lastUpdated = $derived(this.currentEntry?.mills || Date.now());
@@ -1181,6 +1185,7 @@ export function tryGetRealtimeStore(): RealtimeStore | null {
 export interface ClockGlucoseSource {
   readonly currentBG: number;
   readonly bgDelta: number;
+  /** Empty when the reading carried no direction. */
   readonly direction: string;
   readonly lastUpdated: number;
   readonly demoMode: boolean;

--- a/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
@@ -38,7 +38,7 @@ interface StoreInternals {
 }
 
 type TestStore = StoreInternals &
-  Pick<RealtimeStore, "currentReservoir" | "destroy">;
+  Pick<RealtimeStore, "currentReservoir" | "entries" | "direction" | "destroy">;
 
 /** Store instance with an empty socket URL, so nothing connects. */
 function makeStore(): TestStore {
@@ -138,6 +138,30 @@ describe("RealtimeStore reservoir freshness", () => {
     await store.performBackfillIfNeeded(true);
 
     expect(store.currentReservoir).toBe(30);
+
+    store.destroy();
+  });
+});
+
+describe("RealtimeStore direction", () => {
+  it("passes the reported direction through", () => {
+    const store = makeStore();
+    store.entries = [{ mills: 1_000, sgv: 120, direction: "FortyFiveDown" }];
+
+    expect(store.direction).toBe("FortyFiveDown");
+
+    store.destroy();
+  });
+
+  it.each([
+    ["an entry with no direction", [{ mills: 1_000, sgv: 120 }]],
+    ["an empty direction", [{ mills: 1_000, sgv: 120, direction: "" }]],
+    ["no entries at all", []],
+  ])("reports no direction for %s rather than Flat", (_case, entries) => {
+    const store = makeStore();
+    store.entries = entries;
+
+    expect(store.direction).toBe("");
 
     store.destroy();
   });

--- a/src/Web/packages/app/src/lib/utils/direction-info.test.ts
+++ b/src/Web/packages/app/src/lib/utils/direction-info.test.ts
@@ -5,6 +5,8 @@ describe("getDirectionInfo", () => {
 	it.each([
 		["NOT COMPUTABLE", "unknown"],
 		["NotComputable", "unknown"],
+		["None", "unknown"],
+		["NONE", "unknown"],
 		["RATE OUT OF RANGE", "out of range"],
 		["RateOutOfRange", "out of range"],
 		["Flat", "stable"],
@@ -13,8 +15,19 @@ describe("getDirectionInfo", () => {
 		expect(getDirectionInfo(direction).label).toBe(label);
 	});
 
-	it("falls back to stable for unrecognised and absent values", () => {
-		expect(getDirectionInfo("Bogus").label).toBe("stable");
-		expect(getDirectionInfo(undefined).label).toBe("stable");
+	it("falls back to unknown for unrecognised and absent values", () => {
+		expect(getDirectionInfo("Bogus").label).toBe("unknown");
+		expect(getDirectionInfo("").label).toBe("unknown");
+		expect(getDirectionInfo(undefined).label).toBe("unknown");
 	});
+
+	it.each(["None", "NONE", "Bogus", "", undefined])(
+		"does not render %s as the stable arrow",
+		(direction) => {
+			const info = getDirectionInfo(direction);
+			expect(info.label).not.toBe("stable");
+			expect(info.icon).not.toBe(getDirectionInfo("Flat").icon);
+			expect(info.css).not.toBe(getDirectionInfo("Flat").css);
+		},
+	);
 });

--- a/src/Web/packages/app/src/lib/utils/index.ts
+++ b/src/Web/packages/app/src/lib/utils/index.ts
@@ -16,10 +16,19 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SvelteComponent = any;
 
-const directionInfo: Partial<Record<
-  Direction,
-  { label: string; icon: SvelteComponent; css: string }
->> = {
+type DirectionInfo = { label: string; icon: SvelteComponent; css: string };
+
+/**
+ * Shown for every direction no arrow can express — none reported, not computable, or a
+ * spelling this build does not know. A trend we do not have must never read as a stable one.
+ */
+const unknownDirectionInfo: DirectionInfo = {
+  label: "unknown",
+  icon: HelpCircle,
+  css: "text-gray-500",
+};
+
+const directionInfo: Partial<Record<Direction, DirectionInfo>> = {
   [Direction.DoubleUp]: {
     label: "rising very fast",
     icon: ArrowUp,
@@ -51,16 +60,13 @@ const directionInfo: Partial<Record<
     icon: ArrowDown,
     css: "text-red-500",
   },
-  [Direction.NotComputable]: {
-    label: "unknown",
-    icon: HelpCircle,
-    css: "text-gray-500",
-  },
   [Direction.RateOutOfRange]: {
     label: "out of range",
     icon: AlertTriangle,
     css: "text-gray-500",
   },
+  [Direction.NONE]: unknownDirectionInfo,
+  [Direction.NotComputable]: unknownDirectionInfo,
 };
 
 /**
@@ -74,11 +80,11 @@ const directionsByName = new Map(
 );
 
 /** Get BG trend direction information */
-export function getDirectionInfo(direction?: Direction | string) {
+export function getDirectionInfo(direction?: Direction | string): DirectionInfo {
   const name = direction
     ? directionsByName.get(normaliseDirection(direction))
     : undefined;
-  return directionInfo[name ?? Direction.Flat] || directionInfo[Direction.Flat]!;
+  return directionInfo[name ?? Direction.NONE] ?? unknownDirectionInfo;
 }
 
 /** Enhanced relative time formatting with internationalization support */


### PR DESCRIPTION
Fixes #837.

## What

The remaining "unknown renders as stable" class, one layer above #835's six surfaces:

- **The realtime store** no longer coerces "no direction" to `"Flat"` — it passes through what the reading carried (empty when none), with the constraint documented on the property. The sibling `PublicClockStore` had the identical `?? "Flat"` (not in the issue) and would have made the `ClockGlucoseSource` contract lie for the anonymous clock route — fixed too.
- **`getDirectionInfo`** gives `None` and unrecognised the existing unknown shape (HelpCircle, "unknown", gray) instead of the green "stable" arrow — the same conflation choice `@nocturne/ui/glucose` already makes, no near-synonym label invented.
- **`MobileHeader`** drops its literal `"NONE"` fallback; no-reading remains a distinct state there (skeleton/stale states hide the arrow block entirely), so unknown-trend and no-data don't collapse.
- **WinUI tray**: `GetArrowRotation` returns `null` for directions no arrow expresses, and `GlucoseCard` mirrors #835's `TrendArrow`: unknown glyph rendered unrotated, arrow glyph rotated. Compile-verified (`-p:Platform=x64 -p:RuntimeIdentifier=win-x64` gets past the environmental arch error; the MSIX packaging step still fails locally as it does on pristine main, and the project has no tests).

Full consumer table in the review: every store consumer enumerated with before → after for the no-direction case (CommandPaletteVitals, MobileHeader, SidebarGlucoseWidget, tab title, both clock paths, RecentEntriesCard, TenantOverviewTile).

## Testing

31 node tests + browser-mode store/tile tests pass; mutation proof restoring both Flat fallbacks fails 7 tests. `pnpm check` 64 errors before and after (baseline verified by stashing the whole diff); the one failing node test and one failing browser test are pre-existing on pristine main (verified by stash).

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
