### PR TITLE
fix(connectors): count a connector's device status by data source, not rig name

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -234,7 +234,10 @@ public class DataSourceService : IDataSourceService
             })
             .ToListAsync(cancellationToken);
 
-        // Also check APS snapshots for devices that might not have entries
+        // Also check APS snapshots for devices that might not have entries. Discovery keys on Device,
+        // not DataSource: an entry's identity here is the uploader string that CreateDataSourceInfo
+        // parses for name, category and icon, so a connector-imported snapshot still lists its rig.
+        // The connector keeps its own entry via GetNonGlucoseStatsAsync, which keys on DataSource.
         var deviceStatusDevices = await _context
             .ApsSnapshots.Where(ds =>
                 ds.Timestamp >= thirtyDaysAgoDate && ds.Device != null && ds.Device != ""
@@ -1120,7 +1123,6 @@ public class DataSourceService : IDataSourceService
     )
     {
         var now = DateTimeOffset.UtcNow;
-        var oneDayAgo = now.AddHours(-24).ToUnixTimeMilliseconds();
         var oneDayAgoDate = now.AddHours(-24).UtcDateTime;
 
         // Query V4 sensor glucose stats
@@ -1205,11 +1207,11 @@ public class DataSourceService : IDataSourceService
             : 0;
 
         var deviceStatusTotal = await _context
-            .ApsSnapshots.Where(ds => ds.Device == dataSource)
+            .ApsSnapshots.Where(ds => ds.DataSource == dataSource || (ds.DataSource == null && ds.Device == dataSource))
             .LongCountAsync(cancellationToken);
         var deviceStatus24h = deviceStatusTotal > 0
             ? await _context.ApsSnapshots
-                .Where(ds => ds.Device == dataSource && ds.Timestamp >= DateTimeOffset.FromUnixTimeMilliseconds(oneDayAgo).UtcDateTime)
+                .Where(ds => (ds.DataSource == dataSource || (ds.DataSource == null && ds.Device == dataSource)) && ds.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceStatsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceStatsTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Covers <see cref="DataSourceService.GetDataSourceStatsAsync"/>'s per-type attribution. Its only
+/// caller (<c>ConnectorHealthService</c>) always passes a connector's data-source id, so every type
+/// must resolve a row through <c>DataSource</c> and fall back to <c>Device</c> only for the legacy
+/// uploader rows that predate the column. Device status used to match on <c>Device</c> alone, which a
+/// connector import never carries, so the connector's device-status count read zero.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DataSourceServiceStatsTests : IDisposable
+{
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private const string DataSource = "nightscout-connector";
+    private const string Rig = "openaps://rig";
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+
+    private readonly Mock<ISensorGlucoseRepository> _sensorGlucose = new();
+    private readonly Mock<IMeterGlucoseRepository> _meterGlucose = new();
+    private readonly Mock<ICalibrationRepository> _calibrations = new();
+    private readonly Mock<IConnectorConfigurationService> _connectorConfig = new();
+
+    public DataSourceServiceStatsTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        db.Tenants.Add(new TenantEntity { Id = TenantId, Slug = "test" });
+        db.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private NocturneDbContext NewContext() => new(_dbOptions) { TenantId = TenantId };
+
+    private DataSourceService CreateService(NocturneDbContext context) => new(
+        context,
+        _sensorGlucose.Object,
+        _meterGlucose.Object,
+        _calibrations.Object,
+        Mock.Of<IAuditContext>(),
+        _connectorConfig.Object,
+        NullLogger<DataSourceService>.Instance);
+
+    private void SeedApsSnapshot(string? dataSource, string? device, DateTime timestamp)
+    {
+        using var db = NewContext();
+        db.ApsSnapshots.Add(new ApsSnapshotEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            DataSource = dataSource,
+            Device = device,
+            Timestamp = timestamp,
+            AidAlgorithm = "Loop",
+        });
+        db.SaveChanges();
+    }
+
+    private async Task<DataSourceStats> StatsFor(string dataSource)
+    {
+        await using var ctx = NewContext();
+        return await CreateService(ctx).GetDataSourceStatsAsync(dataSource);
+    }
+
+    [Fact]
+    public async Task Stats_AttributeAnImportedSnapshotToItsConnector()
+    {
+        // The shape DeviceStatusDecomposer writes for a connector import: Device is the rig string the
+        // uploader reported, DataSource is the connector id.
+        SeedApsSnapshot(DataSource, Rig, DateTime.UtcNow);
+
+        var stats = await StatsFor(DataSource);
+
+        stats.TypeBreakdown.Should().Contain(new KeyValuePair<string, long>("DeviceStatus", 1));
+        stats.TypeBreakdownLast24Hours.Should().Contain(new KeyValuePair<string, int>("DeviceStatus", 1));
+    }
+
+    [Fact]
+    public async Task Stats_ExcludeSnapshotsFromAnotherDataSource()
+    {
+        SeedApsSnapshot("glooko", Rig, DateTime.UtcNow);
+
+        var stats = await StatsFor(DataSource);
+
+        stats.TypeBreakdown.Should().NotContainKey("DeviceStatus");
+    }
+
+    [Fact]
+    public async Task Stats_StillAttributeALegacyUploaderSnapshotByDevice()
+    {
+        // A direct v1 devicestatus upload carries no DataSource, so Device is the only handle on it.
+        SeedApsSnapshot(null, DataSource, DateTime.UtcNow);
+
+        var stats = await StatsFor(DataSource);
+
+        stats.TypeBreakdown.Should().Contain(new KeyValuePair<string, long>("DeviceStatus", 1));
+    }
+
+    [Fact]
+    public async Task Stats_CountOnlyRecentSnapshotsIn24HourBreakdown()
+    {
+        SeedApsSnapshot(DataSource, Rig, DateTime.UtcNow);
+        SeedApsSnapshot(DataSource, Rig, DateTime.UtcNow.AddHours(-25));
+
+        var stats = await StatsFor(DataSource);
+
+        stats.TypeBreakdown.Should().Contain(new KeyValuePair<string, long>("DeviceStatus", 2));
+        stats.TypeBreakdownLast24Hours.Should().Contain(new KeyValuePair<string, int>("DeviceStatus", 1));
+    }
+}


### PR DESCRIPTION
Fixes #869.

- **Per-source device-status stats** (`GetDataSourceStatsAsync`) filtered `ds.Device == dataSource`, while every sibling type in the method — and the #868 purge/summary fix — uses `DataSource == dataSource || (DataSource == null && Device == dataSource)`. `DeviceStatusDecomposer` writes connector imports as `Device = rig string, DataSource = connector id`, so a connector's device-status count read 0. Now uses the siblings' predicate. The method's only caller (`ConnectorHealthService`) always passes a connector data-source id, so nothing regresses.
- While in those lines: the 24h branch recomputed the same cutoff instant from unix millis; it now reuses the `oneDayAgoDate` every sibling uses.
- **Discovery grouping (issue item 2) was judged intentional, not fixed**: the discovery query's identity is the uploader string that `CreateDataSourceInfo` parses for name/category/icon (`openaps://`, `xdrip`, …) — keying it on DataSource would collapse the rig into the connector and erase the AID-system entry, and the connector already gets its own entry via `GetNonGlucoseStatsAsync`. A constraint comment now records the asymmetry so it stops getting re-flagged.

Tests: new `DataSourceServiceStatsTests` (4 facts) seeding the realistic `DataSource = connector, Device = openaps://rig` shape, plus foreign-connector exclusion, legacy null-DataSource fallback, and the 24h window. Mutation-verified at review: reverting the predicate fails exactly the 2 attribution tests. Full API unit suite: 5807 passed / 0 failed.

Follow-ups found during this work (the demo purge that can never match its device-status rows, timestamp queries missing the legacy fallback, and rig-named entries whose delete silently removes 0 rows) are filed separately.
