### PR TITLE
refactor(connectors): the shared publish path owns LastEntryTimes and progress

### DIFF
--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -92,8 +92,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         CareLinkConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null)
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
@@ -402,15 +401,15 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
 
             await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabledTypes,
                 CareLinkTreatmentMapper.MapBoluses(data, pumpOffsetMs), PublishBolusDataAsync,
-                config, cancellationToken);
+                config, cancellationToken, timestampOf: b => b.Timestamp);
 
             await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabledTypes,
                 CareLinkTreatmentMapper.MapCarbIntakes(data, pumpOffsetMs), PublishCarbIntakeDataAsync,
-                config, cancellationToken);
+                config, cancellationToken, timestampOf: c => c.Timestamp);
 
             await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabledTypes,
                 CareLinkTreatmentMapper.MapTempBasals(data, pumpOffsetMs), PublishTempBasalDataAsync,
-                config, cancellationToken);
+                config, cancellationToken, timestampOf: t => t.StartTimestamp);
 
             // Not routed through PublishRecordTypeAsync: system events would have to be gated and
             // counted under DeviceEvents, which CareLink does not declare supported, so the helper

--- a/src/Connectors/Nocturne.Connectors.Core/Models/SyncMessageType.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Models/SyncMessageType.cs
@@ -7,7 +7,6 @@ public enum SyncMessageType
 {
     Authenticating,
     FetchingData,
-    FetchingDataType,
     ProcessingDataType,
     PublishingDataType,
     SyncComplete,

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -35,6 +35,11 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     private WriteOrigin? _treatmentPublishOrigin;
     private WriteOrigin? _devicePublishOrigin;
 
+    // Carried on the instance rather than through PerformSyncInternalAsync's callees so the shared
+    // publish path can report without every connector threading it; safe for the same reason the
+    // publish-origin memos above are.
+    private ISyncProgressReporter? _progressReporter;
+
     /// <summary>
     ///     Base constructor for connector services using IHttpClientFactory pattern
     /// </summary>
@@ -92,7 +97,25 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         ISyncProgressReporter? progressReporter = null
     )
     {
-        return await PerformSyncInternalAsync(request, config, cancellationToken, progressReporter);
+        return await RunSyncInternalAsync(request, config, cancellationToken, progressReporter);
+    }
+
+    private async Task<SyncResult> RunSyncInternalAsync(
+        SyncRequest request,
+        TConfig config,
+        CancellationToken cancellationToken,
+        ISyncProgressReporter? progressReporter
+    )
+    {
+        _progressReporter = progressReporter;
+        try
+        {
+            return await PerformSyncInternalAsync(request, config, cancellationToken);
+        }
+        finally
+        {
+            _progressReporter = null;
+        }
     }
 
     public void Dispose()
@@ -382,9 +405,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     protected abstract Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TConfig config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null
-    );
+        CancellationToken cancellationToken);
 
     protected virtual Task<IEnumerable<Entry>> FetchGlucoseDataRangeAsync(
         DateTime? from,
@@ -612,9 +633,15 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
-    ///     Reusable helper that checks whether a data type is active, publishes a batch of records,
-    ///     updates the <see cref="SyncResult"/> counts, and logs the outcome.
+    ///     Reusable helper that checks whether a data type is active, reports publish progress,
+    ///     publishes a batch of records, updates the <see cref="SyncResult"/> counts and
+    ///     <see cref="SyncResult.LastEntryTimes"/>, and logs the outcome.
     /// </summary>
+    /// <param name="timestampOf">
+    ///     Extracts a record's canonical timestamp for <see cref="SyncResult.LastEntryTimes"/>.
+    ///     <c>null</c> — the parameter or an individual return — means the record carries no time
+    ///     to report, and nothing is recorded for the type.
+    /// </param>
     protected async Task PublishRecordTypeAsync<T>(
         SyncResult result,
         SyncDataType dataType,
@@ -623,13 +650,19 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         Func<List<T>, TConfig, CancellationToken, Task<bool>> publishFunc,
         TConfig config,
         CancellationToken cancellationToken,
-        string? context = null) where T : class
+        string? context = null,
+        Func<T, DateTime?>? timestampOf = null) where T : class
     {
         if (!activeTypes.Contains(dataType) || records.Count == 0) return;
+
+        await ReportSyncMessageAsync(SyncMessageType.PublishingDataType,
+            new() { ["count"] = records.Count.ToString(), ["dataType"] = dataType.ToString() },
+            cancellationToken);
 
         var success = await publishFunc(records, config, cancellationToken);
         result.ItemsSynced.TryGetValue(dataType, out var prev);
         result.ItemsSynced[dataType] = prev + records.Count;
+        RecordLastEntryTime(result, dataType, records, timestampOf);
         if (!success)
         {
             result.Success = false;
@@ -641,6 +674,63 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             _logger.LogInformation("Synced {Count} {Type} records{Context}",
                 records.Count, dataType, ctx);
         }
+    }
+
+    /// <summary>
+    ///     Raises <see cref="SyncResult.LastEntryTimes"/> for a type to the newest timestamp in a
+    ///     published batch. Max-compare, not assignment: a connector that publishes several batches
+    ///     per type is under no obligation to deliver them in chronological order.
+    /// </summary>
+    private static void RecordLastEntryTime<T>(
+        SyncResult result,
+        SyncDataType dataType,
+        List<T> records,
+        Func<T, DateTime?>? timestampOf)
+    {
+        if (timestampOf is null) return;
+
+        DateTime? newest = null;
+        foreach (var record in records)
+        {
+            var time = timestampOf(record);
+            if (time.HasValue && (newest is null || time.Value > newest.Value))
+                newest = time;
+        }
+
+        if (newest is null) return;
+
+        // A recorded null must still be raised: lifted comparison against null is false, so
+        // `newest > existing` alone would leave a null-valued entry in place forever.
+        if (!result.LastEntryTimes.TryGetValue(dataType, out var existing)
+            || existing is null
+            || newest.Value > existing.Value)
+            result.LastEntryTimes[dataType] = newest;
+    }
+
+    /// <summary>
+    ///     Converts a legacy mills field to a UTC timestamp, treating a non-positive value as absent.
+    /// </summary>
+    protected static DateTime? TimestampFromMills(long mills) =>
+        mills > 0 ? DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime : null;
+
+    /// <summary>
+    ///     Reports a sync-progress message to the reporter supplied for this run, if any.
+    /// </summary>
+    protected Task ReportSyncMessageAsync(
+        SyncMessageType messageType,
+        Dictionary<string, string>? messageParams,
+        CancellationToken cancellationToken)
+    {
+        if (_progressReporter is null) return Task.CompletedTask;
+
+        return _progressReporter.ReportProgressAsync(new SyncProgressEvent
+        {
+            ConnectorId = ConnectorSource,
+            ConnectorName = ServiceName,
+            Phase = SyncPhase.Syncing,
+            MessageType = messageType,
+            MessageParams = messageParams,
+        }, cancellationToken);
     }
 
     #region V4 Publishing Methods
@@ -978,7 +1068,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
                 DataTypes = SupportedDataTypes,
             };
 
-            var result = await PerformSyncInternalAsync(request, config, cancellationToken, progressReporter);
+            var result = await RunSyncInternalAsync(request, config, cancellationToken, progressReporter);
 
             if (result.Success)
             {

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
@@ -78,13 +78,11 @@ public class DexcomConnectorService : BaseConnectorService<DexcomConnectorConfig
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         DexcomConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null
-    )
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
+        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
         if (!enabledTypes.Contains(SyncDataType.Glucose))
         {
             result.EndTime = DateTimeOffset.UtcNow;
@@ -94,26 +92,10 @@ public class DexcomConnectorService : BaseConnectorService<DexcomConnectorConfig
         try
         {
             var sensorGlucose = await FetchSensorGlucoseAsync(config, request.From);
-            var sgList = sensorGlucose.ToList();
 
-            if (sgList.Count > 0)
-            {
-                var success = await PublishSensorGlucoseDataAsync(sgList, config, cancellationToken);
-                result.ItemsSynced[SyncDataType.Glucose] = sgList.Count;
-                result.LastEntryTimes[SyncDataType.Glucose] = DateTimeOffset
-                    .FromUnixTimeMilliseconds(sgList.Max(s => s.Mills))
-                    .UtcDateTime;
-
-                if (!success)
-                {
-                    result.Success = false;
-                    result.Errors.Add("SensorGlucose publish failed");
-                }
-                else
-                {
-                    _logger.LogInformation("Synced {Count} SensorGlucose records from Dexcom", sgList.Count);
-                }
-            }
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+                sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken,
+                "Dexcom", s => s.Timestamp);
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
@@ -77,13 +77,11 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         EversenseConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null
-    )
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
+        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
         if (!enabledTypes.Contains(SyncDataType.Glucose))
         {
             result.EndTime = DateTimeOffset.UtcNow;
@@ -156,23 +154,9 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
                 return result;
             }
 
-            var success = await PublishSensorGlucoseDataAsync([sg], config, cancellationToken);
-            result.ItemsSynced[SyncDataType.Glucose] = 1;
-            result.LastEntryTimes[SyncDataType.Glucose] = sg.Timestamp;
-
-            if (!success)
-            {
-                result.Success = false;
-                result.Errors.Add("SensorGlucose publish failed");
-            }
-            else
-            {
-                _logger.LogInformation(
-                    "[{ConnectorSource}] Synced 1 SensorGlucose record ({Mgdl} mg/dL at {Timestamp})",
-                    ConnectorSource,
-                    sg.Mgdl,
-                    sg.Timestamp);
-            }
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+                [sg], PublishSensorGlucoseDataAsync, config, cancellationToken,
+                "Eversense", s => s.Timestamp);
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
@@ -168,13 +168,11 @@ public class LibreConnectorService(
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         LibreLinkUpConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null
-    )
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
+        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
         if (!enabledTypes.Contains(SyncDataType.Glucose))
         {
             result.EndTime = DateTimeOffset.UtcNow;
@@ -184,26 +182,10 @@ public class LibreConnectorService(
         try
         {
             var sensorGlucose = await FetchSensorGlucoseAsync(config, request.From);
-            var sgList = sensorGlucose.ToList();
 
-            if (sgList.Count > 0)
-            {
-                var success = await PublishSensorGlucoseDataAsync(sgList, config, cancellationToken);
-                result.ItemsSynced[SyncDataType.Glucose] = sgList.Count;
-                result.LastEntryTimes[SyncDataType.Glucose] = DateTimeOffset
-                    .FromUnixTimeMilliseconds(sgList.Max(s => s.Mills))
-                    .UtcDateTime;
-
-                if (!success)
-                {
-                    result.Success = false;
-                    result.Errors.Add("SensorGlucose publish failed");
-                }
-                else
-                {
-                    _logger.LogInformation("Synced {Count} SensorGlucose records from LibreLinkUp", sgList.Count);
-                }
-            }
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+                sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken,
+                "LibreLinkUp", s => s.Timestamp);
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -250,9 +250,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         GlookoConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null
-    )
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult
         {
@@ -266,7 +264,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             // See GlookoSyncContext: this run's entire working state lives here, never on the service.
             var context = new GlookoSyncContext(config, ConnectorSource, _glookoLogger);
 
-            await ReportMessageAsync(progressReporter, SyncMessageType.Authenticating, null, cancellationToken);
+            await ReportSyncMessageAsync(SyncMessageType.Authenticating, null, cancellationToken);
 
             if (!await AuthenticateWithConfigAsync(context))
             {
@@ -309,7 +307,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             {
                 try
                 {
-                    await RunSyncPassAsync(context, chunks, activeTypes, result, cancellationToken, progressReporter);
+                    await RunSyncPassAsync(context, chunks, activeTypes, result, cancellationToken);
                     break;
                 }
                 catch (GlookoDataForbiddenException ex) when (attempt == 0)
@@ -346,7 +344,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 }
             }
 
-            await ReportMessageAsync(progressReporter,
+            await ReportSyncMessageAsync(
                 result.Success ? SyncMessageType.SyncComplete : SyncMessageType.SyncFailed,
                 null, cancellationToken);
 
@@ -359,7 +357,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             result.Success = false;
             result.Message = "Sync failed with exception";
             result.Errors.Add(ex.Message);
-            await ReportMessageAsync(progressReporter, SyncMessageType.SyncFailed, null, cancellationToken);
+            await ReportSyncMessageAsync(SyncMessageType.SyncFailed, null, cancellationToken);
             result.EndTime = DateTime.UtcNow;
             return result;
         }
@@ -375,14 +373,13 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         List<(DateTime From, DateTime To)> chunks,
         HashSet<SyncDataType> activeTypes,
         SyncResult result,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter)
+        CancellationToken cancellationToken)
     {
         for (var i = 0; i < chunks.Count; i++)
         {
             var (chunkFrom, chunkTo) = chunks[i];
 
-            await ReportMessageAsync(progressReporter, SyncMessageType.FetchingData,
+            await ReportSyncMessageAsync(SyncMessageType.FetchingData,
                 new()
                 {
                     ["from"] = chunkFrom.ToString("MMM dd"),
@@ -412,7 +409,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         }
 
         // Profiles (V3 device settings — used in both modes, no V2 equivalent)
-        await ReportMessageAsync(progressReporter, SyncMessageType.ProcessingDataType,
+        await ReportSyncMessageAsync(SyncMessageType.ProcessingDataType,
             new() { ["dataType"] = SyncDataType.Profiles.ToString() }, cancellationToken);
 
         if (activeTypes.Contains(SyncDataType.Profiles))
@@ -465,33 +462,33 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         var batchData = await FetchBatchDataAsync(context, fromDate, toDate);
         if (batchData == null) return false;
 
-        // 1. Glucose
         var sensorGlucose = context.SensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
-            sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
-        UpdateLastEntryTime(result, SyncDataType.Glucose, sensorGlucose);
+            sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken,
+            timestampOf: s => s.Timestamp);
 
         var bgChecks = context.SensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
-            bgChecks, PublishBGCheckDataAsync, config, cancellationToken);
+            bgChecks, PublishBGCheckDataAsync, config, cancellationToken,
+            timestampOf: b => b.Timestamp);
 
-        // 2. Treatments (boluses → carbs+foods)
         var (boluses, carbs, _) = context.V4TreatmentMapper.MapBatchData(batchData);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-            boluses, PublishBolusDataAsync, config, cancellationToken);
+            boluses, PublishBolusDataAsync, config, cancellationToken,
+            timestampOf: b => b.Timestamp);
 
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
-            carbs, PublishCarbIntakeDataAsync, config, cancellationToken);
+            carbs, PublishCarbIntakeDataAsync, config, cancellationToken,
+            timestampOf: c => c.Timestamp);
 
-        // 3. Foods + attribution (coupled with carbs)
+        // Food attribution resolves against the carbs published above.
         var foodEntryImports = batchData.Foods is { Length: > 0 }
             ? context.V4TreatmentMapper.MapFoodsToConnectorEntries(batchData) : [];
         Func<string, string?> foodResolver = externalEntryId => $"glooko_food_{externalEntryId}";
         await PublishFoodEntriesAndAttributeAsync(
             foodEntryImports, carbs, foodResolver, config, cancellationToken);
 
-        // 4. State spans
         if (activeTypes.Contains(SyncDataType.StateSpans))
         {
             var stateSpans = context.StateSpanMapper.TransformV2ToStateSpans(batchData);
@@ -499,7 +496,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 await PublishStateSpanDataAsync(stateSpans, config, cancellationToken);
         }
 
-        // 5. Temp basals
         if (activeTypes.Contains(SyncDataType.TempBasals))
         {
             var tempBasals = context.TempBasalMapper.TransformV2ToTempBasals(batchData);
@@ -537,20 +533,19 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             _logger.LogWarning(histEx, "[{ConnectorSource}] V3 histories fetch failed, meal data will be unavailable", ConnectorSource);
         }
 
-        // 1. Glucose
         if (config.V3IncludeCgmBackfill)
         {
             var sensorGlucose = context.SensorGlucoseMapper.TransformV3ToSensorGlucose(v3Data, context.MeterUnits).ToList();
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
-                sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
-            UpdateLastEntryTime(result, SyncDataType.Glucose, sensorGlucose);
+                sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken,
+                timestampOf: s => s.Timestamp);
         }
 
         var bgChecks = context.SensorGlucoseMapper.TransformV3ToBGChecks(v3Data, context.MeterUnits).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
-            bgChecks, PublishBGCheckDataAsync, config, cancellationToken);
+            bgChecks, PublishBGCheckDataAsync, config, cancellationToken,
+            timestampOf: b => b.Timestamp);
 
-        // 2. Treatments (boluses → carbs+foods)
         var (v3Boluses, v3BolusCarbIntakes, _) = context.V4TreatmentMapper.MapV3Boluses(v3Data);
 
         // Carbs: bolus wizard + history meals (preferred) or carbAll (fallback)
@@ -564,21 +559,25 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             allCarbs.AddRange(context.V4TreatmentMapper.MapV3CarbAll(v3Data));
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-            v3Boluses, PublishBolusDataAsync, config, cancellationToken);
+            v3Boluses, PublishBolusDataAsync, config, cancellationToken,
+            timestampOf: b => b.Timestamp);
 
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
-            allCarbs, PublishCarbIntakeDataAsync, config, cancellationToken);
+            allCarbs, PublishCarbIntakeDataAsync, config, cancellationToken,
+            timestampOf: c => c.Timestamp);
 
-        // 2b. Manual insulin (pen injections: gkInsulinBasal → BasalInjection, gkInsulinBolus → Bolus)
+        // Pen injections: gkInsulinBasal → BasalInjection, gkInsulinBolus → Bolus.
         var (manualBasalInjections, manualBoluses) = context.V4TreatmentMapper.MapV3ManualInsulin(v3Data);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-            manualBoluses, PublishBolusDataAsync, config, cancellationToken);
+            manualBoluses, PublishBolusDataAsync, config, cancellationToken,
+            timestampOf: b => b.Timestamp);
 
         await PublishRecordTypeAsync(result, SyncDataType.BasalInjections, activeTypes,
-            manualBasalInjections, PublishBasalInjectionDataAsync, config, cancellationToken);
+            manualBasalInjections, PublishBasalInjectionDataAsync, config, cancellationToken,
+            timestampOf: b => b.Timestamp);
 
-        // 3. Foods + attribution (coupled with carbs)
+        // Food attribution resolves against the carbs published above.
         GlookoFood[]? v2Foods = null;
         if (historyMealCarbs.Count > 0)
         {
@@ -615,7 +614,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         await PublishFoodEntriesAndAttributeAsync(
             foodEntryImports, allCarbs, foodResolver, config, cancellationToken);
 
-        // 4. State spans
         if (activeTypes.Contains(SyncDataType.StateSpans))
         {
             var stateSpans = context.StateSpanMapper.TransformV3ToStateSpans(v3Data);
@@ -624,7 +622,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 await PublishStateSpanDataAsync(stateSpans, config, cancellationToken);
         }
 
-        // 4b. Temp basals
         if (activeTypes.Contains(SyncDataType.TempBasals))
         {
             var tempBasals = context.TempBasalMapper.TransformV3ToTempBasals(v3Data);
@@ -632,7 +629,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 result.ItemsSynced[SyncDataType.TempBasals] = tempBasals.Count;
         }
 
-        // 5. Device events + system events (summed into single ItemsSynced entry)
+        // Device events and system events share one ItemsSynced entry: Glooko declares no separate
+        // system-event toggle, so both are gated and counted under DeviceEvents.
         if (activeTypes.Contains(SyncDataType.DeviceEvents))
         {
             var deviceEventCount = 0;
@@ -713,18 +711,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
         _logger.LogInformation("[{ConnectorSource}] Attributed {Count}/{Total} food entries to carb intakes",
             ConnectorSource, attributedCount, pendingEntries.Count);
-    }
-
-    /// <summary>
-    ///     Updates <see cref="SyncResult.LastEntryTimes"/> with the most recent glucose timestamp,
-    ///     keeping the max across multiple chunks.
-    /// </summary>
-    private static void UpdateLastEntryTime(SyncResult result, SyncDataType dataType, List<SensorGlucose> records)
-    {
-        if (records.Count == 0) return;
-        var maxTime = DateTimeOffset.FromUnixTimeMilliseconds(records.Max(s => s.Mills)).UtcDateTime;
-        if (!result.LastEntryTimes.TryGetValue(dataType, out var existing) || maxTime > existing)
-            result.LastEntryTimes[dataType] = maxTime;
     }
 
     // ── V2 batch data fetching ──────────────────────────────────────────
@@ -1069,22 +1055,4 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         }
     }
 
-    // ── Progress reporting ──────────────────────────────────────────────
-
-    private Task ReportMessageAsync(
-        ISyncProgressReporter? reporter,
-        SyncMessageType messageType,
-        Dictionary<string, string>? messageParams,
-        CancellationToken ct)
-    {
-        if (reporter == null) return Task.CompletedTask;
-        return reporter.ReportProgressAsync(new SyncProgressEvent
-        {
-            ConnectorId = ConnectorSource,
-            ConnectorName = ServiceName,
-            Phase = SyncPhase.Syncing,
-            MessageType = messageType,
-            MessageParams = messageParams,
-        }, ct);
-    }
 }

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
@@ -95,9 +95,7 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         MyFitnessPalConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null
-    )
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -96,9 +96,7 @@ public class MyLifeConnectorService(
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         MyLifeConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null
-    )
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
@@ -183,29 +181,9 @@ public class MyLifeConnectorService(
                         .MapSensorGlucose(batch.Events.Where(e => e.EventDateTime >= glucoseSinceTicks))
                         .ToList();
 
-                    if (sgList.Count > 0)
-                    {
-                        var success = await PublishSensorGlucoseDataAsync(sgList, config, cancellationToken);
-                        result.ItemsSynced.TryGetValue(SyncDataType.Glucose, out var prevCount);
-                        result.ItemsSynced[SyncDataType.Glucose] = prevCount + sgList.Count;
-
-                        if (!success)
-                        {
-                            result.Success = false;
-                            result.Errors.Add("SensorGlucose publish failed");
-                        }
-                        else
-                        {
-                            var maxMills = sgList.Max(s => s.Mills);
-                            var maxTime = DateTimeOffset.FromUnixTimeMilliseconds(maxMills).UtcDateTime;
-                            if (!result.LastEntryTimes.TryGetValue(SyncDataType.Glucose, out var existing) || maxTime > existing)
-                                result.LastEntryTimes[SyncDataType.Glucose] = maxTime;
-
-                            _logger.LogInformation(
-                                "Synced {Count} SensorGlucose records from {Month}",
-                                sgList.Count, batch.Month);
-                        }
-                    }
+                    await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
+                        sgList, PublishSensorGlucoseDataAsync, config, cancellationToken, batch.Month,
+                        timestampOf: s => s.Timestamp);
                 }
 
                 // Shared treatment filtering and context for records + state spans
@@ -228,17 +206,23 @@ public class MyLifeConnectorService(
 
                         var monthCtx = batch.Month;
                         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-                            records.Boluses, PublishBolusDataAsync, config, cancellationToken, monthCtx);
+                            records.Boluses, PublishBolusDataAsync, config, cancellationToken, monthCtx,
+                            b => b.Timestamp);
                         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
-                            records.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken, monthCtx);
+                            records.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken, monthCtx,
+                            c => c.Timestamp);
                         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
-                            records.BGChecks, PublishBGCheckDataAsync, config, cancellationToken, monthCtx);
+                            records.BGChecks, PublishBGCheckDataAsync, config, cancellationToken, monthCtx,
+                            b => b.Timestamp);
                         await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, activeTypes,
-                            records.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken, monthCtx);
+                            records.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken, monthCtx,
+                            b => b.Timestamp);
                         await PublishRecordTypeAsync(result, SyncDataType.Notes, activeTypes,
-                            records.Notes, PublishNoteDataAsync, config, cancellationToken, monthCtx);
+                            records.Notes, PublishNoteDataAsync, config, cancellationToken, monthCtx,
+                            n => n.Timestamp);
                         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
-                            records.DeviceEvents, PublishDeviceEventDataAsync, config, cancellationToken, monthCtx);
+                            records.DeviceEvents, PublishDeviceEventDataAsync, config, cancellationToken, monthCtx,
+                            d => d.Timestamp);
                     }
 
                     // TempBasal state spans
@@ -247,7 +231,8 @@ public class MyLifeConnectorService(
                         var tempBasals = MyLifeStateSpanMapper.MapTempBasals(treatmentEvents, treatmentContext).ToList();
 
                         await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-                            tempBasals, PublishTempBasalDataAsync, config, cancellationToken, batch.Month);
+                            tempBasals, PublishTempBasalDataAsync, config, cancellationToken, batch.Month,
+                            t => t.StartTimestamp);
                     }
                 }
 
@@ -263,11 +248,13 @@ public class MyLifeConnectorService(
 
                 var profiles = MyLifePumpSettingsMapper.MapToProfiles(readouts);
                 await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
-                    profiles, PublishProfileDataAsync, config, cancellationToken);
+                    profiles, PublishProfileDataAsync, config, cancellationToken,
+                    timestampOf: p => TimestampFromMills(p.Mills));
 
                 var profileStateSpans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource);
                 await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-                    profileStateSpans, PublishStateSpanDataAsync, config, cancellationToken, "pump settings");
+                    profileStateSpans, PublishStateSpanDataAsync, config, cancellationToken, "pump settings",
+                    s => s.StartTimestamp);
             }
         }
         catch (Exception ex)

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -161,8 +161,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TConfig config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null)
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
@@ -170,7 +169,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             request.DataTypes = SupportedDataTypes;
 
         var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
-        var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToList();
+        var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
         // For open-ended background catch-up (no explicit upper bound), each data type
         // resolves its own "since" from its OWN latest stored record rather than reusing
@@ -282,23 +281,9 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             try
             {
                 var profiles = await FetchProfilesAsync();
-                var profileList = profiles.ToList();
-                result.ItemsSynced[SyncDataType.Profiles] = profileList.Count;
-                if (profileList.Count > 0)
-                {
-                    result.LastEntryTimes[SyncDataType.Profiles] = profileList
-                        .Where(p => p.Mills > 0)
-                        .Select(p => DateTimeOffset.FromUnixTimeMilliseconds(p.Mills).UtcDateTime)
-                        .DefaultIfEmpty()
-                        .Max();
-                    var publishSuccess = await PublishProfileDataAsync(
-                        profileList, config, cancellationToken);
-                    if (!publishSuccess)
-                    {
-                        result.Success = false;
-                        result.Errors.Add("Profiles publish failed");
-                    }
-                }
+                await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
+                    profiles.ToList(), PublishProfileDataAsync, config, cancellationToken,
+                    timestampOf: p => TimestampFromMills(p.Mills));
             }
             catch (Exception ex)
             {
@@ -436,6 +421,11 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     private static DateTime? AnchorUnboundedFetch(DateTime? from, DateTime? to) =>
         from is null && to is null ? DateTime.UtcNow : to;
 
+    /// <summary>
+    ///     Outcome of one crawled collection. <paramref name="NewestTime"/> spans every page of the
+    ///     crawl, including the resume pass below the low-water mark, so it cannot come from the
+    ///     shared publish path: that sees one page at a time and never the crawl as a whole.
+    /// </summary>
     private sealed record PagedCrawlOutcome(int Count, DateTime? NewestTime, bool Success);
 
     private Task<DateTime?> GetBackfillLowWaterMarkAsync(string collection) =>

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -113,8 +113,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         NocturneRemoteConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null)
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
@@ -122,7 +121,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             request.DataTypes = SupportedDataTypes;
 
         var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
-        var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToList();
+        var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
         foreach (var type in activeTypes)
         {
@@ -130,30 +129,22 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
             try
             {
-                var (count, lastTime, success) = type switch
+                await (type switch
                 {
-                    SyncDataType.Glucose => await SyncSensorGlucoseAsync(request, config, cancellationToken),
-                    SyncDataType.ManualBG => await SyncBGChecksAsync(request, config, cancellationToken),
-                    SyncDataType.Boluses => await SyncBolusesAsync(request, config, cancellationToken),
-                    SyncDataType.CarbIntake => await SyncCarbIntakeAsync(request, config, cancellationToken),
-                    SyncDataType.BolusCalculations => await SyncBolusCalculationsAsync(request, config, cancellationToken),
-                    SyncDataType.Notes => await SyncNotesAsync(request, config, cancellationToken),
-                    SyncDataType.DeviceEvents => await SyncDeviceEventsAsync(request, config, cancellationToken),
-                    SyncDataType.StateSpans => await SyncStateSpansAsync(request, config, cancellationToken),
-                    SyncDataType.Profiles => await SyncProfilesAsync(config, cancellationToken),
-                    SyncDataType.DeviceStatus => await SyncDeviceStatusAsync(request, config, cancellationToken),
-                    SyncDataType.Activity => await SyncActivityAsync(request, config, cancellationToken),
-                    SyncDataType.Food => await SyncFoodAsync(config, cancellationToken),
-                    _ => (0, null, true)
-                };
-
-                result.ItemsSynced[type] = count;
-                result.LastEntryTimes[type] = lastTime;
-                if (!success)
-                {
-                    result.Success = false;
-                    result.Errors.Add($"{type} publish failed");
-                }
+                    SyncDataType.Glucose => SyncSensorGlucoseAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.ManualBG => SyncBGChecksAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Boluses => SyncBolusesAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.CarbIntake => SyncCarbIntakeAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.BolusCalculations => SyncBolusCalculationsAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Notes => SyncNotesAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.DeviceEvents => SyncDeviceEventsAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.StateSpans => SyncStateSpansAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Profiles => SyncProfilesAsync(config, result, activeTypes, cancellationToken),
+                    SyncDataType.DeviceStatus => SyncDeviceStatusAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Activity => SyncActivityAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Food => SyncFoodAsync(config, result, activeTypes, cancellationToken),
+                    _ => Task.CompletedTask
+                });
             }
             catch (Exception ex)
             {
@@ -169,165 +160,150 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
     #region V4 Data Type Sync Methods
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncSensorGlucoseAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncSensorGlucoseAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedV4Async<SensorGlucose>(
             NocturneRemoteConstants.SensorGlucose, request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var prepared = ImportHelper.PrepareForImport(records);
-        var lastTime = prepared.Max(r => r.Timestamp);
-        var success = await PublishSensorGlucoseDataAsync(prepared, config, ct);
-        return (prepared.Count, lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
+            ImportHelper.PrepareForImport(records), PublishSensorGlucoseDataAsync, config, ct,
+            timestampOf: r => r.Timestamp);
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncBGChecksAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncBGChecksAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedV4Async<BGCheck>(
             NocturneRemoteConstants.BGChecks, request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var prepared = ImportHelper.PrepareForImport(records);
-        var lastTime = prepared.Max(r => r.Timestamp);
-        var success = await PublishBGCheckDataAsync(prepared, config, ct);
-        return (prepared.Count, lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
+            ImportHelper.PrepareForImport(records), PublishBGCheckDataAsync, config, ct,
+            timestampOf: r => r.Timestamp);
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncBolusesAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncBolusesAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedV4Async<Bolus>(
             NocturneRemoteConstants.Boluses, request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var prepared = ImportHelper.PrepareForImport(records);
-        var lastTime = prepared.Max(r => r.Timestamp);
-        var success = await PublishBolusDataAsync(prepared, config, ct);
-        return (prepared.Count, lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
+            ImportHelper.PrepareForImport(records), PublishBolusDataAsync, config, ct,
+            timestampOf: r => r.Timestamp);
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncCarbIntakeAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncCarbIntakeAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedV4Async<CarbIntake>(
             NocturneRemoteConstants.CarbIntake, request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var prepared = ImportHelper.PrepareForImport(records);
-        var lastTime = prepared.Max(r => r.Timestamp);
-        var success = await PublishCarbIntakeDataAsync(prepared, config, ct);
-        return (prepared.Count, lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
+            ImportHelper.PrepareForImport(records), PublishCarbIntakeDataAsync, config, ct,
+            timestampOf: r => r.Timestamp);
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncBolusCalculationsAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncBolusCalculationsAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedV4Async<BolusCalculation>(
             NocturneRemoteConstants.BolusCalculations, request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var prepared = ImportHelper.PrepareForImport(records);
-        var lastTime = prepared.Max(r => r.Timestamp);
-        var success = await PublishBolusCalculationDataAsync(prepared, config, ct);
-        return (prepared.Count, lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, activeTypes,
+            ImportHelper.PrepareForImport(records), PublishBolusCalculationDataAsync, config, ct,
+            timestampOf: r => r.Timestamp);
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncNotesAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncNotesAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedV4Async<Note>(
             NocturneRemoteConstants.Notes, request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var prepared = ImportHelper.PrepareForImport(records);
-        var lastTime = prepared.Max(r => r.Timestamp);
-        var success = await PublishNoteDataAsync(prepared, config, ct);
-        return (prepared.Count, lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.Notes, activeTypes,
+            ImportHelper.PrepareForImport(records), PublishNoteDataAsync, config, ct,
+            timestampOf: r => r.Timestamp);
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncDeviceEventsAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncDeviceEventsAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedV4Async<DeviceEvent>(
             NocturneRemoteConstants.DeviceEvents, request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var prepared = ImportHelper.PrepareForImport(records);
-        var lastTime = prepared.Max(r => r.Timestamp);
-        var success = await PublishDeviceEventDataAsync(prepared, config, ct);
-        return (prepared.Count, lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
+            ImportHelper.PrepareForImport(records), PublishDeviceEventDataAsync, config, ct,
+            timestampOf: r => r.Timestamp);
     }
 
     #endregion
 
     #region Legacy Model Sync Methods
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncStateSpansAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncStateSpansAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedLegacyAsync<StateSpan>(
             NocturneRemoteConstants.StateSpans, request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var lastTime = records
-            .Select(s => s.StartTimestamp)
-            .DefaultIfEmpty()
-            .Max();
-        var success = await PublishStateSpanDataAsync(records, config, ct);
-        return (records.Count, lastTime == default ? null : lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
+            records, PublishStateSpanDataAsync, config, ct,
+            timestampOf: s => s.StartTimestamp == default ? null : s.StartTimestamp);
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncProfilesAsync(
-        NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncProfilesAsync(
+        NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedLegacyAsync<Profile>(
             NocturneRemoteConstants.ProfileRecords, null, null, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var lastTime = records
-            .Where(p => p.Mills > 0)
-            .Select(p => DateTimeOffset.FromUnixTimeMilliseconds(p.Mills).UtcDateTime)
-            .DefaultIfEmpty()
-            .Max();
-        var success = await PublishProfileDataAsync(records, config, ct);
-        return (records.Count, lastTime == default ? null : lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
+            records, PublishProfileDataAsync, config, ct,
+            timestampOf: p => TimestampFromMills(p.Mills));
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncDeviceStatusAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncDeviceStatusAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         // DeviceStatus uses the v1 API because the publisher only supports the legacy model.
         // The remote instance exposes v1 compatibility endpoints.
         var records = await FetchV1DeviceStatusAsync(request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var lastTime = records
-            .Select(d => DateTimeOffset.TryParse(d.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
-            .Where(dt => dt.HasValue)
-            .Max();
-        var success = await PublishDeviceStatusAsync(records, config, ct);
-        return (records.Count, lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, activeTypes,
+            records, PublishDeviceStatusAsync, config, ct,
+            timestampOf: d => ParseCreatedAt(d.CreatedAt));
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncActivityAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    private async Task SyncActivityAsync(
+        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedLegacyAsync<Activity>(
             NocturneRemoteConstants.Activity, request.From, request.To, ct);
-        if (records.Count == 0) return (0, null, true);
 
-        var lastTime = records
-            .Select(a => DateTimeOffset.TryParse(a.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
-            .Where(dt => dt.HasValue)
-            .Max();
-        var success = await PublishActivityDataAsync(records, config, ct);
-        return (records.Count, lastTime, success);
+        await PublishRecordTypeAsync(result, SyncDataType.Activity, activeTypes,
+            records, PublishActivityDataAsync, config, ct,
+            timestampOf: a => ParseCreatedAt(a.CreatedAt));
     }
 
-    private async Task<(int count, DateTime? lastTime, bool success)> SyncFoodAsync(
-        NocturneRemoteConnectorConfiguration config, CancellationToken ct)
+    /// <summary>Parses a legacy ISO createdAt string, treating an unparseable value as absent.</summary>
+    private static DateTime? ParseCreatedAt(string? createdAt) =>
+        DateTimeOffset.TryParse(createdAt, out var dto) ? dto.UtcDateTime : null;
+
+    private async Task SyncFoodAsync(
+        NocturneRemoteConnectorConfiguration config, SyncResult result,
+        HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         // Foods endpoint returns a flat array, not PaginatedResponse
         var url = BuildAbsoluteUrl($"{NocturneRemoteConstants.Foods}?count={_config.MaxCount}");
@@ -339,14 +315,14 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
                 "[{ConnectorSource}] Failed to fetch foods: HTTP {StatusCode}",
                 ConnectorSource,
                 (int)response.StatusCode);
-            return (0, null, true);
+            return;
         }
 
         var foods = await DeserializeResponseAsync<Food[]>(response, ct);
-        if (foods == null || foods.Length == 0) return (0, null, true);
 
-        var success = await PublishFoodDataAsync(foods, config, ct);
-        return (foods.Length, null, success);
+        // Food carries no per-record time, so no timestamp selector is supplied.
+        await PublishRecordTypeAsync(result, SyncDataType.Food, activeTypes,
+            foods?.ToList() ?? [], PublishFoodDataAsync, config, ct);
     }
 
     #endregion

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -55,8 +55,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TandemConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null)
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
         var enabled = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
@@ -134,7 +133,8 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
         await PublishRecordTypeAsync<Nocturne.Core.Models.Profile>(
             result, SyncDataType.Profiles, enabled, [profile],
-            PublishProfileDataAsync, config, cancellationToken);
+            PublishProfileDataAsync, config, cancellationToken,
+            timestampOf: p => TimestampFromMills(p.Mills));
     }
 
     private async Task SyncEventsAsync(
@@ -209,42 +209,50 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     {
         if (groups.TryGetValue(TandemEventClass.CgmReading, out var cgmEvents))
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabled,
-                cgm.Map(cgmEvents), PublishSensorGlucoseDataAsync, config, cancellationToken);
+                cgm.Map(cgmEvents), PublishSensorGlucoseDataAsync, config, cancellationToken,
+                timestampOf: s => s.Timestamp);
 
         if (groups.TryGetValue(TandemEventClass.Bolus, out var bolusEvents))
         {
             var decomposed = bolus.Map(bolusEvents);
             await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabled,
-                decomposed.Boluses, PublishBolusDataAsync, config, cancellationToken);
+                decomposed.Boluses, PublishBolusDataAsync, config, cancellationToken,
+                timestampOf: b => b.Timestamp);
             await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabled,
-                decomposed.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken);
+                decomposed.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken,
+                timestampOf: c => c.Timestamp);
             await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, enabled,
-                decomposed.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken);
+                decomposed.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken,
+                timestampOf: b => b.Timestamp);
         }
 
         if (groups.TryGetValue(TandemEventClass.Basal, out var basalEvents))
             await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabled,
                 basal.Map(basalEvents, windowEnd, config.IgnoreZeroUnitBasal), PublishTempBasalDataAsync,
-                config, cancellationToken);
+                config, cancellationToken, timestampOf: t => t.StartTimestamp);
 
         var devEvents = Concat(groups, TandemEventClass.Cartridge, TandemEventClass.CgmStartJoinStop,
             TandemEventClass.BasalSuspension, TandemEventClass.BasalResume);
         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabled,
-            deviceEvents.Map(devEvents), PublishDeviceEventDataAsync, config, cancellationToken);
+            deviceEvents.Map(devEvents), PublishDeviceEventDataAsync, config, cancellationToken,
+            timestampOf: d => d.Timestamp);
 
         // Alarms and CGM alerts are gated and accounted under DeviceEvents — there is no dedicated
         // SyncDataType for them — so a publish failure flips Success.
         var sysEvents = Concat(groups, TandemEventClass.Alarm, TandemEventClass.CgmAlert);
         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabled,
-            systemEvents.Map(sysEvents), PublishSystemEventDataAsync, config, cancellationToken);
+            systemEvents.Map(sysEvents), PublishSystemEventDataAsync, config, cancellationToken,
+            timestampOf: e => TimestampFromMills(e.Mills));
 
         if (groups.TryGetValue(TandemEventClass.UserMode, out var userModeEvents))
             await PublishRecordTypeAsync(result, SyncDataType.StateSpans, enabled,
-                userMode.Map(userModeEvents), PublishStateSpanDataAsync, config, cancellationToken);
+                userMode.Map(userModeEvents), PublishStateSpanDataAsync, config, cancellationToken,
+                timestampOf: s => s.StartTimestamp);
 
         if (groups.TryGetValue(TandemEventClass.DeviceStatus, out var dailyBasal))
             await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, enabled,
-                deviceStatus.Map(dailyBasal), PublishDeviceStatusAsync, config, cancellationToken);
+                deviceStatus.Map(dailyBasal), PublishDeviceStatusAsync, config, cancellationToken,
+                timestampOf: d => TimestampFromMills(d.Mills));
     }
 
     private async Task<TandemPumpLogsResponse?> FetchWindowAsync(

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -56,8 +56,7 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TidepoolConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null)
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
@@ -96,27 +95,9 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
                     request.From, request.To);
 
                 if (bgValues != null)
-                {
-                    var sgList = _sensorGlucoseMapper.MapBgValues(bgValues).ToList();
-                    result.ItemsSynced[SyncDataType.Glucose] = sgList.Count;
-                    if (sgList.Count > 0)
-                    {
-                        result.LastEntryTimes[SyncDataType.Glucose] = DateTimeOffset
-                            .FromUnixTimeMilliseconds(sgList.Max(s => s.Mills)).UtcDateTime;
-                        var publishSuccess = await PublishSensorGlucoseDataAsync(sgList, config, cancellationToken);
-                        if (!publishSuccess)
-                        {
-                            result.Success = false;
-                            result.Errors.Add("Glucose publish failed");
-                        }
-                        else
-                        {
-                            _logger.LogInformation(
-                                "[{ConnectorSource}] Synced {Count} SensorGlucose records from Tidepool",
-                                ConnectorSource, sgList.Count);
-                        }
-                    }
-                }
+                    await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
+                        _sensorGlucoseMapper.MapBgValues(bgValues).ToList(), PublishSensorGlucoseDataAsync,
+                        config, cancellationToken, "Tidepool", s => s.Timestamp);
             }
             catch (Exception ex)
             {

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -59,11 +59,10 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TwiistConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null)
+        CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
+        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
 
         try
         {
@@ -92,25 +91,25 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
             // Glucose from binary blob
             if (enabledTypes.Contains(SyncDataType.Glucose))
             {
-                await SyncGlucoseAsync(package.Status, result, config, cancellationToken);
+                await SyncGlucoseAsync(package.Status, result, enabledTypes, config, cancellationToken);
             }
 
             // Boluses from insulin history
             if (enabledTypes.Contains(SyncDataType.Boluses))
             {
-                await SyncBolusesAsync(package.Status, result, config, cancellationToken);
+                await SyncBolusesAsync(package.Status, result, enabledTypes, config, cancellationToken);
             }
 
             // Carbs from meal history
             if (enabledTypes.Contains(SyncDataType.CarbIntake))
             {
-                await SyncCarbIntakeAsync(package.Status, result, config, cancellationToken);
+                await SyncCarbIntakeAsync(package.Status, result, enabledTypes, config, cancellationToken);
             }
 
             // Temp basals from the insulin-delivery blob (closed-loop enacted rates)
             if (enabledTypes.Contains(SyncDataType.TempBasals))
             {
-                await SyncTempBasalsAsync(package.Status, result, config, cancellationToken);
+                await SyncTempBasalsAsync(package.Status, result, enabledTypes, config, cancellationToken);
             }
         }
         catch (OperationCanceledException)
@@ -130,7 +129,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     }
 
     private async Task SyncGlucoseAsync(
-        TwiistStatus status, SyncResult result,
+        TwiistStatus status, SyncResult result, HashSet<SyncDataType> enabledTypes,
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var glucoseRecords = TwiistBlobDecoder.ParseGlucoseRecords(status.GlucoseHistory?.Data);
@@ -150,101 +149,41 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
             latest.Direction = TwiistGlucoseMapper.ParseTrend(status.Summary.LastGlucoseTrend);
         }
 
-        if (sensorGlucose.Count > 0)
-        {
-            var success = await PublishSensorGlucoseDataAsync(sensorGlucose, config, cancellationToken);
-            result.ItemsSynced[SyncDataType.Glucose] = sensorGlucose.Count;
-            result.LastEntryTimes[SyncDataType.Glucose] = DateTimeOffset
-                .FromUnixTimeMilliseconds(sensorGlucose.Max(s => s.Mills))
-                .UtcDateTime;
-
-            if (!success)
-            {
-                result.Success = false;
-                result.Errors.Add("SensorGlucose publish failed");
-            }
-            else
-            {
-                _logger.LogInformation("[{Source}] Synced {Count} glucose records from Twiist",
-                    ConnectorSource, sensorGlucose.Count);
-            }
-        }
+        await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+            sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken,
+            "Twiist", s => s.Timestamp);
     }
 
     private async Task SyncBolusesAsync(
-        TwiistStatus status, SyncResult result,
+        TwiistStatus status, SyncResult result, HashSet<SyncDataType> enabledTypes,
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        var boluses = _insulinMapper.MapBoluses(status.InsulinHistory).ToList();
-        if (boluses.Count == 0) return;
-
-        var success = await PublishBolusDataAsync(boluses, config, cancellationToken);
-        result.ItemsSynced[SyncDataType.Boluses] = boluses.Count;
-        result.LastEntryTimes[SyncDataType.Boluses] = DateTimeOffset
-            .FromUnixTimeMilliseconds(boluses.Max(b => b.Mills))
-            .UtcDateTime;
-
-        if (!success)
-        {
-            result.Success = false;
-            result.Errors.Add("Bolus publish failed");
-        }
-        else
-        {
-            _logger.LogInformation("[{Source}] Synced {Count} bolus records from Twiist",
-                ConnectorSource, boluses.Count);
-        }
+        await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabledTypes,
+            _insulinMapper.MapBoluses(status.InsulinHistory).ToList(), PublishBolusDataAsync,
+            config, cancellationToken, "Twiist", b => b.Timestamp);
     }
 
     private async Task SyncCarbIntakeAsync(
-        TwiistStatus status, SyncResult result,
+        TwiistStatus status, SyncResult result, HashSet<SyncDataType> enabledTypes,
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        var carbs = _mealMapper.MapMeals(status.MealHistory).ToList();
-        if (carbs.Count == 0) return;
-
-        var success = await PublishCarbIntakeDataAsync(carbs, config, cancellationToken);
-        result.ItemsSynced[SyncDataType.CarbIntake] = carbs.Count;
-        result.LastEntryTimes[SyncDataType.CarbIntake] = DateTimeOffset
-            .FromUnixTimeMilliseconds(carbs.Max(c => c.Mills))
-            .UtcDateTime;
-
-        if (!success)
-        {
-            result.Success = false;
-            result.Errors.Add("CarbIntake publish failed");
-        }
-        else
-        {
-            _logger.LogInformation("[{Source}] Synced {Count} meal records from Twiist",
-                ConnectorSource, carbs.Count);
-        }
+        await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabledTypes,
+            _mealMapper.MapMeals(status.MealHistory).ToList(), PublishCarbIntakeDataAsync,
+            config, cancellationToken, "Twiist", c => c.Timestamp);
     }
 
     private async Task SyncTempBasalsAsync(
-        TwiistStatus status, SyncResult result,
+        TwiistStatus status, SyncResult result, HashSet<SyncDataType> enabledTypes,
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var scheduledRate = _tempBasalMapper.ParseScheduledRate(status.Details?.BasalRateUnitsPerHour);
         var tempBasals = _tempBasalMapper.MapTempBasals(status.InsulinDelivery?.Data, scheduledRate)
             .Concat(_tempBasalMapper.MapSuspensions(status.InsulinHistory))
             .ToList();
-        if (tempBasals.Count == 0) return;
 
-        var success = await PublishTempBasalDataAsync(tempBasals, config, cancellationToken);
-        result.ItemsSynced[SyncDataType.TempBasals] = tempBasals.Count;
-        result.LastEntryTimes[SyncDataType.TempBasals] = tempBasals.Max(t => t.StartTimestamp);
-
-        if (!success)
-        {
-            result.Success = false;
-            result.Errors.Add("TempBasal publish failed");
-        }
-        else
-        {
-            _logger.LogInformation("[{Source}] Synced {Count} temp basal records from Twiist",
-                ConnectorSource, tempBasals.Count);
-        }
+        await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabledTypes,
+            tempBasals, PublishTempBasalDataAsync, config, cancellationToken,
+            "Twiist", t => t.StartTimestamp);
     }
 
     /// <summary>

--- a/src/Web/packages/app/src/lib/utils/sync-messages.ts
+++ b/src/Web/packages/app/src/lib/utils/sync-messages.ts
@@ -4,7 +4,6 @@ import { getDataTypeLabel } from "./data-type-labels";
 const MESSAGE_TEMPLATES: Record<SyncMessageType, string> = {
 	Authenticating: "Authenticating...",
 	FetchingData: "Fetching data from {from} to {to}...",
-	FetchingDataType: "Fetching {dataType}...",
 	ProcessingDataType: "Processing {dataType}...",
 	PublishingDataType: "Publishing {count} {dataType} records...",
 	SyncComplete: "Sync complete",

--- a/src/Web/packages/app/src/lib/websocket/types.ts
+++ b/src/Web/packages/app/src/lib/websocket/types.ts
@@ -88,7 +88,6 @@ export interface NotificationUpdateEvent {
 export type SyncMessageType =
   | "Authenticating"
   | "FetchingData"
-  | "FetchingDataType"
   | "ProcessingDataType"
   | "PublishingDataType"
   | "SyncComplete"

--- a/tests/Integration/Nocturne.Connectors.Tests/BaseConnectorServiceTests.cs
+++ b/tests/Integration/Nocturne.Connectors.Tests/BaseConnectorServiceTests.cs
@@ -136,8 +136,7 @@ public class TestConnectorService : BaseConnectorService<TestConnectorConfigurat
     protected override Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TestConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null)
+        CancellationToken cancellationToken)
         => throw new NotSupportedException();
 
     // Public wrapper for testing protected method

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
@@ -35,8 +35,7 @@ public class BaseConnectorServiceTests
         protected override Task<SyncResult> PerformSyncInternalAsync(
             SyncRequest request,
             TestConfig config,
-            CancellationToken cancellationToken,
-            ISyncProgressReporter? progressReporter = null)
+            CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
         // Exposes the protected retry helper so its attempt-count behaviour can be tested directly.

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
@@ -1,0 +1,305 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Services;
+
+/// <summary>
+///     Covers the bookkeeping the shared publish path owns for every connector:
+///     <see cref="SyncResult.LastEntryTimes"/> and per-type publish progress.
+/// </summary>
+public class PublishRecordTypePathTests
+{
+    private sealed class TimedRecord
+    {
+        public DateTime? At { get; init; }
+    }
+
+    private sealed class TestConfig : BaseConnectorConfiguration
+    {
+        protected override void ValidateSourceSpecificConfiguration() { }
+    }
+
+    private sealed class TestConnectorService : BaseConnectorService<TestConfig>
+    {
+        private readonly Func<SyncResult, CancellationToken, Task> _syncBody;
+
+        public TestConnectorService(Func<SyncResult, CancellationToken, Task> syncBody)
+            : base(new HttpClient(),
+                new ConnectorServerResolver<TestConfig>(null, null, null),
+                NullLogger<TestConnectorService>.Instance)
+        {
+            _syncBody = syncBody;
+        }
+
+        protected override string ConnectorSource => "test";
+        public override string ServiceName => "Test";
+
+        public override Task<bool> AuthenticateAsync() => Task.FromResult(true);
+
+        protected override async Task<SyncResult> PerformSyncInternalAsync(
+            SyncRequest request,
+            TestConfig config,
+            CancellationToken cancellationToken)
+        {
+            var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
+            await _syncBody(result, cancellationToken);
+            return result;
+        }
+
+        public Task PublishAsync(
+            SyncResult result,
+            SyncDataType dataType,
+            HashSet<SyncDataType> activeTypes,
+            List<TimedRecord> records,
+            Func<TimedRecord, DateTime?>? timestampOf,
+            bool publishSucceeds = true,
+            CancellationToken cancellationToken = default)
+            => PublishRecordTypeAsync(result, dataType, activeTypes, records,
+                (_, _, _) => Task.FromResult(publishSucceeds),
+                new TestConfig(), cancellationToken, timestampOf: timestampOf);
+    }
+
+    private static readonly DateTime Older = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Newer = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static Task<SyncResult> RunAsync(
+        Func<TestConnectorService, SyncResult, Task> body,
+        ISyncProgressReporter? reporter = null)
+    {
+        TestConnectorService? service = null;
+        service = new TestConnectorService((result, _) => body(service!, result));
+        return service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            new TestConfig(),
+            CancellationToken.None,
+            reporter);
+    }
+
+    [Fact]
+    public async Task LastEntryTimes_LaterBatchWithOlderMax_DoesNotRegressTheValue()
+    {
+        // Arrange: two batches for the same type, the newer data published first — the order a
+        // paginated or chunked crawl can easily produce.
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        // Act
+        var result = await RunAsync(async (service, syncResult) =>
+        {
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Newer }], r => r.At);
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Older }], r => r.At);
+        });
+
+        // Assert: max-compare, not assignment
+        result.LastEntryTimes[SyncDataType.Glucose].Should().Be(Newer);
+    }
+
+    [Fact]
+    public async Task LastEntryTimes_LaterBatchWithNewerMax_RaisesTheValue()
+    {
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        var result = await RunAsync(async (service, syncResult) =>
+        {
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Older }], r => r.At);
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Newer }], r => r.At);
+        });
+
+        result.LastEntryTimes[SyncDataType.Glucose].Should().Be(Newer);
+    }
+
+    [Fact]
+    public async Task LastEntryTimes_ExistingNullValue_IsRaised()
+    {
+        // Arrange: lifted comparison against null is false, so a null-valued entry would survive
+        // a plain `newest > existing` guard forever.
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        // Act
+        var result = await RunAsync(async (service, syncResult) =>
+        {
+            syncResult.LastEntryTimes[SyncDataType.Glucose] = null;
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Older }], r => r.At);
+        });
+
+        // Assert
+        result.LastEntryTimes[SyncDataType.Glucose].Should().Be(Older);
+    }
+
+    [Fact]
+    public async Task LastEntryTimes_NoSelector_RecordsNothing()
+    {
+        // Arrange: a record type that carries no time opts out by passing no selector.
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        // Act
+        var result = await RunAsync((service, syncResult) =>
+            service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Newer }], timestampOf: null));
+
+        // Assert: the batch still counts, it just has no time to report
+        result.ItemsSynced[SyncDataType.Glucose].Should().Be(1);
+        result.LastEntryTimes.Should().NotContainKey(SyncDataType.Glucose);
+    }
+
+    [Fact]
+    public async Task LastEntryTimes_SelectorReturnsNullForEveryRecord_RecordsNothing()
+    {
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        var result = await RunAsync((service, syncResult) =>
+            service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = null }], r => r.At));
+
+        result.LastEntryTimes.Should().NotContainKey(SyncDataType.Glucose);
+    }
+
+    [Fact]
+    public async Task InactiveType_RecordsNothing()
+    {
+        // Arrange: the tenant has the type switched off
+        var active = new HashSet<SyncDataType> { SyncDataType.Boluses };
+
+        // Act
+        var result = await RunAsync((service, syncResult) =>
+            service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Newer }], r => r.At));
+
+        // Assert
+        result.LastEntryTimes.Should().BeEmpty();
+        result.ItemsSynced.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EmptyBatch_RecordsNothing()
+    {
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        var result = await RunAsync((service, syncResult) =>
+            service.PublishAsync(syncResult, SyncDataType.Glucose, active, [], r => r.At));
+
+        result.LastEntryTimes.Should().BeEmpty();
+        result.ItemsSynced.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FailedPublish_StillRecordsLastEntryTime()
+    {
+        // Arrange: LastEntryTimes reports what the sync saw, matching ItemsSynced, which the same
+        // helper already counts regardless of publish outcome.
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        // Act
+        var result = await RunAsync((service, syncResult) =>
+            service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Newer }], r => r.At, publishSucceeds: false));
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.LastEntryTimes[SyncDataType.Glucose].Should().Be(Newer);
+    }
+
+    [Fact]
+    public async Task Progress_EmitsPublishingDataTypePerPublishedBatch()
+    {
+        // Arrange
+        var reported = new List<SyncProgressEvent>();
+        var reporter = new Mock<ISyncProgressReporter>();
+        reporter
+            .Setup(r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<SyncProgressEvent, CancellationToken>((e, _) => reported.Add(e))
+            .Returns(Task.CompletedTask);
+
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose, SyncDataType.Boluses };
+
+        // Act
+        await RunAsync(async (service, syncResult) =>
+        {
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Newer }, new TimedRecord { At = Older }], r => r.At);
+            await service.PublishAsync(syncResult, SyncDataType.Boluses, active,
+                [new TimedRecord { At = Newer }], r => r.At);
+        }, reporter.Object);
+
+        // Assert
+        reported.Should().HaveCount(2);
+        reported.Should().OnlyContain(e => e.MessageType == SyncMessageType.PublishingDataType
+                                        && e.Phase == SyncPhase.Syncing
+                                        && e.ConnectorId == "test");
+        reported[0].MessageParams.Should().Contain("dataType", nameof(SyncDataType.Glucose))
+            .And.Contain("count", "2");
+        reported[1].MessageParams.Should().Contain("dataType", nameof(SyncDataType.Boluses))
+            .And.Contain("count", "1");
+    }
+
+    [Fact]
+    public async Task Progress_SkippedPublishEmitsNothing()
+    {
+        // Arrange
+        var reporter = new Mock<ISyncProgressReporter>();
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        // Act: one gated-off type and one empty batch
+        await RunAsync(async (service, syncResult) =>
+        {
+            await service.PublishAsync(syncResult, SyncDataType.Boluses, active,
+                [new TimedRecord { At = Newer }], r => r.At);
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active, [], r => r.At);
+        }, reporter.Object);
+
+        // Assert
+        reporter.Verify(
+            r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Progress_NoReporter_PublishesWithoutReporting()
+    {
+        // Arrange
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        // Act
+        var result = await RunAsync((service, syncResult) =>
+            service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Newer }], r => r.At));
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ItemsSynced[SyncDataType.Glucose].Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Progress_NotCarriedAcrossRuns()
+    {
+        // Arrange: the reporter is per-run state on a per-run service instance, so a publish
+        // outside a sync run must not reach the previous run's reporter.
+        var reporter = new Mock<ISyncProgressReporter>();
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+        TestConnectorService? captured = null;
+
+        await RunAsync((service, syncResult) =>
+        {
+            captured = service;
+            return Task.CompletedTask;
+        }, reporter.Object);
+
+        // Act
+        await captured!.PublishAsync(new SyncResult(), SyncDataType.Glucose, active,
+            [new TimedRecord { At = Newer }], r => r.At);
+
+        // Assert
+        reporter.Verify(
+            r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SupportedDataTypesFromRegistrationTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SupportedDataTypesFromRegistrationTests.cs
@@ -35,8 +35,7 @@ public class SupportedDataTypesFromRegistrationTests
         protected override Task<SyncResult> PerformSyncInternalAsync(
             SyncRequest request,
             TConfig config,
-            CancellationToken cancellationToken,
-            ISyncProgressReporter? progressReporter = null)
+            CancellationToken cancellationToken)
             => throw new NotSupportedException();
     }
 


### PR DESCRIPTION
Fixes #818, #819, #824.

## What

The shared publish path now owns the sync bookkeeping the connectors each hand-rolled:

**#819 — `LastEntryTimes`.** `PublishRecordTypeAsync` takes an optional `Func<T, DateTime?>` timestamp selector (nullable at both levels: omitted = type carries no time; null return = record carries none) and max-compares — the correct semantics where the nine per-connector copies disagreed between assignment and max. Deleted: Glooko's private helper, MyLife's inline compare, the verbatim re-implementations in Dexcom/Eversense/LibreLinkUp/Tidepool/Twiist, Nightscout's plain profile site, and NocturneRemote's entire `(count, lastTime, success)` tuple plumbing across 12 methods. Kept with a documented reason: Nightscout's four crawl sites, whose `NewestTime` spans every page plus the low-water-mark resume the publish path never sees. Tandem, CareLink, MyLife and Glooko types that never recorded times now do — the issue's headline. Verified independently at review: **nothing reads `LastEntryTimes` anywhere** (writers only), so the record-on-failed-publish choice matches `ItemsSynced` and can mislead no consumer; filed separately as its own question.

**#818 — progress.** The shared path emits `PublishingDataType` per published batch. Carriage is an instance field set/cleared by one wrapper around both base call sites — justified by the DI evidence (connector services are transient typed HTTP clients, resolved fresh per sync) and by the identical pre-existing pattern (`_glucosePublishOrigin` memos, CareLink's `_accessToken`). Consequence: `progressReporter` became dead in all twelve `PerformSyncInternalAsync` overrides and is removed from the abstract signature — the plumbing that carried nothing. `FetchingDataType` is deleted end-to-end (enum + frontend string + union member): no shared fetch seam exists, and faking a fetch signal would be worse than removing dead vocabulary.

**#824 — the Glooko banners** in both the V2 and V3 blocks (the issue cited only V2; the V3 block carried identical copies), keeping only the comments with real content — the carb/food ordering constraint, the pen-injection mapping, and the shared device/system-event counter fact.

## Testing

11 new base-path tests (max-compare both directions incl. the lifted-null subtlety, selector opt-outs, gate/empty skips, record-on-failure, progress per batch, absent-reporter no-op, reporter-not-carried-across-runs). Mutation-proven: max→assignment fails exactly the regression test. All 11 connector suites: 533/0; API: 5760/0/5 skipped. No existing expectation needed changing.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
