### PR TITLE
chore(tests): make the solution guard bidirectional and prune the dead test docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,8 +70,7 @@ dotnet run --project src/API/Nocturne.API
 # Run tests (exclude integration/performance/E2E)
 dotnet test --filter "Category!=Integration&Category!=Performance&Category!=E2E"
 
-# Run integration tests (requires Docker)
-cd tests/Infrastructure/Docker && docker-compose -f docker-compose.test.yml up -d
+# Run integration tests (requires Docker; Testcontainers starts what each suite needs)
 dotnet test --filter "Category=Integration"
 
 # Generate TypeScript API client (uses NSwag with .NET 10)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,19 +33,31 @@ jobs:
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
-      # A project outside nocturne.sln is built by nothing that says "build everything", so it
-      # can rot uncompilable indefinitely. scripts/Shared is the one deliberate exclusion: it is
-      # consumed by the file-based apps in scripts/ through `#:project`, never by the product build.
-      - name: Every project is in the solution
+      # No job here builds nocturne.sln: every .NET job runs named projects only (see the
+      # per-project loop in Test), so nothing in CI gates solution membership except this check.
+      # The solution is still the only thing that claims to build everything, so it has to track
+      # the tree both ways — a project it omits can rot uncompilable, and an entry whose file is
+      # gone breaks every solution-wide command. scripts/Shared is the one deliberate omission:
+      # the file-based apps in scripts/ consume it through `#:project`, never the product build.
+      - name: Solution and project tree agree
         run: |
-          orphans=$(comm -23 \
-            <(git ls-files '*.csproj' | grep -vx 'scripts/Shared/Shared.csproj' | sort) \
-            <(dotnet sln nocturne.sln list | grep '\.csproj$' | sed 's|\\|/|g' | sort))
-          if [ -n "$orphans" ]; then
-            echo "These projects are missing from nocturne.sln:"
-            echo "$orphans"
+          tracked=$(git ls-files '*.csproj' | sort)
+          listed=$(dotnet sln nocturne.sln list | { grep '\.csproj$' || true; } | sed 's|\\|/|g' | sort)
+          if [ -z "$tracked" ] || [ -z "$listed" ]; then
+            echo "Nothing to compare: git found $(printf '%s' "$tracked" | grep -c .) csproj, nocturne.sln listed $(printf '%s' "$listed" | grep -c .)"
             exit 1
           fi
+          absent=$(comm -23 <(echo "$tracked") <(echo "$listed") | { grep -vx 'scripts/Shared/Shared.csproj' || true; })
+          dangling=$(comm -13 <(echo "$tracked") <(echo "$listed"))
+          if [ -n "$absent" ]; then
+            echo "Missing from nocturne.sln:"
+            echo "$absent"
+          fi
+          if [ -n "$dangling" ]; then
+            echo "Listed in nocturne.sln but not a tracked file:"
+            echo "$dangling"
+          fi
+          [ -z "$absent$dangling" ]
 
       # Entering Nocturne.E2E.Tests starts the whole Aspire stack, so it must stay uncollected
       # unless RunE2E is set; a csproj edit that re-arms it would wedge every unfiltered run.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,16 +33,13 @@ jobs:
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
-      # No job here builds nocturne.sln: every .NET job runs named projects only (see the
-      # per-project loop in Test), so nothing in CI gates solution membership except this check.
-      # The solution is still the only thing that claims to build everything, so it has to track
-      # the tree both ways — a project it omits can rot uncompilable, and an entry whose file is
-      # gone breaks every solution-wide command. scripts/Shared is the one deliberate omission:
-      # the file-based apps in scripts/ consume it through `#:project`, never the product build.
+      # No job here builds nocturne.sln — CI runs named projects only (see Test below) — so this
+      # is the only thing gating solution membership, and it has to hold in both directions.
+      # scripts/Shared is the deliberate omission: scripts/ consumes it through `#:project`.
       - name: Solution and project tree agree
         run: |
-          tracked=$(git ls-files '*.csproj' | sort)
-          listed=$(dotnet sln nocturne.sln list | { grep '\.csproj$' || true; } | sed 's|\\|/|g' | sort)
+          tracked=$(git -c core.quotePath=false ls-files '*.csproj' | sort)
+          listed=$(dotnet sln nocturne.sln list | { grep -E '\.csproj[[:space:]]*$' || true; } | sed 's|\\|/|g; s|[[:space:]]*$||' | sort)
           if [ -z "$tracked" ] || [ -z "$listed" ]; then
             echo "Nothing to compare: git found $(printf '%s' "$tracked" | grep -c .) csproj, nocturne.sln listed $(printf '%s' "$listed" | grep -c .)"
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,7 @@ dotnet build
 # Run unit tests (excludes integration/performance/E2E)
 dotnet test --filter "Category!=Integration&Category!=Performance&Category!=E2E"
 
-# Run integration tests (requires Docker containers)
-cd tests/Infrastructure/Docker && docker-compose -f docker-compose.test.yml up -d
+# Run integration tests (requires Docker; Testcontainers starts what each suite needs)
 dotnet test --filter "Category=Integration"
 
 # Run the end-to-end suite (opt-in; stands up the whole Aspire stack)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,7 @@ dotnet test --filter "Category!=Integration&Category!=Performance&Category!=E2E"
 # Run a single test class
 dotnet test --filter "FullyQualifiedName~EntryServiceTests"
 
-# Run integration tests (requires Docker)
-cd tests/Infrastructure/Docker && docker-compose -f docker-compose.test.yml up -d
+# Run integration tests (requires Docker; Testcontainers starts what each suite needs)
 dotnet test --filter "Category=Integration"
 
 # Run the end-to-end suite (opt-in; stands up the whole Aspire stack)

--- a/tests/Performance/Nocturne.API.Performance.Tests/Program.cs
+++ b/tests/Performance/Nocturne.API.Performance.Tests/Program.cs
@@ -1,4 +1,12 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using Nocturne.API.Performance.Tests.Benchmarks;
 
-BenchmarkSwitcher.FromAssembly(typeof(StatisticsServiceBenchmarks).Assembly).Run(args);
+// BenchmarkDotNet's default toolchain rebuilds the whole API graph into a generated project and
+// trips its own build timeout, then reports success having executed nothing. Run in-process.
+var config = DefaultConfig.Instance
+    .AddJob(Job.Default.WithToolchain(InProcessNoEmitToolchain.Instance));
+
+BenchmarkSwitcher.FromAssembly(typeof(StatisticsServiceBenchmarks).Assembly).Run(args, config);

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ This directory contains the test suites for the Nocturne project.
 - **Parity Tests**: Golden corpora that pin behaviour — legacy Nightscout responses and the alert engine
 - **Performance Tests**: BenchmarkDotNet benchmarks
 - **E2E Tests**: The whole Aspire stack, opt-in (see below)
-- **Test Infrastructure**: Docker containers and fixtures shared across suites
+- **Shared fixtures**: Helpers, fakes and seed data reused across suites
 
 ## Directory Structure
 
@@ -29,18 +29,18 @@ tests/
 
 ## Quick Start
 
-```bash
-# Start test infrastructure
-cd tests/Infrastructure/Docker
-docker-compose -f docker-compose.test.yml up -d
+`dotnet test` accepts a directory only when it holds exactly one project or solution file, so a project directory works and `tests/Unit/` does not (MSB1003). Given no path — as in every bare `dotnet test` in this file — it resolves `nocturne.sln` from the repo root, and the solution carries the Windows-only Desktop and Widget projects; on Linux, name a project.
 
-# Run every collected test (the E2E suite is opt-in and stays out)
+```bash
+# Everything collected, E2E excluded (solution-scoped, so Windows only)
 dotnet test
 
-# Narrow by category, or name one project — `dotnet test` takes a project or
-# solution, never a directory
+# One category (also solution-scoped)
 dotnet test --filter "Category=Integration"
-dotnet test tests/Unit/Nocturne.API.Tests
+
+# One project, on any OS. Unit projects carry a few Category=Performance tests with
+# machine-dependent thresholds, so the default filter belongs here too
+dotnet test tests/Unit/Nocturne.API.Tests --filter "Category!=Integration&Category!=Performance&Category!=E2E"
 
 # Run the end-to-end suite (stands up the whole Aspire stack)
 dotnet test tests/E2E/Nocturne.E2E.Tests -p:RunE2E=true
@@ -80,10 +80,11 @@ docker run hello-world
 
 `Nocturne.API.Performance.Tests` benchmarks entry projection, treatment mapping and the statistics service. `Nocturne.Infrastructure.Data.Performance.Tests` benchmarks pagination, insulin-delivery and sensor-glucose queries and the linked-records filter against a Testcontainers PostgreSQL.
 
-Both are BenchmarkDotNet hosts, so they take a benchmark filter as an argument:
+Both are BenchmarkDotNet hosts: list what they carry, then filter down to what you want (`--filter '*'` runs everything).
 
 ```bash
-dotnet run --project tests/Performance/Nocturne.API.Performance.Tests -c Release -- --filter '*'
+dotnet run --project tests/Performance/Nocturne.API.Performance.Tests -c Release -- --list flat
+dotnet run --project tests/Performance/Nocturne.API.Performance.Tests -c Release -- --filter '*EntityToDomain_100'
 ```
 
 ## Fast Tests (Excludes slow tests by default)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,88 +1,33 @@
 # Nocturne Testing Framework
 
-This directory contains comprehensive testing infrastructure for the Nocturne project, including unit tests, integration tests, performance tests, and migration tool validation.
+This directory contains the test suites for the Nocturne project.
 
 ## Overview
 
-The testing framework provides:
-
 - **Unit Tests**: Fast, isolated component testing with mocking
-- **Integration Tests**: End-to-end testing with real databases via Testcontainers
-- **Performance Tests**: Benchmarking and load testing with BenchmarkDotNet and NBomber
-- **Migration Tool Tests**: Comprehensive validation of PostgreSQL migration functionality
-- **Test Infrastructure**: Docker containers and automated test environment management
+- **Integration Tests**: Real databases and a running API, via Testcontainers and Aspire
+- **Parity Tests**: Golden corpora that pin behaviour — legacy Nightscout responses and the alert engine
+- **Performance Tests**: BenchmarkDotNet benchmarks
+- **E2E Tests**: The whole Aspire stack, opt-in (see below)
+- **Test Infrastructure**: Docker containers and fixtures shared across suites
 
 ## Directory Structure
 
 ```
 tests/
 ├── Unit/                          # Fast unit tests with mocking
-│   └── Nocturne.API.Tests/       # API component tests
 ├── Integration/                   # Integration tests with real databases
-│   └── Nocturne.API.Tests/       # API integration tests
-├── E2E/                           # Aspire-hosted end-to-end tests (opt-in, see below)
-├── Performance/                   # Performance and load testing
+├── E2E/                           # Aspire-hosted end-to-end tests (opt-in)
+├── Parity/                        # Alert-engine golden corpus and its generator
+├── Performance/                   # BenchmarkDotNet benchmark projects
+├── Shared/                        # Fixtures and helpers shared across suites
 └── Infrastructure/                # Test environment setup
     └── Docker/                    # Docker containers for testing
         ├── docker-compose.test.yml
-        ├── mongodb-init/          # MongoDB initialization
         └── postgresql-init/       # PostgreSQL initialization
 ```
 
-## Migration Tool Testing Framework
-
-### Comprehensive Test Categories
-
-✅ **Unit Tests**: All core components with 90%+ coverage
-
-- Configuration validation tests
-- Data transformation logic tests
-- Service layer tests with mocking
-- Utility function tests
-- Error handling tests
-
-✅ **Integration Tests**: Real database testing
-
-- End-to-end migration tests
-- Database connection tests
-- Schema creation/validation tests
-- Checkpoint/resume functionality tests
-- Parallel processing tests
-
-✅ **Performance Tests**: Large dataset validation
-
-- Large dataset migration tests (1M+ records)
-- Memory usage validation
-- Processing speed benchmarks
-- Concurrent migration tests
-- Resource utilization monitoring
-
-✅ **Data Integrity Tests**: Comprehensive validation
-
-- Round-trip data validation
-- Record count verification
-- Data type preservation tests
-- Relationship integrity tests
-- Complex nested data tests
-
-✅ **Error Handling Tests**: Robust error scenarios
-
-- Connection failure handling
-- Data corruption scenarios
-- Resource exhaustion testing
-- Recovery mechanism validation
-- Graceful degradation tests
-
-### Test Data Scenarios
-
-The framework supports multiple test data scenarios:
-
-- **Normal Data**: Well-formed documents with realistic values
-- **Edge Cases**: Boundary conditions and special characters
-- **Large Datasets**: 1M+ records for performance testing
-- **Corrupt Data**: Invalid types and malformed structures
-
-### Quick Start
+## Quick Start
 
 ```bash
 # Start test infrastructure
@@ -92,45 +37,20 @@ docker-compose -f docker-compose.test.yml up -d
 # Run every collected test (the E2E suite is opt-in and stays out)
 dotnet test
 
-# Run specific test categories
-dotnet test tests/Unit/                    # Unit tests only
-dotnet test tests/Integration/             # Integration tests only
-dotnet test tests/Performance/             # Performance tests
+# Narrow by category, or name one project — `dotnet test` takes a project or
+# solution, never a directory
+dotnet test --filter "Category=Integration"
+dotnet test tests/Unit/Nocturne.API.Tests
 
 # Run the end-to-end suite (stands up the whole Aspire stack)
 dotnet test tests/E2E/Nocturne.E2E.Tests -p:RunE2E=true
 ```
 
-## API Testing (Legacy)
+## Docker Setup for Integration Tests
 
-### Test Categories
+Integration tests need Docker: Testcontainers starts PostgreSQL for the data suites, and MongoDB plus a mock Nightscout server for the migration suite. Unit tests have no external dependencies.
 
-#### Unit Tests
-
-Unit tests run without external dependencies and test individual components in isolation. These tests are fast and can be run without any setup.
-
-#### Integration Tests
-
-Integration tests use real MongoDB containers via Testcontainers to test end-to-end functionality. These tests require Docker to be installed and running.
-
-### Running API Tests
-
-```bash
-# Running All Tests
-dotnet test
-
-# Running Only Unit Tests
-dotnet test --filter "FullyQualifiedName!~Integration"
-
-# Running Only Integration Tests
-dotnet test --filter "FullyQualifiedName~Integration"
-```
-
-### Docker Setup for Integration Tests
-
-Integration tests require Docker to be installed and running to create MongoDB test containers.
-
-#### Installing Docker
+### Installing Docker
 
 **Windows**
 
@@ -149,53 +69,22 @@ Integration tests require Docker to be installed and running to create MongoDB t
 2. Start the Docker service
 3. Add your user to the docker group (optional, to run without sudo)
 
-#### Verifying Docker Installation
+### Verifying Docker Installation
 
 ```bash
 docker --version
 docker run hello-world
 ```
 
-### API Test Structure
-
-```
-Nocturne.API.Tests/
-├── Controllers/           # Controller unit tests
-├── Services/             # Service unit tests
-├── Models/               # Model unit tests
-├── Integration/          # Integration tests
-│   ├── EntriesIntegrationTests.cs      # End-to-end API tests
-│   └── MongoDbServiceIntegrationTests.cs # Database integration tests
-└── GlobalUsings.cs       # Global using statements
-```
-
 ## Performance Testing
 
-### Available Benchmarks
+`Nocturne.API.Performance.Tests` benchmarks entry projection, treatment mapping and the statistics service. `Nocturne.Infrastructure.Data.Performance.Tests` benchmarks pagination, insulin-delivery and sensor-glucose queries and the linked-records filter against a Testcontainers PostgreSQL.
 
-1. **Data Transformation Benchmarks**
+Both are BenchmarkDotNet hosts, so they take a benchmark filter as an argument:
 
-   - Single document transformation
-   - Batch processing performance
-   - Memory usage patterns
-   - Concurrent transformation
-
-2. **Validation Benchmarks**
-
-   - Connection string validation
-   - JSON structure validation
-   - Type compatibility checking
-   - Document batch validation
-
-3. **Load Testing**
-   - Sustained load simulation (100-500 ops/sec)
-   - Stress testing to breaking point
-   - Memory pressure scenarios
-   - Concurrent migration simulation
-
-### Running Performance Tests
-
-# Test Execution Scripts
+```bash
+dotnet run --project tests/Performance/Nocturne.API.Performance.Tests -c Release -- --filter '*'
+```
 
 ## Fast Tests (Excludes slow tests by default)
 
@@ -213,7 +102,7 @@ dotnet test --filter "Category!=Integration&Category!=Performance&Category!=E2E"
 
 ```bash
 # Run only performance/benchmark tests
-dotnet test --filter "Category=Performance|Category=BenchmarkDotNet"
+dotnet test --filter "Category=Performance"
 
 # Run cache performance tests specifically
 dotnet test --filter "FullyQualifiedName~CachePerformanceBenchmarks"
@@ -222,18 +111,8 @@ dotnet test --filter "FullyQualifiedName~CachePerformanceBenchmarks"
 ### Integration Tests
 
 ```bash
-# Run all integration tests
+# Run all integration tests (Docker required)
 dotnet test --filter "Category=Integration"
-
-# Run integration tests with containers (Docker required)
-dotnet test --filter "Category=Integration&Category=Docker"
-```
-
-### Load & Stress Tests
-
-```bash
-# Run load/stress tests (takes significant time)
-dotnet test --filter "Category=Load|Category=Stress"
 ```
 
 ## Complete Test Suite (All tests including slow ones)
@@ -272,12 +151,9 @@ dotnet test --filter "Category=Integration" --logger "trx" --results-directory T
 
 ## Adding New Tests
 
-### Migration Tool Tests
+### Migration tests
 
-1. **Unit Tests**: Add to the appropriate service test class in `tests/Unit/`
-2. **Integration Tests**: Use `TestDatabaseManager` for database setup in `tests/Integration/`
-3. **Performance Tests**: Add benchmarks using BenchmarkDotNet patterns
-4. **Test Data**: Extend `TestDataGenerator` for new scenarios
+Nightscout import is an API feature (`src/API/Nocturne.API/Services/Migration`), so its coverage sits with the API suites: unit tests in `tests/Unit/Nocturne.API.Tests/Migration/`, and `tests/Integration/Nocturne.API.Tests/Migration/` driving both source paths — a MongoDB Testcontainer seeded from Nightscout fixtures, and a mock Nightscout API server.
 
 ### API Tests
 
@@ -285,7 +161,3 @@ dotnet test --filter "Category=Integration" --logger "trx" --results-directory T
 2. **Integration Tests**: Add to Integration folder with database setup
 3. **Use mocking**: For external dependencies in unit tests
 4. **Follow patterns**: Use existing base classes and patterns
-
----
-
-This comprehensive testing framework ensures reliability, performance, and data integrity across all components of the Nocturne project.

--- a/tests/Unit/Nocturne.API.Tests/README.md
+++ b/tests/Unit/Nocturne.API.Tests/README.md
@@ -1,146 +1,41 @@
-# Nocturne API Tests
+# Nocturne API Unit Tests
 
-This directory contains unit tests and integration tests for the Nocturne API.
-
-## Test Categories
-
-### Unit Tests
-
-Unit tests run without external dependencies and test individual components in isolation. These tests are fast and can
-be run without any setup.
-
-### Integration Tests
-
-Integration tests use real MongoDB containers via Testcontainers to test end-to-end functionality. These tests require
-Docker to be installed and running.
+Unit tests for the Nocturne API: no database, no Docker, no containers. The API's integration tests
+live in `tests/Integration/Nocturne.API.Tests`.
 
 ## Running Tests
 
-### Running All Tests
-
 ```bash
-dotnet test
+# The whole project. Five tests here are Category=Performance — memory and throughput thresholds
+# that depend on the machine — and the standard filter is what keeps them out
+dotnet test tests/Unit/Nocturne.API.Tests --filter "Category!=Integration&Category!=Performance&Category!=E2E"
+
+# One class
+dotnet test tests/Unit/Nocturne.API.Tests --filter "FullyQualifiedName~EntryServiceTests"
 ```
-
-### Running Only Unit Tests
-
-```bash
-dotnet test --filter "FullyQualifiedName!~Integration"
-```
-
-### Running Only Integration Tests
-
-```bash
-dotnet test --filter "FullyQualifiedName~Integration"
-```
-
-## Docker Setup for Integration Tests
-
-Integration tests require Docker to be installed and running to create MongoDB test containers.
-
-### Installing Docker
-
-#### Windows
-
-1. Download and install [Docker Desktop for Windows](https://docs.docker.com/desktop/windows/install/)
-2. Start Docker Desktop
-3. Ensure WSL 2 backend is enabled (recommended)
-
-#### macOS
-
-1. Download and install [Docker Desktop for Mac](https://docs.docker.com/desktop/mac/install/)
-2. Start Docker Desktop
-
-#### Linux
-
-1. Install Docker Engine using your distribution's package manager
-2. Start the Docker service
-3. Add your user to the docker group (optional, to run without sudo)
-
-### Verifying Docker Installation
-
-```bash
-docker --version
-docker run hello-world
-```
-
-### Troubleshooting Docker Issues
-
-If you encounter Docker-related errors when running integration tests:
-
-1. **Docker not running**: Ensure Docker Desktop is started (Windows/macOS) or the Docker service is running (Linux)
-
-2. **Permission issues (Linux)**: Add your user to the docker group:
-
-   ```bash
-   sudo usermod -aG docker $USER
-   newgrp docker
-   ```
-
-3. **WSL 2 issues (Windows)**: Ensure WSL 2 backend is enabled in Docker Desktop settings
-
-4. **Port conflicts**: If you have MongoDB running locally on port 27017, the tests will automatically use a different
-   port
 
 ## Test Structure
 
-```
-Nocturne.API.Tests/
-├── Controllers/           # Controller unit tests
-├── Services/             # Service unit tests
-├── Models/               # Model unit tests
-├── Integration/          # Integration tests
-│   ├── EntriesIntegrationTests.cs      # End-to-end API tests
-│   └── MongoDbServiceIntegrationTests.cs # Database integration tests
-└── GlobalUsings.cs       # Global using statements
-```
-
-## Test Data
-
-Integration tests automatically seed test data into temporary MongoDB containers. Each test run uses a fresh database
-instance, ensuring test isolation.
+Tests mirror the API's own layout — `Controllers/`, `Services/`, `Middleware/`, `Validators/` and so
+on — with `TestDoubles/` for shared fakes, `GoldenFiles/` for the recorded v1/v2/v3 responses, and
+`TestSuite/` for the tests that police the suite itself.
 
 ## Best Practices
 
 1. **Arrange-Act-Assert**: All tests follow the AAA pattern with clear separation between sections
 2. **Test Isolation**: Each test is independent and doesn't rely on other tests
 3. **Descriptive Names**: Test method names clearly describe what is being tested
-4. **Fast Unit Tests**: Unit tests run quickly without external dependencies
-5. **Comprehensive Integration**: Integration tests cover real-world scenarios
-
-## Continuous Integration
-
-When running in CI/CD environments:
-
-1. Ensure Docker is available in the CI environment
-2. Consider using pre-built MongoDB images to speed up test execution
-3. Use test parallelization carefully with integration tests to avoid port conflicts
+4. **Use mocking**: For external dependencies, so these tests stay in milliseconds
 
 ## Adding New Tests
 
-### Unit Tests
-
-1. Create tests in the appropriate folder (Controllers, Services, Models)
-2. Use mocking for external dependencies
-3. Focus on testing a single component in isolation
-
-### Integration Tests
-
-1. Add tests to the Integration folder
-2. Use the existing base classes for database setup
-3. Test real interactions between components
-4. Verify end-to-end scenarios
-
-## Performance Considerations
-
-- Unit tests should complete in milliseconds
-- Integration tests may take several seconds due to container startup
-- Consider using `[Collection]` attributes to control test parallelization
-- Use `Skip` attribute to temporarily disable slow or flaky tests
+1. Create tests in the folder matching the code under test
+2. Mock external dependencies and test a single component in isolation
+3. Use `[Collection]` to control parallelisation, and `Skip` to park a flaky test
 
 ## Legacy Tests
 
-Legacy tests from the original Nocturne application are marked with the `[Parity]` attribute. These tests ensure that
+Legacy tests from the original Nightscout application are marked with the `[Parity]` attribute. These tests ensure that
 the new C# codebase maintains 1:1 functionality with the original implementation.
 
 ### List of Legacy Tests still to implement:


### PR DESCRIPTION
Closes #912.

Two halves: prune dead prose from the tests docs, and make the solution-completeness guard hold in both directions.

## The guard

`comm -23` only caught on-disk-but-not-in-sln, so a sln entry pointing at a deleted csproj was invisible — and that entry breaks every solution-wide command. The step now reports both arms and fails on either, refuses to compare when discovery returns nothing on either side, and moves the `scripts/Shared` exclusion onto the *absent* arm only so it cannot mask a dangling entry.

Verified on Linux in `mcr.microsoft.com/dotnet/sdk:10.0` (matching `ubuntu-latest`), running the step body extracted verbatim from the YAML under both `bash -e {0}` — GitHub's default — and `bash -eo pipefail`, which is what adding `shell: bash` would give. Every case behaves identically in both:

| Case | Result |
|---|---|
| pristine tree | exit 0, silent |
| tracked csproj absent from the sln | reports it, exit 1 |
| sln entry with no tracked file | reports it, exit 1 (the reported defect — the old guard exited **0**) |
| both at once | both arms reported, exit 1 |
| zero discovery on either side | "Nothing to compare", exit 1 (the old guard passed vacuously in both directions) |
| corrupt sln, `dotnet sln list` non-zero | exit 1, no false green |
| duplicate sln entry | exit 1 |
| case-variant or `.\`-prefixed entry | exit 1 |
| csproj tracked inside a gitignored directory | exit 1 |

Two further hardenings after review found holes on both sides:

- **`git ls-files` honours `core.quotePath`** and emits octal-escaped C-quoted paths, while `dotnet sln list` emits raw UTF-8. A correctly-registered `Nocturne.Connectors.Médtronic` was reported on **both** arms at once — CI telling a contributor to do what they had already done. Now `git -c core.quotePath=false`. Pre-existing on the absent arm; no current path is affected, and space-containing paths were already safe.
- **`grep '\.csproj$'` anchors on end-of-line**, so an sln entry with trailing whitespace dropped out of the comparison entirely and went green once its file was deleted — precisely the defect this change exists to catch. Now `grep -E '\.csproj[[:space:]]*$'` plus a trim.

**No CI solution build was added, deliberately.** #912 suggests one so that "in the solution" starts meaning "built by CI", but it would be red on arrival: every .NET job runs `ubuntu-latest`, and the solution carries three `net10.0-windows*` projects whose MSIX toolchain ships Windows-only binaries — which is why the Test step already loops per project. A `windows-latest` job would need WindowsAppSDK/MSIX tooling and the widget's signing thumbprint, duplicating `widget-store.yml` for no extra coverage. The guard's comment now claims only what is true: no job builds `nocturne.sln`, so nothing gates solution membership except this check.

This also corrects #886's last item, which is wrong on both halves. `widget-store.yml` does not pass `-p:Platform`; it uses `msbuild` with `WidgetStoreBuild=true`. And a solution-wide `dotnet build` does **not** fail on the platform — `nocturne.sln` maps that project's `Debug|Any CPU` to `Debug|x64`. Only a direct csproj build needs `-p:Platform=x64`.

## The docs

`tests/README.md` documented a "Migration Tool Testing Framework" for a tool no longer in the tree. The dead prose ran well past the three lines the issue cites: a `TestDataGenerator` and `TestDatabaseManager` that exist nowhere, NBomber load tests with no NBomber reference in any csproj, a `mongodb-init/` directory that does not exist, filters for four `Category` values no test carries (`Load`, `Stress`, `BenchmarkDotNet`, `Docker` — every trait in the repo was enumerated to confirm), a stray mid-document `h1`, and quick-start commands failing with `MSBUILD : error MSB1003`.

The capability moved into the API rather than being replaced, so the section is now a pointer to where it lives: `Services/Migration/`, plus unit coverage and integration tests driving both source paths — a seeded MongoDB Testcontainer and a mock Nightscout server.

`tests/Unit/Nocturne.API.Tests/README.md` carried the same dead prose one directory down (230 → 124 lines): an `Integration/` folder the project does not have, `MongoDbServiceIntegrationTests.cs` which exists nowhere, and `EntriesIntegrationTests.cs` which exists in a different project. The `[Parity]` checklist is kept — that attribute is genuinely used — with one correction: "legacy tests from the original **Nocturne** application" now reads **Nightscout**.

Three claims introduced by the first revision were themselves false and are fixed:

- **"`dotnet test` takes a project or solution, never a directory"** — disproved by the line directly below it. A directory works when it holds exactly one project or solution file; `tests/Unit/` failed because it holds none.
- **A benchmark command that ran nothing.** The documented invocation burned 2m18s and reported `executed benchmarks: 0` with **RC=0** — a command that looks like it worked. Repaired rather than documented around: `Nocturne.API.Performance.Tests` now uses `InProcessNoEmitToolchain`, matching its sibling. Same invocation afterwards executes 1 benchmark (`Mean = 4.571 us, N = 95`).
- **A Quick Start that started a broken compose stack.** `docker-compose.test.yml` bind-mounts four paths that do not exist, and the same revision had already deleted one of them from the tree diagram as non-existent. Nothing in the test suites reads that file — the integration suites use Testcontainers. The step is removed here and from `AGENTS.md`, `CLAUDE.md` and `.github/copilot-instructions.md`, which all carried the identical broken command.

Every command the READMEs now hand out was executed as written, except the E2E line (stands up Aspire) and the two solution-scoped lines, which the prose now scopes honestly. The eleven surviving rootless `dotnet test` invocations are covered at one site: with no path, `dotnet test` resolves `nocturne.sln` and is therefore Windows-only.

## Found while verifying, filed not fixed

- **#938** — the per-project runs are documented with the standard category filter because `Category=Performance` tests in that project fail on a clean tree (a 10 MB memory threshold and a wall-clock budget), while every CI and documented invocation filters them out. That keeps the documented commands honest but does not fix the underlying "red locally, green in CI" split.
- `Nocturne.Widget.Windows11.csproj:2-9` claims a command-line `dotnet build` cannot work for want of VS tooling. Disproved — both `-p:Platform=x64` and the solution build succeed from the CLI.
- `tests/Infrastructure/Docker/docker-compose.test.yml` is now referenced by no doc and no suite, and its four bind mounts are dead. A candidate for deletion, which is a separate call.
