### PR TITLE
test(connectors): prove Glooko's per-chunk counts accumulate

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConstants.cs
@@ -129,6 +129,12 @@ public static class GlookoConstants
     /// </summary>
     public static readonly TimeSpan SessionLifetime = TimeSpan.FromHours(24);
 
+    /// <summary>
+    ///     Width of one fetch window. A sync request's range is sliced into chunks this wide, each
+    ///     fetched and published on its own.
+    /// </summary>
+    public static readonly TimeSpan SyncChunkSize = TimeSpan.FromDays(14);
+
     // -- Device information (sent during sign-in) -----------------------------
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -296,7 +296,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 : context.TimeMapper.ToGlookoTime(DateTime.UtcNow.AddMonths(-6)).AddDays(-1);
             var to = context.TimeMapper.ToGlookoTime(DateTime.UtcNow).AddDays(1);
 
-            var chunks = DateChunker.Chunk(from, to, TimeSpan.FromDays(14)).ToList();
+            var chunks = DateChunker.Chunk(from, to, GlookoConstants.SyncChunkSize).ToList();
 
             _logger.LogInformation(
                 "[{ConnectorSource}] Syncing {From:yyyy-MM-dd} to {To:yyyy-MM-dd} in {ChunkCount} chunk(s)",

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceMultiChunkTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceMultiChunkTests.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Glooko.Configurations;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+/// A sync window wider than one chunk is fetched and published a chunk at a time, so every
+/// <see cref="SyncResult.ItemsSynced"/> entry must be the sum over the chunks. A count that is
+/// assigned rather than accumulated reports only the last chunk's work, and a publish that never
+/// touches the dictionary reports none at all — either way the tenant's sync summary understates
+/// what landed.
+/// </summary>
+public class GlookoConnectorServiceMultiChunkTests
+{
+    /// <summary>
+    /// The chunks carry different record counts (one, then two), so a per-chunk count, the last
+    /// chunk's count and the sum are three different numbers.
+    /// </summary>
+    private static int RecordsInChunk(int chunkOrdinal) => chunkOrdinal + 1;
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SyncDataAsync_AcrossChunks_SumsStateSpansAndTempBasals(bool useV3Api)
+    {
+        var handler = new GlookoEndpointHandler(RecordsInChunk);
+        var service = GlookoSyncHarness.Service(handler);
+
+        var result = await service.SyncDataAsync(
+            BuildRequest(), GlookoSyncHarness.Config(useV3Api), CancellationToken.None);
+
+        handler.WindowCount.Should().Be(2,
+            "the window must actually span more than one chunk, or the assertions below prove nothing");
+        result.Success.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+
+        // Three suspended basals across the two chunks, plus the device settings' active program.
+        result.ItemsSynced[SyncDataType.StateSpans].Should().Be(4);
+
+        // V2 draws temp basals from the temporary-basal and suspend-basal endpoints alike; V3's
+        // suspended basals are the only temp-basal series the payload carries.
+        result.ItemsSynced[SyncDataType.TempBasals].Should().Be(useV3Api ? 3 : 6);
+
+        if (useV3Api)
+            // One reservoir change (device event) and one pump alarm (system event) per record.
+            result.ItemsSynced[SyncDataType.DeviceEvents].Should().Be(6);
+
+        // The device-settings fetch runs once per pass, after the chunks.
+        result.ItemsSynced[SyncDataType.Profiles].Should().Be(1);
+    }
+
+    /// <summary>
+    /// State spans are the one publish with no chunk-level toggle of its own on the V2 path, so a
+    /// sync that asks for nothing else must still report the spans it landed.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SyncDataAsync_AcrossChunks_CountsStateSpansWhenTheyAreTheOnlyTypeRequested(
+        bool useV3Api)
+    {
+        var handler = new GlookoEndpointHandler(RecordsInChunk);
+        var service = GlookoSyncHarness.Service(handler);
+        var request = BuildRequest();
+        request.DataTypes = [SyncDataType.StateSpans];
+
+        var result = await service.SyncDataAsync(
+            request, GlookoSyncHarness.Config(useV3Api), CancellationToken.None);
+
+        handler.WindowCount.Should().Be(2,
+            "the window must actually span more than one chunk, or the assertions below prove nothing");
+        result.Success.Should().BeTrue();
+        service.Published.Should().Contain(PublishKind.StateSpans);
+
+        // Profiles are not requested, so the device-settings spans are never fetched.
+        result.ItemsSynced[SyncDataType.StateSpans].Should().Be(3);
+        result.ItemsSynced.Should().NotContainKey(SyncDataType.Profiles);
+    }
+
+    /// <summary>
+    /// A window one day wider than a chunk, padded a day each side by the sync itself, spans exactly
+    /// two chunks.
+    /// </summary>
+    private static SyncRequest BuildRequest() => new()
+    {
+        DataTypes =
+        [
+            SyncDataType.StateSpans, SyncDataType.TempBasals,
+            SyncDataType.DeviceEvents, SyncDataType.Profiles,
+        ],
+        From = DateTime.UtcNow - (GlookoConstants.SyncChunkSize + TimeSpan.FromDays(1)),
+    };
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceMultiChunkTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceMultiChunkTests.cs
@@ -52,8 +52,8 @@ public class GlookoConnectorServiceMultiChunkTests
     }
 
     /// <summary>
-    /// State spans are the one publish with no chunk-level toggle of its own on the V2 path, so a
-    /// sync that asks for nothing else must still report the spans it landed.
+    /// A sync that asks for state spans and nothing else must still report the spans it landed,
+    /// rather than publishing them uncounted and summarising the run as zero work.
     /// </summary>
     [Theory]
     [InlineData(true)]

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
@@ -1,16 +1,8 @@
-using System.Net;
-using System.Text;
-using System.Text.Json;
 using FluentAssertions;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
-using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Glooko.Configurations;
-using Nocturne.Connectors.Glooko.Services;
-using Nocturne.Core.Constants;
-using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
@@ -26,16 +18,6 @@ namespace Nocturne.Connectors.Glooko.Tests.Services;
 /// </summary>
 public class GlookoConnectorServicePublishFailureTests
 {
-    public enum PublishKind
-    {
-        StateSpans,
-        ProfileStateSpans,
-        TempBasals,
-        DeviceEvents,
-        SystemEvents,
-        Profiles,
-    }
-
     // Device and system events come from the V3 graph series; the V2 endpoints carry neither.
     [Theory]
     [InlineData(true, PublishKind.StateSpans)]
@@ -171,42 +153,6 @@ public class GlookoConnectorServicePublishFailureTests
 
     // ── Test infrastructure ─────────────────────────────────────────────
 
-    private const string PatientCode = "eu-west-1-indigo-killdeer-4650";
-
-    private static readonly long EventUnixSeconds =
-        new DateTimeOffset(new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc)).ToUnixTimeSeconds();
-
-    private const string EventTimestamp = "2026-01-10T00:00:00Z";
-
-    /// <summary>
-    /// One suspended-basal span (mapped to both a state span and a temp basal), one reservoir change
-    /// (a device event) and one pump alarm (a system event).
-    /// </summary>
-    private static string GraphPayload() => $$$"""
-        {"series":{
-          "suspendBasal":[{"x":{{{EventUnixSeconds}}},"duration":1800,"label":"Suspended"}],
-          "reservoirChange":[{"x":{{{EventUnixSeconds}}},"label":"Reservoir change"}],
-          "pumpAlarm":[{"x":{{{EventUnixSeconds}}},"alarmType":"OCCLUSION","label":"Occlusion"}]
-        }}
-        """;
-
-    /// <summary>
-    /// One settings snapshot carrying a basal segment (which maps to a single profile) and an active
-    /// basal program (which maps to a single profile state span).
-    /// </summary>
-    private static string DeviceSettingsPayload() =>
-        """
-        {"deviceSettings":{"pumps":{"pump-1":{"@TS@":{
-          "basalSettings":{"activeBasalProgram":"Default"},
-          "pumpProfilesBasal":[{"segments":{"profileName":"Default","current":true,
-            "data":[{"segmentStart":0.0,"duration":24.0,"value":0.8}]}}]
-        }}}}}
-        """.Replace("@TS@", EventTimestamp);
-
-    /// <summary>One standalone V2 food record, which maps to a single connector food entry import.</summary>
-    private static string FoodsPayload() =>
-        $"{{\"foods\":[{{\"guid\":\"food-1\",\"timestamp\":\"{EventTimestamp}\",\"carbs\":30.0,\"name\":\"Toast\"}}]}}";
-
     private static SyncRequest BuildRequest() => new()
     {
         DataTypes =
@@ -217,18 +163,12 @@ public class GlookoConnectorServicePublishFailureTests
         From = DateTime.UtcNow.AddDays(-3), // single chunk keeps one request per endpoint
     };
 
-    private static GlookoConnectorConfiguration BuildConfig(bool useV3Api) => new()
-    {
-        ConnectSource = ConnectSource.Glooko,
-        Email = "user@example.com",
-        Password = "secret",
-        Server = GlookoConstants.RegionEU,
-        UseV3Api = useV3Api,
-    };
+    private static GlookoConnectorConfiguration BuildConfig(bool useV3Api) =>
+        GlookoSyncHarness.Config(useV3Api);
 
     private static RecordingGlookoConnectorService BuildService(
         PublishKind? rejected, IConnectorPublisher? publisher = null) =>
-        new(new HttpClient(new GlookoEndpointHandler()), new StaticGlookoTokenProvider(), rejected, publisher);
+        GlookoSyncHarness.Service(new GlookoEndpointHandler(), rejected, publisher);
 
     /// <summary>
     /// A publisher whose food-entry import answers <paramref name="imported"/>. Every other publish
@@ -258,159 +198,4 @@ public class GlookoConnectorServicePublishFailureTests
                 It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
             Times.Once,
             "the import must actually be attempted, or the assertions below prove nothing");
-
-    /// <summary>
-    /// Accepts every publish except the one under test, and records which publishes were reached.
-    /// </summary>
-    private sealed class RecordingGlookoConnectorService : GlookoConnectorService
-    {
-        private readonly PublishKind? _rejected;
-
-        public RecordingGlookoConnectorService(
-            HttpClient httpClient, GlookoAuthTokenProvider tokenProvider, PublishKind? rejected,
-            IConnectorPublisher? publisher = null)
-            : base(
-                httpClient,
-                new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
-                NullLogger<GlookoConnectorService>.Instance,
-                Mock.Of<IRetryDelayStrategy>(),
-                Mock.Of<IRateLimitingStrategy>(),
-                tokenProvider,
-                publisher)
-        {
-            _rejected = rejected;
-        }
-
-        public List<PublishKind> Published { get; } = [];
-
-        // Profile state spans reach the same publish as the chunks' spans; the profile mapper's
-        // OriginalId prefix is what tells the two batches apart.
-        protected override Task<bool> PublishStateSpanDataAsync(
-            IEnumerable<StateSpan> stateSpans, GlookoConnectorConfiguration config,
-            CancellationToken cancellationToken = default) =>
-            Record(stateSpans.All(s =>
-                s.OriginalId?.StartsWith("glooko_active_profile_", StringComparison.Ordinal) == true)
-                ? PublishKind.ProfileStateSpans
-                : PublishKind.StateSpans);
-
-        protected override Task<bool> PublishTempBasalDataAsync(
-            IEnumerable<TempBasal> records, GlookoConnectorConfiguration config,
-            CancellationToken cancellationToken = default) => Record(PublishKind.TempBasals);
-
-        protected override Task<bool> PublishDeviceEventDataAsync(
-            IEnumerable<DeviceEvent> records, GlookoConnectorConfiguration config,
-            CancellationToken cancellationToken = default) => Record(PublishKind.DeviceEvents);
-
-        protected override Task<bool> PublishSystemEventDataAsync(
-            IEnumerable<SystemEvent> systemEvents, GlookoConnectorConfiguration config,
-            CancellationToken cancellationToken = default) => Record(PublishKind.SystemEvents);
-
-        protected override Task<bool> PublishProfileDataAsync(
-            IEnumerable<Profile> profiles, GlookoConnectorConfiguration config,
-            CancellationToken cancellationToken = default) => Record(PublishKind.Profiles);
-
-        private Task<bool> Record(PublishKind kind)
-        {
-            Published.Add(kind);
-            return Task.FromResult(kind != _rejected);
-        }
-    }
-
-    /// <summary>
-    /// Issues a fixed session cookie and patient code, standing in for a completed Glooko login.
-    /// </summary>
-    private sealed class StaticGlookoTokenProvider : GlookoAuthTokenProvider
-    {
-        public StaticGlookoTokenProvider()
-            : base(
-                new HttpClient(),
-                new ConnectorTokenCache(),
-                new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
-                new FakeTenantAccessor(),
-                NullLogger<GlookoAuthTokenProvider>.Instance)
-        {
-        }
-
-        protected override Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
-            GlookoConnectorConfiguration config, CancellationToken cancellationToken)
-        {
-            const string cookie = "_logbook-web_session=sess";
-            var userData = JsonSerializer.Serialize(
-                new GlookoUserData { User = new GlookoUserLogin { GlookoCode = PatientCode } });
-
-            return Task.FromResult<(string?, DateTime, IReadOnlyDictionary<string, string>?)>(
-                (cookie, DateTime.UtcNow.AddHours(1), new Dictionary<string, string>
-                {
-                    ["SessionCookie"] = cookie,
-                    ["UserData"] = userData,
-                }));
-        }
-
-        private sealed class FakeTenantAccessor : ITenantAccessor
-        {
-            public bool IsResolved => true;
-            public Guid TenantId => Guid.Empty;
-            public TenantContext? Context => null;
-            public void SetTenant(TenantContext context) { }
-        }
-    }
-
-    /// <summary>
-    /// Serves both fetch paths: the V3 graph plus the V2 pump endpoints, each carrying one suspended
-    /// basal and one temporary basal so the two modes publish the same record types. Device settings
-    /// are shared — the profile block runs in both modes.
-    /// </summary>
-    private sealed class GlookoEndpointHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            var path = request.RequestUri?.PathAndQuery ?? string.Empty;
-
-            if (Matches(path, GlookoConstants.V3UsersPath))
-                return Json("{\"currentUser\":{\"meterUnits\":\"mgdl\",\"timezone\":\"Australia/Sydney\"}}");
-
-            if (Matches(path, GlookoConstants.V3GraphDataPath))
-                return Json(GraphPayload());
-
-            if (Matches(path, GlookoConstants.V3HistoriesPath))
-                return Json("{\"histories\":[]}");
-
-            if (Matches(path, GlookoConstants.V3DeviceSettingsPath))
-                return Json(DeviceSettingsPayload());
-
-            if (Matches(path, GlookoConstants.SuspendBasalsPath))
-                return Json($"{{\"suspendBasals\":[{{\"timestamp\":\"{EventTimestamp}\",\"duration\":1800}}]}}");
-
-            if (Matches(path, GlookoConstants.TemporaryBasalsPath))
-                return Json($"{{\"temporaryBasals\":[{{\"timestamp\":\"{EventTimestamp}\",\"duration\":1800,\"rate\":0.5}}]}}");
-
-            if (Matches(path, GlookoConstants.ScheduledBasalsPath))
-                return Json("{\"scheduledBasals\":[]}");
-
-            if (Matches(path, GlookoConstants.NormalBolusesPath))
-                return Json("{\"normalBoluses\":[]}");
-
-            if (Matches(path, GlookoConstants.CgmReadingsPath))
-                return Json("{\"readings\":[]}");
-
-            if (Matches(path, GlookoConstants.FoodsPath))
-                return Json(FoodsPayload());
-
-            // MeterReadingsPath is a prefix of the CGM path's parent, so it is matched last.
-            if (Matches(path, GlookoConstants.MeterReadingsPath))
-                return Json("{\"readings\":[]}");
-
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-        }
-
-        private static bool Matches(string pathAndQuery, string endpoint) =>
-            pathAndQuery.Contains(endpoint, StringComparison.OrdinalIgnoreCase);
-
-        private static Task<HttpResponseMessage> Json(string body) =>
-            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(body, Encoding.UTF8, "application/json"),
-            });
-    }
 }

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
@@ -1,0 +1,306 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Services;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+/// A Glooko sync driven end to end against fake endpoints: an authenticated session, both fetch
+/// paths' endpoints, and a service that intercepts every publish instead of reaching a publisher.
+/// </summary>
+internal static class GlookoSyncHarness
+{
+    public const string PatientCode = "eu-west-1-indigo-killdeer-4650";
+
+    public static GlookoConnectorConfiguration Config(bool useV3Api) => new()
+    {
+        ConnectSource = ConnectSource.Glooko,
+        Email = "user@example.com",
+        Password = "secret",
+        Server = GlookoConstants.RegionEU,
+        UseV3Api = useV3Api,
+    };
+
+    public static RecordingGlookoConnectorService Service(
+        GlookoEndpointHandler handler,
+        PublishKind? rejected = null,
+        IConnectorPublisher? publisher = null) =>
+        new(new HttpClient(handler), new StaticGlookoTokenProvider(), rejected, publisher);
+}
+
+/// <summary>
+/// The publishes a Glooko sync reaches. System events have no <see cref="SyncDataType"/> of their
+/// own and profile state spans share the state-span publish, so both are named separately here.
+/// </summary>
+public enum PublishKind
+{
+    StateSpans,
+    ProfileStateSpans,
+    TempBasals,
+    DeviceEvents,
+    SystemEvents,
+    Profiles,
+}
+
+/// <summary>
+/// Accepts every publish except the one under test, and records which publishes were reached.
+/// </summary>
+internal sealed class RecordingGlookoConnectorService : GlookoConnectorService
+{
+    private readonly PublishKind? _rejected;
+
+    public RecordingGlookoConnectorService(
+        HttpClient httpClient, GlookoAuthTokenProvider tokenProvider, PublishKind? rejected,
+        IConnectorPublisher? publisher = null)
+        : base(
+            httpClient,
+            new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
+            NullLogger<GlookoConnectorService>.Instance,
+            Mock.Of<IRetryDelayStrategy>(),
+            Mock.Of<IRateLimitingStrategy>(),
+            tokenProvider,
+            publisher)
+    {
+        _rejected = rejected;
+    }
+
+    public List<PublishKind> Published { get; } = [];
+
+    // Profile state spans reach the same publish as the chunks' spans; the profile mapper's
+    // OriginalId prefix is what tells the two batches apart.
+    protected override Task<bool> PublishStateSpanDataAsync(
+        IEnumerable<StateSpan> stateSpans, GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken = default) =>
+        Record(stateSpans.All(s =>
+            s.OriginalId?.StartsWith("glooko_active_profile_", StringComparison.Ordinal) == true)
+            ? PublishKind.ProfileStateSpans
+            : PublishKind.StateSpans);
+
+    protected override Task<bool> PublishTempBasalDataAsync(
+        IEnumerable<TempBasal> records, GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken = default) => Record(PublishKind.TempBasals);
+
+    protected override Task<bool> PublishDeviceEventDataAsync(
+        IEnumerable<DeviceEvent> records, GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken = default) => Record(PublishKind.DeviceEvents);
+
+    protected override Task<bool> PublishSystemEventDataAsync(
+        IEnumerable<SystemEvent> systemEvents, GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken = default) => Record(PublishKind.SystemEvents);
+
+    protected override Task<bool> PublishProfileDataAsync(
+        IEnumerable<Profile> profiles, GlookoConnectorConfiguration config,
+        CancellationToken cancellationToken = default) => Record(PublishKind.Profiles);
+
+    private Task<bool> Record(PublishKind kind)
+    {
+        Published.Add(kind);
+        return Task.FromResult(kind != _rejected);
+    }
+}
+
+/// <summary>
+/// Issues a fixed session cookie and patient code, standing in for a completed Glooko login.
+/// </summary>
+internal sealed class StaticGlookoTokenProvider : GlookoAuthTokenProvider
+{
+    public StaticGlookoTokenProvider()
+        : base(
+            new HttpClient(),
+            new ConnectorTokenCache(),
+            new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
+            new FakeTenantAccessor(),
+            NullLogger<GlookoAuthTokenProvider>.Instance)
+    {
+    }
+
+    protected override Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
+        GlookoConnectorConfiguration config, CancellationToken cancellationToken)
+    {
+        const string cookie = "_logbook-web_session=sess";
+        var userData = JsonSerializer.Serialize(
+            new GlookoUserData { User = new GlookoUserLogin { GlookoCode = GlookoSyncHarness.PatientCode } });
+
+        return Task.FromResult<(string?, DateTime, IReadOnlyDictionary<string, string>?)>(
+            (cookie, DateTime.UtcNow.AddHours(1), new Dictionary<string, string>
+            {
+                ["SessionCookie"] = cookie,
+                ["UserData"] = userData,
+            }));
+    }
+
+    private sealed class FakeTenantAccessor : ITenantAccessor
+    {
+        public bool IsResolved => true;
+        public Guid TenantId => Guid.Empty;
+        public TenantContext? Context => null;
+        public void SetTenant(TenantContext context) { }
+    }
+}
+
+/// <summary>
+/// Serves both fetch paths: the V3 graph plus the V2 pump endpoints, each carrying the same number
+/// of suspended basals and temporary basals so the two modes publish the same record types. Device
+/// settings are shared — the profile block runs in both modes — and carry no date window.
+/// </summary>
+/// <param name="recordsPerWindow">
+///     How many of each record type a request window carries, by the order in which the sync first
+///     asks for that window. Defaults to one per window.
+/// </param>
+internal sealed class GlookoEndpointHandler(Func<int, int>? recordsPerWindow = null) : HttpMessageHandler
+{
+    private readonly Func<int, int> _recordsPerWindow = recordsPerWindow ?? (_ => 1);
+    private readonly List<string> _windows = [];
+    private readonly Lock _gate = new();
+
+    private const string DeviceSettingsTimestamp = "2026-01-10T00:00:00Z";
+
+    /// <summary>How many distinct date windows the sync has asked for.</summary>
+    public int WindowCount
+    {
+        get { lock (_gate) return _windows.Count; }
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var path = request.RequestUri?.PathAndQuery ?? string.Empty;
+
+        if (Matches(path, GlookoConstants.V3UsersPath))
+            return Json("{\"currentUser\":{\"meterUnits\":\"mgdl\",\"timezone\":\"Australia/Sydney\"}}");
+
+        if (Matches(path, GlookoConstants.V3DeviceSettingsPath))
+            return Json(DeviceSettingsPayload());
+
+        if (Matches(path, GlookoConstants.V3HistoriesPath))
+            return Json("{\"histories\":[]}");
+
+        var window = ResolveWindow(request.RequestUri?.Query ?? string.Empty);
+
+        if (Matches(path, GlookoConstants.V3GraphDataPath))
+            return Json(GraphPayload(window));
+
+        if (Matches(path, GlookoConstants.SuspendBasalsPath))
+            return Json(Records("suspendBasals", window,
+                at => $"{{\"timestamp\":\"{Iso(at)}\",\"duration\":1800}}"));
+
+        if (Matches(path, GlookoConstants.TemporaryBasalsPath))
+            return Json(Records("temporaryBasals", window,
+                at => $"{{\"timestamp\":\"{Iso(at)}\",\"duration\":1800,\"rate\":0.5}}"));
+
+        if (Matches(path, GlookoConstants.ScheduledBasalsPath))
+            return Json("{\"scheduledBasals\":[]}");
+
+        if (Matches(path, GlookoConstants.NormalBolusesPath))
+            return Json("{\"normalBoluses\":[]}");
+
+        if (Matches(path, GlookoConstants.CgmReadingsPath))
+            return Json("{\"readings\":[]}");
+
+        if (Matches(path, GlookoConstants.FoodsPath))
+            return Json(Records("foods", window with { Records = 1 },
+                at => $"{{\"guid\":\"food_{at.Ticks}\",\"timestamp\":\"{Iso(at)}\",\"carbs\":30.0,\"name\":\"Toast\"}}"));
+
+        // MeterReadingsPath is a prefix of the CGM path's parent, so it is matched last.
+        if (Matches(path, GlookoConstants.MeterReadingsPath))
+            return Json("{\"readings\":[]}");
+
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+    }
+
+    /// <summary>A request's date window, and how many records of each type it should carry.</summary>
+    private readonly record struct Window(DateTime Start, int Records);
+
+    private Window ResolveWindow(string query)
+    {
+        var startDate = QueryValue(query, "startDate");
+        var start = DateTime.TryParse(startDate, null, System.Globalization.DateTimeStyles.AdjustToUniversal
+            | System.Globalization.DateTimeStyles.AssumeUniversal, out var parsed)
+            ? parsed
+            : DateTime.UtcNow;
+
+        int ordinal;
+        lock (_gate)
+        {
+            ordinal = _windows.IndexOf(startDate ?? string.Empty);
+            if (ordinal < 0)
+            {
+                _windows.Add(startDate ?? string.Empty);
+                ordinal = _windows.Count - 1;
+            }
+        }
+
+        return new Window(start, _recordsPerWindow(ordinal));
+    }
+
+    /// <summary>
+    /// One suspended basal per record (mapped to both a state span and a temp basal), one reservoir
+    /// change (a device event) and one pump alarm (a system event).
+    /// </summary>
+    private static string GraphPayload(Window window)
+    {
+        var series = string.Join(",",
+            Property("suspendBasal", window, at => $"{{\"x\":{Unix(at)},\"duration\":1800,\"label\":\"Suspended\"}}"),
+            Property("reservoirChange", window, at => $"{{\"x\":{Unix(at)},\"label\":\"Reservoir change\"}}"),
+            Property("pumpAlarm", window, at => $"{{\"x\":{Unix(at)},\"alarmType\":\"OCCLUSION\",\"label\":\"Occlusion\"}}"));
+
+        return $"{{\"series\":{{{series}}}}}";
+    }
+
+    /// <summary>
+    /// One settings snapshot carrying a basal segment (which maps to a single profile) and an active
+    /// basal program (which maps to a single profile state span).
+    /// </summary>
+    private static string DeviceSettingsPayload() =>
+        """
+        {"deviceSettings":{"pumps":{"pump-1":{"@TS@":{
+          "basalSettings":{"activeBasalProgram":"Default"},
+          "pumpProfilesBasal":[{"segments":{"profileName":"Default","current":true,
+            "data":[{"segmentStart":0.0,"duration":24.0,"value":0.8}]}}]
+        }}}}}
+        """.Replace("@TS@", DeviceSettingsTimestamp);
+
+    /// <summary>
+    /// A single-property envelope holding one record per <see cref="Window.Records"/>, each an hour
+    /// further into the window so no two share a timestamp.
+    /// </summary>
+    private static string Records(string property, Window window, Func<DateTime, string> record) =>
+        $"{{{Property(property, window, record)}}}";
+
+    private static string Property(string property, Window window, Func<DateTime, string> record) =>
+        $"\"{property}\":["
+        + string.Join(",", Enumerable.Range(1, window.Records).Select(i => record(window.Start.AddHours(i))))
+        + "]";
+
+    private static string Iso(DateTime at) => at.ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+    private static long Unix(DateTime at) => new DateTimeOffset(at, TimeSpan.Zero).ToUnixTimeSeconds();
+
+    private static string? QueryValue(string query, string key) => query
+        .TrimStart('?')
+        .Split('&', StringSplitOptions.RemoveEmptyEntries)
+        .Select(pair => pair.Split('=', 2))
+        .Where(pair => pair.Length == 2 && pair[0] == key)
+        .Select(pair => Uri.UnescapeDataString(pair[1]))
+        .FirstOrDefault();
+
+    private static bool Matches(string pathAndQuery, string endpoint) =>
+        pathAndQuery.Contains(endpoint, StringComparison.OrdinalIgnoreCase);
+
+    private static Task<HttpResponseMessage> Json(string body) =>
+        Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        });
+}


### PR DESCRIPTION
Closes #863 — with evidence rather than new fixes: both defects were already repaired by intervening PRs, and what was genuinely missing was the multi-chunk coverage that would have caught them.

## The verdicts

**Temp basals assigned instead of accumulated** — fixed by #803, which routed both sites (V2/V3) through `PublishRecordTypeAsync`; the helper accumulates `prev + count`, and no `ItemsSynced[...] =` assignment survives in the file.

**State spans published but never counted** — fixed by #803 (the two chunk-level sites) plus #921 (the profile/device-settings publish, counting under StateSpans), with #918's explicit zeros covering active-but-empty. The issue's `LastEntryTimes` parenthetical is moot — the member no longer exists.

**The coverage gap was real**: the publish-failure suite ran a deliberately single-chunk window, so nothing anywhere failed if counts were assigned rather than summed.

## What this PR adds

Four multi-chunk tests (V2/V3 × two scenarios) driving an exactly-two-chunk window derived from the sync's own slicing — the inline `TimeSpan.FromDays(14)` becomes `GlookoConstants.SyncChunkSize` so the test binds to the real chunk width, and `WindowCount == 2` pins the premise. Chunks carry different counts so per-chunk, last-chunk and sum are three distinct numbers. The publish-failure suite's nested harness is extracted to `GlookoSyncHarness` (per-window record counts; the default preserves every existing test's expectations — all 93 prior Glooko tests unchanged and green).

Mutation-proved in both historical defect shapes: accumulation reverted to assignment → 4/4 fail; state-span publishes re-inlined past the counting helper → 4/4 fail.

Glooko 97/97; Connectors.Core 128/128.
