### PR TITLE
refactor(connectors): route hand-rolled publish bookkeeping through the shared path

### DIFF
--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -242,8 +242,11 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
 
         if (isStale)
         {
+            // The payload arrived and held nothing recent enough to publish, which is a checked
+            // result rather than an unchecked one, so it still owes the tenant a count.
             _logger.LogDebug("[{ConnectorSource}] Skipping SGVs — data is stale (>{Threshold} min)",
                 ConnectorSource, CareLinkConstants.StaleDataThresholdMinutes);
+            RecordPublishOutcome(result, SyncDataType.Glucose, 0, success: true);
             return;
         }
 

--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -249,23 +249,8 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
 
         try
         {
-            var sgRecords = _sgMapper.Map(data);
-            if (sgRecords.Count > 0)
-            {
-                var success = await PublishSensorGlucoseDataAsync(sgRecords, config, cancellationToken);
-                result.ItemsSynced[SyncDataType.Glucose] = sgRecords.Count;
-                if (!success)
-                {
-                    result.Success = false;
-                    result.Errors.Add($"{SyncDataType.Glucose} publish failed");
-                }
-                else
-                {
-                    _logger.LogInformation(
-                        "[{ConnectorSource}] Synced {Count} SensorGlucose records",
-                        ConnectorSource, sgRecords.Count);
-                }
-            }
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+                _sgMapper.Map(data), PublishSensorGlucoseDataAsync, config, cancellationToken);
         }
         catch (OperationCanceledException) { throw; }
         catch (HttpRequestException ex)
@@ -292,23 +277,17 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
         SyncResult result,
         CancellationToken cancellationToken)
     {
+        // Gated here as well as in the shared path, so a switched-off type is not mapped at all.
         if (!enabledTypes.Contains(SyncDataType.DeviceStatus))
             return;
 
         try
         {
-            var deviceStatus = CareLinkDeviceStatusMapper.Map(data);
-            var success = await PublishDeviceStatusAsync([deviceStatus], config, cancellationToken);
-            result.ItemsSynced[SyncDataType.DeviceStatus] = 1;
-            if (!success)
-            {
-                result.Success = false;
-                result.Errors.Add("DeviceStatus publish failed");
-            }
-            else
-            {
-                _logger.LogInformation("[{ConnectorSource}] Synced DeviceStatus", ConnectorSource);
-            }
+            List<Nocturne.Core.Models.DeviceStatus> deviceStatuses =
+                CareLinkDeviceStatusMapper.Map(data) is { } deviceStatus ? [deviceStatus] : [];
+
+            await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, enabledTypes,
+                deviceStatuses, PublishDeviceStatusAsync, config, cancellationToken);
         }
         catch (OperationCanceledException) { throw; }
         catch (HttpRequestException ex)

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -685,8 +685,8 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
     /// <summary>
     ///     Reusable helper that checks whether a data type is active, reports publish progress,
-    ///     publishes a batch of records, updates the <see cref="SyncResult"/> counts, and logs the
-    ///     outcome.
+    ///     publishes a batch of records, and records the outcome through
+    ///     <see cref="RecordPublishOutcome"/>.
     /// </summary>
     /// <param name="context">
     ///     Detail about this batch — where it came from, or what it held — appended to the success log
@@ -710,10 +710,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         if (records.Count == 0)
         {
-            // An active type the sync did look at reports an explicit zero: the tenant's sync card
-            // renders a badge per key, so a missing key reads as "never checked" rather than
-            // "checked, found nothing". TryAdd so a later empty page cannot erase an earlier count.
-            result.ItemsSynced.TryAdd(dataType, 0);
+            RecordPublishOutcome(result, dataType, 0, success: true);
             return false;
         }
 
@@ -722,20 +719,50 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             cancellationToken);
 
         var success = await publishFunc(records, config, cancellationToken);
-        result.ItemsSynced.TryGetValue(dataType, out var prev);
-        result.ItemsSynced[dataType] = prev + records.Count;
+        RecordPublishOutcome(result, dataType, records.Count, success, context);
+        return success;
+    }
+
+    /// <summary>
+    ///     The bookkeeping every published record type owes the run: the per-type count the tenant's
+    ///     sync card renders, the canonical failure string, and the success log. Connectors whose
+    ///     publish shape does not fit <see cref="PublishRecordTypeAsync{T}"/> — a streaming crawl that
+    ///     publishes page by page, or one fetch feeding several types — record through this instead of
+    ///     writing the three by hand.
+    /// </summary>
+    /// <remarks>
+    ///     A type the sync looked at records a count even when it came back empty: the card renders a
+    ///     badge per key, so a missing key reads as "never checked" rather than "checked, found
+    ///     nothing". Counts accumulate, so a paginated crawl can report each page and a later empty
+    ///     page cannot erase what an earlier one landed. Callers report the count once the publish has
+    ///     returned, so a publish that throws records nothing while one that reports failure records
+    ///     the batch it handed over — the count is what reached the publisher, not what the publisher
+    ///     accepted.
+    /// </remarks>
+    /// <param name="context">
+    ///     Detail about this batch — where it came from, or what it held — appended to the success log
+    ///     in parentheses.
+    /// </param>
+    protected void RecordPublishOutcome(
+        SyncResult result,
+        SyncDataType dataType,
+        int count,
+        bool success,
+        string? context = null)
+    {
+        result.ItemsSynced.TryGetValue(dataType, out var previous);
+        result.ItemsSynced[dataType] = previous + count;
+
         if (!success)
         {
             result.Success = false;
             result.Errors.Add($"{dataType} publish failed");
         }
-        else
+        else if (count > 0)
         {
             _logger.LogInformation("[{ConnectorSource}] Synced {Count} {Type} records{Context}",
-                ConnectorSource, records.Count, dataType, context != null ? $" ({context})" : "");
+                ConnectorSource, count, dataType, context != null ? $" ({context})" : "");
         }
-
-        return success;
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
@@ -28,7 +28,6 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
     private readonly IRetryDelayStrategy _retryDelayStrategy;
     private readonly MyFitnessPalAuthTokenProvider _tokenProvider;
     private readonly IConnectorConfigurationService _configService;
-    private readonly IConnectorPublisher? _connectorPublisher;
     private readonly MyFitnessPalFoodEntryMapper _mapper;
 
     private string? _accessToken;
@@ -49,7 +48,6 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
             retryDelayStrategy ?? throw new ArgumentNullException(nameof(retryDelayStrategy));
         _tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
         _configService = configService ?? throw new ArgumentNullException(nameof(configService));
-        _connectorPublisher = publisher;
         _mapper = new MyFitnessPalFoodEntryMapper(logger);
     }
 
@@ -95,7 +93,8 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
 
         // This override replaces the base's data-type dispatch, so the toggle it would have
         // honoured has to be checked here.
-        if (!config.GetEnabledDataTypes(SupportedDataTypes).Contains(SyncDataType.Food))
+        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
+        if (!enabledTypes.Contains(SyncDataType.Food))
         {
             _logger.LogInformation(
                 "[{ConnectorSource}] Food sync is disabled; nothing to do", ConnectorSource);
@@ -104,12 +103,7 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
         }
 
         if (!await AuthenticateWithConfigAsync(config, cancellationToken))
-        {
-            result.Success = false;
-            result.Errors.Add("Authentication failed for MyFitnessPal");
-            result.EndTime = DateTimeOffset.UtcNow;
-            return result;
-        }
+            return AuthenticationFailedResult();
 
         // The request carries UTC instants; pin the kind so the window is not reinterpreted as local.
         var from = AsUtc(request.From ?? DateTime.UtcNow.AddDays(-config.LookbackDays));
@@ -135,34 +129,14 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
         var mealNames = await ResolveMealNamesAsync(read.Entries, from, to, cancellationToken);
 
         var foodEntryImports = _mapper.Map(read.Entries, config, from, to, mealNames);
-        var count = foodEntryImports.Count;
 
-        if (count > 0)
-        {
-            if (_connectorPublisher is not { IsAvailable: true })
-            {
-                _logger.LogWarning("Publisher not available for connector food entry submission");
-                result.Success = false;
-                result.Errors.Add("Publisher not available");
-            }
-            else
-            {
-                var imported = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
-                    foodEntryImports,
-                    ConnectorSource, WriteOrigin.Live,
-                    cancellationToken
-                ); // Food is a dormant broadcast category — origin irrelevant until wired.
-                if (imported == null)
-                {
-                    result.Success = false;
-                    result.Errors.Add("Failed to publish food entries");
-                }
-            }
-        }
+        await PublishRecordTypeAsync(result, SyncDataType.Food, enabledTypes, foodEntryImports,
+            PublishFoodEntriesAsync, config, cancellationToken,
+            context: $"since {from:yyyy-MM-dd}");
 
         // Outside the publish branch: a window the user has emptied maps to no imports at all, and
         // that case still has to withdraw every entry stored for it.
-        if (result.Success && _connectorPublisher is { IsAvailable: true })
+        if (result.Success && Publisher is { IsAvailable: true })
         {
             await WithdrawDeletedEntriesAsync(read, from, to, cancellationToken);
 
@@ -175,16 +149,33 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
             }
         }
 
-        result.ItemsSynced[SyncDataType.Food] = count;
-        _logger.LogInformation(
-            "[{ConnectorSource}] Synced {Count} food entries from MyFitnessPal since {From:yyyy-MM-dd}",
-            ConnectorSource,
-            count,
-            from
-        );
-
         result.EndTime = DateTimeOffset.UtcNow;
         return result;
+    }
+
+    /// <summary>
+    /// Adapts the food-catalog publish to the shared publish path: the publisher reports a rejected
+    /// import with a null result rather than a flag, and returns an empty list when it reached the
+    /// catalog but nothing was accepted.
+    /// </summary>
+    private async Task<bool> PublishFoodEntriesAsync(
+        List<ConnectorFoodEntryImport> entries,
+        MyFitnessPalConnectorConfiguration config,
+        CancellationToken cancellationToken)
+    {
+        if (Publisher is not { IsAvailable: true } publisher)
+        {
+            _logger.LogWarning("Publisher not available for connector food entry submission");
+            return false;
+        }
+
+        var imported = await publisher.Metadata.PublishConnectorFoodEntriesAsync(
+            entries,
+            ConnectorSource, WriteOrigin.Live,
+            cancellationToken
+        ); // Food is a dormant broadcast category — origin irrelevant until wired.
+
+        return imported != null;
     }
 
     private static DateTimeOffset AsUtc(DateTime value) =>
@@ -393,7 +384,7 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
         // filtered on a consumed time this connector fabricates from the meal name, so an entry
         // whose meal name changed between cycles can move hours and fall outside the window while
         // still existing upstream. Comparing against that set would read the move as a deletion.
-        await _connectorPublisher!.Metadata.ReconcileConnectorFoodEntriesAsync(
+        await Publisher!.Metadata.ReconcileConnectorFoodEntriesAsync(
             read.Entries.Select(e => e.Id),
             from,
             to,

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -164,7 +164,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         // ranged syncs (request.To set, e.g. a manual re-import) honour request.From/To as-is.
         var openEnded = request.To is null;
 
-        // Handle Glucose
         // Glucose keeps request.From — for background syncs the framework already derived
         // it from the latest glucose entry, so it is glucose's own independent cursor.
         //
@@ -196,7 +195,8 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             }
         }
 
-        // Handle Treatments — Nightscout fetches all treatment types as one batch
+        // Nightscout fetches every treatment type as one batch, so each active sub-type
+        // carries the whole batch's outcome.
         SyncDataType[] treatmentTypes =
         [
             SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.ManualBG,
@@ -218,8 +218,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     oldestOf: p => OldestCreatedAt(p, t => t.CreatedAt),
                     publishAsync: p => PublishTreatmentDataInBatchesAsync(p, config, cancellationToken));
 
-                // One fetch covers every treatment sub-type, so each active one carries the whole
-                // batch's outcome.
                 foreach (var treatmentType in treatmentTypes.Where(activeTypes.Contains))
                     RecordPublishOutcome(result, treatmentType, outcome.Count, outcome.Success);
             }
@@ -231,7 +229,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             }
         }
 
-        // Handle Profiles
         if (activeTypes.Contains(SyncDataType.Profiles))
         {
             try
@@ -248,7 +245,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             }
         }
 
-        // Handle DeviceStatus
         if (activeTypes.Contains(SyncDataType.DeviceStatus))
         {
             try
@@ -276,7 +272,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             }
         }
 
-        // Handle Food
         if (activeTypes.Contains(SyncDataType.Food))
         {
             try
@@ -293,7 +288,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             }
         }
 
-        // Handle Activity
         if (activeTypes.Contains(SyncDataType.Activity))
         {
             try

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -186,17 +186,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     oldestOf: OldestEntryTime,
                     publishAsync: p => PublishGlucoseDataInBatchesAsync(p, config, cancellationToken));
 
-                _logger.LogInformation(
-                    "[{ConnectorSource}] Retrieved {Count} glucose entries from Nightscout",
-                    ConnectorSource,
-                    outcome.Count);
-
-                result.ItemsSynced[SyncDataType.Glucose] = outcome.Count;
-                if (!outcome.Success)
-                {
-                    result.Success = false;
-                    result.Errors.Add("Glucose publish failed");
-                }
+                RecordPublishOutcome(result, SyncDataType.Glucose, outcome.Count, outcome.Success);
             }
             catch (Exception ex)
             {
@@ -228,23 +218,10 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     oldestOf: p => OldestCreatedAt(p, t => t.CreatedAt),
                     publishAsync: p => PublishTreatmentDataInBatchesAsync(p, config, cancellationToken));
 
-                _logger.LogInformation(
-                    "[{ConnectorSource}] Retrieved {Count} treatments from Nightscout",
-                    ConnectorSource,
-                    outcome.Count);
-
-                if (outcome.Count > 0)
-                {
-                    // Report count under each enabled treatment sub-type
-                    foreach (var tt in treatmentTypes.Where(t => activeTypes.Contains(t)))
-                        result.ItemsSynced[tt] = outcome.Count;
-                }
-
-                if (!outcome.Success)
-                {
-                    result.Success = false;
-                    result.Errors.Add("Treatments publish failed");
-                }
+                // One fetch covers every treatment sub-type, so each active one carries the whole
+                // batch's outcome.
+                foreach (var treatmentType in treatmentTypes.Where(activeTypes.Contains))
+                    RecordPublishOutcome(result, treatmentType, outcome.Count, outcome.Success);
             }
             catch (Exception ex)
             {
@@ -289,17 +266,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     oldestOf: p => OldestCreatedAt(p, d => d.CreatedAt),
                     publishAsync: p => PublishDeviceStatusAsync(p, config, cancellationToken));
 
-                _logger.LogInformation(
-                    "[{ConnectorSource}] Retrieved {Count} device statuses from Nightscout",
-                    ConnectorSource,
-                    outcome.Count);
-
-                result.ItemsSynced[SyncDataType.DeviceStatus] = outcome.Count;
-                if (!outcome.Success)
-                {
-                    result.Success = false;
-                    result.Errors.Add("DeviceStatus publish failed");
-                }
+                RecordPublishOutcome(result, SyncDataType.DeviceStatus, outcome.Count, outcome.Success);
             }
             catch (Exception ex)
             {
@@ -315,18 +282,8 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             try
             {
                 var foods = await FetchFoodAsync();
-                var foodList = foods.ToList();
-                result.ItemsSynced[SyncDataType.Food] = foodList.Count;
-                if (foodList.Count > 0)
-                {
-                    var publishSuccess = await PublishFoodDataAsync(
-                        foodList, config, cancellationToken);
-                    if (!publishSuccess)
-                    {
-                        result.Success = false;
-                        result.Errors.Add("Food publish failed");
-                    }
-                }
+                await PublishRecordTypeAsync(result, SyncDataType.Food, activeTypes,
+                    foods.ToList(), PublishFoodDataAsync, config, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -353,17 +310,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                     oldestOf: p => OldestCreatedAt(p, a => a.CreatedAt),
                     publishAsync: p => PublishActivityDataAsync(p, config, cancellationToken));
 
-                _logger.LogInformation(
-                    "[{ConnectorSource}] Retrieved {Count} activities from Nightscout",
-                    ConnectorSource,
-                    outcome.Count);
-
-                result.ItemsSynced[SyncDataType.Activity] = outcome.Count;
-                if (!outcome.Success)
-                {
-                    result.Success = false;
-                    result.Errors.Add("Activity publish failed");
-                }
+                RecordPublishOutcome(result, SyncDataType.Activity, outcome.Count, outcome.Success);
             }
             catch (Exception ex)
             {

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -93,8 +93,7 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
 
                 if (bgValues is null)
                 {
-                    result.Success = false;
-                    result.Errors.Add("Failed to fetch Glucose");
+                    ReportFailedFetch(result, SyncDataType.Glucose, activeTypes);
                 }
                 else
                 {
@@ -125,11 +124,13 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
 
                 var (mappedBoluses, mappedCarbs, _) = _v4TreatmentMapper.MapTreatments(boluses, foods);
 
-                if (boluses is null || foods is null)
-                {
-                    result.Success = false;
-                    result.Errors.Add("Failed to fetch Treatments");
-                }
+                // Both fetches are issued whenever either type is active, because the correlation
+                // that pairs a carb intake with a bolus needs the boluses even when boluses
+                // themselves are not being synced.
+                if (boluses is null)
+                    ReportFailedFetch(result, SyncDataType.Boluses, activeTypes);
+                if (foods is null)
+                    ReportFailedFetch(result, SyncDataType.CarbIntake, activeTypes);
 
                 // Boluses come from the bolus fetch and carb intakes from the food fetch, so each
                 // type is reported only when its own fetch came back.
@@ -151,6 +152,31 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
 
         result.EndTime = DateTimeOffset.UtcNow;
         return result;
+    }
+
+    /// <summary>
+    ///     Reports a fetch that came back null (see <see cref="FetchDataAsync{T}"/>) as a failure of
+    ///     the run, but only for a type the tenant enabled.
+    /// </summary>
+    /// <remarks>
+    ///     A failed run withholds the connector's last-successful-sync stamp and shows the tenant a
+    ///     red connector, so a fetch issued only to support another type — the bolus fetch feeding
+    ///     the carb correlation — must not be able to fail the sync. Losing it costs that
+    ///     correlation and nothing else.
+    /// </remarks>
+    private void ReportFailedFetch(
+        SyncResult result, SyncDataType dataType, HashSet<SyncDataType> activeTypes)
+    {
+        if (!activeTypes.Contains(dataType))
+        {
+            _logger.LogDebug(
+                "[{ConnectorSource}] {DataType} fetch failed for a type that is switched off",
+                ConnectorSource, dataType);
+            return;
+        }
+
+        result.Success = false;
+        result.Errors.Add($"Failed to fetch {dataType}");
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -81,7 +81,7 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
             }
         }
 
-        // Handle Glucose (CBG + SMBG → SensorGlucose)
+        // CBG and SMBG both map to SensorGlucose.
         if (activeTypes.Contains(SyncDataType.Glucose))
         {
             try
@@ -91,10 +91,17 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
                     $"{TidepoolConstants.DataTypes.Cbg},{TidepoolConstants.DataTypes.Smbg}",
                     request.From, request.To);
 
-                if (bgValues != null)
+                if (bgValues is null)
+                {
+                    result.Success = false;
+                    result.Errors.Add("Failed to fetch Glucose");
+                }
+                else
+                {
                     await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                         _sensorGlucoseMapper.MapBgValues(bgValues).ToList(), PublishSensorGlucoseDataAsync,
                         config, cancellationToken);
+                }
             }
             catch (Exception ex)
             {
@@ -104,7 +111,6 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
             }
         }
 
-        // Handle Boluses and CarbIntake
         SyncDataType[] treatmentTypes = [SyncDataType.Boluses, SyncDataType.CarbIntake];
         if (activeTypes.Any(t => treatmentTypes.Contains(t)))
         {
@@ -119,11 +125,21 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
 
                 var (mappedBoluses, mappedCarbs, _) = _v4TreatmentMapper.MapTreatments(boluses, foods);
 
-                await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-                    mappedBoluses, PublishBolusDataAsync, config, cancellationToken);
+                if (boluses is null || foods is null)
+                {
+                    result.Success = false;
+                    result.Errors.Add("Failed to fetch Treatments");
+                }
 
-                await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
-                    mappedCarbs, PublishCarbIntakeDataAsync, config, cancellationToken);
+                // Boluses come from the bolus fetch and carb intakes from the food fetch, so each
+                // type is reported only when its own fetch came back.
+                if (boluses is not null)
+                    await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
+                        mappedBoluses, PublishBolusDataAsync, config, cancellationToken);
+
+                if (foods is not null)
+                    await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
+                        mappedCarbs, PublishCarbIntakeDataAsync, config, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -140,6 +156,12 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
     /// <summary>
     ///     Fetches typed data from the Tidepool API data endpoint.
     /// </summary>
+    /// <returns>
+    ///     The deserialized collection, or <c>null</c> when the fetch failed — no token, an error
+    ///     response, or exhausted retries. A caller must not read that as an empty window: a type
+    ///     the sync could not check has to go unreported, because the count the tenant's sync card
+    ///     renders as "checked, found nothing" is a claim the source was reached.
+    /// </returns>
     private async Task<T?> FetchDataAsync<T>(
         TidepoolConnectorConfiguration config,
         string dataType, DateTime? startDate = null, DateTime? endDate = null) where T : class

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -76,11 +76,8 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
             var token = await _tokenProvider.GetValidTokenAsync(config, cancellationToken);
             if (string.IsNullOrEmpty(token))
             {
-                result.Success = false;
-                result.Errors.Add("Authentication failed");
-                result.EndTime = DateTimeOffset.UtcNow;
                 _logger.LogWarning("[{ConnectorSource}] Sync failed: authentication unsuccessful", ConnectorSource);
-                return result;
+                return AuthenticationFailedResult();
             }
         }
 
@@ -122,35 +119,11 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
 
                 var (mappedBoluses, mappedCarbs, _) = _v4TreatmentMapper.MapTreatments(boluses, foods);
 
-                if (activeTypes.Contains(SyncDataType.Boluses) && mappedBoluses.Count > 0)
-                {
-                    var success = await PublishBolusDataAsync(mappedBoluses, config, cancellationToken);
-                    if (success)
-                    {
-                        result.ItemsSynced[SyncDataType.Boluses] = mappedBoluses.Count;
-                        _logger.LogInformation("[{ConnectorSource}] Synced {Count} Bolus records", ConnectorSource, mappedBoluses.Count);
-                    }
-                    else
-                    {
-                        result.Success = false;
-                        result.Errors.Add($"{SyncDataType.Boluses} publish failed");
-                    }
-                }
+                await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
+                    mappedBoluses, PublishBolusDataAsync, config, cancellationToken);
 
-                if (activeTypes.Contains(SyncDataType.CarbIntake) && mappedCarbs.Count > 0)
-                {
-                    var success = await PublishCarbIntakeDataAsync(mappedCarbs, config, cancellationToken);
-                    if (success)
-                    {
-                        result.ItemsSynced[SyncDataType.CarbIntake] = mappedCarbs.Count;
-                        _logger.LogInformation("[{ConnectorSource}] Synced {Count} CarbIntake records", ConnectorSource, mappedCarbs.Count);
-                    }
-                    else
-                    {
-                        result.Success = false;
-                        result.Errors.Add("CarbIntake publish failed");
-                    }
-                }
+                await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
+                    mappedCarbs, PublishCarbIntakeDataAsync, config, cancellationToken);
             }
             catch (Exception ex)
             {

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
@@ -385,6 +385,58 @@ public class NightscoutConnectorPaginationTests
     }
 
     [Fact]
+    public async Task FetchTreatments_MultiplePagesFeedingSeveralTypes_RecordTheWholeTotalUnderEach()
+    {
+        // The treatments crawl is one paginated fetch feeding every active sub-type, so each of
+        // them has to carry the total across all pages — a count taken from the last page alone,
+        // or recorded for only the first sub-type, silently under-reports what the sync stored.
+        var page1 = CreateTreatments(MaxCount, BaseTime);
+        var page2Start = page1
+            .Select(t => DateTimeOffset.Parse(t.CreatedAt!, CultureInfo.InvariantCulture))
+            .Min()
+            .AddMilliseconds(-1);
+        var page2 = CreateTreatments(4, page2Start);
+
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(page1));
+        handler.Enqueue(JsonResponse(page2));
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "https://nightscout.example.com",
+            ApiSecret = "test-secret",
+            MaxCount = MaxCount,
+        };
+        var service = CreateService(handler, config, withPublisher: true);
+
+        var request = new Nocturne.Connectors.Core.Models.SyncRequest
+        {
+            From = BaseTime.AddHours(-6).UtcDateTime,
+            To = BaseTime.UtcDateTime,
+            DataTypes =
+            [
+                Nocturne.Connectors.Core.Models.SyncDataType.Boluses,
+                Nocturne.Connectors.Core.Models.SyncDataType.CarbIntake,
+                Nocturne.Connectors.Core.Models.SyncDataType.DeviceEvents,
+            ],
+        };
+
+        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().BeEquivalentTo(
+            new Dictionary<Nocturne.Connectors.Core.Models.SyncDataType, int>
+            {
+                [Nocturne.Connectors.Core.Models.SyncDataType.Boluses] = MaxCount + 4,
+                [Nocturne.Connectors.Core.Models.SyncDataType.CarbIntake] = MaxCount + 4,
+                [Nocturne.Connectors.Core.Models.SyncDataType.DeviceEvents] = MaxCount + 4,
+            });
+        handler.RequestUrls.Count(u => u.Contains("treatments.json")).Should().Be(2,
+            "the total must span more than one page for this to prove anything");
+    }
+
+    [Fact]
     public async Task FetchTreatments_ActiveTypesWithNoTreatments_RecordExplicitZeros()
     {
         // One fetch covers every treatment sub-type, and each active one has to say zero when it

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
@@ -385,6 +385,46 @@ public class NightscoutConnectorPaginationTests
     }
 
     [Fact]
+    public async Task FetchTreatments_ActiveTypesWithNoTreatments_RecordExplicitZeros()
+    {
+        // One fetch covers every treatment sub-type, and each active one has to say zero when it
+        // came back empty: the tenant's sync card renders a badge per key, so a missing key reads
+        // as "never checked" rather than "checked, found nothing".
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(Array.Empty<Treatment>()));
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "https://nightscout.example.com",
+            ApiSecret = "test-secret",
+            MaxCount = MaxCount,
+        };
+        var service = CreateService(handler, config, withPublisher: true);
+
+        var request = new Nocturne.Connectors.Core.Models.SyncRequest
+        {
+            From = BaseTime.AddHours(-2).UtcDateTime,
+            To = BaseTime.UtcDateTime,
+            DataTypes =
+            [
+                Nocturne.Connectors.Core.Models.SyncDataType.Boluses,
+                Nocturne.Connectors.Core.Models.SyncDataType.CarbIntake,
+            ],
+        };
+
+        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().BeEquivalentTo(
+            new Dictionary<Nocturne.Connectors.Core.Models.SyncDataType, int>
+            {
+                [Nocturne.Connectors.Core.Models.SyncDataType.Boluses] = 0,
+                [Nocturne.Connectors.Core.Models.SyncDataType.CarbIntake] = 0,
+            });
+    }
+
+    [Fact]
     public async Task FetchTreatments_MultiplePages_ReturnsAll()
     {
         var page1 = CreateTreatments(MaxCount, BaseTime);

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NightscoutConnectorPaginationTests.cs
@@ -354,6 +354,67 @@ public class NightscoutConnectorPaginationTests
     #region Treatment pagination tests
 
     [Fact]
+    public async Task FetchTreatments_WhenThePublishIsRejected_FailsAndReportsEveryActiveSubType()
+    {
+        // The whole batch is one publish, so its rejection belongs to every sub-type the batch was
+        // carrying — a tenant told only that "treatments" failed cannot tell which of their toggles
+        // is affected, and the counts still report what the sync handed over.
+        var handler = new SequentialMockHandler();
+        handler.Enqueue(JsonResponse(Array.Empty<Entry>())); // auth check
+        handler.Enqueue(JsonResponse(CreateTreatments(5, BaseTime)));
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "https://nightscout.example.com",
+            ApiSecret = "test-secret",
+            MaxCount = MaxCount,
+        };
+
+        var treatmentMock = new Mock<ITreatmentPublisher>();
+        treatmentMock.Setup(p => p.PublishTreatmentsAsync(
+                It.IsAny<IEnumerable<Treatment>>(), It.IsAny<string>(),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var publisherMock = new Mock<IConnectorPublisher>();
+        publisherMock.Setup(p => p.IsAvailable).Returns(true);
+        publisherMock.Setup(p => p.Treatments).Returns(treatmentMock.Object);
+        publisherMock.Setup(p => p.Glucose).Returns(Mock.Of<IGlucosePublisher>());
+        publisherMock.Setup(p => p.Metadata).Returns(Mock.Of<IMetadataPublisher>());
+
+        var service = new NightscoutConnectorService(
+            new HttpClient(handler) { BaseAddress = new Uri(config.Url) },
+            new ConnectorServerResolver<NightscoutConnectorConfiguration>(null, null, null),
+            Mock.Of<ILogger<NightscoutConnectorService>>(),
+            Mock.Of<IRetryDelayStrategy>(),
+            Mock.Of<IRateLimitingStrategy>(),
+            new ConnectorRegistration<NightscoutConnectorConfiguration>(config, "Nightscout"),
+            publisherMock.Object);
+
+        var request = new Nocturne.Connectors.Core.Models.SyncRequest
+        {
+            From = BaseTime.AddHours(-2).UtcDateTime,
+            To = BaseTime.UtcDateTime,
+            DataTypes =
+            [
+                Nocturne.Connectors.Core.Models.SyncDataType.Boluses,
+                Nocturne.Connectors.Core.Models.SyncDataType.CarbIntake,
+            ],
+        };
+
+        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+
+        result.Success.Should().BeFalse("a batch that never reached the tenant is not a successful sync");
+        result.Errors.Should().BeEquivalentTo(["Boluses publish failed", "CarbIntake publish failed"]);
+        result.ItemsSynced.Should().BeEquivalentTo(
+            new Dictionary<Nocturne.Connectors.Core.Models.SyncDataType, int>
+            {
+                [Nocturne.Connectors.Core.Models.SyncDataType.Boluses] = 5,
+                [Nocturne.Connectors.Core.Models.SyncDataType.CarbIntake] = 5,
+            });
+    }
+
+    [Fact]
     public async Task FetchTreatments_SinglePage_ReturnsAll()
     {
         var treatments = CreateTreatments(5, BaseTime);
@@ -387,9 +448,10 @@ public class NightscoutConnectorPaginationTests
     [Fact]
     public async Task FetchTreatments_MultiplePagesFeedingSeveralTypes_RecordTheWholeTotalUnderEach()
     {
-        // The treatments crawl is one paginated fetch feeding every active sub-type, so each of
-        // them has to carry the total across all pages — a count taken from the last page alone,
-        // or recorded for only the first sub-type, silently under-reports what the sync stored.
+        // The treatments crawl is one paginated fetch feeding every active sub-type. What is pinned
+        // is that the recorded count spans every page rather than just the last, and that it
+        // reaches every active sub-type rather than the first — not the per-type repetition itself,
+        // which is this connector's existing reporting shape for a batch it cannot split.
         var page1 = CreateTreatments(MaxCount, BaseTime);
         var page2Start = page1
             .Select(t => DateTimeOffset.Parse(t.CreatedAt!, CultureInfo.InvariantCulture))

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
@@ -141,6 +141,45 @@ public class CareLinkConnectorServiceTests
             "a switched-off type is never handed to the publisher, so it cannot fail");
     }
 
+    /// <summary>
+    /// A payload with no sensor readings still records a zero for glucose: the tenant's sync card
+    /// renders a badge per key, so a missing key reads as "never checked" rather than "checked,
+    /// found nothing".
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenGlucoseIsActiveButEmpty_RecordsAnExplicitZero()
+    {
+        // lastSG present (so the monitor payload is used) but no sgs array, and no medical-device
+        // update time, so the data does not read as stale and the glucose step does run.
+        var handler = new CareLinkFakeHandler
+        {
+            MonitorDataJson = """
+                {
+                  "currentServerTime": 1767261600000,
+                  "lastSG": {}
+                }
+                """
+        };
+        var fixture = new ServiceFixture(handler, new CareLinkConnectorConfiguration
+        {
+            Username = "user@example.com",
+            Server = "EU",
+            SyncDeviceStatus = false,
+            SyncBoluses = false,
+            SyncCarbIntake = false,
+            SyncTempBasals = false,
+            SyncDeviceEvents = false,
+        });
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.ItemsSynced.Should().Equal(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Glucose] = 0,
+        });
+    }
+
     private const string AlarmDateTime = "2026-01-01T10:00:00";
     private const string NotificationBeforeAlarm = "2026-01-01T09:55:00";
 

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
@@ -10,6 +10,8 @@ using Nocturne.Connectors.Core.Services;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
 using Xunit;
 
 namespace Nocturne.Connectors.CareLink.Tests.Services;
@@ -180,6 +182,120 @@ public class CareLinkConnectorServiceTests
         });
     }
 
+    /// <summary>
+    /// Every reading in the payload is counted, not merely the batch existing at all: a count that
+    /// silently drops records is how a tenant comes to believe a gap in their glucose history was
+    /// never uploaded.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_CountsEverySensorGlucoseRecordPublished()
+    {
+        var handler = new CareLinkFakeHandler
+        {
+            MonitorDataJson = """
+                {
+                  "currentServerTime": 1767261600000,
+                  "lastSG": { "sg": 120, "datetime": "2026-01-01T10:00:00", "kind": "SG" },
+                  "sgs": [
+                    { "sg": 100, "datetime": "2026-01-01T09:50:00", "kind": "SG" },
+                    { "sg": 110, "datetime": "2026-01-01T09:55:00", "kind": "SG" },
+                    { "sg": 120, "datetime": "2026-01-01T10:00:00", "kind": "SG" }
+                  ]
+                }
+                """
+        };
+        var fixture = new ServiceFixture(handler, GlucoseOnlyConfiguration(), withPublisher: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().Equal(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Glucose] = 3,
+        });
+        fixture.PublishedGlucose.Should().HaveCount(3);
+    }
+
+    /// <summary>
+    /// Device status is mapped from the same payload every cycle, so an active toggle always
+    /// reports exactly the one record it published.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_CountsTheDeviceStatusItPublishes()
+    {
+        var handler = new CareLinkFakeHandler
+        {
+            MonitorDataJson = """
+                {
+                  "currentServerTime": 1767261600000,
+                  "lastSG": {}
+                }
+                """
+        };
+        var config = GlucoseOnlyConfiguration();
+        config.SyncDeviceStatus = true;
+        var fixture = new ServiceFixture(handler, config, withPublisher: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.DeviceStatus] },
+            fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Glucose] = 0,
+            [SyncDataType.DeviceStatus] = 1,
+        });
+        fixture.PublishedDeviceStatuses.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A payload too old to publish has still been checked, so glucose reports a zero rather than
+    /// leaving the tenant a missing badge that reads as "never checked".
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheDataIsStale_RecordsAnExplicitZero()
+    {
+        // A medical-device update an hour behind the server clock is past the staleness threshold,
+        // so the readings in the payload are deliberately not published.
+        var handler = new CareLinkFakeHandler
+        {
+            MonitorDataJson = """
+                {
+                  "currentServerTime": 1767261600000,
+                  "lastMedicalDeviceDataUpdateServerTime": 1767258000000,
+                  "lastSG": { "sg": 120, "datetime": "2026-01-01T09:00:00", "kind": "SG" },
+                  "sgs": [
+                    { "sg": 120, "datetime": "2026-01-01T09:00:00", "kind": "SG" }
+                  ]
+                }
+                """
+        };
+        var fixture = new ServiceFixture(handler, GlucoseOnlyConfiguration(), withPublisher: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.ItemsSynced.Should().Equal(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Glucose] = 0,
+        });
+        fixture.PublishedGlucose.Should().BeEmpty("stale readings are deliberately not published");
+    }
+
+    /// <summary>Leaves only the glucose step able to publish.</summary>
+    private static CareLinkConnectorConfiguration GlucoseOnlyConfiguration() => new()
+    {
+        Username = "user@example.com",
+        Server = "EU",
+        SyncDeviceStatus = false,
+        SyncBoluses = false,
+        SyncCarbIntake = false,
+        SyncTempBasals = false,
+        SyncDeviceEvents = false,
+    };
+
     private const string AlarmDateTime = "2026-01-01T10:00:00";
     private const string NotificationBeforeAlarm = "2026-01-01T09:55:00";
 
@@ -250,8 +366,13 @@ public class CareLinkConnectorServiceTests
     {
         internal CareLinkConnectorService Service { get; }
         internal CareLinkConnectorConfiguration Config { get; }
+        internal List<SensorGlucose> PublishedGlucose { get; } = [];
+        internal List<Nocturne.Core.Models.DeviceStatus> PublishedDeviceStatuses { get; } = [];
 
-        internal ServiceFixture(CareLinkFakeHandler handler, CareLinkConnectorConfiguration? config = null)
+        internal ServiceFixture(
+            CareLinkFakeHandler handler,
+            CareLinkConnectorConfiguration? config = null,
+            bool withPublisher = false)
         {
             Config = config ?? new CareLinkConnectorConfiguration
             {
@@ -280,12 +401,43 @@ public class CareLinkConnectorServiceTests
                 Mock.Of<IRetryDelayStrategy>(),
                 handler);
 
+            IConnectorPublisher? publisher = null;
+            if (withPublisher)
+            {
+                var glucose = new Mock<IGlucosePublisher>();
+                glucose
+                    .Setup(p => p.PublishSensorGlucoseAsync(
+                        It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<string>(),
+                        It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+                    .Callback<IEnumerable<SensorGlucose>, string, WriteOrigin, CancellationToken>(
+                        (batch, _, _, _) => PublishedGlucose.AddRange(batch))
+                    .ReturnsAsync(true);
+
+                var device = new Mock<IDevicePublisher>();
+                device
+                    .Setup(p => p.PublishDeviceStatusAsync(
+                        It.IsAny<IEnumerable<Nocturne.Core.Models.DeviceStatus>>(), It.IsAny<string>(),
+                        It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+                    .Callback<IEnumerable<Nocturne.Core.Models.DeviceStatus>, string, WriteOrigin, CancellationToken>(
+                        (batch, _, _, _) => PublishedDeviceStatuses.AddRange(batch))
+                    .ReturnsAsync(true);
+
+                var mock = new Mock<IConnectorPublisher>();
+                mock.Setup(p => p.IsAvailable).Returns(true);
+                mock.Setup(p => p.Glucose).Returns(glucose.Object);
+                mock.Setup(p => p.Device).Returns(device.Object);
+                mock.Setup(p => p.Treatments).Returns(Mock.Of<ITreatmentPublisher>());
+                mock.Setup(p => p.Metadata).Returns(Mock.Of<IMetadataPublisher>());
+                publisher = mock.Object;
+            }
+
             Service = new CareLinkConnectorService(
                 new HttpClient(handler),
                 serverResolver,
                 tokenProvider,
                 configService.Object,
-                NullLogger<CareLinkConnectorService>.Instance);
+                NullLogger<CareLinkConnectorService>.Instance,
+                publisher);
         }
     }
 

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
@@ -284,6 +284,35 @@ public class CareLinkConnectorServiceTests
         fixture.PublishedGlucose.Should().BeEmpty("stale readings are deliberately not published");
     }
 
+    /// <summary>
+    /// The zero the stale path records goes through <c>RecordPublishOutcome</c>, which deliberately
+    /// has no active-type check of its own — so the step's own toggle gate is the only thing keeping
+    /// a switched-off type from being badged, and it has to stay.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenGlucoseIsDisabledAndTheDataIsStale_RecordsNothing()
+    {
+        var handler = new CareLinkFakeHandler
+        {
+            MonitorDataJson = """
+                {
+                  "currentServerTime": 1767261600000,
+                  "lastMedicalDeviceDataUpdateServerTime": 1767258000000,
+                  "lastSG": { "sg": 120, "datetime": "2026-01-01T09:00:00", "kind": "SG" }
+                }
+                """
+        };
+        var config = GlucoseOnlyConfiguration();
+        config.SyncGlucose = false;
+        var fixture = new ServiceFixture(handler, config, withPublisher: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        result.ItemsSynced.Should().BeEmpty(
+            "a type the tenant switched off is never reported, stale payload or not");
+    }
+
     /// <summary>Leaves only the glucose step able to publish.</summary>
     private static CareLinkConnectorConfiguration GlucoseOnlyConfiguration() => new()
     {

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
@@ -192,6 +192,25 @@ public class PublishRecordTypePathTests
     }
 
     [Fact]
+    public async Task SuccessLog_IsSuppressedForARejectedPublish()
+    {
+        // Arrange: the log says "Synced", so it must not appear for a batch the publisher refused —
+        // a triage reading it would take the records for stored.
+        var logger = new RecordingLogger();
+        var active = new HashSet<SyncDataType> { SyncDataType.Boluses };
+        var service = new TestConnectorService((_, _) => Task.CompletedTask, logger);
+        var result = new SyncResult { Success = true };
+
+        // Act
+        await service.PublishAsync(result, SyncDataType.Boluses, active,
+            [new PublishedRecord(), new PublishedRecord()], publishSucceeds: false);
+
+        // Assert
+        result.ItemsSynced[SyncDataType.Boluses].Should().Be(2, "the batch still reached the publisher");
+        logger.Messages.Should().NotContain(m => m.Contains("Synced"));
+    }
+
+    [Fact]
     public async Task ThrowingPublish_RecordsNoCount()
     {
         // Arrange: the count is recorded once the publish has returned, so a batch whose publish

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
@@ -58,6 +58,15 @@ public class PublishRecordTypePathTests
             => PublishRecordTypeAsync(result, dataType, activeTypes, records,
                 (_, _, _) => Task.FromResult(publishSucceeds),
                 new TestConfig(), cancellationToken);
+
+        public Task<bool> PublishThrowingAsync(
+            SyncResult result,
+            SyncDataType dataType,
+            HashSet<SyncDataType> activeTypes,
+            List<PublishedRecord> records)
+            => PublishRecordTypeAsync(result, dataType, activeTypes, records,
+                (_, _, _) => throw new InvalidOperationException("publisher exploded"),
+                new TestConfig(), CancellationToken.None);
     }
 
     private static Task<SyncResult> RunAsync(
@@ -139,6 +148,25 @@ public class PublishRecordTypePathTests
         // Assert
         result.Success.Should().BeFalse();
         result.ItemsSynced[SyncDataType.Glucose].Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ThrowingPublish_RecordsNoCount()
+    {
+        // Arrange: the count is recorded once the publish has returned, so a batch whose publish
+        // threw is not reported as handed over — unlike one the publisher rejected, which is.
+        // Connectors catch the throw and report it as a sync error instead.
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose };
+        var result = new SyncResult { Success = true };
+        var service = new TestConnectorService((_, _) => Task.CompletedTask);
+
+        // Act
+        var publish = () => service.PublishThrowingAsync(result, SyncDataType.Glucose, active,
+            [new PublishedRecord()]);
+
+        // Assert
+        await publish.Should().ThrowAsync<InvalidOperationException>();
+        result.ItemsSynced.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.Connectors.Core.Interfaces;
@@ -21,14 +22,34 @@ public class PublishRecordTypePathTests
         protected override void ValidateSourceSpecificConfiguration() { }
     }
 
+    /// <summary>Captures the messages the shared publish path logs, which no fixture otherwise sees.</summary>
+    private sealed class RecordingLogger : ILogger<TestConnectorService>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
+    }
+
     private sealed class TestConnectorService : BaseConnectorService<TestConfig>
     {
         private readonly Func<SyncResult, CancellationToken, Task> _syncBody;
 
-        public TestConnectorService(Func<SyncResult, CancellationToken, Task> syncBody)
+        public TestConnectorService(
+            Func<SyncResult, CancellationToken, Task> syncBody,
+            ILogger<TestConnectorService>? logger = null)
             : base(new HttpClient(),
                 new ConnectorServerResolver<TestConfig>(null, null, null),
-                NullLogger<TestConnectorService>.Instance)
+                logger ?? NullLogger<TestConnectorService>.Instance)
         {
             _syncBody = syncBody;
         }
@@ -148,6 +169,26 @@ public class PublishRecordTypePathTests
         // Assert
         result.Success.Should().BeFalse();
         result.ItemsSynced[SyncDataType.Glucose].Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SuccessLog_CoversThePublishedBatchAndNotTheEmptyOne()
+    {
+        // Arrange: the empty path records its zero without logging, so a run over quiet types does
+        // not fill the log with "Synced 0" lines it has nothing to say about.
+        var logger = new RecordingLogger();
+        var active = new HashSet<SyncDataType> { SyncDataType.Glucose, SyncDataType.Boluses };
+        var service = new TestConnectorService((_, _) => Task.CompletedTask, logger);
+        var result = new SyncResult { Success = true };
+
+        // Act
+        await service.PublishAsync(result, SyncDataType.Glucose, active,
+            [new PublishedRecord(), new PublishedRecord()]);
+        await service.PublishAsync(result, SyncDataType.Boluses, active, []);
+
+        // Assert
+        logger.Messages.Should().ContainSingle(m => m.Contains("Synced"))
+            .Which.Should().Contain("Synced 2 Glucose records");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/PublishRecordTypePathTests.cs
@@ -130,6 +130,9 @@ public class PublishRecordTypePathTests
             service.PublishAsync(syncResult, SyncDataType.Glucose, active, []));
 
         // Assert
+        result.Success.Should().BeTrue(
+            "finding nothing is not a failure: reporting one would turn every quiet but enabled "
+            + "type red and freeze the connector's last successful sync");
         result.ItemsSynced.Should().Equal(new Dictionary<SyncDataType, int>
         {
             [SyncDataType.Glucose] = 0,

--- a/tests/Unit/Nocturne.Connectors.MyFitnessPal.Tests/Services/MyFitnessPalConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyFitnessPal.Tests/Services/MyFitnessPalConnectorServiceTests.cs
@@ -1,0 +1,178 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.MyFitnessPal.Configurations;
+using Nocturne.Connectors.MyFitnessPal.Services;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.Connectors.MyFitnessPal.Tests.Services;
+
+public class MyFitnessPalConnectorServiceTests
+{
+    /// <summary>
+    /// A rejected food publish reports the shared per-type failure string and still counts the
+    /// batch the sync handed over, so the tenant's sync card shows which type failed rather than a
+    /// connector-specific phrasing the rest of the platform does not use.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenFoodPublishIsRejected_ReportsTheSharedFailure()
+    {
+        var fixture = new ServiceFixture(new MyFitnessPalFakeHandler(), publishSucceeds: false);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Food] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeFalse("a food batch that never reached the tenant is not a successful sync");
+        result.Errors.Should().Contain("Food publish failed");
+        result.ItemsSynced[SyncDataType.Food].Should().Be(1);
+    }
+
+    /// <summary>
+    /// An empty diary window records an explicit zero: the tenant's sync card renders a badge per
+    /// key, so a missing key reads as "never checked" rather than "checked, found nothing".
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheDiaryWindowIsEmpty_RecordsAnExplicitZero()
+    {
+        var fixture = new ServiceFixture(
+            new MyFitnessPalFakeHandler { HasDiaryEntry = false }, publishSucceeds: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Food] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().Equal(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Food] = 0,
+        });
+    }
+
+    /// <summary>Wires the connector service and a real token provider onto one fake handler.</summary>
+    private sealed class ServiceFixture
+    {
+        internal MyFitnessPalConnectorService Service { get; }
+        internal MyFitnessPalConnectorConfiguration Config { get; }
+
+        internal ServiceFixture(MyFitnessPalFakeHandler handler, bool publishSucceeds)
+        {
+            Config = new MyFitnessPalConnectorConfiguration
+            {
+                Username = "user@example.com",
+                Password = "secret",
+            };
+
+            var tenantAccessor = new Mock<ITenantAccessor>();
+            tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+            tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+
+            var serverResolver = new ConnectorServerResolver<MyFitnessPalConnectorConfiguration>(
+                null, null, null);
+
+            var tokenProvider = new MyFitnessPalAuthTokenProvider(
+                new HttpClient(handler),
+                new ConnectorTokenCache(),
+                serverResolver,
+                tenantAccessor.Object,
+                NullLogger<MyFitnessPalAuthTokenProvider>.Instance,
+                Mock.Of<IRetryDelayStrategy>());
+
+            var configService = new Mock<IConnectorConfigurationService>();
+            configService
+                .Setup(s => s.GetSecretsAsync("MyFitnessPal", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dictionary<string, string>());
+
+            var metadata = new Mock<IMetadataPublisher>();
+            metadata
+                .Setup(p => p.PublishConnectorFoodEntriesAsync(
+                    It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<WriteOrigin>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(publishSucceeds ? new List<ConnectorFoodEntry>() : null);
+
+            var publisher = new Mock<IConnectorPublisher>();
+            publisher.Setup(p => p.IsAvailable).Returns(true);
+            publisher.Setup(p => p.Metadata).Returns(metadata.Object);
+
+            Service = new MyFitnessPalConnectorService(
+                new HttpClient(handler),
+                serverResolver,
+                NullLogger<MyFitnessPalConnectorService>.Instance,
+                Mock.Of<IRetryDelayStrategy>(),
+                tokenProvider,
+                configService.Object,
+                publisher.Object);
+        }
+    }
+
+    /// <summary>
+    /// Serves the OAuth token endpoint and one page of the GraphQL food diary. The legacy per-day
+    /// diary is left to 404, which costs the day its meal names and nothing else.
+    /// </summary>
+    private sealed class MyFitnessPalFakeHandler : HttpMessageHandler
+    {
+        private static readonly string Today =
+            DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        internal bool HasDiaryEntry { get; init; } = true;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (path == MyFitnessPalConstants.Endpoints.Token)
+                return Task.FromResult(Json(
+                    """{"access_token":"token","refresh_token":"refresh","expires_in":3600,"user_id":"u1"}"""));
+
+            if (path == MyFitnessPalConstants.Endpoints.GraphQl)
+                return Task.FromResult(Json(DiaryPage()));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private string DiaryPage()
+        {
+            var edges = HasDiaryEntry
+                ? $$"""
+                    {
+                      "node": {
+                        "__typename": "ActiveFoodDiaryEntry",
+                        "id": "entry-1",
+                        "date": "{{Today}}",
+                        "consumedAt": "12:00:00",
+                        "quantity": 1
+                      },
+                      "syncEdgeInfo": { "operation": "UPSERT" }
+                    }
+                    """
+                : "";
+
+            return $$"""
+                {
+                  "data": {
+                    "batchSync": {
+                      "foodDiaryEntries": {
+                        "edges": [{{edges}}],
+                        "pageInfo": { "hasPreviousPage": false }
+                      }
+                    }
+                  }
+                }
+                """;
+        }
+
+        private static HttpResponseMessage Json(string body) =>
+            new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolConnectorServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -7,6 +8,7 @@ using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Tidepool.Configurations;
 using Nocturne.Connectors.Tidepool.Services;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
 using Xunit;
 
@@ -18,57 +20,125 @@ public class TidepoolConnectorServiceTests
     /// When authentication fails, the sync must report failure (so the connector surfaces as
     /// unhealthy) rather than silently returning a successful, empty result. Previously a missing
     /// token made the data fetches return null without error, so a bad-credential tenant was
-    /// recorded as healthy and never alerted.
+    /// recorded as healthy and never alerted. The failure takes the shared shape: the summary in
+    /// <c>Message</c> for the tenant's sync card and the source-qualified detail in <c>Errors</c>,
+    /// which is what gets persisted as the connector's last error.
     /// </summary>
     [Fact]
     public async Task SyncDataAsync_ReportsFailure_WhenAuthenticationFails()
     {
-        // Auth endpoint returns 401 → token provider yields no token.
-        var authHandler = new StubHandler(HttpStatusCode.Unauthorized,
-            "{\"code\":401,\"reason\":\"No user matched the given details\"}");
-        using var authClient = new HttpClient(authHandler);
-        using var dataClient = new HttpClient(); // never reached — auth fails first
+        var fixture = new ServiceFixture(new TidepoolFakeHandler { LoginSucceeds = false });
 
-        var resolver = new ConnectorServerResolver<TidepoolConnectorConfiguration>(null, null, "api.tidepool.org");
-
-        var tenantAccessor = new Mock<ITenantAccessor>();
-        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
-        tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());
-
-        var retryDelay = new Mock<IRetryDelayStrategy>();
-        retryDelay.Setup(r => r.ApplyRetryDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
-        var rateLimiting = new Mock<IRateLimitingStrategy>();
-        rateLimiting.Setup(r => r.ApplyDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
-
-        var tokenProvider = new TidepoolAuthTokenProvider(
-            authClient,
-            new ConnectorTokenCache(),
-            resolver,
-            tenantAccessor.Object,
-            NullLogger<TidepoolAuthTokenProvider>.Instance,
-            retryDelay.Object);
-
-        var service = new TidepoolConnectorService(
-            dataClient,
-            resolver,
-            NullLogger<TidepoolConnectorService>.Instance,
-            retryDelay.Object,
-            rateLimiting.Object,
-            tokenProvider);
-
-        var config = new TidepoolConnectorConfiguration { Username = "wrong@example.com", Password = "nope" };
-        var request = new SyncRequest { DataTypes = [SyncDataType.Glucose] };
-
-        var result = await service.SyncDataAsync(request, config, CancellationToken.None);
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
 
         result.Success.Should().BeFalse("an authentication failure must mark the sync unhealthy");
-        result.Errors.Should().Contain(e => e.Contains("auth", StringComparison.OrdinalIgnoreCase));
+        result.Message.Should().Be("Authentication failed");
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Be($"Authentication failed for {DataSources.TidepoolConnector}");
     }
 
-    private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    /// <summary>
+    /// A window Tidepool has no treatments for still records a count for each active treatment
+    /// type: the tenant's sync card renders a badge per key, so a missing key reads as "never
+    /// checked" rather than "checked, found nothing".
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTreatmentTypesAreActiveButEmpty_RecordExplicitZeros()
     {
+        var fixture = new ServiceFixture(new TidepoolFakeHandler());
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Boluses, SyncDataType.CarbIntake] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Boluses] = 0,
+            [SyncDataType.CarbIntake] = 0,
+        });
+    }
+
+    /// <summary>Wires the connector service and a real token provider onto one fake handler.</summary>
+    private sealed class ServiceFixture
+    {
+        internal TidepoolConnectorService Service { get; }
+        internal TidepoolConnectorConfiguration Config { get; }
+
+        internal ServiceFixture(TidepoolFakeHandler handler)
+        {
+            Config = new TidepoolConnectorConfiguration
+            {
+                Username = "user@example.com",
+                Password = "secret",
+            };
+
+            var tenantAccessor = new Mock<ITenantAccessor>();
+            tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+            tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+
+            var serverResolver = new ConnectorServerResolver<TidepoolConnectorConfiguration>(
+                null, null, TidepoolFakeHandler.Host);
+
+            var tokenProvider = new TidepoolAuthTokenProvider(
+                new HttpClient(handler),
+                new ConnectorTokenCache(),
+                serverResolver,
+                tenantAccessor.Object,
+                NullLogger<TidepoolAuthTokenProvider>.Instance,
+                Mock.Of<IRetryDelayStrategy>());
+
+            Service = new TidepoolConnectorService(
+                new HttpClient(handler),
+                serverResolver,
+                NullLogger<TidepoolConnectorService>.Instance,
+                Mock.Of<IRetryDelayStrategy>(),
+                Mock.Of<IRateLimitingStrategy>(),
+                tokenProvider);
+        }
+    }
+
+    /// <summary>
+    /// Serves Tidepool's Basic-auth login and an empty data collection for every requested type.
+    /// A rejected login answers the way bad credentials do: a non-retryable 401.
+    /// </summary>
+    private sealed class TidepoolFakeHandler : HttpMessageHandler
+    {
+        internal const string Host = "api.tidepool.example";
+        private const string UserId = "user-1";
+
+        internal bool LoginSucceeds { get; init; } = true;
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
-            => Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) });
+        {
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (path == "/auth/login")
+            {
+                if (!LoginSucceeds)
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                    {
+                        Content = new StringContent(
+                            """{"code":401,"reason":"No user matched the given details"}"""),
+                    });
+
+                var response = Json($$"""{"userid":"{{UserId}}"}""");
+                response.Headers.Add(TidepoolConstants.Headers.SessionToken, "session-token");
+                return Task.FromResult(response);
+            }
+
+            if (path == $"/data/{UserId}")
+                return Task.FromResult(Json("[]"));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static HttpResponseMessage Json(string body) =>
+            new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
     }
 }

--- a/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolConnectorServiceTests.cs
@@ -127,9 +127,113 @@ public class TidepoolConnectorServiceTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse("a sync whose every request was rejected has not succeeded");
-        result.Errors.Should().BeEquivalentTo(["Failed to fetch Glucose", "Failed to fetch Treatments"]);
+        result.Errors.Should().BeEquivalentTo(
+            ["Failed to fetch Glucose", "Failed to fetch Boluses", "Failed to fetch CarbIntake"]);
         result.ItemsSynced.Should().BeEmpty(
             "a type the sync could not check must stay unreported rather than claim a zero");
+    }
+
+    /// <summary>
+    /// The two collections are fetched concurrently with independent retry budgets, so one coming
+    /// back while the other is rejected is ordinary. The type whose fetch failed goes unreported;
+    /// the one that answered is still counted, because a single combined guard would throw away a
+    /// batch the sync did retrieve.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenOnlyTheBolusFetchIsRejected_LeavesBolusesUnreported()
+    {
+        var handler = new TidepoolFakeHandler
+        {
+            BolusStatus = HttpStatusCode.Forbidden,
+            FoodJson = """
+                [
+                  { "id": "f1", "time": "2026-01-01T12:00:00Z",
+                    "nutrition": { "carbohydrate": { "net": 40 } } }
+                ]
+                """,
+        };
+        var fixture = new ServiceFixture(handler, withPublisher: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Boluses, SyncDataType.CarbIntake] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().BeEquivalentTo(["Failed to fetch Boluses"]);
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.CarbIntake] = 1,
+        }, "a rejected bolus fetch must not report a bolus count, and must not cost the carbs");
+    }
+
+    /// <summary>The mirror of the bolus case, so neither type can be guarded on the other fetch.</summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenOnlyTheFoodFetchIsRejected_LeavesCarbIntakeUnreported()
+    {
+        var handler = new TidepoolFakeHandler
+        {
+            FoodStatus = HttpStatusCode.Forbidden,
+            BolusJson = """
+                [
+                  { "id": "b1", "time": "2026-01-01T08:00:00Z", "normal": 1.5 },
+                  { "id": "b2", "time": "2026-01-01T09:00:00Z", "normal": 2.5 },
+                  { "id": "b3", "time": "2026-01-01T10:00:00Z", "normal": 3.5 }
+                ]
+                """,
+        };
+        var fixture = new ServiceFixture(handler, withPublisher: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Boluses, SyncDataType.CarbIntake] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().BeEquivalentTo(["Failed to fetch CarbIntake"]);
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Boluses] = 3,
+        });
+    }
+
+    /// <summary>
+    /// The bolus fetch is issued even with boluses switched off, because the carb correlation needs
+    /// it. Its failure must not fail the run: a failed run withholds the last-successful-sync stamp
+    /// and shows a red connector, so a tenant whose enabled types all synced would be told — stickily
+    /// — that their connector is broken.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAnInactiveTypesFetchIsRejected_StillReportsSuccess()
+    {
+        var handler = new TidepoolFakeHandler
+        {
+            BolusStatus = HttpStatusCode.Forbidden,
+            FoodJson = """
+                [
+                  { "id": "f1", "time": "2026-01-01T12:00:00Z",
+                    "nutrition": { "carbohydrate": { "net": 40 } } }
+                ]
+                """,
+        };
+        var fixture = new ServiceFixture(handler, withPublisher: true, config: new TidepoolConnectorConfiguration
+        {
+            Username = "user@example.com",
+            Password = "secret",
+            SyncBoluses = false,
+        });
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Boluses, SyncDataType.CarbIntake] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue("no type the tenant enabled failed to sync");
+        result.Errors.Should().BeEmpty();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.CarbIntake] = 1,
+        });
     }
 
     /// <summary>Wires the connector service and a real token provider onto one fake handler.</summary>
@@ -140,9 +244,12 @@ public class TidepoolConnectorServiceTests
         internal List<Bolus> PublishedBoluses { get; } = [];
         internal List<CarbIntake> PublishedCarbIntakes { get; } = [];
 
-        internal ServiceFixture(TidepoolFakeHandler handler, bool withPublisher = false)
+        internal ServiceFixture(
+            TidepoolFakeHandler handler,
+            bool withPublisher = false,
+            TidepoolConnectorConfiguration? config = null)
         {
-            Config = new TidepoolConnectorConfiguration
+            Config = config ?? new TidepoolConnectorConfiguration
             {
                 Username = "user@example.com",
                 Password = "secret",
@@ -215,6 +322,11 @@ public class TidepoolConnectorServiceTests
         /// <summary>Status for the data endpoint; anything but OK is how a 403 or 404 arrives.</summary>
         internal HttpStatusCode DataStatus { get; init; } = HttpStatusCode.OK;
 
+        /// <summary>Per-type overrides, so one collection can be rejected while the other answers.</summary>
+        internal HttpStatusCode? BolusStatus { get; init; }
+
+        internal HttpStatusCode? FoodStatus { get; init; }
+
         internal string BolusJson { get; init; } = "[]";
         internal string FoodJson { get; init; } = "[]";
 
@@ -239,13 +351,17 @@ public class TidepoolConnectorServiceTests
 
             if (path == $"/data/{UserId}")
             {
-                if (DataStatus != HttpStatusCode.OK)
-                    return Task.FromResult(new HttpResponseMessage(DataStatus));
-
                 var query = Uri.UnescapeDataString(request.RequestUri.Query);
-                if (query.Contains($"type={TidepoolConstants.DataTypes.Bolus}", StringComparison.Ordinal))
+                var isBolus = query.Contains($"type={TidepoolConstants.DataTypes.Bolus}", StringComparison.Ordinal);
+                var isFood = query.Contains($"type={TidepoolConstants.DataTypes.Food}", StringComparison.Ordinal);
+
+                var status = (isBolus ? BolusStatus : isFood ? FoodStatus : null) ?? DataStatus;
+                if (status != HttpStatusCode.OK)
+                    return Task.FromResult(new HttpResponseMessage(status));
+
+                if (isBolus)
                     return Task.FromResult(Json(BolusJson));
-                if (query.Contains($"type={TidepoolConstants.DataTypes.Food}", StringComparison.Ordinal))
+                if (isFood)
                     return Task.FromResult(Json(FoodJson));
 
                 return Task.FromResult(Json("[]"));

--- a/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tidepool.Tests/Services/TidepoolConnectorServiceTests.cs
@@ -10,6 +10,8 @@ using Nocturne.Connectors.Tidepool.Configurations;
 using Nocturne.Connectors.Tidepool.Services;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
 using Xunit;
 
 namespace Nocturne.Connectors.Tidepool.Tests.Services;
@@ -63,13 +65,82 @@ public class TidepoolConnectorServiceTests
         });
     }
 
+    /// <summary>
+    /// Boluses come from the bolus fetch and carb intakes from the food fetch. The two counts
+    /// differ, so reporting one type's batch under the other's key cannot pass, and the published
+    /// payloads are checked as well so a swap beneath the counting cannot pass either.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_RecordsEachTreatmentTypeUnderItsOwnKey()
+    {
+        var handler = new TidepoolFakeHandler
+        {
+            BolusJson = """
+                [
+                  { "id": "b1", "time": "2026-01-01T08:00:00Z", "normal": 1.5 },
+                  { "id": "b2", "time": "2026-01-01T09:00:00Z", "normal": 2.5 },
+                  { "id": "b3", "time": "2026-01-01T10:00:00Z", "normal": 3.5 }
+                ]
+                """,
+            FoodJson = """
+                [
+                  { "id": "f1", "time": "2026-01-01T12:00:00Z",
+                    "nutrition": { "carbohydrate": { "net": 40 } } }
+                ]
+                """,
+        };
+        var fixture = new ServiceFixture(handler, withPublisher: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Boluses, SyncDataType.CarbIntake] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Boluses] = 3,
+            [SyncDataType.CarbIntake] = 1,
+        });
+        fixture.PublishedBoluses.Should().HaveCount(3);
+        fixture.PublishedCarbIntakes.Should().ContainSingle()
+            .Which.Carbs.Should().Be(40);
+    }
+
+    /// <summary>
+    /// Every data request being rejected must not be reported as a window that held nothing. The
+    /// fetch returns null rather than throwing, so without a guard the mapper yields empty lists
+    /// and the sync card states — in green — that Tidepool was reached and had no insulin or carbs.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenEveryDataFetchIsRejected_ReportsFailureAndRecordsNoCounts()
+    {
+        var fixture = new ServiceFixture(
+            new TidepoolFakeHandler { DataStatus = HttpStatusCode.Forbidden }, withPublisher: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest
+            {
+                DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses, SyncDataType.CarbIntake],
+            },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse("a sync whose every request was rejected has not succeeded");
+        result.Errors.Should().BeEquivalentTo(["Failed to fetch Glucose", "Failed to fetch Treatments"]);
+        result.ItemsSynced.Should().BeEmpty(
+            "a type the sync could not check must stay unreported rather than claim a zero");
+    }
+
     /// <summary>Wires the connector service and a real token provider onto one fake handler.</summary>
     private sealed class ServiceFixture
     {
         internal TidepoolConnectorService Service { get; }
         internal TidepoolConnectorConfiguration Config { get; }
+        internal List<Bolus> PublishedBoluses { get; } = [];
+        internal List<CarbIntake> PublishedCarbIntakes { get; } = [];
 
-        internal ServiceFixture(TidepoolFakeHandler handler)
+        internal ServiceFixture(TidepoolFakeHandler handler, bool withPublisher = false)
         {
             Config = new TidepoolConnectorConfiguration
             {
@@ -92,18 +163,46 @@ public class TidepoolConnectorServiceTests
                 NullLogger<TidepoolAuthTokenProvider>.Instance,
                 Mock.Of<IRetryDelayStrategy>());
 
+            IConnectorPublisher? publisher = null;
+            if (withPublisher)
+            {
+                var treatments = new Mock<ITreatmentPublisher>();
+                treatments
+                    .Setup(p => p.PublishBolusesAsync(
+                        It.IsAny<IEnumerable<Bolus>>(), It.IsAny<string>(),
+                        It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+                    .Callback<IEnumerable<Bolus>, string, WriteOrigin, CancellationToken>(
+                        (batch, _, _, _) => PublishedBoluses.AddRange(batch))
+                    .ReturnsAsync(true);
+                treatments
+                    .Setup(p => p.PublishCarbIntakesAsync(
+                        It.IsAny<IEnumerable<CarbIntake>>(), It.IsAny<string>(),
+                        It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+                    .Callback<IEnumerable<CarbIntake>, string, WriteOrigin, CancellationToken>(
+                        (batch, _, _, _) => PublishedCarbIntakes.AddRange(batch))
+                    .ReturnsAsync(true);
+
+                var mock = new Mock<IConnectorPublisher>();
+                mock.Setup(p => p.IsAvailable).Returns(true);
+                mock.Setup(p => p.Treatments).Returns(treatments.Object);
+                mock.Setup(p => p.Glucose).Returns(Mock.Of<IGlucosePublisher>());
+                mock.Setup(p => p.Metadata).Returns(Mock.Of<IMetadataPublisher>());
+                publisher = mock.Object;
+            }
+
             Service = new TidepoolConnectorService(
                 new HttpClient(handler),
                 serverResolver,
                 NullLogger<TidepoolConnectorService>.Instance,
                 Mock.Of<IRetryDelayStrategy>(),
                 Mock.Of<IRateLimitingStrategy>(),
-                tokenProvider);
+                tokenProvider,
+                publisher);
         }
     }
 
     /// <summary>
-    /// Serves Tidepool's Basic-auth login and an empty data collection for every requested type.
+    /// Serves Tidepool's Basic-auth login and the data collection for each requested type.
     /// A rejected login answers the way bad credentials do: a non-retryable 401.
     /// </summary>
     private sealed class TidepoolFakeHandler : HttpMessageHandler
@@ -112,6 +211,12 @@ public class TidepoolConnectorServiceTests
         private const string UserId = "user-1";
 
         internal bool LoginSucceeds { get; init; } = true;
+
+        /// <summary>Status for the data endpoint; anything but OK is how a 403 or 404 arrives.</summary>
+        internal HttpStatusCode DataStatus { get; init; } = HttpStatusCode.OK;
+
+        internal string BolusJson { get; init; } = "[]";
+        internal string FoodJson { get; init; } = "[]";
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
@@ -133,7 +238,18 @@ public class TidepoolConnectorServiceTests
             }
 
             if (path == $"/data/{UserId}")
+            {
+                if (DataStatus != HttpStatusCode.OK)
+                    return Task.FromResult(new HttpResponseMessage(DataStatus));
+
+                var query = Uri.UnescapeDataString(request.RequestUri.Query);
+                if (query.Contains($"type={TidepoolConstants.DataTypes.Bolus}", StringComparison.Ordinal))
+                    return Task.FromResult(Json(BolusJson));
+                if (query.Contains($"type={TidepoolConstants.DataTypes.Food}", StringComparison.Ordinal))
+                    return Task.FromResult(Json(FoodJson));
+
                 return Task.FromResult(Json("[]"));
+            }
 
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
         }


### PR DESCRIPTION
Closes #919.

The shared publish helper owns three things every published record type needs — the per-type `ItemsSynced` count the tenant's sync card renders as a badge, the canonical failure string, and the structured success log. Four connectors hand-rolled that bookkeeping, so their types got none of it. A missing badge reads as "never checked" rather than "checked, found nothing".

`RecordPublishOutcome` extracts the trio out of `PublishRecordTypeAsync`, so a connector whose publish shape does not fit the helper — a streaming crawl that publishes page by page, or one fetch feeding several types — records through it instead of writing the three by hand. Nightscout, CareLink, Tidepool and MyFitnessPal are routed through one or the other. Nightscout's `outcome.Count > 0` gate is gone, so active-but-empty treatment sub-types now say zero.

## The count-after-publish quirk

Preserved and documented once, on `RecordPublishOutcome`. A publish that **throws** records no count; one that returns **false** records the batch. That asymmetry is deliberate: a returned false is a reported rejection of a batch that demonstrably reached the publisher, while a throw leaves the batch's fate unknown and the connector's catch converts it into a `Failed to sync X` error instead. `ItemsSynced` reports what the sync handed over, not what the publisher accepted.

One correction to the first revision of this branch: the quirk is now **uniform**, not "preserved exactly". Nightscout's `Food` block previously recorded its count *before* publishing, so main kept `Food = N` when the publish threw and this branch drops the key. That is the only site where the old behaviour was the opposite, and normalising it is intended.

## Two regressions caught at review, both fixed

Worth recording, because the second was introduced by the fix for the first.

**A confident zero after a total fetch failure.** `Tidepool.FetchDataAsync` returns null for every non-throwing failure — 403, 404, bad JSON, failed re-auth, exhausted retries. Routing the treatments block through the shared helper made null read as an empty window, so a rejected sync produced a green card asserting "0 boluses, 0 carbintake" where main showed no badges at all. Turning silence into a confident zero is worse than the missing key it replaced, and it is the trap `NightscoutConnectorService` already documents and throws to avoid.

Each type is now guarded on **its own** fetch — `MapTreatments` sources boluses only from the bolus fetch and carbs only from the food fetch — so a food fetch that fails no longer discards boluses that arrived fine, and a genuinely empty array still records an honest zero.

**A sticky red connector for a type the tenant switched off.** Reporting that fetch failure then marked the run failed regardless of whether the failed type was enabled. `ConnectorBackgroundService` maps `Success = false` to `isHealthy: false` and never advances `lastSuccessfulSync`, so a carbs-only tenant whose account rejects the bolus endpoint got a permanently red connector while everything they enabled synced perfectly — a lying health state rather than a lying badge, and sticky.

`ReportFailedFetch` now fails the run only for a type the tenant enabled. Both fetches are still issued, because the correlation path needs boluses to attach `CorrelationId` to carbs even when boluses are not synced; an inactive type's failed fetch costs that correlation and nothing else, and is logged at debug.

## Behavioural deltas

1. A failed Nightscout treatments publish yields one canonical error per active sub-type instead of one combined `Treatments publish failed`.
2. Nightscout's per-type `Retrieved N … from Nightscout` logs are replaced by the shared `Synced N {Type} records`, which is silent at zero.
3. Tidepool records a count when a publish fails, not only on success.
4. Auth-failure text for MyFitnessPal and Tidepool is now source-qualified via the shared `AuthenticationFailedResult()`, and both set `Message`.
5. Tidepool reports a failure when a fetch returns null (glucose and treatments); previously `Success = true` with no error, on main too. The combined `Failed to fetch Treatments` is per-type.
6. Nightscout `Food` moves from count-before-publish to count-after (above).
7. MyFitnessPal's `Publisher not available` and `Failed to publish food entries` both become `Food publish failed`, rendered as bullets on the card.
8. Five call sites now emit a `PublishingDataType` progress event they never emitted, surfacing as "Publishing {count} {dataType} records..." during a sync.
9. CareLink records an explicit zero on the stale-payload path, so a tenant whose pump is offline sees a `0` glucose badge each cycle where they previously saw none.
10. `ReportFailedFetch` logs a new debug line for an inactive type's failed fetch. The Tidepool fixture uses `NullLogger`, so this string is declared rather than pinned.

Plus log text: `SensorGlucose` → `Glucose`, `Bolus` → `Boluses`, `Synced DeviceStatus` → `Synced 1 DeviceStatus records`.

**A real bug fixed incidentally:** CareLink device status previously built a list that could contain `null` (the mapper returns `DeviceStatus?`) and reported a count of 1 regardless. It now publishes nothing and reports 0 in that case.

## Scope

The issue's second bullet — CareLink adopting `EnsureAuthenticatedAsync` — is **declined, not done**. CareLink syncs through the background overload, which authenticates via the parameterless `AuthenticateAsync()` that CareLink deliberately stubs to `true` because its credentials are per-tenant config. `EnsureAuthenticatedAsync` is only reached from the `SyncRequest` overload, so moving the real authentication there would leave every scheduled CareLink sync unauthenticated. Adopting it properly needs Nightscout's `_currentConfig` priming, which changes `AuthenticateAsync`'s semantics.

**The consolidation is not complete.** `ReportFailedFetch` is Tidepool-private, and MyFitnessPal still hand-rolls the same "a null fetch failed an active type" shape. A second occurrence is the point at which it should move to `BaseConnectorService`.

## Verification

Mutation-proved, each reverted and re-verified: breaking accumulation (`previous + count` → `count`) fails 9 tests across Core, CareLink and Glooko; the Nightscout paging total (`count += page.Length` → `=`) fails 4; the treatments fan-out (`.Where(activeTypes.Contains)` → `.Take(1)`) fails 3; swapping Tidepool's bolus and carb keys fails 2; cross-guarding a type on the other fetch fails 2; a single combined guard fails 3; dropping the active-type gate fails 1; deleting CareLink's glucose toggle gate fails 1; truncating CareLink's glucose batch fails 1; publishing no device status fails 1; moving the success log out of its `else` fails 1; and `success: true` → `false` on the empty-batch path fails 1 in its own suite, where it previously passed 131/131.

Accumulation is unreachable from Nightscout by construction — `CrawlAndPublishAsync` returns an already-summed total and each of the six treatment sub-types is recorded once — so no honest test there can catch that mutation. What is pinned instead is Nightscout's own property: one multi-page fetch feeding several active sub-types, each carrying the whole total.

Three hostile fresh-context review rounds. Rounds one and two each found a defect the passing suite hid; the third found none.

Tests: Core 131, CareLink 89, Tidepool 14, MyFitnessPal 52, Nightscout 54, Glooko 97, MyLife 32, Tandem 58, Twiist 30, Dexcom 6, Eversense 24; full `Nocturne.API.Tests` 5979 passed.
