### PR TITLE
fix(data): give "rows this source produced" one owner so purges and totals see every row

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
@@ -178,9 +178,9 @@ public class DemoAdminController : ControllerBase
         db.TenantId = tenant.Id;
 
         var deleted = 0L;
-        deleted += await db.SensorGlucose.PurgeAsync(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService), ct);
-        deleted += await db.MeterGlucose.PurgeAsync(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService), ct);
-        deleted += await db.Calibrations.PurgeAsync(e => e.DataSource == DataSources.DemoService || (e.DataSource == null && e.Device == DataSources.DemoService), ct);
+        deleted += await db.SensorGlucose.PurgeAsync(SourceFilter.For<SensorGlucoseEntity>(DataSources.DemoService), ct);
+        deleted += await db.MeterGlucose.PurgeAsync(SourceFilter.For<MeterGlucoseEntity>(DataSources.DemoService), ct);
+        deleted += await db.Calibrations.PurgeAsync(SourceFilter.For<CalibrationEntity>(DataSources.DemoService), ct);
 
         return Ok(new DemoDeleteResultDto(deleted));
     }
@@ -202,15 +202,15 @@ public class DemoAdminController : ControllerBase
         db.TenantId = tenant.Id;
 
         var deleted = 0L;
-        deleted += await db.Boluses.PurgeAsync(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService), ct);
-        deleted += await db.CarbIntakes.PurgeAsync(c => c.DataSource == DataSources.DemoService || (c.DataSource == null && c.Device == DataSources.DemoService), ct);
-        deleted += await db.BGChecks.PurgeAsync(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService), ct);
-        deleted += await db.Notes.PurgeAsync(n => n.DataSource == DataSources.DemoService || (n.DataSource == null && n.Device == DataSources.DemoService), ct);
-        deleted += await db.DeviceEvents.PurgeAsync(de => de.DataSource == DataSources.DemoService || (de.DataSource == null && de.Device == DataSources.DemoService), ct);
-        deleted += await db.BolusCalculations.PurgeAsync(bc => bc.DataSource == DataSources.DemoService || (bc.DataSource == null && bc.Device == DataSources.DemoService), ct);
-        deleted += await db.TempBasals.PurgeAsync(t => t.DataSource == DataSources.DemoService || (t.DataSource == null && t.Device == DataSources.DemoService), ct);
+        deleted += await db.Boluses.PurgeAsync(SourceFilter.For<BolusEntity>(DataSources.DemoService), ct);
+        deleted += await db.CarbIntakes.PurgeAsync(SourceFilter.For<CarbIntakeEntity>(DataSources.DemoService), ct);
+        deleted += await db.BGChecks.PurgeAsync(SourceFilter.For<BGCheckEntity>(DataSources.DemoService), ct);
+        deleted += await db.Notes.PurgeAsync(SourceFilter.For<NoteEntity>(DataSources.DemoService), ct);
+        deleted += await db.DeviceEvents.PurgeAsync(SourceFilter.For<DeviceEventEntity>(DataSources.DemoService), ct);
+        deleted += await db.BolusCalculations.PurgeAsync(SourceFilter.For<BolusCalculationEntity>(DataSources.DemoService), ct);
+        deleted += await db.TempBasals.PurgeAsync(SourceFilter.For<TempBasalEntity>(DataSources.DemoService), ct);
         deleted += await db.StateSpans.PurgeAsync(s => s.Source == DataSources.DemoService, ct);
-        deleted += await db.ApsSnapshots.PurgeAsync(a => a.Device == DataSources.DemoService, ct);
+        deleted += await db.ApsSnapshots.PurgeAsync(SourceFilter.For<ApsSnapshotEntity>(DataSources.DemoService), ct);
 
         return Ok(new DemoDeleteResultDto(deleted));
     }

--- a/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/ServicesController.cs
@@ -334,7 +334,7 @@ public class ServicesController : ControllerBase
             {
                 if (result.ErrorCode == DataSourceDeleteError.NotFound)
                 {
-                    return NotFound(result);
+                    return Problem(detail: $"Data source not found: {id}", statusCode: 404, title: "Not Found");
                 }
                 return StatusCode(500, result);
             }
@@ -408,7 +408,7 @@ public class ServicesController : ControllerBase
             {
                 if (result.ErrorCode == DataSourceDeleteError.NotFound)
                 {
-                    return NotFound(result);
+                    return Problem(detail: $"Connector not found: {id}", statusCode: 404, title: "Not Found");
                 }
                 return StatusCode(500, result);
             }

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -12,6 +12,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Services;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Connectors;
@@ -783,48 +784,48 @@ public class DataSourceService : IDataSourceService
 
         // Glucose
         var sensorGlucoseCount = await _context
-            .SensorGlucose.Where(sg => sg.DataSource == deviceId || (sg.DataSource == null && sg.Device == deviceId))
+            .SensorGlucose.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (sensorGlucoseCount > 0) counts[nameof(SyncDataType.Glucose)] = sensorGlucoseCount;
 
         var meterGlucoseCount = await _context
-            .MeterGlucose.Where(mg => mg.DataSource == deviceId || (mg.DataSource == null && mg.Device == deviceId))
+            .MeterGlucose.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (meterGlucoseCount > 0) counts[nameof(SyncDataType.ManualBG)] = meterGlucoseCount;
 
         var calibrationsCount = await _context
-            .Calibrations.Where(c => c.DataSource == deviceId || (c.DataSource == null && c.Device == deviceId))
+            .Calibrations.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (calibrationsCount > 0) counts[nameof(SyncDataType.Calibrations)] = calibrationsCount;
 
         // Treatments
         var bolusCount = await _context
-            .Boluses.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId))
+            .Boluses.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (bolusCount > 0) counts[nameof(SyncDataType.Boluses)] = bolusCount;
 
         var carbIntakeCount = await _context
-            .CarbIntakes.Where(c => c.DataSource == deviceId || (c.DataSource == null && c.Device == deviceId))
+            .CarbIntakes.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (carbIntakeCount > 0) counts[nameof(SyncDataType.CarbIntake)] = carbIntakeCount;
 
         var bgChecksCount = await _context
-            .BGChecks.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId))
+            .BGChecks.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (bgChecksCount > 0) counts[nameof(SyncDataType.BGChecks)] = bgChecksCount;
 
         var bolusCalcCount = await _context
-            .BolusCalculations.Where(bc => bc.DataSource == deviceId || (bc.DataSource == null && bc.Device == deviceId))
+            .BolusCalculations.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (bolusCalcCount > 0) counts[nameof(SyncDataType.BolusCalculations)] = bolusCalcCount;
 
         var notesCount = await _context
-            .Notes.Where(n => n.DataSource == deviceId || (n.DataSource == null && n.Device == deviceId))
+            .Notes.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (notesCount > 0) counts[nameof(SyncDataType.Notes)] = notesCount;
 
         var deviceEventsCount = await _context
-            .DeviceEvents.Where(de => de.DataSource == deviceId || (de.DataSource == null && de.Device == deviceId))
+            .DeviceEvents.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (deviceEventsCount > 0) counts[nameof(SyncDataType.DeviceEvents)] = deviceEventsCount;
 
@@ -833,10 +834,8 @@ public class DataSourceService : IDataSourceService
             .LongCountAsync(cancellationToken);
         if (stateSpansCount > 0) counts[nameof(SyncDataType.StateSpans)] = stateSpansCount;
 
-        // Device status. Device carries the rig string the uploader reported (e.g. "openaps://host"),
-        // so an imported snapshot is only reachable through DataSource.
         var deviceStatusCount = await _context
-            .ApsSnapshots.Where(ds => ds.DataSource == deviceId || (ds.DataSource == null && ds.Device == deviceId))
+            .ApsSnapshots.FromSource(deviceId)
             .LongCountAsync(cancellationToken);
         if (deviceStatusCount > 0) counts[nameof(SyncDataType.DeviceStatus)] = deviceStatusCount;
 
@@ -908,51 +907,53 @@ public class DataSourceService : IDataSourceService
     }
 
     /// <summary>
-    /// Deletes every data type written by <paramref name="deviceId"/>, routing each entity through
-    /// the strongest audited path it supports so the deletes are attributed to the current request
-    /// and the soft-delete dedup keeps them from re-importing — the same way glucose already behaves.
-    /// Returns the per-type deleted counts (non-zero entries only).
+    /// Deletes every data type attributable to <paramref name="source"/> (<see cref="SourceFilter"/>),
+    /// routing each entity through the strongest audited path it supports so the deletes are
+    /// attributed to the current request and the soft-delete dedup keeps them from re-importing —
+    /// the same way glucose already behaves. Returns the per-type deleted counts (non-zero only).
     /// </summary>
     /// <remarks>
     /// Capability matrix (entity interfaces decide the path):
     /// <list type="bullet">
     /// <item>Glucose and the auditable+soft-deletable records (Bolus, CarbIntake, BolusCalculation,
-    ///   DeviceEvent, BGCheck, Note, ApsSnapshot) take the audited soft-delete path, which stamps the
+    ///   DeviceEvent, BGCheck, Note, ApsSnapshot, TempBasal) take the audited soft-delete path, which stamps the
     ///   <c>deleted_by_user</c> flag the soft-delete dedup reads to block re-import
     ///   (<see cref="SoftDeleteDedupExtensions"/>).</item>
     /// <item>StateSpan is auditable but not soft-deletable, so it takes the audited hard-delete path.</item>
     /// </list>
     /// </remarks>
     private async Task<Dictionary<string, long>> DeleteAllSourceDataAsync(
-        string deviceId,
+        string source,
         CancellationToken cancellationToken
     )
     {
         // Glucose: audited soft-delete, user-attributed (via the V4 repositories).
-        var sensorGlucoseDeleted = await _sensorGlucose.DeleteBySourceAsync(deviceId, cancellationToken);
-        var meterGlucoseDeleted = await _meterGlucose.DeleteBySourceAsync(deviceId, cancellationToken);
-        var calibrationsDeleted = await _calibrations.DeleteBySourceAsync(deviceId, cancellationToken);
+        var sensorGlucoseDeleted = await _sensorGlucose.DeleteBySourceAsync(source, cancellationToken);
+        var meterGlucoseDeleted = await _meterGlucose.DeleteBySourceAsync(source, cancellationToken);
+        var calibrationsDeleted = await _calibrations.DeleteBySourceAsync(source, cancellationToken);
 
         // Auditable + soft-deletable records: audited soft-delete, user-attributed.
-        var scope = $"data_source={deviceId}";
+        var scope = $"data_source={source}";
         var bolusesDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.Boluses.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId)), _auditContext, scope, cancellationToken);
+            _context.Boluses.FromSource(source), _auditContext, scope, cancellationToken);
         var carbIntakesDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.CarbIntakes.Where(c => c.DataSource == deviceId || (c.DataSource == null && c.Device == deviceId)), _auditContext, scope, cancellationToken);
+            _context.CarbIntakes.FromSource(source), _auditContext, scope, cancellationToken);
         var bolusCalcsDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.BolusCalculations.Where(bc => bc.DataSource == deviceId || (bc.DataSource == null && bc.Device == deviceId)), _auditContext, scope, cancellationToken);
+            _context.BolusCalculations.FromSource(source), _auditContext, scope, cancellationToken);
         var deviceEventsDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.DeviceEvents.Where(de => de.DataSource == deviceId || (de.DataSource == null && de.Device == deviceId)), _auditContext, scope, cancellationToken);
+            _context.DeviceEvents.FromSource(source), _auditContext, scope, cancellationToken);
         var bgChecksDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.BGChecks.Where(b => b.DataSource == deviceId || (b.DataSource == null && b.Device == deviceId)), _auditContext, scope, cancellationToken);
+            _context.BGChecks.FromSource(source), _auditContext, scope, cancellationToken);
         var notesDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.Notes.Where(n => n.DataSource == deviceId || (n.DataSource == null && n.Device == deviceId)), _auditContext, scope, cancellationToken);
+            _context.Notes.FromSource(source), _auditContext, scope, cancellationToken);
         var deviceStatusDeleted = await _context.AuditedSoftDeleteAsync(
-            _context.ApsSnapshots.Where(ds => ds.DataSource == deviceId || (ds.DataSource == null && ds.Device == deviceId)), _auditContext, scope, cancellationToken);
+            _context.ApsSnapshots.FromSource(source), _auditContext, scope, cancellationToken);
+        var tempBasalsDeleted = await _context.AuditedSoftDeleteAsync(
+            _context.TempBasals.FromSource(source), _auditContext, scope, cancellationToken);
 
         // StateSpan is auditable but not soft-deletable: audited hard delete.
         var stateSpansDeleted = await _context.AuditedExecuteDeleteAsync(
-            _context.StateSpans.Where(s => s.Source == deviceId), _auditContext, cancellationToken);
+            _context.StateSpans.Where(s => s.Source == source), _auditContext, cancellationToken);
 
         var deletedCounts = new Dictionary<string, long>();
         if (sensorGlucoseDeleted > 0) deletedCounts[nameof(SyncDataType.Glucose)] = sensorGlucoseDeleted;
@@ -965,6 +966,7 @@ public class DataSourceService : IDataSourceService
         if (notesDeleted > 0) deletedCounts[nameof(SyncDataType.Notes)] = notesDeleted;
         if (deviceEventsDeleted > 0) deletedCounts[nameof(SyncDataType.DeviceEvents)] = deviceEventsDeleted;
         if (deviceStatusDeleted > 0) deletedCounts[nameof(SyncDataType.DeviceStatus)] = deviceStatusDeleted;
+        if (tempBasalsDeleted > 0) deletedCounts[nameof(SyncDataType.TempBasals)] = tempBasalsDeleted;
         if (stateSpansDeleted > 0) deletedCounts[nameof(SyncDataType.StateSpans)] = stateSpansDeleted;
 
         return deletedCounts;
@@ -981,8 +983,6 @@ public class DataSourceService : IDataSourceService
 
     private static string ExtractDeviceDescription(string deviceId, string prefix)
     {
-        // Try to extract useful info from device ID
-        // e.g., "xDrip-DexcomG6" -> "xDrip+ on DexcomG6"
         var parts = deviceId.Split(new[] { '-', '_', ' ' }, StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length > 1)
         {
@@ -1001,7 +1001,6 @@ public class DataSourceService : IDataSourceService
 
         try
         {
-            // Find the data source to get the actual device ID or data source string
             var sources = await GetActiveDataSourcesAsync(cancellationToken);
             var source = sources.FirstOrDefault(s =>
                 s.Id == dataSourceId || s.DeviceId == dataSourceId
@@ -1016,9 +1015,6 @@ public class DataSourceService : IDataSourceService
                     $"Data source not found: {dataSourceId}");
             }
 
-            // The deviceId is the raw Device field value from sensor_glucose (e.g. "dexcom-connector",
-            // "xDrip-DexcomG6 Samsung Galaxy S21"). For connectors this also matches DataSource.
-            // For uploaders, Device is set by the client app and DataSource may differ.
             var deviceId = source.DeviceId;
 
             var deletedCounts = await DeleteAllSourceDataAsync(deviceId, cancellationToken);
@@ -1046,7 +1042,7 @@ public class DataSourceService : IDataSourceService
             return DataSourceDeleteResult.Failed(
                 dataSourceId,
                 DataSourceDeleteError.DeleteFailed,
-                ex.Message);
+                "Failed to delete data source data");
         }
     }
 
@@ -1059,24 +1055,21 @@ public class DataSourceService : IDataSourceService
 
         try
         {
-            // Delete glucose data from V4 tables
             var glucoseDeleted = await DeleteGlucoseDataBySourceAsync(
                 DataSources.DemoService,
                 cancellationToken
             );
 
-            // Delete V4 treatment records by data source
-            var treatmentsDeleted = await _context.Boluses.PurgeAsync(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.CarbIntakes.PurgeAsync(c => c.DataSource == DataSources.DemoService || (c.DataSource == null && c.Device == DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.BGChecks.PurgeAsync(b => b.DataSource == DataSources.DemoService || (b.DataSource == null && b.Device == DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.Notes.PurgeAsync(n => n.DataSource == DataSources.DemoService || (n.DataSource == null && n.Device == DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.DeviceEvents.PurgeAsync(de => de.DataSource == DataSources.DemoService || (de.DataSource == null && de.Device == DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.BolusCalculations.PurgeAsync(bc => bc.DataSource == DataSources.DemoService || (bc.DataSource == null && bc.Device == DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.TempBasals.PurgeAsync(t => t.DataSource == DataSources.DemoService || (t.DataSource == null && t.Device == DataSources.DemoService), cancellationToken);
+            var treatmentsDeleted = await _context.Boluses.PurgeAsync(SourceFilter.For<BolusEntity>(DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.CarbIntakes.PurgeAsync(SourceFilter.For<CarbIntakeEntity>(DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.BGChecks.PurgeAsync(SourceFilter.For<BGCheckEntity>(DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.Notes.PurgeAsync(SourceFilter.For<NoteEntity>(DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.DeviceEvents.PurgeAsync(SourceFilter.For<DeviceEventEntity>(DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.BolusCalculations.PurgeAsync(SourceFilter.For<BolusCalculationEntity>(DataSources.DemoService), cancellationToken);
+            treatmentsDeleted += await _context.TempBasals.PurgeAsync(SourceFilter.For<TempBasalEntity>(DataSources.DemoService), cancellationToken);
             treatmentsDeleted += await _context.StateSpans.PurgeAsync(s => s.Source == DataSources.DemoService, cancellationToken);
 
-            // Delete APS snapshots - demo data uses the demo-service device
-            var deviceStatusDeleted = await _context.ApsSnapshots.PurgeAsync(ds => ds.Device == DataSources.DemoService, cancellationToken);
+            var deviceStatusDeleted = await _context.ApsSnapshots.PurgeAsync(SourceFilter.For<ApsSnapshotEntity>(DataSources.DemoService), cancellationToken);
 
             var deletedCounts = new Dictionary<string, long>();
             if (glucoseDeleted > 0) deletedCounts[nameof(SyncDataType.Glucose)] = glucoseDeleted;
@@ -1101,7 +1094,7 @@ public class DataSourceService : IDataSourceService
             return DataSourceDeleteResult.Failed(
                 DataSources.DemoService,
                 DataSourceDeleteError.DeleteFailed,
-                ex.Message);
+                "Failed to delete demo data");
         }
     }
 
@@ -1116,7 +1109,7 @@ public class DataSourceService : IDataSourceService
 
         // Query V4 sensor glucose stats
         var sgStats = await _context
-            .SensorGlucose.Where(sg => sg.DataSource == dataSource || (sg.DataSource == null && sg.Device == dataSource))
+            .SensorGlucose.FromSource(dataSource)
             .GroupBy(_ => 1)
             .Select(g => new
             {
@@ -1142,65 +1135,92 @@ public class DataSourceService : IDataSourceService
 
         // Query V4 table counts for per-type breakdown
         var meterGlucoseTotal = await _context
-            .MeterGlucose.Where(mg => mg.DataSource == dataSource || (mg.DataSource == null && mg.Device == dataSource))
+            .MeterGlucose.FromSource(dataSource)
             .LongCountAsync(cancellationToken);
         var meterGlucose24h = meterGlucoseTotal > 0
             ? await _context.MeterGlucose
-                .Where(mg => (mg.DataSource == dataSource || (mg.DataSource == null && mg.Device == dataSource)) && mg.Timestamp >= oneDayAgoDate)
+                .FromSource(dataSource)
+                .Where(mg => mg.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var bolusesTotal = await _context
-            .Boluses.Where(b => b.DataSource == dataSource || (b.DataSource == null && b.Device == dataSource))
+            .Boluses.FromSource(dataSource)
             .LongCountAsync(cancellationToken);
         var boluses24h = bolusesTotal > 0
             ? await _context.Boluses
-                .Where(b => (b.DataSource == dataSource || (b.DataSource == null && b.Device == dataSource)) && b.Timestamp >= oneDayAgoDate)
+                .FromSource(dataSource)
+                .Where(b => b.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var carbIntakesTotal = await _context
-            .CarbIntakes.Where(c => c.DataSource == dataSource || (c.DataSource == null && c.Device == dataSource))
+            .CarbIntakes.FromSource(dataSource)
             .LongCountAsync(cancellationToken);
         var carbIntakes24h = carbIntakesTotal > 0
             ? await _context.CarbIntakes
-                .Where(c => (c.DataSource == dataSource || (c.DataSource == null && c.Device == dataSource)) && c.Timestamp >= oneDayAgoDate)
+                .FromSource(dataSource)
+                .Where(c => c.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var bolusCalcsTotal = await _context
-            .BolusCalculations.Where(bc => bc.DataSource == dataSource || (bc.DataSource == null && bc.Device == dataSource))
+            .BolusCalculations.FromSource(dataSource)
             .LongCountAsync(cancellationToken);
         var bolusCalcs24h = bolusCalcsTotal > 0
             ? await _context.BolusCalculations
-                .Where(bc => (bc.DataSource == dataSource || (bc.DataSource == null && bc.Device == dataSource)) && bc.Timestamp >= oneDayAgoDate)
+                .FromSource(dataSource)
+                .Where(bc => bc.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var notesTotal = await _context
-            .Notes.Where(n => n.DataSource == dataSource || (n.DataSource == null && n.Device == dataSource))
+            .Notes.FromSource(dataSource)
             .LongCountAsync(cancellationToken);
         var notes24h = notesTotal > 0
             ? await _context.Notes
-                .Where(n => (n.DataSource == dataSource || (n.DataSource == null && n.Device == dataSource)) && n.Timestamp >= oneDayAgoDate)
+                .FromSource(dataSource)
+                .Where(n => n.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var deviceEventsTotal = await _context
-            .DeviceEvents.Where(de => de.DataSource == dataSource || (de.DataSource == null && de.Device == dataSource))
+            .DeviceEvents.FromSource(dataSource)
             .LongCountAsync(cancellationToken);
         var deviceEvents24h = deviceEventsTotal > 0
             ? await _context.DeviceEvents
-                .Where(de => (de.DataSource == dataSource || (de.DataSource == null && de.Device == dataSource)) && de.Timestamp >= oneDayAgoDate)
+                .FromSource(dataSource)
+                .Where(de => de.Timestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
         var deviceStatusTotal = await _context
-            .ApsSnapshots.Where(ds => ds.DataSource == dataSource || (ds.DataSource == null && ds.Device == dataSource))
+            .ApsSnapshots.FromSource(dataSource)
             .LongCountAsync(cancellationToken);
         var deviceStatus24h = deviceStatusTotal > 0
             ? await _context.ApsSnapshots
-                .Where(ds => (ds.DataSource == dataSource || (ds.DataSource == null && ds.Device == dataSource)) && ds.Timestamp >= oneDayAgoDate)
+                .FromSource(dataSource)
+                .Where(ds => ds.Timestamp >= oneDayAgoDate)
+                .CountAsync(cancellationToken)
+            : 0;
+
+        var bgChecksTotal = await _context
+            .BGChecks.FromSource(dataSource)
+            .LongCountAsync(cancellationToken);
+        var bgChecks24h = bgChecksTotal > 0
+            ? await _context.BGChecks
+                .FromSource(dataSource)
+                .Where(b => b.Timestamp >= oneDayAgoDate)
+                .CountAsync(cancellationToken)
+            : 0;
+
+        var tempBasalsTotal = await _context
+            .TempBasals.FromSource(dataSource)
+            .LongCountAsync(cancellationToken);
+        var tempBasals24h = tempBasalsTotal > 0
+            ? await _context.TempBasals
+                .FromSource(dataSource)
+                .Where(t => t.StartTimestamp >= oneDayAgoDate)
                 .CountAsync(cancellationToken)
             : 0;
 
@@ -1217,11 +1237,17 @@ public class DataSourceService : IDataSourceService
         if (bolusCalcsTotal > 0) { typeBreakdown[nameof(SyncDataType.BolusCalculations)] = bolusCalcsTotal; typeBreakdown24h[nameof(SyncDataType.BolusCalculations)] = bolusCalcs24h; }
         if (notesTotal > 0) { typeBreakdown[nameof(SyncDataType.Notes)] = notesTotal; typeBreakdown24h[nameof(SyncDataType.Notes)] = notes24h; }
         if (deviceEventsTotal > 0) { typeBreakdown[nameof(SyncDataType.DeviceEvents)] = deviceEventsTotal; typeBreakdown24h[nameof(SyncDataType.DeviceEvents)] = deviceEvents24h; }
+        if (bgChecksTotal > 0) { typeBreakdown[nameof(SyncDataType.BGChecks)] = bgChecksTotal; typeBreakdown24h[nameof(SyncDataType.BGChecks)] = bgChecks24h; }
+        if (tempBasalsTotal > 0) { typeBreakdown[nameof(SyncDataType.TempBasals)] = tempBasalsTotal; typeBreakdown24h[nameof(SyncDataType.TempBasals)] = tempBasals24h; }
         if ((stateSpanStats?.TotalStateSpans ?? 0) > 0) { typeBreakdown[nameof(SyncDataType.StateSpans)] = stateSpanStats!.TotalStateSpans; typeBreakdown24h[nameof(SyncDataType.StateSpans)] = stateSpanStats.StateSpansLast24Hours; }
         if (deviceStatusTotal > 0) { typeBreakdown[nameof(SyncDataType.DeviceStatus)] = deviceStatusTotal; typeBreakdown24h[nameof(SyncDataType.DeviceStatus)] = deviceStatus24h; }
 
-        var totalTreatments = bolusesTotal + carbIntakesTotal + bolusCalcsTotal + notesTotal + deviceEventsTotal;
-        var treatments24h = boluses24h + carbIntakes24h + bolusCalcs24h + notes24h + deviceEvents24h;
+        // Treatment totals cover exactly the types the first/last treatment timestamps span, so a
+        // source with only one of them cannot report zero treatments alongside a treatment time.
+        var totalTreatments = bolusesTotal + carbIntakesTotal + bolusCalcsTotal + notesTotal
+            + deviceEventsTotal + bgChecksTotal + tempBasalsTotal;
+        var treatments24h = boluses24h + carbIntakes24h + bolusCalcs24h + notes24h
+            + deviceEvents24h + bgChecks24h + tempBasals24h;
         var lastTreatmentTime = await GetLatestTreatmentTimestampBySourceAsync(dataSource, cancellationToken);
         var firstTreatmentTime = await GetOldestTreatmentTimestampBySourceAsync(dataSource, cancellationToken);
 
@@ -1284,13 +1310,13 @@ public class DataSourceService : IDataSourceService
     {
         var timestamps = new[]
         {
-            await _context.Boluses.AsNoTracking().Where(b => b.DataSource == dataSource).OrderByDescending(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.CarbIntakes.AsNoTracking().Where(c => c.DataSource == dataSource).OrderByDescending(c => c.Timestamp).Select(c => (DateTime?)c.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.BGChecks.AsNoTracking().Where(b => b.DataSource == dataSource).OrderByDescending(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.Notes.AsNoTracking().Where(n => n.DataSource == dataSource).OrderByDescending(n => n.Timestamp).Select(n => (DateTime?)n.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.DeviceEvents.AsNoTracking().Where(d => d.DataSource == dataSource).OrderByDescending(d => d.Timestamp).Select(d => (DateTime?)d.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.TempBasals.AsNoTracking().Where(t => t.DataSource == dataSource).OrderByDescending(t => t.StartTimestamp).Select(t => (DateTime?)t.StartTimestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.BolusCalculations.AsNoTracking().Where(b => b.DataSource == dataSource).OrderByDescending(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.Boluses.AsNoTracking().FromSource(dataSource).OrderByDescending(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.CarbIntakes.AsNoTracking().FromSource(dataSource).OrderByDescending(c => c.Timestamp).Select(c => (DateTime?)c.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.BGChecks.AsNoTracking().FromSource(dataSource).OrderByDescending(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.Notes.AsNoTracking().FromSource(dataSource).OrderByDescending(n => n.Timestamp).Select(n => (DateTime?)n.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.DeviceEvents.AsNoTracking().FromSource(dataSource).OrderByDescending(d => d.Timestamp).Select(d => (DateTime?)d.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.TempBasals.AsNoTracking().FromSource(dataSource).OrderByDescending(t => t.StartTimestamp).Select(t => (DateTime?)t.StartTimestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.BolusCalculations.AsNoTracking().FromSource(dataSource).OrderByDescending(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
         };
         return timestamps.Where(t => t.HasValue).Select(t => t!.Value).DefaultIfEmpty().Max() is var max && max == default ? null : max;
     }
@@ -1301,13 +1327,13 @@ public class DataSourceService : IDataSourceService
     {
         var timestamps = new[]
         {
-            await _context.Boluses.AsNoTracking().Where(b => b.DataSource == dataSource).OrderBy(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.CarbIntakes.AsNoTracking().Where(c => c.DataSource == dataSource).OrderBy(c => c.Timestamp).Select(c => (DateTime?)c.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.BGChecks.AsNoTracking().Where(b => b.DataSource == dataSource).OrderBy(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.Notes.AsNoTracking().Where(n => n.DataSource == dataSource).OrderBy(n => n.Timestamp).Select(n => (DateTime?)n.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.DeviceEvents.AsNoTracking().Where(d => d.DataSource == dataSource).OrderBy(d => d.Timestamp).Select(d => (DateTime?)d.Timestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.TempBasals.AsNoTracking().Where(t => t.DataSource == dataSource).OrderBy(t => t.StartTimestamp).Select(t => (DateTime?)t.StartTimestamp).FirstOrDefaultAsync(cancellationToken),
-            await _context.BolusCalculations.AsNoTracking().Where(b => b.DataSource == dataSource).OrderBy(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.Boluses.AsNoTracking().FromSource(dataSource).OrderBy(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.CarbIntakes.AsNoTracking().FromSource(dataSource).OrderBy(c => c.Timestamp).Select(c => (DateTime?)c.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.BGChecks.AsNoTracking().FromSource(dataSource).OrderBy(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.Notes.AsNoTracking().FromSource(dataSource).OrderBy(n => n.Timestamp).Select(n => (DateTime?)n.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.DeviceEvents.AsNoTracking().FromSource(dataSource).OrderBy(d => d.Timestamp).Select(d => (DateTime?)d.Timestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.TempBasals.AsNoTracking().FromSource(dataSource).OrderBy(t => t.StartTimestamp).Select(t => (DateTime?)t.StartTimestamp).FirstOrDefaultAsync(cancellationToken),
+            await _context.BolusCalculations.AsNoTracking().FromSource(dataSource).OrderBy(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
         };
         return timestamps.Where(t => t.HasValue).Select(t => t!.Value).DefaultIfEmpty().Min() is var min && min == default ? null : min;
     }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISourcedEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISourcedEntity.cs
@@ -1,0 +1,22 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// An entity that records where its row came from, through two independent handles:
+/// <see cref="DataSource"/> — stamped by connector imports, the demo seeder and the V4 write
+/// endpoints — and <see cref="Device"/>, the string the uploader reported for itself (a rig name
+/// such as <c>openaps://host</c>, a phone model, or the connector's own id). Either may be null,
+/// and a row's two handles frequently disagree.
+///
+/// Implementers MUST map both as ordinary EF columns (plain auto-properties with a <c>[Column]</c>
+/// mapping) so generic <c>ctx.Set&lt;TEntity&gt;()</c> queries translate the interface-member access
+/// to SQL, the same way they already do for <see cref="ITenantScoped.TenantId"/>.
+/// </summary>
+/// <seealso cref="Extensions.SourceFilter"/>
+public interface ISourcedEntity
+{
+    /// <summary>Origin data source identifier.</summary>
+    string? DataSource { get; set; }
+
+    /// <summary>Device identifier the uploader reported.</summary>
+    string? Device { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
@@ -3,19 +3,18 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// <summary>
 /// A V4 record entity that carries the canonical time-series columns the shared
 /// <see cref="Repositories.V4.V4RepositoryBase{TModel,TEntity}"/> filters, orders, and watermarks
-/// on. Extends <see cref="IV4Entity"/> (Id, LegacyId, TenantId, DeletedAt) with the domain
-/// timestamp, data source, and device. Span-shaped types (e.g. TempBasal, which keys on
-/// StartTimestamp) deliberately do NOT implement this and stay off the shared base.
+/// on. Extends <see cref="IV4Entity"/> (Id, LegacyId, TenantId, DeletedAt) and
+/// <see cref="ISourcedEntity"/> (data source, device) with the domain timestamp. Span-shaped types
+/// (e.g. TempBasal, which keys on StartTimestamp) deliberately do NOT implement this and stay off
+/// the shared base.
 ///
-/// Implementers MUST map these three members as ordinary EF columns (plain auto-properties with a
+/// Implementers MUST map these members as ordinary EF columns (plain auto-properties with a
 /// <c>[Column]</c> mapping) — not explicit-interface implementations, backing-field-only, or
 /// <c>[NotMapped]</c> — so the base's generic <c>ctx.Set&lt;TEntity&gt;()</c> queries translate the
 /// interface-member access to SQL (the same way it already does for ITenantScoped.TenantId and
 /// ISoftDeletable.DeletedAt).
 /// </summary>
-public interface IV4TimeSeriesEntity : IV4Entity
+public interface IV4TimeSeriesEntity : IV4Entity, ISourcedEntity
 {
     DateTime Timestamp { get; set; }
-    string? DataSource { get; set; }
-    string? Device { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TempBasalEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TempBasal
 /// </summary>
 [Table("temp_basals")]
-public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, IDeviceAttributedEntity, ISystemTimestamped
+public class TempBasalEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Entity, ISourcedEntity, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SourceFilter.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SourceFilter.cs
@@ -1,0 +1,29 @@
+using System.Linq.Expressions;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// The one predicate for "the rows a data source produced".
+/// </summary>
+/// <remarks>
+/// A row carries two independent handles on its origin (<see cref="ISourcedEntity"/>), and
+/// data-source discovery surfaces a list entry under whichever handle it found: glucose and APS
+/// discovery group by <c>Device</c>, the non-glucose aggregate groups by <c>DataSource</c>. A
+/// caller holding one such identifier therefore cannot know which handle it names, so a lookup or
+/// purge has to match either. Matching <c>DataSource</c> alone misses a rig surfaced from APS
+/// discovery (its snapshots carry the importing connector's id); requiring <c>DataSource</c> to be
+/// null before falling back to <c>Device</c> misses the same rows.
+/// </remarks>
+public static class SourceFilter
+{
+    /// <summary>Rows whose <c>DataSource</c> or <c>Device</c> is <paramref name="source"/>.</summary>
+    public static Expression<Func<TEntity, bool>> For<TEntity>(string source)
+        where TEntity : ISourcedEntity
+        => e => e.DataSource == source || e.Device == source;
+
+    /// <summary>Applies <see cref="For{TEntity}"/> to <paramref name="rows"/>.</summary>
+    public static IQueryable<TEntity> FromSource<TEntity>(this IQueryable<TEntity> rows, string source)
+        where TEntity : ISourcedEntity
+        => rows.Where(For<TEntity>(source));
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CalibrationRepository.cs
@@ -7,6 +7,7 @@ using Nocturne.Core.Models;
 using Nocturne.Core.Models.Projections;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 
@@ -70,7 +71,7 @@ public class CalibrationRepository : V4RepositoryBase<Calibration, CalibrationEn
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.Calibrations
-            .Where(e => e.DataSource == source || (e.DataSource == null && e.Device == source))
+            .FromSource(source)
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/MeterGlucoseRepository.cs
@@ -72,7 +72,7 @@ public class MeterGlucoseRepository : V4RepositoryBase<MeterGlucose, MeterGlucos
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.MeterGlucose
-            .Where(e => e.DataSource == source || (e.DataSource == null && e.Device == source))
+            .FromSource(source)
             .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -452,7 +452,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.SensorGlucose
             .AsNoTracking()
-            .Where(e => e.DataSource == source || (e.DataSource == null && e.Device == source))
+            .FromSource(source)
             .CountAsync(ct);
     }
 
@@ -466,8 +466,7 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
         return await ctx.AuditedSoftDeleteAsync(
-            ctx.SensorGlucose.Where(e => e.DataSource == source || (e.DataSource == null && e.Device == source)),
-            AuditContext, $"data_source={source}", ct);
+            ctx.SensorGlucose.FromSource(source), AuditContext, $"data_source={source}", ct);
     }
 
     /// <inheritdoc />

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerDeleteFailureMappingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/ServicesControllerDeleteFailureMappingTests.cs
@@ -1,5 +1,8 @@
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -16,7 +19,9 @@ namespace Nocturne.API.Tests.Controllers.V4.Platform;
 /// <summary>
 /// The delete endpoints distinguish "no such source" (404) from "the delete failed" (500) by
 /// <see cref="DataSourceDeleteResult.ErrorCode"/>, so the mapping survives any rewording of the
-/// human-readable <see cref="DataSourceDeleteResult.Error"/> message.
+/// human-readable <see cref="DataSourceDeleteResult.Error"/> message. A 404 answers with the
+/// RFC-7807 body the sibling GET lookups and the generated client's 404 branch both expect, not
+/// with the domain result.
 /// </summary>
 [Trait("Category", "Unit")]
 public class ServicesControllerDeleteFailureMappingTests
@@ -33,7 +38,24 @@ public class ServicesControllerDeleteFailureMappingTests
             Mock.Of<IConnectorSyncService>(),
             Mock.Of<ILogger<ServicesController>>(),
             Mock.Of<ITenantAccessor>(),
-            Options.Create(new BaseDomainOptions()));
+            Options.Create(new BaseDomainOptions()))
+        {
+            ProblemDetailsFactory = new PassThroughProblemDetailsFactory(),
+        };
+
+    /// <summary>Stands in for the MVC-registered factory, which needs a request scope.</summary>
+    private sealed class PassThroughProblemDetailsFactory : ProblemDetailsFactory
+    {
+        public override ProblemDetails CreateProblemDetails(
+            HttpContext httpContext, int? statusCode = null, string? title = null,
+            string? type = null, string? detail = null, string? instance = null) =>
+            new() { Status = statusCode, Title = title, Type = type, Detail = detail, Instance = instance };
+
+        public override ValidationProblemDetails CreateValidationProblemDetails(
+            HttpContext httpContext, ModelStateDictionary modelStateDictionary, int? statusCode = null,
+            string? title = null, string? type = null, string? detail = null, string? instance = null) =>
+            new(modelStateDictionary) { Status = statusCode, Title = title, Type = type, Detail = detail, Instance = instance };
+    }
 
     [Fact]
     public async Task DeleteDataSourceData_MissingSource_Returns404_WhateverTheMessageSays()
@@ -47,7 +69,10 @@ public class ServicesControllerDeleteFailureMappingTests
 
         var response = await CreateController().DeleteDataSourceData(DataSourceId, CancellationToken.None);
 
-        response.Result.Should().BeOfType<NotFoundObjectResult>();
+        var problem = response.Result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(404);
+        problem.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Contain(DataSourceId);
     }
 
     [Fact]
@@ -62,8 +87,9 @@ public class ServicesControllerDeleteFailureMappingTests
 
         var response = await CreateController().DeleteDataSourceData(DataSourceId, CancellationToken.None);
 
-        response.Result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(500);
+        var failure = response.Result.Should().BeOfType<ObjectResult>().Subject;
+        failure.StatusCode.Should().Be(500);
+        failure.Value.Should().BeOfType<DataSourceDeleteResult>();
     }
 
     [Fact]
@@ -78,7 +104,10 @@ public class ServicesControllerDeleteFailureMappingTests
 
         var response = await CreateController().DeleteConnectorData(ConnectorId, CancellationToken.None);
 
-        response.Result.Should().BeOfType<NotFoundObjectResult>();
+        var problem = response.Result.Should().BeOfType<ObjectResult>().Subject;
+        problem.StatusCode.Should().Be(404);
+        problem.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Contain(ConnectorId);
     }
 
     [Fact]
@@ -93,7 +122,8 @@ public class ServicesControllerDeleteFailureMappingTests
 
         var response = await CreateController().DeleteConnectorData(ConnectorId, CancellationToken.None);
 
-        response.Result.Should().BeOfType<ObjectResult>()
-            .Which.StatusCode.Should().Be(500);
+        var failure = response.Result.Should().BeOfType<ObjectResult>().Subject;
+        failure.StatusCode.Should().Be(500);
+        failure.Value.Should().BeOfType<DataSourceDeleteResult>();
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteDataSourceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteDataSourceTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Audit;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Covers <see cref="DataSourceService.DeleteDataSourceDataAsync"/> for the entries that data-source
+/// discovery surfaces from APS snapshots. Such an entry is keyed by the rig string the uploader
+/// reported while the row's DataSource names the connector that imported it, so a purge that
+/// required DataSource to match — or to be null before falling back to Device — matched nothing and
+/// still reported success.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DataSourceServiceDeleteDataSourceTests : IDisposable
+{
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private const string Rig = "openaps://rig";
+    private const string OtherRig = "openaps://other";
+    private const string ImportingConnector = "nightscout-connector";
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+
+    private readonly Mock<ISensorGlucoseRepository> _sensorGlucose = new();
+    private readonly Mock<IMeterGlucoseRepository> _meterGlucose = new();
+    private readonly Mock<ICalibrationRepository> _calibrations = new();
+    private readonly Mock<IConnectorConfigurationService> _connectorConfig = new();
+
+    private readonly AuditContext _auditContext = new()
+    {
+        SubjectId = Guid.Parse("00000000-0000-0000-0000-0000000000aa"),
+        SubjectName = "admin@example.com",
+        AuthType = "OAuthAccessToken",
+    };
+
+    public DataSourceServiceDeleteDataSourceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        db.Tenants.Add(new TenantEntity { Id = TenantId, Slug = "test" });
+        db.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private NocturneDbContext NewContext() => new(_dbOptions) { TenantId = TenantId };
+
+    private DataSourceService CreateService(NocturneDbContext context) => new(
+        context,
+        _sensorGlucose.Object,
+        _meterGlucose.Object,
+        _calibrations.Object,
+        _auditContext,
+        _connectorConfig.Object,
+        NullLogger<DataSourceService>.Instance);
+
+    /// <summary>The shape DeviceStatusDecomposer writes for a connector-imported snapshot.</summary>
+    private void SeedImportedSnapshot(string legacyId, string rig)
+    {
+        using var db = NewContext();
+        db.ApsSnapshots.Add(new ApsSnapshotEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            LegacyId = legacyId,
+            DataSource = ImportingConnector,
+            Device = rig,
+            Timestamp = DateTime.UtcNow,
+            AidAlgorithm = "Loop",
+        });
+        db.SaveChanges();
+    }
+
+    [Fact]
+    public async Task DeleteDataSourceData_DeletesTheSnapshotsOfARigDiscoveredFromDeviceStatus()
+    {
+        SeedImportedSnapshot("aps-1", Rig);
+
+        await using (var ctx = NewContext())
+        {
+            var result = await CreateService(ctx).DeleteDataSourceDataAsync(Rig);
+
+            result.Success.Should().BeTrue();
+            result.DeletedCounts.Should().Contain(new KeyValuePair<string, long>("DeviceStatus", 1));
+        }
+
+        await using var assert = NewContext();
+        (await assert.ApsSnapshots.IgnoreQueryFilters().SingleAsync(a => a.LegacyId == "aps-1"))
+            .DeletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteDataSourceData_LeavesAnotherRigsSnapshotsAlone()
+    {
+        SeedImportedSnapshot("aps-1", Rig);
+        SeedImportedSnapshot("aps-2", OtherRig);
+
+        await using (var ctx = NewContext())
+            await CreateService(ctx).DeleteDataSourceDataAsync(Rig);
+
+        await using var assert = NewContext();
+        (await assert.ApsSnapshots.IgnoreQueryFilters().SingleAsync(a => a.LegacyId == "aps-2"))
+            .DeletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteDataSourceData_UnknownSource_ReturnsNotFound()
+    {
+        await using var ctx = NewContext();
+
+        var result = await CreateService(ctx).DeleteDataSourceDataAsync("no-such-source");
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(Core.Models.Services.DataSourceDeleteError.NotFound);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteDemoDataTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDeleteDemoDataTests.cs
@@ -12,6 +12,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Services.Demo.Services;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.Connectors;
@@ -19,7 +20,8 @@ namespace Nocturne.API.Tests.Services.Connectors;
 /// <summary>
 /// A demo reset has to leave the tables empty. The purge used to run under the soft-delete query
 /// filter, so any record a visitor had deleted survived the reset and could then be neither read nor
-/// purged.
+/// purged. It also matched device status on <c>Device</c>, which the demo feed sets to the Trio rig
+/// name — so the seeded shape here is the one both demo writers actually produce.
 /// </summary>
 [Trait("Category", "Unit")]
 public class DataSourceServiceDeleteDemoDataTests : IDisposable
@@ -109,10 +111,13 @@ public class DataSourceServiceDeleteDemoDataTests : IDisposable
             Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
             StartTimestamp = timestamp, Rate = 0.5, Origin = "pump", DeletedAt = deletedAt,
         });
+        // Both demo writers stamp DataSource = demo-service and leave Device as the Trio rig name:
+        // the seeder through DeviceStatusDecomposer, the realtime tick through the V4 endpoints.
         db.ApsSnapshots.Add(new ApsSnapshotEntity
         {
-            Id = Guid.CreateVersion7(), TenantId = TenantId, Device = DataSources.DemoService,
-            Timestamp = timestamp, AidAlgorithm = "Loop", DeletedAt = deletedAt,
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Device = DemoDeviceStatusGenerator.DeviceName,
+            Timestamp = timestamp, AidAlgorithm = "Trio", DeletedAt = deletedAt,
         });
         db.StateSpans.Add(new StateSpanEntity
         {

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceStatsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceStatsTests.cs
@@ -19,9 +19,12 @@ namespace Nocturne.API.Tests.Services.Connectors;
 /// <summary>
 /// Covers <see cref="DataSourceService.GetDataSourceStatsAsync"/>'s per-type attribution. Its only
 /// caller (<c>ConnectorHealthService</c>) always passes a connector's data-source id, so every type
-/// must resolve a row through <c>DataSource</c> and fall back to <c>Device</c> only for the legacy
-/// uploader rows that predate the column. Device status used to match on <c>Device</c> alone, which a
+/// must resolve a row through either origin handle so the legacy uploader rows that predate the
+/// <c>DataSource</c> column still count. Device status used to match on <c>Device</c> alone, which a
 /// connector import never carries, so the connector's device-status count read zero.
+///
+/// The treatment totals also have to span exactly the types the first/last treatment timestamps do,
+/// or a source reports zero treatments next to a non-null treatment time.
 /// </summary>
 [Trait("Category", "Unit")]
 public class DataSourceServiceStatsTests : IDisposable
@@ -137,5 +140,90 @@ public class DataSourceServiceStatsTests : IDisposable
 
         stats.TypeBreakdown.Should().Contain(new KeyValuePair<string, long>("DeviceStatus", 2));
         stats.TypeBreakdownLast24Hours.Should().Contain(new KeyValuePair<string, int>("DeviceStatus", 1));
+    }
+
+    [Fact]
+    public async Task Stats_DateALegacyUploaderTreatmentThatOnlyCarriesDevice()
+    {
+        // A direct v1 treatment upload carries no DataSource, so the row counts toward the totals
+        // through its Device — the first/last treatment times have to resolve it the same way.
+        SeedBolus(null, DataSource, DateTime.UtcNow);
+
+        var stats = await StatsFor(DataSource);
+
+        stats.TotalTreatments.Should().Be(1);
+        stats.LastTreatmentTime.Should().NotBeNull();
+        stats.FirstTreatmentTime.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Stats_CountTempBasalsAmongTheTreatments()
+    {
+        // Temp basals date the treatment window, so they have to be in the totals it belongs to.
+        SeedTempBasal(DataSource, DateTime.UtcNow);
+
+        var stats = await StatsFor(DataSource);
+
+        stats.TypeBreakdown.Should().Contain(new KeyValuePair<string, long>("TempBasals", 1));
+        stats.TotalTreatments.Should().Be(1);
+        stats.TreatmentsLast24Hours.Should().Be(1);
+        stats.LastTreatmentTime.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Stats_CountBGChecksAmongTheTreatments()
+    {
+        SeedBGCheck(DataSource, DateTime.UtcNow);
+
+        var stats = await StatsFor(DataSource);
+
+        stats.TypeBreakdown.Should().Contain(new KeyValuePair<string, long>("BGChecks", 1));
+        stats.TotalTreatments.Should().Be(1);
+        stats.TreatmentsLast24Hours.Should().Be(1);
+        stats.LastTreatmentTime.Should().NotBeNull();
+    }
+
+    private void SeedBolus(string? dataSource, string? device, DateTime timestamp)
+    {
+        using var db = NewContext();
+        db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            DataSource = dataSource,
+            Device = device,
+            Timestamp = timestamp,
+            Insulin = 1.5,
+        });
+        db.SaveChanges();
+    }
+
+    private void SeedTempBasal(string? dataSource, DateTime startTimestamp)
+    {
+        using var db = NewContext();
+        db.TempBasals.Add(new TempBasalEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            DataSource = dataSource,
+            StartTimestamp = startTimestamp,
+            Rate = 0.5,
+            Origin = "pump",
+        });
+        db.SaveChanges();
+    }
+
+    private void SeedBGCheck(string? dataSource, DateTime timestamp)
+    {
+        using var db = NewContext();
+        db.BGChecks.Add(new BGCheckEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            DataSource = dataSource,
+            Timestamp = timestamp,
+            Glucose = 100,
+        });
+        db.SaveChanges();
     }
 }


### PR DESCRIPTION
Closes #884. Addresses #876 items 1, 2 and 4 (item 3, the openapi-remote-codegen status-code handling, stays in the issue).

## What changed

**One predicate for "rows a data source produced".** `SourceFilter.For` / `.FromSource(source)` (`DataSource == source || Device == source`) replaces the ~30 hand-inlined copies of the old two-arm predicate across `DataSourceService`, `DemoAdminController` and the three V4 glucose repositories. The rationale lives once, on `SourceFilter`: discovery surfaces a list entry under whichever handle it found (glucose/APS discovery group by `Device`, the non-glucose aggregate by `DataSource`), so a caller holding one identifier cannot know which handle it names — a lookup or purge has to match either. `IV4TimeSeriesEntity`'s source columns moved to a new `ISourcedEntity` (interface-only; `TempBasalEntity` implements it; no schema change).

This fixes #884 item 3: a rig surfaced by APS discovery (`DataSource = "<connector>", Device = "openaps://rig"`) matched neither arm of the old predicate, so deleting it reported success having deleted nothing.

**Demo purge matches its rows** (#884 item 1). The issue's diagnosis was partly stale — demo device status no longer decomposes with `source: null`; both demo writers already stamp `DataSource = demo-service` (`SampleDataSeeder`, `DemoApiClient`). The defect was real anyway: the purge matched on `Device == "demo-service"` while the rows carry `Device = "Trio"`. It now purges through the shared predicate. Purging by the `"Trio"` device name was rejected as unsafe: `DeleteDemoDataAsync` is reachable from `ServicesController` (`[RequireAdmin]`, any tenant, not gated on demo), and a real Trio rig uploads `Device = "Trio"`. The existing test seeded the fictional shape that hid this; it now seeds what production writes.

**Per-source timestamps gained the Device arm, and the treatment totals cover what the timestamps span** (#884 item 2): the first/last-treatment unions now use the shared predicate, and BGChecks + TempBasals joined `TotalTreatments`/`TypeBreakdown`, so a temp-basal-only source can no longer report 0 treatments alongside a non-null last-treatment time.

**Purges now delete temp basals** — both connector and data-source deletes route them through the audited soft-delete path. Re-import is blocked: `TempBasalRepository` participates in the soft-delete dedup (`GetBlockingLegacyIdsAsync<TempBasalEntity>`).

**#876:** raw `ex.Message` no longer reaches tenant clients from the two delete paths (generic strings; detail stays in the log); the two deletes' 404s are now RFC-7807 `Problem` documents like the GETs — the old `NotFound(DataSourceDeleteResult)` body was never read (the generated NSwag client already treated 404 as `ProblemDetails` and threw), so this makes the code match its own declared contract and improves the message the frontend shows; narrating comments removed.

## Behavioural deltas

- The widened predicate is a superset everywhere it landed (counts, stats, purges): entries can only match more rows, never fewer. Deleting a device entry now also removes connector-imported rows for that device — that is the fix.
- `GetDataSourceStatsAsync` totals grew: BGChecks and TempBasals now count toward `TotalTreatments`/`TreatmentsLast24Hours` and appear in `TypeBreakdown`.
- Delete 404 body: `DataSourceDeleteResult` → `ProblemDetails` (status unchanged; the old body was demonstrably unconsumed).
- Error strings on delete failure are now generic.

## Tests

New: rig-discovered-snapshot delete (fails if the predicate narrows back — mutation-verified), another-rig's-rows-survive over-delete guard, unknown-source 404, legacy-uploader treatment timestamp (fails on `DataSource ==`-only — mutation-verified), TempBasals/BGChecks counted in stats (fails when removed from the breakdown — mutation-verified). The demo-purge test reseeded to the real production shape (fails on the old `Device ==` predicate — mutation-verified). The 404-shape tests assert `ProblemDetails` and that the 500 path still carries `DataSourceDeleteResult`.

Full solution builds clean; `Nocturne.API.Tests` 5837 passed / 0 failed; `Nocturne.Infrastructure.Data.Tests` 636 passed / 0 failed.
