### PR TITLE
fix(connectors): stop Glooko's last publishes swallowing failures, and keep joined errors inside last_error_message

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -427,8 +427,12 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         }
         else
         {
+            // A connector reports one error per failing type per chunk, so a long backfill window
+            // against a persistently failing publisher repeats the same message hundreds of times.
+            // Distinct keeps the joined string informative and bounded; the write site truncates
+            // whatever still exceeds the column.
             var errorMessage = result.Errors.Count > 0
-                ? string.Join("; ", result.Errors)
+                ? string.Join("; ", result.Errors.Distinct(StringComparer.Ordinal))
                 : !string.IsNullOrWhiteSpace(result.Message)
                     ? result.Message
                     : "Sync failed";

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -427,10 +427,8 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         }
         else
         {
-            // A connector reports one error per failing type per chunk, so a long backfill window
-            // against a persistently failing publisher repeats the same message hundreds of times.
-            // Distinct keeps the joined string informative and bounded; the write site truncates
-            // whatever still exceeds the column.
+            // Distinct because the same message repeats per chunk; see
+            // ConnectorConfigurationEntity.LastErrorMessageMaxLength.
             var errorMessage = result.Errors.Count > 0
                 ? string.Join("; ", result.Errors.Distinct(StringComparer.Ordinal))
                 : !string.IsNullOrWhiteSpace(result.Message)

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
@@ -951,7 +951,7 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
             if (lastErrorMessage == string.Empty)
                 config.LastErrorMessage = null; // Explicit clear
             else
-                config.LastErrorMessage = lastErrorMessage;
+                config.LastErrorMessage = FitErrorMessageToColumn(lastErrorMessage);
         }
 
         if (lastErrorAt.HasValue)
@@ -974,5 +974,21 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
             connectorName,
             config.IsHealthy
         );
+    }
+
+    /// <summary>
+    ///     Fits a health error message inside
+    ///     <see cref="ConnectorConfigurationEntity.LastErrorMessageMaxLength"/>, marking the cut so a
+    ///     reader can tell the message is incomplete. Callers join every error of a run, which a long
+    ///     backfill against a failing publisher can grow past the column.
+    /// </summary>
+    private static string FitErrorMessageToColumn(string message)
+    {
+        const string marker = "... (truncated)";
+        const int max = ConnectorConfigurationEntity.LastErrorMessageMaxLength;
+
+        return message.Length <= max
+            ? message
+            : string.Concat(message.AsSpan(0, max - marker.Length), marker);
     }
 }

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
@@ -977,18 +977,22 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
     }
 
     /// <summary>
-    ///     Fits a health error message inside
+    ///     Fits a health error message to
     ///     <see cref="ConnectorConfigurationEntity.LastErrorMessageMaxLength"/>, marking the cut so a
-    ///     reader can tell the message is incomplete. Callers join every error of a run, which a long
-    ///     backfill against a failing publisher can grow past the column.
+    ///     reader can tell the message is incomplete.
     /// </summary>
     private static string FitErrorMessageToColumn(string message)
     {
         const string marker = "... (truncated)";
         const int max = ConnectorConfigurationEntity.LastErrorMessageMaxLength;
 
-        return message.Length <= max
-            ? message
-            : string.Concat(message.AsSpan(0, max - marker.Length), marker);
+        if (message.Length <= max)
+            return message;
+
+        var cut = max - marker.Length;
+        if (char.IsHighSurrogate(message[cut - 1]))
+            cut--;
+
+        return string.Concat(message.AsSpan(0, cut), marker);
     }
 }

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -58,6 +58,9 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     public override string ServiceName => "Glooko";
     protected override string ConnectorSource => DataSources.GlookoConnector;
 
+    private const string SyncSucceededMessage = "Sync completed successfully";
+    private const string PublishFailedMessage = "Sync failed while publishing data";
+
 
     // ── Authentication ──────────────────────────────────────────────────
 
@@ -255,7 +258,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         var result = new SyncResult
         {
             Success = true,
-            Message = "Sync completed successfully",
+            Message = SyncSucceededMessage,
             StartTime = DateTime.UtcNow
         };
 
@@ -335,13 +338,18 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                     result.ItemsSynced.Clear();
                     result.Errors.Clear();
                     result.Success = true;
-                    result.Message = "Sync completed successfully";
+                    result.Message = SyncSucceededMessage;
 
                     _logger.LogInformation(
                         "[{ConnectorSource}] Re-authenticated after 403; retrying sync with patient code {Code}",
                         ConnectorSource, context.PatientCode);
                 }
             }
+
+            // Fetch and authentication failures name themselves; a publish rejection only flips
+            // Success, and Message is the documented fallback for consumers that have no Errors.
+            if (!result.Success && result.Message == SyncSucceededMessage)
+                result.Message = PublishFailedMessage;
 
             result.EndTime = DateTime.UtcNow;
             return result;
@@ -418,13 +426,12 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                         PublishProfileDataAsync, context.Config, cancellationToken,
                         "device settings");
 
-                    var profileStateSpans = context.ProfileMapper.TransformDeviceSettingsToStateSpans(deviceSettings);
-                    if (profileStateSpans.Count > 0)
-                    {
-                        await PublishStateSpanDataAsync(profileStateSpans, context.Config, cancellationToken);
-                        _logger.LogInformation("[{ConnectorSource}] Published {Count} profile state spans from device settings",
-                            ConnectorSource, profileStateSpans.Count);
-                    }
+                    // The spans derive from the device settings but are state spans, so they gate and
+                    // count under StateSpans like every other state-span publish, not under Profiles.
+                    await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
+                        context.ProfileMapper.TransformDeviceSettingsToStateSpans(deviceSettings),
+                        PublishStateSpanDataAsync, context.Config, cancellationToken,
+                        "device settings");
                 }
             }
             catch (GlookoDataForbiddenException) { throw; }
@@ -474,7 +481,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             ? context.V4TreatmentMapper.MapFoodsToConnectorEntries(batchData) : [];
         Func<string, string?> foodResolver = externalEntryId => $"glooko_food_{externalEntryId}";
         await PublishFoodEntriesAndAttributeAsync(
-            foodEntryImports, carbs, foodResolver, config, cancellationToken);
+            foodEntryImports, carbs, foodResolver, result, config, cancellationToken);
 
         await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
             context.StateSpanMapper.TransformV2ToStateSpans(batchData),
@@ -587,7 +594,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         }
 
         await PublishFoodEntriesAndAttributeAsync(
-            foodEntryImports, allCarbs, foodResolver, config, cancellationToken);
+            foodEntryImports, allCarbs, foodResolver, result, config, cancellationToken);
 
         var stateSpans = context.StateSpanMapper.TransformV3ToStateSpans(v3Data);
         stateSpans.AddRange(context.StateSpanMapper.TransformV3PumpModeToStateSpans(v3Data));
@@ -620,6 +627,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         List<ConnectorFoodEntryImport> foodEntryImports,
         List<CarbIntake> carbIntakes,
         Func<string, string?>? foodEntryToCarbLegacyId,
+        SyncResult result,
         GlookoConnectorConfiguration config,
         CancellationToken cancellationToken)
     {
@@ -629,7 +637,17 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         var importedEntries = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
             foodEntryImports, ConnectorSource, WriteOrigin.Live, cancellationToken); // Food is a dormant broadcast category — origin irrelevant until wired.
 
-        if (importedEntries is not { Count: > 0 })
+        // The publisher returns null only from its own catch; an import that reached the catalog
+        // returns a list, empty when nothing was accepted. Food has no SyncDataType toggle on this
+        // connector, so the failure is reported rather than routed through PublishRecordTypeAsync.
+        if (importedEntries is null)
+        {
+            result.Success = false;
+            result.Errors.Add("Food entries publish failed");
+            return;
+        }
+
+        if (importedEntries.Count == 0)
             return;
 
         _logger.LogInformation("[{ConnectorSource}] Published {Count} food entries to connector food catalog",

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorConfigurationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorConfigurationEntity.cs
@@ -91,8 +91,11 @@ public class ConnectorConfigurationEntity : ITenantScoped, ISystemTimestamped
     public DateTime? LastSuccessfulSync { get; set; }
 
     /// <summary>
-    /// Maximum stored length of <see cref="LastErrorMessage"/>. Writers must fit the message to it:
-    /// an over-length assignment fails the very write that records the failure.
+    /// Maximum stored length of <see cref="LastErrorMessage"/>. Writers must fit the message to it,
+    /// and must not cut inside a surrogate pair: a connector reports one error per failing type per
+    /// chunk, so a long backfill against a persistently failing publisher joins a multi-KB string,
+    /// and either an over-length value or a lone surrogate fails the very write that was recording
+    /// the failure.
     /// </summary>
     public const int LastErrorMessageMaxLength = 1000;
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorConfigurationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ConnectorConfigurationEntity.cs
@@ -91,10 +91,16 @@ public class ConnectorConfigurationEntity : ITenantScoped, ISystemTimestamped
     public DateTime? LastSuccessfulSync { get; set; }
 
     /// <summary>
+    /// Maximum stored length of <see cref="LastErrorMessage"/>. Writers must fit the message to it:
+    /// an over-length assignment fails the very write that records the failure.
+    /// </summary>
+    public const int LastErrorMessageMaxLength = 1000;
+
+    /// <summary>
     /// The error message from the most recent failure
     /// </summary>
     [Column("last_error_message")]
-    [MaxLength(1000)]
+    [MaxLength(LastErrorMessageMaxLength)]
     public string? LastErrorMessage { get; set; }
 
     /// <summary>

--- a/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
+++ b/src/Web/packages/app/src/lib/config/connectorPropertyMeta.ts
@@ -86,7 +86,8 @@ export const connectorPropertyMeta = {
   },
   SyncStateSpans: {
     label: 'Sync State Spans',
-    description: 'Sync device state periods like suspend, resume, and mode changes',
+    description:
+      'Sync device state periods like suspend, resume, and mode changes. Turning this off also declines the active-profile and basal-program periods, so the therapy timeline and chart bands lose them.',
     category: 'Sync',
   },
   SyncTempBasals: {

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -302,6 +302,49 @@ public class ConnectorBackgroundServiceTests
             "Expected the specific error messages from SyncResult.Errors to be passed to UpdateHealthStateAsync");
     }
 
+    /// <summary>
+    /// Connectors report one error per failing type per chunk, so a backfill window against a
+    /// persistently failing publisher repeats the same message once per chunk. The joined health
+    /// message must carry it once: an unbounded join overflows last_error_message and fails the very
+    /// write that records the failure.
+    /// </summary>
+    [Fact]
+    public async Task FailedSync_WithRepeatedErrors_JoinsEachDistinctMessageOnce()
+    {
+        var (cleanup, connStr) = CreateSqliteDb();
+        using var _ = cleanup;
+
+        var syncResult = new SyncResult
+        {
+            Success = false,
+            Message = "Fallback message",
+            Errors = [.. Enumerable.Repeat("StateSpans publish failed", 20)]
+        };
+
+        var configServiceMock = BuildEnabledConfigMock();
+        var config = new TestConnectorConfig { Enabled = true, SyncIntervalMinutes = 5 };
+        var serviceProvider = BuildServiceProvider(connStr, configServiceMock, config);
+
+        var sut = new TestConnectorBackgroundService(
+            serviceProvider,
+            syncResult,
+            NullLogger<TestConnectorBackgroundService>.Instance);
+
+        await sut.ExecuteOnceAsync(CancellationToken.None);
+
+        configServiceMock.Verify(
+            x => x.UpdateHealthStateAsync(
+                "TestConnector",
+                It.IsAny<DateTime?>(),
+                It.IsAny<DateTime?>(),
+                "StateSpans publish failed",
+                It.IsAny<DateTime?>(),
+                false,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "twenty identical chunk errors must collapse to one entry in the health message");
+    }
+
     [Fact]
     public async Task FailedSync_WithNoErrors_FallsBackToMessage()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/ConnectorBackgroundServiceTests.cs
@@ -303,13 +303,11 @@ public class ConnectorBackgroundServiceTests
     }
 
     /// <summary>
-    /// Connectors report one error per failing type per chunk, so a backfill window against a
-    /// persistently failing publisher repeats the same message once per chunk. The joined health
-    /// message must carry it once: an unbounded join overflows last_error_message and fails the very
-    /// write that records the failure.
+    /// A repeated error must reach the health message once, and two errors that differ only in case
+    /// are different errors; see <c>ConnectorConfigurationEntity.LastErrorMessageMaxLength</c>.
     /// </summary>
     [Fact]
-    public async Task FailedSync_WithRepeatedErrors_JoinsEachDistinctMessageOnce()
+    public async Task FailedSync_WithRepeatedErrors_JoinsEachDistinctMessageOnceCaseSensitively()
     {
         var (cleanup, connStr) = CreateSqliteDb();
         using var _ = cleanup;
@@ -318,7 +316,11 @@ public class ConnectorBackgroundServiceTests
         {
             Success = false,
             Message = "Fallback message",
-            Errors = [.. Enumerable.Repeat("StateSpans publish failed", 20)]
+            Errors =
+            [
+                .. Enumerable.Repeat("StateSpans publish failed", 20),
+                .. Enumerable.Repeat("statespans publish failed", 20),
+            ]
         };
 
         var configServiceMock = BuildEnabledConfigMock();
@@ -337,12 +339,12 @@ public class ConnectorBackgroundServiceTests
                 "TestConnector",
                 It.IsAny<DateTime?>(),
                 It.IsAny<DateTime?>(),
-                "StateSpans publish failed",
+                "StateSpans publish failed; statespans publish failed",
                 It.IsAny<DateTime?>(),
                 false,
                 It.IsAny<CancellationToken>()),
             Times.Once,
-            "twenty identical chunk errors must collapse to one entry in the health message");
+            "identical chunk errors collapse to one entry, but a case difference is a different error");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorHealthErrorMessageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorHealthErrorMessageTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -18,9 +19,8 @@ using Xunit;
 namespace Nocturne.API.Tests.Services.Connectors;
 
 /// <summary>
-/// <c>last_error_message</c> is length-constrained, and its writer is handed the join of every error
-/// a sync produced — one per failing type per chunk. An over-length assignment fails the write that
-/// was recording the failure, so the service fits the message to the column instead.
+/// The health-state write fits the joined sync errors to the column; see
+/// <see cref="ConnectorConfigurationEntity.LastErrorMessageMaxLength"/>.
 /// </summary>
 public class ConnectorHealthErrorMessageTests : IDisposable
 {
@@ -97,6 +97,31 @@ public class ConnectorHealthErrorMessageTests : IDisposable
         stored.Length.Should().Be(ConnectorConfigurationEntity.LastErrorMessageMaxLength);
         stored.Should().EndWith(TruncationMarker);
         stored.Should().StartWith(joined[..100]);
+    }
+
+    /// <summary>
+    /// A cut that lands between a surrogate pair leaves a lone surrogate, which the driver's strict
+    /// UTF-8 encoder rejects — the same failed write the truncation exists to prevent.
+    /// </summary>
+    [Fact]
+    public async Task UpdateHealthStateAsync_WhenTheCutLandsInsideASurrogatePair_StoresEncodableText()
+    {
+        // The cut keeps 985 chars less the marker, so the pair's high surrogate lands on the boundary.
+        var message = new string('a', 984) + "😀" + new string('b', 100);
+        message.Length.Should().BeGreaterThan(ConnectorConfigurationEntity.LastErrorMessageMaxLength);
+
+        await _service.UpdateHealthStateAsync(ConnectorName, lastErrorMessage: message, isHealthy: false);
+
+        // The tracked entity, not a re-read: SQLite substitutes a replacement character on the way
+        // out, which would hide the lone surrogate the driver has to encode.
+        var stored = _dbContext.ConnectorConfigurations.Local.Single().LastErrorMessage!;
+        stored.Length.Should().BeLessThanOrEqualTo(ConnectorConfigurationEntity.LastErrorMessageMaxLength);
+        stored.Should().EndWith(TruncationMarker);
+        stored.Should().NotContainAny("\uD83D", "\uDE00");
+
+        var strictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+        var encode = () => strictUtf8.GetBytes(stored);
+        encode.Should().NotThrow<EncoderFallbackException>("a lone surrogate cannot be encoded for the write");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorHealthErrorMessageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorHealthErrorMessageTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Connectors;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Utilities;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// <c>last_error_message</c> is length-constrained, and its writer is handed the join of every error
+/// a sync produced — one per failing type per chunk. An over-length assignment fails the write that
+/// was recording the failure, so the service fits the message to the column instead.
+/// </summary>
+public class ConnectorHealthErrorMessageTests : IDisposable
+{
+    private const string ConnectorName = "Glooko";
+    private const string TruncationMarker = "... (truncated)";
+
+    private readonly SqliteConnection _connection;
+    private readonly NocturneDbContext _dbContext;
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly ConnectorConfigurationService _service;
+
+    public ConnectorHealthErrorMessageTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        _dbContext = new NocturneDbContext(dbOptions) { TenantId = _tenantId };
+        _dbContext.Database.EnsureCreated();
+
+        _dbContext.Tenants.Add(new TenantEntity
+        {
+            Id = _tenantId,
+            Slug = "test",
+            DisplayName = "Test",
+            IsActive = true,
+        });
+        _dbContext.ConnectorConfigurations.Add(new ConnectorConfigurationEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            ConnectorName = ConnectorName,
+            IsHealthy = true,
+        });
+        _dbContext.SaveChanges();
+
+        var encryptionService = new Mock<ISecretEncryptionService>();
+        encryptionService.Setup(e => e.IsConfigured).Returns(true);
+
+        _service = new ConnectorConfigurationService(
+            _dbContext,
+            encryptionService.Object,
+            Mock.Of<ISignalRBroadcastService>(),
+            Mock.Of<IAuditContext>(),
+            new ConfigurationBuilder().Build(),
+            Mock.Of<IHostEnvironment>(),
+            Enumerable.Empty<IConnectorCacheInvalidator>(),
+            NullLogger<ConnectorConfigurationService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task UpdateHealthStateAsync_WithAnOverlongErrorMessage_StoresItTruncatedAndMarked()
+    {
+        // Enough distinct chunk errors that de-duplication cannot bring the join under the column.
+        var errors = Enumerable.Range(1, 40)
+            .Select(i => $"Chunk {i}/40 failed (2026-01-{i % 28 + 1:00} to 2026-02-{i % 28 + 1:00})");
+        var joined = string.Join("; ", errors);
+        joined.Length.Should().BeGreaterThan(ConnectorConfigurationEntity.LastErrorMessageMaxLength);
+
+        await _service.UpdateHealthStateAsync(ConnectorName, lastErrorMessage: joined, isHealthy: false);
+
+        var stored = (await _service.GetHealthStateAsync(ConnectorName))!.LastErrorMessage!;
+        stored.Length.Should().Be(ConnectorConfigurationEntity.LastErrorMessageMaxLength);
+        stored.Should().EndWith(TruncationMarker);
+        stored.Should().StartWith(joined[..100]);
+    }
+
+    [Fact]
+    public async Task UpdateHealthStateAsync_WithAMessageThatFits_StoresItUnchanged()
+    {
+        const string message = "StateSpans publish failed";
+
+        await _service.UpdateHealthStateAsync(ConnectorName, lastErrorMessage: message, isHealthy: false);
+
+        var stored = (await _service.GetHealthStateAsync(ConnectorName))!.LastErrorMessage;
+        stored.Should().Be(message);
+    }
+
+    [Fact]
+    public async Task UpdateHealthStateAsync_AtExactlyTheColumnLength_StoresItUnchanged()
+    {
+        var message = new string('x', ConnectorConfigurationEntity.LastErrorMessageMaxLength);
+
+        await _service.UpdateHealthStateAsync(ConnectorName, lastErrorMessage: message, isHealthy: false);
+
+        var stored = (await _service.GetHealthStateAsync(ConnectorName))!.LastErrorMessage;
+        stored.Should().Be(message);
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
@@ -11,6 +11,7 @@ using Nocturne.Connectors.Glooko.Configurations;
 using Nocturne.Connectors.Glooko.Services;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Xunit;
@@ -20,14 +21,15 @@ namespace Nocturne.Connectors.Glooko.Tests.Services;
 /// <summary>
 /// A rejected publish must reach <see cref="SyncResult.Success"/> and <see cref="SyncResult.Errors"/>
 /// for every data type Glooko syncs, on both the V2 and the V3 fetch path. A tenant whose state spans,
-/// temp basals, device events, system events or profiles never land otherwise sees a green sync with
-/// that data missing, indistinguishable from a cycle that had none of it to publish.
+/// temp basals, device events, system events, profiles or food entries never land otherwise sees a
+/// green sync with that data missing, indistinguishable from a cycle that had none of it to publish.
 /// </summary>
 public class GlookoConnectorServicePublishFailureTests
 {
     public enum PublishKind
     {
         StateSpans,
+        ProfileStateSpans,
         TempBasals,
         DeviceEvents,
         SystemEvents,
@@ -37,11 +39,13 @@ public class GlookoConnectorServicePublishFailureTests
     // Device and system events come from the V3 graph series; the V2 endpoints carry neither.
     [Theory]
     [InlineData(true, PublishKind.StateSpans)]
+    [InlineData(true, PublishKind.ProfileStateSpans)]
     [InlineData(true, PublishKind.TempBasals)]
     [InlineData(true, PublishKind.DeviceEvents)]
     [InlineData(true, PublishKind.SystemEvents)]
     [InlineData(true, PublishKind.Profiles)]
     [InlineData(false, PublishKind.StateSpans)]
+    [InlineData(false, PublishKind.ProfileStateSpans)]
     [InlineData(false, PublishKind.TempBasals)]
     [InlineData(false, PublishKind.Profiles)]
     public async Task SyncDataAsync_WhenOnePublishIsRejected_ReportsFailure(
@@ -58,6 +62,47 @@ public class GlookoConnectorServicePublishFailureTests
         result.Errors.Should().ContainSingle();
     }
 
+    /// <summary>
+    /// The result is constructed optimistically, so a publish-only failure must not leave the
+    /// success literal behind: <see cref="SyncResult.Message"/> is the documented fallback for
+    /// consumers that find no <see cref="SyncResult.Errors"/>.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SyncDataAsync_WhenAPublishIsRejected_ReplacesTheOptimisticMessage(bool useV3Api)
+    {
+        var service = BuildService(PublishKind.StateSpans);
+
+        var result = await service.SyncDataAsync(
+            BuildRequest(), BuildConfig(useV3Api), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Be("Sync failed while publishing data");
+    }
+
+    /// <summary>
+    /// Profile state spans are state spans, so the tenant's StateSpans toggle governs them even
+    /// though the device-settings fetch that produces them is gated on Profiles.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SyncDataAsync_WhenStateSpansAreNotRequested_DoesNotPublishProfileStateSpans(
+        bool useV3Api)
+    {
+        var service = BuildService(rejected: null);
+        var request = BuildRequest();
+        request.DataTypes = [SyncDataType.Profiles];
+
+        var result = await service.SyncDataAsync(request, BuildConfig(useV3Api), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        service.Published.Should().Contain(PublishKind.Profiles);
+        service.Published.Should().NotContain(PublishKind.ProfileStateSpans);
+        result.ItemsSynced.Should().NotContainKey(SyncDataType.StateSpans);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -71,7 +116,8 @@ public class GlookoConnectorServicePublishFailureTests
 
         result.Success.Should().BeTrue();
         result.Errors.Should().BeEmpty();
-        result.ItemsSynced[SyncDataType.StateSpans].Should().Be(1);
+        // One span from the chunk's suspended basal, one from the device settings' active program.
+        result.ItemsSynced[SyncDataType.StateSpans].Should().Be(2);
         result.ItemsSynced[SyncDataType.Profiles].Should().Be(1);
 
         if (useV3Api)
@@ -86,6 +132,41 @@ public class GlookoConnectorServicePublishFailureTests
             result.ItemsSynced[SyncDataType.TempBasals].Should().Be(2);
             result.ItemsSynced.Should().NotContainKey(SyncDataType.DeviceEvents);
         }
+    }
+
+    /// <summary>
+    /// The food-entry publisher is metadata-shaped: it answers with the imported entries, and with
+    /// <c>null</c> only from its own catch. A rejected import must therefore be reported, and an
+    /// import that accepted nothing must not be. Both fetch paths share the publish helper; the V2
+    /// endpoints are the ones that carry standalone foods.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheFoodEntryPublishFails_ReportsFailure()
+    {
+        var (publisher, metadata) = BuildFoodPublisher(imported: null);
+        var service = BuildService(rejected: null, publisher);
+
+        var result = await service.SyncDataAsync(
+            BuildRequest(), BuildConfig(useV3Api: false), CancellationToken.None);
+
+        VerifyFoodEntriesWerePublished(metadata);
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Contain("Food entries");
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_WhenTheFoodEntryPublishImportsNothing_ReportsSuccess()
+    {
+        var (publisher, metadata) = BuildFoodPublisher(imported: []);
+        var service = BuildService(rejected: null, publisher);
+
+        var result = await service.SyncDataAsync(
+            BuildRequest(), BuildConfig(useV3Api: false), CancellationToken.None);
+
+        VerifyFoodEntriesWerePublished(metadata);
+        result.Success.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
     }
 
     // ── Test infrastructure ─────────────────────────────────────────────
@@ -110,17 +191,21 @@ public class GlookoConnectorServicePublishFailureTests
         """;
 
     /// <summary>
-    /// One settings snapshot carrying a basal segment, which maps to a single profile. It carries no
-    /// <c>basalSettings.activeBasalProgram</c>, so it yields no profile state spans — those publish
-    /// through a separate hand-inlined call this theory does not cover.
+    /// One settings snapshot carrying a basal segment (which maps to a single profile) and an active
+    /// basal program (which maps to a single profile state span).
     /// </summary>
     private static string DeviceSettingsPayload() =>
         """
         {"deviceSettings":{"pumps":{"pump-1":{"@TS@":{
+          "basalSettings":{"activeBasalProgram":"Default"},
           "pumpProfilesBasal":[{"segments":{"profileName":"Default","current":true,
             "data":[{"segmentStart":0.0,"duration":24.0,"value":0.8}]}}]
         }}}}}
         """.Replace("@TS@", EventTimestamp);
+
+    /// <summary>One standalone V2 food record, which maps to a single connector food entry import.</summary>
+    private static string FoodsPayload() =>
+        $"{{\"foods\":[{{\"guid\":\"food-1\",\"timestamp\":\"{EventTimestamp}\",\"carbs\":30.0,\"name\":\"Toast\"}}]}}";
 
     private static SyncRequest BuildRequest() => new()
     {
@@ -141,8 +226,38 @@ public class GlookoConnectorServicePublishFailureTests
         UseV3Api = useV3Api,
     };
 
-    private static RecordingGlookoConnectorService BuildService(PublishKind? rejected) =>
-        new(new HttpClient(new GlookoEndpointHandler()), new StaticGlookoTokenProvider(), rejected);
+    private static RecordingGlookoConnectorService BuildService(
+        PublishKind? rejected, IConnectorPublisher? publisher = null) =>
+        new(new HttpClient(new GlookoEndpointHandler()), new StaticGlookoTokenProvider(), rejected, publisher);
+
+    /// <summary>
+    /// A publisher whose food-entry import answers <paramref name="imported"/>. Every other publish
+    /// the sync reaches is intercepted by <see cref="RecordingGlookoConnectorService"/>.
+    /// </summary>
+    private static (IConnectorPublisher Publisher, Mock<IMetadataPublisher> Metadata) BuildFoodPublisher(
+        IReadOnlyList<ConnectorFoodEntry>? imported)
+    {
+        var metadata = new Mock<IMetadataPublisher>();
+        metadata
+            .Setup(m => m.PublishConnectorFoodEntriesAsync(
+                It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(), It.IsAny<string>(),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(imported);
+
+        var publisher = new Mock<IConnectorPublisher>();
+        publisher.SetupGet(p => p.IsAvailable).Returns(true);
+        publisher.SetupGet(p => p.Metadata).Returns(metadata.Object);
+
+        return (publisher.Object, metadata);
+    }
+
+    private static void VerifyFoodEntriesWerePublished(Mock<IMetadataPublisher> metadata) =>
+        metadata.Verify(
+            m => m.PublishConnectorFoodEntriesAsync(
+                It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(), It.IsAny<string>(),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the import must actually be attempted, or the assertions below prove nothing");
 
     /// <summary>
     /// Accepts every publish except the one under test, and records which publishes were reached.
@@ -152,23 +267,31 @@ public class GlookoConnectorServicePublishFailureTests
         private readonly PublishKind? _rejected;
 
         public RecordingGlookoConnectorService(
-            HttpClient httpClient, GlookoAuthTokenProvider tokenProvider, PublishKind? rejected)
+            HttpClient httpClient, GlookoAuthTokenProvider tokenProvider, PublishKind? rejected,
+            IConnectorPublisher? publisher = null)
             : base(
                 httpClient,
                 new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
                 NullLogger<GlookoConnectorService>.Instance,
                 Mock.Of<IRetryDelayStrategy>(),
                 Mock.Of<IRateLimitingStrategy>(),
-                tokenProvider)
+                tokenProvider,
+                publisher)
         {
             _rejected = rejected;
         }
 
         public List<PublishKind> Published { get; } = [];
 
+        // Profile state spans reach the same publish as the chunks' spans; the profile mapper's
+        // OriginalId prefix is what tells the two batches apart.
         protected override Task<bool> PublishStateSpanDataAsync(
             IEnumerable<StateSpan> stateSpans, GlookoConnectorConfiguration config,
-            CancellationToken cancellationToken = default) => Record(PublishKind.StateSpans);
+            CancellationToken cancellationToken = default) =>
+            Record(stateSpans.All(s =>
+                s.OriginalId?.StartsWith("glooko_active_profile_", StringComparison.Ordinal) == true)
+                ? PublishKind.ProfileStateSpans
+                : PublishKind.StateSpans);
 
         protected override Task<bool> PublishTempBasalDataAsync(
             IEnumerable<TempBasal> records, GlookoConnectorConfiguration config,
@@ -272,7 +395,7 @@ public class GlookoConnectorServicePublishFailureTests
                 return Json("{\"readings\":[]}");
 
             if (Matches(path, GlookoConstants.FoodsPath))
-                return Json("{\"foods\":[]}");
+                return Json(FoodsPayload());
 
             // MeterReadingsPath is a prefix of the CGM path's parent, so it is matched last.
             if (Matches(path, GlookoConstants.MeterReadingsPath))


### PR DESCRIPTION
Closes #910.

## The last two swallowing publishes

**Profile state spans** (`GlookoConnectorService.cs:429-434` — the block closed issue #784 named but never fixed) route through `PublishRecordTypeAsync`, counting under **StateSpans**, not Profiles: they are `StateSpan` records, every other state-span publish in the connector counts there, and the V3 graph path already emits profile-category spans under that counter — two counters for the same data would have been the new inconsistency. Declared consequence: the publish is now additionally gated on the tenant's StateSpans toggle (`Profiles` on + `StateSpans` off no longer writes them).

**Food entries**: null from the metadata publisher is provably the failure discriminator (its only null return is its own catch; the import service returns a non-nullable list, empty for nothing-to-import). Failure now sets `Success=false` + an `Errors` entry; empty still reports success. Deliberately *not* routed through `PublishRecordTypeAsync` — `SyncDataType.Food` isn't in Glooko's supported set, so active-type gating would have silently disabled the food publish entirely.

## Honest `Message`

On a publish-only failure `SyncResult.Message` now reads "Sync failed while publishing data" instead of the optimistic construction literal (fetch/auth paths already name themselves; the Errors-preferred consumer logic is untouched).

## The `last_error_message` overflow (shared sites only)

The health-state join de-duplicates errors (order-preserving `Distinct`), and the write site truncates to the column's `[MaxLength(1000)]` — now a shared const on the entity, so the attribute and the truncation cannot drift — with a `"... (truncated)"` marker. A long backfill window against a persistently-failing publisher no longer 22001s the very write meant to record the failure.

## Tests
Both API modes drive the profile-span rows (told apart by the mapper's `glooko_active_profile_` prefix), the counting decision is pinned (`ItemsSynced[StateSpans] == 2`), the new toggle gate is pinned in both modes, food failure/empty are distinguished with the import verified attempted, and the join/truncation tests cover dedup, the >1000 case (exact stored length, marker, head preserved) and both boundaries. Five mutations, each named, each failing exactly its own tests. Glooko 93/93; Connectors.Core 124/124; API.Tests 5891/0.

Deliberately untouched: `BaseConnectorService`'s log/zero code, so this merges cleanly with #918.
