### PR TITLE
fix(api): require a signed-up account to probe name availability once setup is done

### DIFF
--- a/src/API/Nocturne.API/Authorization/AnonymousUntilSetupCompleteAttribute.cs
+++ b/src/API/Nocturne.API/Authorization/AnonymousUntilSetupCompleteAttribute.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Nocturne.API.Extensions;
+using Nocturne.API.Services.Identity;
+
+namespace Nocturne.API.Authorization;
+
+/// <summary>
+/// Narrows an <c>[AllowAnonymous]</c> endpoint to first-run setup: anonymous while the instance
+/// has no account anyone can sign in with, authenticated callers only once it has.
+/// </summary>
+/// <remarks>
+/// For endpoints the setup wizard needs before any credential exists, whether or not anything
+/// still calls them once it does. Left permanently anonymous, such an endpoint answers questions
+/// about the instance to anyone who asks — a name-availability probe is a membership oracle for
+/// the set of names in use, and rate limiting bounds the probe rate without bounding the sweep.
+/// <para>
+/// A plain MVC authorization filter rather than a policy: <c>[AllowAnonymous]</c> suppresses the
+/// authorization middleware's policy evaluation, so a policy attached here would never be asked.
+/// Filters are not suppressed, so this runs on every request to the endpoint.
+/// </para>
+/// <para>
+/// The refusal reads only the request's own credentials and the instance's setup state, never the
+/// caller's input, so it costs the same and says the same thing whatever was asked about.
+/// </para>
+/// </remarks>
+/// <seealso cref="IInstanceSetupState"/>
+/// <seealso cref="DenyDemoSubjectAttribute"/>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class AnonymousUntilSetupCompleteAttribute : Attribute, IAsyncAuthorizationFilter
+{
+    public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
+    {
+        if (context.HttpContext.IsAuthenticated())
+            return;
+
+        var setupState = context.HttpContext.RequestServices.GetRequiredService<IInstanceSetupState>();
+
+        if (await setupState.IsSetupCompleteAsync(context.HttpContext.RequestAborted))
+            context.Result = new UnauthorizedResult();
+    }
+}

--- a/src/API/Nocturne.API/Controllers/V4/Identity/MyTenantsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MyTenantsController.cs
@@ -109,10 +109,14 @@ public class MyTenantsController : ControllerBase
     /// <inheritdoc cref="ITenantService.ValidateSlugAsync"/>
     [HttpGet("validate-slug")]
     [AllowAnonymous]
+    [AnonymousUntilSetupComplete]
+    [DenyDemoSubject]
     [AllowDuringSetup]
     [EnableRateLimiting("name-availability")]
     [RemoteQuery]
     [ProducesResponseType(typeof(SlugValidationResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> ValidateSlug([FromQuery] string slug, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(slug))

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -14,6 +14,7 @@ using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.API.Extensions;
 using Nocturne.API.Services.Auth;
+using Nocturne.API.Services.Identity;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Extensions;
@@ -47,6 +48,7 @@ public partial class SetupController : ControllerBase
     private readonly OperatorConfiguration _operatorConfig;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly PlatformAdminBootstrapService _platformAdminBootstrap;
+    private readonly IInstanceSetupState _setupState;
     private readonly ILogger<SetupController> _logger;
 
     public SetupController(
@@ -61,6 +63,7 @@ public partial class SetupController : ControllerBase
         IOptions<OperatorConfiguration> operatorConfig,
         IHttpClientFactory httpClientFactory,
         PlatformAdminBootstrapService platformAdminBootstrap,
+        IInstanceSetupState setupState,
         ILogger<SetupController> logger)
     {
         _tenantService = tenantService;
@@ -74,6 +77,7 @@ public partial class SetupController : ControllerBase
         _operatorConfig = operatorConfig.Value;
         _httpClientFactory = httpClientFactory;
         _platformAdminBootstrap = platformAdminBootstrap;
+        _setupState = setupState;
         _logger = logger;
     }
 
@@ -81,6 +85,12 @@ public partial class SetupController : ControllerBase
     private static partial Regex UsernamePattern();
 
     private static readonly HashSet<string> ReservedUsernames = ["admin", "system"];
+
+    /// <summary>
+    /// Whether the username webhook's last attempt has already been reported. See
+    /// <see cref="AskUsernameWebhookAsync"/>.
+    /// </summary>
+    private static int _usernameWebhookOutageReported;
 
     /// <summary>
     /// Create the first tenant on a fresh install. Only succeeds when zero tenants exist.
@@ -93,8 +103,7 @@ public partial class SetupController : ControllerBase
     public async Task<IActionResult> CreateTenant(
         [FromBody] SetupTenantRequest request, CancellationToken ct)
     {
-        // Block if any tenant already has a member with credentials (passkey or OIDC).
-        if (await AnyTenantHasCredentialedMemberAsync(ct))
+        if (await _setupState.IsSetupCompleteAsync(ct))
             return Conflict(new { error = "setup_already_complete" });
 
         if (string.IsNullOrWhiteSpace(request.Slug) || string.IsNullOrWhiteSpace(request.DisplayName))
@@ -114,9 +123,13 @@ public partial class SetupController : ControllerBase
     /// Check whether a username is available for the owner account.
     /// </summary>
     [HttpGet("validate-username")]
+    [AnonymousUntilSetupComplete]
+    [DenyDemoSubject]
     [EnableRateLimiting("name-availability")]
     [RemoteQuery]
     [ProducesResponseType(typeof(SlugValidationResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> ValidateUsername(
         [FromQuery] string username, CancellationToken ct)
     {
@@ -146,28 +159,8 @@ public partial class SetupController : ControllerBase
         if (exists)
             return Ok(new SlugValidationResult(false, "This username is already taken"));
 
-        if (!string.IsNullOrEmpty(_operatorConfig.UsernameValidationWebhookUrl))
-        {
-            try
-            {
-                var client = _httpClientFactory.CreateClient("username-validation");
-                var response = await client.PostAsJsonAsync(
-                    _operatorConfig.UsernameValidationWebhookUrl,
-                    new { username = normalized },
-                    ct);
-
-                if (response.IsSuccessStatusCode)
-                {
-                    var result = await response.Content.ReadFromJsonAsync<SlugValidationResult>(ct);
-                    if (result is { IsValid: false })
-                        return Ok(result);
-                }
-            }
-            catch
-            {
-                // Webhook failure should not block validation — fall through to success
-            }
-        }
+        if (await AskUsernameWebhookAsync(normalized, ct) is { IsValid: false } refusal)
+            return Ok(refusal);
 
         return Ok(new SlugValidationResult(true));
     }
@@ -409,41 +402,61 @@ public partial class SetupController : ControllerBase
     #region Private Helpers
 
     /// <summary>
-    /// Whether any tenant on the instance already has a member holding a real credential (passkey
-    /// or linked OIDC identity), i.e. whether first-run setup has already produced a usable
-    /// account somewhere.
+    /// The operator's username-validation webhook's verdict, or <see langword="null"/> when no
+    /// webhook is configured or it could not answer.
     /// </summary>
     /// <remarks>
-    /// Asked per tenant under that tenant's own pin, then OR'd. The equivalent single query over
-    /// every tenant's memberships has no tenant to be pinned to, and a membership hidden from it
-    /// would read as "no credentialed member exists" — re-opening setup on a configured instance.
+    /// Fails open. The webhook is an operator's extra restriction layered on the checks above, and
+    /// only this advisory probe consults it — the owner-creation steps never do, so refusing here
+    /// would not keep the name from being taken. An outage that refused every username instead
+    /// would strand the operator on the one screen with no way past it, on an instance that has no
+    /// account yet to correct the configuration from.
     /// <para>
-    /// The per-iteration re-pin is confined to a context of its own, so the caller is not left
-    /// holding one pinned to whichever tenant happened to be enumerated last.
+    /// The endpoint is anonymous, so a caller sets the request volume; one log line per outage
+    /// keeps that from being a log-volume lever. The latch reopens when the webhook next answers.
     /// </para>
     /// </remarks>
-    private async Task<bool> AnyTenantHasCredentialedMemberAsync(CancellationToken ct)
+    private async Task<SlugValidationResult?> AskUsernameWebhookAsync(string username, CancellationToken ct)
     {
-        await using var context = await _dbFactory.CreateDbContextAsync(ct);
+        if (string.IsNullOrEmpty(_operatorConfig.UsernameValidationWebhookUrl))
+            return null;
 
-        var tenantIds = await context.Tenants.AsNoTracking()
-            .Select(t => t.Id)
-            .ToListAsync(ct);
+        Exception? failure = null;
+        int? statusCode = null;
 
-        foreach (var tenantId in tenantIds)
+        try
         {
-            await context.PinTenantAsync(tenantId, ct);
+            var client = _httpClientFactory.CreateClient("username-validation");
+            var response = await client.PostAsJsonAsync(
+                _operatorConfig.UsernameValidationWebhookUrl,
+                new { username },
+                ct);
 
-            var hasCredentialedMember = await context.TenantMembers.AsNoTracking()
-                .Where(m => m.TenantId == tenantId)
-                .AnyAsync(m =>
-                    context.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
-                    context.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId), ct);
+            if (response.IsSuccessStatusCode)
+            {
+                Interlocked.Exchange(ref _usernameWebhookOutageReported, 0);
+                return await response.Content.ReadFromJsonAsync<SlugValidationResult>(ct);
+            }
 
-            if (hasCredentialedMember) return true;
+            statusCode = (int)response.StatusCode;
+        }
+        catch (Exception ex)
+        {
+            if (ct.IsCancellationRequested)
+                return null;
+
+            failure = ex;
         }
 
-        return false;
+        if (Interlocked.Exchange(ref _usernameWebhookOutageReported, 1) == 0)
+        {
+            _logger.LogWarning(
+                failure,
+                "Username validation webhook did not answer ({Outcome}); usernames are being accepted without it",
+                statusCode?.ToString() ?? "unreachable");
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -464,20 +477,10 @@ public partial class SetupController : ControllerBase
 
         var tenant = tenants[0];
 
-        // Pin the RLS context to query the tenant-scoped members table
-        await context.PinTenantAsync(tenant.Id, ct);
-
-        // Setup is "complete" only once a member holds real credentials (passkey or
-        // OIDC). A credential-less member is a half-finished setup left behind by an
-        // abandoned or failed WebAuthn/OIDC ceremony — EnsureOwnerSubjectAsync reuses
-        // that subject idempotently, so let the flow resume instead of dead-ending on
-        // owner_already_exists. Mirrors the CreateTenant guard and
-        // TenantSetupMiddleware's hasCredentials check.
-        var hasOwnerWithCredentials = await context.TenantMembers
-            .Where(m => m.TenantId == tenant.Id)
-            .AnyAsync(m =>
-                context.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
-                context.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId), ct);
+        // A credential-less member is a half-finished setup left behind by an abandoned or failed
+        // WebAuthn/OIDC ceremony — EnsureOwnerSubjectAsync reuses that subject idempotently, so
+        // let the flow resume instead of dead-ending on owner_already_exists.
+        var hasOwnerWithCredentials = await _setupState.TenantHasCredentialedMemberAsync(tenant.Id, ct);
 
         if (hasOwnerWithCredentials)
             return (null, Conflict(new { error = "owner_already_exists" }));

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -342,6 +342,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<ITenantRoleService, TenantRoleService>();
         services.AddScoped<ITenantService, TenantService>();
         services.AddScoped<ITenantOverviewService, TenantOverviewService>();
+        services.AddScoped<IInstanceSetupState, InstanceSetupState>();
         services.AddScoped<DemoTenantService>();
         services.AddScoped<ScalarAuthProvider>();
 

--- a/src/API/Nocturne.API/Services/Identity/IInstanceSetupState.cs
+++ b/src/API/Nocturne.API/Services/Identity/IInstanceSetupState.cs
@@ -1,0 +1,29 @@
+namespace Nocturne.API.Services.Identity;
+
+/// <summary>
+/// Whether first-run setup has produced a usable account somewhere on the instance.
+/// </summary>
+/// <remarks>
+/// The instance-wide counterpart to <see cref="Middleware.TenantSetupMiddleware"/>'s per-tenant
+/// check. The tenantless surface — first-tenant creation, the slug availability probe — resolves
+/// no tenant, so that middleware passes those requests through and cannot answer for them.
+/// </remarks>
+public interface IInstanceSetupState
+{
+    /// <summary>
+    /// Whether any tenant on the instance has a member holding a real credential (a passkey or a
+    /// linked OIDC identity).
+    /// </summary>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns><see langword="true"/> once an account exists that someone can sign in with.</returns>
+    Task<bool> IsSetupCompleteAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// The same question asked of one tenant: whether it has a member holding a passkey or a
+    /// linked OIDC identity.
+    /// </summary>
+    /// <param name="tenantId">The tenant to ask about.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns><see langword="true"/> when that tenant already has a signed-up account.</returns>
+    Task<bool> TenantHasCredentialedMemberAsync(Guid tenantId, CancellationToken ct = default);
+}

--- a/src/API/Nocturne.API/Services/Identity/InstanceSetupState.cs
+++ b/src/API/Nocturne.API/Services/Identity/InstanceSetupState.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
+
+namespace Nocturne.API.Services.Identity;
+
+/// <inheritdoc cref="IInstanceSetupState"/>
+public sealed class InstanceSetupState : IInstanceSetupState
+{
+    private readonly IDbContextFactory<NocturneDbContext> _dbFactory;
+
+    public InstanceSetupState(IDbContextFactory<NocturneDbContext> dbFactory)
+    {
+        _dbFactory = dbFactory;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Asked per tenant under that tenant's own pin, then OR'd. The equivalent single query over
+    /// every tenant's memberships has no tenant to be pinned to, and a membership hidden from it
+    /// would read as "no credentialed member exists" — re-opening setup on a configured instance.
+    /// </remarks>
+    public async Task<bool> IsSetupCompleteAsync(CancellationToken ct = default)
+    {
+        await using var context = await _dbFactory.CreateDbContextAsync(ct);
+
+        var tenantIds = await context.Tenants.AsNoTracking()
+            .Select(t => t.Id)
+            .ToListAsync(ct);
+
+        foreach (var tenantId in tenantIds)
+        {
+            if (await HasCredentialedMemberAsync(context, tenantId, ct))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TenantHasCredentialedMemberAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        await using var context = await _dbFactory.CreateDbContextAsync(ct);
+
+        return await HasCredentialedMemberAsync(context, tenantId, ct);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="tenantId"/> has a member holding a passkey or a linked OIDC
+    /// identity, read under that tenant's pin.
+    /// </summary>
+    /// <remarks>
+    /// The caller's context is re-pinned, so it must be one the caller owns — never the
+    /// request-scoped context, which the rest of the request would then find pinned elsewhere.
+    /// </remarks>
+    private static async Task<bool> HasCredentialedMemberAsync(
+        NocturneDbContext context, Guid tenantId, CancellationToken ct)
+    {
+        await context.PinTenantAsync(tenantId, ct);
+
+        return await context.TenantMembers.AsNoTracking()
+            .Where(m => m.TenantId == tenantId)
+            .AnyAsync(m =>
+                context.PasskeyCredentials.Any(c => c.SubjectId == m.SubjectId) ||
+                context.SubjectOidcIdentities.Any(o => o.SubjectId == m.SubjectId), ct);
+    }
+}

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/AccountCreation.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/AccountCreation.svelte
@@ -15,7 +15,12 @@
     setupOwnerOidc,
     validateSetupUsername,
   } from "../setup.remote";
-  import { FormError, FormField, useAvailability } from "$lib/forms";
+  import {
+    describeSubmitError,
+    FormError,
+    FormField,
+    useAvailability,
+  } from "$lib/forms";
   import {
     describePasskeyError,
     parseCeremonyOptions,
@@ -85,8 +90,10 @@
       window.location.href = result.authorizationUrl ?? "/setup";
     } catch (err) {
       console.error("Starting the external sign-in failed:", err);
-      oidcError =
-        "We couldn't start sign-in with that provider. Please try again.";
+      oidcError = describeSubmitError(
+        err,
+        "We couldn't start sign-in with that provider. Please try again.",
+      );
       isRedirecting = false;
       selectedProvider = null;
     }

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/TenantIdentity.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/TenantIdentity.svelte
@@ -2,7 +2,12 @@
   import { Input } from "$lib/components/ui/input";
   import { Button } from "$lib/components/ui/button";
   import { Check, Loader2, ArrowRight } from "lucide-svelte";
-  import { FormError, FormField, useAvailability } from "$lib/forms";
+  import {
+    describeSubmitError,
+    FormError,
+    FormField,
+    useAvailability,
+  } from "$lib/forms";
   import { setupTenant, validateSetupSlug, setSetupTenantSlug } from "../setup.remote";
 
   let {
@@ -44,8 +49,10 @@
       onComplete(normalizedSlug);
     } catch (err) {
       console.error("Creating the instance failed:", err);
-      submitError =
-        "We couldn't create your instance. Please try again in a moment.";
+      submitError = describeSubmitError(
+        err,
+        "We couldn't create your instance. Please try again in a moment.",
+      );
     } finally {
       submitting = false;
     }

--- a/tests/Unit/Nocturne.API.Tests/Authorization/AnonymousUntilSetupCompleteTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/AnonymousUntilSetupCompleteTests.cs
@@ -1,0 +1,253 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Configuration;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// The slug availability probe over the real pipeline: anonymous while the instance has no account
+/// anyone can sign in with, authenticated callers only once it has.
+/// </summary>
+/// <remarks>
+/// Driven through the routed endpoint rather than the filter in isolation, because the value of the
+/// gate is that it runs — an <c>[AllowAnonymous]</c> endpoint suppresses policy evaluation, so a
+/// guard expressed as a policy would read as protection and never be asked.
+/// <para>
+/// The seeded instance has an owner holding a passkey, so setup is complete unless a test says
+/// otherwise. One factory, so one <c>name-availability</c> bucket (60 per minute) across the class.
+/// </para>
+/// </remarks>
+public partial class AnonymousUntilSetupCompleteTests : IClassFixture<AuthenticationTestFactory>
+{
+    private const string SlugProbe = "/api/v4/me/tenants/validate-slug?slug=";
+    private const string UsernameProbe = "/api/v4/setup/validate-username?username=";
+
+    /// <summary>
+    /// Both name-availability probes. They answer the same kind of question off the same rate
+    /// limiter, so they carry the same gate — a username is the stronger of the two to confirm,
+    /// being an account identifier rather than a public subdomain.
+    /// </summary>
+    public static TheoryData<string> Probes => [SlugProbe, UsernameProbe];
+
+    private readonly AuthenticationTestFactory _factory;
+
+    public AnonymousUntilSetupCompleteTests(AuthenticationTestFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Theory]
+    [MemberData(nameof(Probes))]
+    public async Task An_anonymous_probe_is_refused_once_the_instance_has_an_account(string probe)
+    {
+        var response = await _factory.CreateClient().GetAsync($"{probe}anything");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Theory]
+    [MemberData(nameof(Probes))]
+    public async Task An_authenticated_probe_is_answered_once_the_instance_has_an_account(string probe)
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", await SessionCookieAsync());
+
+        var response = await client.GetAsync($"{probe}anything");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Theory]
+    [MemberData(nameof(Probes))]
+    public async Task An_anonymous_probe_is_answered_while_the_instance_has_no_account(string probe)
+    {
+        var credentials = await TakeCredentialsAwayAsync();
+        try
+        {
+            var response = await _factory.CreateClient().GetAsync($"{probe}anything");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        finally
+        {
+            await GiveCredentialsBackAsync(credentials);
+        }
+    }
+
+    /// <summary>
+    /// A demo session is handed to any anonymous caller, so the subject behind it stands for no one
+    /// — "authenticated" here has to mean a person who signed up, or the gate is bypassed by anyone
+    /// willing to take a demo session first.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Probes))]
+    public async Task A_demo_session_is_refused_once_the_instance_has_an_account(string probe)
+    {
+        var demoSubjectId = await SeedDemoSubjectAsync();
+        try
+        {
+            var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.Add("Cookie", await SessionCookieAsync(demoSubjectId));
+
+            var response = await client.GetAsync($"{probe}anything");
+
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+        finally
+        {
+            await RemoveSubjectAsync(demoSubjectId);
+        }
+    }
+
+    /// <summary>
+    /// The refusal answers "who is asking", not "is this name free", so everything a caller can see
+    /// of it — status, headers and body — is the same for a name in use as for one that is free.
+    /// </summary>
+    [Theory]
+    [InlineData(SlugProbe, "default", "nobody-has-this-one")]
+    [InlineData(UsernameProbe, "test", "nobody-has-this-one")]
+    public async Task The_refusal_is_the_same_response_whether_the_name_is_taken_or_free(
+        string probe, string takenName, string freeName)
+    {
+        await EnsureNameIsTakenAsync(probe, takenName);
+
+        var client = _factory.CreateClient();
+
+        var taken = await DescribeAsync(await client.GetAsync($"{probe}{takenName}"));
+        var free = await DescribeAsync(await client.GetAsync($"{probe}{freeName}"));
+
+        taken.Should().StartWith("401").And.NotContain(takenName);
+        free.Should().NotContain(freeName);
+        taken.Should().Be(free);
+    }
+
+    /// <summary>
+    /// Makes <paramref name="takenName"/> genuinely in use, so the comparison is between a hit and
+    /// a miss rather than between two misses. The seeded tenant already holds the slug; a username
+    /// is held on the membership row rather than on the subject, and the membership row is what the
+    /// username probe reads.
+    /// </summary>
+    private async Task EnsureNameIsTakenAsync(string probe, string takenName)
+    {
+        if (probe != UsernameProbe)
+            return;
+
+        await using var db = await DbAsync();
+
+        var member = await db.TenantMembers
+            .FirstAsync(m => m.SubjectId == TestDatabaseSeeder.TestSubjectId);
+        member.Username = takenName;
+        await db.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Everything a caller can see of a response bar the clock and the per-request trace id:
+    /// status, headers and body. Without the headers this would be comparing an empty string to an
+    /// empty string on any response that carries no body.
+    /// </summary>
+    private static async Task<string> DescribeAsync(HttpResponseMessage response)
+    {
+        var headers = response.Headers.Concat(response.Content.Headers)
+            .Where(h => h.Key != "Date")
+            .OrderBy(h => h.Key, StringComparer.Ordinal)
+            .Select(h => $"{h.Key}: {string.Join(", ", h.Value)}");
+
+        var described = string.Join("\n", headers
+            .Prepend(((int)response.StatusCode).ToString())
+            .Append(await response.Content.ReadAsStringAsync()));
+
+        return TraceParent().Replace(described, "<trace>");
+    }
+
+    [GeneratedRegex("[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}")]
+    private static partial Regex TraceParent();
+
+    /// <summary>
+    /// A cookie header carrying a real session for the seeded owner, which is how the authenticated
+    /// admin page reaches this endpoint.
+    /// </summary>
+    private async Task<string> SessionCookieAsync(Guid? subjectId = null)
+    {
+        using var scope = _factory.Services.CreateScope();
+
+        var session = await scope.ServiceProvider
+            .GetRequiredService<ISessionService>()
+            .IssueSessionAsync(
+                subjectId ?? TestDatabaseSeeder.TestSubjectId,
+                new SessionContext(DeviceDescription: "Gate test"));
+
+        var cookieName = scope.ServiceProvider
+            .GetRequiredService<IOptions<OidcOptions>>().Value.Cookie.AccessTokenName;
+
+        return $"{cookieName}={session.AccessToken}";
+    }
+
+    private async Task<List<PasskeyCredentialEntity>> TakeCredentialsAwayAsync()
+    {
+        await using var db = await DbAsync();
+
+        var credentials = await db.PasskeyCredentials.ToListAsync();
+        db.PasskeyCredentials.RemoveRange(credentials);
+        await db.SaveChangesAsync();
+
+        return credentials;
+    }
+
+    private async Task GiveCredentialsBackAsync(List<PasskeyCredentialEntity> credentials)
+    {
+        await using var db = await DbAsync();
+
+        db.PasskeyCredentials.AddRange(credentials);
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<Guid> SeedDemoSubjectAsync()
+    {
+        await using var db = await DbAsync();
+
+        var subjectId = Guid.CreateVersion7();
+        db.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = "Demo Visitor",
+            Username = "demo-visitor",
+            IsActive = true,
+            IsSystemSubject = false,
+            IsDemoSubject = true,
+        });
+        db.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestDatabaseSeeder.TenantId,
+            SubjectId = subjectId,
+        });
+        await db.SaveChangesAsync();
+
+        return subjectId;
+    }
+
+    private async Task RemoveSubjectAsync(Guid subjectId)
+    {
+        await using var db = await DbAsync();
+
+        db.TenantMembers.RemoveRange(
+            await db.TenantMembers.Where(m => m.SubjectId == subjectId).ToListAsync());
+        db.Subjects.RemoveRange(
+            await db.Subjects.Where(s => s.Id == subjectId).ToListAsync());
+        await db.SaveChangesAsync();
+    }
+
+    private Task<NocturneDbContext> DbAsync() =>
+        _factory.Services
+            .GetRequiredService<IDbContextFactory<NocturneDbContext>>()
+            .CreateDbContextAsync();
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Text;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +13,8 @@ using Moq;
 using Nocturne.API.Configuration;
 using Nocturne.API.Controllers.V4;
 using Nocturne.API.Services.Auth;
+using Nocturne.API.Services.Identity;
+using Nocturne.API.Tests.Services.Connectors;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Configuration;
@@ -40,6 +44,9 @@ public class SetupControllerTests : IDisposable
     private readonly Mock<ISubjectService> _subjectService;
     private readonly Mock<IOidcAuthService> _oidcAuthService;
     private readonly PlatformOptions _platformOptions;
+    private readonly Mock<IDbContextFactory<NocturneDbContext>> _dbFactory;
+    private readonly IOptions<OidcOptions> _oidcOptions;
+    private readonly PlatformAdminBootstrapService _platformAdminBootstrap;
     private readonly SetupController _controller;
 
     public SetupControllerTests()
@@ -62,7 +69,7 @@ public class SetupControllerTests : IDisposable
         _subjectService = new Mock<ISubjectService>();
         _oidcAuthService = new Mock<IOidcAuthService>();
 
-        var oidcOptions = Options.Create(new OidcOptions
+        _oidcOptions = Options.Create(new OidcOptions
         {
             Cookie = new CookieSettings
             {
@@ -72,8 +79,8 @@ public class SetupControllerTests : IDisposable
             },
         });
 
-        var dbFactory = new Mock<IDbContextFactory<NocturneDbContext>>();
-        dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+        _dbFactory = new Mock<IDbContextFactory<NocturneDbContext>>();
+        _dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
                 var ctx = new NocturneDbContext(_dbOptions);
@@ -83,30 +90,38 @@ public class SetupControllerTests : IDisposable
         // A real instance, not a mock: the platform-admin grant is part of the
         // behaviour under test, and BootstrapAsync is not virtual.
         _platformOptions = new PlatformOptions();
-        var platformAdminBootstrap = new PlatformAdminBootstrapService(
-            dbFactory.Object,
+        _platformAdminBootstrap = new PlatformAdminBootstrapService(
+            _dbFactory.Object,
             Options.Create(_platformOptions),
             NullLogger<PlatformAdminBootstrapService>.Instance);
 
-        _controller = new SetupController(
+        _controller = BuildController(
+            new OperatorConfiguration(),
+            new Mock<IHttpClientFactory>().Object,
+            new Mock<ILogger<SetupController>>().Object);
+    }
+
+    private SetupController BuildController(
+        OperatorConfiguration operatorConfig,
+        IHttpClientFactory httpClientFactory,
+        ILogger<SetupController> logger) =>
+        new(
             _tenantService.Object,
             _passkeyService.Object,
             _recoveryCodeService.Object,
             _sessionService.Object,
             _subjectService.Object,
-            dbFactory.Object,
-            oidcOptions,
+            _dbFactory.Object,
+            _oidcOptions,
             _oidcAuthService.Object,
-            Options.Create(new OperatorConfiguration()),
-            new Mock<IHttpClientFactory>().Object,
-            platformAdminBootstrap,
-            new Mock<ILogger<SetupController>>().Object);
-
-        _controller.ControllerContext = new ControllerContext
+            Options.Create(operatorConfig),
+            httpClientFactory,
+            _platformAdminBootstrap,
+            new InstanceSetupState(_dbFactory.Object),
+            logger)
         {
-            HttpContext = new DefaultHttpContext(),
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
         };
-    }
 
     public void Dispose()
     {
@@ -519,6 +534,75 @@ public class SetupControllerTests : IDisposable
         var validation = ok.Value.Should().BeOfType<SlugValidationResult>().Subject;
         validation.IsValid.Should().BeFalse();
     }
+
+    /// <summary>
+    /// A configured webhook that cannot answer must not become a wall across the one screen the
+    /// operator has no way past, so the name is admitted. And the endpoint is anonymous, so the
+    /// caller chooses the request count — the log volume must not follow it.
+    /// </summary>
+    [Fact]
+    public async Task ValidateUsername_WhenTheWebhookIsDown_AdmitsTheNameAndReportsTheOutageOnce()
+    {
+        var logger = new Mock<ILogger<SetupController>>();
+        var controller = BuildWebhookController(
+            logger,
+            // An answering webhook first, so the report is owed whatever an earlier test in this
+            // process left latched.
+            HttpStatusCode.OK,
+            HttpStatusCode.ServiceUnavailable,
+            HttpStatusCode.ServiceUnavailable);
+        await SeedConfiguredTenantAsync("test", "Test");
+
+        await controller.ValidateUsername("primed", CancellationToken.None);
+        var first = await controller.ValidateUsername("owner-one", CancellationToken.None);
+        var second = await controller.ValidateUsername("owner-two", CancellationToken.None);
+
+        foreach (var result in new[] { first, second })
+        {
+            result.Should().BeOfType<OkObjectResult>()
+                .Which.Value.Should().BeOfType<SlugValidationResult>()
+                .Which.IsValid.Should().BeTrue();
+        }
+
+        VerifyOutageReported(logger, Times.Once());
+    }
+
+    private SetupController BuildWebhookController(
+        Mock<ILogger<SetupController>> logger, params HttpStatusCode[] responses)
+    {
+        var handler = new SequentialMockHandler();
+        foreach (var status in responses)
+        {
+            handler.Enqueue(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(
+                    """{"isValid":true}""", Encoding.UTF8, "application/json"),
+            });
+        }
+
+        var httpClientFactory = new Mock<IHttpClientFactory>();
+        httpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler));
+
+        return BuildController(
+            new OperatorConfiguration
+            {
+                UsernameValidationWebhookUrl = "https://webhook.invalid/validate",
+            },
+            httpClientFactory.Object,
+            logger.Object);
+    }
+
+    private static void VerifyOutageReported(
+        Mock<ILogger<SetupController>> logger, Times times) =>
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            times);
 
     // ── OwnerComplete binds the enrolment to a server-resolved subject ────
 


### PR DESCRIPTION
Closes #916.

`GET /api/v4/me/tenants/validate-slug` was `[AllowAnonymous]` with no first-run gate, so on an established instance any anonymous caller could probe which tenant slugs exist. #915 bounded the probe *rate* at 60/min; this closes the oracle itself.

Its two legitimate callers are the setup wizard, which runs before any account exists and genuinely needs anonymity, and the authenticated admin tenants page. So the gate allows anonymous access only while setup is incomplete, and requires a real signed-up account afterwards.

## The same oracle next door

`SetupController.ValidateUsername` is the sibling name-availability probe, on the same rate-limit bucket, and it was ungated in exactly the same way — anonymous, post-setup, answering "This username is already taken" for the first tenant's members. That is a **user**-enumeration oracle, which is worse than the slug one: slugs are public subdomains by design, usernames are account identifiers, and confirming one is the first half of a targeted phishing or credential-stuffing attempt. Both endpoints are gated here.

Its only caller is the wizard's account-creation step, and `/api/v4/setup/` is a tenantless prefix, so nothing legitimate reaches it once setup is done.

Controller audit, stated so the next reader does not have to re-derive it: `ValidateUsername` was the only unguarded probe. `CreateTenant` self-guards with a 409 `setup_already_complete`, and `OwnerOptions`, `OwnerComplete`, `OwnerOidc` and `OidcCallback` all refuse a configured instance via `GetSoleTenantWithoutOwnerAsync`. Those four are POSTs taking no caller-supplied name, so their refusals disclose instance setup state and nothing per-name.

## Why a filter and not a policy

`[AnonymousUntilSetupComplete]` is an `IAsyncAuthorizationFilter`, deliberately. `[AllowAnonymous]` suppresses the authorization middleware's policy evaluation entirely, so a policy or requirement attached to these actions would have read as protection and never been asked — correct code, never reached. MVC authorization filters are not suppressed, so this runs on every request.

`[DenyDemoSubject]` is applied alongside it. A visitor holding a demo session is authenticated in the sense the gate tests for, so without it the fix would have been bypassable on any instance with the demo tenant enabled — the "authenticated is not the same as signed up" gap that attribute exists for. It early-returns with no database access when a request carries no subject, so it costs an anonymous first-run probe nothing.

## Setup state

The instance-wide question already existed inside `SetupController` as `AnyTenantHasCredentialedMemberAsync`, backing the `setup_already_complete` guard. It is extracted to `IInstanceSetupState` and both former copies now delegate to it, so three copies of that query became one.

Note that `[AllowDuringSetup]`/`TenantSetupMiddleware` could not answer here, contrary to the issue's suggested fix shape: it answers a *per-tenant* question, and both of these paths are tenantless (`validate-slug` is in `TenantlessAllowedPaths`, `/api/v4/setup/` is a tenantless prefix), so no tenant resolves and the middleware passes the request straight through.

`IsSetupCompleteAsync` short-circuits on the first tenant holding a credentialed member, so a refusal on an established instance costs one tenant-id query plus one pin plus one membership query. The full scan happens only when the answer is "incomplete", which is a fresh instance. Enumeration order is unspecified, so an instance whose first-enumerated tenants are all provisioned-but-ownerless would scan past them — the hosted provisioner's shape, bounded by the rate limiter either way.

## What the refusal discloses

A bare 401. `ITenantService.ValidateSlugAsync` is never reached, so there is no per-slug query and no timing or shape difference between a taken and a free name, and neither the slug nor the username is echoed anywhere, including logs — logging a probed value would turn enumeration into attacker-controlled log content.

It does disclose that **this instance has finished setup**. That is accepted rather than overlooked: the login page already announces the same fact, and hiding it behind a 404 would cost honesty in the response for no real gain.

The 401 still consumes a rate-limiter permit, since the limiter middleware runs before MVC authorization filters, so the gate is not a cheaper probe than a real one.

## Webhook (issue part 2)

`ValidateUsername`'s bare `catch {}` swallowed every webhook error, so an unreachable or misconfigured `UsernameValidationWebhookUrl` silently degraded to "no validation" with no log. Failures are now logged, and non-success HTTP statuses are reported too — previously a 500 from the webhook was as silent as an unreachable host.

**Fails open, deliberately.** The webhook is advisory: `OwnerOptions` and `OwnerComplete` never consult it, so refusing on webhook-down would not stop the username being taken, only lie to the user about it. And the screen it gates is first-run owner creation on an instance with no account, so failing closed strands the operator with no way past and no admin session to fix the misconfiguration from.

The log is latched to once per outage via `Interlocked.Exchange`, reset when the webhook next answers. The endpoint is anonymous and rate-limited, so per-request logging would have handed a caller a log-volume lever. The probed username is never logged.

## Verification

Ten theory rows over both probes, driven through the real routed pipeline — `WebApplicationFactory<Program>`, routed endpoint, all middleware, real rate limiter — not filters invoked in isolation.

Mutation-proved, each restored: removing `[AnonymousUntilSetupComplete]` from either action turns the anonymous post-setup probe from 401 back to 200 (the failure output is the oracle itself — `200 {"isValid":false,"message":"This username is already taken"}`); removing `[DenyDemoSubject]` turns the demo session from 403 to 200; forcing the gate to ignore setup state breaks the pre-setup wizard path; forcing it to ignore credentials breaks the authenticated admin path; and emitting the probed name in a response header fails the leak comparison on both endpoints.

One correction found by that last mutation: the original leak test asserted only that the *body* omitted the name, and a 401 body is a ProblemDetails carrying no name at all, so it was very nearly vacuous. It now compares status, all headers and body for a taken name against a free one on both endpoints.

Tests: 5987 passed, 0 failed. `dotnet build nocturne.sln` succeeded.

## Also

The two hardcoded error strings from the issue comments now route through `describeSubmitError`, so a genuinely-taken slug submitted after a throttled probe shows the server's specific reason rather than a generic line. Line references in the issue were a few lines off in both files; the substance was right.

Worth recording for whoever tests this next: the legacy `api-secret` header does **not** authenticate on this tenantless surface, which only honours subject-scoped credentials. The authenticated tests mint a real session via `ISessionService` and send it as the access-token cookie, matching what the admin page's server-side client actually does.
