### PR TITLE
fix(auth): mark recovery-session tokens with an unmintable scope

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -62,6 +62,20 @@ public class PasskeyController : ControllerBase
     private static readonly TimeSpan RecoverySessionLifetime = TimeSpan.FromMinutes(10);
 
     /// <summary>
+    /// What makes a token a recovery session, as opposed to any credential that merely carries
+    /// <see cref="RecoverySessionPermission"/>. It sits outside
+    /// <see cref="Core.Models.Authorization.OAuthScopes.ValidRequestScopes"/>, so no client can
+    /// register it and no scope gate resolves anything from it, leaving
+    /// <see cref="RecoveryVerify"/> its only source.
+    /// </summary>
+    private const string RecoverySessionScope = "auth:recovery:enrol";
+
+    /// <summary>
+    /// The authority a recovery session confers: enrol a replacement passkey, nothing else.
+    /// </summary>
+    private const string RecoverySessionPermission = "passkey:manage";
+
+    /// <summary>
     /// Shown for every recovery-mode refusal so the response never distinguishes an unknown
     /// username from an account that still has a working sign-in method.
     /// </summary>
@@ -195,7 +209,8 @@ public class PasskeyController : ControllerBase
         if (!validation.IsValid || validation.Claims is null)
             return null;
 
-        return validation.Claims.Permissions.Contains("passkey:manage")
+        return validation.Claims.Scopes.Contains(RecoverySessionScope)
+            && validation.Claims.Permissions.Contains(RecoverySessionPermission)
             ? validation.Claims.SubjectId
             : null;
     }
@@ -644,8 +659,9 @@ public class PasskeyController : ControllerBase
 
         var recoveryToken = _jwtService.GenerateAccessToken(
             subjectInfo,
-            permissions: ["passkey:manage"],
+            permissions: [RecoverySessionPermission],
             roles: [],
+            scopes: [RecoverySessionScope],
             lifetime: RecoverySessionLifetime);
 
         var cookieOptions = RecoveryCookieOptions();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -190,7 +190,14 @@ public class PasskeyControllerTests : IDisposable
         };
 
     /// <summary>Presents a recovery-session cookie that the JWT service accepts for this subject.</summary>
-    private void GiveRecoverySession(Guid subjectId, params string[] permissions)
+    private void GiveRecoverySession(Guid subjectId, params string[] permissions) =>
+        GiveRecoveryCookie(subjectId, ["auth:recovery:enrol"], permissions);
+
+    /// <summary>
+    /// Presents a cookie carrying whatever claim shape the caller names, so a token that is not a
+    /// recovery session can be put where one is expected.
+    /// </summary>
+    private void GiveRecoveryCookie(Guid subjectId, string[] scopes, string[] permissions)
     {
         const string token = "recovery-token";
         _controller.ControllerContext.HttpContext.Request.Headers.Cookie =
@@ -200,6 +207,7 @@ public class PasskeyControllerTests : IDisposable
             .Returns(JwtValidationResult.Success(new JwtClaims
             {
                 SubjectId = subjectId,
+                Scopes = [.. scopes],
                 Permissions = [.. permissions],
             }));
     }
@@ -342,6 +350,23 @@ public class PasskeyControllerTests : IDisposable
     {
         var subjectId = await SeedMemberAsync("owner", withPasskey: true);
         GiveRecoverySession(subjectId, "glucose.read");
+
+        var result = await _controller.RegisterOptions(
+            new PasskeyRegisterOptionsRequest { Username = "owner" });
+
+        Assert.Equal(401, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RegisterOptions_WithAPasskeyManageTokenThatIsNotARecoverySession_IsRefused()
+    {
+        // Spending a recovery code is what buys an enrolment. A token that merely carries the same
+        // permission — anything a future mint site emits — is not that proof.
+        var subjectId = await SeedMemberAsync("owner", withPasskey: true);
+        GiveRecoveryCookie(subjectId, scopes: [], permissions: ["passkey:manage"]);
 
         var result = await _controller.RegisterOptions(
             new PasskeyRegisterOptionsRequest { Username = "owner" });

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyRecoverySessionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyRecoverySessionTests.cs
@@ -77,6 +77,15 @@ public class PasskeyRecoverySessionTests : IClassFixture<AuthenticationTestFacto
     }
 
     [Fact]
+    public async Task A_passkey_manage_token_that_is_not_a_recovery_session_cannot_enrol_a_passkey()
+    {
+        var response = await PostAsync(
+            "register/options", new { username = Username }, SessionShapedPasskeyManageToken());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
     public async Task No_recovery_session_cannot_enrol_a_passkey()
     {
         var response = await PostAsync("register/options", new { username = Username }, cookie: null);
@@ -117,6 +126,19 @@ public class PasskeyRecoverySessionTests : IClassFixture<AuthenticationTestFacto
             notBefore: DateTime.UtcNow.AddMinutes(-20),
             expires: DateTime.UtcNow.AddMinutes(-10),
             signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256)));
+    }
+
+    /// <summary>
+    /// A token the API itself signs and would honour as a session, carrying the permission a
+    /// recovery session carries but nothing that says a recovery code bought it.
+    /// </summary>
+    private string SessionShapedPasskeyManageToken()
+    {
+        using var scope = _factory.Services.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<IJwtService>().GenerateAccessToken(
+            new SubjectInfo { Id = TestDatabaseSeeder.TestSubjectId },
+            permissions: ["passkey:manage"],
+            roles: []);
     }
 
     /// <summary>Spends a freshly issued recovery code and returns the recovery-session token.</summary>


### PR DESCRIPTION
Fixes #849.

## What

`TryReadRecoverySessionSubject` accepted any valid JWT carrying a `passkey:manage` permission. The recovery token is now marked by the scope `auth:recovery:enrol` — the CareLink desktop-token convention: a colon-form scope outside `OAuthScopes.ValidRequestScopes`, so no client can register it, no scope gate resolves anything from it, and `RecoveryVerify` is its only source. The check requires both the scope and the permission; the two literals became named constants at one site.

**Bonus hardening**: the recovery token was previously *session-shaped* (no scopes), so `SessionCookieHandler.IsGrantShaped` returned false — pasting the recovery cookie's value into the access-token cookie yielded a **full session**. Carrying a scope makes it grant-shaped and refused in that position.

## Review gates

Two-stage. The hostile review (fresh-context) attacked both claims and reported SURVIVES with work shown: every `GenerateAccessToken` call site enumerated (the scope is unmintable — `passkey:manage` appears nowhere else in src/, `Normalize` drops unregistered scopes, no refresh/exchange path copies inbound claims); the `IsGrantShaped` refusal verified against the actual predicate; scope parsing checked for case/space smuggling (ordinal, single constant — moot anyway); no legitimate flow regressed; the ≤10-min rollout window bounded by the JWT `exp`. Its own mutation (dropping the permission arm) was caught by a dedicated test, proving both arms are covered — plus the author's mutation (dropping the scope arm) fails two named tests.

## Testing

Passkey suite 86/0; full API suite 5766/0/5 skipped.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
