### PR TITLE
fix(carelink): declare DeviceEvents so system events are gateable and counted

### DIFF
--- a/src/Connectors/Nocturne.Connectors.CareLink/Configurations/CareLinkConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Configurations/CareLinkConnectorConfiguration.cs
@@ -11,7 +11,7 @@ namespace Nocturne.Connectors.CareLink.Configurations;
     "Medtronic CareLink",
     SupportsHistoricalSync = false,
     SupportsManualSync = true,
-    SupportedDataTypes = [SyncDataType.Glucose, SyncDataType.DeviceStatus, SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.TempBasals, SyncDataType.StateSpans],
+    SupportedDataTypes = [SyncDataType.Glucose, SyncDataType.DeviceStatus, SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.TempBasals, SyncDataType.StateSpans, SyncDataType.DeviceEvents],
     DefaultActiveThresholdMinutes = 10,
     DefaultStaleThresholdMinutes = 30
 )]

--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -134,7 +134,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
 
         await PublishSensorGlucoseStepAsync(data, config, enabledTypes, isStale, result, cancellationToken);
         await PublishDeviceStatusStepAsync(data, config, enabledTypes, result, cancellationToken);
-        await PublishAlarmStepAsync(data, config, result, cancellationToken);
+        await PublishAlarmStepAsync(data, config, enabledTypes, result, cancellationToken);
         await PublishTreatmentsStepAsync(data, config, enabledTypes, result, cancellationToken);
 
         // Persist refresh token if it changed during sync
@@ -334,13 +334,15 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     }
 
     /// <summary>
-    ///     Publishes the latest alarm as a SystemEvent, deduped by datetime+code. A rejected publish
-    ///     fails the sync and leaves the dedup key behind so the next cycle retries the same alarm;
+    ///     Publishes the latest alarm as a SystemEvent, deduped by datetime+code. An alarm that did
+    ///     not reach the tenant leaves the dedup key behind so the next cycle retries it;
     ///     a transport exception is only logged, matching the pre-existing policy for this step.
+    ///     Gating and counting follow <see cref="PublishSystemEventDataAsync"/>.
     /// </summary>
     private async Task PublishAlarmStepAsync(
         CareLinkData data,
         CareLinkConnectorConfiguration config,
+        HashSet<SyncDataType> enabledTypes,
         SyncResult result,
         CancellationToken cancellationToken)
     {
@@ -355,20 +357,11 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
                 var pumpOffsetMs = Utilities.CareLinkTimestampParser.CalculatePumpOffsetMs(
                     data.MedicalDeviceTime ?? "", data.CurrentServerTime);
                 var systemEvent = CareLinkSystemEventMapper.Map(data.LastAlarm, pumpOffsetMs, data.CurrentServerTime);
-                if (systemEvent != null)
-                {
-                    if (await PublishSystemEventDataAsync([systemEvent], config, cancellationToken))
-                    {
-                        _lastAlarmKey = alarmKey;
-                        _logger.LogInformation("[{ConnectorSource}] Published alarm event {Code}",
-                            ConnectorSource, data.LastAlarm.Code);
-                    }
-                    else
-                    {
-                        result.Success = false;
-                        result.Errors.Add("Alarm event publish failed");
-                    }
-                }
+                if (systemEvent != null
+                    && await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabledTypes,
+                        [systemEvent], PublishSystemEventDataAsync, config, cancellationToken,
+                        context: "the last alarm", timestampOf: e => TimestampFromMills(e.Mills)))
+                    _lastAlarmKey = alarmKey;
             }
         }
         catch (OperationCanceledException) { throw; }
@@ -411,20 +404,10 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
                 CareLinkTreatmentMapper.MapTempBasals(data, pumpOffsetMs), PublishTempBasalDataAsync,
                 config, cancellationToken, timestampOf: t => t.StartTimestamp);
 
-            // Not routed through PublishRecordTypeAsync: system events would have to be gated and
-            // counted under DeviceEvents, which CareLink does not declare supported, so the helper
-            // would suppress them outright.
-            var notifications = CareLinkSystemEventMapper.MapNotifications(data.NotificationHistory, pumpOffsetMs);
-            if (notifications.Count > 0)
-            {
-                if (await PublishSystemEventDataAsync(notifications, config, cancellationToken))
-                    _logger.LogInformation("[{ConnectorSource}] Synced {Count} notification events", ConnectorSource, notifications.Count);
-                else
-                {
-                    result.Success = false;
-                    result.Errors.Add("Notification events publish failed");
-                }
-            }
+            await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabledTypes,
+                CareLinkSystemEventMapper.MapNotifications(data.NotificationHistory, pumpOffsetMs),
+                PublishSystemEventDataAsync, config, cancellationToken,
+                context: "notification history", timestampOf: e => TimestampFromMills(e.Mills));
         }
         catch (OperationCanceledException) { throw; }
         catch (HttpRequestException ex)

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -611,7 +611,10 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
-    ///     Submits system event data directly to the API via HTTP
+    ///     Submits system event data directly to the API via HTTP. System events have no
+    ///     <see cref="SyncDataType"/> of their own, so a connector routing them through
+    ///     <see cref="PublishRecordTypeAsync{T}"/> gates and counts them under
+    ///     <see cref="SyncDataType.DeviceEvents"/>.
     /// </summary>
     protected virtual async Task<bool> PublishSystemEventDataAsync(
         IEnumerable<SystemEvent> systemEvents,
@@ -642,7 +645,11 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     ///     <c>null</c> — the parameter or an individual return — means the record carries no time
     ///     to report, and nothing is recorded for the type.
     /// </param>
-    protected async Task PublishRecordTypeAsync<T>(
+    /// <returns>
+    ///     Whether the batch reached the tenant. An inactive type, an empty batch and a rejected
+    ///     publish are alike <c>false</c>: no record was accepted in any of them.
+    /// </returns>
+    protected async Task<bool> PublishRecordTypeAsync<T>(
         SyncResult result,
         SyncDataType dataType,
         HashSet<SyncDataType> activeTypes,
@@ -653,7 +660,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         string? context = null,
         Func<T, DateTime?>? timestampOf = null) where T : class
     {
-        if (!activeTypes.Contains(dataType) || records.Count == 0) return;
+        if (!activeTypes.Contains(dataType) || records.Count == 0) return false;
 
         await ReportSyncMessageAsync(SyncMessageType.PublishingDataType,
             new() { ["count"] = records.Count.ToString(), ["dataType"] = dataType.ToString() },
@@ -674,6 +681,8 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             _logger.LogInformation("Synced {Count} {Type} records{Context}",
                 records.Count, dataType, ctx);
         }
+
+        return success;
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -629,8 +629,8 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 result.ItemsSynced[SyncDataType.TempBasals] = tempBasals.Count;
         }
 
-        // Device events and system events share one ItemsSynced entry: Glooko declares no separate
-        // system-event toggle, so both are gated and counted under DeviceEvents.
+        // Device events and system events share one ItemsSynced entry — see
+        // <see cref="BaseConnectorService{TConfig}.PublishSystemEventDataAsync"/>.
         if (activeTypes.Contains(SyncDataType.DeviceEvents))
         {
             var deviceEventCount = 0;

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -237,8 +237,6 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             deviceEvents.Map(devEvents), PublishDeviceEventDataAsync, config, cancellationToken,
             timestampOf: d => d.Timestamp);
 
-        // Alarms and CGM alerts are gated and accounted under DeviceEvents — there is no dedicated
-        // SyncDataType for them — so a publish failure flips Success.
         var sysEvents = Concat(groups, TandemEventClass.Alarm, TandemEventClass.CgmAlert);
         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabled,
             systemEvents.Map(sysEvents), PublishSystemEventDataAsync, config, cancellationToken,

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
@@ -111,9 +111,60 @@ public class CareLinkConnectorServiceTests
             new SyncRequest(), fixture.Config, CancellationToken.None);
 
         first.Success.Should().BeFalse("an alarm that never reached the tenant is not a successful sync");
-        first.Errors.Should().Contain("Alarm event publish failed");
-        second.Errors.Should().Contain("Alarm event publish failed",
+        first.Errors.Should().Contain("DeviceEvents publish failed");
+        second.Errors.Should().Contain("DeviceEvents publish failed",
             "the dedup key must not advance past an alarm that was never published");
+        second.ItemsSynced.GetValueOrDefault(SyncDataType.DeviceEvents).Should().Be(1,
+            "the second cycle must attempt the same alarm again");
+    }
+
+    /// <summary>
+    /// Both system-event paths — the last alarm and the notification history — are gated and counted
+    /// under the DeviceEvents toggle, which a CareLink tenant that never saw the toggle has on.
+    /// </summary>
+    [Theory]
+    [InlineData(true, 2)]
+    [InlineData(false, 0)]
+    public async Task SyncDataAsync_GatesSystemEventsOnTheDeviceEventsToggle(
+        bool syncDeviceEvents, int expectedCount)
+    {
+        var handler = new CareLinkFakeHandler
+        {
+            MonitorDataJson = """
+                {
+                  "currentServerTime": 1767261600000,
+                  "lastSG": {},
+                  "lastAlarm": {
+                    "type": "PUMP_SUSPEND",
+                    "code": 816,
+                    "flash": true,
+                    "datetime": "2026-01-01T10:00:00"
+                  },
+                  "notificationHistory": {
+                    "activeNotifications": [
+                      {
+                        "referenceGUID": "11111111-1111-1111-1111-111111111111",
+                        "triggeredDateTime": "2026-01-01T09:55:00",
+                        "type": "ALERT",
+                        "faultId": 105,
+                        "messageId": "BC_SID_LOW_RESERVOIR"
+                      }
+                    ]
+                  }
+                }
+                """
+        };
+        var config = AlarmOnlyConfiguration();
+        config.SyncDeviceEvents = syncDeviceEvents;
+        var fixture = new ServiceFixture(handler, config);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest(), fixture.Config, CancellationToken.None);
+
+        result.ItemsSynced.GetValueOrDefault(SyncDataType.DeviceEvents).Should().Be(expectedCount);
+        result.LastEntryTimes.ContainsKey(SyncDataType.DeviceEvents).Should().Be(expectedCount > 0);
+        result.Errors.Contains("DeviceEvents publish failed").Should().Be(expectedCount > 0,
+            "a switched-off type is never handed to the publisher, so it cannot fail");
     }
 
     /// <summary>Leaves only the alarm step able to publish, so its failure cannot be confused for another step's.</summary>

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -128,35 +129,9 @@ public class CareLinkConnectorServiceTests
     public async Task SyncDataAsync_GatesSystemEventsOnTheDeviceEventsToggle(
         bool syncDeviceEvents, int expectedCount)
     {
-        var handler = new CareLinkFakeHandler
-        {
-            MonitorDataJson = """
-                {
-                  "currentServerTime": 1767261600000,
-                  "lastSG": {},
-                  "lastAlarm": {
-                    "type": "PUMP_SUSPEND",
-                    "code": 816,
-                    "flash": true,
-                    "datetime": "2026-01-01T10:00:00"
-                  },
-                  "notificationHistory": {
-                    "activeNotifications": [
-                      {
-                        "referenceGUID": "11111111-1111-1111-1111-111111111111",
-                        "triggeredDateTime": "2026-01-01T09:55:00",
-                        "type": "ALERT",
-                        "faultId": 105,
-                        "messageId": "BC_SID_LOW_RESERVOIR"
-                      }
-                    ]
-                  }
-                }
-                """
-        };
         var config = AlarmOnlyConfiguration();
         config.SyncDeviceEvents = syncDeviceEvents;
-        var fixture = new ServiceFixture(handler, config);
+        var fixture = new ServiceFixture(SystemEventHandler(NotificationBeforeAlarm), config);
 
         var result = await fixture.Service.SyncDataAsync(
             new SyncRequest(), fixture.Config, CancellationToken.None);
@@ -166,6 +141,59 @@ public class CareLinkConnectorServiceTests
         result.Errors.Contains("DeviceEvents publish failed").Should().Be(expectedCount > 0,
             "a switched-off type is never handed to the publisher, so it cannot fail");
     }
+
+    /// <summary>
+    /// DeviceEvents' last-entry time is the newest of the two system-event paths, so each path in
+    /// turn is the one that must report a time: whichever is newer has to win the max-compare.
+    /// </summary>
+    [Theory]
+    [InlineData(NotificationBeforeAlarm, AlarmDateTime)]
+    [InlineData(NotificationAfterAlarm, NotificationAfterAlarm)]
+    public async Task SyncDataAsync_RecordsTheNewestSystemEventTimeUnderDeviceEvents(
+        string notificationDateTime, string expectedNewest)
+    {
+        var fixture = new ServiceFixture(
+            SystemEventHandler(notificationDateTime), AlarmOnlyConfiguration());
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest(), fixture.Config, CancellationToken.None);
+
+        result.LastEntryTimes[SyncDataType.DeviceEvents].Should().Be(
+            DateTime.Parse(expectedNewest, CultureInfo.InvariantCulture));
+    }
+
+    private const string AlarmDateTime = "2026-01-01T10:00:00";
+    private const string NotificationBeforeAlarm = "2026-01-01T09:55:00";
+    private const string NotificationAfterAlarm = "2026-01-01T10:05:00";
+
+    /// <summary>A payload feeding both system-event paths: the last alarm and one notification.</summary>
+    private static CareLinkFakeHandler SystemEventHandler(string notificationDateTime) => new()
+    {
+        // Server time equals the alarm time, so no pump offset is applied and the strings are UTC.
+        MonitorDataJson = $$"""
+            {
+              "currentServerTime": 1767261600000,
+              "lastSG": {},
+              "lastAlarm": {
+                "type": "PUMP_SUSPEND",
+                "code": 816,
+                "flash": true,
+                "datetime": "{{AlarmDateTime}}"
+              },
+              "notificationHistory": {
+                "activeNotifications": [
+                  {
+                    "referenceGUID": "11111111-1111-1111-1111-111111111111",
+                    "triggeredDateTime": "{{notificationDateTime}}",
+                    "type": "ALERT",
+                    "faultId": 105,
+                    "messageId": "BC_SID_LOW_RESERVOIR"
+                  }
+                ]
+              }
+            }
+            """
+    };
 
     /// <summary>Leaves only the alarm step able to publish, so its failure cannot be confused for another step's.</summary>
     private static CareLinkConnectorConfiguration AlarmOnlyConfiguration() => new()

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
@@ -51,7 +51,7 @@ public class PublishRecordTypePathTests
             return result;
         }
 
-        public Task PublishAsync(
+        public Task<bool> PublishAsync(
             SyncResult result,
             SyncDataType dataType,
             HashSet<SyncDataType> activeTypes,
@@ -206,6 +206,31 @@ public class PublishRecordTypePathTests
         // Assert
         result.Success.Should().BeFalse();
         result.LastEntryTimes[SyncDataType.Glucose].Should().Be(Newer);
+    }
+
+    [Fact]
+    public async Task ReturnValue_IsTrueOnlyForAnAcceptedPublish()
+    {
+        // Arrange: connectors advance a cursor on the return value — CareLink's alarm dedup key
+        // holds an alarm the tenant never took, whatever the reason it did not take it.
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+        var outcomes = new List<bool>();
+
+        // Act: gated-off type, empty batch, rejected publish, accepted publish
+        await RunAsync(async (service, syncResult) =>
+        {
+            outcomes.Add(await service.PublishAsync(syncResult, SyncDataType.Boluses, active,
+                [new TimedRecord { At = Newer }], r => r.At));
+            outcomes.Add(await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [], r => r.At));
+            outcomes.Add(await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Newer }], r => r.At, publishSucceeds: false));
+            outcomes.Add(await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new TimedRecord { At = Newer }], r => r.At));
+        });
+
+        // Assert
+        outcomes.Should().Equal(false, false, false, true);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #829.

## What

CareLink published SystemEvents (pump alarms, notification history) without declaring `DeviceEvents` — un-gateable, uncounted, and the reason #825 had to leave those two sites hand-inlined. The declaration is added and both sites route through `PublishRecordTypeAsync`, gated and counted under `DeviceEvents` with timestamp selectors. The helper returns `Task<bool>` ("batch reached the tenant") so the alarm dedup key still advances only on a successful publish; the now-false #825 constraint comments are deleted, and the shared rationale lives once on `PublishSystemEventDataAsync` (Tandem's and Glooko's copies replaced with crefs).

**No tenant silently loses alarms**: the toggle initialiser is `true` and the config binder only overwrites keys present in stored JSON; since the toggle was never rendered for CareLink, no UI-originated `syncDeviceEvents: false` can exist. Verified through the save path too — the form posts only stored + user-touched keys, never materialised schema defaults.

## Review gates

Two-stage. The hostile review reported SURVIVES on both merge-gating questions with the work shown: the stale-client save path cannot write the toggle off, and the `_lastAlarmKey` instance field turns out to be per-sync anyway (transient service) — the real cross-sync dedup is the DB upsert on deterministic `OriginalId`, so no duplicate or suppressed alarm is reachable (pre-existing property, now documented by this trail). Its mutation testing found the helper's new return-value contract and the per-site timestamp selectors untested; the follow-up commit pins all four return arms and each site's selector individually, each with a mutation proof killing exactly the intended test.

One post-deploy check worth running (hostile reviewer's residual): a hand-crafted API `PUT` could historically have stored an inert `syncDeviceEvents: false` on a CareLink row that becomes load-bearing now — `SELECT ... WHERE ConfigurationJson ? 'syncDeviceEvents'` on CareLink connector rows.

## Testing

CareLink 85/85, Core 118/118, Tandem 58/58, Glooko 73/73, API 5760/0. Five mutation proofs across declaration, gating, accumulation, return contract, and both timestamp selectors.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
