### PR TITLE
fix(connectors): give basal injections a sync toggle and stop calling attempts retries

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorPropertyKey.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorPropertyKey.cs
@@ -20,6 +20,7 @@ public enum ConnectorPropertyKey
     SyncGlucose,
     SyncManualBG,
     SyncBoluses,
+    SyncBasalInjections,
     SyncCarbIntake,
     SyncBolusCalculations,
     SyncNotes,

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IConnectorConfiguration.cs
@@ -24,7 +24,8 @@ public interface IConnectorConfiguration
     bool Enabled { get; set; }
 
     /// <summary>
-    ///     Maximum retry attempts for failed operations
+    ///     Total attempts a connector operation gets, not retries on top of a first try; 0 and 1
+    ///     both mean a single attempt.
     /// </summary>
     int MaxRetryAttempts { get; set; }
 

--- a/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
@@ -66,6 +66,9 @@ public abstract class BaseConnectorConfiguration : IConnectorConfiguration
     [ConnectorProperty(ConnectorPropertyKey.SyncBoluses, DefaultValue = "true")]
     public bool SyncBoluses { get; set; } = true;
 
+    [ConnectorProperty(ConnectorPropertyKey.SyncBasalInjections, DefaultValue = "true")]
+    public bool SyncBasalInjections { get; set; } = true;
+
     [ConnectorProperty(ConnectorPropertyKey.SyncCarbIntake, DefaultValue = "true")]
     public bool SyncCarbIntake { get; set; } = true;
 
@@ -110,8 +113,8 @@ public abstract class BaseConnectorConfiguration : IConnectorConfiguration
 
     /// <summary>
     ///     Whether this configuration has <paramref name="type"/> switched on. A data type with no
-    ///     sync toggle property — Calibrations, BasalInjections and BGChecks — has nothing to switch
-    ///     it off, so it syncs whenever the connector declares it supported.
+    ///     sync toggle property — Calibrations and BGChecks — has nothing to switch it off, so it
+    ///     syncs whenever the connector declares it supported.
     /// </summary>
     public bool IsDataTypeEnabled(SyncDataType type)
         => !SyncToggleProperties(GetType()).TryGetValue(type, out var toggle)

--- a/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
+++ b/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
@@ -28,8 +28,8 @@ export const connectorPropertyMeta = {
     category: 'General',
   },
   MaxRetryAttempts: {
-    label: 'Max Retry Attempts',
-    description: 'Maximum number of retry attempts on failure',
+    label: 'Max Attempts',
+    description: 'Total connection attempts per sync before giving up (minimum 1)',
     category: 'Advanced',
   },
   BatchSize: {
@@ -57,6 +57,11 @@ export const connectorPropertyMeta = {
   SyncBoluses: {
     label: 'Sync Boluses',
     description: 'Sync insulin bolus delivery records',
+    category: 'Sync',
+  },
+  SyncBasalInjections: {
+    label: 'Sync Basal Injections',
+    description: 'Sync long-acting basal insulin injections',
     category: 'Sync',
   },
   SyncCarbIntake: {

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/BaseConnectorConfigurationTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/BaseConnectorConfigurationTests.cs
@@ -93,6 +93,23 @@ public class BaseConnectorConfigurationTests
     }
 
     [Fact]
+    public void SyncBasalInjections_IsEnabledByDefault()
+    {
+        var config = new TestConnectorConfiguration();
+
+        Assert.True(config.SyncBasalInjections);
+        Assert.True(config.IsDataTypeEnabled(SyncDataType.BasalInjections));
+    }
+
+    [Fact]
+    public void IsDataTypeEnabled_BasalInjections_FollowsToggle()
+    {
+        var config = new TestConnectorConfiguration { SyncBasalInjections = false };
+
+        Assert.False(config.IsDataTypeEnabled(SyncDataType.BasalInjections));
+    }
+
+    [Fact]
     public void GetEnabledDataTypes_IncludesTempBasals_WhenSupportedAndEnabled()
     {
         var config = new TestConnectorConfiguration();

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorSyncToggleTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorSyncToggleTests.cs
@@ -69,8 +69,9 @@ public class ConnectorSyncToggleTests
             .Except(ConnectorSyncToggles.ByPropertyKey.Values)
             .ToList();
 
-        untoggled.Should().Contain(
-            [SyncDataType.Calibrations, SyncDataType.BasalInjections, SyncDataType.BGChecks]);
+        untoggled.Should().Contain([SyncDataType.Calibrations, SyncDataType.BGChecks]);
+        untoggled.Should().NotContain(SyncDataType.BasalInjections,
+            "a connector declares basal injections supported, so the user must be able to switch them off");
 
         var allTogglesOff = new TestConnectorConfiguration();
         foreach (var key in ConnectorSyncToggles.ByPropertyKey.Keys)


### PR DESCRIPTION
Fixes #788 and #789.

## #788 — BasalInjections gets a sync toggle
`SyncBasalInjections` added to `ConnectorPropertyKey` and `BaseConnectorConfiguration` (default **true**, so no existing tenant's sync silently stops on upgrade), plus the TypeScript meta entry. Post-#773 plumbing verified end to end: `ConnectorSyncToggles` derives the type mapping from the enum name, the schema filter only surfaces the control on connectors that declare the type (Glooko only), `IsDataTypeEnabled` resolves the property by reflection, and the JSON binder skips absent keys so stored rows keep the default. Key identity is `Key.ToString()` (never ordinal — re-verified at review), so the mid-enum insertion shifts nothing persisted.

The C#↔TS mirror test did its job: it failed after the C# change ("contains 1 item(s) less") and went green with the TS entry — plus two new facts pinning the default and the toggle-off path, and the untoggled-set test now asserts BasalInjections is NOT in it.

## #789 — the copy stops calling attempts retries
Settings form: "Max Retry Attempts / Maximum number of retry attempts on failure" → "Max Attempts / Total connection attempts per sync before giving up (minimum 1)". The XML doc (which lives on `IConnectorConfiguration`, not the base class) now states the total-attempts semantics including the floor-of-1. Property name deliberately untouched — it is persisted in configuration rows and mirrored in TS; the rename remains deferred per the issue.

Tests: Connectors.Core 120/120, Glooko 73/73, API suite green apart from one wall-clock perf flake reproduced as pre-existing and appended to #873.
