### PR TITLE
refactor(connectors): collapse three retry loops onto one clamped loop

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IConnectorConfiguration.cs
@@ -34,6 +34,9 @@ public interface IConnectorConfiguration
     /// </summary>
     int BatchSize { get; set; }
 
+    /// <summary>
+    ///     Minimum minutes between syncs for one tenant; 0 or less leaves the connector unscheduled.
+    /// </summary>
     int SyncIntervalMinutes { get; set; }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Core/Services/AuthTokenProviderBase.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/AuthTokenProviderBase.cs
@@ -159,6 +159,14 @@ public abstract class AuthTokenProviderBase<TConfig>(
     protected abstract Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
         TConfig config, CancellationToken cancellationToken);
 
+    /// <summary>
+    ///     Attempts <paramref name="operation"/> under the shared connector retry loop; see
+    ///     <see cref="ConnectorRetryLoop.RunAsync{T}"/> for the attempt-budget and delay contract.
+    /// </summary>
+    /// <param name="operation">
+    ///     Receives the 0-based attempt index and returns the token it acquired, or null plus whether
+    ///     the failure is worth another attempt.
+    /// </param>
     protected async Task<T?> ExecuteWithRetryAsync<T>(
         Func<int, Task<(T? Result, bool ShouldRetry)>> operation,
         IRetryDelayStrategy retryDelayStrategy,
@@ -167,46 +175,46 @@ public abstract class AuthTokenProviderBase<TConfig>(
         CancellationToken cancellationToken)
         where T : class
     {
-        for (var attempt = 0; attempt < maxRetries; attempt++)
-        {
-            try
+        return await ConnectorRetryLoop.RunAsync<T>(
+            async (attempt, _) =>
             {
-                var (result, shouldRetry) = await operation(attempt);
-                if (result != null)
-                    return result;
+                try
+                {
+                    var (result, shouldRetry) = await operation(attempt);
+                    if (result != null)
+                        return RetryStep<T>.Complete(result);
 
-                if (!shouldRetry)
-                    return null;
+                    return shouldRetry ? RetryStep<T>.RetryAfterDelay : RetryStep<T>.Complete(default);
+                }
+                catch (HttpRequestException ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "HTTP error during {OperationName} attempt {Attempt}",
+                        operationName,
+                        attempt + 1);
 
-                if (attempt < maxRetries - 1)
-                    await retryDelayStrategy.ApplyRetryDelayAsync(attempt);
-            }
-            catch (HttpRequestException ex)
+                    return RetryStep<T>.RetryAfterDelay;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Unexpected error during {OperationName} attempt {Attempt}",
+                        operationName,
+                        attempt + 1);
+
+                    return RetryStep<T>.Complete(default);
+                }
+            },
+            retryDelayStrategy,
+            maxRetries,
+            attempts =>
             {
-                _logger.LogWarning(
-                    ex,
-                    "HTTP error during {OperationName} attempt {Attempt}",
-                    operationName,
-                    attempt + 1);
-
-                if (attempt < maxRetries - 1)
-                    await retryDelayStrategy.ApplyRetryDelayAsync(attempt);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(
-                    ex,
-                    "Unexpected error during {OperationName} attempt {Attempt}",
-                    operationName,
-                    attempt + 1);
+                _logger.LogError("{OperationName} failed after {MaxRetries} attempts", operationName, attempts);
                 return null;
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
-        }
-
-        _logger.LogError("{OperationName} failed after {MaxRetries} attempts", operationName, maxRetries);
-        return null;
+            },
+            cancellationToken);
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Core/Services/AuthTokenProviderBase.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/AuthTokenProviderBase.cs
@@ -167,6 +167,7 @@ public abstract class AuthTokenProviderBase<TConfig>(
     ///     Receives the 0-based attempt index and returns the token it acquired, or null plus whether
     ///     the failure is worth another attempt.
     /// </param>
+    /// <param name="maxRetries">Total attempts, not retries on top of a first try; clamped to a floor of one.</param>
     protected async Task<T?> ExecuteWithRetryAsync<T>(
         Func<int, Task<(T? Result, bool ShouldRetry)>> operation,
         IRetryDelayStrategy retryDelayStrategy,

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -1238,7 +1238,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     /// <param name="operation">The async operation to execute</param>
     /// <param name="retryStrategy">Strategy for calculating retry delays</param>
     /// <param name="reAuthenticateOnUnauthorized">Optional callback to re-authenticate on 401 responses</param>
-    /// <param name="maxRetries">Maximum number of attempts (default: 3)</param>
+    /// <param name="maxRetries">Total attempts, not retries on top of a first try; clamped to a floor of one (default: 3).</param>
     /// <param name="operationName">Name of the operation for logging</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The result of the operation, or default(T) on failure</returns>

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -1230,18 +1230,15 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     #region Retry and HTTP Helpers
 
     /// <summary>
-    ///     Executes an async operation with retry logic and exponential backoff.
-    ///     Automatically tracks success/failure for health monitoring.
+    ///     Executes an async operation under the shared connector retry loop, tracking success and
+    ///     failure for health monitoring. See <see cref="ConnectorRetryLoop.RunAsync{T}"/> for the
+    ///     attempt-budget and delay contract.
     /// </summary>
     /// <typeparam name="T">The return type of the operation</typeparam>
     /// <param name="operation">The async operation to execute</param>
     /// <param name="retryStrategy">Strategy for calculating retry delays</param>
     /// <param name="reAuthenticateOnUnauthorized">Optional callback to re-authenticate on 401 responses</param>
-    /// <param name="maxRetries">
-    ///     Maximum number of attempts (default: 3). Clamped to a floor of 1 so a connector's
-    ///     configured MaxRetryAttempts of 0 still makes a single attempt instead of skipping
-    ///     the operation entirely.
-    /// </param>
+    /// <param name="maxRetries">Maximum number of attempts (default: 3)</param>
     /// <param name="operationName">Name of the operation for logging</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The result of the operation, or default(T) on failure</returns>
@@ -1254,131 +1251,128 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         CancellationToken cancellationToken = default
     )
     {
-        // Connectors pass their configured MaxRetryAttempts, which allows 0; the loop needs at
-        // least one attempt for the operation to run.
-        maxRetries = Math.Max(1, maxRetries);
-
         var opName = operationName ?? "operation";
         HttpRequestException? lastException = null;
 
-        for (var attempt = 0; attempt < maxRetries; attempt++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            try
+        return await ConnectorRetryLoop.RunAsync<T>(
+            async (attempt, attempts) =>
             {
-                _logger.LogDebug(
-                    "[{ConnectorSource}] Executing {Operation} (attempt {Attempt}/{MaxRetries})",
-                    ConnectorSource,
-                    opName,
-                    attempt + 1,
-                    maxRetries
-                );
-
-                var result = await operation();
-
-                // Success - track it and return
-                TrackSuccessfulRequest();
-                return result;
-            }
-            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
-            {
-                _logger.LogWarning(
-                    "[{ConnectorSource}] Unauthorized response during {Operation}, attempting re-authentication",
-                    ConnectorSource,
-                    opName
-                );
-
-                if (reAuthenticateOnUnauthorized != null)
+                try
                 {
-                    var reAuthSuccess = await reAuthenticateOnUnauthorized();
-                    if (reAuthSuccess)
-                    {
-                        _logger.LogInformation(
-                            "[{ConnectorSource}] Re-authentication successful, retrying {Operation}",
-                            ConnectorSource,
-                            opName
-                        );
-                        continue; // Retry with new credentials
-                    }
+                    _logger.LogDebug(
+                        "[{ConnectorSource}] Executing {Operation} (attempt {Attempt}/{MaxRetries})",
+                        ConnectorSource,
+                        opName,
+                        attempt + 1,
+                        attempts
+                    );
+
+                    var result = await operation();
+
+                    TrackSuccessfulRequest();
+                    return RetryStep<T>.Complete(result);
                 }
+                catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    _logger.LogWarning(
+                        "[{ConnectorSource}] Unauthorized response during {Operation}, attempting re-authentication",
+                        ConnectorSource,
+                        opName
+                    );
 
-                TrackFailedRequest("Unauthorized and re-authentication failed");
-                return default;
-            }
-            catch (HttpRequestException ex) when (IsRetryableStatusCode(ex.StatusCode))
+                    if (reAuthenticateOnUnauthorized != null)
+                    {
+                        var reAuthSuccess = await reAuthenticateOnUnauthorized();
+                        if (reAuthSuccess)
+                        {
+                            _logger.LogInformation(
+                                "[{ConnectorSource}] Re-authentication successful, retrying {Operation}",
+                                ConnectorSource,
+                                opName
+                            );
+                            return RetryStep<T>.RetryImmediately;
+                        }
+                    }
+
+                    TrackFailedRequest("Unauthorized and re-authentication failed");
+                    return RetryStep<T>.Complete(default);
+                }
+                catch (HttpRequestException ex) when (IsRetryableStatusCode(ex.StatusCode))
+                {
+                    lastException = ex;
+                    _logger.LogWarning(
+                        "[{ConnectorSource}] Retryable error during {Operation} (attempt {Attempt}): {StatusCode}",
+                        ConnectorSource,
+                        opName,
+                        attempt + 1,
+                        ex.StatusCode
+                    );
+
+                    return RetryStep<T>.RetryAfterDelay;
+                }
+                catch (HttpRequestException ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "[{ConnectorSource}] Non-retryable HTTP error during {Operation}: {StatusCode}",
+                        ConnectorSource,
+                        opName,
+                        ex.StatusCode
+                    );
+                    TrackFailedRequest($"HTTP {ex.StatusCode}");
+                    return RetryStep<T>.Complete(default);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "[{ConnectorSource}] JSON parsing error during {Operation}",
+                        ConnectorSource,
+                        opName
+                    );
+                    TrackFailedRequest("JSON parsing error");
+                    return RetryStep<T>.Complete(default);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogInformation(
+                        "[{ConnectorSource}] {Operation} was cancelled",
+                        ConnectorSource,
+                        opName
+                    );
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "[{ConnectorSource}] Unexpected error during {Operation}",
+                        ConnectorSource,
+                        opName
+                    );
+                    TrackFailedRequest($"Unexpected error: {ex.Message}");
+                    return RetryStep<T>.Complete(default);
+                }
+            },
+            retryStrategy,
+            maxRetries,
+            attempts =>
             {
-                lastException = ex;
-                _logger.LogWarning(
-                    "[{ConnectorSource}] Retryable error during {Operation} (attempt {Attempt}): {StatusCode}",
+                TrackFailedRequest($"All {attempts} attempts failed");
+                _logger.LogError(
+                    "[{ConnectorSource}] {Operation} failed after {MaxRetries} attempts",
                     ConnectorSource,
                     opName,
-                    attempt + 1,
-                    ex.StatusCode
+                    attempts
                 );
 
-                if (attempt < maxRetries - 1)
-                    await retryStrategy.ApplyRetryDelayAsync(attempt);
-            }
-            catch (HttpRequestException ex)
-            {
-                // Non-retryable HTTP error
-                _logger.LogError(
-                    ex,
-                    "[{ConnectorSource}] Non-retryable HTTP error during {Operation}: {StatusCode}",
-                    ConnectorSource,
-                    opName,
-                    ex.StatusCode
-                );
-                TrackFailedRequest($"HTTP {ex.StatusCode}");
-                return default;
-            }
-            catch (JsonException ex)
-            {
-                _logger.LogError(
-                    ex,
-                    "[{ConnectorSource}] JSON parsing error during {Operation}",
-                    ConnectorSource,
-                    opName
-                );
-                TrackFailedRequest("JSON parsing error");
-                return default;
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogInformation(
-                    "[{ConnectorSource}] {Operation} was cancelled",
-                    ConnectorSource,
-                    opName
-                );
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(
-                    ex,
-                    "[{ConnectorSource}] Unexpected error during {Operation}",
-                    ConnectorSource,
-                    opName
-                );
-                TrackFailedRequest($"Unexpected error: {ex.Message}");
-                return default;
-            }
-        }
+                if (lastException != null)
+                    throw lastException;
 
-        // All retries exhausted
-        TrackFailedRequest($"All {maxRetries} attempts failed");
-        _logger.LogError(
-            "[{ConnectorSource}] {Operation} failed after {MaxRetries} attempts",
-            ConnectorSource,
-            opName,
-            maxRetries
+                return default;
+            },
+            cancellationToken
         );
-
-        if (lastException != null)
-            throw lastException;
-
-        return default;
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorRetryLoop.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorRetryLoop.cs
@@ -1,0 +1,78 @@
+using Nocturne.Connectors.Core.Interfaces;
+
+namespace Nocturne.Connectors.Core.Services;
+
+/// <summary>
+///     How one attempt inside <see cref="ConnectorRetryLoop"/> ended.
+/// </summary>
+internal enum RetryStepDecision
+{
+    /// <summary>The run is over; the step's result is the run's result.</summary>
+    Complete,
+
+    /// <summary>Spend another attempt, after the delay for the attempt just made.</summary>
+    RetryAfterDelay,
+
+    /// <summary>Spend another attempt with no delay, the cause of the failure having been repaired.</summary>
+    RetryImmediately
+}
+
+/// <summary>
+///     The outcome of one attempt inside <see cref="ConnectorRetryLoop"/>.
+/// </summary>
+internal readonly record struct RetryStep<T>(RetryStepDecision Decision, T? Result)
+{
+    internal static RetryStep<T> Complete(T? result) => new(RetryStepDecision.Complete, result);
+
+    internal static RetryStep<T> RetryAfterDelay { get; } = new(RetryStepDecision.RetryAfterDelay, default);
+
+    internal static RetryStep<T> RetryImmediately { get; } = new(RetryStepDecision.RetryImmediately, default);
+}
+
+/// <summary>
+///     The single attempt-sequencing loop shared by the connector base classes: it owns the attempt
+///     budget, the delay between attempts and the cancellation check, while each caller's step
+///     delegate owns what counts as success, what is retryable, and how failures are reported.
+/// </summary>
+internal static class ConnectorRetryLoop
+{
+    /// <summary>
+    ///     Runs <paramref name="step"/> until it completes or the attempt budget is spent.
+    /// </summary>
+    /// <param name="step">
+    ///     Receives the 0-based attempt index and the clamped budget, and decides whether the run is
+    ///     over. Exceptions it does not handle leave the loop.
+    /// </param>
+    /// <param name="retryDelayStrategy">Supplies the delay between attempts; never applied after the last one.</param>
+    /// <param name="maxAttempts">
+    ///     Total attempts, not retries on top of a first try, clamped to a floor of one.
+    ///     Connectors pass a configured <see cref="IConnectorConfiguration.MaxRetryAttempts"/>, which
+    ///     allows 0, and the operation has to run at least once for the call to mean anything.
+    /// </param>
+    /// <param name="onAttemptsExhausted">Produces the result once every attempt has been spent.</param>
+    /// <param name="cancellationToken">Checked before each attempt.</param>
+    internal static async Task<T?> RunAsync<T>(
+        Func<int, int, Task<RetryStep<T>>> step,
+        IRetryDelayStrategy retryDelayStrategy,
+        int maxAttempts,
+        Func<int, T?> onAttemptsExhausted,
+        CancellationToken cancellationToken)
+    {
+        maxAttempts = Math.Max(1, maxAttempts);
+
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var outcome = await step(attempt, maxAttempts);
+
+            if (outcome.Decision == RetryStepDecision.Complete)
+                return outcome.Result;
+
+            if (outcome.Decision == RetryStepDecision.RetryAfterDelay && attempt < maxAttempts - 1)
+                await retryDelayStrategy.ApplyRetryDelayAsync(attempt);
+        }
+
+        return onAttemptsExhausted(maxAttempts);
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorRetryLoop.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorRetryLoop.cs
@@ -5,7 +5,7 @@ namespace Nocturne.Connectors.Core.Services;
 /// <summary>
 ///     How one attempt inside <see cref="ConnectorRetryLoop"/> ended.
 /// </summary>
-internal enum RetryStepDecision
+public enum RetryStepDecision
 {
     /// <summary>The run is over; the step's result is the run's result.</summary>
     Complete,
@@ -20,13 +20,13 @@ internal enum RetryStepDecision
 /// <summary>
 ///     The outcome of one attempt inside <see cref="ConnectorRetryLoop"/>.
 /// </summary>
-internal readonly record struct RetryStep<T>(RetryStepDecision Decision, T? Result)
+public readonly record struct RetryStep<T>(RetryStepDecision Decision, T? Result)
 {
-    internal static RetryStep<T> Complete(T? result) => new(RetryStepDecision.Complete, result);
+    public static RetryStep<T> Complete(T? result) => new(RetryStepDecision.Complete, result);
 
-    internal static RetryStep<T> RetryAfterDelay { get; } = new(RetryStepDecision.RetryAfterDelay, default);
+    public static RetryStep<T> RetryAfterDelay { get; } = new(RetryStepDecision.RetryAfterDelay, default);
 
-    internal static RetryStep<T> RetryImmediately { get; } = new(RetryStepDecision.RetryImmediately, default);
+    public static RetryStep<T> RetryImmediately { get; } = new(RetryStepDecision.RetryImmediately, default);
 }
 
 /// <summary>
@@ -34,7 +34,7 @@ internal readonly record struct RetryStep<T>(RetryStepDecision Decision, T? Resu
 ///     budget, the delay between attempts and the cancellation check, while each caller's step
 ///     delegate owns what counts as success, what is retryable, and how failures are reported.
 /// </summary>
-internal static class ConnectorRetryLoop
+public static class ConnectorRetryLoop
 {
     /// <summary>
     ///     Runs <paramref name="step"/> until it completes or the attempt budget is spent.
@@ -51,12 +51,14 @@ internal static class ConnectorRetryLoop
     /// </param>
     /// <param name="onAttemptsExhausted">Produces the result once every attempt has been spent.</param>
     /// <param name="cancellationToken">Checked before each attempt.</param>
-    internal static async Task<T?> RunAsync<T>(
+    /// <param name="onBeforeRetryDelay">Invoked with the just-finished attempt's index only when a delay follows it.</param>
+    public static async Task<T?> RunAsync<T>(
         Func<int, int, Task<RetryStep<T>>> step,
         IRetryDelayStrategy retryDelayStrategy,
         int maxAttempts,
         Func<int, T?> onAttemptsExhausted,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action<int>? onBeforeRetryDelay = null)
     {
         maxAttempts = Math.Max(1, maxAttempts);
 
@@ -70,7 +72,10 @@ internal static class ConnectorRetryLoop
                 return outcome.Result;
 
             if (outcome.Decision == RetryStepDecision.RetryAfterDelay && attempt < maxAttempts - 1)
+            {
+                onBeforeRetryDelay?.Invoke(attempt);
                 await retryDelayStrategy.ApplyRetryDelayAsync(attempt);
+            }
         }
 
         return onAttemptsExhausted(maxAttempts);

--- a/src/Connectors/Nocturne.Connectors.Glooko/Nocturne.Connectors.Glooko.csproj
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Nocturne.Connectors.Glooko.csproj
@@ -8,6 +8,9 @@
         <Product>Nocturne Connectors</Product>
     </PropertyGroup>
     <ItemGroup>
+        <InternalsVisibleTo Include="Nocturne.Connectors.Glooko.Tests" />
+    </ItemGroup>
+    <ItemGroup>
         <ProjectReference Include="..\..\Core\Nocturne.Core.Models\Nocturne.Core.Models.csproj"/>
         <ProjectReference Include="..\Nocturne.Connectors.Core\Nocturne.Connectors.Core.csproj"/>
         <ProjectReference Include="..\..\Infrastructure\Nocturne.Infrastructure.Data\Nocturne.Infrastructure.Data.csproj"/>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -164,53 +164,59 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
     /// <summary>
     ///     Fetches from a Glooko endpoint with retry logic and exponential backoff.
+    ///     Throws rather than returning null once the attempts are spent, so a caller cannot mistake
+    ///     an exhausted endpoint for one that legitimately had no data.
     /// </summary>
-    private async Task<JsonElement?> FetchFromGlookoEndpointWithRetry(
+    /// <param name="maxRetries">Total attempts, not retries on top of a first try; clamped to a floor of one.</param>
+    internal async Task<JsonElement?> FetchFromGlookoEndpointWithRetry(
         GlookoSyncContext context, string url, int maxRetries = 3)
     {
         HttpRequestException? lastException = null;
 
-        for (var attempt = 0; attempt < maxRetries; attempt++)
-        {
-            try
+        return await ConnectorRetryLoop.RunAsync<JsonElement?>(
+            async (attempt, _) =>
             {
-                var result = await FetchFromGlookoEndpoint(context, url);
-                if (result.HasValue) return result;
+                try
+                {
+                    var result = await FetchFromGlookoEndpoint(context, url);
+                    if (result.HasValue)
+                        return RetryStep<JsonElement?>.Complete(result);
 
-                _logger.LogWarning("Attempt {AttemptNumber} failed for {Url}", attempt + 1, url);
-            }
-            catch (GlookoDataForbiddenException)
-            {
-                // The patient code is part of the URL; retrying it unchanged will 403 again.
-                // Bubble up immediately so the caller can re-authenticate and rebuild URLs.
-                throw;
-            }
-            catch (HttpRequestException ex) when (ex.Message.Contains("422"))
-            {
-                lastException = ex;
-                _logger.LogWarning("Rate limited (422) on attempt {AttemptNumber} for {Url}", attempt + 1, url);
-            }
-            catch (HttpRequestException ex)
-            {
-                lastException = ex;
-                _logger.LogError(ex, "Attempt {AttemptNumber} failed for {Url}", attempt + 1, url);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Attempt {AttemptNumber} failed for {Url}", attempt + 1, url);
-                lastException = new HttpRequestException($"Request failed: {ex.Message}", ex);
-            }
+                    _logger.LogWarning("Attempt {AttemptNumber} failed for {Url}", attempt + 1, url);
+                }
+                catch (GlookoDataForbiddenException)
+                {
+                    // The patient code is part of the URL; retrying it unchanged will 403 again.
+                    // Bubble up immediately so the caller can re-authenticate and rebuild URLs.
+                    throw;
+                }
+                catch (HttpRequestException ex) when (ex.Message.Contains("422"))
+                {
+                    lastException = ex;
+                    _logger.LogWarning("Rate limited (422) on attempt {AttemptNumber} for {Url}", attempt + 1, url);
+                }
+                catch (HttpRequestException ex)
+                {
+                    lastException = ex;
+                    _logger.LogError(ex, "Attempt {AttemptNumber} failed for {Url}", attempt + 1, url);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Attempt {AttemptNumber} failed for {Url}", attempt + 1, url);
+                    lastException = new HttpRequestException($"Request failed: {ex.Message}", ex);
+                }
 
-            if (attempt < maxRetries - 1)
+                return RetryStep<JsonElement?>.RetryAfterDelay;
+            },
+            _retryDelayStrategy,
+            maxRetries,
+            attempts =>
             {
-                _logger.LogInformation("Applying retry backoff before retry {RetryNumber}", attempt + 2);
-                await _retryDelayStrategy.ApplyRetryDelayAsync(attempt);
-            }
-        }
-
-        _logger.LogError("All {MaxRetries} attempts failed for {Url}", maxRetries, url);
-        if (lastException != null) throw lastException;
-        throw new HttpRequestException($"All {maxRetries} attempts failed for {url}");
+                _logger.LogError("All {MaxRetries} attempts failed for {Url}", attempts, url);
+                throw lastException ?? new HttpRequestException($"All {attempts} attempts failed for {url}");
+            },
+            CancellationToken.None,
+            attempt => _logger.LogInformation("Applying retry backoff before retry {RetryNumber}", attempt + 2));
     }
 
     // ── URL construction ────────────────────────────────────────────────

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalAuthTokenProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalAuthTokenProvider.cs
@@ -38,12 +38,10 @@ public class MyFitnessPalAuthTokenProvider(
     protected override async Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
         MyFitnessPalConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        var maxRetries = Math.Max(1, config.MaxRetryAttempts);
-
         var token = await ExecuteWithRetryAsync(
             async attempt => await RequestTokenAsync(config, attempt, cancellationToken),
             _retryDelayStrategy,
-            maxRetries,
+            config.MaxRetryAttempts,
             "MyFitnessPal authentication",
             cancellationToken
         );

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/AuthTokenProviderBaseRetryTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/AuthTokenProviderBaseRetryTests.cs
@@ -19,6 +19,7 @@ public class AuthTokenProviderBaseRetryTests
     public async Task ExecuteWithRetryAsync_ZeroMaxRetries_AttemptsExactlyOnce()
     {
         using var provider = BuildProvider();
+        var delays = new RecordingRetryDelayStrategy();
         var attempts = 0;
 
         var token = await provider.InvokeExecuteWithRetryAsync(
@@ -27,16 +28,19 @@ public class AuthTokenProviderBaseRetryTests
                 attempts++;
                 return Task.FromResult<(string? Result, bool ShouldRetry)>((null, true));
             },
+            delays,
             maxRetries: 0);
 
         token.Should().BeNull();
         attempts.Should().Be(1, "0 is clamped to a single attempt");
+        delays.DelayedAttempts.Should().BeEmpty("a single attempt has nothing to wait between");
     }
 
     [Fact]
     public async Task ExecuteWithRetryAsync_RetryableFailure_AttemptsUpToMaxRetries()
     {
         using var provider = BuildProvider();
+        var delays = new RecordingRetryDelayStrategy();
         var attempts = 0;
 
         var token = await provider.InvokeExecuteWithRetryAsync(
@@ -45,10 +49,12 @@ public class AuthTokenProviderBaseRetryTests
                 attempts++;
                 return Task.FromResult<(string? Result, bool ShouldRetry)>((null, true));
             },
+            delays,
             maxRetries: 3);
 
         token.Should().BeNull();
         attempts.Should().Be(3, "maxRetries counts attempts, not retries on top of a first try");
+        delays.DelayedAttempts.Should().Equal([0, 1], "three attempts leave two gaps to delay in");
     }
 
     private static RetryTokenProvider BuildProvider() => new(
@@ -71,10 +77,11 @@ public class AuthTokenProviderBaseRetryTests
         // Exposes the protected retry helper so its attempt-count behaviour can be tested directly.
         public Task<string?> InvokeExecuteWithRetryAsync(
             Func<int, Task<(string? Result, bool ShouldRetry)>> operation,
+            IRetryDelayStrategy retryDelayStrategy,
             int maxRetries)
             => ExecuteWithRetryAsync(
                 operation,
-                Mock.Of<IRetryDelayStrategy>(),
+                retryDelayStrategy,
                 maxRetries,
                 "test token acquisition",
                 CancellationToken.None);

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/AuthTokenProviderBaseRetryTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/AuthTokenProviderBaseRetryTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Services;
+
+/// <summary>
+///     Token acquisition runs on the same retry loop as the connector services, so a configured
+///     MaxRetryAttempts of 0 has to buy one attempt here too instead of skipping acquisition.
+/// </summary>
+public class AuthTokenProviderBaseRetryTests
+{
+    [Fact]
+    public async Task ExecuteWithRetryAsync_ZeroMaxRetries_AttemptsExactlyOnce()
+    {
+        using var provider = BuildProvider();
+        var attempts = 0;
+
+        var token = await provider.InvokeExecuteWithRetryAsync(
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult<(string? Result, bool ShouldRetry)>((null, true));
+            },
+            maxRetries: 0);
+
+        token.Should().BeNull();
+        attempts.Should().Be(1, "0 is clamped to a single attempt");
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetryAsync_RetryableFailure_AttemptsUpToMaxRetries()
+    {
+        using var provider = BuildProvider();
+        var attempts = 0;
+
+        var token = await provider.InvokeExecuteWithRetryAsync(
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult<(string? Result, bool ShouldRetry)>((null, true));
+            },
+            maxRetries: 3);
+
+        token.Should().BeNull();
+        attempts.Should().Be(3, "maxRetries counts attempts, not retries on top of a first try");
+    }
+
+    private static RetryTokenProvider BuildProvider() => new(
+        new HttpClient(),
+        new ConnectorTokenCache(),
+        new ConnectorServerResolver<TestConnectorConfig>(null, null, null),
+        Mock.Of<ITenantAccessor>(),
+        NullLogger<RetryTokenProvider>.Instance);
+
+    private sealed class RetryTokenProvider(
+        HttpClient httpClient,
+        IConnectorTokenCache tokenCache,
+        IConnectorServerResolver<TestConnectorConfig> serverResolver,
+        ITenantAccessor tenantAccessor,
+        ILogger logger)
+        : AuthTokenProviderBase<TestConnectorConfig>(httpClient, tokenCache, serverResolver, tenantAccessor, logger)
+    {
+        protected override string ConnectorName => "Test";
+
+        // Exposes the protected retry helper so its attempt-count behaviour can be tested directly.
+        public Task<string?> InvokeExecuteWithRetryAsync(
+            Func<int, Task<(string? Result, bool ShouldRetry)>> operation,
+            int maxRetries)
+            => ExecuteWithRetryAsync(
+                operation,
+                Mock.Of<IRetryDelayStrategy>(),
+                maxRetries,
+                "test token acquisition",
+                CancellationToken.None);
+
+        protected override Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
+            TestConnectorConfig config, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
@@ -40,8 +40,10 @@ public class BaseConnectorServiceTests
         public Task<string?> InvokeExecuteWithRetryAsync(
             Func<Task<string?>> operation,
             IRetryDelayStrategy retryDelayStrategy,
-            int maxRetries)
-            => ExecuteWithRetryAsync(operation, retryDelayStrategy, maxRetries: maxRetries);
+            int maxRetries,
+            Func<Task<bool>>? reAuthenticateOnUnauthorized = null)
+            => ExecuteWithRetryAsync(
+                operation, retryDelayStrategy, reAuthenticateOnUnauthorized, maxRetries);
 
         // Expose the protected per-run publish-origin resolvers so the watermark→origin mapping
         // and the per-run memoization (anti-flood guard) can be asserted directly.
@@ -106,13 +108,16 @@ public class BaseConnectorServiceTests
             throw new HttpRequestException("unavailable", null, HttpStatusCode.ServiceUnavailable);
         };
 
+        var delays = new RecordingRetryDelayStrategy();
+
         // Act: the helper exhausts every attempt then surfaces the last error
         var act = async () =>
-            await service.InvokeExecuteWithRetryAsync(alwaysFails, Mock.Of<IRetryDelayStrategy>(), maxRetries: 5);
+            await service.InvokeExecuteWithRetryAsync(alwaysFails, delays, maxRetries: 5);
 
         // Assert
         await act.Should().ThrowAsync<HttpRequestException>();
         attempts.Should().Be(5, "maxRetries should drive the number of attempts");
+        delays.DelayedAttempts.Should().Equal([0, 1, 2, 3], "five attempts leave four gaps to delay in");
     }
 
     [Fact]
@@ -128,13 +133,77 @@ public class BaseConnectorServiceTests
             throw new HttpRequestException("unavailable", null, HttpStatusCode.ServiceUnavailable);
         };
 
+        var delays = new RecordingRetryDelayStrategy();
+
         // Act
         var act = async () =>
-            await service.InvokeExecuteWithRetryAsync(alwaysFails, Mock.Of<IRetryDelayStrategy>(), maxRetries: 0);
+            await service.InvokeExecuteWithRetryAsync(alwaysFails, delays, maxRetries: 0);
 
         // Assert
         await act.Should().ThrowAsync<HttpRequestException>();
         attempts.Should().Be(1, "0 is clamped to a single attempt");
+        delays.DelayedAttempts.Should().BeEmpty("a single attempt has nothing to wait between");
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetryAsync_UnauthorizedWithSuccessfulReauth_RetriesImmediatelyWithoutDelay()
+    {
+        // Arrange: every attempt 401s and every re-authentication succeeds, so the run only ends
+        // when the attempt budget does
+        var service = new TestConnectorService(new HttpClient(), Mock.Of<ILogger<TestConnectorService>>());
+        var delays = new RecordingRetryDelayStrategy();
+        var attempts = 0;
+        var reAuthentications = 0;
+
+        Func<Task<string?>> alwaysUnauthorized = () =>
+        {
+            attempts++;
+            throw new HttpRequestException("unauthorized", null, HttpStatusCode.Unauthorized);
+        };
+
+        // Act
+        var result = await service.InvokeExecuteWithRetryAsync(
+            alwaysUnauthorized,
+            delays,
+            maxRetries: 3,
+            () =>
+            {
+                reAuthentications++;
+                return Task.FromResult(true);
+            });
+
+        // Assert
+        result.Should().BeNull();
+        attempts.Should().Be(3, "a re-authenticated retry spends an attempt, so the run terminates");
+        reAuthentications.Should().Be(3);
+        delays.DelayedAttempts.Should().BeEmpty(
+            "fresh credentials replace the backoff rather than waiting one out");
+        service.FailedRequestCount.Should().Be(1, "the exhausted run tracks exactly one failure");
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetryAsync_UnauthorizedWithFailedReauth_StopsWithoutSpendingAnotherAttempt()
+    {
+        // Arrange: re-authentication fails, so retrying the same rejected credentials is pointless
+        var service = new TestConnectorService(new HttpClient(), Mock.Of<ILogger<TestConnectorService>>());
+        var delays = new RecordingRetryDelayStrategy();
+        var attempts = 0;
+
+        Func<Task<string?>> alwaysUnauthorized = () =>
+        {
+            attempts++;
+            throw new HttpRequestException("unauthorized", null, HttpStatusCode.Unauthorized);
+        };
+
+        // Act
+        var result = await service.InvokeExecuteWithRetryAsync(
+            alwaysUnauthorized, delays, maxRetries: 3, () => Task.FromResult(false));
+
+        // Assert
+        result.Should().BeNull();
+        attempts.Should().Be(1, "there is nothing to retry with once re-authentication fails");
+        delays.DelayedAttempts.Should().BeEmpty();
+        service.FailedRequestCount.Should().Be(1);
     }
 
     private static (TestConnectorService service, Mock<IConnectorPublisher> publisher,

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorRetryLoopTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorRetryLoopTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Nocturne.Connectors.Core.Services;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Services;
+
+/// <summary>
+///     The loop every connector retry path runs on: where the delays fall, and which decision buys
+///     an attempt without one.
+/// </summary>
+public class ConnectorRetryLoopTests
+{
+    [Fact]
+    public async Task RunAsync_RetryAfterDelay_DelaysBetweenAttemptsButNotAfterTheLast()
+    {
+        var delays = new RecordingRetryDelayStrategy();
+        var announced = new List<int>();
+        var spent = new List<int>();
+
+        var result = await ConnectorRetryLoop.RunAsync<string>(
+            (attempt, _) =>
+            {
+                spent.Add(attempt);
+                return Task.FromResult(RetryStep<string>.RetryAfterDelay);
+            },
+            delays,
+            maxAttempts: 3,
+            _ => null,
+            CancellationToken.None,
+            announced.Add);
+
+        result.Should().BeNull();
+        spent.Should().Equal(0, 1, 2);
+        delays.DelayedAttempts.Should().Equal([0, 1], "three attempts leave two gaps to delay in");
+        announced.Should().Equal([0, 1], "the hook announces a delay, so it cannot fire after the last attempt");
+    }
+
+    [Fact]
+    public async Task RunAsync_RetryImmediately_SpendsAnAttemptWithoutDelaying()
+    {
+        var delays = new RecordingRetryDelayStrategy();
+        var announced = new List<int>();
+        var spent = new List<int>();
+
+        var result = await ConnectorRetryLoop.RunAsync<string>(
+            (attempt, _) =>
+            {
+                spent.Add(attempt);
+                return Task.FromResult(RetryStep<string>.RetryImmediately);
+            },
+            delays,
+            maxAttempts: 3,
+            _ => null,
+            CancellationToken.None,
+            announced.Add);
+
+        result.Should().BeNull();
+        spent.Should().Equal([0, 1, 2], "an immediate retry still consumes an attempt, so the run terminates");
+        delays.DelayedAttempts.Should().BeEmpty();
+        announced.Should().BeEmpty();
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/RecordingRetryDelayStrategy.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/RecordingRetryDelayStrategy.cs
@@ -1,0 +1,20 @@
+using Nocturne.Connectors.Core.Interfaces;
+
+namespace Nocturne.Connectors.Core.Tests.Services;
+
+/// <summary>
+///     Records the attempt each applied delay followed, so a retry test can pin how many delays a
+///     run applied and where they fell rather than only that the run finished.
+/// </summary>
+internal sealed class RecordingRetryDelayStrategy : IRetryDelayStrategy
+{
+    private readonly List<int> _delayedAttempts = [];
+
+    public IReadOnlyList<int> DelayedAttempts => _delayedAttempts;
+
+    public Task ApplyRetryDelayAsync(int attemptNumber)
+    {
+        _delayedAttempts.Add(attemptNumber);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoFetchRetryTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoFetchRetryTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Services;
+using Nocturne.Core.Constants;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+/// The Glooko fetch path spends its attempts and then throws, and a 403 on a patient-scoped URL
+/// abandons the remaining attempts because the stale patient code will 403 again unchanged.
+/// </summary>
+public class GlookoFetchRetryTests
+{
+    private const string Url = "/api/v2/pumps/temporary_basals?patient=eu-west-1-indigo-killdeer-4650";
+
+    [Fact]
+    public async Task FetchWithRetry_WhenEveryAttemptFails_ThrowsAfterSpendingEveryAttempt()
+    {
+        var handler = new CountingHandler(() => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var (service, delays) = BuildService(handler);
+
+        var act = () => service.FetchFromGlookoEndpointWithRetry(Context(), Url);
+
+        (await act.Should().ThrowAsync<HttpRequestException>()).WithMessage("*500*");
+        handler.Requests.Should().Be(3, "three attempts, not three retries on top of a first try");
+        delays.Verify(d => d.ApplyRetryDelayAsync(It.IsAny<int>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task FetchWithRetry_WhenForbidden_BailsOutWithoutSpendingTheRemainingAttempts()
+    {
+        var handler = new CountingHandler(() => new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent(
+                "{\"status\":403,\"code\":\"data_cant_view\"}", Encoding.UTF8, "application/json"),
+        });
+        var (service, delays) = BuildService(handler);
+
+        var act = () => service.FetchFromGlookoEndpointWithRetry(Context(), Url);
+
+        await act.Should().ThrowAsync<GlookoDataForbiddenException>();
+        handler.Requests.Should().Be(1, "the patient code is part of the URL, so retrying it unchanged would 403 again");
+        delays.Verify(d => d.ApplyRetryDelayAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    private static GlookoSyncContext Context()
+    {
+        var config = new GlookoConnectorConfiguration
+        {
+            ConnectSource = ConnectSource.Glooko,
+            Email = "user@example.com",
+            Password = "secret",
+            Server = GlookoConstants.RegionEU,
+        };
+
+        return new GlookoSyncContext(config, DataSources.GlookoConnector, NullLogger.Instance)
+        {
+            SessionCookie = "_logbook-web_session=sess",
+        };
+    }
+
+    private static (GlookoConnectorService service, Mock<IRetryDelayStrategy> delays) BuildService(
+        CountingHandler handler)
+    {
+        var delays = new Mock<IRetryDelayStrategy>();
+        delays.Setup(d => d.ApplyRetryDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
+
+        var service = new GlookoConnectorService(
+            new HttpClient(handler),
+            new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
+            NullLogger<GlookoConnectorService>.Instance,
+            delays.Object,
+            Mock.Of<IRateLimitingStrategy>(),
+            new StaticGlookoTokenProvider());
+
+        return (service, delays);
+    }
+
+    private sealed class CountingHandler(Func<HttpResponseMessage> response) : HttpMessageHandler
+    {
+        private int _requests;
+
+        public int Requests => Volatile.Read(ref _requests);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _requests);
+            return Task.FromResult(response());
+        }
+    }
+}


### PR DESCRIPTION
Closes #888.

`AuthTokenProviderBase.ExecuteWithRetryAsync` was a second copy of the retry loop `BaseConnectorService.ExecuteWithRetryAsync` already owned — same attempts-not-retries semantics, but without the `Math.Max(1, maxRetries)` floor, so a configured `0` made zero attempts and fell through. `GlookoConnectorService.FetchFromGlookoEndpointWithRetry` was a third copy, also unclamped.

All three now run on one `ConnectorRetryLoop.RunAsync`, which owns the attempt budget, the clamp, the inter-attempt delay and the cancellation check. Each caller passes a step delegate that decides what counts as success, what is retryable, and how failures are reported — so what genuinely differs between them stays with them, and only the sequencing is shared. There is now exactly one retry loop, one clamp site and one delay site in `src/Connectors`.

## The issue's premise was wrong in a way that matters

#888 says every caller passes a literal constant, making the zero case unreachable. `MyFitnessPalAuthTokenProvider` passed `config.MaxRetryAttempts`, and `MaxRetryAttempts` is `[ConnectorProperty(..., MinValue = 0, MaxValue = 10)]` with validation that only rejects negatives. The zero-attempt case *was* reachable from tenant configuration on the MyFitnessPal token path, masked solely by that caller's own local `Math.Max(1, …)`. That redundant clamp is removed here; the shared one covers it.

## Behavioural change

Behaviourally identical to main apart from the intended clamp fix, plus two cancellation deltas on the token-provider path, both absorbed by `GetValidTokenAsync`:

- A token already cancelled on entry now throws before the first attempt instead of making one doomed vendor-login attempt.
- Cancellation observed only after the final attempt now logs the exhausted-attempts error and returns null instead of throwing.

`GetValidTokenAsync` catches all exceptions including `OperationCanceledException` and returns null, and releases its per-tenant semaphore in a `finally`, so callers see "no token" either way and no lock leaks. The direction of change reduces vendor-login hits.

The Glooko collapse carries no delta at all. `CancellationToken.None` preserves that method's pre-existing absence of a cancellation check, and `maxRetries` stays a literal `3` at all five call sites — deliberately not wired to `MaxRetryAttempts`, since changing how often we hit a vendor's endpoint is a per-vendor policy decision (#790), not a tidy-up.

## Verification

Mutation-proved, each reverted and re-verified:

| Mutation | Result |
|---|---|
| Remove the clamp | 2 failures across **both** suites — evidence the loop is genuinely shared, not re-copied |
| `Math.Min` instead of `Math.Max` | 4 failures |
| Loop bound `<=` (retries-not-attempts) | 4 failures |
| Drop `attempt < maxAttempts - 1` (delay after the final attempt) | 5 failures in Core |
| 401 re-auth waits out a backoff | 2 failures |
| Hoist the delay-announce hook out of its guard | 1 failure |
| Glooko exhaustion returns null instead of throwing | 1 failure |
| Glooko forbidden bail-out consumes the budget | 1 failure |

A hostile fresh-context review reproduced main's semantics via A/B differential tests — the same scratch suite run against `origin/main`'s file and against this branch — and got identical operation, re-auth and delay counts plus identical `FailedRequestCount` across all eight outcome paths (success, 401→success, 401-reauth-fail, reauth-throws, retryable-exhausted, stale-`lastException`, pre-cancelled, mid-flight cancellation). It confirmed every log and exception string is verbatim from main, and found no secret leakage. Its three findings were all missing coverage rather than defects, and all three are closed here.

Tests: Core 134 passed, Glooko 99, MyFitnessPal 50; all 15 connector projects build clean.

## Scope notes

`ConnectorRetryLoop` is `public` because Glooko is a separate assembly. `Nocturne.Connectors.Core` has no packaging properties and is not in `sdk-publish.yml`, so this widens no published API surface.

Adjacent, reported rather than fixed: `GlookoConnectorService.cs:193` matches the rate-limit arm with `ex.Message.Contains("422")`, string-coupled to a message constructed two methods up at `:147`. A 500 whose message happened to contain "422" would be logged as a rate limit. Switching to `ex.StatusCode` changes which exceptions take that arm, so it is behaviour rather than tidy-up.
