### PR TITLE
fix(auth): bound the passkey ceremonies with client-address rate limits

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
@@ -142,6 +143,7 @@ public class PasskeyController : ControllerBase
     [HttpPost("register/options")]
     [DenyDemoSubject]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-register")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -247,6 +249,7 @@ public class PasskeyController : ControllerBase
     [HttpPost("register/complete")]
     [DenyDemoSubject]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-register")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyRegisterCompleteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -302,6 +305,7 @@ public class PasskeyController : ControllerBase
     /// </remarks>
     [HttpPost("recovery-mode/options")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-register")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -330,6 +334,7 @@ public class PasskeyController : ControllerBase
     /// </summary>
     [HttpPost("recovery-mode/complete")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-register")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyRegisterCompleteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -486,6 +491,7 @@ public class PasskeyController : ControllerBase
     /// </summary>
     [HttpPost("login/discoverable/options")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-login")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<PasskeyOptionsResponse>> DiscoverableLoginOptions()
@@ -505,6 +511,7 @@ public class PasskeyController : ControllerBase
     /// </summary>
     [HttpPost("login/options")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-login")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -530,6 +537,7 @@ public class PasskeyController : ControllerBase
     /// </summary>
     [HttpPost("login/complete")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-login")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyLoginCompleteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -608,6 +616,7 @@ public class PasskeyController : ControllerBase
     /// </summary>
     [HttpPost("recovery/verify")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-recovery")]
     [RemoteCommand]
     [ProducesResponseType(typeof(RecoveryVerifyResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -898,6 +907,7 @@ public class PasskeyController : ControllerBase
     /// <returns>A <see cref="PasskeyOptionsResponse"/> with the WebAuthn options and challenge token, or <c>404</c> if access requests are disabled.</returns>
     [HttpPost("access-request/options")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-access-request")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -983,6 +993,7 @@ public class PasskeyController : ControllerBase
     /// <returns><c>200 OK</c> on success, or <c>400</c> / <c>404</c> on error.</returns>
     [HttpPost("access-request/complete")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-access-request")]
     [RemoteCommand]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -1067,6 +1078,7 @@ public class PasskeyController : ControllerBase
     /// </summary>
     [HttpPost("invite/options")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-register")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -1147,6 +1159,7 @@ public class PasskeyController : ControllerBase
     /// </remarks>
     [HttpPost("invite/complete")]
     [AllowAnonymous]
+    [EnableRateLimiting("passkey-register")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyRegistrationResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -109,9 +109,11 @@ public static class ServiceRegistrationExtensions
         // The passkey ceremonies. An assertion is phishing-resistant and its challenge is a
         // stateless Data Protection token, so what these bound is the work each attempt costs —
         // the credential lookup, the audit row a failure writes, and the crypto the completion
-        // step runs.
-        ("passkey-login", 10, TimeSpan.FromMinutes(1)),
-        ("passkey-register", 10, TimeSpan.FromMinutes(1)),
+        // step runs. Two things set the ceilings well above that work: a ceremony spends two
+        // permits (options then complete), and a household or clinic behind one NAT is a single
+        // partition, so the whole family signs in from one bucket.
+        ("passkey-login", 30, TimeSpan.FromMinutes(1)),
+        ("passkey-register", 20, TimeSpan.FromMinutes(1)),
         // A recovery code is a one-time human-typed secret and the last way back into an account,
         // so the ceiling has to leave room to mistype ten characters under stress. The window,
         // not the ceiling, is what makes this an order of magnitude tighter than totp-login: an

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -106,6 +106,21 @@ public static class ServiceRegistrationExtensions
         ("oauth-register", 10, TimeSpan.FromHours(1)),
         ("oauth-device-approve", 20, TimeSpan.FromMinutes(1)),
         ("totp-login", 10, TimeSpan.FromMinutes(1)),
+        // The passkey ceremonies. An assertion is phishing-resistant and its challenge is a
+        // stateless Data Protection token, so what these bound is the work each attempt costs —
+        // the credential lookup, the audit row a failure writes, and the crypto the completion
+        // step runs.
+        ("passkey-login", 10, TimeSpan.FromMinutes(1)),
+        ("passkey-register", 10, TimeSpan.FromMinutes(1)),
+        // A recovery code is a one-time human-typed secret and the last way back into an account,
+        // so the ceiling has to leave room to mistype ten characters under stress. The window,
+        // not the ceiling, is what makes this an order of magnitude tighter than totp-login: an
+        // authenticator code rotates every 30 seconds, a recovery code does not.
+        ("passkey-recovery", 10, TimeSpan.FromMinutes(10)),
+        // The one anonymous ceremony that writes a row before any credential exists: each start
+        // files a pending subject under a display name not already taken, and nothing else prunes
+        // them.
+        ("passkey-access-request", 5, TimeSpan.FromMinutes(10)),
         ("guest-activate", 5, TimeSpan.FromMinutes(10)),
         // Friction against naive abuse only — this does NOT bound the refresh_tokens table. The
         // real ceiling is DemoSessionLimits.MaxLiveSessions, enforced on the subject id.

--- a/src/Web/packages/app/src/lib/forms/submit-error.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.ts
@@ -2,6 +2,10 @@
 export const GENERIC_SUBMIT_ERROR =
   "We couldn't save your changes. Please try again.";
 
+/** Shown when a rate limiter turned the attempt away, so the credential is unspent. */
+export const RATE_LIMITED_ERROR =
+  "Too many attempts. Please wait a few minutes and try again.";
+
 /** The HTTP status carried by a thrown value, if it has one. */
 export function errorStatus(err: unknown): number | undefined {
   if (err && typeof err === "object" && "status" in err) {

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/auth.remote.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/auth.remote.ts
@@ -16,8 +16,15 @@ import { invalid, redirect } from "@sveltejs/kit";
 
 import type { OidcProviderInfo } from "$lib/api/generated/nocturne-api-client";
 import { clearAuthCookies } from "$lib/config/auth-cookies";
-import { errorStatus } from "$lib/forms/submit-error";
+import { errorStatus, RATE_LIMITED_ERROR } from "$lib/forms/submit-error";
 import { safeReturnUrl } from "$lib/server/return-url";
+import { classifyRecoveryError, type RecoveryFailure } from "./recovery-error";
+
+const RECOVERY_FAILURE_MESSAGES: Record<RecoveryFailure, string> = {
+  // The API deliberately doesn't say which of the two was wrong.
+  rejected: "That username and recovery code don't match.",
+  "rate-limited": RATE_LIMITED_ERROR,
+};
 
 // ============================================================================
 // Helper Functions
@@ -274,14 +281,15 @@ export const signInWithRecoveryCode = form(
   async (data, issue) => {
     const api = getApiClient();
 
-    let verified = false;
+    let failure: RecoveryFailure | null = null;
     try {
       const result = await api.passkey.recoveryVerify({
         username: data.username,
         code: data.code,
       });
-      verified = result?.success === true;
+      if (result?.success !== true) failure = "rejected";
     } catch (err) {
+      failure = classifyRecoveryError(err);
       // Log the status only: the response carries the submitted credentials.
       console.error(
         "Recovery code sign-in failed with status:",
@@ -289,10 +297,7 @@ export const signInWithRecoveryCode = form(
       );
     }
 
-    // The API deliberately doesn't say which of the two was wrong.
-    if (!verified) {
-      invalid(issue.code("That username and recovery code don't match."));
-    }
+    if (failure) invalid(issue.code(RECOVERY_FAILURE_MESSAGES[failure]));
 
     const destination = new URLSearchParams({
       username: data.username,

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery-error.test.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery-error.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { classifyRecoveryError } from "./recovery-error";
+
+describe("classifyRecoveryError", () => {
+  it("recognises the rate limiter", () => {
+    expect(
+      classifyRecoveryError({ status: 429, message: "Too Many Requests" })
+    ).toBe("rate-limited");
+  });
+
+  it("does not read the rate limiter's body as a refused code", () => {
+    // The limiter answers with its own shape; a caller matching on the body
+    // rather than the status would call a throttled attempt a wrong code.
+    expect(
+      classifyRecoveryError({
+        status: 429,
+        error: "rate_limit_exceeded",
+        error_description: "Too many requests. Please try again later.",
+      })
+    ).toBe("rate-limited");
+  });
+
+  it("treats the API's refusal as a wrong username or code", () => {
+    expect(
+      classifyRecoveryError({ status: 400, message: "Invalid username or recovery code" })
+    ).toBe("rejected");
+  });
+
+  it("treats a transport failure as a wrong username or code", () => {
+    expect(classifyRecoveryError(new Error("fetch failed"))).toBe("rejected");
+    expect(classifyRecoveryError(null)).toBe("rejected");
+  });
+});

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery-error.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/recovery-error.ts
@@ -1,0 +1,17 @@
+import { errorStatus } from "$lib/forms/submit-error";
+
+/**
+ * Why a recovery-code sign-in didn't succeed.
+ *
+ * - `rejected` — the username or the code was refused. The API answers the same
+ *   way for both, so this cannot be narrowed further.
+ * - `rate-limited` — too many attempts from this address. The limiter turns the
+ *   attempt away before the code is read, so a correct code is still unspent;
+ *   reported as `rejected` it would tell the holder of a working code, on the one
+ *   path that exists for an emergency, that their last way in is dead.
+ */
+export type RecoveryFailure = "rejected" | "rate-limited";
+
+export function classifyRecoveryError(err: unknown): RecoveryFailure {
+  return errorStatus(err) === 429 ? "rate-limited" : "rejected";
+}

--- a/src/Web/packages/app/src/routes/(unauthenticated)/guest/guest.remote.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/guest/guest.remote.ts
@@ -1,6 +1,7 @@
 import { form, getRequestEvent } from "$app/server";
 import { invalid, redirect } from "@sveltejs/kit";
 import { z } from "zod";
+import { RATE_LIMITED_ERROR } from "$lib/forms/submit-error";
 import {
   classifyActivationError,
   type ActivationFailure,
@@ -9,8 +10,7 @@ import {
 const FAILURE_MESSAGES: Record<ActivationFailure, string> = {
   rejected:
     "That code didn't work. It may have expired, already been used, or been entered slightly differently. Ask whoever shared it to send a new one.",
-  "rate-limited":
-    "Too many attempts. Please wait a few minutes and try again.",
+  "rate-limited": RATE_LIMITED_ERROR,
   unavailable:
     "We couldn't check that code just now. Please try again in a moment.",
 };

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyRateLimitTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyRateLimitTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Extensions;
+using Nocturne.API.Tests.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// Guards the bounds on the passkey ceremonies. Every one of them is reachable without a session,
+/// and one — recovery-code verification — takes a secret a person types, so the sweep pins the rule
+/// that an anonymous ceremony carries a ceiling rather than today's endpoint list.
+/// </summary>
+public class PasskeyRateLimitTests
+{
+    [Fact]
+    public void EveryAnonymousPasskeyCeremony_CarriesAClientAddressPolicy()
+    {
+        var ceremonies = AnonymousCeremonies();
+
+        // A sweep that discovers nothing would pass while guarding nothing.
+        ceremonies.Should().HaveCountGreaterThan(10,
+            "the scan should discover the anonymous passkey ceremonies");
+
+        var uncovered = ceremonies
+            .Where(a => PolicyOn(a) is null)
+            .Select(a => a.Name)
+            .ToList();
+
+        uncovered.Should().BeEmpty(
+            "an anonymous ceremony with no ceiling can be replayed without bound. Uncovered: "
+            + string.Join(", ", uncovered));
+
+        var policyNames = ServiceRegistrationExtensions.ClientAddressPolicies
+            .Select(p => p.Policy)
+            .ToList();
+
+        ceremonies.Select(PolicyOn).Distinct().Should().BeSubsetOf(policyNames,
+            "a policy outside the table keys on the connection, which for a remote function is "
+            + "the SSR container shared by every user");
+    }
+
+    /// <summary>
+    /// Each ceremony's ceiling, pinned so widening one is a deliberate edit rather than a side
+    /// effect of renaming a policy.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(PasskeyController.LoginOptions), "passkey-login")]
+    [InlineData(nameof(PasskeyController.DiscoverableLoginOptions), "passkey-login")]
+    [InlineData(nameof(PasskeyController.LoginComplete), "passkey-login")]
+    [InlineData(nameof(PasskeyController.RegisterOptions), "passkey-register")]
+    [InlineData(nameof(PasskeyController.RegisterComplete), "passkey-register")]
+    [InlineData(nameof(PasskeyController.RecoveryModeOptions), "passkey-register")]
+    [InlineData(nameof(PasskeyController.RecoveryModeComplete), "passkey-register")]
+    [InlineData(nameof(PasskeyController.InviteOptions), "passkey-register")]
+    [InlineData(nameof(PasskeyController.InviteComplete), "passkey-register")]
+    [InlineData(nameof(PasskeyController.RecoveryVerify), "passkey-recovery")]
+    [InlineData(nameof(PasskeyController.AccessRequestOptions), "passkey-access-request")]
+    [InlineData(nameof(PasskeyController.AccessRequestComplete), "passkey-access-request")]
+    public void EachCeremony_CarriesItsOwnPolicy(string action, string policy)
+    {
+        PolicyOn(Action(action)).Should().Be(policy);
+    }
+
+    /// <summary>
+    /// The management actions are reached with a session, which is its own ceiling. A limit landing
+    /// on them would throttle a signed-in person for the sake of an attacker who has to sign in
+    /// first.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(PasskeyController.ListCredentials))]
+    [InlineData(nameof(PasskeyController.RemoveCredential))]
+    [InlineData(nameof(PasskeyController.RegenerateRecoveryCodes))]
+    [InlineData(nameof(PasskeyController.GetRecoveryStatus))]
+    [InlineData(nameof(PasskeyController.CompleteOnboarding))]
+    public void SessionGatedManagement_CarriesNoPolicy(string action)
+    {
+        PolicyOn(Action(action)).Should().BeNull();
+    }
+
+    /// <summary>
+    /// The ceiling over the real pipeline. The limiter runs ahead of tenant resolution, so a caller
+    /// grinding recovery codes is turned away before the subject lookup and before the audit row a
+    /// failure would write.
+    /// </summary>
+    /// <remarks>
+    /// On its own host, because the window is spent by the time this returns and the partition here
+    /// is the connection: the test server presents no client address, and the signed header that
+    /// would name one is not honoured under
+    /// <see cref="AuthenticationTestFactory"/> — its configuration reaches the built host but not
+    /// the <c>builder.Configuration</c> the policy table reads the instance key from.
+    /// </remarks>
+    [Fact]
+    public async Task RecoveryVerify_TurnsAwayTheAttemptPastTheCeiling()
+    {
+        var permitLimit = ServiceRegistrationExtensions.ClientAddressPolicies
+            .Single(p => p.Policy == "passkey-recovery").PermitLimit;
+
+        await using var factory = new AuthenticationTestFactory();
+        using var client = factory.CreateClient();
+
+        for (var attempt = 1; attempt <= permitLimit; attempt++)
+        {
+            var allowed = await VerifyAsync(client);
+            allowed.StatusCode.Should().NotBe(HttpStatusCode.TooManyRequests,
+                $"attempt {attempt} is within the ceiling of {permitLimit}");
+        }
+
+        var rejected = await VerifyAsync(client);
+
+        rejected.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    private static Task<HttpResponseMessage> VerifyAsync(HttpClient client) =>
+        client.PostAsJsonAsync(
+            "/api/auth/passkey/recovery/verify",
+            new { username = "test", code = "AAAAA-BBBBB" });
+
+    private static string? PolicyOn(MethodInfo action) =>
+        action.GetCustomAttribute<EnableRateLimitingAttribute>()?.PolicyName;
+
+    private static MethodInfo Action(string name) =>
+        typeof(PasskeyController).GetMethod(name)
+        ?? throw new InvalidOperationException($"No action named {name} on PasskeyController.");
+
+    private static List<MethodInfo> AnonymousCeremonies() =>
+        typeof(PasskeyController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetCustomAttributes<HttpPostAttribute>().Any()
+                && m.GetCustomAttribute<AllowAnonymousAttribute>() is not null)
+            .ToList();
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyRecoverySessionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyRecoverySessionTests.cs
@@ -19,6 +19,11 @@ namespace Nocturne.API.Tests.Controllers;
 /// The recovery-code path over the real pipeline: spending a code has to leave the caller able to
 /// enrol a replacement passkey, and able to do nothing else.
 /// </summary>
+/// <remarks>
+/// One factory, so one rate limiter, and the test server presents no client address — every test
+/// here draws from the same <c>passkey-recovery</c> bucket (10 per 10 minutes). Adding recovery
+/// verifications in bulk trips a 429 on whichever test happens to run last.
+/// </remarks>
 public class PasskeyRecoverySessionTests : IClassFixture<AuthenticationTestFactory>
 {
     private const string RecoveryCookieName = ".Nocturne.RecoverySession";


### PR DESCRIPTION
Fixes #845.

## What

`PasskeyController` carried no rate limit at all — including the recovery-code verify path (short human-typed one-time codes) and the ceremonies. Twelve anonymous endpoints join #842's `ClientAddressPolicies` table: `passkey-login` 30/1m, `passkey-register` 20/1m (shared by register/recovery-mode/invite ceremonies), `passkey-recovery` 10/10m, `passkey-access-request` 5/10m. Session-gated management endpoints and the every-page-load `GET status` (tenant flags only, verified no enumeration surface) stay unlimited, pinned by test.

Ceilings are sized for this deployment's reality — a ceremony spends two permits and a household or clinic behind one NAT is a single partition (the constraint lives on the table comment). Recovery's tightness comes from its 10× window, not its ceiling: codes are ~50 bits so grinding is infeasible at any rate — the limit bounds audit-write amplification and each failure's auth-audit row.

**Partition honesty** (correcting the first commit message's overclaim): the signed end-user address applies to SSR-originated traffic, which is how every one of these endpoints is actually called by the app. Direct `/api` calls fall back to the XFF-derived connection address, spoofable per the tracked #846 — so against a header-rotating attacker these limits are a bound on honest traffic, not a defence; #846 is where that closes.

## Review gates

Two-stage. The hostile review reported survives with one must-fix, applied: a throttled recovery attempt was indistinguishable from a wrong code on the emergency carer path (the catch-all rendered "don't match" for a 429). Recovery failures are now classified (mirroring the guest-activation precedent), with the rate-limit copy hoisted to one shared constant rather than a near-duplicate string; the reviewer verified a 429'd attempt burns no code (limiter short-circuits pre-controller). It also confirmed: challenge minting is stateless (no accumulation), access-request row creation is bounded by the display-name dedup, TotpController was already covered, and two full-suite runs showed zero rate-limit test bleed.

## Testing

115 passkey/rate-limit tests pass post-rebase over #865. Mutation proofs: removing one attribute fails 4 guards (coverage + behavioural 429); breaking the 429 classifier fails 2 vitest cases. Known flake for the record: `DocumentProcessingServiceTests.ProcessDocuments_WithLargeTextFields_SanitizesEfficiently` is timing-sensitive and failed once in a full run, passing in isolation — unrelated, a fourth known-flaky.

https://claude.ai/code/session_01QVu35DdVT79uU71YFHrcup
