### PR TITLE
chore(connectors): delete the producerless SyncProgressEvent fields

### DIFF
--- a/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
+++ b/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
@@ -684,10 +684,9 @@ public class SignalRBroadcastService : ISignalRBroadcastService
         try
         {
             _logger.LogDebug(
-                "Broadcasting sync progress for {ConnectorId}: {Phase} - {DataType}",
+                "Broadcasting sync progress for {ConnectorId}: {Phase}",
                 progress.ConnectorId,
-                progress.Phase,
-                progress.CurrentDataType
+                progress.Phase
             );
 
             await _configHubContext

--- a/src/Connectors/Nocturne.Connectors.Core/Models/SyncProgressEvent.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Models/SyncProgressEvent.cs
@@ -5,10 +5,6 @@ public class SyncProgressEvent
     public required string ConnectorId { get; set; }
     public required string ConnectorName { get; set; }
     public SyncPhase Phase { get; set; }
-    public SyncDataType? CurrentDataType { get; set; }
-    public List<SyncDataType> CompletedDataTypes { get; set; } = [];
-    public int TotalDataTypes { get; set; }
-    public Dictionary<SyncDataType, int> ItemsSyncedSoFar { get; set; } = new();
     public string? ErrorMessage { get; set; }
     public SyncMessageType? MessageType { get; set; }
     public Dictionary<string, string>? MessageParams { get; set; }

--- a/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
@@ -37,10 +37,6 @@
 
   interface SyncProgress {
     phase: string;
-    currentDataType: string | null;
-    completedDataTypes: string[];
-    totalDataTypes: number;
-    itemsSyncedSoFar: Record<string, number>;
     messageType: SyncMessageType | null;
     messageParams: Record<string, string> | null;
   }

--- a/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
@@ -41,10 +41,6 @@
     last24hBreakdown?: Record<string, number>;
     syncProgress?: {
       phase: string;
-      currentDataType: string | null;
-      completedDataTypes: string[];
-      totalDataTypes: number;
-      itemsSyncedSoFar: Record<string, number>;
       messageType: SyncMessageType | null;
       messageParams: Record<string, string> | null;
     } | null;
@@ -179,12 +175,7 @@
               class="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100 text-xs"
             >
               <Loader2 class="h-3 w-3 mr-1 animate-spin" />
-              {#if syncProgress?.currentDataType}
-                Syncing {syncProgress.currentDataType}
-                ({syncProgress.completedDataTypes.length}/{syncProgress.totalDataTypes})
-              {:else}
-                Syncing
-              {/if}
+              Syncing
             </Badge>
           {:else if syncProgress?.phase === "Completed"}
             <Badge
@@ -342,13 +333,6 @@
           <Clock class="inline h-3 w-3" />
           {formatAge(lastSuccessfulSync ?? lastSeen)}
         </p>
-        {/if}
-        {#if syncProgress?.phase === "Syncing" && Object.keys(syncProgress.itemsSyncedSoFar).length > 0}
-          <p class="text-xs text-blue-600 dark:text-blue-400">
-            {Object.entries(syncProgress.itemsSyncedSoFar)
-              .map(([type, count]) => `${count.toLocaleString()} ${type}`)
-              .join(", ")} synced so far
-          </p>
         {/if}
 
         <!-- Error detail -->

--- a/src/Web/packages/app/src/lib/websocket/types.ts
+++ b/src/Web/packages/app/src/lib/websocket/types.ts
@@ -97,10 +97,6 @@ export interface SyncProgressEvent {
   connectorId: string;
   connectorName: string;
   phase: "Syncing" | "Completed" | "Failed";
-  currentDataType: string | null;
-  completedDataTypes: string[];
-  totalDataTypes: number;
-  itemsSyncedSoFar: Record<string, number>;
   errorMessage: string | null;
   timestamp: string;
   messageType: SyncMessageType | null;


### PR DESCRIPTION
Addresses the SyncProgressEvent half of #862 (the `LastEntryTimes` half is a give-it-a-reader-or-delete-it maintainer decision and is deliberately untouched).

`CompletedDataTypes`, `TotalDataTypes`, `ItemsSyncedSoFar` and `CurrentDataType` were never assigned anywhere — the only construction site of `SyncProgressEvent` in the repo (`BaseConnectorService.cs:735`) sets none of them, so every wire consumer has only ever seen null/0/empty. Deleted:

- the four C# properties;
- the `{DataType}` placeholder from the broadcast debug log (only C# read);
- the fields from the hand-written TS mirror (`websocket/types.ts`) and from BOTH duplicate component-local mirrors (`ServerConnectorsCard`, `DataSourceRow`);
- the `DataSourceRow` renders that existed solely to consume them: the "Syncing <type> (n/total)" badge branch (collapsed to the plain "Syncing" it always showed in practice) and the "synced so far" paragraph gated on a dictionary that was always empty.

Kept: the `.po` locale entries for the deleted copy (the translations workflow owns those and re-syncs on main), and the component-local mirror types themselves (trimmed rather than unified — the three-way duplication is filed separately).

Tests: Connectors.Core 118/118, API unit suite 5803 passed / 0 failed; nothing referenced the deleted fields, no test pinned the payload shape. `pnpm check` unchanged at the 64-error baseline, zero in touched files.

Verified independently at review: repo-wide grep (C#, TS, sdk, crates) finds no surviving reference outside locale files.
