### PR TITLE
fix(treatments): attribute the single-treatment delete and the remaining connector purges

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -915,12 +915,11 @@ public class DataSourceService : IDataSourceService
     /// <remarks>
     /// Capability matrix (entity interfaces decide the path):
     /// <list type="bullet">
-    /// <item>Glucose and the auditable+soft-deletable treatments (Bolus, CarbIntake, BolusCalculation,
-    ///   DeviceEvent) take the audited soft-delete path, which stamps the <c>deleted_by_user</c> flag the
-    ///   soft-delete dedup reads to block re-import (<see cref="SoftDeleteDedupExtensions"/>).</item>
+    /// <item>Glucose and the auditable+soft-deletable records (Bolus, CarbIntake, BolusCalculation,
+    ///   DeviceEvent, BGCheck, Note, ApsSnapshot) take the audited soft-delete path, which stamps the
+    ///   <c>deleted_by_user</c> flag the soft-delete dedup reads to block re-import
+    ///   (<see cref="SoftDeleteDedupExtensions"/>).</item>
     /// <item>StateSpan is auditable but not soft-deletable, so it takes the audited hard-delete path.</item>
-    /// <item>BGChecks, Notes and device status are soft-deletable but not auditable, so they soft-delete
-    ///   without an audit row; with the connector disabled they do not re-import.</item>
     /// </list>
     /// </remarks>
     private async Task<Dictionary<string, long>> DeleteAllSourceDataAsync(
@@ -933,7 +932,7 @@ public class DataSourceService : IDataSourceService
         var meterGlucoseDeleted = await _meterGlucose.DeleteBySourceAsync(deviceId, cancellationToken);
         var calibrationsDeleted = await _calibrations.DeleteBySourceAsync(deviceId, cancellationToken);
 
-        // Auditable + soft-deletable treatments: audited soft-delete, user-attributed.
+        // Auditable + soft-deletable records: audited soft-delete, user-attributed.
         var scope = $"data_source={deviceId}";
         var bolusesDeleted = await _context.AuditedSoftDeleteAsync(
             _context.Boluses.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId)), _auditContext, scope, cancellationToken);
@@ -943,18 +942,16 @@ public class DataSourceService : IDataSourceService
             _context.BolusCalculations.Where(bc => bc.DataSource == deviceId || (bc.DataSource == null && bc.Device == deviceId)), _auditContext, scope, cancellationToken);
         var deviceEventsDeleted = await _context.AuditedSoftDeleteAsync(
             _context.DeviceEvents.Where(de => de.DataSource == deviceId || (de.DataSource == null && de.Device == deviceId)), _auditContext, scope, cancellationToken);
+        var bgChecksDeleted = await _context.AuditedSoftDeleteAsync(
+            _context.BGChecks.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId)), _auditContext, scope, cancellationToken);
+        var notesDeleted = await _context.AuditedSoftDeleteAsync(
+            _context.Notes.Where(n => n.DataSource == deviceId || (n.DataSource == null && n.Device == deviceId)), _auditContext, scope, cancellationToken);
+        var deviceStatusDeleted = await _context.AuditedSoftDeleteAsync(
+            _context.ApsSnapshots.Where(ds => ds.Device == deviceId), _auditContext, scope, cancellationToken);
 
         // StateSpan is auditable but not soft-deletable: audited hard delete.
         var stateSpansDeleted = await _context.AuditedExecuteDeleteAsync(
             _context.StateSpans.Where(s => s.Source == deviceId), _auditContext, cancellationToken);
-
-        // Soft-deletable but not auditable: soft-delete without an audit row.
-        var bgChecksDeleted = await _context.SoftDeleteAsync(
-            _context.BGChecks.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId)), cancellationToken);
-        var notesDeleted = await _context.SoftDeleteAsync(
-            _context.Notes.Where(n => n.DataSource == deviceId || (n.DataSource == null && n.Device == deviceId)), cancellationToken);
-        var deviceStatusDeleted = await _context.SoftDeleteAsync(
-            _context.ApsSnapshots.Where(ds => ds.Device == deviceId), cancellationToken);
 
         var deletedCounts = new Dictionary<string, long>();
         if (sensorGlucoseDeleted > 0) deletedCounts[nameof(SyncDataType.Glucose)] = sensorGlucoseDeleted;

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -829,9 +829,10 @@ public class DataSourceService : IDataSourceService
             .LongCountAsync(cancellationToken);
         if (stateSpansCount > 0) counts[nameof(SyncDataType.StateSpans)] = stateSpansCount;
 
-        // Device status
+        // Device status. Device carries the rig string the uploader reported (e.g. "openaps://host"),
+        // so an imported snapshot is only reachable through DataSource.
         var deviceStatusCount = await _context
-            .ApsSnapshots.Where(ds => ds.Device == deviceId)
+            .ApsSnapshots.Where(ds => ds.DataSource == deviceId || (ds.DataSource == null && ds.Device == deviceId))
             .LongCountAsync(cancellationToken);
         if (deviceStatusCount > 0) counts[nameof(SyncDataType.DeviceStatus)] = deviceStatusCount;
 
@@ -947,7 +948,7 @@ public class DataSourceService : IDataSourceService
         var notesDeleted = await _context.AuditedSoftDeleteAsync(
             _context.Notes.Where(n => n.DataSource == deviceId || (n.DataSource == null && n.Device == deviceId)), _auditContext, scope, cancellationToken);
         var deviceStatusDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.ApsSnapshots.Where(ds => ds.Device == deviceId), _auditContext, scope, cancellationToken);
+            _context.ApsSnapshots.Where(ds => ds.DataSource == deviceId || (ds.DataSource == null && ds.Device == deviceId)), _auditContext, scope, cancellationToken);
 
         // StateSpan is auditable but not soft-deletable: audited hard delete.
         var stateSpansDeleted = await _context.AuditedExecuteDeleteAsync(

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -1543,10 +1543,9 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     /// (<see cref="SoftDeleteDedupExtensions"/>).
     /// </summary>
     /// <remarks>
-    /// A legacy id fans out to a handful of correlated rows, never a set, so the per-record
-    /// <c>delete</c> audit rows this overload writes below its materialization cap are the right shape
-    /// — the same call the V4 repositories' own by-legacy-id delete makes. The materialized entities
-    /// are unused here because the v4-native delete broadcast is still deferred.
+    /// A legacy id fans out to a handful of correlated rows, never a set, so the per-record audit
+    /// rows <see cref="AuditedBulkDeleteExtensions.AuditedSoftDeleteWithEntitiesAsync{T}"/> writes
+    /// below its cap are the right shape.
     /// </remarks>
     private async Task<int> DeleteRecordsByLegacyId<T>(
         DbSet<T> dbSet, string legacyId, string scope, CancellationToken ct)

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -1520,44 +1520,39 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     public async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         // origin is accepted for interface uniformity; the v4-native delete broadcast is deferred to the glucose-unification follow-up (deletes here bypass the repository chokepoint).
-        var strategy = _dbContext.Database.CreateExecutionStrategy();
+        var scope = $"legacy_id={legacyId}";
+        var deleted = 0;
 
-        return await strategy.ExecuteAsync(async () =>
-        {
-            await using var tx = await _dbContext.Database.BeginTransactionAsync(ct);
-            var now = DateTime.UtcNow;
-            var deleted = 0;
+        deleted += await DeleteRecordsByLegacyId(_dbContext.Boluses, legacyId, scope, ct);
+        deleted += await DeleteRecordsByLegacyId(_dbContext.TempBasals, legacyId, scope, ct);
+        deleted += await DeleteRecordsByLegacyId(_dbContext.CarbIntakes, legacyId, scope, ct);
+        deleted += await DeleteRecordsByLegacyId(_dbContext.BGChecks, legacyId, scope, ct);
+        deleted += await DeleteRecordsByLegacyId(_dbContext.Notes, legacyId, scope, ct);
+        deleted += await DeleteRecordsByLegacyId(_dbContext.DeviceEvents, legacyId, scope, ct);
+        deleted += await DeleteRecordsByLegacyId(_dbContext.BolusCalculations, legacyId, scope, ct);
 
-            deleted += await _dbContext.Boluses
-                .Where(e => e.LegacyId == legacyId)
-                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
-            deleted += await _dbContext.TempBasals
-                .Where(e => e.LegacyId == legacyId)
-                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
-            deleted += await _dbContext.CarbIntakes
-                .Where(e => e.LegacyId == legacyId)
-                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
-            deleted += await _dbContext.BGChecks
-                .Where(e => e.LegacyId == legacyId)
-                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
-            deleted += await _dbContext.Notes
-                .Where(e => e.LegacyId == legacyId)
-                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
-            deleted += await _dbContext.DeviceEvents
-                .Where(e => e.LegacyId == legacyId)
-                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
-            deleted += await _dbContext.BolusCalculations
-                .Where(e => e.LegacyId == legacyId)
-                .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, now), ct);
+        if (deleted > 0)
+            _logger.LogDebug("Soft-deleted {Count} v4 records for legacy treatment {LegacyId}", deleted, legacyId);
 
-            await tx.CommitAsync(ct);
-
-            if (deleted > 0)
-                _logger.LogDebug("Soft-deleted {Count} v4 records for legacy treatment {LegacyId}", deleted, legacyId);
-
-            return deleted;
-        });
+        return deleted;
     }
+
+    /// <summary>
+    /// Soft-deletes one legacy treatment's decomposed records through the audited path, so a
+    /// user-issued delete is attributed and a later connector resync cannot re-create it
+    /// (<see cref="SoftDeleteDedupExtensions"/>).
+    /// </summary>
+    /// <remarks>
+    /// A legacy id fans out to a handful of correlated rows, never a set, so the per-record
+    /// <c>delete</c> audit rows this overload writes below its materialization cap are the right shape
+    /// — the same call the V4 repositories' own by-legacy-id delete makes. The materialized entities
+    /// are unused here because the v4-native delete broadcast is still deferred.
+    /// </remarks>
+    private async Task<int> DeleteRecordsByLegacyId<T>(
+        DbSet<T> dbSet, string legacyId, string scope, CancellationToken ct)
+        where T : class, IV4Entity, IAuditable
+        => (await _dbContext.AuditedSoftDeleteWithEntitiesAsync(
+            dbSet.Where(e => e.LegacyId == legacyId), _auditContext, scope, ct)).Count;
 
     /// <inheritdoc />
     public async Task<long> BulkDeleteAsync(string? find, WriteOrigin origin, CancellationToken ct = default)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
@@ -223,18 +223,6 @@ public static class AuditedBulkDeleteExtensions
     }
 
     /// <summary>
-    /// Executes a bulk soft delete without audit trail by setting <c>DeletedAt</c> on all matching rows.
-    /// </summary>
-    public static async Task<int> SoftDeleteAsync<T>(
-        this NocturneDbContext context,
-        IQueryable<T> query,
-        CancellationToken ct = default) where T : class, ISoftDeletable
-    {
-        return await query.ExecuteUpdateAsync(
-            s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
-    }
-
-    /// <summary>
     /// Stamps <c>DeletedAt</c> and the dedup attribution flag in one update: a user-initiated delete
     /// blocks resync re-creation, a system sweep leaves the row re-creatable
     /// (<see cref="SoftDeleteDedupExtensions"/>). Runs whether or not an audit row is written.

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
@@ -138,12 +138,15 @@ public class DataSourceServiceDeleteConnectorDataTests : IDisposable
             Timestamp = DateTime.UtcNow,
             Text = "hello",
         });
+        // An imported snapshot's Device is the rig string the uploader reported, so only DataSource
+        // ties it back to the connector.
         db.ApsSnapshots.Add(new ApsSnapshotEntity
         {
             Id = Guid.CreateVersion7(),
             TenantId = TenantId,
             LegacyId = "aps-1",
-            Device = _deviceId,
+            DataSource = _deviceId,
+            Device = "openaps://rig",
             Timestamp = DateTime.UtcNow,
             AidAlgorithm = "Loop",
         });
@@ -185,7 +188,6 @@ public class DataSourceServiceDeleteConnectorDataTests : IDisposable
             .ToListAsync())
             .Should().ContainSingle().Which.AuthType.Should().Be(AuthType);
 
-        // BGChecks, notes and device status are auditable too, so they take the same path.
         (await assertCtx.BGChecks.IgnoreQueryFilters().SingleAsync(b => b.LegacyId == "bgcheck-1"))
             .DeletedAt.Should().NotBeNull();
         (await assertCtx.ApsSnapshots.IgnoreQueryFilters().SingleAsync(a => a.LegacyId == "aps-1"))
@@ -203,9 +205,18 @@ public class DataSourceServiceDeleteConnectorDataTests : IDisposable
         await using (var ctx = NewContext())
             await CreateService(ctx).DeleteConnectorDataAsync(ConnectorId);
 
-        // The dedup that guards bulk-create now treats every user-deleted row as blocking, so the
-        // next sync cannot re-import them.
         await using var assertCtx = NewContext();
+
+        // An active row blocks re-import too, so each row must be shown deleted before "blocking"
+        // says anything about attribution.
+        (await assertCtx.Boluses.IgnoreQueryFilters().SingleAsync(b => b.LegacyId == "bolus-1")).DeletedAt.Should().NotBeNull();
+        (await assertCtx.CarbIntakes.IgnoreQueryFilters().SingleAsync(c => c.LegacyId == "carb-1")).DeletedAt.Should().NotBeNull();
+        (await assertCtx.BGChecks.IgnoreQueryFilters().SingleAsync(b => b.LegacyId == "bgcheck-1")).DeletedAt.Should().NotBeNull();
+        (await assertCtx.Notes.IgnoreQueryFilters().SingleAsync(n => n.LegacyId == "note-1")).DeletedAt.Should().NotBeNull();
+        (await assertCtx.ApsSnapshots.IgnoreQueryFilters().SingleAsync(a => a.LegacyId == "aps-1")).DeletedAt.Should().NotBeNull();
+
+        // The dedup that guards bulk-create treats every user-deleted row as blocking, so the next
+        // sync cannot re-import them.
         (await assertCtx.GetBlockingLegacyIdsAsync<BolusEntity>(["bolus-1"])).Should().Contain("bolus-1");
         (await assertCtx.GetBlockingLegacyIdsAsync<CarbIntakeEntity>(["carb-1"])).Should().Contain("carb-1");
         (await assertCtx.GetBlockingLegacyIdsAsync<BGCheckEntity>(["bgcheck-1"])).Should().Contain("bgcheck-1");

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
@@ -120,7 +120,6 @@ public class DataSourceServiceDeleteConnectorDataTests : IDisposable
             StartTimestamp = DateTime.UtcNow,
         });
 
-        // Soft-deletable but not auditable: soft-delete without an audit row.
         db.BGChecks.Add(new BGCheckEntity
         {
             Id = Guid.CreateVersion7(),
@@ -129,6 +128,15 @@ public class DataSourceServiceDeleteConnectorDataTests : IDisposable
             DataSource = _deviceId,
             Timestamp = DateTime.UtcNow,
             Glucose = 100,
+        });
+        db.Notes.Add(new NoteEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = "note-1",
+            DataSource = _deviceId,
+            Timestamp = DateTime.UtcNow,
+            Text = "hello",
         });
         db.ApsSnapshots.Add(new ApsSnapshotEntity
         {
@@ -177,30 +185,32 @@ public class DataSourceServiceDeleteConnectorDataTests : IDisposable
             .ToListAsync())
             .Should().ContainSingle().Which.AuthType.Should().Be(AuthType);
 
-        // Non-auditable types are soft-deleted with no audit row.
-        var bgCheck = await assertCtx.BGChecks.IgnoreQueryFilters()
-            .SingleAsync(b => b.LegacyId == "bgcheck-1");
-        bgCheck.DeletedAt.Should().NotBeNull();
+        // BGChecks, notes and device status are auditable too, so they take the same path.
+        (await assertCtx.BGChecks.IgnoreQueryFilters().SingleAsync(b => b.LegacyId == "bgcheck-1"))
+            .DeletedAt.Should().NotBeNull();
         (await assertCtx.ApsSnapshots.IgnoreQueryFilters().SingleAsync(a => a.LegacyId == "aps-1"))
             .DeletedAt.Should().NotBeNull();
-        (await assertCtx.MutationAuditLog.AnyAsync(a => a.EntityType == "BGCheck"))
-            .Should().BeFalse();
+        (await assertCtx.MutationAuditLog.Where(a => a.Action == "bulk_delete")
+            .Select(a => a.EntityType).ToListAsync())
+            .Should().Contain(["BGCheck", "Note", "ApsSnapshot"]);
     }
 
     [Fact]
-    public async Task DeleteConnectorData_BlocksReimportOfAuditableTreatments()
+    public async Task DeleteConnectorData_BlocksReimportOfEveryAuditableType()
     {
         SeedOneOfEachType();
 
         await using (var ctx = NewContext())
             await CreateService(ctx).DeleteConnectorDataAsync(ConnectorId);
 
-        // The dedup that guards bulk-create now treats the user-deleted bolus as blocking, so the
-        // next sync cannot re-import it.
+        // The dedup that guards bulk-create now treats every user-deleted row as blocking, so the
+        // next sync cannot re-import them.
         await using var assertCtx = NewContext();
-        var blocked = await assertCtx.GetBlockingLegacyIdsAsync<BolusEntity>(
-            new HashSet<string> { "bolus-1" });
-        blocked.Should().Contain("bolus-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<BolusEntity>(["bolus-1"])).Should().Contain("bolus-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<CarbIntakeEntity>(["carb-1"])).Should().Contain("carb-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<BGCheckEntity>(["bgcheck-1"])).Should().Contain("bgcheck-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<NoteEntity>(["note-1"])).Should().Contain("note-1");
+        (await assertCtx.GetBlockingLegacyIdsAsync<ApsSnapshotEntity>(["aps-1"])).Should().Contain("aps-1");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerDeleteTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerDeleteTests.cs
@@ -23,13 +23,13 @@ using Xunit;
 namespace Nocturne.API.Tests.Services.V4;
 
 /// <summary>
-/// Covers the legacy v1 bulk delete (<c>DELETE /api/v1/treatments?find[created_at][…]</c>) reaching
-/// <see cref="TreatmentDecomposer.BulkDeleteAsync"/>: every record type in the window must be
-/// soft-deleted through the audited path so the delete is attributed and
+/// Covers the legacy delete paths through <see cref="TreatmentDecomposer"/> — the v1 bulk delete
+/// (<c>DELETE /api/v1/treatments?find[created_at][…]</c>) and the v1/v3 single-treatment delete: every
+/// record either removes must be soft-deleted through the audited path so the delete is attributed and
 /// <see cref="SoftDeleteDedupExtensions"/> stops a connector resync re-creating what the user removed.
 /// </summary>
 [Trait("Category", "Unit")]
-public class TreatmentDecomposerBulkDeleteTests : IDisposable
+public class TreatmentDecomposerDeleteTests : IDisposable
 {
     private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
 
@@ -38,6 +38,9 @@ public class TreatmentDecomposerBulkDeleteTests : IDisposable
     /// <summary>Every seeded record sits inside this window; the find query below brackets it.</summary>
     private static readonly DateTime Inside = new(2023, 1, 1, 10, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime Outside = new(2024, 6, 1, 10, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>The legacy treatment id every decomposed row shares on the single-delete path.</summary>
+    private const string LegacyTreatmentId = "treat-1";
 
     private const string Find =
         "find[created_at][$gte]=2023-01-01T00:00:00.000Z&find[created_at][$lte]=2023-01-02T00:00:00.000Z";
@@ -53,7 +56,7 @@ public class TreatmentDecomposerBulkDeleteTests : IDisposable
         Endpoint = "DELETE /api/v1/treatments"
     };
 
-    public TreatmentDecomposerBulkDeleteTests()
+    public TreatmentDecomposerDeleteTests()
     {
         _connection = new SqliteConnection("DataSource=:memory:");
         _connection.Open();
@@ -97,15 +100,21 @@ public class TreatmentDecomposerBulkDeleteTests : IDisposable
         NullLogger<TreatmentDecomposer>.Instance);
 
     /// <summary>One record of every type the sweep covers, plus a bolus outside the window.</summary>
-    private void SeedOneOfEachType()
+    /// <param name="legacyIdFor">
+    /// Maps a record type to the legacy id it is seeded with, so the by-time sweep can seed distinct
+    /// ids while the by-legacy-id delete seeds one treatment's worth of correlated rows.
+    /// </param>
+    private void SeedOneOfEachType(Func<string, string>? legacyIdFor = null)
     {
+        legacyIdFor ??= type => $"{type}-1";
+
         using var db = NewContext();
 
         db.Boluses.Add(new BolusEntity
         {
             Id = Guid.CreateVersion7(),
             TenantId = TenantId,
-            LegacyId = "bolus-1",
+            LegacyId = legacyIdFor("bolus"),
             Timestamp = Inside,
             Insulin = 1.5
         });
@@ -121,7 +130,7 @@ public class TreatmentDecomposerBulkDeleteTests : IDisposable
         {
             Id = Guid.CreateVersion7(),
             TenantId = TenantId,
-            LegacyId = "carb-1",
+            LegacyId = legacyIdFor("carb"),
             Timestamp = Inside,
             Carbs = 20
         });
@@ -129,7 +138,7 @@ public class TreatmentDecomposerBulkDeleteTests : IDisposable
         {
             Id = Guid.CreateVersion7(),
             TenantId = TenantId,
-            LegacyId = "bgcheck-1",
+            LegacyId = legacyIdFor("bgcheck"),
             Timestamp = Inside,
             Glucose = 100
         });
@@ -137,7 +146,7 @@ public class TreatmentDecomposerBulkDeleteTests : IDisposable
         {
             Id = Guid.CreateVersion7(),
             TenantId = TenantId,
-            LegacyId = "note-1",
+            LegacyId = legacyIdFor("note"),
             Timestamp = Inside,
             Text = "hello"
         });
@@ -145,7 +154,7 @@ public class TreatmentDecomposerBulkDeleteTests : IDisposable
         {
             Id = Guid.CreateVersion7(),
             TenantId = TenantId,
-            LegacyId = "devevent-1",
+            LegacyId = legacyIdFor("devevent"),
             Timestamp = Inside,
             EventType = "Site Change"
         });
@@ -153,14 +162,14 @@ public class TreatmentDecomposerBulkDeleteTests : IDisposable
         {
             Id = Guid.CreateVersion7(),
             TenantId = TenantId,
-            LegacyId = "boluscalc-1",
+            LegacyId = legacyIdFor("boluscalc"),
             Timestamp = Inside
         });
         db.TempBasals.Add(new TempBasalEntity
         {
             Id = Guid.CreateVersion7(),
             TenantId = TenantId,
-            LegacyId = "tempbasal-1",
+            LegacyId = legacyIdFor("tempbasal"),
             StartTimestamp = Inside,
             Rate = 0.8,
             Origin = "Algorithm"
@@ -236,6 +245,80 @@ public class TreatmentDecomposerBulkDeleteTests : IDisposable
 
         (await assertCtx.GetBlockingLegacyIdsAsync<BolusEntity>(["bolus-1"])).Should().BeEmpty();
         (await assertCtx.GetBlockingLegacyIdsAsync<TempBasalEntity>(["tempbasal-1"])).Should().BeEmpty();
+        (await assertCtx.MutationAuditLog.AnyAsync()).Should().BeFalse();
+    }
+
+    private async Task<int> DeleteByLegacyIdAsync(IAuditContext auditContext)
+    {
+        await using var ctx = NewContext();
+        return await CreateDecomposer(ctx, auditContext)
+            .DeleteByLegacyIdAsync(LegacyTreatmentId, WriteOrigin.Live);
+    }
+
+    [Fact]
+    public async Task DeleteByLegacyId_UserContext_BlocksConnectorResyncFromRecreatingEveryType()
+    {
+        SeedOneOfEachType(_ => LegacyTreatmentId);
+
+        (await DeleteByLegacyIdAsync(_userAuditContext)).Should().Be(7);
+
+        await using var assertCtx = NewContext();
+
+        (await assertCtx.GetBlockingLegacyIdsAsync<BolusEntity>([LegacyTreatmentId])).Should().Contain(LegacyTreatmentId);
+        (await assertCtx.GetBlockingLegacyIdsAsync<CarbIntakeEntity>([LegacyTreatmentId])).Should().Contain(LegacyTreatmentId);
+        (await assertCtx.GetBlockingLegacyIdsAsync<BGCheckEntity>([LegacyTreatmentId])).Should().Contain(LegacyTreatmentId);
+        (await assertCtx.GetBlockingLegacyIdsAsync<NoteEntity>([LegacyTreatmentId])).Should().Contain(LegacyTreatmentId);
+        (await assertCtx.GetBlockingLegacyIdsAsync<DeviceEventEntity>([LegacyTreatmentId])).Should().Contain(LegacyTreatmentId);
+        (await assertCtx.GetBlockingLegacyIdsAsync<BolusCalculationEntity>([LegacyTreatmentId])).Should().Contain(LegacyTreatmentId);
+        (await assertCtx.GetBlockingLegacyIdsAsync<TempBasalEntity>([LegacyTreatmentId])).Should().Contain(LegacyTreatmentId);
+    }
+
+    [Fact]
+    public async Task DeleteByLegacyId_UserContext_LeavesOtherTreatmentsUntouched()
+    {
+        SeedOneOfEachType(_ => LegacyTreatmentId);
+
+        await DeleteByLegacyIdAsync(_userAuditContext);
+
+        await using var assertCtx = NewContext();
+        var other = await assertCtx.Boluses.IgnoreQueryFilters()
+            .SingleAsync(b => b.LegacyId == "bolus-outside");
+        other.DeletedAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// One treatment's fan-out is a handful of rows, not a set, so each gets its own <c>delete</c>
+    /// audit row rather than the <c>bulk_delete</c> summary the by-time sweep writes.
+    /// </summary>
+    [Fact]
+    public async Task DeleteByLegacyId_UserContext_AuditsEachDecomposedRecordIndividually()
+    {
+        SeedOneOfEachType(_ => LegacyTreatmentId);
+
+        await DeleteByLegacyIdAsync(_userAuditContext);
+
+        await using var assertCtx = NewContext();
+        var entries = await assertCtx.MutationAuditLog.ToListAsync();
+
+        entries.Should().OnlyContain(a => a.Action == "delete" && a.EntityId != null && a.AuthType == AuthType);
+        entries.Select(a => a.EntityType).Should().BeEquivalentTo(
+            new[] { "Bolus", "CarbIntake", "BGCheck", "Note", "DeviceEvent", "BolusCalculation", "TempBasal" });
+    }
+
+    [Fact]
+    public async Task DeleteByLegacyId_SystemContext_LeavesRecordsRecreatableAndUnaudited()
+    {
+        SeedOneOfEachType(_ => LegacyTreatmentId);
+
+        (await DeleteByLegacyIdAsync(SystemAuditContext.ForService("connector:nightscout"))).Should().Be(7);
+
+        await using var assertCtx = NewContext();
+        var bolus = await assertCtx.Boluses.IgnoreQueryFilters()
+            .SingleAsync(b => b.LegacyId == LegacyTreatmentId);
+        bolus.DeletedAt.Should().NotBeNull();
+
+        (await assertCtx.GetBlockingLegacyIdsAsync<BolusEntity>([LegacyTreatmentId])).Should().BeEmpty();
+        (await assertCtx.GetBlockingLegacyIdsAsync<TempBasalEntity>([LegacyTreatmentId])).Should().BeEmpty();
         (await assertCtx.MutationAuditLog.AnyAsync()).Should().BeFalse();
     }
 }


### PR DESCRIPTION
Fixes #856.

## What

The two remaining user-initiated delete paths that skipped `deleted_by_user` (so connector resyncs resurrected what users deleted):

- **The single-treatment v1/v3 delete** (`TreatmentDecomposer.DeleteByLegacyIdAsync`) routes its seven tables through `AuditedSoftDeleteWithEntitiesAsync` with scope `legacy_id={id}` — per-record `delete` audit rows, the correct shape for a fan-out of a handful of correlated rows, and the same call the V4 repositories make for their own by-legacy-id deletes. The hand-rolled cross-table transaction goes (the helper owns its own; nesting would throw); the partial-failure matrix was walked adversarially at review — every deleted row carries its flag and audit atomically, retry is idempotent with no double-audit, and no partial state can cause resurrection.
- **The connector purge** routes BGChecks, Notes and ApsSnapshots through `AuditedSoftDeleteAsync` (all three are `IAuditable` today; the "not auditable" capability-matrix comment was stale). The unattributed `SoftDeleteAsync` helper is deleted at zero remaining callers — the trap that produced this bug class.

## Found and fixed during hostile review

The ApsSnapshot purge filtered `Device == deviceId` only, but the decomposer maps `Device` = the rig string and `DataSource` = the connector id — so **"delete all my connector data" left connector-imported loop history alive**, the pre-delete summary under-counted the same rows, and the new audit row misdescribed its own predicate. Both sites now use the six siblings' `DataSource ||` predicate, the test seeds the realistic shape, and one mutation proof double-proves the fix and the closed test tautology (an active row also blocks re-import, so the old test passed even when a purge was skipped — it now asserts `DeletedAt` first).

## Review gates

Two-stage: my review, then a hostile fresh-context review (verdict: survives; three mutations — a system-context substitution, a null-context purge, and a skipped purge — each caught or leading to the tautology fix above; the fan-out cap proven unreachable via the `(tenant_id, legacy_id)` unique index).

## Testing

API 5768/0, Infrastructure.Data 636/0. Mutation proofs: bare-update revert fails exactly the resync-block and per-record-audit tests; the filter revert fails exactly the new precondition.

Known related debt (not this PR): the per-source stats at `DataSourceService.cs:1208` carry the same rig-vs-connector predicate; being filed.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
