### PR TITLE
fix(data): route the remaining V4 soft deletes through the audited path, and system-attribute the background scopes

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/DemoServiceHealthMonitor.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/DemoServiceHealthMonitor.cs
@@ -1,3 +1,4 @@
+using Nocturne.API.Services.Audit;
 using Nocturne.Core.Contracts.Connectors;
 
 namespace Nocturne.API.Services.BackgroundServices;
@@ -42,6 +43,8 @@ public class DemoServiceConfiguration
 /// </remarks>
 public class DemoServiceHealthMonitor : BackgroundService
 {
+    internal const string AuditEndpoint = "service:demo-health-monitor";
+
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<DemoServiceHealthMonitor> _logger;
     private readonly DemoServiceConfiguration _config;
@@ -185,6 +188,12 @@ public class DemoServiceHealthMonitor : BackgroundService
         try
         {
             using var scope = _serviceProvider.CreateScope();
+
+            // Attribute the cleanup to the monitor rather than to whoever last ran a request, so the
+            // demo data it soft-deletes stays re-seedable after the service recovers.
+            using var systemScope = SystemAuditScope.PushForScope(
+                scope.ServiceProvider, AuditEndpoint);
+
             var dataSourceService = scope.ServiceProvider.GetRequiredService<IDataSourceService>();
 
             _logger.LogInformation("Cleaning up demo data...");

--- a/src/API/Nocturne.API/Services/Monitoring/TrackerAlertRuleBackfillService.cs
+++ b/src/API/Nocturne.API/Services/Monitoring/TrackerAlertRuleBackfillService.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Services.Audit;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 
@@ -21,6 +22,8 @@ namespace Nocturne.API.Services.Monitoring;
 /// <seealso cref="TrackerAlertRuleSyncService"/>
 public sealed class TrackerAlertRuleBackfillService : BackgroundService
 {
+    internal const string AuditEndpoint = "service:tracker-alert-rule-backfill";
+
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<TrackerAlertRuleBackfillService> _logger;
 
@@ -80,6 +83,12 @@ public sealed class TrackerAlertRuleBackfillService : BackgroundService
                 var tenantAccessor = tenantScope.ServiceProvider.GetRequiredService<ITenantAccessor>();
                 tenantAccessor.SetTenant(new TenantContext(
                     tenantId, slug ?? string.Empty, displayName ?? string.Empty, true, IsDemo: false));
+
+                // Attribute the backfill's rule writes to the service rather than to whoever last
+                // held the scope's audit context.
+                using var systemScope = SystemAuditScope.PushForScope(
+                    tenantScope.ServiceProvider, AuditEndpoint);
+
                 var sync = tenantScope.ServiceProvider.GetRequiredService<ITrackerAlertRuleSyncService>();
 
                 foreach (var definitionId in definitionIds)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbRatioScheduleRepository.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
@@ -90,9 +91,9 @@ public class CarbRatioScheduleRepository : V4RepositoryBase<CarbRatioSchedule, C
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx
-            .CarbRatioSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+        return await ctx.AuditedSoftDeleteAsync(
+            ctx.CarbRatioSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix)),
+            AuditContext, $"legacy_id_prefix={prefix}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceStatusExtrasRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Extensions;
@@ -14,14 +15,17 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 public class DeviceStatusExtrasRepository : IDeviceStatusExtrasRepository
 {
     private readonly ITenantDbContextFactory _contextFactory;
+    private readonly IAuditContext _auditContext;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DeviceStatusExtrasRepository"/> class.
     /// </summary>
     /// <param name="contextFactory">The tenant database context factory.</param>
-    public DeviceStatusExtrasRepository(ITenantDbContextFactory contextFactory)
+    /// <param name="auditContext">The audit context for tracking mutations.</param>
+    public DeviceStatusExtrasRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext)
     {
         _contextFactory = contextFactory;
+        _auditContext = auditContext;
     }
 
     /// <summary>
@@ -68,9 +72,9 @@ public class DeviceStatusExtrasRepository : IDeviceStatusExtrasRepository
     public async Task<int> DeleteByCorrelationIdAsync(Guid correlationId, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.DeviceStatusExtras
-            .Where(e => e.CorrelationId == correlationId)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+        return await ctx.AuditedSoftDeleteAsync(
+            ctx.DeviceStatusExtras.Where(e => e.CorrelationId == correlationId),
+            _auditContext, $"correlation_id={correlationId}", ct);
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -149,8 +149,9 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.Notes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier)
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+        return await ctx.AuditedSoftDeleteAsync(
+            ctx.Notes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
+            AuditContext, $"sync_identifier={dataSource}/{syncIdentifier}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensitivityScheduleRepository.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
@@ -90,9 +91,9 @@ public class SensitivityScheduleRepository : V4RepositoryBase<SensitivitySchedul
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx
-            .SensitivitySchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+        return await ctx.AuditedSoftDeleteAsync(
+            ctx.SensitivitySchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix)),
+            AuditContext, $"legacy_id_prefix={prefix}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TargetRangeScheduleRepository.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
@@ -90,9 +91,9 @@ public class TargetRangeScheduleRepository : V4RepositoryBase<TargetRangeSchedul
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx
-            .TargetRangeSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+        return await ctx.AuditedSoftDeleteAsync(
+            ctx.TargetRangeSchedules.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix)),
+            AuditContext, $"legacy_id_prefix={prefix}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TherapySettingsRepository.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
@@ -90,9 +91,9 @@ public class TherapySettingsRepository : V4RepositoryBase<TherapySettings, Thera
     public async Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx
-            .TherapySettings.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix))
-            .ExecuteUpdateAsync(s => s.SetProperty(e => e.DeletedAt, DateTime.UtcNow), ct);
+        return await ctx.AuditedSoftDeleteAsync(
+            ctx.TherapySettings.Where(e => e.LegacyId != null && e.LegacyId.StartsWith(prefix)),
+            AuditContext, $"legacy_id_prefix={prefix}", ct);
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/DemoServiceHealthMonitorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/DemoServiceHealthMonitorTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Services.Audit;
+using Nocturne.API.Services.BackgroundServices;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Models.Services;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Tests.Services.BackgroundServices;
+
+[Trait("Category", "Unit")]
+public class DemoServiceHealthMonitorTests
+{
+    /// <summary>
+    /// The cleanup soft-deletes demo glucose through the audited repositories, so its DI scope has to
+    /// carry system attribution on both context paths: a user-attributed delete stamps
+    /// <c>deleted_by_user</c> and permanently blocks the demo rows from being re-seeded once the
+    /// service recovers.
+    /// </summary>
+    [Fact]
+    public async Task CleanupDemoData_RunsUnderSystemAttribution_OnBothContextPaths()
+    {
+        var cleanupCalled = new TaskCompletionSource();
+        bool? ambientIsSystem = null;
+        bool? contextIsSystem = null;
+        string? contextEndpoint = null;
+
+        var services = new ServiceCollection();
+        services.AddScoped<IAuditContext, AuditContext>();
+        services.AddScoped(_ => new NocturneDbContext(
+            new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseSqlite("Filename=:memory:")
+                .Options));
+        services.AddScoped<IDataSourceService>(sp =>
+        {
+            var ambient = sp.GetRequiredService<IAuditContext>();
+            var dbContext = sp.GetRequiredService<NocturneDbContext>();
+            var stub = new Mock<IDataSourceService>();
+            stub.Setup(x => x.DeleteDemoDataAsync(It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    ambientIsSystem = ambient.IsSystem;
+                    contextIsSystem = dbContext.AuditContext?.IsSystem;
+                    contextEndpoint = dbContext.AuditContext?.Endpoint;
+                    cleanupCalled.TrySetResult();
+                    return Task.FromResult(new DataSourceDeleteResult { Success = true });
+                });
+            return stub.Object;
+        });
+
+        var monitor = new DemoServiceHealthMonitor(
+            services.BuildServiceProvider(),
+            new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DemoService:Enabled"] = "true",
+                ["DemoService:Url"] = "http://demo.invalid",
+                ["DemoService:FailureThreshold"] = "1",
+                ["DemoService:HealthCheckIntervalSeconds"] = "60",
+            }).Build(),
+            new StubHttpClientFactory(HttpStatusCode.ServiceUnavailable),
+            NullLogger<DemoServiceHealthMonitor>.Instance);
+
+        await monitor.StartAsync(CancellationToken.None);
+        // The body is thread-pool scheduled, so wait for the cleanup before stopping the host.
+        await cleanupCalled.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await monitor.StopAsync(CancellationToken.None);
+
+        ambientIsSystem.Should().BeTrue(
+            "repositories stamp factory-created contexts from the ambient audit context");
+        contextIsSystem.Should().BeTrue(
+            "the interceptor prefers the scoped context's own audit context");
+        contextEndpoint.Should().Be(DemoServiceHealthMonitor.AuditEndpoint);
+    }
+
+    private sealed class StubHttpClientFactory(HttpStatusCode status) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(new StubHandler(status));
+
+        private sealed class StubHandler(HttpStatusCode status) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(new HttpResponseMessage(status));
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Monitoring/TrackerAlertRuleBackfillServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Monitoring/TrackerAlertRuleBackfillServiceTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Multitenancy;
+using Nocturne.API.Services.Audit;
+using Nocturne.API.Services.Monitoring;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.API.Tests.Services.Monitoring;
+
+[Trait("Category", "Unit")]
+public class TrackerAlertRuleBackfillServiceTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"TrackerBackfill_{Guid.NewGuid():N}.db");
+    private readonly Guid _tenantId = Guid.NewGuid();
+
+    public void Dispose()
+    {
+        // SQLite pools the file handle past the last context's disposal.
+        try { File.Delete(_dbPath); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// The backfill's rule writes go through the interceptor, which derives attribution from the
+    /// scope's audit context — a bare scope resolves a blank user context and records every
+    /// synthesised, updated and orphaned managed rule as an actorless user mutation.
+    /// </summary>
+    [Fact]
+    public async Task Backfill_SyncsUnderSystemAttribution()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+
+        using (var seed = new NocturneDbContext(options) { TenantId = _tenantId })
+        {
+            seed.Database.EnsureCreated();
+            seed.Tenants.Add(new TenantEntity
+            {
+                Id = _tenantId, Slug = "test", DisplayName = "Test", IsActive = true
+            });
+            var definitionId = Guid.CreateVersion7();
+            seed.TrackerDefinitions.Add(new TrackerDefinitionEntity
+            {
+                Id = definitionId, TenantId = _tenantId, UserId = "dev", Name = "Cannula"
+            });
+            seed.TrackerNotificationThresholds.Add(new TrackerNotificationThresholdEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = _tenantId,
+                TrackerDefinitionId = definitionId,
+                Hours = 24,
+                AlertRuleId = null,
+            });
+            seed.SaveChanges();
+        }
+
+        var synced = new TaskCompletionSource();
+        bool? ambientIsSystem = null;
+        string? contextEndpoint = null;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IDbContextFactory<NocturneDbContext>>(
+            new StubDbContextFactory(options));
+        services.AddScoped(sp =>
+            sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext());
+        services.AddScoped<IAuditContext, AuditContext>();
+        services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
+        services.AddScoped<ITrackerAlertRuleSyncService>(sp =>
+        {
+            var ambient = sp.GetRequiredService<IAuditContext>();
+            var dbContext = sp.GetRequiredService<NocturneDbContext>();
+            var stub = new Mock<ITrackerAlertRuleSyncService>();
+            stub.Setup(x => x.SyncDefinitionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    ambientIsSystem = ambient.IsSystem;
+                    contextEndpoint = dbContext.AuditContext?.Endpoint;
+                    synced.TrySetResult();
+                    return Task.CompletedTask;
+                });
+            return stub.Object;
+        });
+
+        var sut = new TrackerAlertRuleBackfillService(
+            services.BuildServiceProvider(),
+            NullLogger<TrackerAlertRuleBackfillService>.Instance);
+
+        await sut.StartAsync(CancellationToken.None);
+        // The body is thread-pool scheduled, so wait for the sync before stopping the host.
+        await synced.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await sut.StopAsync(CancellationToken.None);
+
+        ambientIsSystem.Should().BeTrue(
+            "the sync service stamps its factory-created contexts from the ambient audit context");
+        contextEndpoint.Should().Be(TrackerAlertRuleBackfillService.AuditEndpoint);
+    }
+
+    private sealed class StubDbContextFactory(DbContextOptions<NocturneDbContext> options)
+        : IDbContextFactory<NocturneDbContext>
+    {
+        public NocturneDbContext CreateDbContext() => new(options);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
@@ -35,7 +35,7 @@ public class DeviceStatusDecomposerTests : IDisposable
         var apsRepo = new ApsSnapshotRepository(ctxFactory, new SystemAuditContext(), NullLogger<ApsSnapshotRepository>.Instance);
         var pumpRepo = new PumpSnapshotRepository(ctxFactory, new SystemAuditContext(), NullLogger<PumpSnapshotRepository>.Instance);
         var uploaderRepo = new UploaderSnapshotRepository(ctxFactory, new SystemAuditContext(), NullLogger<UploaderSnapshotRepository>.Instance);
-        _extrasRepo = new DeviceStatusExtrasRepository(ctxFactory);
+        _extrasRepo = new DeviceStatusExtrasRepository(ctxFactory, new SystemAuditContext());
         _stateSpanServiceMock = new Mock<IStateSpanService>();
         _deviceServiceMock = new Mock<IDeviceService>();
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/AuditedSoftDeleteTestBase.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/AuditedSoftDeleteTestBase.cs
@@ -1,0 +1,109 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Tests.Shared.Infrastructure;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Harness for the repository delete suites that assert on the audited soft-delete path: an
+/// in-memory SQLite database (<c>ExecuteUpdateAsync</c> and the audit transaction need a relational
+/// provider), a seeded tenant, and readers for the row's delete state and <c>mutation_audit_log</c>.
+/// The repository under test is rebuilt whenever the audit context changes, because the context is
+/// a constructor dependency.
+/// </summary>
+public abstract class AuditedSoftDeleteTestBase<TEntity> : IDisposable
+    where TEntity : class, ISoftDeletable
+{
+    protected static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _options;
+    private readonly NocturneDbContext _context;
+
+    protected AuditedSoftDeleteTestBase()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seedContext = new NocturneDbContext(_options) { TenantId = TestTenantId })
+        {
+            seedContext.Database.EnsureCreated();
+            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seedContext.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(_options) { TenantId = TestTenantId };
+        UseAuditContext(new UserAuditContext());
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Builds the repository under test against <paramref name="auditContext"/>.</summary>
+    protected abstract void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext);
+
+    /// <summary>The name <c>mutation_audit_log</c> records for this entity type.</summary>
+    protected abstract string AuditEntityType { get; }
+
+    protected static ILogger<T> Logger<T>() => NullLogger<T>.Instance;
+
+    protected void UseAuditContext(IAuditContext auditContext) =>
+        CreateRepository(new TestTenantDbContextFactory(_context), auditContext);
+
+    /// <summary>Persists <paramref name="row"/> and returns its id.</summary>
+    protected Guid Add(TEntity row)
+    {
+        _context.Set<TEntity>().Add(row);
+        _context.SaveChanges();
+        return (Guid)_context.Entry(row).Property("Id").CurrentValue!;
+    }
+
+    private NocturneDbContext Verify() => new(_options) { TenantId = TestTenantId };
+
+    protected async Task<(DateTime? DeletedAt, bool DeletedByUser)> ReadDeleteStateAsync(Guid id)
+    {
+        await using var verify = Verify();
+        var row = await verify.Set<TEntity>()
+            .IgnoreQueryFilters()
+            .SingleAsync(e => EF.Property<Guid>(e, "Id") == id);
+        return (row.DeletedAt, (bool)verify.Entry(row).Property("DeletedByUser").CurrentValue!);
+    }
+
+    protected async Task<List<MutationAuditLogEntity>> ReadAuditLogAsync()
+    {
+        await using var verify = Verify();
+        return await verify.Set<MutationAuditLogEntity>().ToListAsync();
+    }
+
+    protected static (int Count, string Scope) ReadSummary(string? changesJson)
+    {
+        using var doc = JsonDocument.Parse(changesJson!);
+        return (doc.RootElement.GetProperty("count").GetInt32(),
+            doc.RootElement.GetProperty("scope").GetString()!);
+    }
+
+    protected sealed class UserAuditContext : IAuditContext
+    {
+        public Guid? SubjectId => Guid.Empty;
+        public string? SubjectName => "tester";
+        public string? AuthType => "SessionCookie";
+        public string? IpAddress => "127.0.0.1";
+        public Guid? TokenId => null;
+        public string? TraceId => null;
+        public string? Endpoint => "DELETE /api/v4/data-sources/dexcom";
+        public bool IsSystem => false;
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceStatusExtrasRepositoryBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceStatusExtrasRepositoryBulkCreateTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -21,7 +22,8 @@ public class DeviceStatusExtrasRepositoryBulkCreateTests : IDisposable
         var dbName = $"device_status_extras_bulk_tests_{Guid.NewGuid()}";
         _context = TestDbContextFactory.CreateInMemoryContext(dbName);
         _context.TenantId = TenantA;
-        _repository = new DeviceStatusExtrasRepository(new TestTenantDbContextFactory(_context));
+        _repository = new DeviceStatusExtrasRepository(
+            new TestTenantDbContextFactory(_context), new SystemAuditContext());
     }
 
     public void Dispose()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/GlucoseSourceDeleteAuditTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/GlucoseSourceDeleteAuditTests.cs
@@ -1,12 +1,9 @@
-using System.Data.Common;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Infrastructure.Data.Services;
-using Nocturne.Tests.Shared.Infrastructure;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -16,49 +13,10 @@ namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 /// and the delete runs through the audited path so a user delete stamps <c>deleted_by_user</c> —
 /// the discriminator that stops the next connector sync re-importing the rows
 /// (<see cref="Nocturne.Infrastructure.Data.Extensions.SoftDeleteDedupExtensions"/>).
-/// In-memory SQLite because <c>ExecuteUpdateAsync</c> and the audit transaction need a relational
-/// provider.
 /// </summary>
-public abstract class GlucoseSourceDeleteAuditTests<TEntity> : IDisposable
+public abstract class GlucoseSourceDeleteAuditTests<TEntity> : AuditedSoftDeleteTestBase<TEntity>
     where TEntity : class, ISoftDeletable, ISourcedEntity
 {
-    protected static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
-
-    private readonly DbConnection _connection;
-    private readonly DbContextOptions<NocturneDbContext> _options;
-    private readonly NocturneDbContext _context;
-
-    protected GlucoseSourceDeleteAuditTests()
-    {
-        _connection = new SqliteConnection("Filename=:memory:");
-        _connection.Open();
-
-        _options = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseSqlite(_connection)
-            .EnableSensitiveDataLogging()
-            .Options;
-
-        using (var seedContext = new NocturneDbContext(_options) { TenantId = TestTenantId })
-        {
-            seedContext.Database.EnsureCreated();
-            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
-            seedContext.SaveChanges();
-        }
-
-        _context = new NocturneDbContext(_options) { TenantId = TestTenantId };
-        UseAuditContext(new UserAuditContext());
-    }
-
-    public void Dispose()
-    {
-        _context.Dispose();
-        _connection.Dispose();
-        GC.SuppressFinalize(this);
-    }
-
-    /// <summary>Builds the repository under test against <paramref name="auditContext"/>.</summary>
-    protected abstract void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext);
-
     /// <summary>A row of the repository's type, unsaved.</summary>
     protected abstract TEntity NewRow(Guid id, DateTime timestamp, string? dataSource, string? device);
 
@@ -66,57 +24,8 @@ public abstract class GlucoseSourceDeleteAuditTests<TEntity> : IDisposable
 
     protected abstract Task<int> DeleteByTimeRangeAsync(DateTime? from, DateTime? to);
 
-    /// <summary>The name <c>mutation_audit_log</c> records for this entity type.</summary>
-    protected abstract string AuditEntityType { get; }
-
-    protected static ILogger<T> Logger<T>() => NullLogger<T>.Instance;
-
-    protected void UseAuditContext(IAuditContext auditContext) =>
-        CreateRepository(new TestTenantDbContextFactory(_context), auditContext);
-
-    private Guid Seed(DateTime timestamp, string? dataSource = null, string? device = null)
-    {
-        var id = Guid.CreateVersion7();
-        _context.Set<TEntity>().Add(NewRow(id, timestamp, dataSource, device));
-        _context.SaveChanges();
-        return id;
-    }
-
-    private NocturneDbContext Verify() => new(_options) { TenantId = TestTenantId };
-
-    private async Task<(DateTime? DeletedAt, bool DeletedByUser)> ReadDeleteStateAsync(Guid id)
-    {
-        await using var verify = Verify();
-        var row = await verify.Set<TEntity>()
-            .IgnoreQueryFilters()
-            .SingleAsync(e => EF.Property<Guid>(e, "Id") == id);
-        return (row.DeletedAt, (bool)verify.Entry(row).Property("DeletedByUser").CurrentValue!);
-    }
-
-    private async Task<List<MutationAuditLogEntity>> ReadAuditLogAsync()
-    {
-        await using var verify = Verify();
-        return await verify.Set<MutationAuditLogEntity>().ToListAsync();
-    }
-
-    private static (int Count, string Scope) ReadSummary(string? changesJson)
-    {
-        using var doc = JsonDocument.Parse(changesJson!);
-        return (doc.RootElement.GetProperty("count").GetInt32(),
-            doc.RootElement.GetProperty("scope").GetString()!);
-    }
-
-    private sealed class UserAuditContext : IAuditContext
-    {
-        public Guid? SubjectId => Guid.Empty;
-        public string? SubjectName => "tester";
-        public string? AuthType => "SessionCookie";
-        public string? IpAddress => "127.0.0.1";
-        public Guid? TokenId => null;
-        public string? TraceId => null;
-        public string? Endpoint => "DELETE /api/v4/data-sources/dexcom";
-        public bool IsSystem => false;
-    }
+    private Guid Seed(DateTime timestamp, string? dataSource = null, string? device = null) =>
+        Add(NewRow(Guid.CreateVersion7(), timestamp, dataSource, device));
 
     [Fact]
     public async Task DeleteBySourceAsync_DeletesRowsUnderEitherOriginHandle_AndSparesOtherSources()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
@@ -1,0 +1,305 @@
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Infrastructure.Data.Services;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// The delete contract owed by the repositories whose delete is keyed on something other than the
+/// data source — a legacy-id prefix, a (data source, sync identifier) pair, a correlation id. Each
+/// must reach exactly the rows its key names, and must run through the audited path so a user delete
+/// stamps <c>deleted_by_user</c> and records one <c>bulk_delete</c> summary row while a system sweep
+/// leaves the rows re-importable
+/// (<see cref="Nocturne.Infrastructure.Data.Extensions.SoftDeleteDedupExtensions"/>).
+/// </summary>
+public abstract class KeyedSoftDeleteAuditTests<TEntity> : AuditedSoftDeleteTestBase<TEntity>
+    where TEntity : class, ISoftDeletable
+{
+    /// <summary>Seeds one row the delete's key names, and returns its id.</summary>
+    protected abstract Guid SeedMatch();
+
+    /// <summary>
+    /// Seeds the rows that sit just outside the key — the boundary the predicate must not cross.
+    /// Returns their ids.
+    /// </summary>
+    protected abstract IReadOnlyList<Guid> SeedNearMisses();
+
+    /// <summary>Issues the delete for the key <see cref="SeedMatch"/> seeds against.</summary>
+    protected abstract Task<int> DeleteAsync();
+
+    /// <summary>The scope string the summary row must carry for that key.</summary>
+    protected abstract string ExpectedScope { get; }
+
+    [Fact]
+    public async Task Delete_ReachesTheKeyedRow_AndSparesTheNearMisses()
+    {
+        var match = SeedMatch();
+        var nearMisses = SeedNearMisses();
+
+        var deleted = await DeleteAsync();
+
+        deleted.Should().Be(1);
+        (await ReadDeleteStateAsync(match)).DeletedAt.Should().NotBeNull();
+        foreach (var id in nearMisses)
+            (await ReadDeleteStateAsync(id)).DeletedAt.Should().BeNull(
+                "a row outside the delete's key must survive");
+    }
+
+    [Fact]
+    public async Task Delete_UserContext_StampsDeletedByUserAndWritesSummaryRow()
+    {
+        var match = SeedMatch();
+
+        var deleted = await DeleteAsync();
+
+        deleted.Should().Be(1);
+        (await ReadDeleteStateAsync(match)).DeletedByUser.Should().BeTrue();
+
+        var log = (await ReadAuditLogAsync()).Should().ContainSingle().Subject;
+        log.Action.Should().Be("bulk_delete");
+        log.EntityType.Should().Be(AuditEntityType);
+        log.EntityId.Should().BeNull();
+        log.SubjectName.Should().Be("tester");
+        ReadSummary(log.ChangesJson).Should().Be((1, ExpectedScope));
+    }
+
+    [Fact]
+    public async Task Delete_SystemContext_LeavesRowsReimportable()
+    {
+        var match = SeedMatch();
+        UseAuditContext(SystemAuditContext.ForService("connector:dexcom"));
+
+        var deleted = await DeleteAsync();
+
+        deleted.Should().Be(1);
+        var state = await ReadDeleteStateAsync(match);
+        state.DeletedAt.Should().NotBeNull();
+        state.DeletedByUser.Should().BeFalse();
+        (await ReadAuditLogAsync()).Should().BeEmpty();
+    }
+}
+
+/// <summary>
+/// Shared shape for the four profile schedule repositories, whose <c>DeleteByLegacyIdPrefixAsync</c>
+/// is one copy-paste each. The near misses pin <c>StartsWith</c>: a legacy id that merely contains
+/// the prefix, one that shares a leading substring with it, and a row with no legacy id at all.
+/// </summary>
+public abstract class LegacyIdPrefixDeleteAuditTests<TEntity> : KeyedSoftDeleteAuditTests<TEntity>
+    where TEntity : class, ISoftDeletable
+{
+    protected const string Prefix = "profile:morning:";
+
+    protected override string ExpectedScope => $"legacy_id_prefix={Prefix}";
+
+    /// <summary>A row of the repository's type carrying <paramref name="legacyId"/>, unsaved.</summary>
+    protected abstract TEntity NewRow(string? legacyId);
+
+    protected override Guid SeedMatch() => Add(NewRow($"{Prefix}0"));
+
+    protected override IReadOnlyList<Guid> SeedNearMisses() =>
+    [
+        Add(NewRow($"copy-of-{Prefix}0")),
+        Add(NewRow("profile:morningstar:0")),
+        Add(NewRow("profile:evening:0")),
+        Add(NewRow(null)),
+    ];
+}
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class CarbRatioScheduleRepositoryPrefixDeleteTests
+    : LegacyIdPrefixDeleteAuditTests<CarbRatioScheduleEntity>
+{
+    private CarbRatioScheduleRepository _repository = null!;
+
+    protected override string AuditEntityType => "CarbRatioSchedule";
+
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new CarbRatioScheduleRepository(
+            contextFactory, auditContext, Logger<CarbRatioScheduleRepository>());
+
+    protected override CarbRatioScheduleEntity NewRow(string? legacyId) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc),
+            ProfileName = "morning",
+            LegacyId = legacyId,
+        };
+
+    protected override Task<int> DeleteAsync() =>
+        _repository.DeleteByLegacyIdPrefixAsync(Prefix, WriteOrigin.Live);
+}
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class SensitivityScheduleRepositoryPrefixDeleteTests
+    : LegacyIdPrefixDeleteAuditTests<SensitivityScheduleEntity>
+{
+    private SensitivityScheduleRepository _repository = null!;
+
+    protected override string AuditEntityType => "SensitivitySchedule";
+
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new SensitivityScheduleRepository(
+            contextFactory, auditContext, Logger<SensitivityScheduleRepository>());
+
+    protected override SensitivityScheduleEntity NewRow(string? legacyId) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc),
+            ProfileName = "morning",
+            LegacyId = legacyId,
+        };
+
+    protected override Task<int> DeleteAsync() =>
+        _repository.DeleteByLegacyIdPrefixAsync(Prefix, WriteOrigin.Live);
+}
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class TargetRangeScheduleRepositoryPrefixDeleteTests
+    : LegacyIdPrefixDeleteAuditTests<TargetRangeScheduleEntity>
+{
+    private TargetRangeScheduleRepository _repository = null!;
+
+    protected override string AuditEntityType => "TargetRangeSchedule";
+
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new TargetRangeScheduleRepository(
+            contextFactory, auditContext, Logger<TargetRangeScheduleRepository>());
+
+    protected override TargetRangeScheduleEntity NewRow(string? legacyId) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc),
+            ProfileName = "morning",
+            LegacyId = legacyId,
+        };
+
+    protected override Task<int> DeleteAsync() =>
+        _repository.DeleteByLegacyIdPrefixAsync(Prefix, WriteOrigin.Live);
+}
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class TherapySettingsRepositoryPrefixDeleteTests
+    : LegacyIdPrefixDeleteAuditTests<TherapySettingsEntity>
+{
+    private TherapySettingsRepository _repository = null!;
+
+    protected override string AuditEntityType => "TherapySettings";
+
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new TherapySettingsRepository(
+            contextFactory, auditContext, Logger<TherapySettingsRepository>());
+
+    protected override TherapySettingsEntity NewRow(string? legacyId) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc),
+            ProfileName = "morning",
+            Dia = 5.0,
+            LegacyId = legacyId,
+        };
+
+    protected override Task<int> DeleteAsync() =>
+        _repository.DeleteByLegacyIdPrefixAsync(Prefix, WriteOrigin.Live);
+}
+
+/// <summary>
+/// The connector-facing note delete. Both halves of the key are load-bearing, so the near misses
+/// vary one at a time: same sync identifier under another source, and another sync identifier under
+/// the same source.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class NoteRepositorySyncIdentifierDeleteTests : KeyedSoftDeleteAuditTests<NoteEntity>
+{
+    private const string DataSource = "dexcom";
+    private const string SyncIdentifier = "note-42";
+
+    private NoteRepository _repository = null!;
+
+    protected override string AuditEntityType => "Note";
+
+    protected override string ExpectedScope => $"sync_identifier={DataSource}/{SyncIdentifier}";
+
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new NoteRepository(
+            contextFactory,
+            new Mock<IDeduplicationService>().Object,
+            auditContext,
+            Logger<NoteRepository>());
+
+    private NoteEntity NewRow(string? dataSource, string? syncIdentifier) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc),
+            Text = "note",
+            DataSource = dataSource,
+            SyncIdentifier = syncIdentifier,
+        };
+
+    protected override Guid SeedMatch() => Add(NewRow(DataSource, SyncIdentifier));
+
+    protected override IReadOnlyList<Guid> SeedNearMisses() =>
+    [
+        Add(NewRow("libre", SyncIdentifier)),
+        Add(NewRow(DataSource, "note-43")),
+        Add(NewRow(DataSource, null)),
+        Add(NewRow(null, SyncIdentifier)),
+    ];
+
+    protected override Task<int> DeleteAsync() =>
+        _repository.DeleteBySyncIdentifierAsync(DataSource, SyncIdentifier, WriteOrigin.Live);
+}
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class DeviceStatusExtrasRepositoryCorrelationDeleteTests
+    : KeyedSoftDeleteAuditTests<DeviceStatusExtrasEntity>
+{
+    private static readonly Guid CorrelationId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private DeviceStatusExtrasRepository _repository = null!;
+
+    protected override string AuditEntityType => "DeviceStatusExtras";
+
+    protected override string ExpectedScope => $"correlation_id={CorrelationId}";
+
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new DeviceStatusExtrasRepository(contextFactory, auditContext);
+
+    private DeviceStatusExtrasEntity NewRow(Guid correlationId) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc),
+            CorrelationId = correlationId,
+            ExtrasJson = "{}",
+        };
+
+    protected override Guid SeedMatch() => Add(NewRow(CorrelationId));
+
+    protected override IReadOnlyList<Guid> SeedNearMisses() =>
+    [
+        Add(NewRow(Guid.Parse("22222222-2222-2222-2222-222222222222"))),
+        Add(NewRow(Guid.Empty)),
+    ];
+
+    protected override Task<int> DeleteAsync() => _repository.DeleteByCorrelationIdAsync(CorrelationId);
+}


### PR DESCRIPTION
Closes #901 — completes the sweep #908 started; after this, the only raw `ExecuteUpdateAsync`-style `DeletedAt` write in the tree is inside the audited helper itself (tracked-entity single-row soft deletes flow through the audit interceptor and were never the defect class).

## The six sites

`DeleteByLegacyIdPrefixAsync` in the four schedule repositories, `NoteRepository.DeleteBySyncIdentifierAsync` (the connector-facing priority), and `DeviceStatusExtrasRepository.DeleteByCorrelationIdAsync` all route through `AuditedSoftDeleteAsync`, with scope strings taken from in-family precedents (`legacy_id_prefix=` from BasalSchedule, `sync_identifier={source}/{id}` from Bolus/DeviceEvent; `correlation_id=` is the first of its kind). `DeviceStatusExtrasRepository` had no audit context and gained one the way its non-base siblings hold it.

**Honest per-type consequence** (verified against each write path, not assumed):
- The four schedules are **audit-only**: their dedup gate is inherited but unreachable — `BulkCreateAsync` has zero callers; the live write path (`ProfileDecomposer` → `CreateAsync`) consults no gate, and the filtered unique index doesn't collide with soft-deleted rows.
- Notes **block on the connector path** (`MetadataPublisher` → `BulkCreateAsync` → the legacy-id gate) The v1/v3 treatment path shares the same gate but cannot normally produce rows this delete matches (nothing server-side stamps `DataSource` there); a client that does send `data_source` + `syncIdentifier` gets the designed user-delete blocking too. The gate keys on legacy id while this delete keys on sync identifier.
- DeviceStatusExtras **genuinely blocks** — `GetBlockingCorrelationIdsAsync` keys on exactly what the delete keys on.

## The background scopes

`DemoServiceHealthMonitor.CleanupDemoDataAsync` ran its cleanup in a bare DI scope, so audited deletes reached from it executed as **user** deletes — live between #908 and #911, whose hard-purge switch closed that specific path (the fix is now prophylactic, one audited call away from mattering again): demo glucose was being stamped `deleted_by_user`, which blocks re-seed after a health flap. It now pushes `SystemAuditScope` (`service:demo-health-monitor`), matching `ConnectorBackgroundService`. A sweep of all 60+ `CreateScope()` sites found one more: `TrackerAlertRuleBackfillService` (actorless audit-row burst on every boot — same class, one severity down), fixed identically; every other site is already covered, read-only, or non-auditable.

## Tests

New keyed-delete contract (3 facts × 6 repositories = 18): the key reaches its row and spares near misses (prefix must not become contains; sync-identifier and correlation exact), user context stamps + writes one `bulk_delete` summary with the exact scope, system context leaves rows re-importable with zero audit rows. #908's SQLite harness was extracted into a shared base rather than copied. The two background services get real `BackgroundService` lifecycle tests asserting both context paths (ambient `IsSystem` + scoped endpoint) — the thread-pool-scheduled body is awaited via a TCS, not raced.

Mutation-proved: reverting all six sites fails exactly the six stamp tests; corrupting each predicate (prefix→contains, dropped DataSource clause, dropped correlation filter) fails the six boundary tests; removing either `PushForScope` fails its service's attribution test.

Infrastructure.Data.Tests 667/667; API.Tests 5874 passed / 0 failed.

