### PR TITLE
fix(api): serve any compatibility analysis by id, and join auth audit events to the request trace

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Platform/CompatibilityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/CompatibilityController.cs
@@ -202,17 +202,7 @@ public class CompatibilityController : ControllerBase
     {
         try
         {
-            var analyses = await _repository.GetAnalysesAsync(
-                null,
-                null,
-                null,
-                null,
-                1,
-                0,
-                cancellationToken
-            );
-
-            var analysis = analyses.FirstOrDefault(a => a.Id == id);
+            var analysis = await _repository.GetAnalysisByIdAsync(id, cancellationToken);
 
             if (analysis == null)
             {

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DiscrepancyController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/DiscrepancyController.cs
@@ -238,13 +238,7 @@ public class DiscrepancyController : ControllerBase
     {
         try
         {
-            var analyses = await _discrepancyRepository.GetAnalysesAsync(
-                count: 1,
-                skip: 0,
-                cancellationToken: cancellationToken
-            );
-
-            var analysis = analyses.FirstOrDefault(a => a.Id == id);
+            var analysis = await _discrepancyRepository.GetAnalysisByIdAsync(id, cancellationToken);
             if (analysis == null)
             {
                 return NotFound($"Discrepancy analysis with ID {id} not found");

--- a/src/API/Nocturne.API/Services/Auth/AuthAuditService.cs
+++ b/src/API/Nocturne.API/Services/Auth/AuthAuditService.cs
@@ -1,4 +1,5 @@
 using Nocturne.API.Extensions;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 
@@ -23,6 +24,7 @@ public class AuthAuditService : IAuthAuditService
 {
     private readonly NocturneDbContext _dbContext;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IAuditContext _auditContext;
     private readonly ILogger<AuthAuditService> _logger;
 
     /// <summary>
@@ -31,10 +33,12 @@ public class AuthAuditService : IAuthAuditService
     public AuthAuditService(
         NocturneDbContext dbContext,
         IHttpContextAccessor httpContextAccessor,
+        IAuditContext auditContext,
         ILogger<AuthAuditService> logger)
     {
         _dbContext = dbContext;
         _httpContextAccessor = httpContextAccessor;
+        _auditContext = auditContext;
         _logger = logger;
     }
 
@@ -67,6 +71,7 @@ public class AuthAuditService : IAuthAuditService
                 ErrorMessage = errorMessage,
                 DetailsJson = detailsJson,
                 RefreshTokenId = refreshTokenId,
+                TraceId = _auditContext.TraceId,
                 CreatedAt = DateTime.UtcNow,
             });
             await _dbContext.SaveChangesAsync();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Abstractions/IDiscrepancyAnalysisRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Abstractions/IDiscrepancyAnalysisRepository.cs
@@ -47,6 +47,14 @@ public interface IDiscrepancyAnalysisRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Retrieves a single discrepancy analysis by identifier, with its detailed discrepancies
+    /// loaded, or <c>null</c> when the current tenant has no analysis with that identifier
+    /// </summary>
+    Task<DiscrepancyAnalysisEntity?> GetAnalysisByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets compatibility metrics for a specified date range
     /// </summary>
     Task<CompatibilityMetrics> GetCompatibilityMetricsAsync(

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DiscrepancyAnalysisEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DiscrepancyAnalysisEntity.cs
@@ -13,9 +13,6 @@ public class DiscrepancyAnalysisEntity : ITenantScoped
     /// <summary>
     /// Identifier of the tenant this discrepancy analysis belongs to
     /// </summary>
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
     [Column("tenant_id")]
     public Guid TenantId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DiscrepancyDetailEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/DiscrepancyDetailEntity.cs
@@ -13,9 +13,6 @@ public class DiscrepancyDetailEntity : ITenantScoped
     /// <summary>
     /// Identifier of the tenant this discrepancy detail belongs to
     /// </summary>
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
     [Column("tenant_id")]
     public Guid TenantId { get; set; }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/DiscrepancyAnalysisRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/DiscrepancyAnalysisRepository.cs
@@ -170,6 +170,23 @@ public class DiscrepancyAnalysisRepository : IDiscrepancyAnalysisRepository
     }
 
     /// <summary>
+    /// Get a single analysis by identifier
+    /// </summary>
+    /// <param name="id">The analysis identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The matching analysis with its discrepancies, or null when none matches.</returns>
+    public async Task<DiscrepancyAnalysisEntity?> GetAnalysisByIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await _context
+            .DiscrepancyAnalyses.Where(a => a.Id == id)
+            .Include(a => a.Discrepancies)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <summary>
     /// Get compatibility metrics for dashboard
     /// </summary>
     /// <param name="fromDate">Optional start date for metrics calculation.</param>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/DirectGrantControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/DirectGrantControllerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -69,6 +70,7 @@ public class DirectGrantControllerTests : IDisposable
         var auditService = new AuthAuditService(
             _dbContext,
             new HttpContextAccessor { HttpContext = httpContext },
+            new AuditContext(),
             new Mock<ILogger<AuthAuditService>>().Object);
         var directGrantService = new DirectGrantService(
             auditService, new Mock<ILogger<DirectGrantService>>().Object);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/TenantDirectGrantControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/TenantDirectGrantControllerTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Controllers.V4.PlatformAdmin;
 using Nocturne.API.Middleware.Handlers;
+using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.Auth;
 using Nocturne.API.Services.Identity;
 using Nocturne.Connectors.Core.Utilities;
@@ -93,6 +94,7 @@ public class TenantDirectGrantControllerTests : IDisposable
             new AuthAuditService(
                 _auditDbContext,
                 new HttpContextAccessor { HttpContext = httpContext },
+                new AuditContext(),
                 new Mock<ILogger<AuthAuditService>>().Object),
             new Mock<ILogger<DirectGrantService>>().Object);
         var tenantMemberService = new TenantMemberService(factory.Object);

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/CompatibilityAnalysisDetailTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/CompatibilityAnalysisDetailTests.cs
@@ -1,0 +1,205 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Configuration;
+using Nocturne.API.Controllers.V4.Platform;
+using Nocturne.API.Controllers.V4.TenantAdmin;
+using Nocturne.API.Services.Compatibility;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Repositories;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Platform;
+
+/// <summary>
+/// The analysis-detail endpoints serve any analysis in the tenant's history, not just the newest
+/// one, and carry the same child discrepancies the list endpoint loads. Driven over the real
+/// repository so the id predicate is proven in the query rather than in memory.
+/// </summary>
+[Trait("Category", "Unit")]
+public class CompatibilityAnalysisDetailTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions;
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly Guid _otherTenantId = Guid.CreateVersion7();
+    private static readonly Guid OlderAnalysisId = new("01900000-0000-7000-8000-000000000001");
+    private static readonly Guid NewerAnalysisId = new("01900000-0000-7000-8000-000000000002");
+    private static readonly Guid OtherTenantAnalysisId = new("01900000-0000-7000-8000-000000000003");
+
+    public CompatibilityAnalysisDetailTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
+            .Options;
+
+        using var seed = new NocturneDbContext(_dbOptions) { TenantId = _tenantId };
+        seed.Database.EnsureCreated();
+        seed.Tenants.Add(Tenant(_tenantId, "default"));
+        seed.DiscrepancyAnalyses.Add(
+            Analysis(OlderAnalysisId, "trace-older", DateTimeOffset.UnixEpoch));
+        seed.DiscrepancyAnalyses.Add(
+            Analysis(NewerAnalysisId, "trace-newer", DateTimeOffset.UnixEpoch.AddDays(1)));
+        seed.DiscrepancyDetails.Add(Detail(OlderAnalysisId, "older-field"));
+        seed.DiscrepancyDetails.Add(Detail(NewerAnalysisId, "newer-field"));
+        seed.SaveChanges();
+
+        using var otherSeed = new NocturneDbContext(_dbOptions) { TenantId = _otherTenantId };
+        otherSeed.Tenants.Add(Tenant(_otherTenantId, "other"));
+        otherSeed.DiscrepancyAnalyses.Add(
+            Analysis(OtherTenantAnalysisId, "trace-other", DateTimeOffset.UnixEpoch.AddDays(2)));
+        otherSeed.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetAnalysisDetail_ServesAnAnalysisOlderThanTheNewest()
+    {
+        var detail = await DetailAsync(OlderAnalysisId);
+
+        detail.Id.Should().Be(OlderAnalysisId);
+        detail.TraceId.Should().Be("trace-older");
+    }
+
+    [Fact]
+    public async Task GetAnalysisDetail_LoadsTheOlderAnalysisChildDiscrepancies()
+    {
+        var detail = await DetailAsync(OlderAnalysisId);
+
+        detail.Discrepancies.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new
+            {
+                Field = "older-field",
+                DiscrepancyType = DiscrepancyType.StringValue,
+                Severity = DiscrepancySeverity.Minor,
+                NightscoutValue = "1",
+                NocturneValue = "2",
+                Description = "differs",
+            });
+    }
+
+    [Fact]
+    public async Task GetAnalysisDetail_StillServesTheNewestAnalysis()
+    {
+        var detail = await DetailAsync(NewerAnalysisId);
+
+        detail.Id.Should().Be(NewerAnalysisId);
+        detail.Discrepancies.Should().ContainSingle().Which.Field.Should().Be("newer-field");
+    }
+
+    [Fact]
+    public async Task GetAnalysisDetail_DoesNotServeAnotherTenantsAnalysis()
+    {
+        var result = await CreateCompatibilityController()
+            .GetAnalysisDetail(OtherTenantAnalysisId);
+
+        result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task GetAnalysisDetail_IsNotFoundForAnUnknownId()
+    {
+        var result = await CreateCompatibilityController().GetAnalysisDetail(Guid.CreateVersion7());
+
+        result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task GetDiscrepancyAnalysis_ServesAnAnalysisOlderThanTheNewest()
+    {
+        var controller = new DiscrepancyController(
+            CreateRepository(), Mock.Of<ILogger<DiscrepancyController>>());
+
+        var result = await controller.GetDiscrepancyAnalysis(OlderAnalysisId);
+
+        var analysis = result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<DiscrepancyAnalysisDto>().Subject;
+        analysis.Id.Should().Be(OlderAnalysisId);
+        analysis.Discrepancies.Should().ContainSingle().Which.Field.Should().Be("older-field");
+    }
+
+    [Fact]
+    public async Task GetDiscrepancyAnalysis_DoesNotServeAnotherTenantsAnalysis()
+    {
+        var controller = new DiscrepancyController(
+            CreateRepository(), Mock.Of<ILogger<DiscrepancyController>>());
+
+        var result = await controller.GetDiscrepancyAnalysis(OtherTenantAnalysisId);
+
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    private async Task<AnalysisDetailDto> DetailAsync(Guid id)
+    {
+        var result = await CreateCompatibilityController().GetAnalysisDetail(id);
+
+        return result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<AnalysisDetailDto>().Subject;
+    }
+
+    private CompatibilityController CreateCompatibilityController() =>
+        new(
+            Mock.Of<IDiscrepancyPersistenceService>(),
+            CreateRepository(),
+            Options.Create(new CompatibilityProxyConfiguration()),
+            Mock.Of<ILogger<CompatibilityController>>());
+
+    private DiscrepancyAnalysisRepository CreateRepository() =>
+        new(new NocturneDbContext(_dbOptions) { TenantId = _tenantId });
+
+    private static TenantEntity Tenant(Guid id, string slug) =>
+        new()
+        {
+            Id = id,
+            Slug = slug,
+            DisplayName = slug,
+            IsActive = true,
+        };
+
+    private static DiscrepancyAnalysisEntity Analysis(
+        Guid id, string traceId, DateTimeOffset timestamp) =>
+        new()
+        {
+            Id = id,
+            TraceId = traceId,
+            AnalysisTimestamp = timestamp,
+            RequestMethod = "GET",
+            RequestPath = "/api/v1/entries",
+            OverallMatch = ResponseMatchType.MinorDifferences,
+            StatusCodeMatch = true,
+            BodyMatch = false,
+            TotalProcessingTimeMs = 12,
+            Summary = "one field differs",
+            MinorDiscrepancyCount = 1,
+        };
+
+    private static DiscrepancyDetailEntity Detail(Guid analysisId, string field) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            AnalysisId = analysisId,
+            DiscrepancyType = DiscrepancyType.StringValue,
+            Severity = DiscrepancySeverity.Minor,
+            Field = field,
+            NightscoutValue = "1",
+            NocturneValue = "2",
+            Description = "differs",
+            RecordedAt = DateTimeOffset.UnixEpoch,
+        };
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/AuthAuditServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/AuthAuditServiceTests.cs
@@ -4,6 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Nocturne.API.Middleware;
+using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Authorization;
@@ -14,8 +16,9 @@ using Xunit;
 namespace Nocturne.API.Tests.Services.Auth;
 
 /// <summary>
-/// Covers how <see cref="AuthAuditService"/> resolves the actor and target tenant of an event
-/// when the caller does not name them, over a real database rather than argument matchers.
+/// Covers how <see cref="AuthAuditService"/> resolves the actor, target tenant and request trace
+/// of an event when the caller does not name them, over a real database rather than argument
+/// matchers.
 /// </summary>
 public class AuthAuditServiceTests : IDisposable
 {
@@ -199,10 +202,32 @@ public class AuthAuditServiceTests : IDisposable
         Assert.Equal(_tenantId, row.TenantId);
     }
 
+    [Fact]
+    public async Task Log_JoinsTheEventToTheTraceTheAuditMiddlewareStamped()
+    {
+        var row = await LogAndReadAsync(
+            AuthAuditEventType.Login,
+            _subjectId,
+            caller: null,
+            requestTrace: "0HN7GKQ8V1J2K:00000003");
+
+        Assert.Equal("0HN7GKQ8V1J2K:00000003", row.TraceId);
+    }
+
+    [Fact]
+    public async Task Log_LeavesTheTraceNullOutsideARequest()
+    {
+        var row = await LogAndReadAsync(AuthAuditEventType.Logout, _subjectId, caller: null);
+
+        Assert.Null(row.TraceId);
+    }
+
     /// <summary>
     /// Writes one event through the real service on a context pinned to
     /// <paramref name="pinnedTenantId"/>, with <paramref name="caller"/> on the ambient request,
-    /// and reads the row back.
+    /// and reads the row back. A non-null <paramref name="requestTrace"/> makes the request one
+    /// <see cref="AuditContextMiddleware"/> has already run over, as it has for every caller of
+    /// the service.
     /// </summary>
     private async Task<AuthAuditLogEntity> LogAndReadAsync(
         string eventType,
@@ -210,12 +235,21 @@ public class AuthAuditServiceTests : IDisposable
         AuthContext? caller,
         Guid? pinnedTenantId = null,
         AuthAuditActor? actor = null,
-        Guid? tenantId = null)
+        Guid? tenantId = null,
+        string? requestTrace = null)
     {
         var httpContext = new DefaultHttpContext();
         if (caller is not null)
         {
             httpContext.Items["AuthContext"] = caller;
+        }
+
+        var auditContext = new AuditContext();
+        if (requestTrace is not null)
+        {
+            httpContext.TraceIdentifier = requestTrace;
+            await new AuditContextMiddleware(_ => Task.CompletedTask)
+                .InvokeAsync(httpContext, auditContext);
         }
 
         await using var dbContext = new NocturneDbContext(_dbOptions)
@@ -226,6 +260,7 @@ public class AuthAuditServiceTests : IDisposable
         var service = new AuthAuditService(
             dbContext,
             new HttpContextAccessor { HttpContext = httpContext },
+            auditContext,
             new Mock<ILogger<AuthAuditService>>().Object);
 
         await service.LogAsync(


### PR DESCRIPTION
Addresses #892 — the issue stays open, narrowed to a repo-wide doc-duplication sweep found during the fix (commented there).

## The detail endpoint serves history (item 1)

`GetAnalysisDetail` fetched `count: 1, skip: 0` and filtered by id in memory — every id but the newest 404'd. A tenant-scoped `GetAnalysisByIdAsync` (same `.Include(a => a.Discrepancies)` as the list path — loaded-shape parity proven by mutation, not inspection) now serves any retained analysis. **Scope extension:** `DiscrepancyController.GetDiscrepancyAnalysis` carried the byte-identical defect behind a second route the issue didn't name; both consume the new call, both covered.

## Auth events join traces (item 2)

`AuthAuditService` stamps `TraceId` from the injected `IAuditContext` — the *same field* the mutation and read audit writers already read, so all three audit families share one correlation key by construction rather than by parallel derivation. Every service caller sits behind the audit middleware; background scopes leave it null, which the column accepts. Pre-existing rows stay NULL (backfill is #913-territory; no schema change here, no migration).

## Item 3

The duplicate `TenantId` summary deleted on both discrepancy entities.

## Tests
7 by-id tests over the real repository (SQLite, both controllers) + 2 trace tests driving the real audit middleware. Four mutants, each killed by its named set: newest-only revert (3 older-analysis tests), dropped Include (3 child assertions — the parity proof), IgnoreQueryFilters (both cross-tenant tests), dropped TraceId assignment (the join test, with the outside-request null test still passing). Harness notes for the next agent: EF-SQLite can't ORDER BY DateTimeOffset (the list path isn't unit-testable there), and v7 Guids aren't monotonic within a millisecond — seeded ids are pinned.

API.Tests 5912/0; Infrastructure.Data.Tests 673/0.

## Declared deltas
- The detail endpoints return any tenant-retained analysis (same DTO, same 404 shape for unknown ids).
- New auth-audit rows carry the request trace id; historical rows stay NULL.
