### PR TITLE
fix(connectors): give every sync run a terminal progress phase

### DIFF
--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -360,7 +360,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
                 if (systemEvent != null
                     && await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabledTypes,
                         [systemEvent], PublishSystemEventDataAsync, config, cancellationToken,
-                        context: "the last alarm", timestampOf: e => TimestampFromMills(e.Mills)))
+                        context: "the last alarm"))
                     _lastAlarmKey = alarmKey;
             }
         }
@@ -394,20 +394,20 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
 
             await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabledTypes,
                 CareLinkTreatmentMapper.MapBoluses(data, pumpOffsetMs), PublishBolusDataAsync,
-                config, cancellationToken, timestampOf: b => b.Timestamp);
+                config, cancellationToken);
 
             await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabledTypes,
                 CareLinkTreatmentMapper.MapCarbIntakes(data, pumpOffsetMs), PublishCarbIntakeDataAsync,
-                config, cancellationToken, timestampOf: c => c.Timestamp);
+                config, cancellationToken);
 
             await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabledTypes,
                 CareLinkTreatmentMapper.MapTempBasals(data, pumpOffsetMs), PublishTempBasalDataAsync,
-                config, cancellationToken, timestampOf: t => t.StartTimestamp);
+                config, cancellationToken);
 
             await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabledTypes,
                 CareLinkSystemEventMapper.MapNotifications(data.NotificationHistory, pumpOffsetMs),
                 PublishSystemEventDataAsync, config, cancellationToken,
-                context: "notification history", timestampOf: e => TimestampFromMills(e.Mills));
+                context: "notification history");
         }
         catch (OperationCanceledException) { throw; }
         catch (HttpRequestException ex)

--- a/src/Connectors/Nocturne.Connectors.Core/Models/SyncResult.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Models/SyncResult.cs
@@ -7,6 +7,5 @@ public class SyncResult
     public DateTimeOffset StartTime { get; init; }
     public DateTimeOffset EndTime { get; set; }
     public Dictionary<SyncDataType, int> ItemsSynced { get; init; } = new();
-    public Dictionary<SyncDataType, DateTime?> LastEntryTimes { get; init; } = new();
     public List<string> Errors { get; init; } = [];
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -657,14 +657,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
     /// <summary>
     ///     Reusable helper that checks whether a data type is active, reports publish progress,
-    ///     publishes a batch of records, updates the <see cref="SyncResult"/> counts and
-    ///     <see cref="SyncResult.LastEntryTimes"/>, and logs the outcome.
+    ///     publishes a batch of records, updates the <see cref="SyncResult"/> counts, and logs the
+    ///     outcome.
     /// </summary>
-    /// <param name="timestampOf">
-    ///     Extracts a record's canonical timestamp for <see cref="SyncResult.LastEntryTimes"/>.
-    ///     <c>null</c> — the parameter or an individual return — means the record carries no time
-    ///     to report, and nothing is recorded for the type.
-    /// </param>
     /// <returns>
     ///     Whether the batch reached the tenant. An inactive type, an empty batch and a rejected
     ///     publish are alike <c>false</c>: no record was accepted in any of them.
@@ -677,8 +672,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         Func<List<T>, TConfig, CancellationToken, Task<bool>> publishFunc,
         TConfig config,
         CancellationToken cancellationToken,
-        string? context = null,
-        Func<T, DateTime?>? timestampOf = null) where T : class
+        string? context = null) where T : class
     {
         if (!activeTypes.Contains(dataType) || records.Count == 0) return false;
 
@@ -689,7 +683,6 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         var success = await publishFunc(records, config, cancellationToken);
         result.ItemsSynced.TryGetValue(dataType, out var prev);
         result.ItemsSynced[dataType] = prev + records.Count;
-        RecordLastEntryTime(result, dataType, records, timestampOf);
         if (!success)
         {
             result.Success = false;
@@ -704,43 +697,6 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return success;
     }
-
-    /// <summary>
-    ///     Raises <see cref="SyncResult.LastEntryTimes"/> for a type to the newest timestamp in a
-    ///     published batch. Max-compare, not assignment: a connector that publishes several batches
-    ///     per type is under no obligation to deliver them in chronological order.
-    /// </summary>
-    private static void RecordLastEntryTime<T>(
-        SyncResult result,
-        SyncDataType dataType,
-        List<T> records,
-        Func<T, DateTime?>? timestampOf)
-    {
-        if (timestampOf is null) return;
-
-        DateTime? newest = null;
-        foreach (var record in records)
-        {
-            var time = timestampOf(record);
-            if (time.HasValue && (newest is null || time.Value > newest.Value))
-                newest = time;
-        }
-
-        if (newest is null) return;
-
-        // A recorded null must still be raised: lifted comparison against null is false, so
-        // `newest > existing` alone would leave a null-valued entry in place forever.
-        if (!result.LastEntryTimes.TryGetValue(dataType, out var existing)
-            || existing is null
-            || newest.Value > existing.Value)
-            result.LastEntryTimes[dataType] = newest;
-    }
-
-    /// <summary>
-    ///     Converts a legacy mills field to a UTC timestamp, treating a non-positive value as absent.
-    /// </summary>
-    protected static DateTime? TimestampFromMills(long mills) =>
-        mills > 0 ? DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime : null;
 
     /// <summary>
     ///     Reports a sync-progress message to the reporter supplied for this run, if any. The

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -97,25 +97,53 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         ISyncProgressReporter? progressReporter = null
     )
     {
-        return await RunSyncInternalAsync(request, config, cancellationToken, progressReporter);
+        return await RunWithProgressAsync(
+            progressReporter,
+            cancellationToken,
+            () => PerformSyncInternalAsync(request, config, cancellationToken));
     }
 
-    private async Task<SyncResult> RunSyncInternalAsync(
-        SyncRequest request,
-        TConfig config,
+    /// <summary>
+    ///     Runs one sync for the lifetime of <paramref name="progressReporter"/> and emits the
+    ///     run's terminal progress message. Owned here rather than by each connector so every
+    ///     sync reaches a terminal <see cref="SyncPhase"/> and the tenant's in-progress indicator
+    ///     always resolves — including when the run never got as far as fetching data.
+    /// </summary>
+    private async Task<SyncResult> RunWithProgressAsync(
+        ISyncProgressReporter? progressReporter,
         CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter
+        Func<Task<SyncResult>> body
     )
     {
         _progressReporter = progressReporter;
         try
         {
-            return await PerformSyncInternalAsync(request, config, cancellationToken);
+            var result = await body();
+            await ReportSyncOutcomeAsync(result.Success, FailureMessage(result), cancellationToken);
+            return result;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await ReportSyncOutcomeAsync(false, ex.Message, cancellationToken);
+            throw;
         }
         finally
         {
             _progressReporter = null;
         }
+    }
+
+    private Task ReportSyncOutcomeAsync(bool success, string? errorMessage, CancellationToken cancellationToken) =>
+        ReportSyncMessageAsync(
+            success ? SyncMessageType.SyncComplete : SyncMessageType.SyncFailed,
+            null, cancellationToken, errorMessage);
+
+    private static string? FailureMessage(SyncResult result)
+    {
+        if (result.Success) return null;
+        return result.Errors.Count > 0
+            ? string.Join("; ", result.Errors)
+            : string.IsNullOrWhiteSpace(result.Message) ? null : result.Message;
     }
 
     public void Dispose()
@@ -715,12 +743,14 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         mills > 0 ? DateTimeOffset.FromUnixTimeMilliseconds(mills).UtcDateTime : null;
 
     /// <summary>
-    ///     Reports a sync-progress message to the reporter supplied for this run, if any.
+    ///     Reports a sync-progress message to the reporter supplied for this run, if any. The
+    ///     message type carries the phase, so a terminal message cannot be emitted as in-progress.
     /// </summary>
     protected Task ReportSyncMessageAsync(
         SyncMessageType messageType,
         Dictionary<string, string>? messageParams,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? errorMessage = null)
     {
         if (_progressReporter is null) return Task.CompletedTask;
 
@@ -728,11 +758,19 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         {
             ConnectorId = ConnectorSource,
             ConnectorName = ServiceName,
-            Phase = SyncPhase.Syncing,
+            Phase = PhaseOf(messageType),
+            ErrorMessage = errorMessage,
             MessageType = messageType,
             MessageParams = messageParams,
         }, cancellationToken);
     }
+
+    private static SyncPhase PhaseOf(SyncMessageType messageType) => messageType switch
+    {
+        SyncMessageType.SyncComplete => SyncPhase.Completed,
+        SyncMessageType.SyncFailed => SyncPhase.Failed,
+        _ => SyncPhase.Syncing,
+    };
 
     #region V4 Publishing Methods
 
@@ -1033,11 +1071,21 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     ///     Main sync method for background synchronization.
     ///     Uses PerformSyncInternalAsync for sequential processing.
     /// </summary>
-    public virtual async Task<SyncResult> SyncDataAsync(
+    public virtual Task<SyncResult> SyncDataAsync(
         TConfig config,
         CancellationToken cancellationToken = default,
         DateTime? since = null,
         ISyncProgressReporter? progressReporter = null
+    ) =>
+        RunWithProgressAsync(
+            progressReporter,
+            cancellationToken,
+            () => RunBackgroundSyncAsync(config, cancellationToken, since));
+
+    private async Task<SyncResult> RunBackgroundSyncAsync(
+        TConfig config,
+        CancellationToken cancellationToken,
+        DateTime? since
     )
     {
         _logger.LogInformation(
@@ -1069,7 +1117,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
                 DataTypes = SupportedDataTypes,
             };
 
-            var result = await RunSyncInternalAsync(request, config, cancellationToken, progressReporter);
+            var result = await PerformSyncInternalAsync(request, config, cancellationToken);
 
             if (result.Success)
             {

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -122,6 +122,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             await ReportSyncOutcomeAsync(result.Success, FailureMessage(result), cancellationToken);
             return result;
         }
+        // A cancelled run has no outcome to report — the caller withdrew it. The background
+        // entry point's own catch-all converts its timeout into a failed result first, so that
+        // path still reports a terminal message through the success path above.
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             await ReportSyncOutcomeAsync(false, ex.Message, cancellationToken);

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
@@ -95,7 +95,7 @@ public class DexcomConnectorService : BaseConnectorService<DexcomConnectorConfig
 
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
                 sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken,
-                "Dexcom", s => s.Timestamp);
+                "Dexcom");
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
@@ -156,7 +156,7 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
 
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
                 [sg], PublishSensorGlucoseDataAsync, config, cancellationToken,
-                "Eversense", s => s.Timestamp);
+                "Eversense");
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
@@ -185,7 +185,7 @@ public class LibreConnectorService(
 
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
                 sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken,
-                "LibreLinkUp", s => s.Timestamp);
+                "LibreLinkUp");
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -333,7 +333,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                     // Drop partial results from the aborted pass; the retry re-syncs from scratch
                     // with the refreshed patient code.
                     result.ItemsSynced.Clear();
-                    result.LastEntryTimes.Clear();
                     result.Errors.Clear();
                     result.Success = true;
                     result.Message = "Sync completed successfully";
@@ -459,23 +458,19 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
         var sensorGlucose = context.SensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
-            sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken,
-            timestampOf: s => s.Timestamp);
+            sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
 
         var bgChecks = context.SensorGlucoseMapper.TransformBatchDataToBGChecks(batchData).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
-            bgChecks, PublishBGCheckDataAsync, config, cancellationToken,
-            timestampOf: b => b.Timestamp);
+            bgChecks, PublishBGCheckDataAsync, config, cancellationToken);
 
         var (boluses, carbs, _) = context.V4TreatmentMapper.MapBatchData(batchData);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-            boluses, PublishBolusDataAsync, config, cancellationToken,
-            timestampOf: b => b.Timestamp);
+            boluses, PublishBolusDataAsync, config, cancellationToken);
 
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
-            carbs, PublishCarbIntakeDataAsync, config, cancellationToken,
-            timestampOf: c => c.Timestamp);
+            carbs, PublishCarbIntakeDataAsync, config, cancellationToken);
 
         // Food attribution resolves against the carbs published above.
         var foodEntryImports = batchData.Foods is { Length: > 0 }
@@ -532,14 +527,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         {
             var sensorGlucose = context.SensorGlucoseMapper.TransformV3ToSensorGlucose(v3Data, context.MeterUnits).ToList();
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
-                sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken,
-                timestampOf: s => s.Timestamp);
+                sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
         }
 
         var bgChecks = context.SensorGlucoseMapper.TransformV3ToBGChecks(v3Data, context.MeterUnits).ToList();
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
-            bgChecks, PublishBGCheckDataAsync, config, cancellationToken,
-            timestampOf: b => b.Timestamp);
+            bgChecks, PublishBGCheckDataAsync, config, cancellationToken);
 
         var (v3Boluses, v3BolusCarbIntakes, _) = context.V4TreatmentMapper.MapV3Boluses(v3Data);
 
@@ -554,23 +547,19 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             allCarbs.AddRange(context.V4TreatmentMapper.MapV3CarbAll(v3Data));
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-            v3Boluses, PublishBolusDataAsync, config, cancellationToken,
-            timestampOf: b => b.Timestamp);
+            v3Boluses, PublishBolusDataAsync, config, cancellationToken);
 
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
-            allCarbs, PublishCarbIntakeDataAsync, config, cancellationToken,
-            timestampOf: c => c.Timestamp);
+            allCarbs, PublishCarbIntakeDataAsync, config, cancellationToken);
 
         // Pen injections: gkInsulinBasal → BasalInjection, gkInsulinBolus → Bolus.
         var (manualBasalInjections, manualBoluses) = context.V4TreatmentMapper.MapV3ManualInsulin(v3Data);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-            manualBoluses, PublishBolusDataAsync, config, cancellationToken,
-            timestampOf: b => b.Timestamp);
+            manualBoluses, PublishBolusDataAsync, config, cancellationToken);
 
         await PublishRecordTypeAsync(result, SyncDataType.BasalInjections, activeTypes,
-            manualBasalInjections, PublishBasalInjectionDataAsync, config, cancellationToken,
-            timestampOf: b => b.Timestamp);
+            manualBasalInjections, PublishBasalInjectionDataAsync, config, cancellationToken);
 
         // Food attribution resolves against the carbs published above.
         GlookoFood[]? v2Foods = null;

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -344,10 +344,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 }
             }
 
-            await ReportSyncMessageAsync(
-                result.Success ? SyncMessageType.SyncComplete : SyncMessageType.SyncFailed,
-                null, cancellationToken);
-
             result.EndTime = DateTime.UtcNow;
             return result;
         }
@@ -357,7 +353,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             result.Success = false;
             result.Message = "Sync failed with exception";
             result.Errors.Add(ex.Message);
-            await ReportSyncMessageAsync(SyncMessageType.SyncFailed, null, cancellationToken);
             result.EndTime = DateTime.UtcNow;
             return result;
         }

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -182,8 +182,7 @@ public class MyLifeConnectorService(
                         .ToList();
 
                     await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
-                        sgList, PublishSensorGlucoseDataAsync, config, cancellationToken, batch.Month,
-                        timestampOf: s => s.Timestamp);
+                        sgList, PublishSensorGlucoseDataAsync, config, cancellationToken, batch.Month);
                 }
 
                 // Shared treatment filtering and context for records + state spans
@@ -206,23 +205,17 @@ public class MyLifeConnectorService(
 
                         var monthCtx = batch.Month;
                         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-                            records.Boluses, PublishBolusDataAsync, config, cancellationToken, monthCtx,
-                            b => b.Timestamp);
+                            records.Boluses, PublishBolusDataAsync, config, cancellationToken, monthCtx);
                         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
-                            records.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken, monthCtx,
-                            c => c.Timestamp);
+                            records.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken, monthCtx);
                         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
-                            records.BGChecks, PublishBGCheckDataAsync, config, cancellationToken, monthCtx,
-                            b => b.Timestamp);
+                            records.BGChecks, PublishBGCheckDataAsync, config, cancellationToken, monthCtx);
                         await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, activeTypes,
-                            records.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken, monthCtx,
-                            b => b.Timestamp);
+                            records.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken, monthCtx);
                         await PublishRecordTypeAsync(result, SyncDataType.Notes, activeTypes,
-                            records.Notes, PublishNoteDataAsync, config, cancellationToken, monthCtx,
-                            n => n.Timestamp);
+                            records.Notes, PublishNoteDataAsync, config, cancellationToken, monthCtx);
                         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
-                            records.DeviceEvents, PublishDeviceEventDataAsync, config, cancellationToken, monthCtx,
-                            d => d.Timestamp);
+                            records.DeviceEvents, PublishDeviceEventDataAsync, config, cancellationToken, monthCtx);
                     }
 
                     // TempBasal state spans
@@ -231,8 +224,7 @@ public class MyLifeConnectorService(
                         var tempBasals = MyLifeStateSpanMapper.MapTempBasals(treatmentEvents, treatmentContext).ToList();
 
                         await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-                            tempBasals, PublishTempBasalDataAsync, config, cancellationToken, batch.Month,
-                            t => t.StartTimestamp);
+                            tempBasals, PublishTempBasalDataAsync, config, cancellationToken, batch.Month);
                     }
                 }
 
@@ -248,13 +240,11 @@ public class MyLifeConnectorService(
 
                 var profiles = MyLifePumpSettingsMapper.MapToProfiles(readouts);
                 await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
-                    profiles, PublishProfileDataAsync, config, cancellationToken,
-                    timestampOf: p => TimestampFromMills(p.Mills));
+                    profiles, PublishProfileDataAsync, config, cancellationToken);
 
                 var profileStateSpans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource);
                 await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-                    profileStateSpans, PublishStateSpanDataAsync, config, cancellationToken, "pump settings",
-                    s => s.StartTimestamp);
+                    profileStateSpans, PublishStateSpanDataAsync, config, cancellationToken, "pump settings");
             }
         }
         catch (Exception ex)

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -207,8 +207,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     outcome.Count);
 
                 result.ItemsSynced[SyncDataType.Glucose] = outcome.Count;
-                if (outcome.NewestTime.HasValue)
-                    result.LastEntryTimes[SyncDataType.Glucose] = outcome.NewestTime.Value;
                 if (!outcome.Success)
                 {
                     result.Success = false;
@@ -255,10 +253,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                 {
                     // Report count under each enabled treatment sub-type
                     foreach (var tt in treatmentTypes.Where(t => activeTypes.Contains(t)))
-                    {
                         result.ItemsSynced[tt] = outcome.Count;
-                        result.LastEntryTimes[tt] = outcome.NewestTime;
-                    }
                 }
 
                 if (!outcome.Success)
@@ -282,8 +277,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             {
                 var profiles = await FetchProfilesAsync();
                 await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
-                    profiles.ToList(), PublishProfileDataAsync, config, cancellationToken,
-                    timestampOf: p => TimestampFromMills(p.Mills));
+                    profiles.ToList(), PublishProfileDataAsync, config, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -318,8 +312,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     outcome.Count);
 
                 result.ItemsSynced[SyncDataType.DeviceStatus] = outcome.Count;
-                if (outcome.NewestTime.HasValue)
-                    result.LastEntryTimes[SyncDataType.DeviceStatus] = outcome.NewestTime;
                 if (!outcome.Success)
                 {
                     result.Success = false;
@@ -385,8 +377,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     outcome.Count);
 
                 result.ItemsSynced[SyncDataType.Activity] = outcome.Count;
-                if (outcome.NewestTime.HasValue)
-                    result.LastEntryTimes[SyncDataType.Activity] = outcome.NewestTime;
                 if (!outcome.Success)
                 {
                     result.Success = false;

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -197,7 +197,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                 var outcome = await CrawlAndPublishAsync(
                     "Glucose", request.From, request.To,
                     FetchGlucosePagesAsync,
-                    newestOf: p => p.Max(e => e.Date),
                     oldestOf: OldestEntryTime,
                     publishAsync: p => PublishGlucoseDataInBatchesAsync(p, config, cancellationToken));
 
@@ -240,7 +239,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                 var outcome = await CrawlAndPublishAsync(
                     "Treatments", treatmentFrom, request.To,
                     FetchTreatmentPagesAsync,
-                    newestOf: p => NewestCreatedAt(p, t => t.CreatedAt),
                     oldestOf: p => OldestCreatedAt(p, t => t.CreatedAt),
                     publishAsync: p => PublishTreatmentDataInBatchesAsync(p, config, cancellationToken));
 
@@ -302,7 +300,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                 var outcome = await CrawlAndPublishAsync(
                     "DeviceStatus", deviceStatusFrom, request.To,
                     FetchDeviceStatusPagesAsync,
-                    newestOf: p => NewestCreatedAt(p, d => d.CreatedAt),
                     oldestOf: p => OldestCreatedAt(p, d => d.CreatedAt),
                     publishAsync: p => PublishDeviceStatusAsync(p, config, cancellationToken));
 
@@ -367,7 +364,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                 var outcome = await CrawlAndPublishAsync(
                     "Activity", activityFrom, request.To,
                     FetchActivityPagesAsync,
-                    newestOf: p => NewestCreatedAt(p, a => a.CreatedAt),
                     oldestOf: p => OldestCreatedAt(p, a => a.CreatedAt),
                     publishAsync: p => PublishActivityDataAsync(p, config, cancellationToken));
 
@@ -444,12 +440,8 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     private static DateTime? AnchorUnboundedFetch(DateTime? from, DateTime? to) =>
         from is null && to is null ? DateTime.UtcNow : to;
 
-    /// <summary>
-    ///     Outcome of one crawled collection. <paramref name="NewestTime"/> spans every page of the
-    ///     crawl, including the resume pass below the low-water mark, so it cannot come from the
-    ///     shared publish path: that sees one page at a time and never the crawl as a whole.
-    /// </summary>
-    private sealed record PagedCrawlOutcome(int Count, DateTime? NewestTime, bool Success);
+    /// <summary>Outcome of one crawled collection, spanning every page of the crawl.</summary>
+    private sealed record PagedCrawlOutcome(int Count, bool Success);
 
     private Task<DateTime?> GetBackfillLowWaterMarkAsync(string collection) =>
         Publisher is { IsAvailable: true } p
@@ -484,14 +476,13 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         DateTime? from,
         DateTime? to,
         Func<DateTime?, DateTime?, IAsyncEnumerable<T[]>> pages,
-        Func<T[], DateTime?> newestOf,
         Func<T[], DateTime?> oldestOf,
         Func<T[], Task<bool>> publishAsync)
     {
         var mark = await GetBackfillLowWaterMarkAsync(collection);
 
         var primary = await CrawlRangeAsync(
-            collection, from, to, pages, newestOf, oldestOf, publishAsync, fullCrawl: from is null);
+            collection, from, to, pages, oldestOf, publishAsync, fullCrawl: from is null);
 
         // Resume the incomplete backfill only when this cycle's primary crawl stored cleanly —
         // a store that is failing right now shouldn't be hammered with the deep history too.
@@ -501,12 +492,9 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
 
         var resume = await CrawlRangeAsync(
             collection, null, mark.Value.AddMilliseconds(-1),
-            pages, newestOf, oldestOf, publishAsync, fullCrawl: true);
+            pages, oldestOf, publishAsync, fullCrawl: true);
 
-        var newest = primary.NewestTime is null || (resume.NewestTime is not null && resume.NewestTime > primary.NewestTime)
-            ? resume.NewestTime
-            : primary.NewestTime;
-        return new PagedCrawlOutcome(primary.Count + resume.Count, newest, resume.Success);
+        return new PagedCrawlOutcome(primary.Count + resume.Count, resume.Success);
     }
 
     /// <summary>
@@ -521,13 +509,11 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         DateTime? from,
         DateTime? to,
         Func<DateTime?, DateTime?, IAsyncEnumerable<T[]>> pages,
-        Func<T[], DateTime?> newestOf,
         Func<T[], DateTime?> oldestOf,
         Func<T[], Task<bool>> publishAsync,
         bool fullCrawl)
     {
         var count = 0;
-        DateTime? newestSeen = null;
         DateTime? lowestPublished = null;
         var success = true;
 
@@ -536,9 +522,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             await foreach (var page in pages(from, to))
             {
                 count += page.Length;
-                var pageNewest = newestOf(page);
-                if (pageNewest.HasValue && (newestSeen is null || pageNewest > newestSeen))
-                    newestSeen = pageNewest;
 
                 if (!await publishAsync(page))
                 {
@@ -572,7 +555,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             await RaiseBackfillLowWaterMarkAsync(collection, lowestPublished);
         }
 
-        return new PagedCrawlOutcome(count, newestSeen, success);
+        return new PagedCrawlOutcome(count, success);
     }
 
     /// <summary>
@@ -672,10 +655,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     /// </summary>
     private static DateTime? OldestCreatedAt<T>(T[] page, Func<T, string?> createdAtOf) =>
         page.Select(item => ParseCreatedAt(createdAtOf(item))?.UtcDateTime).Min();
-
-    /// <summary>Newest created_at on a page; the counterpart of <see cref="OldestCreatedAt{T}"/>.</summary>
-    private static DateTime? NewestCreatedAt<T>(T[] page, Func<T, string?> createdAtOf) =>
-        page.Select(item => ParseCreatedAt(createdAtOf(item))?.UtcDateTime).Max();
 
     /// <summary>
     ///     Oldest created_at on a page as the source wrote it — the key the source orders and

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -168,8 +168,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.SensorGlucose, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
-            ImportHelper.PrepareForImport(records), PublishSensorGlucoseDataAsync, config, ct,
-            timestampOf: r => r.Timestamp);
+            ImportHelper.PrepareForImport(records), PublishSensorGlucoseDataAsync, config, ct);
     }
 
     private async Task SyncBGChecksAsync(
@@ -180,8 +179,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.BGChecks, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
-            ImportHelper.PrepareForImport(records), PublishBGCheckDataAsync, config, ct,
-            timestampOf: r => r.Timestamp);
+            ImportHelper.PrepareForImport(records), PublishBGCheckDataAsync, config, ct);
     }
 
     private async Task SyncBolusesAsync(
@@ -192,8 +190,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.Boluses, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-            ImportHelper.PrepareForImport(records), PublishBolusDataAsync, config, ct,
-            timestampOf: r => r.Timestamp);
+            ImportHelper.PrepareForImport(records), PublishBolusDataAsync, config, ct);
     }
 
     private async Task SyncCarbIntakeAsync(
@@ -204,8 +201,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.CarbIntake, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
-            ImportHelper.PrepareForImport(records), PublishCarbIntakeDataAsync, config, ct,
-            timestampOf: r => r.Timestamp);
+            ImportHelper.PrepareForImport(records), PublishCarbIntakeDataAsync, config, ct);
     }
 
     private async Task SyncBolusCalculationsAsync(
@@ -216,8 +212,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.BolusCalculations, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, activeTypes,
-            ImportHelper.PrepareForImport(records), PublishBolusCalculationDataAsync, config, ct,
-            timestampOf: r => r.Timestamp);
+            ImportHelper.PrepareForImport(records), PublishBolusCalculationDataAsync, config, ct);
     }
 
     private async Task SyncNotesAsync(
@@ -228,8 +223,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.Notes, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Notes, activeTypes,
-            ImportHelper.PrepareForImport(records), PublishNoteDataAsync, config, ct,
-            timestampOf: r => r.Timestamp);
+            ImportHelper.PrepareForImport(records), PublishNoteDataAsync, config, ct);
     }
 
     private async Task SyncDeviceEventsAsync(
@@ -240,8 +234,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.DeviceEvents, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
-            ImportHelper.PrepareForImport(records), PublishDeviceEventDataAsync, config, ct,
-            timestampOf: r => r.Timestamp);
+            ImportHelper.PrepareForImport(records), PublishDeviceEventDataAsync, config, ct);
     }
 
     #endregion
@@ -256,8 +249,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.StateSpans, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-            records, PublishStateSpanDataAsync, config, ct,
-            timestampOf: s => s.StartTimestamp == default ? null : s.StartTimestamp);
+            records, PublishStateSpanDataAsync, config, ct);
     }
 
     private async Task SyncProfilesAsync(
@@ -268,8 +260,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.ProfileRecords, null, null, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
-            records, PublishProfileDataAsync, config, ct,
-            timestampOf: p => TimestampFromMills(p.Mills));
+            records, PublishProfileDataAsync, config, ct);
     }
 
     private async Task SyncDeviceStatusAsync(
@@ -281,8 +272,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         var records = await FetchV1DeviceStatusAsync(request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, activeTypes,
-            records, PublishDeviceStatusAsync, config, ct,
-            timestampOf: d => ParseCreatedAt(d.CreatedAt));
+            records, PublishDeviceStatusAsync, config, ct);
     }
 
     private async Task SyncActivityAsync(
@@ -293,8 +283,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             NocturneRemoteConstants.Activity, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Activity, activeTypes,
-            records, PublishActivityDataAsync, config, ct,
-            timestampOf: a => ParseCreatedAt(a.CreatedAt));
+            records, PublishActivityDataAsync, config, ct);
     }
 
     /// <summary>Parses a legacy ISO createdAt string, treating an unparseable value as absent.</summary>

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -286,10 +286,6 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             records, PublishActivityDataAsync, config, ct);
     }
 
-    /// <summary>Parses a legacy ISO createdAt string, treating an unparseable value as absent.</summary>
-    private static DateTime? ParseCreatedAt(string? createdAt) =>
-        DateTimeOffset.TryParse(createdAt, out var dto) ? dto.UtcDateTime : null;
-
     private async Task SyncFoodAsync(
         NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -133,8 +133,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
         await PublishRecordTypeAsync<Nocturne.Core.Models.Profile>(
             result, SyncDataType.Profiles, enabled, [profile],
-            PublishProfileDataAsync, config, cancellationToken,
-            timestampOf: p => TimestampFromMills(p.Mills));
+            PublishProfileDataAsync, config, cancellationToken);
     }
 
     private async Task SyncEventsAsync(
@@ -209,48 +208,40 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     {
         if (groups.TryGetValue(TandemEventClass.CgmReading, out var cgmEvents))
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabled,
-                cgm.Map(cgmEvents), PublishSensorGlucoseDataAsync, config, cancellationToken,
-                timestampOf: s => s.Timestamp);
+                cgm.Map(cgmEvents), PublishSensorGlucoseDataAsync, config, cancellationToken);
 
         if (groups.TryGetValue(TandemEventClass.Bolus, out var bolusEvents))
         {
             var decomposed = bolus.Map(bolusEvents);
             await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabled,
-                decomposed.Boluses, PublishBolusDataAsync, config, cancellationToken,
-                timestampOf: b => b.Timestamp);
+                decomposed.Boluses, PublishBolusDataAsync, config, cancellationToken);
             await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabled,
-                decomposed.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken,
-                timestampOf: c => c.Timestamp);
+                decomposed.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken);
             await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, enabled,
-                decomposed.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken,
-                timestampOf: b => b.Timestamp);
+                decomposed.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken);
         }
 
         if (groups.TryGetValue(TandemEventClass.Basal, out var basalEvents))
             await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabled,
                 basal.Map(basalEvents, windowEnd, config.IgnoreZeroUnitBasal), PublishTempBasalDataAsync,
-                config, cancellationToken, timestampOf: t => t.StartTimestamp);
+                config, cancellationToken);
 
         var devEvents = Concat(groups, TandemEventClass.Cartridge, TandemEventClass.CgmStartJoinStop,
             TandemEventClass.BasalSuspension, TandemEventClass.BasalResume);
         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabled,
-            deviceEvents.Map(devEvents), PublishDeviceEventDataAsync, config, cancellationToken,
-            timestampOf: d => d.Timestamp);
+            deviceEvents.Map(devEvents), PublishDeviceEventDataAsync, config, cancellationToken);
 
         var sysEvents = Concat(groups, TandemEventClass.Alarm, TandemEventClass.CgmAlert);
         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabled,
-            systemEvents.Map(sysEvents), PublishSystemEventDataAsync, config, cancellationToken,
-            timestampOf: e => TimestampFromMills(e.Mills));
+            systemEvents.Map(sysEvents), PublishSystemEventDataAsync, config, cancellationToken);
 
         if (groups.TryGetValue(TandemEventClass.UserMode, out var userModeEvents))
             await PublishRecordTypeAsync(result, SyncDataType.StateSpans, enabled,
-                userMode.Map(userModeEvents), PublishStateSpanDataAsync, config, cancellationToken,
-                timestampOf: s => s.StartTimestamp);
+                userMode.Map(userModeEvents), PublishStateSpanDataAsync, config, cancellationToken);
 
         if (groups.TryGetValue(TandemEventClass.DeviceStatus, out var dailyBasal))
             await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, enabled,
-                deviceStatus.Map(dailyBasal), PublishDeviceStatusAsync, config, cancellationToken,
-                timestampOf: d => TimestampFromMills(d.Mills));
+                deviceStatus.Map(dailyBasal), PublishDeviceStatusAsync, config, cancellationToken);
     }
 
     private async Task<TandemPumpLogsResponse?> FetchWindowAsync(

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -97,7 +97,7 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
                 if (bgValues != null)
                     await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                         _sensorGlucoseMapper.MapBgValues(bgValues).ToList(), PublishSensorGlucoseDataAsync,
-                        config, cancellationToken, "Tidepool", s => s.Timestamp);
+                        config, cancellationToken, "Tidepool");
             }
             catch (Exception ex)
             {

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -151,7 +151,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
 
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
             sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken,
-            "Twiist", s => s.Timestamp);
+            "Twiist");
     }
 
     private async Task SyncBolusesAsync(
@@ -160,7 +160,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     {
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabledTypes,
             _insulinMapper.MapBoluses(status.InsulinHistory).ToList(), PublishBolusDataAsync,
-            config, cancellationToken, "Twiist", b => b.Timestamp);
+            config, cancellationToken, "Twiist");
     }
 
     private async Task SyncCarbIntakeAsync(
@@ -169,7 +169,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     {
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabledTypes,
             _mealMapper.MapMeals(status.MealHistory).ToList(), PublishCarbIntakeDataAsync,
-            config, cancellationToken, "Twiist", c => c.Timestamp);
+            config, cancellationToken, "Twiist");
     }
 
     private async Task SyncTempBasalsAsync(
@@ -183,7 +183,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
 
         await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabledTypes,
             tempBasals, PublishTempBasalDataAsync, config, cancellationToken,
-            "Twiist", t => t.StartTimestamp);
+            "Twiist");
     }
 
     /// <summary>

--- a/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
@@ -33,19 +33,13 @@
   import DataSourceRow from "$lib/components/settings/DataSourceRow.svelte";
   import AppLogo from "$lib/components/ui/AppLogo.svelte";
   import { mapConnectorStatus } from "$lib/utils/connector-display";
-  import type { SyncMessageType } from "$lib/websocket/types";
-
-  interface SyncProgress {
-    phase: string;
-    messageType: SyncMessageType | null;
-    messageParams: Record<string, string> | null;
-  }
+  import type { SyncProgressEvent } from "$lib/websocket/types";
 
   interface Props {
     availableConnectors: AvailableConnector[];
     connectorStatuses: ConnectorStatusWithDescription[];
     connectorCapabilitiesById: Record<string, ConnectorCapabilities | null>;
-    syncProgressByConnector: Record<string, SyncProgress>;
+    syncProgressByConnector: Record<string, SyncProgressEvent>;
     activeDataSources: DataSourceInfo[];
     isLoadingConnectorStatuses: boolean;
     isManualSyncing: boolean;

--- a/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
@@ -12,7 +12,7 @@
   import AppLogo from "$lib/components/ui/AppLogo.svelte";
   import { getDataTypeLabel } from "$lib/utils/data-type-labels";
   import { formatSyncMessage } from "$lib/utils/sync-messages";
-  import type { SyncMessageType } from "$lib/websocket/types";
+  import type { SyncProgressEvent } from "$lib/websocket/types";
   import { lastSeen as formatAge } from "$lib/utils/formatting";
 
   export type DataSourceStatus =
@@ -39,11 +39,10 @@
     lastSuccessfulSync?: Date;
     totalBreakdown?: Record<string, number>;
     last24hBreakdown?: Record<string, number>;
-    syncProgress?: {
-      phase: string;
-      messageType: SyncMessageType | null;
-      messageParams: Record<string, string> | null;
-    } | null;
+    syncProgress?: Pick<
+      SyncProgressEvent,
+      "phase" | "messageType" | "messageParams"
+    > | null;
     badges?: Snippet;
     actions?: Snippet;
     onclick?: () => void;

--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -90,6 +90,9 @@ export class RealtimeStore {
   /** Live sync progress by connector ID (from SignalR sync progress events) */
   syncProgressByConnector = $state<Record<string, SyncProgressEvent>>({});
 
+  /** How long a completed/failed sync stays on screen before the entry is dropped. */
+  private static readonly TERMINAL_SYNC_PROGRESS_LINGER_MS = 2_000;
+
   /** Bound event handlers for cleanup */
   private handleVisibilityChange: (() => void) | null = null;
   private handleWindowFocus: (() => void) | null = null;
@@ -522,16 +525,16 @@ export class RealtimeStore {
     });
 
     this.websocketClient.on("syncProgress", (event: SyncProgressEvent) => {
-      if (event.phase === "Syncing") {
-        this.syncProgressByConnector = { ...this.syncProgressByConnector, [event.connectorId]: event };
-      } else {
-        // Show completed/failed state briefly, then clear
-        this.syncProgressByConnector = { ...this.syncProgressByConnector, [event.connectorId]: event };
-        setTimeout(() => {
-          const { [event.connectorId]: _, ...rest } = this.syncProgressByConnector;
-          this.syncProgressByConnector = rest;
-        }, 2000);
-      }
+      this.syncProgressByConnector = { ...this.syncProgressByConnector, [event.connectorId]: event };
+      if (event.phase === "Syncing") return;
+
+      // Show the completed/failed state briefly, then clear — unless a new run for the same
+      // connector has already replaced it.
+      setTimeout(() => {
+        if (this.syncProgressByConnector[event.connectorId] !== event) return;
+        const { [event.connectorId]: _, ...rest } = this.syncProgressByConnector;
+        this.syncProgressByConnector = rest;
+      }, RealtimeStore.TERMINAL_SYNC_PROGRESS_LINGER_MS);
     });
 
   }

--- a/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
@@ -29,16 +29,22 @@ vi.mock("svelte-sonner", () => ({
 }));
 
 import { RealtimeStore } from "./realtime-store.svelte";
-import type { StorageEvent } from "$lib/websocket/types";
+import type { StorageEvent, SyncProgressEvent } from "$lib/websocket/types";
 
 /** The realtime/backfill entry points, which the class keeps private. */
 interface StoreInternals {
   handleCreate(event: StorageEvent): void;
   performBackfillIfNeeded(force?: boolean): Promise<void>;
+  websocketClient: {
+    eventHandlers: { syncProgress?: (event: SyncProgressEvent) => void };
+  };
 }
 
 type TestStore = StoreInternals &
-  Pick<RealtimeStore, "currentReservoir" | "entries" | "direction" | "destroy">;
+  Pick<
+    RealtimeStore,
+    "currentReservoir" | "entries" | "direction" | "syncProgressByConnector" | "destroy"
+  >;
 
 /** Store instance with an empty socket URL, so nothing connects. */
 function makeStore(): TestStore {
@@ -162,6 +168,92 @@ describe("RealtimeStore direction", () => {
     store.entries = entries;
 
     expect(store.direction).toBe("");
+
+    store.destroy();
+  });
+});
+
+describe("RealtimeStore sync progress", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function syncEvent(
+    connectorId: string,
+    phase: SyncProgressEvent["phase"],
+    messageType: SyncProgressEvent["messageType"]
+  ): SyncProgressEvent {
+    return {
+      connectorId,
+      connectorName: connectorId,
+      phase,
+      errorMessage: null,
+      timestamp: new Date().toISOString(),
+      messageType,
+      messageParams: null,
+    };
+  }
+
+  function emit(store: TestStore, event: SyncProgressEvent): void {
+    store.websocketClient.eventHandlers.syncProgress?.(event);
+  }
+
+  it("holds an in-progress sync on screen indefinitely", () => {
+    const store = makeStore();
+
+    emit(store, syncEvent("glooko", "Syncing", "FetchingData"));
+    vi.advanceTimersByTime(60_000);
+
+    expect(store.syncProgressByConnector.glooko?.phase).toBe("Syncing");
+
+    store.destroy();
+  });
+
+  it.each(["Completed", "Failed"] as const)(
+    "clears a %s sync after the linger window",
+    (phase) => {
+      const store = makeStore();
+
+      emit(store, syncEvent("glooko", "Syncing", "FetchingData"));
+      emit(store, syncEvent("glooko", phase, phase === "Completed" ? "SyncComplete" : "SyncFailed"));
+
+      // Still visible while the outcome lingers.
+      vi.advanceTimersByTime(1_999);
+      expect(store.syncProgressByConnector.glooko?.phase).toBe(phase);
+
+      vi.advanceTimersByTime(1);
+      expect(store.syncProgressByConnector.glooko).toBeUndefined();
+
+      store.destroy();
+    }
+  );
+
+  it("keeps a new run that started inside the previous run's linger window", () => {
+    const store = makeStore();
+
+    emit(store, syncEvent("glooko", "Completed", "SyncComplete"));
+    vi.advanceTimersByTime(1_000);
+    emit(store, syncEvent("glooko", "Syncing", "FetchingData"));
+    vi.advanceTimersByTime(1_000);
+
+    expect(store.syncProgressByConnector.glooko?.phase).toBe("Syncing");
+
+    store.destroy();
+  });
+
+  it("clears only the connector that finished", () => {
+    const store = makeStore();
+
+    emit(store, syncEvent("glooko", "Syncing", "FetchingData"));
+    emit(store, syncEvent("dexcom", "Completed", "SyncComplete"));
+    vi.advanceTimersByTime(2_000);
+
+    expect(store.syncProgressByConnector.dexcom).toBeUndefined();
+    expect(store.syncProgressByConnector.glooko?.phase).toBe("Syncing");
 
     store.destroy();
   });

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -137,34 +136,12 @@ public class CareLinkConnectorServiceTests
             new SyncRequest(), fixture.Config, CancellationToken.None);
 
         result.ItemsSynced.GetValueOrDefault(SyncDataType.DeviceEvents).Should().Be(expectedCount);
-        result.LastEntryTimes.ContainsKey(SyncDataType.DeviceEvents).Should().Be(expectedCount > 0);
         result.Errors.Contains("DeviceEvents publish failed").Should().Be(expectedCount > 0,
             "a switched-off type is never handed to the publisher, so it cannot fail");
     }
 
-    /// <summary>
-    /// DeviceEvents' last-entry time is the newest of the two system-event paths, so each path in
-    /// turn is the one that must report a time: whichever is newer has to win the max-compare.
-    /// </summary>
-    [Theory]
-    [InlineData(NotificationBeforeAlarm, AlarmDateTime)]
-    [InlineData(NotificationAfterAlarm, NotificationAfterAlarm)]
-    public async Task SyncDataAsync_RecordsTheNewestSystemEventTimeUnderDeviceEvents(
-        string notificationDateTime, string expectedNewest)
-    {
-        var fixture = new ServiceFixture(
-            SystemEventHandler(notificationDateTime), AlarmOnlyConfiguration());
-
-        var result = await fixture.Service.SyncDataAsync(
-            new SyncRequest(), fixture.Config, CancellationToken.None);
-
-        result.LastEntryTimes[SyncDataType.DeviceEvents].Should().Be(
-            DateTime.Parse(expectedNewest, CultureInfo.InvariantCulture));
-    }
-
     private const string AlarmDateTime = "2026-01-01T10:00:00";
     private const string NotificationBeforeAlarm = "2026-01-01T09:55:00";
-    private const string NotificationAfterAlarm = "2026-01-01T10:05:00";
 
     /// <summary>A payload feeding both system-event paths: the last alarm and one notification.</summary>
     private static CareLinkFakeHandler SystemEventHandler(string notificationDateTime) => new()

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
@@ -10,14 +10,11 @@ namespace Nocturne.Connectors.Core.Tests.Services;
 
 /// <summary>
 ///     Covers the bookkeeping the shared publish path owns for every connector:
-///     <see cref="SyncResult.LastEntryTimes"/> and per-type publish progress.
+///     per-type counts and publish progress.
 /// </summary>
 public class PublishRecordTypePathTests
 {
-    private sealed class TimedRecord
-    {
-        public DateTime? At { get; init; }
-    }
+    private sealed class PublishedRecord;
 
     private sealed class TestConfig : BaseConnectorConfiguration
     {
@@ -55,17 +52,13 @@ public class PublishRecordTypePathTests
             SyncResult result,
             SyncDataType dataType,
             HashSet<SyncDataType> activeTypes,
-            List<TimedRecord> records,
-            Func<TimedRecord, DateTime?>? timestampOf,
+            List<PublishedRecord> records,
             bool publishSucceeds = true,
             CancellationToken cancellationToken = default)
             => PublishRecordTypeAsync(result, dataType, activeTypes, records,
                 (_, _, _) => Task.FromResult(publishSucceeds),
-                new TestConfig(), cancellationToken, timestampOf: timestampOf);
+                new TestConfig(), cancellationToken);
     }
-
-    private static readonly DateTime Older = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-    private static readonly DateTime Newer = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
 
     private static Task<SyncResult> RunAsync(
         Func<TestConnectorService, SyncResult, Task> body,
@@ -81,89 +74,6 @@ public class PublishRecordTypePathTests
     }
 
     [Fact]
-    public async Task LastEntryTimes_LaterBatchWithOlderMax_DoesNotRegressTheValue()
-    {
-        // Arrange: two batches for the same type, the newer data published first — the order a
-        // paginated or chunked crawl can easily produce.
-        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
-
-        // Act
-        var result = await RunAsync(async (service, syncResult) =>
-        {
-            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Newer }], r => r.At);
-            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Older }], r => r.At);
-        });
-
-        // Assert: max-compare, not assignment
-        result.LastEntryTimes[SyncDataType.Glucose].Should().Be(Newer);
-    }
-
-    [Fact]
-    public async Task LastEntryTimes_LaterBatchWithNewerMax_RaisesTheValue()
-    {
-        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
-
-        var result = await RunAsync(async (service, syncResult) =>
-        {
-            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Older }], r => r.At);
-            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Newer }], r => r.At);
-        });
-
-        result.LastEntryTimes[SyncDataType.Glucose].Should().Be(Newer);
-    }
-
-    [Fact]
-    public async Task LastEntryTimes_ExistingNullValue_IsRaised()
-    {
-        // Arrange: lifted comparison against null is false, so a null-valued entry would survive
-        // a plain `newest > existing` guard forever.
-        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
-
-        // Act
-        var result = await RunAsync(async (service, syncResult) =>
-        {
-            syncResult.LastEntryTimes[SyncDataType.Glucose] = null;
-            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Older }], r => r.At);
-        });
-
-        // Assert
-        result.LastEntryTimes[SyncDataType.Glucose].Should().Be(Older);
-    }
-
-    [Fact]
-    public async Task LastEntryTimes_NoSelector_RecordsNothing()
-    {
-        // Arrange: a record type that carries no time opts out by passing no selector.
-        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
-
-        // Act
-        var result = await RunAsync((service, syncResult) =>
-            service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Newer }], timestampOf: null));
-
-        // Assert: the batch still counts, it just has no time to report
-        result.ItemsSynced[SyncDataType.Glucose].Should().Be(1);
-        result.LastEntryTimes.Should().NotContainKey(SyncDataType.Glucose);
-    }
-
-    [Fact]
-    public async Task LastEntryTimes_SelectorReturnsNullForEveryRecord_RecordsNothing()
-    {
-        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
-
-        var result = await RunAsync((service, syncResult) =>
-            service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = null }], r => r.At));
-
-        result.LastEntryTimes.Should().NotContainKey(SyncDataType.Glucose);
-    }
-
-    [Fact]
     public async Task InactiveType_RecordsNothing()
     {
         // Arrange: the tenant has the type switched off
@@ -172,10 +82,9 @@ public class PublishRecordTypePathTests
         // Act
         var result = await RunAsync((service, syncResult) =>
             service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Newer }], r => r.At));
+                [new PublishedRecord()]));
 
         // Assert
-        result.LastEntryTimes.Should().BeEmpty();
         result.ItemsSynced.Should().BeEmpty();
     }
 
@@ -185,27 +94,26 @@ public class PublishRecordTypePathTests
         var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
 
         var result = await RunAsync((service, syncResult) =>
-            service.PublishAsync(syncResult, SyncDataType.Glucose, active, [], r => r.At));
+            service.PublishAsync(syncResult, SyncDataType.Glucose, active, []));
 
-        result.LastEntryTimes.Should().BeEmpty();
         result.ItemsSynced.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task FailedPublish_StillRecordsLastEntryTime()
+    public async Task FailedPublish_StillCountsTheBatch()
     {
-        // Arrange: LastEntryTimes reports what the sync saw, matching ItemsSynced, which the same
-        // helper already counts regardless of publish outcome.
+        // Arrange: ItemsSynced reports what the sync handed to the publisher, whatever the
+        // publisher then did with it.
         var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
 
         // Act
         var result = await RunAsync((service, syncResult) =>
             service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Newer }], r => r.At, publishSucceeds: false));
+                [new PublishedRecord()], publishSucceeds: false));
 
         // Assert
         result.Success.Should().BeFalse();
-        result.LastEntryTimes[SyncDataType.Glucose].Should().Be(Newer);
+        result.ItemsSynced[SyncDataType.Glucose].Should().Be(1);
     }
 
     [Fact]
@@ -220,13 +128,13 @@ public class PublishRecordTypePathTests
         await RunAsync(async (service, syncResult) =>
         {
             outcomes.Add(await service.PublishAsync(syncResult, SyncDataType.Boluses, active,
-                [new TimedRecord { At = Newer }], r => r.At));
+                [new PublishedRecord()]));
             outcomes.Add(await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [], r => r.At));
+                []));
             outcomes.Add(await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Newer }], r => r.At, publishSucceeds: false));
+                [new PublishedRecord()], publishSucceeds: false));
             outcomes.Add(await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Newer }], r => r.At));
+                [new PublishedRecord()]));
         });
 
         // Assert
@@ -250,9 +158,9 @@ public class PublishRecordTypePathTests
         await RunAsync(async (service, syncResult) =>
         {
             await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Newer }, new TimedRecord { At = Older }], r => r.At);
+                [new PublishedRecord(), new PublishedRecord()]);
             await service.PublishAsync(syncResult, SyncDataType.Boluses, active,
-                [new TimedRecord { At = Newer }], r => r.At);
+                [new PublishedRecord()]);
         }, reporter.Object);
 
         // Assert: the run's own terminal message is not a publish message
@@ -276,8 +184,8 @@ public class PublishRecordTypePathTests
         await RunAsync(async (service, syncResult) =>
         {
             await service.PublishAsync(syncResult, SyncDataType.Boluses, active,
-                [new TimedRecord { At = Newer }], r => r.At);
-            await service.PublishAsync(syncResult, SyncDataType.Glucose, active, [], r => r.At);
+                [new PublishedRecord()]);
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active, []);
         }, reporter.Object);
 
         // Assert
@@ -297,7 +205,7 @@ public class PublishRecordTypePathTests
         // Act
         var result = await RunAsync((service, syncResult) =>
             service.PublishAsync(syncResult, SyncDataType.Glucose, active,
-                [new TimedRecord { At = Newer }], r => r.At));
+                [new PublishedRecord()]));
 
         // Assert
         result.Success.Should().BeTrue();
@@ -321,7 +229,7 @@ public class PublishRecordTypePathTests
 
         // Act
         await captured!.PublishAsync(new SyncResult(), SyncDataType.Glucose, active,
-            [new TimedRecord { At = Newer }], r => r.At);
+            [new PublishedRecord()]);
 
         // Assert
         reporter.Verify(

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
@@ -255,14 +255,13 @@ public class PublishRecordTypePathTests
                 [new TimedRecord { At = Newer }], r => r.At);
         }, reporter.Object);
 
-        // Assert
-        reported.Should().HaveCount(2);
-        reported.Should().OnlyContain(e => e.MessageType == SyncMessageType.PublishingDataType
-                                        && e.Phase == SyncPhase.Syncing
-                                        && e.ConnectorId == "test");
-        reported[0].MessageParams.Should().Contain("dataType", nameof(SyncDataType.Glucose))
+        // Assert: the run's own terminal message is not a publish message
+        var publishes = reported.Where(e => e.MessageType == SyncMessageType.PublishingDataType).ToList();
+        publishes.Should().HaveCount(2);
+        publishes.Should().OnlyContain(e => e.Phase == SyncPhase.Syncing && e.ConnectorId == "test");
+        publishes[0].MessageParams.Should().Contain("dataType", nameof(SyncDataType.Glucose))
             .And.Contain("count", "2");
-        reported[1].MessageParams.Should().Contain("dataType", nameof(SyncDataType.Boluses))
+        publishes[1].MessageParams.Should().Contain("dataType", nameof(SyncDataType.Boluses))
             .And.Contain("count", "1");
     }
 
@@ -283,7 +282,9 @@ public class PublishRecordTypePathTests
 
         // Assert
         reporter.Verify(
-            r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()),
+            r => r.ReportProgressAsync(
+                It.Is<SyncProgressEvent>(e => e.MessageType == SyncMessageType.PublishingDataType),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -324,7 +325,9 @@ public class PublishRecordTypePathTests
 
         // Assert
         reporter.Verify(
-            r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()),
+            r => r.ReportProgressAsync(
+                It.Is<SyncProgressEvent>(e => e.MessageType == SyncMessageType.PublishingDataType),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 }

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
@@ -167,8 +167,7 @@ public class SyncTerminalPhaseTests
     [Fact]
     public async Task CancelledSync_ReportsNothing()
     {
-        // Arrange: the reporter's own transport is cancelled with the run, so a cancelled sync has
-        // nowhere to send a terminal message.
+        // Arrange: a run the caller withdrew has no outcome to report.
         var (reporter, reported) = BuildReporter();
 
         // Act

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
@@ -1,0 +1,226 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Services;
+
+/// <summary>
+///     Covers the terminal progress message every sync ends with. A run that never reports a
+///     terminal <see cref="SyncPhase"/> leaves the tenant's connector stuck on "syncing" until the
+///     page is reloaded, so the outcome is reported by the shared run wrapper rather than left to
+///     each connector.
+/// </summary>
+public class SyncTerminalPhaseTests
+{
+    private sealed class TestConfig : BaseConnectorConfiguration
+    {
+        protected override void ValidateSourceSpecificConfiguration() { }
+    }
+
+    private sealed class TestConnectorService : BaseConnectorService<TestConfig>
+    {
+        private readonly Func<SyncResult, Task> _syncBody;
+
+        public TestConnectorService(Func<SyncResult, Task> syncBody)
+            : base(new HttpClient(),
+                new ConnectorServerResolver<TestConfig>(null, null, null),
+                NullLogger<TestConnectorService>.Instance)
+        {
+            _syncBody = syncBody;
+        }
+
+        public bool AuthenticationSucceeds { get; init; } = true;
+
+        protected override string ConnectorSource => "test";
+        public override string ServiceName => "Test";
+
+        public override Task<bool> AuthenticateAsync() => Task.FromResult(AuthenticationSucceeds);
+
+        protected override async Task<SyncResult> PerformSyncInternalAsync(
+            SyncRequest request,
+            TestConfig config,
+            CancellationToken cancellationToken)
+        {
+            var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
+            await _syncBody(result);
+            return result;
+        }
+    }
+
+    private static (Mock<ISyncProgressReporter> Reporter, List<SyncProgressEvent> Reported) BuildReporter()
+    {
+        var reported = new List<SyncProgressEvent>();
+        var reporter = new Mock<ISyncProgressReporter>();
+        reporter
+            .Setup(r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<SyncProgressEvent, CancellationToken>((e, _) => reported.Add(e))
+            .Returns(Task.CompletedTask);
+        return (reporter, reported);
+    }
+
+    private static Task<SyncResult> RunAsync(
+        Func<SyncResult, Task> body,
+        ISyncProgressReporter reporter,
+        bool authenticationSucceeds = true)
+        => new TestConnectorService(body) { AuthenticationSucceeds = authenticationSucceeds }
+            .SyncDataAsync(
+                new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+                new TestConfig(),
+                CancellationToken.None,
+                reporter);
+
+    [Fact]
+    public async Task SuccessfulSync_ReportsCompletedPhaseWithNoErrorMessage()
+    {
+        // Arrange
+        var (reporter, reported) = BuildReporter();
+
+        // Act
+        await RunAsync(_ => Task.CompletedTask, reporter.Object);
+
+        // Assert
+        reported.Should().HaveCount(1);
+        reported[0].MessageType.Should().Be(SyncMessageType.SyncComplete);
+        reported[0].Phase.Should().Be(SyncPhase.Completed);
+        reported[0].ErrorMessage.Should().BeNull();
+        reported[0].ConnectorId.Should().Be("test");
+    }
+
+    [Fact]
+    public async Task FailedSync_ReportsFailedPhaseCarryingTheRecordedErrors()
+    {
+        // Arrange
+        var (reporter, reported) = BuildReporter();
+
+        // Act
+        await RunAsync(result =>
+        {
+            result.Success = false;
+            result.Message = "Sync failed with exception";
+            result.Errors.Add("Glucose publish failed");
+            result.Errors.Add("Boluses publish failed");
+            return Task.CompletedTask;
+        }, reporter.Object);
+
+        // Assert: the errors are what went wrong; the summary message is the coarser fallback
+        reported.Should().HaveCount(1);
+        reported[0].MessageType.Should().Be(SyncMessageType.SyncFailed);
+        reported[0].Phase.Should().Be(SyncPhase.Failed);
+        reported[0].ErrorMessage.Should().Be("Glucose publish failed; Boluses publish failed");
+    }
+
+    [Fact]
+    public async Task FailedSyncWithNoRecordedErrors_FallsBackToTheResultMessage()
+    {
+        // Arrange
+        var (reporter, reported) = BuildReporter();
+
+        // Act
+        await RunAsync(result =>
+        {
+            result.Success = false;
+            result.Message = "Authentication failed";
+            return Task.CompletedTask;
+        }, reporter.Object);
+
+        // Assert
+        reported.Should().ContainSingle().Which.ErrorMessage.Should().Be("Authentication failed");
+    }
+
+    [Fact]
+    public async Task FailedSyncWithNothingToSay_ReportsFailedWithoutAnErrorMessage()
+    {
+        // Arrange: a connector that flags failure but records neither errors nor a message
+        var (reporter, reported) = BuildReporter();
+
+        // Act
+        await RunAsync(result =>
+        {
+            result.Success = false;
+            return Task.CompletedTask;
+        }, reporter.Object);
+
+        // Assert
+        reported.Should().ContainSingle().Which.Phase.Should().Be(SyncPhase.Failed);
+        reported[0].ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ThrowingSync_ReportsFailedPhaseAndRethrows()
+    {
+        // Arrange: a connector that lets an exception escape still has to release the UI
+        var (reporter, reported) = BuildReporter();
+
+        // Act
+        var act = () => RunAsync(_ => throw new InvalidOperationException("upstream went away"), reporter.Object);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        reported.Should().ContainSingle().Which.Phase.Should().Be(SyncPhase.Failed);
+        reported[0].ErrorMessage.Should().Be("upstream went away");
+    }
+
+    [Fact]
+    public async Task CancelledSync_ReportsNothing()
+    {
+        // Arrange: the reporter's own transport is cancelled with the run, so a cancelled sync has
+        // nowhere to send a terminal message.
+        var (reporter, reported) = BuildReporter();
+
+        // Act
+        var act = () => RunAsync(_ => throw new OperationCanceledException(), reporter.Object);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        reported.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BackgroundSync_AuthenticationFailure_ReportsFailedPhase()
+    {
+        // Arrange: the background entry point authenticates before any connector code runs, and a
+        // rejected credential is the commonest way a sync ends without fetching anything.
+        var (reporter, reported) = BuildReporter();
+        var service = new TestConnectorService(_ => Task.CompletedTask) { AuthenticationSucceeds = false };
+
+        // Act
+        var result = await service.SyncDataAsync(new TestConfig(), CancellationToken.None, null, reporter.Object);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        reported.Should().ContainSingle().Which.Phase.Should().Be(SyncPhase.Failed);
+        reported[0].ErrorMessage.Should().Be("Authentication failed for test");
+    }
+
+    [Fact]
+    public async Task BackgroundSync_Success_ReportsCompletedPhaseOnce()
+    {
+        // Arrange
+        var (reporter, reported) = BuildReporter();
+        var service = new TestConnectorService(_ => Task.CompletedTask);
+
+        // Act
+        await service.SyncDataAsync(new TestConfig(), CancellationToken.None, null, reporter.Object);
+
+        // Assert: one wrapper owns the outcome, so the two entry points cannot double-report
+        reported.Should().ContainSingle().Which.Phase.Should().Be(SyncPhase.Completed);
+    }
+
+    [Fact]
+    public async Task NoReporter_SyncStillCompletes()
+    {
+        // Arrange
+        var service = new TestConnectorService(_ => Task.CompletedTask);
+
+        // Act
+        var result = await service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, new TestConfig(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
@@ -65,6 +65,43 @@ public class GlookoConnectorServiceReauthTests
         tokenProvider.AcquireCount.Should().Be(2, "it should re-auth exactly once before giving up");
     }
 
+    /// <summary>
+    /// The terminal progress message belongs to the shared run wrapper, which emits it once per
+    /// run. A connector that reports its own outcome as well would hand the tenant two terminal
+    /// messages, and the second would outlive the first's clear timer.
+    /// </summary>
+    [Theory]
+    [InlineData(true, SyncPhase.Completed)]
+    [InlineData(false, SyncPhase.Failed)]
+    public async Task SyncDataAsync_ReportsExactlyOneTerminalMessage(
+        bool codeRefreshes, SyncPhase expectedPhase)
+    {
+        var tokenProvider = new SwitchingGlookoTokenProvider(
+            codeRefreshes ? [OldCode, NewCode] : [OldCode]);
+        var handler = new PatientCodeAwareHandler(forbiddenCode: OldCode);
+        var service = BuildService(handler, tokenProvider);
+
+        var reported = new List<SyncProgressEvent>();
+        var reporter = new Mock<ISyncProgressReporter>();
+        reporter
+            .Setup(r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<SyncProgressEvent, CancellationToken>((e, _) => reported.Add(e))
+            .Returns(Task.CompletedTask);
+
+        var request = new SyncRequest
+        {
+            DataTypes = [SyncDataType.Glucose],
+            From = DateTime.UtcNow.AddDays(-3),
+        };
+
+        await service.SyncDataAsync(request, BuildConfig(), CancellationToken.None, reporter.Object);
+
+        reported.Should().NotBeEmpty(
+            "a run that reported nothing at all would satisfy the count below vacuously");
+        reported.Where(e => e.Phase != SyncPhase.Syncing)
+            .Should().ContainSingle().Which.Phase.Should().Be(expectedPhase);
+    }
+
     // ── Test infrastructure ─────────────────────────────────────────────
 
     private static GlookoConnectorConfiguration BuildConfig() => new()

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceStateIsolationTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceStateIsolationTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.Connectors.Core.Interfaces;
@@ -15,6 +16,7 @@ using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Timezones;
 using Nocturne.Core.Models.Timezones;
+using Nocturne.Core.Models.V4;
 using Xunit;
 
 namespace Nocturne.Connectors.Glooko.Tests.Services;
@@ -82,15 +84,16 @@ public class GlookoConnectorServiceStateIsolationTests
         var configA = BuildConfig("a@example.com", GlookoConstants.RegionEU, includeCgmBackfill: true);
         var configB = BuildConfig("b@example.com", GlookoConstants.RegionUS, includeCgmBackfill: true);
 
-        var results = await Task.WhenAll(
+        await Task.WhenAll(
             RunSyncAsync(service, TenantA, configA),
             RunSyncAsync(service, TenantB, configB));
 
         handler.RunsOverlapped.Should().BeTrue(
             "the runs must actually overlap for the timeline isolation to be under test");
 
-        results[0].LastEntryTimes[SyncDataType.Glucose].Should().Be(SydneyUtc);
-        results[1].LastEntryTimes[SyncDataType.Glucose].Should().Be(TorontoUtc);
+        service.PublishedGlucose.Should().BeEquivalentTo(
+            new[] { (TenantA, SydneyUtc), (TenantB, TorontoUtc) },
+            "each run must resolve the reading through its own tenant's timeline");
     }
 
     /// <summary>
@@ -155,7 +158,7 @@ public class GlookoConnectorServiceStateIsolationTests
         V3IncludeCgmBackfill = includeCgmBackfill,
     };
 
-    private static GlookoConnectorService BuildService(
+    private static CapturingGlookoConnectorService BuildService(
         InterleavingHandler handler, ITimezoneTimelineService? timezoneTimelineService = null) =>
         new(
             new HttpClient(handler),
@@ -164,7 +167,35 @@ public class GlookoConnectorServiceStateIsolationTests
             Mock.Of<IRetryDelayStrategy>(),
             Mock.Of<IRateLimitingStrategy>(),
             new PerTenantGlookoTokenProvider(),
-            timezoneTimelineService: timezoneTimelineService);
+            timezoneTimelineService);
+
+    /// <summary>
+    /// Records the tenant each published reading was published under. The publish sink is the only
+    /// place a run's resolved timezone timeline is observable from outside the service.
+    /// </summary>
+    private sealed class CapturingGlookoConnectorService(
+        HttpClient httpClient,
+        IConnectorServerResolver<GlookoConnectorConfiguration> serverResolver,
+        ILogger<GlookoConnectorService> logger,
+        IRetryDelayStrategy retryDelayStrategy,
+        IRateLimitingStrategy rateLimitingStrategy,
+        GlookoAuthTokenProvider tokenProvider,
+        ITimezoneTimelineService? timezoneTimelineService)
+        : GlookoConnectorService(httpClient, serverResolver, logger, retryDelayStrategy,
+            rateLimitingStrategy, tokenProvider, timezoneTimelineService: timezoneTimelineService)
+    {
+        public ConcurrentBag<(Guid TenantId, DateTime Timestamp)> PublishedGlucose { get; } = [];
+
+        protected override Task<bool> PublishSensorGlucoseDataAsync(
+            IEnumerable<SensorGlucose> records,
+            GlookoConnectorConfiguration config,
+            CancellationToken cancellationToken = default)
+        {
+            foreach (var record in records)
+                PublishedGlucose.Add((AmbientTenant.Id, record.Timestamp));
+            return Task.FromResult(true);
+        }
+    }
 
     /// <summary>
     /// The tenant each run is pinned to, per async flow — standing in for the per-tenant DI scope a


### PR DESCRIPTION
Closes #862. Addresses #883 — the issue stays open only for the narrow remainder noted at the end.

## What changed

**Terminal phase, derived not declared.** `ReportSyncMessageAsync` no longer hardcodes `Phase = Syncing`; the phase is derived from the message type (`PhaseOf`: SyncComplete → Completed, SyncFailed → Failed), so a terminal message emitted as in-progress is unrepresentable — which was the bug.

**The terminal message moved up a level (declared in-scope expansion).** Only Glooko ever emitted `SyncComplete`/`SyncFailed`; fixing the derivation alone would have unstuck one connector of eleven. A `RunWithProgressAsync` wrapper now owns the run's terminal emit on both public entry points, sourced from the result's own `Success`; Glooko's hand-rolled emits are deleted. The wrapper reports and **rethrows** on exception (contract unchanged) and stays silent on manual cancellation � a run the caller withdrew has no outcome to report. The background path's own catch-all converts its per-tenant timeout into a failed result, so that path still reports SyncFailed.

**`ErrorMessage` got its producer** (#883 item 2): joined `result.Errors`, else `Message`, else the exception message. Wire field names unchanged; the desktop/widget trees don't consume `syncProgress` (grepped) and the bridge forwards opaquely.

**One TS mirror** (#883 item 3): `DataSourceRow` uses `Pick<SyncProgressEvent, …>`, `ServerConnectorsCard` drops its local interface; `websocket/types.ts` is the single mirror.

**Store clear logic** now actually runs: the unreachable branch collapsed into one path with a linger constant, plus an identity guard so a stale timer can't wipe a fresh run's entry.

**`SyncResult.LastEntryTimes` deleted** (#862): this is a documented response-schema removal, not a purely internal one � `SyncResult` is the 200 body of the manual-sync and reset-cursor endpoints � but a `--no-ignore` repo-wide search found zero readers of the field anywhere, and every `SyncResult` property is optional in the generated Zod schema, so stale clients tolerate the removal. The adversarial review also caught two writer chains the deletion stranded (Nightscout's newest-time apparatus, NocturneRemote's `ParseCreatedAt`) � both now deleted too; the field, `RecordLastEntryTime`, the `timestampOf` plumbing and 44 call sites across 11 connectors are gone. #862's other half (four producerless event fields) was already fixed on main by #881. Glooko's timezone-isolation test lost this field as its observable and now captures what each run actually published (mutation-proved: shared timeline between tenants fails it).

## Behavioural deltas
- The Syncing badge clears ~2s after a run ends; "Sync Complete"/"Sync Failed" badges and the connector-status refresh `$effect` become reachable (the fix).
- Terminal events now fire for **all** connectors and on the background path's pre-fetch auth failure — not just Glooko.
- `ManualSyncDialog` now appends its previously-unreachable final "Sync complete"/"Sync failed" line.
- The connector-settings page's status refresh now fires once per terminal event per connector (previously never), a new recurring refresh source while that page is open.
- `errorMessage` travels on the wire on failure (no consumer yet; field name pre-existing).

## Tests
9 new C# tests (`SyncTerminalPhaseTests`), each mutation-proved (phase arms removed → 6 fail; ErrorMessage dropped → 4 fail; background overload bypassed, exception path silenced, cancellation guard removed → 1 targeted failure each). 4 new vitest cases on the store (terminal-never-clears → 3 fail; identity guard removed → 1 fails).

Hostile-review round: one-terminal-per-run is now pinned by a Glooko-level guard theory (re-adding the hand-rolled emit fails exactly the 2 new cases while the other 73 pass � reproducing the reviewer's exploit).

Full solution build 0 errors; all 11 connector unit suites 542 passed; API.Tests 5853 passed / 0 failed; vitest 14 passed; `pnpm check` 64 errors before and after (none in touched files).

