### PR TITLE
chore(deps): delete four redundant references, keep the one NuGet audits

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Nocturne.Infrastructure.Data.csproj
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Nocturne.Infrastructure.Data.csproj
@@ -20,15 +20,12 @@
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     </ItemGroup>
     <ItemGroup>
-        <!-- The shared framework above supplies these too, so NuGet calls them redundant
-             (NU1510). They stay: System.Security.Cryptography.Xml pins advisory fixes ahead of
-             the framework's copy, and the configuration and logging packages carry the
-             design-time configuration loading path. The suppression is per-reference, not
-             project-wide, so a reference that becomes genuinely redundant is still reported. -->
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" NoWarn="NU1510" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" NoWarn="NU1510" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" NoWarn="NU1510" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" NoWarn="NU1510" />
+        <!-- Microsoft.AspNetCore.App supplies the assembly, so this reference delivers nothing and
+             NuGet reports it as redundant (NU1510). It stays because NuGet audits the pre-pruning
+             graph: without it the transitive resolves to the 10.0.8 that GHSA-23rf-6693-g89p and
+             four sibling advisories cover, and the solution restore reports 120 NU1903. Deleting it
+             needs the EF Core family on 10.0.10 first, so that Microsoft.AspNetCore.DataProtection
+             10.0.10 can carry the fixed transitive without an NU1605 downgrade. -->
         <PackageReference Include="System.Security.Cryptography.Xml" NoWarn="NU1510" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
Correction to #897, prompted by its adversarial review: the NU1510 suppression rationale that merged there was wrong. With the `FrameworkReference` in place, NuGet prunes all five suppressed references to `_._` — they deliver zero compile and zero runtime assets (all five appear in the ref pack's `PackageOverrides.txt`), so "design-time configuration loading" was false and the four configuration/logging references are deleted outright. Their central pins stay; each still has other consumers (Logging.Abstractions ×14, Configuration.Json/EnvironmentVariables ×2, Options.ConfigurationExtensions ×1).

**`System.Security.Cryptography.Xml` stays, for a different reason than #897 claimed.** The reviewer was right that the assembly never ships — but NuGet audits the *pre-pruning* graph. A/B on `dotnet restore nocturne.sln --force`: with the reference, 0 warnings; without it, **120 × NU1903 high-severity** (GHSA-23rf-6693-g89p and four siblings) as the transitive from `Microsoft.AspNetCore.DataProtection` 10.0.8 resolves to the vulnerable 10.0.8. The reference is #814's audit-graph lift, not a shipped-assembly pin. The clean deletion path exists but is a separate PR: `DataProtection` 10.0.10 carries the fixed transitive, but requires `Microsoft.EntityFrameworkCore >= 10.0.10`, which NU1605s against the current 10.0.8 EF pins — i.e. an EF Core family bump unlocks it. The comment now records exactly that.

Note for the record (tracked in #903): the advisory here is a build-time audit signal only — the shipped API container takes this assembly from the `aspnet:10.0` base image, so the patch level that matters at runtime is the image's.

## Verification
Clean project restore and full `dotnet restore nocturne.sln --force`: 0 NU1510, 0 NU1903, zero warnings (independently re-verified). `Nocturne.Infrastructure.Data.Tests`: 636 passed / 0 failed. `Nocturne.Tools.DiagramGen` (out-of-solution console consumer of Infrastructure.Data): builds clean.
