### PR TITLE
fix(services): count and classify every source discovery finds, and give the demo purge one owner

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Admin/DemoAdminController.cs
@@ -9,8 +9,6 @@ using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
-using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Controllers.V4.Admin;
 
@@ -177,10 +175,7 @@ public class DemoAdminController : ControllerBase
 
         db.TenantId = tenant.Id;
 
-        var deleted = 0L;
-        deleted += await db.SensorGlucose.PurgeAsync(SourceFilter.For<SensorGlucoseEntity>(DataSources.DemoService), ct);
-        deleted += await db.MeterGlucose.PurgeAsync(SourceFilter.For<MeterGlucoseEntity>(DataSources.DemoService), ct);
-        deleted += await db.Calibrations.PurgeAsync(SourceFilter.For<CalibrationEntity>(DataSources.DemoService), ct);
+        var deleted = await DemoDataPurge.PurgeEntriesAsync(db, ct);
 
         return Ok(new DemoDeleteResultDto(deleted));
     }
@@ -201,16 +196,8 @@ public class DemoAdminController : ControllerBase
 
         db.TenantId = tenant.Id;
 
-        var deleted = 0L;
-        deleted += await db.Boluses.PurgeAsync(SourceFilter.For<BolusEntity>(DataSources.DemoService), ct);
-        deleted += await db.CarbIntakes.PurgeAsync(SourceFilter.For<CarbIntakeEntity>(DataSources.DemoService), ct);
-        deleted += await db.BGChecks.PurgeAsync(SourceFilter.For<BGCheckEntity>(DataSources.DemoService), ct);
-        deleted += await db.Notes.PurgeAsync(SourceFilter.For<NoteEntity>(DataSources.DemoService), ct);
-        deleted += await db.DeviceEvents.PurgeAsync(SourceFilter.For<DeviceEventEntity>(DataSources.DemoService), ct);
-        deleted += await db.BolusCalculations.PurgeAsync(SourceFilter.For<BolusCalculationEntity>(DataSources.DemoService), ct);
-        deleted += await db.TempBasals.PurgeAsync(SourceFilter.For<TempBasalEntity>(DataSources.DemoService), ct);
-        deleted += await db.StateSpans.PurgeAsync(s => s.Source == DataSources.DemoService, ct);
-        deleted += await db.ApsSnapshots.PurgeAsync(SourceFilter.For<ApsSnapshotEntity>(DataSources.DemoService), ct);
+        var deleted = await DemoDataPurge.PurgeTreatmentsAsync(db, ct)
+            + await DemoDataPurge.PurgeDeviceStatusAsync(db, ct);
 
         return Ok(new DemoDeleteResultDto(deleted));
     }

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -54,7 +54,11 @@ public class DataSourceService : IDataSourceService
         _logger = logger;
     }
 
-    private record TableStats(long Count, int CountLast24H, DateTime Latest, DateTime? Oldest, SourceHandle Handle);
+    /// <param name="Handle">
+    /// Which handle the bucket's key names, or <see langword="null"/> when no contributing table
+    /// could tell.
+    /// </param>
+    private record TableStats(long Count, int CountLast24H, DateTime Latest, DateTime? Oldest, SourceHandle? Handle);
 
     private static void ApplyStatus(DataSourceInfo info, DateTimeOffset now, int activeMinutes, int staleMinutes)
     {
@@ -140,14 +144,24 @@ public class DataSourceService : IDataSourceService
     /// Aggregates every non-glucose table a source can produce rows in, bucketed by the source
     /// identifier the row carries. The bucket key is <c>DataSource ?? Device</c>, the same key the
     /// discovery merge resolves an entry under, and each bucket records which handle produced it
-    /// (<see cref="SourceHandle"/>) so an entry surfaced from a bucket alone can say so.
+    /// (<see cref="SourceHandle"/>) so an entry surfaced from a bucket alone can say so — or records
+    /// that no contributing table could tell.
     /// </summary>
     private async Task<Dictionary<string, TableStats>> GetNonGlucoseStatsAsync(
         DateTime thirtyDaysAgo, DateTime last24HoursDate, CancellationToken ct)
     {
         var result = new Dictionary<string, TableStats>(StringComparer.OrdinalIgnoreCase);
 
-        void Merge(string? key, long count, int count24h, DateTime latest, DateTime? oldest, SourceHandle handle)
+        // A table that stores the two handles in separate columns can say which one the key came
+        // from; one that stores a single undifferentiated origin cannot, and contributes null so the
+        // bucket keeps whatever evidence the other tables carry. Only a row bearing an actual
+        // DataSource column value proves the key is a data source, so that answer wins over Device.
+        static SourceHandle? CombineHandles(SourceHandle? left, SourceHandle? right) =>
+            left == SourceHandle.DataSource || right == SourceHandle.DataSource
+                ? SourceHandle.DataSource
+                : left ?? right;
+
+        void Merge(string? key, long count, int count24h, DateTime latest, DateTime? oldest, SourceHandle? handle)
         {
             if (string.IsNullOrEmpty(key) || count == 0) return;
             if (result.TryGetValue(key, out var existing))
@@ -158,7 +172,7 @@ public class DataSourceService : IDataSourceService
                     latest > existing.Latest ? latest : existing.Latest,
                     oldest.HasValue && (!existing.Oldest.HasValue || oldest.Value < existing.Oldest.Value)
                         ? oldest : existing.Oldest,
-                    existing.Handle == SourceHandle.DataSource ? SourceHandle.DataSource : handle);
+                    CombineHandles(existing.Handle, handle));
             }
             else
             {
@@ -206,13 +220,16 @@ public class DataSourceService : IDataSourceService
             .ToListAsync(ct);
         foreach (var s in tbStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest, HandleOf(s.FromDataSource));
 
-        // StateSpan carries a single origin handle, the data source that produced the span.
+        // StateSpan records one undifferentiated origin: its writers populate Source from the
+        // reported device string (DeviceStatusDecomposer) or from the row's data source, falling back
+        // to the entering party (TreatmentDecomposer). It therefore names neither handle in
+        // particular and contributes no evidence about which one its bucket's key is.
         var ssStats = await _context.StateSpans
             .Where(s => s.StartTimestamp >= thirtyDaysAgo)
             .GroupBy(s => s.Source)
             .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.StartTimestamp >= last24HoursDate), Latest = g.Max(x => x.StartTimestamp), Oldest = (DateTime?)g.Min(x => x.StartTimestamp) })
             .ToListAsync(ct);
-        foreach (var s in ssStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest, SourceHandle.DataSource);
+        foreach (var s in ssStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest, null);
 
         return result;
     }
@@ -242,6 +259,10 @@ public class DataSourceService : IDataSourceService
                 TotalCount = g.LongCount(),
                 Last24HCount = g.Count(e => e.Timestamp >= last24HoursDate),
             })
+            // Sibling devices sharing a data source both resolve to its single non-glucose bucket,
+            // and only the first of them claims it. Ordering by the group key makes which one that is
+            // the same on every refresh instead of whatever the grouping happened to return.
+            .OrderBy(d => d.Device)
             .ToListAsync(cancellationToken);
 
         // Also check APS snapshots for devices that might not have entries. Discovery keys on Device,
@@ -377,7 +398,7 @@ public class DataSourceService : IDataSourceService
         {
             if (processedNonGlucoseKeys.Contains(key)) continue;
 
-            var info = CreateDataSourceInfo(key, key, stats.Handle);
+            var info = CreateDataSourceInfo(key, key, stats.Handle ?? SourceHandle.Unknown);
             info.LastSeen = new DateTimeOffset(stats.Latest, TimeSpan.Zero);
             info.FirstSeen = stats.Oldest.HasValue ? new DateTimeOffset(stats.Oldest.Value, TimeSpan.Zero) : info.LastSeen;
             info.TotalEntries = stats.Count;

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.API.Services.Demo;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Core.Utilities;
@@ -989,19 +990,6 @@ public class DataSourceService : IDataSourceService
         return deletedCounts;
     }
 
-    /// <inheritdoc />
-    public async Task<long> DeleteGlucoseDataBySourceAsync(
-        string dataSource,
-        CancellationToken cancellationToken = default
-    )
-    {
-        var sgDeleted = await _sensorGlucose.DeleteBySourceAsync(dataSource, cancellationToken);
-        var mgDeleted = await _meterGlucose.DeleteBySourceAsync(dataSource, cancellationToken);
-        var calDeleted = await _calibrations.DeleteBySourceAsync(dataSource, cancellationToken);
-
-        return sgDeleted + mgDeleted + calDeleted;
-    }
-
     internal static string GenerateId(string deviceId) => $"ds-{HashUtils.Sha256Hex(deviceId)[..8]}";
 
     internal static string CleanDeviceName(string deviceId)
@@ -1085,21 +1073,9 @@ public class DataSourceService : IDataSourceService
 
         try
         {
-            var glucoseDeleted = await DeleteGlucoseDataBySourceAsync(
-                DataSources.DemoService,
-                cancellationToken
-            );
-
-            var treatmentsDeleted = await _context.Boluses.PurgeAsync(SourceFilter.For<BolusEntity>(DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.CarbIntakes.PurgeAsync(SourceFilter.For<CarbIntakeEntity>(DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.BGChecks.PurgeAsync(SourceFilter.For<BGCheckEntity>(DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.Notes.PurgeAsync(SourceFilter.For<NoteEntity>(DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.DeviceEvents.PurgeAsync(SourceFilter.For<DeviceEventEntity>(DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.BolusCalculations.PurgeAsync(SourceFilter.For<BolusCalculationEntity>(DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.TempBasals.PurgeAsync(SourceFilter.For<TempBasalEntity>(DataSources.DemoService), cancellationToken);
-            treatmentsDeleted += await _context.StateSpans.PurgeAsync(s => s.Source == DataSources.DemoService, cancellationToken);
-
-            var deviceStatusDeleted = await _context.ApsSnapshots.PurgeAsync(SourceFilter.For<ApsSnapshotEntity>(DataSources.DemoService), cancellationToken);
+            var glucoseDeleted = await DemoDataPurge.PurgeEntriesAsync(_context, cancellationToken);
+            var treatmentsDeleted = await DemoDataPurge.PurgeTreatmentsAsync(_context, cancellationToken);
+            var deviceStatusDeleted = await DemoDataPurge.PurgeDeviceStatusAsync(_context, cancellationToken);
 
             var deletedCounts = new Dictionary<string, long>();
             if (glucoseDeleted > 0) deletedCounts[nameof(SyncDataType.Glucose)] = glucoseDeleted;

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -12,6 +12,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Services;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 
@@ -52,7 +53,7 @@ public class DataSourceService : IDataSourceService
         _logger = logger;
     }
 
-    private record TableStats(long Count, int CountLast24H, DateTime Latest, DateTime? Oldest);
+    private record TableStats(long Count, int CountLast24H, DateTime Latest, DateTime? Oldest, SourceHandle Handle);
 
     private static void ApplyStatus(DataSourceInfo info, DateTimeOffset now, int activeMinutes, int staleMinutes)
     {
@@ -134,12 +135,18 @@ public class DataSourceService : IDataSourceService
         return result;
     }
 
+    /// <summary>
+    /// Aggregates every non-glucose table a source can produce rows in, bucketed by the source
+    /// identifier the row carries. The bucket key is <c>DataSource ?? Device</c>, the same key the
+    /// discovery merge resolves an entry under, and each bucket records which handle produced it
+    /// (<see cref="SourceHandle"/>) so an entry surfaced from a bucket alone can say so.
+    /// </summary>
     private async Task<Dictionary<string, TableStats>> GetNonGlucoseStatsAsync(
         DateTime thirtyDaysAgo, DateTime last24HoursDate, CancellationToken ct)
     {
         var result = new Dictionary<string, TableStats>(StringComparer.OrdinalIgnoreCase);
 
-        void Merge(string? key, long count, int count24h, DateTime latest, DateTime? oldest)
+        void Merge(string? key, long count, int count24h, DateTime latest, DateTime? oldest, SourceHandle handle)
         {
             if (string.IsNullOrEmpty(key) || count == 0) return;
             if (result.TryGetValue(key, out var existing))
@@ -149,62 +156,62 @@ public class DataSourceService : IDataSourceService
                     existing.CountLast24H + count24h,
                     latest > existing.Latest ? latest : existing.Latest,
                     oldest.HasValue && (!existing.Oldest.HasValue || oldest.Value < existing.Oldest.Value)
-                        ? oldest : existing.Oldest);
+                        ? oldest : existing.Oldest,
+                    existing.Handle == SourceHandle.DataSource ? SourceHandle.DataSource : handle);
             }
             else
             {
-                result[key] = new TableStats(count, count24h, latest, oldest);
+                result[key] = new TableStats(count, count24h, latest, oldest, handle);
             }
         }
 
-        var mgStats = await _context.MeterGlucose
-            .Where(mg => mg.Timestamp >= thirtyDaysAgo)
-            .GroupBy(mg => mg.DataSource ?? mg.Device)
-            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
-            .ToListAsync(ct);
-        foreach (var s in mgStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+        static SourceHandle HandleOf(bool fromDataSource) =>
+            fromDataSource ? SourceHandle.DataSource : SourceHandle.Device;
 
-        var bolusStats = await _context.Boluses
-            .Where(b => b.Timestamp >= thirtyDaysAgo)
-            .GroupBy(b => b.DataSource ?? b.Device)
-            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
-            .ToListAsync(ct);
-        foreach (var s in bolusStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+        async Task MergeTimeSeriesAsync<TEntity>() where TEntity : class, IV4TimeSeriesEntity
+        {
+            var stats = await _context.Set<TEntity>()
+                .Where(e => e.Timestamp >= thirtyDaysAgo)
+                .GroupBy(e => e.DataSource ?? e.Device)
+                .Select(g => new
+                {
+                    Key = g.Key,
+                    FromDataSource = g.Max(x => x.DataSource) != null,
+                    Count = g.LongCount(),
+                    Count24H = g.Count(x => x.Timestamp >= last24HoursDate),
+                    Latest = g.Max(x => x.Timestamp),
+                    Oldest = (DateTime?)g.Min(x => x.Timestamp),
+                })
+                .ToListAsync(ct);
 
-        var carbStats = await _context.CarbIntakes
-            .Where(c => c.Timestamp >= thirtyDaysAgo)
-            .GroupBy(c => c.DataSource ?? c.Device)
-            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
-            .ToListAsync(ct);
-        foreach (var s in carbStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+            foreach (var s in stats)
+                Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest, HandleOf(s.FromDataSource));
+        }
 
-        var bgStats = await _context.BGChecks
-            .Where(b => b.Timestamp >= thirtyDaysAgo)
-            .GroupBy(b => b.DataSource ?? b.Device)
-            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
-            .ToListAsync(ct);
-        foreach (var s in bgStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+        await MergeTimeSeriesAsync<MeterGlucoseEntity>();
+        await MergeTimeSeriesAsync<BolusEntity>();
+        await MergeTimeSeriesAsync<CarbIntakeEntity>();
+        await MergeTimeSeriesAsync<BGCheckEntity>();
+        await MergeTimeSeriesAsync<NoteEntity>();
+        await MergeTimeSeriesAsync<DeviceEventEntity>();
+        await MergeTimeSeriesAsync<BolusCalculationEntity>();
+        await MergeTimeSeriesAsync<ApsSnapshotEntity>();
 
-        var noteStats = await _context.Notes
-            .Where(n => n.Timestamp >= thirtyDaysAgo)
-            .GroupBy(n => n.DataSource ?? n.Device)
-            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
+        // TempBasal is span-shaped, so it keys on StartTimestamp and stays off IV4TimeSeriesEntity.
+        var tbStats = await _context.TempBasals
+            .Where(t => t.StartTimestamp >= thirtyDaysAgo)
+            .GroupBy(t => t.DataSource ?? t.Device)
+            .Select(g => new { Key = g.Key, FromDataSource = g.Max(x => x.DataSource) != null, Count = g.LongCount(), Count24H = g.Count(x => x.StartTimestamp >= last24HoursDate), Latest = g.Max(x => x.StartTimestamp), Oldest = (DateTime?)g.Min(x => x.StartTimestamp) })
             .ToListAsync(ct);
-        foreach (var s in noteStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+        foreach (var s in tbStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest, HandleOf(s.FromDataSource));
 
-        var deStats = await _context.DeviceEvents
-            .Where(de => de.Timestamp >= thirtyDaysAgo)
-            .GroupBy(de => de.DataSource ?? de.Device)
-            .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.Timestamp >= last24HoursDate), Latest = g.Max(x => x.Timestamp), Oldest = (DateTime?)g.Min(x => x.Timestamp) })
-            .ToListAsync(ct);
-        foreach (var s in deStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
-
+        // StateSpan carries a single origin handle, the data source that produced the span.
         var ssStats = await _context.StateSpans
             .Where(s => s.StartTimestamp >= thirtyDaysAgo)
             .GroupBy(s => s.Source)
             .Select(g => new { Key = g.Key, Count = g.LongCount(), Count24H = g.Count(x => x.StartTimestamp >= last24HoursDate), Latest = g.Max(x => x.StartTimestamp), Oldest = (DateTime?)g.Min(x => x.StartTimestamp) })
             .ToListAsync(ct);
-        foreach (var s in ssStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest);
+        foreach (var s in ssStats) Merge(s.Key, s.Count, s.Count24H, s.Latest, s.Oldest, SourceHandle.DataSource);
 
         return result;
     }
@@ -245,7 +252,12 @@ public class DataSourceService : IDataSourceService
                 ds.Timestamp >= thirtyDaysAgoDate && ds.Device != null && ds.Device != ""
             )
             .GroupBy(ds => ds.Device)
-            .Select(g => new { Device = g.Key!, LastMills = new DateTimeOffset(g.Max(ds => ds.Timestamp), TimeSpan.Zero).ToUnixTimeMilliseconds() })
+            .Select(g => new
+            {
+                Device = g.Key!,
+                DataSource = g.Max(ds => ds.DataSource),
+                LastMills = new DateTimeOffset(g.Max(ds => ds.Timestamp), TimeSpan.Zero).ToUnixTimeMilliseconds(),
+            })
             .ToListAsync(cancellationToken);
 
         // Batch-aggregate non-glucose tables
@@ -261,9 +273,39 @@ public class DataSourceService : IDataSourceService
         var dataSources = new List<DataSourceInfo>();
         var processedNonGlucoseKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        // A bucket is consumed by exactly one entry, or by none and surfaced as its own entry below.
+        // An entry claims the bucket its own key names first; the Device-field fallback may then take
+        // only a bucket no entry claims that way, which is the same entry the leftover loop would
+        // have built for it. Without that exclusivity a bucket reachable from two entries is added
+        // to both and any consumer summing the list double-counts it.
+        var primaryKeys = new HashSet<string>(
+            entryDevices.Select(d => d.DataSource ?? d.Device), StringComparer.OrdinalIgnoreCase);
+
+        TableStats? Claim(string key) =>
+            nonGlucoseStats.TryGetValue(key, out var stats) && processedNonGlucoseKeys.Add(key)
+                ? stats
+                : null;
+
+        static void MergeStats(DataSourceInfo info, TableStats stats)
+        {
+            info.TotalEntries += stats.Count;
+            info.EntriesLast24Hours += stats.CountLast24H;
+
+            var latest = new DateTimeOffset(stats.Latest, TimeSpan.Zero);
+            if (latest > info.LastSeen)
+                info.LastSeen = latest;
+
+            if (stats.Oldest.HasValue)
+            {
+                var oldest = new DateTimeOffset(stats.Oldest.Value, TimeSpan.Zero);
+                if (!info.FirstSeen.HasValue || oldest < info.FirstSeen)
+                    info.FirstSeen = oldest;
+            }
+        }
+
         foreach (var device in entryDevices)
         {
-            var info = CreateDataSourceInfo(device.Device, device.DataSource);
+            var info = CreateDataSourceInfo(device.Device, device.DataSource, SourceHandle.Device);
             info.LastSeen = new DateTimeOffset(device.LastTimestamp, TimeSpan.Zero);
             info.FirstSeen = new DateTimeOffset(device.FirstTimestamp, TimeSpan.Zero);
             info.TotalEntries = device.TotalCount;
@@ -291,37 +333,14 @@ public class DataSourceService : IDataSourceService
 
             // Merge non-glucose stats
             var mergeKey = device.DataSource ?? device.Device;
-            if (nonGlucoseStats.TryGetValue(mergeKey, out var ngStats))
-            {
-                info.TotalEntries += ngStats.Count;
-                info.EntriesLast24Hours += ngStats.CountLast24H;
-                var ngLastSeen = new DateTimeOffset(ngStats.Latest, TimeSpan.Zero);
-                if (ngLastSeen > info.LastSeen)
-                    info.LastSeen = ngLastSeen;
-                if (ngStats.Oldest.HasValue)
-                {
-                    var ngFirstSeen = new DateTimeOffset(ngStats.Oldest.Value, TimeSpan.Zero);
-                    if (!info.FirstSeen.HasValue || ngFirstSeen < info.FirstSeen)
-                        info.FirstSeen = ngFirstSeen;
-                }
-                processedNonGlucoseKeys.Add(mergeKey);
-            }
+            if (Claim(mergeKey) is { } ngStats)
+                MergeStats(info, ngStats);
+
             // Also try matching by Device field
-            if (mergeKey != device.Device && nonGlucoseStats.TryGetValue(device.Device, out var ngDeviceStats))
-            {
-                info.TotalEntries += ngDeviceStats.Count;
-                info.EntriesLast24Hours += ngDeviceStats.CountLast24H;
-                var ngLastSeen = new DateTimeOffset(ngDeviceStats.Latest, TimeSpan.Zero);
-                if (ngLastSeen > info.LastSeen)
-                    info.LastSeen = ngLastSeen;
-                if (ngDeviceStats.Oldest.HasValue)
-                {
-                    var ngFirstSeen = new DateTimeOffset(ngDeviceStats.Oldest.Value, TimeSpan.Zero);
-                    if (!info.FirstSeen.HasValue || ngFirstSeen < info.FirstSeen)
-                        info.FirstSeen = ngFirstSeen;
-                }
-                processedNonGlucoseKeys.Add(device.Device);
-            }
+            if (mergeKey != device.Device
+                && !primaryKeys.Contains(device.Device)
+                && Claim(device.Device) is { } ngDeviceStats)
+                MergeStats(info, ngDeviceStats);
 
             // Apply status with resolved thresholds
             var (activeMinutes, staleMinutes) = ResolveThresholds(connectorKey, thresholdOverrides);
@@ -335,22 +354,15 @@ public class DataSourceService : IDataSourceService
         {
             if (!dataSources.Any(d => d.DeviceId == dsDevice.Device))
             {
-                var info = CreateDataSourceInfo(dsDevice.Device, null);
+                var info = CreateDataSourceInfo(dsDevice.Device, dsDevice.DataSource, SourceHandle.Device);
                 info.LastSeen = DateTimeOffset.FromUnixTimeMilliseconds(dsDevice.LastMills);
                 info.FirstSeen = info.LastSeen;
                 info.TotalEntries = 0;
                 info.EntriesLast24Hours = 0;
 
                 // Merge non-glucose stats if available
-                if (nonGlucoseStats.TryGetValue(dsDevice.Device, out var ngStats))
-                {
-                    info.TotalEntries = ngStats.Count;
-                    info.EntriesLast24Hours = ngStats.CountLast24H;
-                    var ngLastSeen = new DateTimeOffset(ngStats.Latest, TimeSpan.Zero);
-                    if (ngLastSeen > info.LastSeen)
-                        info.LastSeen = ngLastSeen;
-                    processedNonGlucoseKeys.Add(dsDevice.Device);
-                }
+                if (Claim(dsDevice.Device) is { } ngStats)
+                    MergeStats(info, ngStats);
 
                 var (activeMinutes, staleMinutes) = ResolveThresholds(dsDevice.Device, thresholdOverrides);
                 ApplyStatus(info, now, activeMinutes, staleMinutes);
@@ -364,7 +376,7 @@ public class DataSourceService : IDataSourceService
         {
             if (processedNonGlucoseKeys.Contains(key)) continue;
 
-            var info = CreateDataSourceInfo(key, key);
+            var info = CreateDataSourceInfo(key, key, stats.Handle);
             info.LastSeen = new DateTimeOffset(stats.Latest, TimeSpan.Zero);
             info.FirstSeen = stats.Oldest.HasValue ? new DateTimeOffset(stats.Oldest.Value, TimeSpan.Zero) : info.LastSeen;
             info.TotalEntries = stats.Count;
@@ -600,9 +612,14 @@ public class DataSourceService : IDataSourceService
     /// <summary>
     /// Create a DataSourceInfo from a device identifier
     /// </summary>
-    private DataSourceInfo CreateDataSourceInfo(string deviceId, string? dataSource)
+    private DataSourceInfo CreateDataSourceInfo(string deviceId, string? dataSource, SourceHandle handle)
     {
-        var info = new DataSourceInfo { Id = GenerateId(deviceId), DeviceId = deviceId };
+        var info = new DataSourceInfo
+        {
+            Id = GenerateId(deviceId),
+            DeviceId = deviceId,
+            DeviceIdHandle = handle,
+        };
 
         // Parse device identifier to determine type
         var lowerDevice = deviceId.ToLowerInvariant();
@@ -972,6 +989,19 @@ public class DataSourceService : IDataSourceService
         return deletedCounts;
     }
 
+    /// <inheritdoc />
+    public async Task<long> DeleteGlucoseDataBySourceAsync(
+        string dataSource,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var sgDeleted = await _sensorGlucose.DeleteBySourceAsync(dataSource, cancellationToken);
+        var mgDeleted = await _meterGlucose.DeleteBySourceAsync(dataSource, cancellationToken);
+        var calDeleted = await _calibrations.DeleteBySourceAsync(dataSource, cancellationToken);
+
+        return sgDeleted + mgDeleted + calDeleted;
+    }
+
     internal static string GenerateId(string deviceId) => $"ds-{HashUtils.Sha256Hex(deviceId)[..8]}";
 
     internal static string CleanDeviceName(string deviceId)
@@ -1336,18 +1366,5 @@ public class DataSourceService : IDataSourceService
             await _context.BolusCalculations.AsNoTracking().FromSource(dataSource).OrderBy(b => b.Timestamp).Select(b => (DateTime?)b.Timestamp).FirstOrDefaultAsync(cancellationToken),
         };
         return timestamps.Where(t => t.HasValue).Select(t => t!.Value).DefaultIfEmpty().Min() is var min && min == default ? null : min;
-    }
-
-    /// <inheritdoc />
-    public async Task<long> DeleteGlucoseDataBySourceAsync(
-        string dataSource,
-        CancellationToken cancellationToken = default
-    )
-    {
-        var sgDeleted = await _sensorGlucose.DeleteBySourceAsync(dataSource, cancellationToken);
-        var mgDeleted = await _meterGlucose.DeleteBySourceAsync(dataSource, cancellationToken);
-        var calDeleted = await _calibrations.DeleteBySourceAsync(dataSource, cancellationToken);
-
-        return sgDeleted + mgDeleted + calDeleted;
     }
 }

--- a/src/API/Nocturne.API/Services/Demo/DemoDataPurge.cs
+++ b/src/API/Nocturne.API/Services/Demo/DemoDataPurge.cs
@@ -1,0 +1,53 @@
+using Nocturne.Core.Constants;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
+
+namespace Nocturne.API.Services.Demo;
+
+/// <summary>
+/// The one owner of "everything the demo service wrote": the table list and the delete that empties
+/// it, for every caller that clears demo data. Takes the context so a caller may bring either
+/// tenant-scoping pattern — an injected scoped context, or a factory context with
+/// <see cref="NocturneDbContext.TenantId"/> pinned from the demo tenant lookup.
+/// </summary>
+/// <remarks>
+/// Hard delete (<see cref="PurgeExtensions.PurgeAsync{TEntity}"/>), unlike the audited soft-delete
+/// every other source's delete routes through: demo data is regenerated wholesale, and the primary
+/// path that does so — <see cref="DemoTenantService.ResetAsync"/> — drops the tenant row and lets the
+/// database cascade clear every tenant-scoped table before the seeder refills it. A
+/// <c>deleted_by_user</c> stamp would only block that regeneration, and the audit trail it would be
+/// written for does not survive the reset either.
+/// </remarks>
+internal static class DemoDataPurge
+{
+    /// <summary>Glucose the demo service wrote: sensor, meter and calibration readings.</summary>
+    public static async Task<long> PurgeEntriesAsync(NocturneDbContext db, CancellationToken ct)
+    {
+        long deleted = await db.SensorGlucose.PurgeAsync(SourceFilter.For<SensorGlucoseEntity>(DataSources.DemoService), ct);
+        deleted += await db.MeterGlucose.PurgeAsync(SourceFilter.For<MeterGlucoseEntity>(DataSources.DemoService), ct);
+        deleted += await db.Calibrations.PurgeAsync(SourceFilter.For<CalibrationEntity>(DataSources.DemoService), ct);
+        return deleted;
+    }
+
+    /// <summary>
+    /// Treatments the demo service wrote: boluses, carbs, BG checks, notes, device events, bolus
+    /// calculations, temp basals and state spans.
+    /// </summary>
+    public static async Task<long> PurgeTreatmentsAsync(NocturneDbContext db, CancellationToken ct)
+    {
+        long deleted = await db.Boluses.PurgeAsync(SourceFilter.For<BolusEntity>(DataSources.DemoService), ct);
+        deleted += await db.CarbIntakes.PurgeAsync(SourceFilter.For<CarbIntakeEntity>(DataSources.DemoService), ct);
+        deleted += await db.BGChecks.PurgeAsync(SourceFilter.For<BGCheckEntity>(DataSources.DemoService), ct);
+        deleted += await db.Notes.PurgeAsync(SourceFilter.For<NoteEntity>(DataSources.DemoService), ct);
+        deleted += await db.DeviceEvents.PurgeAsync(SourceFilter.For<DeviceEventEntity>(DataSources.DemoService), ct);
+        deleted += await db.BolusCalculations.PurgeAsync(SourceFilter.For<BolusCalculationEntity>(DataSources.DemoService), ct);
+        deleted += await db.TempBasals.PurgeAsync(SourceFilter.For<TempBasalEntity>(DataSources.DemoService), ct);
+        deleted += await db.StateSpans.PurgeAsync(s => s.Source == DataSources.DemoService, ct);
+        return deleted;
+    }
+
+    /// <summary>APS snapshots the demo service wrote.</summary>
+    public static async Task<long> PurgeDeviceStatusAsync(NocturneDbContext db, CancellationToken ct) =>
+        await db.ApsSnapshots.PurgeAsync(SourceFilter.For<ApsSnapshotEntity>(DataSources.DemoService), ct);
+}

--- a/src/Core/Nocturne.Core.Contracts/Connectors/IDataSourceService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Connectors/IDataSourceService.cs
@@ -157,15 +157,4 @@ public interface IDataSourceService
         string dataSource,
         CancellationToken cancellationToken = default
     );
-
-    /// <summary>
-    /// Delete all glucose data (sensor glucose, meter glucose, calibrations) for a given data source.
-    /// </summary>
-    /// <param name="dataSource">The data source identifier.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Total number of records deleted across all glucose tables.</returns>
-    Task<long> DeleteGlucoseDataBySourceAsync(
-        string dataSource,
-        CancellationToken cancellationToken = default
-    );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
@@ -149,14 +149,6 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>, IDevic
     Task<DateTime?> GetOldestTimestampAsync(string? source = null, CancellationToken ct = default);
 
     /// <summary>
-    /// Count <see cref="SensorGlucose"/> records matching the given data source.
-    /// </summary>
-    /// <param name="source">Data source identifier (e.g., connector name).</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of matching records.</returns>
-    Task<int> CountBySourceAsync(string source, CancellationToken ct = default);
-
-    /// <summary>
     /// Delete all <see cref="SensorGlucose"/> records matching the given data source.
     /// </summary>
     /// <param name="source">Data source identifier (e.g., connector name).</param>

--- a/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
+++ b/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
@@ -3,6 +3,18 @@ using System.Text.Json.Serialization;
 namespace Nocturne.Core.Models.Services;
 
 /// <summary>
+/// Which of the two independent origin handles a row carries — the data source stamped by connector
+/// imports, the demo seeder and the V4 write endpoints, or the device string the uploader reported
+/// for itself — a given identifier names.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<SourceHandle>))]
+public enum SourceHandle
+{
+    [JsonStringEnumMemberName("device")] Device,
+    [JsonStringEnumMemberName("dataSource")] DataSource,
+}
+
+/// <summary>
 /// Represents information about a data source that's been pushing data to Nocturne.
 /// This is derived from analyzing the `device` field on entries and devicestatus records.
 /// </summary>
@@ -25,6 +37,13 @@ public class DataSourceInfo
     /// </summary>
     [JsonPropertyName("deviceId")]
     public string DeviceId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Which origin handle <see cref="DeviceId"/> names, so a consumer holding a list entry does not
+    /// have to guess whether it is a data source or a reported device string.
+    /// </summary>
+    [JsonPropertyName("deviceIdHandle")]
+    public SourceHandle DeviceIdHandle { get; set; } = SourceHandle.Device;
 
     /// <summary>
     /// Category of data source: cgm, pump, uploader, aid-system, connector, manual, unknown

--- a/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
+++ b/src/Core/Nocturne.Core.Models/Services/DataSourceInfo.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
 namespace Nocturne.Core.Models.Services;
@@ -10,8 +11,22 @@ namespace Nocturne.Core.Models.Services;
 [JsonConverter(typeof(JsonStringEnumConverter<SourceHandle>))]
 public enum SourceHandle
 {
-    [JsonStringEnumMemberName("device")] Device,
-    [JsonStringEnumMemberName("dataSource")] DataSource,
+    /// <summary>The device string the uploader reported for itself.</summary>
+    [EnumMember(Value = "device"), JsonStringEnumMemberName("device")]
+    Device,
+
+    /// <summary>The data source stamped on the row by whatever wrote it.</summary>
+    [EnumMember(Value = "dataSource"), JsonStringEnumMemberName("dataSource")]
+    DataSource,
+
+    /// <summary>
+    /// Either handle could name it. Rows that record a single undifferentiated origin — a state
+    /// span's <c>Source</c>, which its writers populate from a device string or from a data source
+    /// depending on what produced the span — cannot say which, so a source discovered only from
+    /// those reports this rather than guessing. Match such an identifier against both handles.
+    /// </summary>
+    [EnumMember(Value = "unknown"), JsonStringEnumMemberName("unknown")]
+    Unknown,
 }
 
 /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -442,21 +442,6 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
     }
 
     /// <summary>
-    /// Counts sensor glucose records for the given data source.
-    /// </summary>
-    /// <param name="source">Data source identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>Number of matching records.</returns>
-    public async Task<int> CountBySourceAsync(string source, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.SensorGlucose
-            .AsNoTracking()
-            .FromSource(source)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
     /// Deletes all sensor glucose records for the given data source.
     /// </summary>
     /// <param name="source">Data source identifier.</param>

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDiscoveryTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDiscoveryTests.cs
@@ -100,6 +100,13 @@ public class DataSourceServiceDiscoveryTests : IDisposable
             DataSource = dataSource, Device = device, Timestamp = timestamp, Mgdl = 120,
         }));
 
+    private void SeedStateSpan(string source, DateTime startTimestamp) =>
+        Seed(db => db.StateSpans.Add(new StateSpanEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, Source = source,
+            Category = "PumpMode", State = "Automatic", StartTimestamp = startTimestamp,
+        }));
+
     private void SeedBolus(string? dataSource, string? device, DateTime timestamp) =>
         Seed(db => db.Boluses.Add(new BolusEntity
         {
@@ -180,6 +187,54 @@ public class DataSourceServiceDiscoveryTests : IDisposable
             .Which.DeviceIdHandle.Should().Be(SourceHandle.DataSource);
         sources.Should().ContainSingle(s => s.DeviceId == RigB)
             .Which.DeviceIdHandle.Should().Be(SourceHandle.Device);
+    }
+
+    [Fact]
+    public async Task Discovery_DoesNotLetAStateSpanPromoteABucketsHandle()
+    {
+        // DeviceStatusDecomposer populates StateSpan.Source from the reported device string, so a
+        // span alongside a device-attributed treatment says nothing about which handle the key is.
+        Seed(db => db.DeviceEvents.Add(new DeviceEventEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId,
+            Device = RigA, Timestamp = DateTime.UtcNow, EventType = "SiteChange",
+        }));
+        SeedStateSpan(RigA, DateTime.UtcNow);
+
+        var sources = await DiscoverAsync();
+
+        sources.Should().ContainSingle(s => s.DeviceId == RigA)
+            .Which.DeviceIdHandle.Should().Be(SourceHandle.Device);
+    }
+
+    [Fact]
+    public async Task Discovery_CallsAStateSpanOnlySourcesHandleUnknown()
+    {
+        // Nothing but a span: its Source may be either handle and no other table can break the tie.
+        SeedStateSpan(RigA, DateTime.UtcNow);
+
+        var sources = await DiscoverAsync();
+
+        var info = sources.Should().ContainSingle(s => s.DeviceId == RigA).Subject;
+        info.DeviceIdHandle.Should().Be(SourceHandle.Unknown);
+        info.TotalEntries.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Discovery_AttributesASharedBucketToTheSameSiblingEveryTime()
+    {
+        // Two rigs importing under one connector contend for its single bucket; the winner must not
+        // depend on the order the grouping returned.
+        SeedSensorGlucose(Connector, RigA, DateTime.UtcNow);
+        SeedSensorGlucose(Connector, RigB, DateTime.UtcNow);
+        SeedBolus(Connector, null, DateTime.UtcNow);
+
+        var first = await DiscoverAsync();
+        var again = await DiscoverAsync();
+
+        first.Should().ContainSingle(s => s.DeviceId == RigA).Which.TotalEntries.Should().Be(2);
+        again.Select(s => (s.DeviceId, s.TotalEntries))
+            .Should().BeEquivalentTo(first.Select(s => (s.DeviceId, s.TotalEntries)));
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDiscoveryTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDiscoveryTests.cs
@@ -208,6 +208,28 @@ public class DataSourceServiceDiscoveryTests : IDisposable
     }
 
     [Fact]
+    public async Task Discovery_LetsARealDataSourceColumnOutrankEarlierDeviceEvidence()
+    {
+        // MeterGlucose merges before Boluses, so Device evidence arrives first; the bucket's
+        // handle must still resolve to the DataSource a later table proves.
+        Seed(db => db.MeterGlucose.Add(new MeterGlucoseEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId,
+            Device = RigA, Timestamp = DateTime.UtcNow, Mgdl = 100,
+        }));
+        Seed(db => db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId,
+            DataSource = RigA, Timestamp = DateTime.UtcNow, Insulin = 1.0,
+        }));
+
+        var sources = await DiscoverAsync();
+
+        sources.Should().ContainSingle(s => s.DeviceId == RigA)
+            .Which.DeviceIdHandle.Should().Be(SourceHandle.DataSource);
+    }
+
+    [Fact]
     public async Task Discovery_CallsAStateSpanOnlySourcesHandleUnknown()
     {
         // Nothing but a span: its Source may be either handle and no other table can break the tie.

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDiscoveryTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/DataSourceServiceDiscoveryTests.cs
@@ -1,0 +1,230 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.Services;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// Covers <see cref="DataSourceService.GetActiveDataSourcesAsync"/>: which tables a discovered
+/// entry's totals span, what an entry surfaced only from APS snapshots classifies as, and the
+/// exclusivity of the non-glucose merge — a bucket of counts belongs to exactly one entry, or the
+/// list a consumer sums over reports the same rows twice.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DataSourceServiceDiscoveryTests : IDisposable
+{
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private const string Connector = "nightscout-connector";
+    private const string RigA = "openaps://rig-a";
+    private const string RigB = "openaps://rig-b";
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+
+    private readonly Mock<ISensorGlucoseRepository> _sensorGlucose = new();
+    private readonly Mock<IMeterGlucoseRepository> _meterGlucose = new();
+    private readonly Mock<ICalibrationRepository> _calibrations = new();
+    private readonly Mock<IConnectorConfigurationService> _connectorConfig = new();
+
+    public DataSourceServiceDiscoveryTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        db.Tenants.Add(new TenantEntity { Id = TenantId, Slug = "test" });
+        db.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private NocturneDbContext NewContext() => new(_dbOptions) { TenantId = TenantId };
+
+    private DataSourceService CreateService(NocturneDbContext context) => new(
+        context,
+        _sensorGlucose.Object,
+        _meterGlucose.Object,
+        _calibrations.Object,
+        Mock.Of<IAuditContext>(),
+        _connectorConfig.Object,
+        NullLogger<DataSourceService>.Instance);
+
+    private async Task<List<DataSourceInfo>> DiscoverAsync()
+    {
+        await using var ctx = NewContext();
+        return await CreateService(ctx).GetActiveDataSourcesAsync();
+    }
+
+    private void Seed(Action<NocturneDbContext> seed)
+    {
+        using var db = NewContext();
+        seed(db);
+        db.SaveChanges();
+    }
+
+    private void SeedSnapshot(string? dataSource, string? device, DateTime timestamp) =>
+        Seed(db => db.ApsSnapshots.Add(new ApsSnapshotEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId,
+            DataSource = dataSource, Device = device, Timestamp = timestamp, AidAlgorithm = "Loop",
+        }));
+
+    private void SeedSensorGlucose(string? dataSource, string? device, DateTime timestamp) =>
+        Seed(db => db.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId,
+            DataSource = dataSource, Device = device, Timestamp = timestamp, Mgdl = 120,
+        }));
+
+    private void SeedBolus(string? dataSource, string? device, DateTime timestamp) =>
+        Seed(db => db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId,
+            DataSource = dataSource, Device = device, Timestamp = timestamp, Insulin = 1.5,
+        }));
+
+    [Fact]
+    public async Task Discovery_CountsASnapshotOnlySource()
+    {
+        // A rig that only ever uploaded device status: no glucose row, no treatment row.
+        SeedSnapshot(null, RigA, DateTime.UtcNow);
+
+        var sources = await DiscoverAsync();
+
+        sources.Should().ContainSingle(s => s.DeviceId == RigA)
+            .Which.TotalEntries.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Discovery_CountsATempBasalOnlySource()
+    {
+        Seed(db => db.TempBasals.Add(new TempBasalEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId,
+            DataSource = RigA, StartTimestamp = DateTime.UtcNow, Rate = 0.5, Origin = "pump",
+        }));
+
+        var sources = await DiscoverAsync();
+
+        sources.Should().ContainSingle(s => s.DeviceId == RigA)
+            .Which.TotalEntries.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Discovery_CountsABolusCalculationOnlySource()
+    {
+        Seed(db => db.BolusCalculations.Add(new BolusCalculationEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId,
+            DataSource = RigA, Timestamp = DateTime.UtcNow,
+        }));
+
+        var sources = await DiscoverAsync();
+
+        sources.Should().ContainSingle(s => s.DeviceId == RigA)
+            .Which.TotalEntries.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Discovery_ClassifiesASnapshotOnlyEntryFromItsDataSource()
+    {
+        // A device string no uploader heuristic recognises: the row's DataSource is the only handle
+        // that can classify it, and device-status discovery projected none.
+        SeedSnapshot(DataSources.DemoService, "pump-42", DateTime.UtcNow);
+
+        var sources = await DiscoverAsync();
+
+        var info = sources.Should().ContainSingle(s => s.DeviceId == "pump-42").Subject;
+        info.Category.Should().Be("demo");
+        info.SourceType.Should().Be("demo");
+    }
+
+    [Fact]
+    public async Task Discovery_NamesTheHandleTheEntryWasFoundUnder()
+    {
+        // RigA is discovered from the glucose rows' Device field; the connector entry exists only
+        // because a treatment bucket carries its DataSource.
+        SeedSensorGlucose(null, RigA, DateTime.UtcNow);
+        SeedBolus(Connector, null, DateTime.UtcNow);
+        SeedBolus(null, RigB, DateTime.UtcNow);
+
+        var sources = await DiscoverAsync();
+
+        sources.Should().ContainSingle(s => s.DeviceId == RigA)
+            .Which.DeviceIdHandle.Should().Be(SourceHandle.Device);
+        sources.Should().ContainSingle(s => s.DeviceId == Connector)
+            .Which.DeviceIdHandle.Should().Be(SourceHandle.DataSource);
+        sources.Should().ContainSingle(s => s.DeviceId == RigB)
+            .Which.DeviceIdHandle.Should().Be(SourceHandle.Device);
+    }
+
+    [Fact]
+    public async Task Discovery_CountsASharedBucketOnceAcrossTheList()
+    {
+        // Two rigs whose rows were imported by the same connector: both entries resolve their merge
+        // key to the connector's single non-glucose bucket.
+        SeedSensorGlucose(Connector, RigA, DateTime.UtcNow);
+        SeedSensorGlucose(Connector, RigB, DateTime.UtcNow);
+        SeedBolus(Connector, null, DateTime.UtcNow);
+        SeedBolus(Connector, null, DateTime.UtcNow);
+
+        var sources = await DiscoverAsync();
+
+        sources.Sum(s => s.TotalEntries).Should().Be(4);
+        sources.Sum(s => s.EntriesLast24Hours).Should().Be(4);
+    }
+
+    [Fact]
+    public async Task Discovery_GivesABucketToTheEntryItsOwnKeyNames()
+    {
+        // The bucket key "openaps://rig-a" is one entry's own merge key and another entry's Device
+        // field. It belongs to the former — the entry the leftover-surfacing loop would build for it.
+        SeedSensorGlucose(Connector, RigA, DateTime.UtcNow);
+        SeedSensorGlucose(RigA, RigB, DateTime.UtcNow);
+        SeedBolus(RigA, null, DateTime.UtcNow);
+
+        var sources = await DiscoverAsync();
+
+        sources.Sum(s => s.TotalEntries).Should().Be(3);
+        sources.Should().ContainSingle(s => s.DeviceId == RigA).Which.TotalEntries.Should().Be(1);
+        sources.Should().ContainSingle(s => s.DeviceId == RigB).Which.TotalEntries.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Discovery_CountsABucketOnceWhenADeviceStatusEntryRepeatsIt()
+    {
+        // The connector's bucket is claimed by the rig entry it imported for; the device-status
+        // entry the connector's own snapshot creates must not add the same bucket again.
+        SeedSensorGlucose(Connector, RigA, DateTime.UtcNow);
+        SeedBolus(Connector, null, DateTime.UtcNow);
+        SeedSnapshot(null, Connector, DateTime.UtcNow);
+
+        var sources = await DiscoverAsync();
+
+        sources.Sum(s => s.TotalEntries).Should().Be(3);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoDataPurgeParityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Demo/DemoDataPurgeParityTests.cs
@@ -1,0 +1,231 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V4.Admin;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Demo;
+
+/// <summary>
+/// The demo purge has two callers — <see cref="DemoAdminController"/>'s entries/treatments deletes
+/// and <see cref="DataSourceService.DeleteDemoDataAsync"/> — and they used to hand-copy the type
+/// list, which drifted. Both now route through the one owner, so each has to empty exactly the same
+/// set of tables and account for the same rows.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DemoDataPurgeParityTests : IDisposable
+{
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    /// <summary>Number of rows <see cref="SeedOneDemoRowOfEveryType"/> writes.</summary>
+    private const int SeededRows = 12;
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+
+    private readonly Mock<ISensorGlucoseRepository> _sensorGlucose = new();
+    private readonly Mock<IMeterGlucoseRepository> _meterGlucose = new();
+    private readonly Mock<ICalibrationRepository> _calibrations = new();
+    private readonly Mock<IConnectorConfigurationService> _connectorConfig = new();
+
+    public DemoDataPurgeParityTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        db.Tenants.Add(new TenantEntity { Id = TenantId, Slug = "demo", IsDemo = true });
+        db.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private NocturneDbContext NewContext() => new(_dbOptions) { TenantId = TenantId };
+
+    private sealed class ContextFactory(DbContextOptions<NocturneDbContext> options)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext() => new(options);
+    }
+
+    private DemoAdminController CreateController() =>
+        new(Mock.Of<ITenantService>(), null!, new ContextFactory(_dbOptions));
+
+    private DataSourceService CreateService(NocturneDbContext context) => new(
+        context,
+        _sensorGlucose.Object,
+        _meterGlucose.Object,
+        _calibrations.Object,
+        Mock.Of<IAuditContext>(),
+        _connectorConfig.Object,
+        NullLogger<DataSourceService>.Instance);
+
+    /// <summary>One demo row in every table the demo seeder and the realtime tick write to.</summary>
+    private void SeedOneDemoRowOfEveryType(bool softDeleted = false)
+    {
+        var timestamp = DateTime.UtcNow;
+        DateTime? deletedAt = softDeleted ? timestamp : null;
+
+        using var db = NewContext();
+        db.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Mgdl = 120, DeletedAt = deletedAt,
+        });
+        db.MeterGlucose.Add(new MeterGlucoseEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Mgdl = 118, DeletedAt = deletedAt,
+        });
+        db.Calibrations.Add(new CalibrationEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Slope = 1, Intercept = 0, DeletedAt = deletedAt,
+        });
+        db.Boluses.Add(new BolusEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Insulin = 1, DeletedAt = deletedAt,
+        });
+        db.CarbIntakes.Add(new CarbIntakeEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Carbs = 20, DeletedAt = deletedAt,
+        });
+        db.BGChecks.Add(new BGCheckEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Glucose = 100, DeletedAt = deletedAt,
+        });
+        db.Notes.Add(new NoteEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, Text = "note", DeletedAt = deletedAt,
+        });
+        db.DeviceEvents.Add(new DeviceEventEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, EventType = "SiteChange", DeletedAt = deletedAt,
+        });
+        db.BolusCalculations.Add(new BolusCalculationEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Timestamp = timestamp, DeletedAt = deletedAt,
+        });
+        db.TempBasals.Add(new TempBasalEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            StartTimestamp = timestamp, Rate = 0.5, Origin = "pump", DeletedAt = deletedAt,
+        });
+        db.StateSpans.Add(new StateSpanEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, Source = DataSources.DemoService,
+            Category = "PumpMode", State = "Automatic", StartTimestamp = timestamp,
+        });
+        db.ApsSnapshots.Add(new ApsSnapshotEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = TenantId, DataSource = DataSources.DemoService,
+            Device = "trio-rig", Timestamp = timestamp, AidAlgorithm = "Trio", DeletedAt = deletedAt,
+        });
+        db.SaveChanges();
+    }
+
+    private async Task<long> RemainingDemoRowsAsync()
+    {
+        await using var db = NewContext();
+        return await db.SensorGlucose.IgnoreQueryFilters().LongCountAsync()
+            + await db.MeterGlucose.IgnoreQueryFilters().LongCountAsync()
+            + await db.Calibrations.IgnoreQueryFilters().LongCountAsync()
+            + await db.Boluses.IgnoreQueryFilters().LongCountAsync()
+            + await db.CarbIntakes.IgnoreQueryFilters().LongCountAsync()
+            + await db.BGChecks.IgnoreQueryFilters().LongCountAsync()
+            + await db.Notes.IgnoreQueryFilters().LongCountAsync()
+            + await db.DeviceEvents.IgnoreQueryFilters().LongCountAsync()
+            + await db.BolusCalculations.IgnoreQueryFilters().LongCountAsync()
+            + await db.TempBasals.IgnoreQueryFilters().LongCountAsync()
+            + await db.StateSpans.IgnoreQueryFilters().LongCountAsync()
+            + await db.ApsSnapshots.IgnoreQueryFilters().LongCountAsync();
+    }
+
+    private async Task<long> ControllerPurgeAsync()
+    {
+        var controller = CreateController();
+
+        var entries = ((DemoDeleteResultDto)((OkObjectResult)await controller.DeleteEntries(default)).Value!).DeletedCount;
+        var treatments = ((DemoDeleteResultDto)((OkObjectResult)await controller.DeleteTreatments(default)).Value!).DeletedCount;
+
+        return entries + treatments;
+    }
+
+    private async Task<long> ServicePurgeAsync()
+    {
+        await using var ctx = NewContext();
+        var result = await CreateService(ctx).DeleteDemoDataAsync();
+
+        result.Success.Should().BeTrue();
+        return result.TotalDeleted;
+    }
+
+    [Fact]
+    public async Task BothPurgePaths_AccountForEveryDemoRowAndLeaveNothingBehind()
+    {
+        SeedOneDemoRowOfEveryType();
+        var controllerDeleted = await ControllerPurgeAsync();
+        (await RemainingDemoRowsAsync()).Should().Be(0);
+
+        SeedOneDemoRowOfEveryType();
+        var serviceDeleted = await ServicePurgeAsync();
+        (await RemainingDemoRowsAsync()).Should().Be(0);
+
+        controllerDeleted.Should().Be(SeededRows);
+        serviceDeleted.Should().Be(SeededRows);
+    }
+
+    [Fact]
+    public async Task BothPurgePaths_PurgeRowsAVisitorHadAlreadyDeleted()
+    {
+        // The demo tenant is regenerated wholesale, so a soft-deleted row has to go too; leaving it
+        // behind makes it unreadable and unpurgeable.
+        SeedOneDemoRowOfEveryType(softDeleted: true);
+
+        await ControllerPurgeAsync();
+
+        (await RemainingDemoRowsAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ServicePurge_ReportsThePerTypeCountsItsCallerRenders()
+    {
+        SeedOneDemoRowOfEveryType();
+
+        await using var ctx = NewContext();
+        var result = await CreateService(ctx).DeleteDemoDataAsync();
+
+        result.DeletedCounts.Should().Contain(new KeyValuePair<string, long>("Glucose", 3));
+        result.DeletedCounts.Should().Contain(new KeyValuePair<string, long>("Treatments", 8));
+        result.DeletedCounts.Should().Contain(new KeyValuePair<string, long>("DeviceStatus", 1));
+    }
+}

--- a/tests/Unit/Nocturne.Core.Models.Tests/Services/DataSourceInfoSerializationTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Services/DataSourceInfoSerializationTests.cs
@@ -16,6 +16,7 @@ public class DataSourceInfoSerializationTests
     [Theory]
     [InlineData(SourceHandle.Device, "device")]
     [InlineData(SourceHandle.DataSource, "dataSource")]
+    [InlineData(SourceHandle.Unknown, "unknown")]
     public void DeviceIdHandle_SerializesAsItsNamedHandle(SourceHandle handle, string expected)
     {
         var json = JsonSerializer.Serialize(new DataSourceInfo { DeviceId = "openaps://rig", DeviceIdHandle = handle });

--- a/tests/Unit/Nocturne.Core.Models.Tests/Services/DataSourceInfoSerializationTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Services/DataSourceInfoSerializationTests.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.Core.Models.Services;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.Services;
+
+/// <summary>
+/// <see cref="DataSourceInfo.DeviceIdHandle"/> is what tells a consumer whether the entry's
+/// <see cref="DataSourceInfo.DeviceId"/> is a data source or a reported device string, so it has to
+/// reach the wire — and as the named handle, not its ordinal.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DataSourceInfoSerializationTests
+{
+    [Theory]
+    [InlineData(SourceHandle.Device, "device")]
+    [InlineData(SourceHandle.DataSource, "dataSource")]
+    public void DeviceIdHandle_SerializesAsItsNamedHandle(SourceHandle handle, string expected)
+    {
+        var json = JsonSerializer.Serialize(new DataSourceInfo { DeviceId = "openaps://rig", DeviceIdHandle = handle });
+
+        using var parsed = JsonDocument.Parse(json);
+        parsed.RootElement.GetProperty("deviceIdHandle").GetString().Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Closes #899. Closes #879. Addresses #896 — the issue stays open for three small adjacencies found during the fix (commented there).

## #896 — discovery counts and classifies everything

**Missing tables** (item 1): `GetNonGlucoseStatsAsync` now aggregates BolusCalculations, TempBasals and ApsSnapshots — and the seven hand-copied per-table aggregates collapsed into one generic `MergeTimeSeriesAsync<TEntity>` over `IV4TimeSeriesEntity` (TempBasal keeps its span-shaped block on `StartTimestamp`; StateSpan its single-handle block). A snapshot-only or temp-basal-only source goes from `totalEntries = 0` to its real count and becomes deletable through the normal path.

**Null DataSource projection** (item 2): device-status discovery projects the dominant `DataSource` (same `Max` rule entry discovery already used) so snapshot-only entries classify as their connector/demo identity instead of "unknown".

**Origin handle on the DTO** (item 3): new `SourceHandle` enum (string-serialized, explicit member names — no ordinal exposure) and additive `DataSourceInfo.deviceIdHandle`, so a consumer holding a list entry no longer guesses which handle `deviceId` names.

**Double-count fixed** (item 4): bucket consumption is now exclusive — one `Claim(key)` gate backed by the processed-set, plus a `primaryKeys` guard so the Device-field fallback can only take a bucket no entry claims by its own key. Tie-break: a bucket belongs to the entry whose own merge key names it, which is exactly the attribution the leftover-surfacing loop would have produced — so list totals are invariant; a shared bucket just stops appearing twice. The three copies of the merge body collapsed into `MergeStats`.

## #899 — one purge owner, dead code out

New `DemoDataPurge` (entries/treatments/device-status) is the single owner of "everything the demo service wrote"; `DemoAdminController` and `DataSourceService.DeleteDemoDataAsync` both consume it, taking the context as a parameter so each keeps its tenant-scoping pattern. The drift-prone hand-copies are gone. `ISensorGlucoseRepository.CountBySourceAsync` (zero callers) deleted, along with `IDataSourceService.DeleteGlucoseDataBySourceAsync`, which became consumerless once glucose joined the shared owner.

## #879 — resolved as a documented constraint

Hard delete is **correct** for demo data, and the rationale now lives at the one owner: `DemoTenantService.ResetAsync` — the primary regeneration path — drops the tenant row and cascades every tenant-scoped table before re-seeding, so a `deleted_by_user` stamp would only fight regeneration, and the audit trail it would serve doesn't survive the reset either. Declared delta: the admin demo-delete's glucose leg switches from audited soft-delete to the same hard purge the controller's endpoints always used (parity, no stamped demo rows left behind).

## Behavioural deltas
- Discovery totals grow for sources with bolus-calc/temp-basal/snapshot rows (consumers: the data-source dialogs and rows; none sums across the list, so the exclusivity fix shows as one of two entries no longer carrying rows it never owned).
- Snapshot-only entries gain their real name/category/icon.
- `deviceIdHandle` is additive and always present.

## Tests
13 new (8 discovery, 3 purge-parity, 2 wire-format), each mutation-proved: dropping any added table fails its counting test; reverting the null projection fails classification and handle tests; reverting `Claim` to the old non-exclusive lookup fails the once-only tests; dropping types from `DemoDataPurge` fails parity **and** the pre-existing demo-purge test. API.Tests full run 5863 passed / 0 failed.



## Hostile-review round

The gate blocked the first cut: a StateSpan bucket asserted `SourceHandle.DataSource`, but `StateSpanEntity.Source` is written as the DEVICE string by `DeviceStatusDecomposer` (and as `DataSource ?? EnteredBy ?? "nightscout"` by `TreatmentDecomposer`), so one span could promote a correct Device-handle bucket. Fixed: StateSpan now contributes no handle evidence; only tables storing both handles vote (real `DataSource` value wins), and a zero-evidence bucket reports the new `unknown` member � honest, and directly actionable since `SourceFilter` matches either handle. Mutation-proved with the gate's exact repro. `entryDevices` gained a deterministic `OrderBy` so sibling-bucket attribution is stable across refreshes (contract-pinned; the underlying nondeterminism is Postgres-side and not reproducible under SQLite). `SourceHandle` now pairs `[EnumMember]` with the STJ name attribute like every sibling enum.

Two further declared deltas (both corrections): device-status entries can move `FirstSeen` earlier (the old branch ignored the bucket's oldest row), and a snapshot carrying a `DataSource` can surface the connector's own entry (the module's documented design, previously unreachable only because ApsSnapshots was missing from the aggregate; rows are counted once).