### PR TITLE
fix(connectors): report a terminal phase on auth failure, record explicit zeros, and restore the publish log detail

### DIFF
--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -265,7 +265,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
                 if (!success)
                 {
                     result.Success = false;
-                    result.Errors.Add("SensorGlucose publish failed");
+                    result.Errors.Add($"{SyncDataType.Glucose} publish failed");
                 }
                 else
                 {
@@ -360,7 +360,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
                 if (systemEvent != null
                     && await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabledTypes,
                         [systemEvent], PublishSystemEventDataAsync, config, cancellationToken,
-                        context: "the last alarm"))
+                        context: "from the last alarm"))
                     _lastAlarmKey = alarmKey;
             }
         }
@@ -407,7 +407,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
             await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabledTypes,
                 CareLinkSystemEventMapper.MapNotifications(data.NotificationHistory, pumpOffsetMs),
                 PublishSystemEventDataAsync, config, cancellationToken,
-                context: "notification history");
+                context: "from notification history");
         }
         catch (OperationCanceledException) { throw; }
         catch (HttpRequestException ex)

--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -98,20 +98,12 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
 
         // Authenticate with per-tenant config
         if (!await AuthenticateWithConfigAsync(config))
-        {
-            result.Success = false;
-            result.Errors.Add("Authentication failed");
-            result.EndTime = DateTimeOffset.UtcNow;
-            return result;
-        }
+            return AuthenticationFailedResult();
 
         if (string.IsNullOrEmpty(_accessToken))
         {
             _logger.LogError("[{ConnectorSource}] No access token available — authentication must succeed before sync", ConnectorSource);
-            result.Success = false;
-            result.Errors.Add("Authentication failed");
-            result.EndTime = DateTimeOffset.UtcNow;
-            return result;
+            return AuthenticationFailedResult();
         }
 
         var userInfo = await FetchUserInfoAsync(config, cancellationToken);

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -92,7 +92,40 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         return await RunWithProgressAsync(
             progressReporter,
             cancellationToken,
-            () => PerformSyncInternalAsync(request, config, cancellationToken));
+            async () => await EnsureAuthenticatedAsync(config, cancellationToken)
+                ? await PerformSyncInternalAsync(request, config, cancellationToken)
+                : AuthenticationFailedResult());
+    }
+
+    /// <summary>
+    ///     Hand-shake run before <see cref="PerformSyncInternalAsync"/> on the requested-range entry
+    ///     point. Connectors that must authenticate before they can fetch override this instead of the
+    ///     <see cref="SyncRequest"/> overload, so a rejected credential still passes through
+    ///     <see cref="RunWithProgressAsync"/> and produces the run's one terminal progress message.
+    ///     The background entry point authenticates through <see cref="AuthenticateAsync"/> in
+    ///     <see cref="RunBackgroundSyncAsync"/> and never reaches this overload, so a connector
+    ///     overriding both is not authenticated twice for one run.
+    /// </summary>
+    protected virtual Task<bool> EnsureAuthenticatedAsync(
+        TConfig config,
+        CancellationToken cancellationToken) => Task.FromResult(true);
+
+    /// <summary>
+    ///     The result of a run that never got past authentication. Carries the detail in
+    ///     <see cref="SyncResult.Errors"/> and the summary in <see cref="SyncResult.Message"/>
+    ///     because the terminal progress message reads the former and the tenant's sync card the latter.
+    /// </summary>
+    private SyncResult AuthenticationFailedResult()
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new SyncResult
+        {
+            Success = false,
+            StartTime = now,
+            EndTime = now,
+            Message = "Authentication failed",
+            Errors = { $"Authentication failed for {ConnectorSource}" },
+        };
     }
 
     /// <summary>
@@ -1049,13 +1082,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             if (!await AuthenticateAsync())
             {
                 _logger.LogError("Authentication failed for {ConnectorSource}", ConnectorSource);
-                return new SyncResult
-                {
-                    Success = false,
-                    StartTime = DateTimeOffset.UtcNow,
-                    EndTime = DateTimeOffset.UtcNow,
-                    Errors = { $"Authentication failed for {ConnectorSource}" }
-                };
+                return AuthenticationFailedResult();
             }
 
             // Determine catch-up timestamp

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -688,6 +688,10 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     ///     publishes a batch of records, updates the <see cref="SyncResult"/> counts, and logs the
     ///     outcome.
     /// </summary>
+    /// <param name="context">
+    ///     Detail about this batch — where it came from, or what it held — appended to the success log
+    ///     in parentheses.
+    /// </param>
     /// <returns>
     ///     Whether the batch reached the tenant. An inactive type, an empty batch and a rejected
     ///     publish are alike <c>false</c>: no record was accepted in any of them.
@@ -727,9 +731,8 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         }
         else
         {
-            var ctx = context != null ? $" from {context}" : "";
-            _logger.LogInformation("Synced {Count} {Type} records{Context}",
-                records.Count, dataType, ctx);
+            _logger.LogInformation("[{ConnectorSource}] Synced {Count} {Type} records{Context}",
+                ConnectorSource, records.Count, dataType, context != null ? $" ({context})" : "");
         }
 
         return success;

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -115,7 +115,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     ///     <see cref="SyncResult.Errors"/> and the summary in <see cref="SyncResult.Message"/>
     ///     because the terminal progress message reads the former and the tenant's sync card the latter.
     /// </summary>
-    private SyncResult AuthenticationFailedResult()
+    protected SyncResult AuthenticationFailedResult()
     {
         var now = DateTimeOffset.UtcNow;
         return new SyncResult

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -702,7 +702,16 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         CancellationToken cancellationToken,
         string? context = null) where T : class
     {
-        if (!activeTypes.Contains(dataType) || records.Count == 0) return false;
+        if (!activeTypes.Contains(dataType)) return false;
+
+        if (records.Count == 0)
+        {
+            // An active type the sync did look at reports an explicit zero: the tenant's sync card
+            // renders a badge per key, so a missing key reads as "never checked" rather than
+            // "checked, found nothing". TryAdd so a later empty page cannot erase an earlier count.
+            result.ItemsSynced.TryAdd(dataType, 0);
+            return false;
+        }
 
         await ReportSyncMessageAsync(SyncMessageType.PublishingDataType,
             new() { ["count"] = records.Count.ToString(), ["dataType"] = dataType.ToString() },

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
@@ -94,8 +94,7 @@ public class DexcomConnectorService : BaseConnectorService<DexcomConnectorConfig
             var sensorGlucose = await FetchSensorGlucoseAsync(config, request.From);
 
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
-                sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken,
-                "Dexcom");
+                sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
@@ -154,9 +154,16 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
                 return result;
             }
 
+            // Debug, not Information: the shared publish log runs at Information and a glucose
+            // value is health data, so the reading stays out of the default-level sink.
+            _logger.LogDebug(
+                "[{ConnectorSource}] Publishing reading {Mgdl} mg/dL at {Timestamp:O}",
+                ConnectorSource,
+                sg.Mgdl,
+                sg.Timestamp);
+
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
-                [sg], PublishSensorGlucoseDataAsync, config, cancellationToken,
-                context: $"{sg.Mgdl} mg/dL at {sg.Timestamp:O}");
+                [sg], PublishSensorGlucoseDataAsync, config, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
@@ -156,7 +156,7 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
 
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
                 [sg], PublishSensorGlucoseDataAsync, config, cancellationToken,
-                "Eversense");
+                context: $"{sg.Mgdl} mg/dL at {sg.Timestamp:O}");
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
@@ -184,8 +184,7 @@ public class LibreConnectorService(
             var sensorGlucose = await FetchSensorGlucoseAsync(config, request.From);
 
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
-                sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken,
-                "LibreLinkUp");
+                sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -416,7 +416,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                     await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
                         context.ProfileMapper.TransformDeviceSettingsToProfiles(deviceSettings),
                         PublishProfileDataAsync, context.Config, cancellationToken,
-                        "device settings");
+                        "from device settings");
 
                     var profileStateSpans = context.ProfileMapper.TransformDeviceSettingsToStateSpans(deviceSettings);
                     if (profileStateSpans.Count > 0)

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -235,7 +235,7 @@ public class MyLifeConnectorService(
 
                 var profileStateSpans = MyLifePumpSettingsMapper.MapToStateSpans(readouts, ConnectorSource);
                 await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-                    profileStateSpans, PublishStateSpanDataAsync, config, cancellationToken, "pump settings");
+                    profileStateSpans, PublishStateSpanDataAsync, config, cancellationToken, "from pump settings");
             }
         }
         catch (Exception ex)

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -140,23 +140,9 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         return await base.SyncDataAsync(config, cancellationToken, since, progressReporter);
     }
 
-    public override async Task<SyncResult> SyncDataAsync(
-        SyncRequest request,
+    protected override Task<bool> EnsureAuthenticatedAsync(
         TConfig config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null)
-    {
-        if (!await AuthenticateWithConfigAsync(config))
-        {
-            return new SyncResult
-            {
-                Success = false,
-                Message = "Authentication failed"
-            };
-        }
-
-        return await base.SyncDataAsync(request, config, cancellationToken, progressReporter);
-    }
+        CancellationToken cancellationToken) => AuthenticateWithConfigAsync(config);
 
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -92,23 +92,9 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         return await base.SyncDataAsync(config, cancellationToken, since, progressReporter);
     }
 
-    public override async Task<SyncResult> SyncDataAsync(
-        SyncRequest request,
+    protected override Task<bool> EnsureAuthenticatedAsync(
         NocturneRemoteConnectorConfiguration config,
-        CancellationToken cancellationToken,
-        ISyncProgressReporter? progressReporter = null)
-    {
-        if (!await AuthenticateWithConfigAsync(config))
-        {
-            return new SyncResult
-            {
-                Success = false,
-                Message = "Authentication failed"
-            };
-        }
-
-        return await base.SyncDataAsync(request, config, cancellationToken, progressReporter);
-    }
+        CancellationToken cancellationToken) => AuthenticateWithConfigAsync(config);
 
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -97,7 +97,7 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
                 if (bgValues != null)
                     await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                         _sensorGlucoseMapper.MapBgValues(bgValues).ToList(), PublishSensorGlucoseDataAsync,
-                        config, cancellationToken, "Tidepool");
+                        config, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -133,7 +133,7 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
                     else
                     {
                         result.Success = false;
-                        result.Errors.Add("Bolus publish failed");
+                        result.Errors.Add($"{SyncDataType.Boluses} publish failed");
                     }
                 }
 

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -150,8 +150,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
         }
 
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
-            sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken,
-            "Twiist");
+            sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
     }
 
     private async Task SyncBolusesAsync(
@@ -160,7 +159,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     {
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabledTypes,
             _insulinMapper.MapBoluses(status.InsulinHistory).ToList(), PublishBolusDataAsync,
-            config, cancellationToken, "Twiist");
+            config, cancellationToken);
     }
 
     private async Task SyncCarbIntakeAsync(
@@ -169,7 +168,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     {
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabledTypes,
             _mealMapper.MapMeals(status.MealHistory).ToList(), PublishCarbIntakeDataAsync,
-            config, cancellationToken, "Twiist");
+            config, cancellationToken);
     }
 
     private async Task SyncTempBasalsAsync(
@@ -182,8 +181,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
             .ToList();
 
         await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabledTypes,
-            tempBasals, PublishTempBasalDataAsync, config, cancellationToken,
-            "Twiist");
+            tempBasals, PublishTempBasalDataAsync, config, cancellationToken);
     }
 
     /// <summary>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -62,6 +62,7 @@
   import { coachmark } from "@nocturne/coach";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import { copyToClipboard } from "$lib/utils";
+  import { createTerminalRunTracker } from "./terminal-run-tracker";
 
   const isPlatformAdmin = $derived((page.data as { isPlatformAdmin?: boolean }).isPlatformAdmin ?? false);
 
@@ -128,12 +129,9 @@
     return entries.find((p) => p.phase === "Syncing") ?? entries.at(-1) ?? null;
   });
 
+  const terminalRuns = createTerminalRunTracker();
   $effect(() => {
-    const progress = syncProgressByConnector;
-    const hasCompleted = Object.values(progress).some(
-      (p) => p.phase === "Completed" || p.phase === "Failed"
-    );
-    if (hasCompleted) {
+    if (terminalRuns.hasNewlyFinishedRun(syncProgressByConnector)) {
       connectorStatusesQuery.refresh();
     }
   });

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/terminal-run-tracker.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/terminal-run-tracker.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { SyncProgressEvent } from "$lib/websocket/types";
+import { createTerminalRunTracker } from "./terminal-run-tracker";
+
+function event(
+  connectorId: string,
+  phase: SyncProgressEvent["phase"],
+  timestamp = "2026-08-21T00:00:00Z",
+): SyncProgressEvent {
+  return {
+    connectorId,
+    connectorName: connectorId,
+    phase,
+    errorMessage: null,
+    timestamp,
+    messageType: null,
+    messageParams: null,
+  };
+}
+
+function map(...events: SyncProgressEvent[]): Record<string, SyncProgressEvent> {
+  return Object.fromEntries(events.map((e) => [e.connectorId, e]));
+}
+
+describe("createTerminalRunTracker", () => {
+  it("reports nothing while every connector is still syncing", () => {
+    const tracker = createTerminalRunTracker();
+
+    expect(tracker.hasNewlyFinishedRun(map(event("glooko", "Syncing")))).toBe(
+      false,
+    );
+  });
+
+  it.each(["Completed", "Failed"] as const)(
+    "reports a %s run once",
+    (phase) => {
+      const tracker = createTerminalRunTracker();
+      const finished = event("glooko", phase);
+
+      expect(tracker.hasNewlyFinishedRun(map(finished))).toBe(true);
+      expect(tracker.hasNewlyFinishedRun(map(finished))).toBe(false);
+    },
+  );
+
+  it("does not re-report while another connector keeps emitting progress", () => {
+    const tracker = createTerminalRunTracker();
+    const finished = event("glooko", "Completed");
+
+    expect(tracker.hasNewlyFinishedRun(map(finished))).toBe(true);
+
+    // The batch's other connector reports three more times inside the linger window.
+    for (const messageNumber of [1, 2, 3]) {
+      expect(
+        tracker.hasNewlyFinishedRun(
+          map(finished, event("dexcom", "Syncing", `2026-08-21T00:00:0${messageNumber}Z`)),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("reports each connector in a batch as it finishes", () => {
+    const tracker = createTerminalRunTracker();
+    const glooko = event("glooko", "Completed");
+
+    expect(tracker.hasNewlyFinishedRun(map(glooko))).toBe(true);
+    expect(
+      tracker.hasNewlyFinishedRun(map(glooko, event("dexcom", "Failed"))),
+    ).toBe(true);
+  });
+
+  it("reports a second run of the same connector inside the linger window", () => {
+    const tracker = createTerminalRunTracker();
+    const first = event("glooko", "Completed", "2026-08-21T00:00:00Z");
+    const second = event("glooko", "Completed", "2026-08-21T00:00:01Z");
+
+    expect(tracker.hasNewlyFinishedRun(map(first))).toBe(true);
+    expect(tracker.hasNewlyFinishedRun(map(second))).toBe(true);
+  });
+
+  it("re-arms once the finished entry is cleared from the store", () => {
+    const tracker = createTerminalRunTracker();
+    const finished = event("glooko", "Completed");
+
+    expect(tracker.hasNewlyFinishedRun(map(finished))).toBe(true);
+    expect(tracker.hasNewlyFinishedRun({})).toBe(false);
+    expect(tracker.hasNewlyFinishedRun(map(finished))).toBe(true);
+  });
+});

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/terminal-run-tracker.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/terminal-run-tracker.ts
@@ -1,0 +1,31 @@
+import type { SyncProgressEvent } from "$lib/websocket/types";
+
+/**
+ * Tracks which connector runs have already been accounted for after finishing.
+ *
+ * A finished run's progress entry lingers on screen for a couple of seconds, during which the
+ * other connectors in a batch keep emitting progress — so a reactive read of the whole progress
+ * map fires repeatedly while one entry lingers. Asking this tracker instead answers "has anything
+ * finished since I last looked", once per run rather than once per message.
+ */
+export function createTerminalRunTracker() {
+  let seen = new Set<string>();
+
+  return {
+    /**
+     * Whether any run has reached a terminal phase since the last call. Runs no longer present
+     * are forgotten, so the set holds at most one entry per connector.
+     */
+    hasNewlyFinishedRun(
+      progressByConnector: Record<string, SyncProgressEvent>,
+    ): boolean {
+      const finished = Object.values(progressByConnector)
+        .filter((p) => p.phase === "Completed" || p.phase === "Failed")
+        .map((p) => `${p.connectorId}@${p.timestamp}`);
+
+      const isNew = finished.some((run) => !seen.has(run));
+      seen = new Set(finished);
+      return isNew;
+    },
+  };
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutBackgroundSyncAuthTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutBackgroundSyncAuthTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Gluroo.Configurations;
 using Nocturne.Connectors.Gluroo.Services;
@@ -105,6 +106,71 @@ public class NightscoutBackgroundSyncAuthTests
 
         result.Should().NotBeNull();
         result.Success.Should().BeTrue("auth should succeed when tenant config URL is provided");
+    }
+
+    /// <summary>
+    ///     The terminal progress message belongs to the shared run wrapper. Nightscout authenticates
+    ///     on the requested-range entry point, and a rejected credential returns before any data is
+    ///     fetched — the run still has to hand the tenant exactly one terminal message, or the
+    ///     connector's badge stays on "syncing" until the page is reloaded.
+    /// </summary>
+    [Theory]
+    [InlineData("secret", SyncPhase.Completed)]
+    [InlineData("", SyncPhase.Failed)]
+    public async Task Nightscout_RequestedSync_ReportsExactlyOneTerminalMessage(
+        string apiSecret, SyncPhase expectedPhase)
+    {
+        var service = CreateNightscoutService(RespondOkJson(), new NightscoutConnectorConfiguration());
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "https://tenant.nightscout.example.com",
+            ApiSecret = apiSecret,
+        };
+        var (reporter, reported) = BuildReporter();
+
+        await service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose], From = DateTime.UtcNow.AddHours(-1) },
+            config, CancellationToken.None, reporter.Object);
+
+        reported.Where(e => e.Phase != SyncPhase.Syncing)
+            .Should().ContainSingle().Which.Phase.Should().Be(expectedPhase);
+    }
+
+    /// <summary>
+    ///     Gluroo inherits <see cref="NightscoutConnectorServiceBase{TConfig}"/> whole, so the same
+    ///     auth guard applies — asserted directly rather than inferred.
+    /// </summary>
+    [Theory]
+    [InlineData("gluroo-secret", SyncPhase.Completed)]
+    [InlineData("", SyncPhase.Failed)]
+    public async Task Gluroo_RequestedSync_ReportsExactlyOneTerminalMessage(
+        string apiSecret, SyncPhase expectedPhase)
+    {
+        var service = CreateGlurooService(RespondOkJson(), new GlurooConnectorConfiguration());
+        var config = new GlurooConnectorConfiguration
+        {
+            Url = "https://app.gluroo.com",
+            ApiSecret = apiSecret,
+        };
+        var (reporter, reported) = BuildReporter();
+
+        await service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose], From = DateTime.UtcNow.AddHours(-1) },
+            config, CancellationToken.None, reporter.Object);
+
+        reported.Where(e => e.Phase != SyncPhase.Syncing)
+            .Should().ContainSingle().Which.Phase.Should().Be(expectedPhase);
+    }
+
+    private static (Mock<ISyncProgressReporter> Reporter, List<SyncProgressEvent> Reported) BuildReporter()
+    {
+        var reported = new List<SyncProgressEvent>();
+        var reporter = new Mock<ISyncProgressReporter>();
+        reporter
+            .Setup(r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<SyncProgressEvent, CancellationToken>((e, _) => reported.Add(e))
+            .Returns(Task.CompletedTask);
+        return (reporter, reported);
     }
 
     private sealed class FuncHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.NocturneRemote.Configurations;
 using Nocturne.Connectors.NocturneRemote.Services;
@@ -82,6 +83,45 @@ public class NocturneRemoteBackgroundSyncAuthTests
 
         var result = await act.Should().NotThrowAsync();
         result.Subject.Success.Should().BeFalse();
+    }
+
+    /// <summary>
+    ///     The terminal progress message belongs to the shared run wrapper. A rejected token returns
+    ///     before any data is fetched, and that path still owes the tenant exactly one terminal
+    ///     message — without it the connector's badge stays on "syncing" until the page is reloaded.
+    /// </summary>
+    [Theory]
+    [InlineData(true, SyncPhase.Completed)]
+    [InlineData(false, SyncPhase.Failed)]
+    public async Task RequestedSync_ReportsExactlyOneTerminalMessage(
+        bool tokenAccepted, SyncPhase expectedPhase)
+    {
+        var handler = tokenAccepted
+            ? RespondOkJson()
+            : new FuncHandler(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("unauthorized")
+            });
+        var service = CreateService(handler, new NocturneRemoteConnectorConfiguration());
+        var config = new NocturneRemoteConnectorConfiguration
+        {
+            Url = "https://remote.nocturne.example.com",
+            Token = "bearer-token",
+        };
+
+        var reported = new List<SyncProgressEvent>();
+        var reporter = new Mock<ISyncProgressReporter>();
+        reporter
+            .Setup(r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<SyncProgressEvent, CancellationToken>((e, _) => reported.Add(e))
+            .Returns(Task.CompletedTask);
+
+        await service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose], From = DateTime.UtcNow.AddHours(-1) },
+            config, CancellationToken.None, reporter.Object);
+
+        reported.Where(e => e.Phase != SyncPhase.Syncing)
+            .Should().ContainSingle().Which.Phase.Should().Be(expectedPhase);
     }
 
     private sealed class FuncHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
@@ -7,6 +7,7 @@ using Nocturne.Connectors.CareLink.Services;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Multitenancy;
 using Xunit;
@@ -171,6 +172,27 @@ public class CareLinkConnectorServiceTests
             }
             """
     };
+
+    /// <summary>
+    /// A run that never got past authentication reports the shared failure shape: the summary in
+    /// <c>Message</c> for the tenant's sync card and the source-qualified detail in <c>Errors</c>,
+    /// which is what gets persisted as the connector's last error. CareLink authenticates inside
+    /// its own sync body, so it has to opt into that shape rather than inherit it.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAuthenticationFails_ReportsTheSharedFailureShape()
+    {
+        // A token response carrying no access token leaves the connector unauthenticated.
+        var fixture = new ServiceFixture(new CareLinkFakeHandler { TokenResponseJson = "{}" });
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Be("Authentication failed");
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Be($"Authentication failed for {DataSources.CareLinkConnector}");
+    }
 
     /// <summary>Leaves only the alarm step able to publish, so its failure cannot be confused for another step's.</summary>
     private static CareLinkConnectorConfiguration AlarmOnlyConfiguration() => new()

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
@@ -89,14 +89,39 @@ public class PublishRecordTypePathTests
     }
 
     [Fact]
-    public async Task EmptyBatch_RecordsNothing()
+    public async Task EmptyBatch_RecordsAnExplicitZero()
     {
+        // Arrange: the tenant's sync card renders a badge per key, so an active type that came back
+        // empty has to say zero — a missing key reads as "never checked".
         var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
 
+        // Act
         var result = await RunAsync((service, syncResult) =>
             service.PublishAsync(syncResult, SyncDataType.Glucose, active, []));
 
-        result.ItemsSynced.Should().BeEmpty();
+        // Assert
+        result.ItemsSynced.Should().Equal(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Glucose] = 0,
+        });
+    }
+
+    [Fact]
+    public async Task EmptyBatchAfterAPublishedOne_LeavesTheCountAlone()
+    {
+        // Arrange: a paginated crawl ends on an empty page, which must not erase what it landed
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+
+        // Act
+        var result = await RunAsync(async (service, syncResult) =>
+        {
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active,
+                [new PublishedRecord(), new PublishedRecord()]);
+            await service.PublishAsync(syncResult, SyncDataType.Glucose, active, []);
+        });
+
+        // Assert
+        result.ItemsSynced[SyncDataType.Glucose].Should().Be(2);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
@@ -35,10 +35,25 @@ public class SyncTerminalPhaseTests
 
         public bool AuthenticationSucceeds { get; init; } = true;
 
+        public int AuthenticateCalls { get; private set; }
+        public int EnsureAuthenticatedCalls { get; private set; }
+
         protected override string ConnectorSource => "test";
         public override string ServiceName => "Test";
 
-        public override Task<bool> AuthenticateAsync() => Task.FromResult(AuthenticationSucceeds);
+        public override Task<bool> AuthenticateAsync()
+        {
+            AuthenticateCalls++;
+            return Task.FromResult(AuthenticationSucceeds);
+        }
+
+        protected override Task<bool> EnsureAuthenticatedAsync(
+            TestConfig config,
+            CancellationToken cancellationToken)
+        {
+            EnsureAuthenticatedCalls++;
+            return Task.FromResult(AuthenticationSucceeds);
+        }
 
         protected override async Task<SyncResult> PerformSyncInternalAsync(
             SyncRequest request,
@@ -207,6 +222,63 @@ public class SyncTerminalPhaseTests
 
         // Assert: one wrapper owns the outcome, so the two entry points cannot double-report
         reported.Should().ContainSingle().Which.Phase.Should().Be(SyncPhase.Completed);
+    }
+
+    [Fact]
+    public async Task RequestedSync_AuthenticationFailure_ReportsOneFailedPhaseAndSkipsTheSync()
+    {
+        // Arrange: the guard runs inside the run wrapper, so a rejected credential on the
+        // requested-range entry point still resolves the tenant's in-progress indicator.
+        var (reporter, reported) = BuildReporter();
+        var syncRan = false;
+        var service = new TestConnectorService(_ =>
+        {
+            syncRan = true;
+            return Task.CompletedTask;
+        }) { AuthenticationSucceeds = false };
+
+        // Act
+        var result = await service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            new TestConfig(),
+            CancellationToken.None,
+            reporter.Object);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        syncRan.Should().BeFalse();
+        reported.Should().ContainSingle().Which.Phase.Should().Be(SyncPhase.Failed);
+        reported[0].ErrorMessage.Should().Be("Authentication failed for test");
+    }
+
+    [Fact]
+    public async Task RequestedSync_AuthenticatesThroughTheGuardOnly()
+    {
+        // Arrange
+        var service = new TestConnectorService(_ => Task.CompletedTask);
+
+        // Act
+        await service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, new TestConfig(), CancellationToken.None);
+
+        // Assert
+        service.EnsureAuthenticatedCalls.Should().Be(1);
+        service.AuthenticateCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task BackgroundSync_AuthenticatesOnceAndNotThroughTheGuard()
+    {
+        // Arrange: the background entry point owns its own hand-shake, so a connector overriding
+        // both hooks must not authenticate twice for one run.
+        var service = new TestConnectorService(_ => Task.CompletedTask);
+
+        // Act
+        await service.SyncDataAsync(new TestConfig(), CancellationToken.None);
+
+        // Assert
+        service.AuthenticateCalls.Should().Be(1);
+        service.EnsureAuthenticatedCalls.Should().Be(0);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
@@ -157,7 +157,9 @@ public class TandemE2eSyncTests
             [SyncDataType.TempBasals] = 2,
             [SyncDataType.DeviceEvents] = 3,
         });
-        result.ItemsSynced.Should().NotContainKey(SyncDataType.StateSpans);
+        // Active but empty: an explicit zero says "checked, found nothing" where a missing key
+        // would read as "never checked".
+        result.ItemsSynced[SyncDataType.StateSpans].Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #883. Closes #866.

## #883 remainder

**Auth failures now produce the run's terminal event** for Nightscout, Gluroo and NocturneRemote. The base class owns an `EnsureAuthenticatedAsync` hook called *inside* `RunWithProgressAsync` on the requested-range entry point; the two connectors' `SyncDataAsync` overrides are deleted in favour of three-line hook overrides (Gluroo inherits Nightscout's wholesale, and is asserted directly, not structurally). No double-authenticate — the background entry point authenticates via `AuthenticateAsync` and never reaches the hook, proven by counting both hooks in both directions. No double-emit — the guard runs inside the wrapper's body, so the wrapper's single terminal emitter stands (mutation: re-adding a hand-rolled emit in Nightscout's auth path fails both new one-terminal theories).

**The connector-status refresh fires once per finished run** instead of once per progress message while a terminal entry lingers: an 8-line `createTerminalRunTracker` keyed on `${connectorId}@${timestamp}` (value comparison, deliberately not object identity through the `$state` proxy), unit-tested over 7 cases including back-to-back runs inside the linger window.

## #866

**Explicit zeros**: an ACTIVE type the shared publish helper looked at and found empty now records `ItemsSynced[type] = 0` (via `TryAdd`, so a paginated crawl ending on an empty page cannot erase an earlier count — tested). "Checked, found nothing" and "never ran" are distinguishable again on the manual-sync card — for helper-routed types; the four connectors still hand-rolling their bookkeeping (#919) keep their `> 0` gates, so e.g. a Tidepool sync shows "0 glucose" but no bolus badge until #919 lands. Consumer sweep: nothing treats presence-of-key as data-exists (health keys off Success/Errors; the dialog sums; zeros render as the intended badges).

**Error-string vocabulary declared and unified**: `"{SyncDataType} publish failed"` is the accepted vocabulary (persisted to health state, shown in the connectors UI) — anything keyed on the pre-#861 strings needs the memo. Two hand-rolled sites that didn't match now interpolate from the enum: CareLink's "SensorGlucose publish failed" → "Glucose publish failed", Tidepool's "Bolus publish failed" → "Boluses publish failed".

**Log detail restored once for everyone**: the helper's success log carries `ConnectorSource` as a structured property and a parenthesised batch context; Eversense again logs the reading value and timestamp. **Declared**: the property is `ConnectorSource` (the dominant convention), not Twiist's old `Source` — structured-log queries filtering Twiist on `Source` must repoint.

## Other declared deltas
- Manual auth failure now returns `Errors = ["Authentication failed for <source>"]` plus both timestamps (previously bare Message, and on these three connectors, nothing at all reached the progress stream).
- Hostile-round corrections: the Eversense reading detail is restored at DEBUG, not the pre-#861 Information level � glucose values are health data and do not belong in the default-level sink (operators who relied on the old line must enable Debug for the Eversense category); CareLink now shares the base auth-failure shape, so its persisted lastErrorMessage becomes "Authentication failed for carelink-connector".
- The Tandem E2E assertion moved from `NotContainKey(StateSpans)` to `[StateSpans] == 0` — the one pre-existing test the zeros invalidated, and the new value is the honest one.

## Tests
Core 128/128; API.Tests 5878/0 (including two per-connector one-terminal theories over accepted/rejected credentials); every connector suite green; vitest 7/7 + 14/14; `pnpm check` at the 64-error baseline with the new module proven in scope. Four mutations, each named and reverted.


