### PR TITLE
fix(api): answer ui-settings demo mode from the service that owns it, and refuse unowned section names

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -37,6 +37,15 @@ public class UISettingsController : ControllerBase, IWriteScopedController
     /// </summary>
     public string WriteScope => OAuthScopes.AlertsReadWrite;
 
+    /// <summary>
+    /// Deadline for the demo service's ui-settings read. The demo service is co-deployed and answers
+    /// this route from memory, so anything slower than a few seconds is a hang, and the demo tenant
+    /// has fixtures to fall back on. The unnamed <see cref="IHttpClientFactory"/> client carries no
+    /// resilience handler, so without a deadline a hung demo service would hold the request open for
+    /// <see cref="HttpClient"/>'s 100-second default.
+    /// </summary>
+    internal static readonly TimeSpan DemoServiceProxyTimeout = TimeSpan.FromSeconds(3);
+
     private readonly ILogger<UISettingsController> _logger;
     private readonly IDemoModeService _demoMode;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -88,10 +97,15 @@ public class UISettingsController : ControllerBase, IWriteScopedController
                 {
                     try
                     {
+                        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(
+                            cancellationToken
+                        );
+                        deadline.CancelAfter(DemoServiceProxyTimeout);
+
                         var httpClient = _httpClientFactory.CreateClient();
                         var response = await httpClient.GetFromJsonAsync<UISettingsConfiguration>(
-                            $"{_demoMode.ServiceUrl}/ui-settings",
-                            cancellationToken
+                            $"{_demoMode.ServiceUrl?.TrimEnd('/')}/ui-settings",
+                            deadline.Token
                         );
 
                         if (response != null)

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Services.Platform;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Models.Authorization;
@@ -37,7 +38,7 @@ public class UISettingsController : ControllerBase, IWriteScopedController
     public string WriteScope => OAuthScopes.AlertsReadWrite;
 
     private readonly ILogger<UISettingsController> _logger;
-    private readonly IConfiguration _configuration;
+    private readonly IDemoModeService _demoMode;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IUISettingsService _settingsService;
 
@@ -45,18 +46,18 @@ public class UISettingsController : ControllerBase, IWriteScopedController
     /// Initializes a new instance of <see cref="UISettingsController"/>.
     /// </summary>
     /// <param name="logger">Logger instance.</param>
-    /// <param name="configuration">Application configuration (used for DemoMode settings).</param>
+    /// <param name="demoMode">Owner of whether this deployment is a demo, and of the demo service URL.</param>
     /// <param name="httpClientFactory">Factory for creating HTTP clients to proxy demo service calls.</param>
     /// <param name="settingsService">Service for persisting and retrieving UI settings.</param>
     public UISettingsController(
         ILogger<UISettingsController> logger,
-        IConfiguration configuration,
+        IDemoModeService demoMode,
         IHttpClientFactory httpClientFactory,
         IUISettingsService settingsService
     )
     {
         _logger = logger;
-        _configuration = configuration;
+        _demoMode = demoMode;
         _httpClientFactory = httpClientFactory;
         _settingsService = settingsService;
     }
@@ -81,21 +82,15 @@ public class UISettingsController : ControllerBase, IWriteScopedController
 
         try
         {
-            // Check if demo mode is enabled
-            var demoEnabled = _configuration.GetValue<bool>("DemoMode:Enabled");
-
-            if (demoEnabled)
+            if (_demoMode.IsEnabled)
             {
-                // Try to fetch from demo service
-                var demoServiceUrl = _configuration.GetValue<string>("DemoMode:ServiceUrl");
-
-                if (!string.IsNullOrEmpty(demoServiceUrl))
+                if (_demoMode.IsConfigured)
                 {
                     try
                     {
                         var httpClient = _httpClientFactory.CreateClient();
                         var response = await httpClient.GetFromJsonAsync<UISettingsConfiguration>(
-                            $"{demoServiceUrl}/ui-settings",
+                            $"{_demoMode.ServiceUrl}/ui-settings",
                             cancellationToken
                         );
 
@@ -193,9 +188,7 @@ public class UISettingsController : ControllerBase, IWriteScopedController
 
         try
         {
-            // Check if demo mode is enabled - in demo mode, we don't persist
-            var demoEnabled = _configuration.GetValue<bool>("DemoMode:Enabled");
-            if (demoEnabled)
+            if (_demoMode.IsEnabled)
             {
                 _logger.LogWarning(
                     "Attempted to save settings in demo mode - returning input unchanged"
@@ -236,8 +229,7 @@ public class UISettingsController : ControllerBase, IWriteScopedController
 
         try
         {
-            var demoEnabled = _configuration.GetValue<bool>("DemoMode:Enabled");
-            if (demoEnabled)
+            if (_demoMode.IsEnabled)
             {
                 return Ok(settings);
             }
@@ -271,8 +263,7 @@ public class UISettingsController : ControllerBase, IWriteScopedController
 
         try
         {
-            var demoEnabled = _configuration.GetValue<bool>("DemoMode:Enabled");
-            if (demoEnabled)
+            if (_demoMode.IsEnabled)
             {
                 return Ok(GenerateDemoAlarmConfiguration());
             }
@@ -311,8 +302,7 @@ public class UISettingsController : ControllerBase, IWriteScopedController
 
         try
         {
-            var demoEnabled = _configuration.GetValue<bool>("DemoMode:Enabled");
-            if (demoEnabled)
+            if (_demoMode.IsEnabled)
             {
                 return Ok(config);
             }
@@ -351,8 +341,7 @@ public class UISettingsController : ControllerBase, IWriteScopedController
 
         try
         {
-            var demoEnabled = _configuration.GetValue<bool>("DemoMode:Enabled");
-            if (demoEnabled)
+            if (_demoMode.IsEnabled)
             {
                 return Ok(
                     new UserAlarmConfiguration
@@ -418,8 +407,7 @@ public class UISettingsController : ControllerBase, IWriteScopedController
 
         try
         {
-            var demoEnabled = _configuration.GetValue<bool>("DemoMode:Enabled");
-            if (demoEnabled)
+            if (_demoMode.IsEnabled)
             {
                 return Ok(
                     new UserAlarmConfiguration { Profiles = new List<AlarmProfileConfiguration>() }

--- a/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Profiles/UISettingsController.cs
@@ -627,8 +627,9 @@ public class UISettingsController : ControllerBase, IWriteScopedController
     }
 
     /// <summary>
-    /// The plugin pills the demo tenant shows. <see cref="FeatureSettings.Plugins"/> has no defaults,
-    /// so there is nothing to inherit here.
+    /// Sample <see cref="FeatureSettings.Plugins"/> entries for the demo tenant, mirroring what the
+    /// demo data service serves so the fallback shows the same settings page. These name the legacy
+    /// Nightscout plugins; they do not decide which pills the demo dashboard shows.
     /// </summary>
     private static Dictionary<string, PluginSettings> GenerateDemoPlugins()
     {

--- a/src/API/Nocturne.API/Services/Platform/DemoModeService.cs
+++ b/src/API/Nocturne.API/Services/Platform/DemoModeService.cs
@@ -17,6 +17,11 @@ public interface IDemoModeService
     /// Whether demo mode is configured (even if the service is not yet healthy).
     /// </summary>
     bool IsConfigured { get; }
+
+    /// <summary>
+    /// Base URL of the external demo data service as configured, or null when none was injected.
+    /// </summary>
+    string? ServiceUrl { get; }
 }
 
 /// <summary>
@@ -45,6 +50,7 @@ public class DemoModeService : IDemoModeService
 {
     private readonly bool _isEnabled;
     private readonly bool _isConfigured;
+    private readonly string? _serviceUrl;
     private readonly ILogger<DemoModeService> _logger;
 
     public DemoModeService(IConfiguration configuration, ILogger<DemoModeService> logger)
@@ -65,7 +71,8 @@ public class DemoModeService : IDemoModeService
 
         // Demo mode is enabled if either source says so
         _isEnabled = demoServiceConfig.Enabled || parametersDemoModeEnabled;
-        _isConfigured = _isEnabled && !string.IsNullOrWhiteSpace(demoServiceConfig.Url);
+        _serviceUrl = demoServiceConfig.Url;
+        _isConfigured = _isEnabled && !string.IsNullOrWhiteSpace(_serviceUrl);
 
         // Log all demo service configuration for debugging
         _logger.LogInformation(
@@ -81,4 +88,7 @@ public class DemoModeService : IDemoModeService
 
     /// <inheritdoc />
     public bool IsConfigured => _isConfigured;
+
+    /// <inheritdoc />
+    public string? ServiceUrl => _serviceUrl;
 }

--- a/src/API/Nocturne.API/Services/Profiles/UISettingsService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/UISettingsService.cs
@@ -149,6 +149,14 @@ public class UISettingsService : IUISettingsService
     )
         where T : class
     {
+        if (UISettingsSections.Find(sectionName) == null && !IsAlarmConfigurationName(sectionName))
+        {
+            throw new ArgumentException(
+                $"Unknown UI settings section: {sectionName}",
+                nameof(sectionName)
+            );
+        }
+
         try
         {
             await WriteSectionAsync(sectionName, sectionSettings, cancellationToken);
@@ -243,13 +251,21 @@ public class UISettingsService : IUISettingsService
         }
     }
 
+    /// <summary>
+    /// The row key owning <paramref name="sectionName"/>. Lowercasing here is what makes
+    /// <c>ui:settings:dataquality</c> the key of the <c>dataQuality</c> section; every read and write
+    /// derives its key from this one function, so the two never disagree.
+    /// </summary>
     private static string GetSectionKey(string sectionName)
     {
-        return sectionName.ToLowerInvariant() switch
-        {
-            "alarms" or "alarmconfiguration" => AlarmConfigurationKey,
-            var name => SettingsKeyPrefix + name,
-        };
+        return IsAlarmConfigurationName(sectionName)
+            ? AlarmConfigurationKey
+            : SettingsKeyPrefix + sectionName.ToLowerInvariant();
+    }
+
+    private static bool IsAlarmConfigurationName(string sectionName)
+    {
+        return sectionName.ToLowerInvariant() is "alarms" or "alarmconfiguration";
     }
 
     private async Task<UserAlarmConfiguration?> ReadAlarmConfigurationAsync(

--- a/src/Core/Nocturne.Core.Contracts/Profiles/IUISettingsService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Profiles/IUISettingsService.cs
@@ -40,10 +40,17 @@ public interface IUISettingsService
     /// Saves a specific section of the UI settings.
     /// </summary>
     /// <typeparam name="T">The section type</typeparam>
-    /// <param name="sectionName">The section name</param>
+    /// <param name="sectionName">
+    /// A <see cref="UISettingsSections"/> name, or <c>alarms</c>/<c>alarmConfiguration</c> for the
+    /// alarm configuration. Reads only ever look under those keys, so any other name would store a
+    /// row nothing can serve.
+    /// </param>
     /// <param name="sectionSettings">The section settings to save</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The saved section settings</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="sectionName"/> names neither a section nor the alarm configuration.
+    /// </exception>
     Task<T> SaveSectionAsync<T>(
         string sectionName,
         T sectionSettings,

--- a/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
@@ -237,6 +237,13 @@ public class FeatureSettings
     [JsonPropertyName("widgets")]
     public List<WidgetConfig> Widgets { get; set; } = GetDefaultWidgets();
 
+    /// <summary>
+    /// Legacy Nightscout plugin toggles, carried for schema compatibility and empty by default.
+    /// Unlike <see cref="Widgets"/> this gates nothing: the dashboard's status pills appear when the
+    /// data behind them arrives, and the tracker pill row is gated by
+    /// <see cref="TrackerPillsSettings.Enabled"/>. Defaults here would ship every tenant a stored
+    /// list nothing reads.
+    /// </summary>
     [JsonPropertyName("plugins")]
     public Dictionary<string, PluginSettings> Plugins { get; set; } = new();
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerDemoModeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerDemoModeTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
@@ -69,46 +70,62 @@ public class UISettingsControllerDemoModeTests
     [Fact]
     public async Task GetUISettings_inDemoMode_servesWhatTheDemoServiceReturns()
     {
-        var proxied = new UISettingsConfiguration
-        {
-            Devices = new DeviceSettings
-            {
-                ConnectedDevices = [new ConnectedDevice { Id = "from-demo-service" }],
-            },
-        };
-        var demoService = new StubDemoService(proxied);
-        var controller = NewController(
-            new UISettingsService(NewDatabase(), NullLogger<UISettingsService>.Instance),
-            DemoMode(enabled: true, serviceUrl: "http://demo-service"),
-            demoService.Factory
-        );
+        var demoService = new StubDemoService(HttpStatusCode.OK, ProxiedSettings);
 
-        var settings = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
+        var settings = await ProxiedGet(demoService);
 
         settings.Devices.ConnectedDevices.Should().ContainSingle().Which.Id.Should()
-            .Be("from-demo-service");
+            .Be(ProxiedDeviceId);
+        demoService.RequestUri.Should().Be("http://demo-service/ui-settings");
+    }
+
+    [Fact]
+    public async Task GetUISettings_inDemoMode_normalisesATrailingSlashOnTheServiceUrl()
+    {
+        var demoService = new StubDemoService(HttpStatusCode.OK, ProxiedSettings);
+
+        await ProxiedGet(demoService, "http://demo-service/");
+
         demoService.RequestUri.Should().Be("http://demo-service/ui-settings");
     }
 
     [Fact]
     public async Task GetUISettings_inDemoMode_fallsBackToItsOwnFixtures_whenTheDemoServiceFails()
     {
-        var demoService = new StubDemoService(HttpStatusCode.InternalServerError);
-        var controller = NewController(
-            new UISettingsService(NewDatabase(), NullLogger<UISettingsService>.Instance),
-            DemoMode(enabled: true, serviceUrl: "http://demo-service"),
-            demoService.Factory
-        );
-
-        var settings = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
+        var settings = await ProxiedGet(new StubDemoService(HttpStatusCode.InternalServerError));
 
         settings.Devices.ConnectedDevices.Should().NotBeEmpty();
     }
 
     [Fact]
+    public async Task GetUISettings_inDemoMode_fallsBackToItsOwnFixtures_whenTheDemoServiceFailsWithAReadableBody()
+    {
+        var settings = await ProxiedGet(
+            new StubDemoService(HttpStatusCode.InternalServerError, ProxiedSettings)
+        );
+
+        settings.Devices.ConnectedDevices.Should().NotBeEmpty();
+        settings.Devices.ConnectedDevices.Select(d => d.Id).Should().NotContain(ProxiedDeviceId);
+    }
+
+    [Fact]
+    public async Task GetUISettings_inDemoMode_stopsWaitingOnAHungDemoService()
+    {
+        var demoService = StubDemoService.Hanging();
+        var elapsed = Stopwatch.StartNew();
+
+        var settings = await ProxiedGet(demoService);
+        elapsed.Stop();
+
+        settings.Devices.ConnectedDevices.Should().NotBeEmpty();
+        demoService.Cancelled.Should().BeTrue();
+        elapsed.Elapsed.Should().BeLessThan(UISettingsController.DemoServiceProxyTimeout * 4);
+    }
+
+    [Fact]
     public async Task GetUISettings_outsideDemoMode_neverCallsTheDemoService()
     {
-        var demoService = new StubDemoService(new UISettingsConfiguration());
+        var demoService = new StubDemoService(HttpStatusCode.OK, ProxiedSettings);
         var controller = NewController(
             new UISettingsService(NewDatabase(), NullLogger<UISettingsService>.Instance),
             DemoMode(enabled: false, serviceUrl: "http://demo-service"),
@@ -118,6 +135,35 @@ public class UISettingsControllerDemoModeTests
         await controller.GetUISettings();
 
         demoService.RequestUri.Should().BeNull();
+    }
+
+    private const string ProxiedDeviceId = "from-demo-service";
+
+    private static UISettingsConfiguration ProxiedSettings =>
+        new()
+        {
+            Devices = new DeviceSettings
+            {
+                ConnectedDevices = [new ConnectedDevice { Id = ProxiedDeviceId }],
+            },
+        };
+
+    /// <summary>
+    /// What <c>GET ui-settings</c> answers in demo mode with <paramref name="demoService"/> standing
+    /// in for the external demo data service.
+    /// </summary>
+    private static async Task<UISettingsConfiguration> ProxiedGet(
+        StubDemoService demoService,
+        string serviceUrl = "http://demo-service"
+    )
+    {
+        var controller = NewController(
+            new UISettingsService(NewDatabase(), NullLogger<UISettingsService>.Instance),
+            DemoMode(enabled: true, serviceUrl: serviceUrl),
+            demoService.Factory
+        );
+
+        return OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
     }
 
     /// <summary>
@@ -153,20 +199,31 @@ public class UISettingsControllerDemoModeTests
     {
         private readonly UISettingsConfiguration? _settings;
         private readonly HttpStatusCode _status;
+        private readonly bool _hangs;
 
-        internal StubDemoService(UISettingsConfiguration settings)
+        internal StubDemoService(HttpStatusCode status, UISettingsConfiguration? settings = null)
         {
+            _status = status;
             _settings = settings;
-            _status = HttpStatusCode.OK;
         }
 
-        internal StubDemoService(HttpStatusCode status)
+        private StubDemoService(bool hangs)
+            : this(HttpStatusCode.OK)
         {
-            _settings = null;
-            _status = status;
+            _hangs = hangs;
+        }
+
+        /// <summary>
+        /// A demo service that never answers, so only the caller's own deadline ends the call.
+        /// </summary>
+        internal static StubDemoService Hanging()
+        {
+            return new StubDemoService(hangs: true);
         }
 
         internal string? RequestUri { get; private set; }
+
+        internal bool Cancelled { get; private set; }
 
         internal IHttpClientFactory Factory
         {
@@ -183,20 +240,30 @@ public class UISettingsControllerDemoModeTests
 
         private sealed class Handler(StubDemoService owner) : HttpMessageHandler
         {
-            protected override Task<HttpResponseMessage> SendAsync(
+            protected override async Task<HttpResponseMessage> SendAsync(
                 HttpRequestMessage request,
                 CancellationToken cancellationToken
             )
             {
                 owner.RequestUri = request.RequestUri?.ToString();
 
-                return Task.FromResult(
-                    new HttpResponseMessage(owner._status)
+                if (owner._hangs)
+                {
+                    try
                     {
-                        Content =
-                            owner._settings == null ? null : JsonContent.Create(owner._settings),
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                     }
-                );
+                    catch (OperationCanceledException)
+                    {
+                        owner.Cancelled = true;
+                        throw;
+                    }
+                }
+
+                return new HttpResponseMessage(owner._status)
+                {
+                    Content = owner._settings == null ? null : JsonContent.Create(owner._settings),
+                };
             }
         }
     }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerDemoModeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerDemoModeTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.API.Services.Profiles;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+using static Nocturne.API.Tests.Controllers.V4.Profiles.UISettingsControllerHarness;
+
+namespace Nocturne.API.Tests.Controllers.V4.Profiles;
+
+/// <summary>
+/// Demo-mode coverage for <see cref="UISettingsController"/>. Demo mode is whatever
+/// <see cref="Nocturne.API.Services.Platform.IDemoModeService"/> says it is, and while it is on the
+/// controller serves fixtures and persists nothing.
+/// </summary>
+[Trait("Category", "Unit")]
+public class UISettingsControllerDemoModeTests
+{
+    [Fact]
+    public async Task SaveUISettings_inDemoMode_persistsNothing()
+    {
+        var settings = new UISettingsConfiguration();
+        settings.Security.RequireAuthForPublicAccess = true;
+
+        await PersistsNothing(c => c.SaveUISettings(settings));
+    }
+
+    [Fact]
+    public async Task SaveNotificationSettings_inDemoMode_persistsNothing()
+    {
+        await PersistsNothing(c => c.SaveNotificationSettings(new NotificationSettings()));
+    }
+
+    [Fact]
+    public async Task SaveAlarmConfiguration_inDemoMode_persistsNothing()
+    {
+        await PersistsNothing(c => c.SaveAlarmConfiguration(new UserAlarmConfiguration()));
+    }
+
+    [Fact]
+    public async Task AddOrUpdateAlarmProfile_inDemoMode_persistsNothing()
+    {
+        await PersistsNothing(c => c.AddOrUpdateAlarmProfile(Profile()));
+    }
+
+    [Fact]
+    public async Task DeleteAlarmProfile_inDemoMode_persistsNothing()
+    {
+        await PersistsNothing(c => c.DeleteAlarmProfile(Profile().Id));
+    }
+
+    [Fact]
+    public async Task GetAlarmConfiguration_inDemoMode_servesTheSampleProfiles()
+    {
+        var controller = NewController(demoMode: true);
+
+        var config = OkValue<UserAlarmConfiguration>(
+            (await controller.GetAlarmConfiguration()).Result
+        );
+
+        config.Profiles.Should().NotBeEmpty();
+        config.Profiles.Select(p => p.AlarmType).Should().Contain(AlarmTriggerType.UrgentLow);
+    }
+
+    [Fact]
+    public async Task GetUISettings_inDemoMode_servesWhatTheDemoServiceReturns()
+    {
+        var proxied = new UISettingsConfiguration
+        {
+            Devices = new DeviceSettings
+            {
+                ConnectedDevices = [new ConnectedDevice { Id = "from-demo-service" }],
+            },
+        };
+        var demoService = new StubDemoService(proxied);
+        var controller = NewController(
+            new UISettingsService(NewDatabase(), NullLogger<UISettingsService>.Instance),
+            DemoMode(enabled: true, serviceUrl: "http://demo-service"),
+            demoService.Factory
+        );
+
+        var settings = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
+
+        settings.Devices.ConnectedDevices.Should().ContainSingle().Which.Id.Should()
+            .Be("from-demo-service");
+        demoService.RequestUri.Should().Be("http://demo-service/ui-settings");
+    }
+
+    [Fact]
+    public async Task GetUISettings_inDemoMode_fallsBackToItsOwnFixtures_whenTheDemoServiceFails()
+    {
+        var demoService = new StubDemoService(HttpStatusCode.InternalServerError);
+        var controller = NewController(
+            new UISettingsService(NewDatabase(), NullLogger<UISettingsService>.Instance),
+            DemoMode(enabled: true, serviceUrl: "http://demo-service"),
+            demoService.Factory
+        );
+
+        var settings = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
+
+        settings.Devices.ConnectedDevices.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetUISettings_outsideDemoMode_neverCallsTheDemoService()
+    {
+        var demoService = new StubDemoService(new UISettingsConfiguration());
+        var controller = NewController(
+            new UISettingsService(NewDatabase(), NullLogger<UISettingsService>.Instance),
+            DemoMode(enabled: false, serviceUrl: "http://demo-service"),
+            demoService.Factory
+        );
+
+        await controller.GetUISettings();
+
+        demoService.RequestUri.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A write endpoint answers 200 in demo mode without leaving a settings row behind.
+    /// </summary>
+    private static async Task PersistsNothing<T>(
+        Func<UISettingsController, Task<ActionResult<T>>> write
+    )
+    {
+        var database = NewDatabase();
+
+        var result = await write(NewController(database, demoMode: true));
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        database.Settings.ToList().Should().BeEmpty();
+    }
+
+    private static AlarmProfileConfiguration Profile()
+    {
+        return new AlarmProfileConfiguration
+        {
+            Id = "demo-profile",
+            Name = "Demo",
+            AlarmType = AlarmTriggerType.Low,
+            Threshold = 70,
+        };
+    }
+
+    /// <summary>
+    /// Stands in for the external demo data service, recording the URL the controller asked for.
+    /// </summary>
+    private sealed class StubDemoService
+    {
+        private readonly UISettingsConfiguration? _settings;
+        private readonly HttpStatusCode _status;
+
+        internal StubDemoService(UISettingsConfiguration settings)
+        {
+            _settings = settings;
+            _status = HttpStatusCode.OK;
+        }
+
+        internal StubDemoService(HttpStatusCode status)
+        {
+            _settings = null;
+            _status = status;
+        }
+
+        internal string? RequestUri { get; private set; }
+
+        internal IHttpClientFactory Factory
+        {
+            get
+            {
+                var factory = new Mock<IHttpClientFactory>();
+                factory
+                    .Setup(f => f.CreateClient(It.IsAny<string>()))
+                    .Returns(() => new HttpClient(new Handler(this)));
+
+                return factory.Object;
+            }
+        }
+
+        private sealed class Handler(StubDemoService owner) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken
+            )
+            {
+                owner.RequestUri = request.RequestUri?.ToString();
+
+                return Task.FromResult(
+                    new HttpResponseMessage(owner._status)
+                    {
+                        Content =
+                            owner._settings == null ? null : JsonContent.Create(owner._settings),
+                    }
+                );
+            }
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerHarness.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerHarness.cs
@@ -2,11 +2,11 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Controllers.V4.Profiles;
+using Nocturne.API.Services.Platform;
 using Nocturne.API.Services.Profiles;
 using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Infrastructure.Data;
@@ -21,21 +21,19 @@ internal static class UISettingsControllerHarness
 {
     private static readonly Guid TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
-    internal static UISettingsController NewController(
-        params (string Key, string Value)[] configuration
-    )
+    internal static UISettingsController NewController(bool demoMode = false)
     {
-        return NewController(NewDatabase(), configuration);
+        return NewController(NewDatabase(), demoMode);
     }
 
     internal static UISettingsController NewController(
         NocturneDbContext dbContext,
-        params (string Key, string Value)[] configuration
+        bool demoMode = false
     )
     {
         return NewController(
             new UISettingsService(dbContext, NullLogger<UISettingsService>.Instance),
-            configuration
+            demoMode
         );
     }
 
@@ -54,7 +52,32 @@ internal static class UISettingsControllerHarness
 
     internal static UISettingsController NewController(
         IUISettingsService settingsService,
-        params (string Key, string Value)[] configuration
+        bool demoMode = false
+    )
+    {
+        return NewController(settingsService, DemoMode(demoMode), Mock.Of<IHttpClientFactory>());
+    }
+
+    /// <summary>
+    /// Demo mode as <see cref="IDemoModeService"/> reports it. Without a service URL the controller
+    /// has nothing to proxy to and serves its own demo fixtures.
+    /// </summary>
+    internal static IDemoModeService DemoMode(bool enabled, string? serviceUrl = null)
+    {
+        var demoMode = new Mock<IDemoModeService>();
+        demoMode.SetupGet(d => d.IsEnabled).Returns(enabled);
+        demoMode
+            .SetupGet(d => d.IsConfigured)
+            .Returns(enabled && !string.IsNullOrWhiteSpace(serviceUrl));
+        demoMode.SetupGet(d => d.ServiceUrl).Returns(serviceUrl);
+
+        return demoMode.Object;
+    }
+
+    internal static UISettingsController NewController(
+        IUISettingsService settingsService,
+        IDemoModeService demoMode,
+        IHttpClientFactory httpClientFactory
     )
     {
         var services = new ServiceCollection();
@@ -62,12 +85,8 @@ internal static class UISettingsControllerHarness
 
         return new UISettingsController(
             NullLogger<UISettingsController>.Instance,
-            new ConfigurationBuilder()
-                .AddInMemoryCollection(
-                    configuration.Select(c => new KeyValuePair<string, string?>(c.Key, c.Value))
-                )
-                .Build(),
-            Mock.Of<IHttpClientFactory>(),
+            demoMode,
+            httpClientFactory,
             settingsService
         )
         {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerSectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Profiles/UISettingsControllerSectionTests.cs
@@ -99,7 +99,7 @@ public class UISettingsControllerSectionTests
     [Fact]
     public async Task GetUISettings_inDemoMode_inheritsEverySectionItDoesNotFixture()
     {
-        var controller = NewController(("DemoMode:Enabled", "true"));
+        var controller = NewController(demoMode: true);
 
         var settings = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
 
@@ -115,7 +115,7 @@ public class UISettingsControllerSectionTests
     [Fact]
     public async Task GetUISettings_inDemoMode_keepsItsSampleDevicesServicesAndPlugins()
     {
-        var controller = NewController(("DemoMode:Enabled", "true"));
+        var controller = NewController(demoMode: true);
 
         var settings = OkValue<UISettingsConfiguration>((await controller.GetUISettings()).Result);
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
@@ -251,6 +251,40 @@ public class UISettingsServiceTests
     }
 
     [Fact]
+    public async Task SaveSectionAsync_refusesANameNoSectionOwns()
+    {
+        var context = NewContext();
+        var service = NewService(context);
+
+        var save = () => service.SaveSectionAsync("dataQaulity", new DataQualitySettings());
+
+        await save.Should().ThrowAsync<ArgumentException>();
+        StoredRows(context).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SaveSectionAsync_acceptsEveryRegisteredSectionAndTheAlarmKey()
+    {
+        var service = NewService(NewContext());
+
+        foreach (var section in UISettingsSections.All)
+        {
+            var save = () =>
+                service.SaveSectionAsync(
+                    section.Name,
+                    Activator.CreateInstance(section.Type)!,
+                    CancellationToken.None
+                );
+
+            await save.Should().NotThrowAsync($"section {section.Name} should be writable");
+        }
+
+        var saveAlarms = () => service.SaveSectionAsync("alarms", new UserAlarmConfiguration());
+
+        await saveAlarms.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task SaveAlarmConfigurationAsync_revivesADeactivatedRow()
     {
         var context = NewContext();

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
@@ -263,9 +263,10 @@ public class UISettingsServiceTests
     }
 
     [Fact]
-    public async Task SaveSectionAsync_acceptsEveryRegisteredSectionAndTheAlarmKey()
+    public async Task SaveSectionAsync_acceptsEveryRegisteredSection()
     {
-        var service = NewService(NewContext());
+        var context = NewContext();
+        var service = NewService(context);
 
         foreach (var section in UISettingsSections.All)
         {
@@ -279,9 +280,35 @@ public class UISettingsServiceTests
             await save.Should().NotThrowAsync($"section {section.Name} should be writable");
         }
 
-        var saveAlarms = () => service.SaveSectionAsync("alarms", new UserAlarmConfiguration());
+        await service.SaveSectionAsync(
+            "DATAQUALITY",
+            new DataQualitySettings
+            {
+                SleepSchedule = new SleepScheduleSettings { BedtimeHour = 1 },
+            }
+        );
 
-        await saveAlarms.Should().NotThrowAsync();
+        (await service.GetSettingsAsync()).DataQuality.SleepSchedule.BedtimeHour.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("alarms")]
+    [InlineData("alarmConfiguration")]
+    [InlineData("AlarmConfiguration")]
+    [InlineData("ALARMS")]
+    public async Task SaveSectionAsync_routesEveryAlarmAliasToTheOwningRow(string alias)
+    {
+        var context = NewContext();
+        var service = NewService(context);
+
+        await service.SaveSectionAsync(alias, AlarmConfiguration("aliased", 123));
+
+        foreach (var config in await EveryAlarmReadPath(service))
+        {
+            config.Profiles.Should().ContainSingle().Which.Threshold.Should().Be(123);
+        }
+
+        StoredRows(context).Select(r => r.Key).Should().Equal([AlarmsKey]);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #895.

## One demo-mode truth (item 1)

`UISettingsController` answered "is demo mode on?" from `DemoMode:Enabled` — a key **no deployment sets on the API process** (verified across the Aspire wiring, both compose bundles, and the Helm charts: the API gets `DemoService__Enabled`; `DemoMode__*` goes only to the demo-service project). All seven inline reads were therefore dead in prod, and an eighth dead read (`DemoMode:ServiceUrl`) meant the demo-service proxy had **never once fired**. The controller now injects `IDemoModeService` (which gained `ServiceUrl`, so the URL has one owner too); `IConfiguration` is gone from the ctor.

**Declared delta, and it's the fix (scope corrected by the hostile round):** the delta is real only where `DemoService__Enabled=true` reaches the API process - upstream `aspire start` demo runs and self-hosters who set it. nocturne.run is unaffected: its cloud AppHost never sets the flag on the API container, so the demo tenant there keeps the persisted path it always had. Where the flag IS set, this controller now actually honours demo mode — reads serve the proxy/fixtures instead of the demo tenant's persisted rows, and the five write endpoints echo without persisting into the demo tenant's database. Repo sweep: no other `DemoMode:Enabled` inline read exists; every other consumer already injects the service.

## Guarded section writer (item 2)

`SaveSectionAsync` validates the name against `UISettingsSections` (plus the alarm alias, extracted so the guard and `GetSectionKey` share one definition) and throws instead of silently writing an orphan `ui:settings:<typo>` row nothing reads. The lowercased-row-key invariant is now stated at the one function that owns it.

## Plugins default (item 3): empty by design — documented, not implemented

The evidence says defaults would be inert schema: zero frontend reads of `features.plugins` (pills are data-driven under a prop; the only setting-gated row uses `trackerPills.enabled`), the plugin-toggle UI was deleted long ago, and the 17-entry list has only ever been demo fixture data. Seeding it would persist 17 keys into every tenant and change nothing on screen. Recorded at the initialiser; the demo fixture's comment no longer implies the defaults are merely missing.

## Known design edge (declared, pre-existing convention)

`IDemoModeService` is a config-derived singleton, deployment-wide - flipping `DemoService__Enabled=true` on a multi-tenant API makes EVERY tenant's UI-settings writes echo without persisting, not just a demo tenant's. That matches the platform convention every other consumer already follows; anyone wiring a cloud demo tenant must do it via the demo service, never by flipping the API flag.

## Tests
Nine new demo-mode controller tests (per-endpoint persists-nothing, the exact proxied URI, proxy-failure fallback, never-called-outside-demo) over a reworked harness that injects the service; two section-guard tests driving the registry, not a copied list. Mutation-proved with per-site attribution: flipping all seven demo checks fails nine tests, one per site; the proxy-URL and guard mutations each fail exactly their own test. Full project run: 5898 passed / 0 failed.

