### PR TITLE
fix(connectors): bound the Nightscout materialized glucose fetch

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -407,14 +407,6 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         TConfig config,
         CancellationToken cancellationToken);
 
-    protected virtual Task<IEnumerable<Entry>> FetchGlucoseDataRangeAsync(
-        DateTime? from,
-        DateTime? to
-    )
-    {
-        return FetchGlucoseDataAsync(from);
-    }
-
     protected virtual Task<IEnumerable<Profile>> FetchProfilesAsync()
     {
         return Task.FromResult(Enumerable.Empty<Profile>());

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -405,9 +405,42 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         return result;
     }
 
+    /// <summary>
+    ///     Ceiling on the list <see cref="FetchGlucoseDataAsync"/> builds — roughly ten weeks of
+    ///     five-minute readings.
+    /// </summary>
+    private const int MaxMaterializedEntries = 20_000;
+
+    /// <summary>
+    ///     Hands back one list, so it stops at <see cref="MaxMaterializedEntries"/> however wide a
+    ///     range the caller asks for: this is the accumulation <see cref="PerformSyncInternalAsync"/>
+    ///     streams to avoid, and importing a range belongs to that path, not this one.
+    /// </summary>
     public override async Task<IEnumerable<Entry>> FetchGlucoseDataAsync(DateTime? since = null)
     {
-        return await FetchGlucoseDataRangeAsync(since, null);
+        var entries = new List<Entry>();
+
+        await foreach (var page in FetchGlucosePagesAsync(since, null))
+        {
+            entries.AddRange(page);
+
+            if (entries.Count >= MaxMaterializedEntries)
+            {
+                _logger.LogWarning(
+                    "[{ConnectorSource}] Glucose fetch stopped at {Count} entries; records older than {Oldest:yyyy-MM-dd HH:mm:ss} were not fetched",
+                    ConnectorSource,
+                    entries.Count,
+                    entries[^1].Date);
+                break;
+            }
+        }
+
+        _logger.LogInformation(
+            "[{ConnectorSource}] Retrieved {Count} glucose entries from Nightscout",
+            ConnectorSource,
+            entries.Count);
+
+        return entries;
     }
 
     /// <summary>
@@ -730,21 +763,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                 treatment.DataSource = ConnectorSource;
             yield return page;
         }
-    }
-
-    protected override async Task<IEnumerable<Entry>> FetchGlucoseDataRangeAsync(
-        DateTime? from, DateTime? to)
-    {
-        var allEntries = new List<Entry>();
-        await foreach (var page in FetchGlucosePagesAsync(from, to))
-            allEntries.AddRange(page);
-
-        _logger.LogInformation(
-            "[{ConnectorSource}] Retrieved {Count} glucose entries from Nightscout",
-            ConnectorSource,
-            allEntries.Count);
-
-        return allEntries;
     }
 
     protected override async Task<IEnumerable<Profile>> FetchProfilesAsync()

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
@@ -281,6 +281,42 @@ public class NightscoutConnectorPaginationTests
     }
 
     [Fact]
+    public async Task FetchGlucoseData_RangeWiderThanTheCeiling_StopsInsteadOfAccumulating()
+    {
+        // This overload hands back one list, so an open-ended range must stop at the ceiling
+        // rather than crawl a multi-year history into memory. Pages are newest-first, so what
+        // it stops short of is the older end.
+        const int pageSize = 5_000;
+        const int ceiling = 20_000;
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "https://nightscout.example.com",
+            ApiSecret = "test-secret",
+            MaxCount = pageSize,
+        };
+
+        var handler = new SequentialMockHandler();
+        var pageStart = BaseTime;
+        // One more full page than the ceiling can hold: without the stop, the crawl takes it too.
+        for (var i = 0; i < (ceiling / pageSize) + 1; i++)
+        {
+            var page = CreateEntries(pageSize, pageStart);
+            handler.Enqueue(JsonResponse(page));
+            pageStart = DateTimeOffset.FromUnixTimeMilliseconds(page.Min(e => e.Mills)).AddMilliseconds(-1);
+        }
+
+        var service = CreateService(handler, config);
+
+        var result = (await service.FetchGlucoseDataAsync()).ToList();
+
+        result.Should().HaveCount(ceiling,
+            "the materialized fetch must stop at its ceiling, not accumulate the whole range");
+        handler.RequestUrls.Should().HaveCount(ceiling / pageSize,
+            "reaching the ceiling must stop the crawl, not just trim what it already fetched");
+    }
+
+    [Fact]
     public async Task FetchGlucoseData_SetsDataSourceOnAllEntries()
     {
         var page1 = CreateEntries(MaxCount, BaseTime);


### PR DESCRIPTION
Fixes #851.

## What the caller graph showed
`FetchGlucoseDataRangeAsync` was pure indirection: one override (Nightscout), one caller (Nightscout's own `FetchGlucoseDataAsync`), nothing else in the repo. The outer member is `IConnectorService` surface whose only in-repo production caller is the connect CLI's dry-run — which passes a user-controlled `--since` (multi-year ranges are legal) but can only construct Glooko/Dexcom/Libre/MyLife, none of which reach the Nightscout implementation.

## The fix
- Deleted `FetchGlucoseDataRangeAsync` (base virtual + Nightscout override) — the OOM accumulation shape the file's own design comment warns about no longer exists anywhere.
- `NightscoutConnectorService.FetchGlucoseDataAsync` iterates `FetchGlucosePagesAsync` directly and stops at a hard ceiling (`MaxMaterializedEntries = 20_000`, ~10 weeks of 5-minute readings), logging the oldest instant it stopped short of. A constraint comment points range imports at the streaming sync path that owns them.
- A date-window clamp was tried first and deliberately rejected: it changes which records come back (and broke 4 existing pagination-semantics tests); the count ceiling bounds memory unconditionally while leaving every date-semantics contract untouched.

## Tests
New `FetchGlucoseData_RangeWiderThanTheCeiling_StopsInsteadOfAccumulating`: serves 5 full pages of 5,000, asserts 20,000 entries AND only 4 HTTP requests (the ceiling stops the crawl, not just trims the result). Mutation-verified: removing the `break` fails exactly that test. Nightscout suite 44/44 (re-run independently at review), all-connector filter 264/264, Connectors.Core 118/118, Tools.Connect 3/3.

Follow-up filed separately: the CLI dry-run always reports zero entries because every connector it can construct returns an empty materialized fetch — which also makes `IConnectorService.FetchGlucoseDataAsync` a materializing member with no live data producer.
