### PR TITLE
fix(api): serve every ui-settings section from one registry and stop fallbacks shadowing the models

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -455,9 +455,9 @@ public class UISettingsController : ControllerBase, IWriteScopedController
     }
 
     /// <summary>
-    /// <see cref="IUISettingsService.GetAlarmConfigurationAsync"/> returns null only when the read
-    /// itself failed — a tenant that has never saved one still gets a configuration — so
-    /// substituting a value here would let the following write replace the tenant's profiles.
+    /// <see cref="IUISettingsService.GetAlarmConfigurationAsync"/> normalizes every successful read
+    /// to a configuration, so null means the read failed. Substituting a value here would let the
+    /// following write replace the tenant's profiles.
     /// </summary>
     private ObjectResult AlarmConfigurationUnavailable()
     {

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -114,8 +114,7 @@ public class UISettingsController : ControllerBase, IWriteScopedController
                     }
                 }
 
-                // Fallback: Generate default demo settings locally
-                return Ok(GenerateDefaultDemoSettings());
+                return Ok(GenerateDemoSettings());
             }
 
             // Read what was persisted by SaveUISettings; the service falls back to
@@ -275,14 +274,12 @@ public class UISettingsController : ControllerBase, IWriteScopedController
             var demoEnabled = _configuration.GetValue<bool>("DemoMode:Enabled");
             if (demoEnabled)
             {
-                return Ok(GenerateDefaultAlarmConfiguration());
+                return Ok(GenerateDemoAlarmConfiguration());
             }
 
-            var config =
-                await _settingsService.GetAlarmConfigurationAsync(cancellationToken)
-                ?? GenerateDefaultAlarmConfiguration();
+            var config = await _settingsService.GetAlarmConfigurationAsync(cancellationToken);
 
-            return Ok(config);
+            return config == null ? AlarmConfigurationUnavailable() : Ok(config);
         }
         catch (Exception ex)
         {
@@ -365,9 +362,12 @@ public class UISettingsController : ControllerBase, IWriteScopedController
                 );
             }
 
-            var config =
-                await _settingsService.GetAlarmConfigurationAsync(cancellationToken)
-                ?? GenerateDefaultAlarmConfiguration();
+            var config = await _settingsService.GetAlarmConfigurationAsync(cancellationToken);
+            if (config == null)
+            {
+                return AlarmConfigurationUnavailable();
+            }
+
             config.Profiles ??= [];
 
             // A blank id would match every other blank-id profile on the next upsert, so the
@@ -426,9 +426,12 @@ public class UISettingsController : ControllerBase, IWriteScopedController
                 );
             }
 
-            var config =
-                await _settingsService.GetAlarmConfigurationAsync(cancellationToken)
-                ?? GenerateDefaultAlarmConfiguration();
+            var config = await _settingsService.GetAlarmConfigurationAsync(cancellationToken);
+            if (config == null)
+            {
+                return AlarmConfigurationUnavailable();
+            }
+
             config.Profiles ??= [];
 
             if (config.Profiles.RemoveAll(p => p.Id == profileId) == 0)
@@ -451,15 +454,28 @@ public class UISettingsController : ControllerBase, IWriteScopedController
         }
     }
 
-    private static UserAlarmConfiguration GenerateDefaultAlarmConfiguration()
+    /// <summary>
+    /// <see cref="IUISettingsService.GetAlarmConfigurationAsync"/> returns null only when the read
+    /// itself failed — a tenant that has never saved one still gets a configuration — so
+    /// substituting a value here would let the following write replace the tenant's profiles.
+    /// </summary>
+    private ObjectResult AlarmConfigurationUnavailable()
+    {
+        return Problem(
+            detail: "Failed to retrieve alarm configuration",
+            statusCode: 500,
+            title: "Internal Server Error"
+        );
+    }
+
+    /// <summary>
+    /// Sample alarm profiles for the demo tenant. Real tenants are deliberately not seeded with
+    /// these: profiles nobody configured would fire alarms nobody asked for.
+    /// </summary>
+    private static UserAlarmConfiguration GenerateDemoAlarmConfiguration()
     {
         return new UserAlarmConfiguration
         {
-            Version = 1,
-            Enabled = true,
-            SoundEnabled = true,
-            VibrationEnabled = true,
-            GlobalVolume = 80,
             Profiles = new List<AlarmProfileConfiguration>
             {
                 new()
@@ -553,7 +569,11 @@ public class UISettingsController : ControllerBase, IWriteScopedController
         };
     }
 
-    private UISettingsConfiguration GenerateDefaultDemoSettings()
+    /// <summary>
+    /// The demo tenant's sample devices and services. Every other section is left at the
+    /// <see cref="UISettingsConfiguration"/> defaults.
+    /// </summary>
+    private UISettingsConfiguration GenerateDemoSettings()
     {
         return new UISettingsConfiguration
         {
@@ -582,203 +602,117 @@ public class UISettingsController : ControllerBase, IWriteScopedController
                         SerialNumber = "POD98765432",
                     },
                 },
-                AutoConnect = true,
-                ShowRawData = false,
-                UploadEnabled = true,
-                CgmConfiguration = new CgmConfiguration
-                {
-                    DataSourcePriority = "cgm",
-                    SensorWarmupHours = 2,
-                },
             },
-            Algorithm = new AlgorithmSettings
+            Features = new FeatureSettings { Plugins = GenerateDemoPlugins() },
+            Services = new ServicesSettings
             {
-                Prediction = new PredictionSettings
+                ConnectedServices = new List<ConnectedService>
                 {
-                    Enabled = true,
-                    Minutes = 30,
-                    Model = "ar2",
+                    new()
+                    {
+                        Id = "dexcom-share-1",
+                        Name = "Dexcom Share",
+                        Type = "cgm",
+                        Description = "Dexcom G7 - Share account",
+                        Status = "connected",
+                        LastSync = DateTimeOffset.UtcNow.AddMinutes(-2),
+                        Icon = "dexcom",
+                        Configured = true,
+                        Enabled = true,
+                    },
+                    new()
+                    {
+                        Id = "nightscout-backup-1",
+                        Name = "Nightscout Backup",
+                        Type = "data",
+                        Description = "yoursite.herokuapp.com",
+                        Status = "connected",
+                        LastSync = DateTimeOffset.UtcNow.AddMinutes(-15),
+                        Icon = "nightscout",
+                        Configured = true,
+                        Enabled = true,
+                    },
                 },
-                Autosens = new AutosensSettings
-                {
-                    Enabled = true,
-                    Min = 0.7,
-                    Max = 1.2,
-                },
-                CarbAbsorption = new CarbAbsorptionSettings
-                {
-                    DefaultMinutes = 30,
-                    MinRateGramsPerHour = 4,
-                },
-                Loop = new LoopSettings
-                {
-                    Enabled = false,
-                    Mode = "open",
-                    MaxBasalRate = 4.0,
-                    MaxBolus = 10.0,
-                    SmbEnabled = false,
-                    UamEnabled = false,
-                },
-                SafetyLimits = new SafetyLimits { MaxIOB = 10.0, MaxDailyBasalMultiplier = 3.0 },
-            },
-            Features = GenerateDefaultFeatureSettings(),
-            Notifications = GenerateDefaultNotificationSettings(),
-            Services = GenerateDefaultServicesSettings(),
-            Security = new SecuritySettings(),
-        };
-    }
-
-    private FeatureSettings GenerateDefaultFeatureSettings()
-    {
-        return new FeatureSettings
-        {
-            Display = new DisplaySettings
-            {
-                NightMode = false,
-                Theme = "system",
-                TimeFormat = "12",
-                Units = "mg/dl",
-                ShowRawBG = false,
-                FocusHours = 3,
-            },
-            Widgets = new List<WidgetConfig>
-            {
-                new() { Id = WidgetId.BgDelta, Enabled = true, Placement = WidgetPlacement.Top },
-                new() { Id = WidgetId.LastUpdated, Enabled = true, Placement = WidgetPlacement.Top },
-                new() { Id = WidgetId.ConnectionStatus, Enabled = true, Placement = WidgetPlacement.Top },
-                new() { Id = WidgetId.GlucoseChart, Enabled = true, Placement = WidgetPlacement.Main },
-                new() { Id = WidgetId.Statistics, Enabled = true, Placement = WidgetPlacement.Main },
-                new() { Id = WidgetId.Predictions, Enabled = true, Placement = WidgetPlacement.Main },
-                new() { Id = WidgetId.DailyStats, Enabled = true, Placement = WidgetPlacement.Main },
-                new() { Id = WidgetId.Treatments, Enabled = true, Placement = WidgetPlacement.Main },
-            },
-            Plugins = new Dictionary<string, PluginSettings>
-            {
-                {
-                    "delta",
-                    new PluginSettings { Enabled = true, Description = "Show glucose change" }
-                },
-                {
-                    "direction",
-                    new PluginSettings { Enabled = true, Description = "Trend arrow indicator" }
-                },
-                {
-                    "timeago",
-                    new PluginSettings { Enabled = true, Description = "Time since last reading" }
-                },
-                {
-                    "iob",
-                    new PluginSettings { Enabled = true, Description = "Insulin on board" }
-                },
-                {
-                    "cob",
-                    new PluginSettings { Enabled = true, Description = "Carbs on board" }
-                },
-                {
-                    "basal",
-                    new PluginSettings { Enabled = true, Description = "Current basal rate" }
-                },
-                {
-                    "cage",
-                    new PluginSettings { Enabled = false, Description = "Cannula/site age" }
-                },
-                {
-                    "sage",
-                    new PluginSettings { Enabled = true, Description = "Sensor age" }
-                },
-                {
-                    "iage",
-                    new PluginSettings { Enabled = false, Description = "Insulin reservoir age" }
-                },
-                {
-                    "bage",
-                    new PluginSettings { Enabled = false, Description = "Pump battery age" }
-                },
-                {
-                    "pump",
-                    new PluginSettings { Enabled = true, Description = "Pump status" }
-                },
-                {
-                    "loop",
-                    new PluginSettings { Enabled = true, Description = "Loop/OpenAPS status" }
-                },
-                {
-                    "upbat",
-                    new PluginSettings { Enabled = false, Description = "Uploader battery" }
-                },
-                {
-                    "devicestatus",
-                    new PluginSettings { Enabled = false, Description = "Device status details" }
-                },
-                {
-                    "bwp",
-                    new PluginSettings { Enabled = false, Description = "Bolus wizard preview" }
-                },
-                {
-                    "treatmentnotify",
-                    new PluginSettings { Enabled = true, Description = "Treatment notifications" }
-                },
-                {
-                    "openaps",
-                    new PluginSettings { Enabled = false, Description = "OpenAPS pill display" }
-                },
+                AvailableServices = GenerateAvailableServices(),
             },
         };
     }
 
-    private NotificationSettings GenerateDefaultNotificationSettings()
+    /// <summary>
+    /// The plugin pills the demo tenant shows. <see cref="FeatureSettings.Plugins"/> has no defaults,
+    /// so there is nothing to inherit here.
+    /// </summary>
+    private static Dictionary<string, PluginSettings> GenerateDemoPlugins()
     {
-        return new NotificationSettings
+        return new Dictionary<string, PluginSettings>
         {
-            AlarmConfiguration = new UserAlarmConfiguration
             {
-                Enabled = true,
-                SoundEnabled = true,
-                VibrationEnabled = true,
-                GlobalVolume = 80,
-                Profiles = new List<AlarmProfileConfiguration>(),
+                "delta",
+                new PluginSettings { Enabled = true, Description = "Show glucose change" }
             },
-        };
-    }
-
-
-    private ServicesSettings GenerateDefaultServicesSettings()
-    {
-        return new ServicesSettings
-        {
-            ConnectedServices = new List<ConnectedService>
             {
-                new()
-                {
-                    Id = "dexcom-share-1",
-                    Name = "Dexcom Share",
-                    Type = "cgm",
-                    Description = "Dexcom G7 - Share account",
-                    Status = "connected",
-                    LastSync = DateTimeOffset.UtcNow.AddMinutes(-2),
-                    Icon = "dexcom",
-                    Configured = true,
-                    Enabled = true,
-                },
-                new()
-                {
-                    Id = "nightscout-backup-1",
-                    Name = "Nightscout Backup",
-                    Type = "data",
-                    Description = "yoursite.herokuapp.com",
-                    Status = "connected",
-                    LastSync = DateTimeOffset.UtcNow.AddMinutes(-15),
-                    Icon = "nightscout",
-                    Configured = true,
-                    Enabled = true,
-                },
+                "direction",
+                new PluginSettings { Enabled = true, Description = "Trend arrow indicator" }
             },
-            AvailableServices = GenerateAvailableServices(),
-            SyncSettings = new SyncSettings
             {
-                AutoSync = true,
-                SyncOnAppOpen = true,
-                BackgroundRefresh = true,
+                "timeago",
+                new PluginSettings { Enabled = true, Description = "Time since last reading" }
+            },
+            {
+                "iob",
+                new PluginSettings { Enabled = true, Description = "Insulin on board" }
+            },
+            {
+                "cob",
+                new PluginSettings { Enabled = true, Description = "Carbs on board" }
+            },
+            {
+                "basal",
+                new PluginSettings { Enabled = true, Description = "Current basal rate" }
+            },
+            {
+                "cage",
+                new PluginSettings { Enabled = false, Description = "Cannula/site age" }
+            },
+            {
+                "sage",
+                new PluginSettings { Enabled = true, Description = "Sensor age" }
+            },
+            {
+                "iage",
+                new PluginSettings { Enabled = false, Description = "Insulin reservoir age" }
+            },
+            {
+                "bage",
+                new PluginSettings { Enabled = false, Description = "Pump battery age" }
+            },
+            {
+                "pump",
+                new PluginSettings { Enabled = true, Description = "Pump status" }
+            },
+            {
+                "loop",
+                new PluginSettings { Enabled = true, Description = "Loop/OpenAPS status" }
+            },
+            {
+                "upbat",
+                new PluginSettings { Enabled = false, Description = "Uploader battery" }
+            },
+            {
+                "devicestatus",
+                new PluginSettings { Enabled = false, Description = "Device status details" }
+            },
+            {
+                "bwp",
+                new PluginSettings { Enabled = false, Description = "Bolus wizard preview" }
+            },
+            {
+                "treatmentnotify",
+                new PluginSettings { Enabled = true, Description = "Treatment notifications" }
+            },
+            {
+                "openaps",
+                new PluginSettings { Enabled = false, Description = "OpenAPS pill display" }
             },
         };
     }

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -140,7 +140,7 @@ public class UISettingsController : ControllerBase, IWriteScopedController
     /// <summary>
     /// Get settings for a specific section.
     /// </summary>
-    /// <param name="section">Section name: devices, therapy, algorithm, features, notifications, or services</param>
+    /// <param name="section">Name of any <see cref="UISettingsSections"/> entry</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Settings for the specified section</returns>
     [HttpGet("{section}")]
@@ -159,15 +159,13 @@ public class UISettingsController : ControllerBase, IWriteScopedController
             && okResult.Value is UISettingsConfiguration config
         )
         {
-            return section.ToLowerInvariant() switch
-            {
-                "devices" => Ok(config.Devices),
-                "algorithm" => Ok(config.Algorithm),
-                "features" => Ok(config.Features),
-                "notifications" => Ok(config.Notifications),
-                "services" => Ok(config.Services),
-                _ => Problem(detail: $"Unknown settings section: {section}", statusCode: 404, title: "Not Found"),
-            };
+            return UISettingsSections.Find(section) is { } known
+                ? Ok(known.Get(config))
+                : Problem(
+                    detail: $"Unknown settings section: {section}",
+                    statusCode: 404,
+                    title: "Not Found"
+                );
         }
 
         return settings.Result ?? StatusCode(500);

--- a/src/API/Nocturne.API/Services/Profiles/UISettingsService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/UISettingsService.cs
@@ -9,9 +9,8 @@ using Nocturne.Infrastructure.Data.Entities;
 namespace Nocturne.API.Services.Profiles;
 
 /// <summary>
-/// Persists per-tenant UI settings as JSON blobs in the settings table, one row per section
-/// (devices, algorithm, features, notifications, services, data quality, security) plus one row for
-/// the alarm configuration.
+/// Persists per-tenant UI settings as JSON blobs in the settings table, one row per
+/// <see cref="UISettingsSections"/> entry plus one row for the alarm configuration.
 /// </summary>
 /// <remarks>
 /// Every value has exactly one owning row. The aggregate <see cref="UISettingsConfiguration"/> is
@@ -27,73 +26,11 @@ public class UISettingsService : IUISettingsService
 {
     private readonly NocturneDbContext _context;
     private readonly ILogger<UISettingsService> _logger;
-    private readonly IConfiguration _configuration;
 
     private const string SettingsKeyPrefix = "ui:settings:";
     private const string LegacyAggregateKey = "ui:settings:complete";
     private const string AlarmConfigurationKey = "ui:settings:notifications:alarms";
     private const string AlarmConfigurationNotes = "xDrip+-style alarm profiles configuration";
-    private const string NotificationsSectionName = "notifications";
-
-    /// <summary>
-    /// A section of <see cref="UISettingsConfiguration"/>, its settings-table row and its property
-    /// name in the persisted JSON (also the suffix of its key, see <see cref="GetSectionKey"/>).
-    /// </summary>
-    private sealed record Section(
-        string Name,
-        Type Type,
-        Func<UISettingsConfiguration, object?> Get,
-        Action<UISettingsConfiguration, object> Set
-    )
-    {
-        public string Key => GetSectionKey(Name);
-    }
-
-    private static readonly Section[] Sections =
-    [
-        new(
-            "devices",
-            typeof(DeviceSettings),
-            s => s.Devices,
-            (s, v) => s.Devices = (DeviceSettings)v
-        ),
-        new(
-            "algorithm",
-            typeof(AlgorithmSettings),
-            s => s.Algorithm,
-            (s, v) => s.Algorithm = (AlgorithmSettings)v
-        ),
-        new(
-            "features",
-            typeof(FeatureSettings),
-            s => s.Features,
-            (s, v) => s.Features = (FeatureSettings)v
-        ),
-        new(
-            NotificationsSectionName,
-            typeof(NotificationSettings),
-            s => s.Notifications,
-            (s, v) => s.Notifications = (NotificationSettings)v
-        ),
-        new(
-            "services",
-            typeof(ServicesSettings),
-            s => s.Services,
-            (s, v) => s.Services = (ServicesSettings)v
-        ),
-        new(
-            "dataQuality",
-            typeof(DataQualitySettings),
-            s => s.DataQuality,
-            (s, v) => s.DataQuality = (DataQualitySettings)v
-        ),
-        new(
-            "security",
-            typeof(SecuritySettings),
-            s => s.Security,
-            (s, v) => s.Security = (SecuritySettings)v
-        ),
-    ];
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -101,15 +38,10 @@ public class UISettingsService : IUISettingsService
         WriteIndented = false,
     };
 
-    public UISettingsService(
-        NocturneDbContext context,
-        ILogger<UISettingsService> logger,
-        IConfiguration configuration
-    )
+    public UISettingsService(NocturneDbContext context, ILogger<UISettingsService> logger)
     {
         _context = context;
         _logger = logger;
-        _configuration = configuration;
     }
 
     /// <inheritdoc />
@@ -124,10 +56,10 @@ public class UISettingsService : IUISettingsService
             var legacyAggregate = legacy == null ? null : JsonNode.Parse(legacy) as JsonObject;
             var settings = new UISettingsConfiguration();
 
-            foreach (var section in Sections)
+            foreach (var section in UISettingsSections.All)
             {
                 var value =
-                    Deserialize(Value(stored, section.Key), section.Type)
+                    Deserialize(Value(stored, GetSectionKey(section.Name)), section.Type)
                     ?? legacyAggregate?[section.Name]?.Deserialize(section.Type, JsonOptions);
 
                 if (value != null)
@@ -158,7 +90,7 @@ public class UISettingsService : IUISettingsService
     {
         try
         {
-            foreach (var section in Sections)
+            foreach (var section in UISettingsSections.All)
             {
                 var value = section.Get(settings);
                 if (value != null)
@@ -195,7 +127,7 @@ public class UISettingsService : IUISettingsService
                 return await GetAlarmConfigurationAsync(cancellationToken) as T;
             }
 
-            if (FindSection(sectionName) is { } section)
+            if (UISettingsSections.Find(sectionName) is { } section)
             {
                 return section.Get(await GetSettingsAsync(cancellationToken)) as T;
             }
@@ -239,7 +171,7 @@ public class UISettingsService : IUISettingsService
     )
     {
         var section = await GetSectionAsync<NotificationSettings>(
-            NotificationsSectionName,
+            UISettingsSections.Notifications,
             cancellationToken
         );
 
@@ -252,7 +184,11 @@ public class UISettingsService : IUISettingsService
         CancellationToken cancellationToken = default
     )
     {
-        return await SaveSectionAsync(NotificationsSectionName, settings, cancellationToken);
+        return await SaveSectionAsync(
+            UISettingsSections.Notifications,
+            settings,
+            cancellationToken
+        );
     }
 
     /// <inheritdoc />
@@ -309,13 +245,6 @@ public class UISettingsService : IUISettingsService
             "alarms" or "alarmconfiguration" => AlarmConfigurationKey,
             var name => SettingsKeyPrefix + name,
         };
-    }
-
-    private static Section? FindSection(string sectionName)
-    {
-        return Sections.FirstOrDefault(s =>
-            string.Equals(s.Name, sectionName, StringComparison.OrdinalIgnoreCase)
-        );
     }
 
     private async Task<UserAlarmConfiguration?> ReadAlarmConfigurationAsync(

--- a/src/API/Nocturne.API/Services/Profiles/UISettingsService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/UISettingsService.cs
@@ -198,8 +198,13 @@ public class UISettingsService : IUISettingsService
     {
         try
         {
-            return await ReadAlarmConfigurationAsync(cancellationToken)
+            UserAlarmConfiguration? stored =
+                await ReadAlarmConfigurationAsync(cancellationToken)
                 ?? (await GetNotificationSettingsAsync(cancellationToken)).AlarmConfiguration;
+
+            // A row carrying an explicit JSON null binds over the property initialiser, so a read
+            // that succeeded can still land here with nothing. Null is reserved for a failed read.
+            return stored ?? new UserAlarmConfiguration();
         }
         catch (Exception ex)
         {

--- a/src/Core/Nocturne.Core.Contracts/Profiles/IUISettingsService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Profiles/IUISettingsService.cs
@@ -72,10 +72,11 @@ public interface IUISettingsService
     );
 
     /// <summary>
-    /// Gets just the alarm configuration from notification settings.
+    /// Gets just the alarm configuration from notification settings. A tenant that has never saved
+    /// one reads back an empty configuration, so null means the read itself failed.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>The alarm configuration, or null if not set</returns>
+    /// <returns>The alarm configuration, or null if it could not be read</returns>
     Task<UserAlarmConfiguration?> GetAlarmConfigurationAsync(
         CancellationToken cancellationToken = default
     );

--- a/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
@@ -3,8 +3,9 @@ using System.Text.Json.Serialization;
 namespace Nocturne.Core.Models.Configuration;
 
 /// <summary>
-/// Complete UI settings configuration that can be served to frontend clients.
-/// This model aggregates all settings pages data - devices, algorithm, features, notifications, and services.
+/// Complete UI settings configuration that can be served to frontend clients. It aggregates the
+/// settings pages listed in <see cref="UISettingsSections"/>, each of which is separately
+/// addressable and separately persisted.
 /// In demo mode, these are generated from demo configuration; in production, they come from the database.
 /// Note: Therapy settings are managed via Nightscout Profiles (/api/v1/profile).
 /// </summary>

--- a/src/Core/Nocturne.Core.Models/Configuration/UISettingsSections.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UISettingsSections.cs
@@ -1,0 +1,84 @@
+namespace Nocturne.Core.Models.Configuration;
+
+/// <summary>
+/// One addressable section of <see cref="UISettingsConfiguration"/>: the name it is known by in API
+/// routes and in persisted setting keys, its type, and how to read and write it on the aggregate.
+/// </summary>
+/// <seealso cref="UISettingsSections"/>
+public sealed record UISettingsSection(
+    string Name,
+    Type Type,
+    Func<UISettingsConfiguration, object?> Get,
+    Action<UISettingsConfiguration, object> Set
+);
+
+/// <summary>
+/// The sections of <see cref="UISettingsConfiguration"/>. Routing, persistence and section lookup all
+/// read this one list, so a section is addressable everywhere or nowhere.
+/// </summary>
+public static class UISettingsSections
+{
+    /// <summary>
+    /// Name of the section carrying <see cref="NotificationSettings"/>.
+    /// </summary>
+    public const string Notifications = "notifications";
+
+    /// <summary>
+    /// Every section, in the order the aggregate declares them.
+    /// </summary>
+    public static IReadOnlyList<UISettingsSection> All { get; } =
+    [
+        new(
+            "devices",
+            typeof(DeviceSettings),
+            s => s.Devices,
+            (s, v) => s.Devices = (DeviceSettings)v
+        ),
+        new(
+            "algorithm",
+            typeof(AlgorithmSettings),
+            s => s.Algorithm,
+            (s, v) => s.Algorithm = (AlgorithmSettings)v
+        ),
+        new(
+            "features",
+            typeof(FeatureSettings),
+            s => s.Features,
+            (s, v) => s.Features = (FeatureSettings)v
+        ),
+        new(
+            Notifications,
+            typeof(NotificationSettings),
+            s => s.Notifications,
+            (s, v) => s.Notifications = (NotificationSettings)v
+        ),
+        new(
+            "services",
+            typeof(ServicesSettings),
+            s => s.Services,
+            (s, v) => s.Services = (ServicesSettings)v
+        ),
+        new(
+            "dataQuality",
+            typeof(DataQualitySettings),
+            s => s.DataQuality,
+            (s, v) => s.DataQuality = (DataQualitySettings)v
+        ),
+        new(
+            "security",
+            typeof(SecuritySettings),
+            s => s.Security,
+            (s, v) => s.Security = (SecuritySettings)v
+        ),
+    ];
+
+    /// <summary>
+    /// The section addressed by <paramref name="name"/>, or null when no section owns that name.
+    /// </summary>
+    public static UISettingsSection? Find(string name)
+    {
+        return All.FirstOrDefault(s =>
+            string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase)
+        );
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerAlarmProfileTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerAlarmProfileTests.cs
@@ -1,16 +1,10 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using Nocturne.API.Controllers.V4.Profiles;
-using Nocturne.API.Services.Profiles;
 using Nocturne.Core.Models.Configuration;
-using Nocturne.Infrastructure.Data;
 using Xunit;
+using static Nocturne.API.Tests.Controllers.V4.Profiles.UISettingsControllerHarness;
 
 namespace Nocturne.API.Tests.Controllers.V4.Profiles;
 
@@ -22,8 +16,6 @@ namespace Nocturne.API.Tests.Controllers.V4.Profiles;
 [Trait("Category", "Unit")]
 public class UISettingsControllerAlarmProfileTests
 {
-    private static readonly Guid TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
-
     [Fact]
     public async Task AddOrUpdateAlarmProfile_isVisibleToGetAlarmConfiguration()
     {
@@ -37,7 +29,7 @@ public class UISettingsControllerAlarmProfileTests
             Threshold = 220,
         });
 
-        var profiles = AlarmConfigOf(await controller.GetAlarmConfiguration()).Profiles;
+        var profiles = await StoredProfiles(controller);
         profiles.Should().ContainSingle(p => p.Id == "night-high")
             .Which.Threshold.Should().Be(220);
     }
@@ -60,7 +52,7 @@ public class UISettingsControllerAlarmProfileTests
             Threshold = 190,
         });
 
-        var profiles = AlarmConfigOf(await controller.GetAlarmConfiguration()).Profiles;
+        var profiles = await StoredProfiles(controller);
         profiles.Should().ContainSingle().Which.Threshold.Should().Be(190);
     }
 
@@ -80,7 +72,7 @@ public class UISettingsControllerAlarmProfileTests
             Name = "Second",
         });
 
-        var profiles = AlarmConfigOf(await controller.GetAlarmConfiguration()).Profiles;
+        var profiles = await StoredProfiles(controller);
         profiles.Should().HaveCount(2);
         profiles.Select(p => p.Id).Should().OnlyHaveUniqueItems().And.NotContain(string.Empty);
     }
@@ -95,8 +87,7 @@ public class UISettingsControllerAlarmProfileTests
 
         await controller.DeleteAlarmProfile("drop");
 
-        AlarmConfigOf(await controller.GetAlarmConfiguration()).Profiles
-            .Select(p => p.Id).Should().Equal("keep");
+        (await StoredProfiles(controller)).Select(p => p.Id).Should().Equal("keep");
     }
 
     [Fact]
@@ -112,41 +103,14 @@ public class UISettingsControllerAlarmProfileTests
 
     // ----- helpers -----
 
-    private static UserAlarmConfiguration AlarmConfigOf(
-        ActionResult<UserAlarmConfiguration> result)
+    private static async Task<List<AlarmProfileConfiguration>> StoredProfiles(
+        UISettingsController controller
+    )
     {
-        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
-        return ok.Value.Should().BeAssignableTo<UserAlarmConfiguration>().Subject;
-    }
+        var config = OkValue<UserAlarmConfiguration>(
+            (await controller.GetAlarmConfiguration()).Result
+        );
 
-    private static UISettingsController NewController()
-    {
-        var options = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        var dbContext = new NocturneDbContext(options) { TenantId = TenantId };
-        var configuration = new ConfigurationBuilder().Build();
-
-        var services = new ServiceCollection();
-        services.AddControllers();
-
-        return new UISettingsController(
-            NullLogger<UISettingsController>.Instance,
-            configuration,
-            Mock.Of<IHttpClientFactory>(),
-            new UISettingsService(
-                dbContext,
-                NullLogger<UISettingsService>.Instance,
-                configuration))
-        {
-            ControllerContext = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext
-                {
-                    RequestServices = services.BuildServiceProvider(),
-                },
-            },
-        };
+        return config.Profiles;
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerAlarmProfileTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerAlarmProfileTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Nocturne.API.Controllers.V4.Profiles;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data.Entities;
 using Xunit;
 using static Nocturne.API.Tests.Controllers.V4.Profiles.UISettingsControllerHarness;
 
@@ -101,6 +102,36 @@ public class UISettingsControllerAlarmProfileTests
 
         result.Result.Should().BeOfType<ObjectResult>()
             .Which.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    /// <summary>
+    /// An explicit JSON null binds over the property initialiser, so these rows deserialize to a
+    /// <see cref="NotificationSettings"/> with no alarm configuration at all. Earlier versions could
+    /// write them; the read has to cope rather than treat it as a failed read.
+    /// </summary>
+    [Theory]
+    [InlineData("ui:settings:complete", """{"notifications":{"alarmConfiguration":null}}""")]
+    [InlineData("ui:settings:notifications", """{"alarmConfiguration":null}""")]
+    public async Task GetAlarmConfiguration_servesAnEmptyConfiguration_forALegacyNullAlarmRow(
+        string key,
+        string value
+    )
+    {
+        var database = NewDatabase();
+        database.Settings.Add(
+            new SettingsEntity
+            {
+                Id = Guid.CreateVersion7(),
+                Key = key,
+                Value = value,
+                IsActive = true,
+            }
+        );
+        await database.SaveChangesAsync();
+
+        var result = await NewController(database).GetAlarmConfiguration();
+
+        OkValue<UserAlarmConfiguration>(result.Result).Profiles.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerAlarmProfileTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerAlarmProfileTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Moq;
 using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Models.Configuration;
 using Xunit;
 using static Nocturne.API.Tests.Controllers.V4.Profiles.UISettingsControllerHarness;
@@ -101,6 +103,50 @@ public class UISettingsControllerAlarmProfileTests
             .Which.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
+    [Fact]
+    public async Task GetAlarmConfiguration_reports500_whenTheStoredConfigurationCannotBeRead()
+    {
+        var controller = NewController(UnreadableAlarmConfiguration().Object);
+
+        var result = await controller.GetAlarmConfiguration();
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    }
+
+    [Fact]
+    public async Task AddOrUpdateAlarmProfile_writesNothing_whenTheStoredConfigurationCannotBeRead()
+    {
+        var settingsService = UnreadableAlarmConfiguration();
+        var controller = NewController(settingsService.Object);
+
+        var result = await controller.AddOrUpdateAlarmProfile(
+            new AlarmProfileConfiguration { Id = "night-high" });
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        settingsService.Verify(
+            s => s.SaveAlarmConfigurationAsync(
+                It.IsAny<UserAlarmConfiguration>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAlarmProfile_writesNothing_whenTheStoredConfigurationCannotBeRead()
+    {
+        var settingsService = UnreadableAlarmConfiguration();
+        var controller = NewController(settingsService.Object);
+
+        var result = await controller.DeleteAlarmProfile("night-high");
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        settingsService.Verify(
+            s => s.SaveAlarmConfigurationAsync(
+                It.IsAny<UserAlarmConfiguration>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     // ----- helpers -----
 
     private static async Task<List<AlarmProfileConfiguration>> StoredProfiles(
@@ -112,5 +158,19 @@ public class UISettingsControllerAlarmProfileTests
         );
 
         return config.Profiles;
+    }
+
+    /// <summary>
+    /// A service whose alarm configuration read fails, which is the only way
+    /// <see cref="IUISettingsService.GetAlarmConfigurationAsync"/> yields null.
+    /// </summary>
+    private static Mock<IUISettingsService> UnreadableAlarmConfiguration()
+    {
+        var settingsService = new Mock<IUISettingsService>();
+        settingsService
+            .Setup(s => s.GetAlarmConfigurationAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserAlarmConfiguration?)null);
+
+        return settingsService;
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerHarness.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerHarness.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.API.Services.Profiles;
+using Nocturne.Core.Contracts.Profiles;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Tests.Controllers.V4.Profiles;
+
+/// <summary>
+/// A <see cref="UISettingsController"/> wired to a real <see cref="UISettingsService"/> over an
+/// in-memory database, so every write can be asserted through the read that serves it.
+/// </summary>
+internal static class UISettingsControllerHarness
+{
+    private static readonly Guid TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    internal static UISettingsController NewController(
+        params (string Key, string Value)[] configuration
+    )
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        var dbContext = new NocturneDbContext(options) { TenantId = TenantId };
+
+        return NewController(
+            new UISettingsService(dbContext, NullLogger<UISettingsService>.Instance),
+            configuration
+        );
+    }
+
+    internal static UISettingsController NewController(
+        IUISettingsService settingsService,
+        params (string Key, string Value)[] configuration
+    )
+    {
+        var services = new ServiceCollection();
+        services.AddControllers();
+
+        return new UISettingsController(
+            NullLogger<UISettingsController>.Instance,
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    configuration.Select(c => new KeyValuePair<string, string?>(c.Key, c.Value))
+                )
+                .Build(),
+            Mock.Of<IHttpClientFactory>(),
+            settingsService
+        )
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    RequestServices = services.BuildServiceProvider(),
+                },
+            },
+        };
+    }
+
+    /// <summary>
+    /// The body of a 200 response, asserting both the status and the body type.
+    /// </summary>
+    internal static T OkValue<T>(ActionResult? result)
+    {
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+
+        return ok.Value.Should().BeAssignableTo<T>().Subject;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerHarness.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerHarness.cs
@@ -25,16 +25,31 @@ internal static class UISettingsControllerHarness
         params (string Key, string Value)[] configuration
     )
     {
-        var options = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
+        return NewController(NewDatabase(), configuration);
+    }
 
-        var dbContext = new NocturneDbContext(options) { TenantId = TenantId };
-
+    internal static UISettingsController NewController(
+        NocturneDbContext dbContext,
+        params (string Key, string Value)[] configuration
+    )
+    {
         return NewController(
             new UISettingsService(dbContext, NullLogger<UISettingsService>.Instance),
             configuration
         );
+    }
+
+    /// <summary>
+    /// An empty tenant database, for tests that seed settings rows the service's own writers cannot
+    /// produce.
+    /// </summary>
+    internal static NocturneDbContext NewDatabase()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new NocturneDbContext(options) { TenantId = TenantId };
     }
 
     internal static UISettingsController NewController(

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerSectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerSectionTests.cs
@@ -70,6 +70,21 @@ public class UISettingsControllerSectionTests
         security.HideGlucoseInFavicon.Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData("Devices")]
+    [InlineData("DEVICES")]
+    [InlineData("dataquality")]
+    [InlineData("DATAQUALITY")]
+    [InlineData("DataQuality")]
+    public async Task GetSectionSettings_matchesSectionNamesWithoutRegardToCase(string section)
+    {
+        var controller = NewController();
+
+        var result = await controller.GetSectionSettings(section);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
     [Fact]
     public async Task GetSectionSettings_reports404_forASectionTheAggregateDoesNotOwn()
     {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerSectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerSectionTests.cs
@@ -9,8 +9,9 @@ using static Nocturne.API.Tests.Controllers.V4.Profiles.UISettingsControllerHarn
 namespace Nocturne.API.Tests.Controllers.V4.Profiles;
 
 /// <summary>
-/// Unit coverage for <c>GET ui-settings/{section}</c> on <see cref="UISettingsController"/>: every
-/// <see cref="UISettingsSections"/> entry must be addressable, and nothing else.
+/// Unit coverage for <c>GET ui-settings/{section}</c> and the demo-mode aggregate on
+/// <see cref="UISettingsController"/>. Every <see cref="UISettingsSections"/> entry must be
+/// addressable, and demo mode must inherit whatever it does not fixture itself.
 /// </summary>
 [Trait("Category", "Unit")]
 public class UISettingsControllerSectionTests
@@ -78,5 +79,33 @@ public class UISettingsControllerSectionTests
 
         result.Result.Should().BeOfType<ObjectResult>()
             .Which.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task GetUISettings_inDemoMode_inheritsEverySectionItDoesNotFixture()
+    {
+        var controller = NewController(("DemoMode:Enabled", "true"));
+
+        var settings = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
+
+        settings.Features.Widgets.Should().BeEquivalentTo(new FeatureSettings().Widgets);
+        settings.Features.Display.Should().BeEquivalentTo(new DisplaySettings());
+        settings.Algorithm.Should().BeEquivalentTo(new AlgorithmSettings());
+        settings.Notifications.Should().BeEquivalentTo(new NotificationSettings());
+        settings.DataQuality.Should().BeEquivalentTo(new DataQualitySettings());
+        settings.Security.Should().BeEquivalentTo(new SecuritySettings());
+        settings.Services.SyncSettings.Should().BeEquivalentTo(new SyncSettings());
+    }
+
+    [Fact]
+    public async Task GetUISettings_inDemoMode_keepsItsSampleDevicesServicesAndPlugins()
+    {
+        var controller = NewController(("DemoMode:Enabled", "true"));
+
+        var settings = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
+
+        settings.Devices.ConnectedDevices.Should().NotBeEmpty();
+        settings.Services.ConnectedServices.Should().NotBeEmpty();
+        settings.Features.Plugins.Should().ContainKey("delta");
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerSectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerSectionTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+using static Nocturne.API.Tests.Controllers.V4.Profiles.UISettingsControllerHarness;
+
+namespace Nocturne.API.Tests.Controllers.V4.Profiles;
+
+/// <summary>
+/// Unit coverage for <c>GET ui-settings/{section}</c> on <see cref="UISettingsController"/>: every
+/// <see cref="UISettingsSections"/> entry must be addressable, and nothing else.
+/// </summary>
+[Trait("Category", "Unit")]
+public class UISettingsControllerSectionTests
+{
+    [Fact]
+    public async Task GetSectionSettings_servesEverySectionTheAggregateOwns()
+    {
+        var controller = NewController();
+        await controller.SaveUISettings(new UISettingsConfiguration());
+
+        foreach (var section in UISettingsSections.All)
+        {
+            var result = await controller.GetSectionSettings(section.Name);
+
+            result
+                .Result.Should()
+                .BeOfType<OkObjectResult>($"section {section.Name} should be addressable")
+                .Which.Value.Should()
+                .BeAssignableTo(section.Type);
+        }
+    }
+
+    [Fact]
+    public async Task GetSectionSettings_servesThePersistedDataQualitySection()
+    {
+        var controller = NewController();
+        var settings = new UISettingsConfiguration();
+        settings.DataQuality.SleepSchedule.BedtimeHour = 1;
+        settings.DataQuality.SleepSchedule.Timezone = "Pacific/Auckland";
+        settings.DataQuality.CompressionLowDetection.Enabled = false;
+        await controller.SaveUISettings(settings);
+
+        var dataQuality = OkValue<DataQualitySettings>(
+            (await controller.GetSectionSettings("dataQuality")).Result
+        );
+
+        dataQuality.SleepSchedule.BedtimeHour.Should().Be(1);
+        dataQuality.SleepSchedule.Timezone.Should().Be("Pacific/Auckland");
+        dataQuality.CompressionLowDetection.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetSectionSettings_servesThePersistedSecuritySection()
+    {
+        var controller = NewController();
+        var settings = new UISettingsConfiguration();
+        settings.Security.RequireAuthForPublicAccess = true;
+        settings.Security.HideGlucoseInFavicon = true;
+        await controller.SaveUISettings(settings);
+
+        var security = OkValue<SecuritySettings>(
+            (await controller.GetSectionSettings("security")).Result
+        );
+
+        security.RequireAuthForPublicAccess.Should().BeTrue();
+        security.HideGlucoseInFavicon.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetSectionSettings_reports404_forASectionTheAggregateDoesNotOwn()
+    {
+        var controller = NewController();
+
+        var result = await controller.GetSectionSettings("therapy");
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.API.Services.Profiles;
 using Nocturne.Core.Models.Configuration;
@@ -354,10 +353,6 @@ public class UISettingsServiceTests
 
     private static UISettingsService NewService(NocturneDbContext context)
     {
-        return new UISettingsService(
-            context,
-            NullLogger<UISettingsService>.Instance,
-            new ConfigurationBuilder().Build()
-        );
+        return new UISettingsService(context, NullLogger<UISettingsService>.Instance);
     }
 }


### PR DESCRIPTION
Addresses #880 items 1, 2, 3 and 5. Item 4 (the persisted connector catalog) is a design decision and stays in the issue.

## What changed

**One section registry.** The `UISettingsService` section list moved to `UISettingsSections` in `Nocturne.Core.Models` next to the aggregate it describes; the controller's parallel five-case switch is gone. `GET /api/v4/ui-settings/{section}` now serves every section the aggregate owns — which fixes `dataQuality` and `security` returning 404 despite being persisted and read by `CompressionLowService`/`CompressionLowDetectionService`. Unknown sections still 404. There is no generic section PUT; the one typed section write (`PUT /notifications`) uses the same registry constant.

**Hostile-review round:** the initial "null only when the read fails" invariant was false at one margin � a legacy-layout row storing an explicit JSON `null` alarm configuration (`ui:settings:complete` or the notifications section row) binds null over the property initialiser and read back as null without an exception, which the guard would have turned into a permanent 500. `GetAlarmConfigurationAsync` now normalizes a successful-read null to an empty configuration (the same result a never-saved tenant gets); the catch path still returns null, so the 500 guard fires only on genuine read failures. Regression theory covers both legacy JSON shapes (reproduced failing pre-fix), and a mixed-case section theory pins the case-insensitive lookup that no test previously guarded.

**Alarm-configuration fallback removed (correction to the issue).** `GenerateDefaultAlarmConfiguration` was not fully dead: a fourth call site — the demo-mode branch of `GET notifications/alarms` — uses it as its primary response, so it survives as `GenerateDemoAlarmConfiguration` (five fields deleted as exact duplicates of `UserAlarmConfiguration`'s initialisers, `Version = 1` included). The three `?? GenerateDefaultAlarmConfiguration()` arms are replaced by a 500 guard: `IUISettingsService.GetAlarmConfigurationAsync` returns null **only** when the stored row cannot be read (`GetNotificationSettingsAsync(...).AlarmConfiguration` is non-nullable with an initialiser), so substituting defaults there was never a virgin-tenant path — it was a failure path that, on the profile POST/DELETE routes, would persist the four built-in profiles over the tenant's real ones. No default seeding was introduced.

**Demo settings inherit the model.** The controller's hand-copied demo defaults (the third copy; #841 removed the service's) collapse onto the model initialisers. Only genuine fixture data remains: sample devices, sample connected services, the plugin pill list (the model default is empty), and the demo alarm profiles.

**Dropped write-only `IConfiguration`** from `UISettingsService`.

## Behavioural deltas

- `GET /ui-settings/dataQuality` and `/security`: 404 → 200 (the fix).
- Demo-mode widget list gains the six widgets it had drifted behind on: Meals, Trackers, TirChart, DailySummary (disabled, Top), Agp (disabled, Main), **BatteryStatus (enabled, Main — the demo dashboard now renders it)**.
- `GET/POST/DELETE notifications/alarms*` return 500 instead of fabricated built-ins when the stored configuration cannot be read (DB failure or corrupt JSON row only).
- Response DTO shapes unchanged; section names are additive.

## Tests

New controller harness (real service over InMemory EF, shared with the alarm-profile tests, replacing a duplicated helper). Coverage: every registry section is addressable; persisted `dataQuality`/`security` round-trip through the section GET; unknown section 404s; demo mode inherits every section it doesn't fixture (asserted against the model initialisers, not a re-copied list); read-failure guard returns 500 and writes nothing (`SaveAlarmConfigurationAsync` verified `Times.Never`).

Mutation-verified: deleting `security` from the registry / short-circuiting the lookup fails 4 new tests plus 2 pre-existing service round-trips; re-adding the `??` fallbacks and emptying the demo fixture fails the other 5.

Full unit run: 5840 passed, 0 failed, 5 skipped (independently reproduced by the hostile reviewer). Post-fix UISettings suite: 33 passed.

