### PR TITLE
chore(deps): drop the dead pins, align the 10.0.x stragglers, and retire the legacy 2.x HTTP package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,6 @@
     <PackageVersion Include="FluentValidation" Version="11.11.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
@@ -46,7 +46,7 @@
     <PackageVersion Include="Npgsql" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
     <!-- ASP.NET Core packages -->
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
     <!-- Infrastructure packages -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,6 @@
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.0" />
     <PackageVersion Include="Aspire.Hosting.Docker" Version="13.3.0" />
     <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.3.0" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.NodeJS.Extensions" Version="9.9.0" />
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.Rust" Version="9.9.0" />
     <PackageVersion Include="Fido2.AspNet" Version="4.0.0" />
@@ -21,27 +20,21 @@
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0" />
     <!-- Entity Framework packages -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
@@ -53,7 +46,6 @@
     <PackageVersion Include="Npgsql" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
     <!-- ASP.NET Core packages -->
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
@@ -63,13 +55,8 @@
     <PackageVersion Include="MongoDB.Bson" Version="3.9.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="SocketIOClient" Version="4.0.4" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.9.32" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
     <PackageVersion Include="Polly" Version="8.6.4" />
-    <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0" />
-    <!-- Health Check packages -->
-    <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <!-- OpenTelemetry packages -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
@@ -94,17 +81,11 @@
     <PackageVersion Include="Testcontainers.MongoDb" Version="4.14.0" />
     <!-- Performance testing packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
-    <PackageVersion Include="NBomber" Version="6.0.0" />
     <!-- Other packages -->
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Spectre.Console" Version="0.53.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.53.0" />
     <PackageVersion Include="WireMock.Net" Version="2.12.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="HtmlAgilityPack" Version="1.11.72" />
-    <PackageVersion Include="RestSharp" Version="111.4.1" />
-    <PackageVersion Include="QRCoder" Version="1.6.0" />
     <PackageVersion Include="HtmlSanitizer" Version="9.1.973" />
     <PackageVersion Include="DotNetEnv" Version="3.1.1" />
     <PackageVersion Include="EfToMermaid" Version="1.1.0" />
@@ -112,7 +93,6 @@
     <PackageVersion Include="dotAPNS" Version="4.6.0" />
     <PackageVersion Include="ShiroTrie" Version="1.0.5" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />
     <!-- Security fix: pin transitive dependency to patch CVE-2026-26127 (Base64Url DoS) -->
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.14" />
     <!-- Security fix: pin StreamJsonRpc's transitive MessagePack (GHSA-hv8m-jj95-wg3x, GHSA-vh6j-jc39-fggf) -->
@@ -123,7 +103,6 @@
     <PackageVersion Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
     <!-- ASP.NET Core additional packages -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.HttpsPolicy" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.6.3" />
@@ -145,7 +124,6 @@
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4654" />
-    <PackageVersion Include="AdaptiveCards" Version="3.1.0" />
     <!-- Windows Desktop Tray packages -->
     <PackageVersion Include="H.NotifyIcon.WinUI" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.0" />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Nocturne.Infrastructure.Data.csproj
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Nocturne.Infrastructure.Data.csproj
@@ -10,8 +10,11 @@
         <InternalsVisibleTo Include="Nocturne.Infrastructure.Data.Tests" />
     </ItemGroup>
     <ItemGroup>
+        <!-- IHttpContextAccessor, for the reason given on MutationAuditInterceptor. -->
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Nocturne.Infrastructure.Data.csproj
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Nocturne.Infrastructure.Data.csproj
@@ -15,16 +15,21 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-        <!-- Added for design-time configuration loading -->
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-        <!-- Added to take vulnerability patched version -->
-        <PackageReference Include="System.Security.Cryptography.Xml" />
+    </ItemGroup>
+    <ItemGroup>
+        <!-- The shared framework above supplies these too, so NuGet calls them redundant
+             (NU1510). They stay: System.Security.Cryptography.Xml pins advisory fixes ahead of
+             the framework's copy, and the configuration and logging packages carry the
+             design-time configuration loading path. The suppression is per-reference, not
+             project-wide, so a reference that becomes genuinely redundant is still reported. -->
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" NoWarn="NU1510" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" NoWarn="NU1510" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" NoWarn="NU1510" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" NoWarn="NU1510" />
+        <PackageReference Include="System.Security.Cryptography.Xml" NoWarn="NU1510" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\Core\Nocturne.Core.Models\Nocturne.Core.Models.csproj" />


### PR DESCRIPTION
Closes #874.

## What changed

**Twenty-one dead `PackageVersion` pins removed** — every one re-verified against the tree (all `*.csproj`/`*.props`/`*.targets`, no `#:package` directives, no lock files, `CentralPackageTransitivePinningEnabled` unset, so all were inert). History on the flagged ones: **NBomber** was real once — its consumer `tests/Performance/Nocturne.Tools.Migration.Performance.Tests` was deleted in the v4-api commit and the pin outlived it. **BenchmarkDotNet.Diagnostics.Windows**, **Swashbuckle.AspNetCore**, **QRCoder**, **HtmlAgilityPack** and **RestSharp** were never referenced by any project in the repo's history. **AdaptiveCards** was referenced once by the widget POC and dropped. `Microsoft.AspNetCore.SignalR` 1.2.0 was doubly dead (unconsumed *and* the deprecated pre-shared-framework package).

**Two stragglers aligned to the 10.0.8 runtime family**: `Microsoft.Extensions.Http` and `Microsoft.AspNetCore.SignalR.Client` (both consumed). Left alone deliberately: `Microsoft.AspNetCore.OpenApi` 10.0.11 and `System.Security.Cryptography.Xml` 10.0.10 are #814's advisory pins (GHSA-v5pm-xwqc-g5wc; GHSA-23rf-6693-g89p et al.) — pulling them back would reintroduce the advisories — and `Microsoft.Extensions.TimeProvider.Testing` 10.4.0 versions on the extensions-libraries cadence, not runtime patches.

**`Microsoft.AspNetCore.Http.Abstractions` 2.3.9 retired** — Infrastructure.Data now takes `FrameworkReference Include="Microsoft.AspNetCore.App"`, matching the five sibling projects that already do this (Infrastructure.Cache, ServiceDefaults, McpServer, two test projects). The dependency is load-bearing, not incidental: `MutationAuditInterceptor` needs `IHttpContextAccessor` because `CarrierResettingDbContextFactory.Reset` nulls `AuditContext` on every acquisition, and for raw-factory callers inside an HTTP request the accessor is the only route back to the scoped audit context — without it those saves silently degrade to unattributed system mutations (there is a dedicated test pinning this). Refactoring the data layer off `IHttpContextAccessor` entirely would be an audit-attribution design change; left for its own issue.

The FrameworkReference makes NuGet flag five of the project's direct references as framework-provided (NU1510). They stay — `System.Security.Cryptography.Xml` is the advisory pin, the configuration/logging packages carry design-time configuration loading — with per-reference `NoWarn="NU1510"` (not project-wide, so a genuinely redundant future reference still gets flagged) and the rationale in one comment that subsumes two older narration comments. Project restore is warning-clean; verified from the consuming test project too.

## Verification

Full solution build: 0 errors, no new warnings (`-p:GenerateNSwagClient=false`). Unit run across 11 assemblies: **7,418 passed, 0 failed, 5 skipped** (the 5 are pre-existing Rust-engine timer-continuity gates). No NU1603/NU1605/NU1608/NU1701 changes, so the version bumps altered no restore behaviour.
