### PR TITLE
fix(services): make data-source delete failures structurally typed

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -332,7 +332,7 @@ public class ServicesController : ControllerBase
             var result = await _dataSourceService.DeleteDataSourceDataAsync(id, cancellationToken);
             if (!result.Success)
             {
-                if (result.Error?.Contains("not found") == true)
+                if (result.ErrorCode == DataSourceDeleteError.NotFound)
                 {
                     return NotFound(result);
                 }
@@ -406,7 +406,7 @@ public class ServicesController : ControllerBase
 
             if (!result.Success)
             {
-                if (result.Error?.Contains("not found") == true)
+                if (result.ErrorCode == DataSourceDeleteError.NotFound)
                 {
                     return NotFound(result);
                 }

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -611,7 +612,7 @@ public class DataSourceService : IDataSourceService
             info.Icon = "xdrip4ios";
             info.Description = ExtractDeviceDescription(deviceId, "xDrip4iOS on");
         }
-        else if (lowerDevice.Contains("xdrip") || lowerDevice.StartsWith("xdrip"))
+        else if (lowerDevice.Contains("xdrip"))
         {
             info.Name = "xDrip+";
             info.SourceType = "xdrip";
@@ -857,12 +858,10 @@ public class DataSourceService : IDataSourceService
             var metadata = ConnectorMetadataService.GetByConnectorId(connectorId);
             if (metadata == null)
             {
-                return new DataSourceDeleteResult
-                {
-                    Success = false,
-                    DataSource = connectorId,
-                    Error = $"Connector not found: {connectorId}",
-                };
+                return DataSourceDeleteResult.Failed(
+                    connectorId,
+                    DataSourceDeleteError.NotFound,
+                    $"Connector not found: {connectorId}");
             }
 
             // Connector's DataSourceId is what we use in the database (e.g. "dexcom-connector")
@@ -898,12 +897,10 @@ public class DataSourceService : IDataSourceService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deleting data for connector: {ConnectorId}", connectorId);
-            return new DataSourceDeleteResult
-            {
-                Success = false,
-                DataSource = connectorId,
-                Error = "Failed to delete connector data",
-            };
+            return DataSourceDeleteResult.Failed(
+                connectorId,
+                DataSourceDeleteError.DeleteFailed,
+                "Failed to delete connector data");
         }
     }
 
@@ -972,13 +969,11 @@ public class DataSourceService : IDataSourceService
 
     internal static string GenerateId(string deviceId) => $"ds-{HashUtils.Sha256Hex(deviceId)[..8]}";
 
-    private static string CleanDeviceName(string deviceId)
+    internal static string CleanDeviceName(string deviceId)
     {
-        // Clean up device ID to make it more readable
         var name = deviceId.Replace("-", " ").Replace("_", " ").Trim();
 
-        // Capitalize first letter of each word
-        return System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(name.ToLower());
+        return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(name.ToLowerInvariant());
     }
 
     private static string ExtractDeviceDescription(string deviceId, string prefix)
@@ -1012,12 +1007,10 @@ public class DataSourceService : IDataSourceService
             if (source == null)
             {
                 _logger.LogWarning("Data source not found: {DataSourceId}", dataSourceId);
-                return new DataSourceDeleteResult
-                {
-                    Success = false,
-                    DataSource = dataSourceId,
-                    Error = $"Data source not found: {dataSourceId}",
-                };
+                return DataSourceDeleteResult.Failed(
+                    dataSourceId,
+                    DataSourceDeleteError.NotFound,
+                    $"Data source not found: {dataSourceId}");
             }
 
             // The deviceId is the raw Device field value from sensor_glucose (e.g. "dexcom-connector",
@@ -1047,12 +1040,10 @@ public class DataSourceService : IDataSourceService
                 "Error deleting data for data source: {DataSourceId}",
                 dataSourceId
             );
-            return new DataSourceDeleteResult
-            {
-                Success = false,
-                DataSource = dataSourceId,
-                Error = ex.Message,
-            };
+            return DataSourceDeleteResult.Failed(
+                dataSourceId,
+                DataSourceDeleteError.DeleteFailed,
+                ex.Message);
         }
     }
 
@@ -1104,12 +1095,10 @@ public class DataSourceService : IDataSourceService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error deleting demo data");
-            return new DataSourceDeleteResult
-            {
-                Success = false,
-                DataSource = DataSources.DemoService,
-                Error = ex.Message,
-            };
+            return DataSourceDeleteResult.Failed(
+                DataSources.DemoService,
+                DataSourceDeleteError.DeleteFailed,
+                ex.Message);
         }
     }
 

--- a/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
+++ b/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
@@ -431,4 +431,43 @@ public class DataSourceDeleteResult
     /// </summary>
     [JsonPropertyName("error")]
     public string? Error { get; set; }
+
+    /// <summary>
+    /// Failure kind for programmatic handling. <see cref="Error"/> is diagnostic only.
+    /// </summary>
+    [JsonPropertyName("errorCode")]
+    public DataSourceDeleteError? ErrorCode { get; set; }
+
+    /// <summary>
+    /// Create a failed result for the named data source.
+    /// </summary>
+    public static DataSourceDeleteResult Failed(
+        string dataSource,
+        DataSourceDeleteError errorCode,
+        string error
+    ) =>
+        new()
+        {
+            Success = false,
+            DataSource = dataSource,
+            ErrorCode = errorCode,
+            Error = error,
+        };
+}
+
+/// <summary>
+/// Why a data source deletion failed.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<DataSourceDeleteError>))]
+public enum DataSourceDeleteError
+{
+    /// <summary>
+    /// No data source or connector matches the requested identifier.
+    /// </summary>
+    NotFound,
+
+    /// <summary>
+    /// The deletion itself failed.
+    /// </summary>
+    DeleteFailed,
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerDeleteFailureMappingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerDeleteFailureMappingTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Controllers.V4.Platform;
+using Nocturne.API.Multitenancy;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Services;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Platform;
+
+/// <summary>
+/// The delete endpoints distinguish "no such source" (404) from "the delete failed" (500) by
+/// <see cref="DataSourceDeleteResult.ErrorCode"/>, so the mapping survives any rewording of the
+/// human-readable <see cref="DataSourceDeleteResult.Error"/> message.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ServicesControllerDeleteFailureMappingTests
+{
+    private const string DataSourceId = "ds-8ba3c03d";
+    private const string ConnectorId = "dexcom";
+
+    private readonly Mock<IDataSourceService> _dataSourceService = new();
+
+    private ServicesController CreateController() =>
+        new(
+            _dataSourceService.Object,
+            Mock.Of<IConnectorHealthService>(),
+            Mock.Of<IConnectorSyncService>(),
+            Mock.Of<ILogger<ServicesController>>(),
+            Mock.Of<ITenantAccessor>(),
+            Options.Create(new BaseDomainOptions()));
+
+    [Fact]
+    public async Task DeleteDataSourceData_MissingSource_Returns404_WhateverTheMessageSays()
+    {
+        _dataSourceService
+            .Setup(s => s.DeleteDataSourceDataAsync(DataSourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DataSourceDeleteResult.Failed(
+                DataSourceId,
+                DataSourceDeleteError.NotFound,
+                "No data source matches that identifier"));
+
+        var response = await CreateController().DeleteDataSourceData(DataSourceId, CancellationToken.None);
+
+        response.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task DeleteDataSourceData_DeleteFailure_Returns500_EvenWhenTheMessageMentionsNotFound()
+    {
+        _dataSourceService
+            .Setup(s => s.DeleteDataSourceDataAsync(DataSourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DataSourceDeleteResult.Failed(
+                DataSourceId,
+                DataSourceDeleteError.DeleteFailed,
+                "relation \"boluses\" not found"));
+
+        var response = await CreateController().DeleteDataSourceData(DataSourceId, CancellationToken.None);
+
+        response.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task DeleteConnectorData_MissingConnector_Returns404_WhateverTheMessageSays()
+    {
+        _dataSourceService
+            .Setup(s => s.DeleteConnectorDataAsync(ConnectorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DataSourceDeleteResult.Failed(
+                ConnectorId,
+                DataSourceDeleteError.NotFound,
+                "No connector matches that identifier"));
+
+        var response = await CreateController().DeleteConnectorData(ConnectorId, CancellationToken.None);
+
+        response.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task DeleteConnectorData_DeleteFailure_Returns500_EvenWhenTheMessageMentionsNotFound()
+    {
+        _dataSourceService
+            .Setup(s => s.DeleteConnectorDataAsync(ConnectorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DataSourceDeleteResult.Failed(
+                ConnectorId,
+                DataSourceDeleteError.DeleteFailed,
+                "sync cursor not found while purging"));
+
+        var response = await CreateController().DeleteConnectorData(ConnectorId, CancellationToken.None);
+
+        response.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(500);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceCleanDeviceNameTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceCleanDeviceNameTests.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using FluentAssertions;
+using Nocturne.API.Services.Connectors;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// The display name derived for an unrecognised device is part of the API response, so it must not
+/// depend on the server's locale — a Turkish-locale host must not spell "xDrip" with a dotless i.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DataSourceServiceCleanDeviceNameTests
+{
+    [Theory]
+    [InlineData("XDRIP-IPHONE", "Xdrip Iphone")]
+    [InlineData("my_INSULIN-pump", "My Insulin Pump")]
+    [InlineData("  dexcom-connector  ", "Dexcom Connector")]
+    public void CleanDeviceName_TitleCasesInvariantly(string deviceId, string expected)
+    {
+        DataSourceService.CleanDeviceName(deviceId).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("tr-TR")]
+    [InlineData("az-AZ")]
+    [InlineData("lt-LT")]
+    [InlineData("en-US")]
+    public void CleanDeviceName_IgnoresTheServerCulture(string culture)
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+            DataSourceService.CleanDeviceName("XDRIP-IPHONE").Should().Be("Xdrip Iphone");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteConnectorDataTests.cs
@@ -11,6 +11,7 @@ using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Services;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -243,6 +244,9 @@ public class DataSourceServiceDeleteConnectorDataTests : IDisposable
         var result = await CreateService(ctx).DeleteConnectorDataAsync("not-a-connector");
 
         result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(
+            DataSourceDeleteError.NotFound,
+            "the controller maps the 404 off the error code, not the message text");
         _connectorConfig.Verify(c => c.SetActiveAsync(
             It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);


### PR DESCRIPTION
Fixes #823.

## What changed
- **Structured not-found signal.** `DataSourceDeleteResult` gains a `DataSourceDeleteError` code (`NotFound` / `DeleteFailed`) plus a `Failed(...)` factory, mirroring the existing `JwtValidationResult` shape (nullable enum `ErrorCode` next to the human `Error`). All five failure returns in `DataSourceService` classify themselves, and `ServicesController` branches on the code instead of `Error?.Contains("not found")` — so rewording a message can no longer flip a 404 into a 500.
- **`CleanDeviceName` is now locale-independent**: `ToLowerInvariant()` + `CultureInfo.InvariantCulture.TextInfo` (was `CurrentCulture` both times — the Turkish-I class of bug). Its two narrating comments are gone.
- **Dropped the redundant `StartsWith("xdrip")` disjunct** that `Contains("xdrip")` already covers.

## Item 4 of the issue: evaluated and deliberately NOT done
The issue suggested the manage dialog send the raw `deviceId` instead of the derived `ds-<hash>` id. Tested empirically: ASP.NET Core never decodes `%2F` inside a path segment (a probe endpoint receiving `loop%3A%2F%2FiPhone%20Name` got the literal string `loop:%2F%2FiPhone Name` — space decoded, slashes not). A slash-bearing device string like Loop's `loop://iPhone` would therefore miss both lookups in the endpoint and become undeletable from the UI. The hash id is the URL-safe stable handle, and #793 already fixed its instability, so the dialog keeps sending it.

## Tests
- New: 4 controller mapping facts (404/500 chosen by error code, with messages deliberately crafted to fail the old substring match) + 7 `CleanDeviceName` cases including tr-TR/az-AZ/lt-LT culture pinning.
- Mutation-proofed: reverting the fixes makes exactly those 6 tests fail; green again with the fixes restored.
- Full `Nocturne.API.Tests` unit run: 5814 passed, 0 failed.

Follow-ups found during this work are filed as #876 (raw exception text to clients, two 404 shapes in the controller, generated remote commands collapsing 404 to 500, remaining narrating comments).
