### PR TITLE
fix(api): bound the remaining anonymous surfaces with client-address rate limits

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MemberInviteController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Nocturne.API.Authorization;
 using OpenApi.Remote.Attributes;
@@ -177,6 +178,7 @@ public class MemberInviteController : ControllerBase
     /// </remarks>
     [HttpGet("{token}/info")]
     [AllowAnonymous]
+    [EnableRateLimiting("invite-lookup")]
     [InviteTokenAuthorized]
     [RemoteQuery]
     [ProducesResponseType(typeof(MemberInviteInfo), StatusCodes.Status200OK)]

--- a/src/API/Nocturne.API/Controllers/V4/Identity/MyTenantsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MyTenantsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Authorization;
@@ -109,6 +110,7 @@ public class MyTenantsController : ControllerBase
     [HttpGet("validate-slug")]
     [AllowAnonymous]
     [AllowDuringSetup]
+    [EnableRateLimiting("name-availability")]
     [RemoteQuery]
     [ProducesResponseType(typeof(SlugValidationResult), StatusCodes.Status200OK)]
     public async Task<IActionResult> ValidateSlug([FromQuery] string slug, CancellationToken ct)

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertInvitesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertInvitesController.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
@@ -108,6 +109,7 @@ public class AlertInvitesController : ControllerBase
     /// </summary>
     [HttpGet("{token}")]
     [AllowAnonymous]
+    [EnableRateLimiting("invite-lookup")]
     [RemoteQuery]
     [ProducesResponseType(typeof(AlertInviteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using OpenApi.Remote.Attributes;
@@ -85,6 +86,7 @@ public partial class SetupController : ControllerBase
     /// Create the first tenant on a fresh install. Only succeeds when zero tenants exist.
     /// </summary>
     [HttpPost("tenant")]
+    [EnableRateLimiting("setup")]
     [RemoteCommand]
     [ProducesResponseType(typeof(SetupTenantResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
@@ -112,6 +114,7 @@ public partial class SetupController : ControllerBase
     /// Check whether a username is available for the owner account.
     /// </summary>
     [HttpGet("validate-username")]
+    [EnableRateLimiting("name-availability")]
     [RemoteQuery]
     [ProducesResponseType(typeof(SlugValidationResult), StatusCodes.Status200OK)]
     public async Task<IActionResult> ValidateUsername(
@@ -174,6 +177,7 @@ public partial class SetupController : ControllerBase
     /// Guard: exactly one tenant must exist with zero non-system members.
     /// </summary>
     [HttpPost("owner/options")]
+    [EnableRateLimiting("setup")]
     [RemoteCommand]
     [ProducesResponseType(typeof(SetupOwnerOptionsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
@@ -215,6 +219,7 @@ public partial class SetupController : ControllerBase
     /// Verifies attestation, generates recovery codes, issues a full JWT session.
     /// </summary>
     [HttpPost("owner/complete")]
+    [EnableRateLimiting("setup")]
     [RemoteCommand]
     [ProducesResponseType(typeof(SetupOwnerCompleteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
@@ -281,6 +286,7 @@ public partial class SetupController : ControllerBase
     /// then redirects to the OIDC provider to link an identity.
     /// </summary>
     [HttpPost("owner/oidc")]
+    [EnableRateLimiting("setup")]
     [RemoteCommand]
     [ProducesResponseType(typeof(SetupOwnerOidcResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
@@ -335,6 +341,7 @@ public partial class SetupController : ControllerBase
     [HttpGet("oidc/callback")]
     [AllowAnonymous]
     [AllowDuringSetup]
+    [EnableRateLimiting("setup")]
     [ProducesResponseType(StatusCodes.Status302Found)]
     public async Task<IActionResult> OidcCallback(
         [FromQuery] string? code,

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -123,6 +123,22 @@ public static class ServiceRegistrationExtensions
         // files a pending subject under a display name not already taken, and nothing else prunes
         // them.
         ("passkey-access-request", 5, TimeSpan.FromMinutes(10)),
+        // First-run setup: creating the tenant, the owner ceremonies (options then complete, so two
+        // permits each) and the OIDC callback that exchanges a code with the provider. Only
+        // reachable while no member of the instance holds a credential, so the ceiling covers one
+        // operator retrying a ceremony rather than a population signing in.
+        ("setup", 20, TimeSpan.FromMinutes(1)),
+        // The "is this name free?" probes — owner username and tenant slug — which a form issues
+        // per keystroke behind a 400ms debounce, so a hunt-and-peck typist spends a permit per
+        // character. Sized well clear of a full name so a wizard cannot throttle itself, while
+        // still bounding what each anonymous request costs: a membership or tenant lookup, and for
+        // the username the operator's optional validation webhook.
+        ("name-availability", 60, TimeSpan.FromMinutes(1)),
+        // The anonymous invite lookups, member and alert. Their tokens are long random strings, so
+        // grinding one is infeasible at any rate; what the ceiling bounds is the database query
+        // each anonymous request costs. An invite page reads once per visit, which leaves the
+        // ceiling room for reloads and for a clinic behind one NAT.
+        ("invite-lookup", 30, TimeSpan.FromMinutes(1)),
         ("guest-activate", 5, TimeSpan.FromMinutes(10)),
         // Friction against naive abuse only — this does NOT bound the refresh_tokens table. The
         // real ceiling is DemoSessionLimits.MaxLiveSessions, enforced on the subject id.

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -130,9 +130,10 @@ public static class ServiceRegistrationExtensions
         ("setup", 20, TimeSpan.FromMinutes(1)),
         // The "is this name free?" probes — owner username and tenant slug — which a form issues
         // per keystroke behind a 400ms debounce, so a hunt-and-peck typist spends a permit per
-        // character. Sized well clear of a full name so a wizard cannot throttle itself, while
-        // still bounding what each anonymous request costs: a membership or tenant lookup, and for
-        // the username the operator's optional validation webhook.
+        // character. Sized for a full name typed that way plus a retry; past that the frontend
+        // carries it, treating a probe it could not complete as unverified rather than refused.
+        // The ceiling bounds what each anonymous request costs: a membership or tenant lookup,
+        // and for the username the operator's optional validation webhook.
         ("name-availability", 60, TimeSpan.FromMinutes(1)),
         // The anonymous invite lookups, member and alert. Their tokens are long random strings, so
         // grinding one is infeasible at any rate; what the ceiling bounds is the database query

--- a/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
+++ b/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { error, isHttpError } from "@sveltejs/kit";
+import config from "../../../../../remote-codegen.config";
+import { describeSubmitError, RATE_LIMITED_ERROR } from "../forms/submit-error";
+import { remoteErrorMessage } from "./remote-error";
+
+/**
+ * What a failed API call looks like by the time a page sees it.
+ *
+ * Every generated remote function ends in the catch block
+ * openapi-remote-codegen 0.2.0 writes: the status is read off the thrown value,
+ * 401 and 403 get a line each, and everything else falls to
+ * {@link config.errorHandling.on500} — which is ours. A status `on500` does not
+ * name is flattened to a 500 and never reaches the browser, so a page cannot
+ * tell "you were throttled" from "this failed". These run the real `on500`
+ * source, compiled the way the build compiles the generated file, over the
+ * shape NSwag actually throws — not a hand-built `{ status }`.
+ */
+async function crossTheBoundary(thrown: unknown): Promise<unknown> {
+  const compiled = await transformWithEsbuild(
+    `(err, status, error) => { ${config.errorHandling.on500("get invite info")}; }`,
+    "on500.ts",
+    { loader: "ts" }
+  );
+  const source = compiled.code.trim().replace(/;$/, "");
+
+  const flatten = new Function(`return ${source}`)() as (
+    err: unknown,
+    status: unknown,
+    error: typeof import("@sveltejs/kit").error
+  ) => never;
+
+  try {
+    flatten(thrown, (thrown as { status?: number })?.status, error);
+  } catch (crossed) {
+    return crossed;
+  }
+
+  throw new Error("the catch block returned without throwing");
+}
+
+/**
+ * NSwag's ApiException, which is what it throws for a status the operation
+ * declares no response type for — the rate limiter's 429 among them. The body
+ * arrives as unparsed text on `response`, and the message is NSwag's own.
+ */
+function nswagApiException(status: number, body: string) {
+  return Object.assign(
+    new Error(
+      `The HTTP status code of the response was not expected (${status}).`
+    ),
+    { status, response: body, result: null }
+  );
+}
+
+const RATE_LIMIT_BODY = JSON.stringify({
+  error: "rate_limit_exceeded",
+  error_description: "Too many requests. Please try again later.",
+});
+
+describe("the status a generated remote function lets through", () => {
+  it("forwards a 429 rather than flattening it to a 500", async () => {
+    const crossed = await crossTheBoundary(nswagApiException(429, RATE_LIMIT_BODY));
+
+    expect(isHttpError(crossed)).toBe(true);
+    expect((crossed as { status: number }).status).toBe(429);
+  });
+
+  it("keeps NSwag's boilerplate out of the message it carries", async () => {
+    const crossed = await crossTheBoundary(nswagApiException(429, RATE_LIMIT_BODY));
+
+    expect(JSON.stringify(crossed)).not.toContain("not expected");
+  });
+
+  it("reads as throttled on the invite page, not as a dead invite", async () => {
+    const crossed = await crossTheBoundary(nswagApiException(429, RATE_LIMIT_BODY));
+
+    expect(
+      describeSubmitError(
+        crossed,
+        "This invite link is invalid or has expired."
+      )
+    ).toBe(RATE_LIMITED_ERROR);
+  });
+
+  it("reads as throttled where a scope refusal would name a permission", async () => {
+    const crossed = await crossTheBoundary(nswagApiException(429, RATE_LIMIT_BODY));
+
+    expect(remoteErrorMessage(crossed, "You need alerts.readwrite.")).toBe(
+      RATE_LIMITED_ERROR
+    );
+  });
+
+  it("still flattens a status it does not forward", async () => {
+    const crossed = await crossTheBoundary(nswagApiException(503, "unavailable"));
+
+    expect((crossed as { status: number }).status).toBe(500);
+    expect(describeSubmitError(crossed, "Couldn't load the invite.")).toBe(
+      "Couldn't load the invite."
+    );
+  });
+});

--- a/src/Web/packages/app/src/lib/api/remote-error.ts
+++ b/src/Web/packages/app/src/lib/api/remote-error.ts
@@ -1,3 +1,5 @@
+import { RATE_LIMITED_ERROR } from "$lib/forms/submit-error";
+
 /**
  * Message to show for a rejected remote function call.
  *
@@ -5,10 +7,13 @@
  * an `HttpError` — a plain `{ status, body: { message } }` object, not an
  * `Error`. A scope refusal is a bare `ForbidResult` with no body, so the 403
  * message is the HTTP client's own boilerplate; the caller's fallback names the
- * permission instead.
+ * permission instead. A 429 is answered from the status for the same reason the
+ * codegen forwards it with a fixed reason, and because a fallback naming the
+ * permission the caller lacks describes the wrong refusal.
  */
 export function remoteErrorMessage(err: unknown, fallback: string): string {
   const e = err as { status?: number; body?: { message?: unknown } } | null;
+  if (e?.status === 429) return RATE_LIMITED_ERROR;
   if (e?.status === 403) return fallback;
 
   const message = e?.body?.message;

--- a/src/Web/packages/app/src/lib/forms/availability.svelte.ts
+++ b/src/Web/packages/app/src/lib/forms/availability.svelte.ts
@@ -23,15 +23,31 @@ export interface Availability {
   readonly error: string | null;
   /** The server confirmed this value is available. */
   readonly valid: boolean;
+  /**
+   * Nothing known says this value can't be used: either the server confirmed it,
+   * or the check itself failed and so refused nothing. Gate submission on this
+   * rather than on {@link valid}, or a check that cannot answer — the rate
+   * limiter turning the probe away, the network dropping — leaves the field
+   * behind a button that never enables, for a value the server may well accept.
+   * The server validates the value again on submit, which is what actually
+   * decides.
+   */
+  readonly submittable: boolean;
 }
 
 interface AvailabilityState {
   validating: boolean;
   error: string | null;
   valid: boolean;
+  submittable: boolean;
 }
 
-const IDLE: AvailabilityState = { validating: false, error: null, valid: false };
+const IDLE: AvailabilityState = {
+  validating: false,
+  error: null,
+  valid: false,
+  submittable: false,
+};
 
 /**
  * Debounced "is this name free?" checking for a single text field.
@@ -61,19 +77,20 @@ export function useAvailability(
         validating: false,
         error: `${label} must be at least ${minLength} characters`,
         valid: false,
+        submittable: false,
       };
     }
 
     // Still waiting for the debounce to settle on the latest keystroke.
     if (debounced.current !== current) {
-      return { validating: true, error: null, valid: false };
+      return { validating: true, error: null, valid: false, submittable: false };
     }
 
     const result = check(current);
 
     // loading: request in flight; !current: result not populated yet
     if (result.loading || !result.current) {
-      return { validating: true, error: null, valid: false };
+      return { validating: true, error: null, valid: false, submittable: false };
     }
 
     if (result.error) {
@@ -81,17 +98,19 @@ export function useAvailability(
         validating: false,
         error: `Could not validate ${label.toLowerCase()}`,
         valid: false,
+        submittable: true,
       };
     }
 
     if (result.current.isValid) {
-      return { validating: false, error: null, valid: true };
+      return { validating: false, error: null, valid: true, submittable: true };
     }
 
     return {
       validating: false,
       error: result.current.message ?? `Invalid ${label.toLowerCase()}`,
       valid: false,
+      submittable: false,
     };
   });
 
@@ -104,6 +123,9 @@ export function useAvailability(
     },
     get valid() {
       return state.valid;
+    },
+    get submittable() {
+      return state.submittable;
     },
   };
 }

--- a/src/Web/packages/app/src/lib/forms/availability.test.ts
+++ b/src/Web/packages/app/src/lib/forms/availability.test.ts
@@ -145,6 +145,60 @@ describe("useAvailability", () => {
     expect(availability.valid).toBe(false);
   });
 
+  it("lets a value whose check failed be submitted anyway", () => {
+    const availability = useAvailability(
+      () => "myslug",
+      () => query({ error: { status: 429 }, current: { isValid: true } }),
+      { label: "Slug" }
+    );
+
+    // The remote query caches its rejection against this argument, so a probe
+    // the rate limiter turned away would otherwise hold the value behind a
+    // disabled button until the page is reloaded.
+    expect(availability.submittable).toBe(true);
+    expect(availability.valid).toBe(false);
+    expect(availability.error).toBe("Could not validate slug");
+  });
+
+  it("does not latch the failure: the same value settles again on a later answer", () => {
+    let throttled = true;
+    const availability = useAvailability(
+      () => "myslug",
+      () =>
+        throttled
+          ? query({ error: { status: 429 }, current: { isValid: true } })
+          : query({ current: { isValid: true } }),
+      { label: "Slug" }
+    );
+
+    expect(availability.error).toBe("Could not validate slug");
+    expect(availability.submittable).toBe(true);
+
+    throttled = false;
+
+    expect(availability.error).toBeNull();
+    expect(availability.valid).toBe(true);
+    expect(availability.submittable).toBe(true);
+  });
+
+  it("still holds back a value the server refused", () => {
+    const availability = useAvailability(
+      () => "myslug",
+      () => query({ current: { isValid: false, message: "Already taken" } }),
+      { label: "Slug" }
+    );
+
+    expect(availability.submittable).toBe(false);
+  });
+
+  it("holds back a value too short to ask about", () => {
+    const availability = useAvailability(() => "ab", () => query({}), {
+      label: "Slug",
+    });
+
+    expect(availability.submittable).toBe(false);
+  });
+
   it("tracks the value it is given", () => {
     let value = "";
     const availability = useAvailability(

--- a/src/Web/packages/app/src/lib/forms/submit-error.test.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { describeSubmitError, GENERIC_SUBMIT_ERROR } from "./submit-error";
+import {
+  describeSubmitError,
+  GENERIC_SUBMIT_ERROR,
+  RATE_LIMITED_ERROR,
+} from "./submit-error";
 
 describe("describeSubmitError", () => {
   it("uses the handler's message for a 4xx", () => {
@@ -25,6 +29,12 @@ describe("describeSubmitError", () => {
     expect(describeSubmitError({ status: 409, body: { message: "  " } })).toBe(
       GENERIC_SUBMIT_ERROR
     );
+  });
+
+  it("reports a throttled attempt as throttled, not as the caller's fallback", () => {
+    expect(
+      describeSubmitError({ status: 429 }, "This invite link is invalid.")
+    ).toBe(RATE_LIMITED_ERROR);
   });
 
   it("uses the caller's fallback", () => {

--- a/src/Web/packages/app/src/lib/forms/submit-error.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.ts
@@ -39,12 +39,19 @@ export function errorMessage(err: unknown): string | undefined {
  * message. Those messages are written for the user, so a 4xx message is shown
  * verbatim; anything else (5xx, network failure, thrown `Error`) falls back to
  * {@link GENERIC_SUBMIT_ERROR} so internals aren't rendered.
+ *
+ * A 429 answers with {@link RATE_LIMITED_ERROR} ahead of either, because the
+ * rate limiter's body carries no `message` and a caller's fallback describes
+ * what it asked for — "this invite link is invalid" for a request the limiter
+ * never let reach the invite.
  */
 export function describeSubmitError(
   err: unknown,
   fallback = GENERIC_SUBMIT_ERROR
 ): string {
   const status = errorStatus(err);
+  if (status === 429) return RATE_LIMITED_ERROR;
+
   if (status !== undefined && status >= 400 && status < 500) {
     return errorMessage(err) ?? fallback;
   }

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/AccountCreation.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/AccountCreation.svelte
@@ -62,7 +62,7 @@
   );
 
   const canSubmit = $derived(
-    displayName.trim().length > 0 && availability.valid,
+    displayName.trim().length > 0 && availability.submittable,
   );
 
   // ── OIDC login ───────────────────────────────────────────────────

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/TenantIdentity.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/TenantIdentity.svelte
@@ -52,7 +52,7 @@
   }
 
   const canSubmit = $derived(
-    availability.valid && displayName.trim().length > 0 && !submitting
+    availability.submittable && displayName.trim().length > 0 && !submitting
   );
 </script>
 

--- a/src/Web/remote-codegen.config.ts
+++ b/src/Web/remote-codegen.config.ts
@@ -38,6 +38,13 @@ export default {
     // message to the user. Falls through to a 500 with the extracted message
     // so the real error is still visible in dev.
     //
+    // 429 is forwarded too, and with a fixed reason rather than the extracted
+    // message: the rate limiter's body declares no typed schema, so NSwag
+    // supplies its own "status code was not expected" text, and flattened to a
+    // 500 the status a caller needs to tell "you were throttled" from "this
+    // failed" never reaches the browser. `describeSubmitError` and
+    // `remoteErrorMessage` resolve the wording from the status.
+    //
     // NSwag throws ProblemDetails directly (not wrapped in ApiException) for
     // responses that declare a typed error schema, so the title/detail/errors
     // fields live on `err` itself — not on `err.body` or `err.response`.
@@ -47,6 +54,7 @@ export default {
       `    const errors = body?.errors ?? e?.errors;\n` +
       `    const flat = errors ? Object.entries(errors).map(([, v]: [string, any]) => Array.isArray(v) ? v.join(', ') : v).join('; ') : undefined;\n` +
       `    const message = flat ?? body?.message ?? body?.title ?? body?.detail ?? e?.message ?? e?.title ?? e?.detail;\n` +
+      `    if (status === 429) throw error(429, 'Too many requests');\n` +
       `    if (status === 400 || status === 409) throw error(status, message ?? 'Request rejected');\n` +
       `    throw error(500, message ?? 'Failed to ${functionName}')`,
   },

--- a/tests/Unit/Nocturne.API.Tests/RateLimiting/AnonymousSurfaceRateLimitTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/RateLimiting/AnonymousSurfaceRateLimitTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.RateLimiting;
+using Nocturne.API.Controllers.V4;
+using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Nocturne.API.Extensions;
+using Nocturne.API.Tests.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.RateLimiting;
+
+/// <summary>
+/// Guards the bounds on the anonymous surfaces outside the passkey ceremonies: first-run setup, the
+/// availability probes, and the invite lookups a caller reaches with a token alone. Sweeps rather
+/// than lists, so an action added to any of these controllers has to answer the same question.
+/// </summary>
+/// <seealso cref="Nocturne.API.Tests.Controllers.PasskeyRateLimitTests"/>
+public class AnonymousSurfaceRateLimitTests
+{
+    /// <summary>
+    /// The controllers whose anonymous actions are swept, beyond the wholly anonymous
+    /// <see cref="SetupController"/>.
+    /// </summary>
+    private static readonly Type[] PartlyAnonymousControllers =
+    [
+        typeof(MemberInviteController),
+        typeof(AlertInvitesController),
+        typeof(MyTenantsController),
+    ];
+
+    /// <summary>
+    /// The whole controller is <c>[AllowAnonymous]</c> and reaches the database before any
+    /// credential exists on the instance, so every action on it carries a ceiling.
+    /// </summary>
+    [Fact]
+    public void EverySetupAction_CarriesAClientAddressPolicy()
+    {
+        var actions = Actions(typeof(SetupController));
+
+        // A sweep that discovers nothing would pass while guarding nothing.
+        actions.Should().HaveCountGreaterThan(4, "the scan should discover the setup actions");
+
+        Uncovered(actions).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Each of these answers from the database on a caller-supplied string with no session, so the
+    /// anonymous request has to cost a permit.
+    /// </summary>
+    [Fact]
+    public void EveryAnonymousLookup_CarriesAClientAddressPolicy()
+    {
+        var actions = PartlyAnonymousControllers
+            .SelectMany(Actions)
+            .Where(m => m.GetCustomAttribute<AllowAnonymousAttribute>() is not null)
+            .ToList();
+
+        actions.Should().HaveCount(3, "the scan should discover the anonymous lookups");
+
+        Uncovered(actions).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Each ceiling, pinned so widening one is a deliberate edit rather than a side effect of
+    /// renaming a policy.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(SetupController), nameof(SetupController.CreateTenant), "setup")]
+    [InlineData(typeof(SetupController), nameof(SetupController.OwnerOptions), "setup")]
+    [InlineData(typeof(SetupController), nameof(SetupController.OwnerComplete), "setup")]
+    [InlineData(typeof(SetupController), nameof(SetupController.OwnerOidc), "setup")]
+    [InlineData(typeof(SetupController), nameof(SetupController.OidcCallback), "setup")]
+    [InlineData(typeof(SetupController), nameof(SetupController.ValidateUsername), "name-availability")]
+    [InlineData(typeof(MyTenantsController), nameof(MyTenantsController.ValidateSlug), "name-availability")]
+    [InlineData(typeof(MemberInviteController), nameof(MemberInviteController.GetInviteInfo), "invite-lookup")]
+    [InlineData(typeof(AlertInvitesController), nameof(AlertInvitesController.ValidateInvite), "invite-lookup")]
+    public void EachAnonymousAction_CarriesItsOwnPolicy(Type controller, string action, string policy)
+    {
+        PolicyOn(Action(controller, action)).Should().Be(policy);
+    }
+
+    /// <summary>
+    /// The availability probes have to survive a form that asks per keystroke, so their ceiling is
+    /// the loosest of the three — pinned against being tightened to a ceremony's number.
+    /// </summary>
+    [Fact]
+    public void TheAvailabilityProbes_AreLooserThanTheSetupCeremonies()
+    {
+        PermitLimit("name-availability").Should().BeGreaterThan(PermitLimit("setup"));
+    }
+
+    /// <summary>
+    /// The ceiling over the real pipeline: the limiter runs ahead of the setup gate, so a caller
+    /// probing usernames is turned away before the membership query and before the operator's
+    /// validation webhook is called.
+    /// </summary>
+    /// <remarks>
+    /// On its own host and partitioning on the connection, for the reason given on
+    /// <see cref="Nocturne.API.Tests.Controllers.PasskeyRateLimitTests"/>'s behavioural test.
+    /// </remarks>
+    [Fact]
+    public async Task ValidateUsername_TurnsAwayTheRequestPastTheCeiling()
+    {
+        await AssertCeilingHolds("name-availability", "/api/v4/setup/validate-username?username=taken");
+    }
+
+    [Fact]
+    public async Task ValidateInvite_TurnsAwayTheRequestPastTheCeiling()
+    {
+        await AssertCeilingHolds("invite-lookup", "/api/v4/alert-invites/no-such-token");
+    }
+
+    private static async Task AssertCeilingHolds(string policy, string url)
+    {
+        var permitLimit = PermitLimit(policy);
+
+        await using var factory = new AuthenticationTestFactory();
+        using var client = factory.CreateClient();
+
+        for (var attempt = 1; attempt <= permitLimit; attempt++)
+        {
+            var allowed = await client.GetAsync(url);
+            allowed.StatusCode.Should().NotBe(HttpStatusCode.TooManyRequests,
+                $"attempt {attempt} is within the ceiling of {permitLimit}");
+        }
+
+        var rejected = await client.GetAsync(url);
+
+        rejected.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        (await rejected.Content.ReadAsStringAsync()).Should().Contain("rate_limit_exceeded",
+            "a throttled caller reads the same body here as on every other limited endpoint");
+    }
+
+    private static int PermitLimit(string policy) =>
+        ServiceRegistrationExtensions.ClientAddressPolicies.Single(p => p.Policy == policy).PermitLimit;
+
+    private static List<string> Uncovered(IEnumerable<MethodInfo> actions)
+    {
+        var table = ServiceRegistrationExtensions.ClientAddressPolicies
+            .Select(p => p.Policy)
+            .ToHashSet();
+
+        return actions
+            .Where(a => PolicyOn(a) is not { } policy || !table.Contains(policy))
+            .Select(a => $"{a.DeclaringType!.Name}.{a.Name}")
+            .ToList();
+    }
+
+    private static string? PolicyOn(MethodInfo action) =>
+        action.GetCustomAttribute<EnableRateLimitingAttribute>()?.PolicyName;
+
+    private static List<MethodInfo> Actions(Type controller) =>
+        controller
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetCustomAttributes<HttpMethodAttribute>().Any())
+            .ToList();
+
+    private static MethodInfo Action(Type controller, string name) =>
+        controller.GetMethod(name)
+        ?? throw new InvalidOperationException($"No action named {name} on {controller.Name}.");
+}


### PR DESCRIPTION
Closes #872.

## What changed

Three new `ClientAddressPolicies` rows, applied via the #870 pattern — plus two same-shaped endpoints the issue's enumeration missed, pulled in scope: **`GET setup/oidc/callback`** (anonymous, performs a provider token exchange) and **`GET me/tenants/validate-slug`** (the sibling per-keystroke probe, and the only one still reachable after the instance is established).

| Policy | Endpoints | Sizing rationale |
|---|---|---|
| `setup` 20/1m | the four Setup POST actions + the OIDC callback | mirrors `passkey-register`; a ceremony spends two permits; reachable only while nobody holds a credential, so it serves one operator retrying |
| `name-availability` 60/1m | setup `validate-username`, `me/tenants/validate-slug` | the forms probe per distinct value behind a 400ms debounce (verified in `availability.svelte.ts` — cached remote query, no per-keypress spam), so 60 clears a 30-char name typed key-by-key twice |
| `invite-lookup` 30/1m | `GetInviteInfo`, `ValidateInvite` | the issue's number; the bound is anonymous DB-query cost, not token grinding; both pages read once per visit (the alert route has no frontend caller at all) |

**The coverage blind spot is closed for these controllers.** `ClientAddressPolicyCoverageTests` can't see an `[AllowAnonymous]` action carrying no attribute (the #759 class — demonstrated by mutation: stripping an endpoint's limit left both existing coverage tests green). A new parity sweep asserts every action on `SetupController` and every anonymous action on the three other controllers carries a table policy, with non-vacuity floors.

**Frontend fix (corrected after the hostile round proved the first cut inert):** the generated remote-function wrapper flattened everything but 400/409 to 500, so the original `describeSubmitError` branch was unreachable. `on500` (remote-codegen.config.ts � the durable site; the generated client is gitignored and regenerated every build) now forwards 429 with a fixed reason, so the status crosses the boundary. **This changes error handling for every generated remote function, repo-wide** � any limited endpoint now reports throttling honestly. Proven end-to-end by compiling the actual `on500` source over a genuine NSwag `ApiException`, with a 503 control confirming everything else still flattens. And the availability probes no longer dead-end the setup wizard: an errored probe reports `submittable` (the server re-validates on submit) while still withholding the green tick � chosen over auto-refresh, because retrying into a rate limiter is the wrong reflex.

Original frontend note, superseded: `describeSubmitError` resolved 429 through its 4xx branch, rendering the caller's fallback — a throttled visitor on the join page would have read "This invite link is invalid or has expired". 429 now short-circuits to the existing `RATE_LIMITED_ERROR` at the one site, consistent with the recovery/activation classifiers.

## Tests
14 new C# (two sweeps, per-action pins, a relative-ceiling pin, and two behavioural 429s through the real pipeline asserting the shared `rate_limit_exceeded` body) + 1 vitest case. Mutation-proved: stripping each controller's attribute fails its sweep/pin/429 tests while the pre-existing coverage tests stay green (the blind spot, on record); `429 → 4290` fails the vitest.

API.Tests full unit run: 5886 passed / 0 failed. Known caveat, unchanged by this PR: the client-address key falls back to `RemoteIpAddress` filled from unauthenticated XFF — parity with every #870 policy; #846 is where that closes.

