### PR TITLE
fix(web): forward a 404 from a generated remote function instead of flattening it to a 500

### DIFF
--- a/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
+++ b/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
@@ -54,6 +54,20 @@ function nswagApiException(status: number, body: string) {
   );
 }
 
+/**
+ * An RFC-7807 body, which NSwag throws as the parsed object itself when the
+ * operation declares a typed error response. `title` is the status phrase, so
+ * the only thing here a caller can act on is the status.
+ */
+function problemDetails(status: number, detail: string) {
+  return {
+    type: `https://tools.ietf.org/html/rfc9110#status.${status}`,
+    title: "Not Found",
+    status,
+    detail,
+  };
+}
+
 const RATE_LIMIT_BODY = JSON.stringify({
   error: "rate_limit_exceeded",
   error_description: "Too many requests. Please try again later.",
@@ -90,6 +104,32 @@ describe("the status a generated remote function lets through", () => {
     expect(remoteErrorMessage(crossed, "You need alerts.readwrite.")).toBe(
       RATE_LIMITED_ERROR
     );
+  });
+
+  it("forwards a 404 rather than flattening it to a 500", async () => {
+    const crossed = await crossTheBoundary(
+      problemDetails(404, "Data source not found: dexcom")
+    );
+
+    expect(isHttpError(crossed) && crossed.status).toBe(404);
+  });
+
+  it("forwards a 404 whose body is empty, as `NotFound()` sends it", async () => {
+    const crossed = await crossTheBoundary(nswagApiException(404, ""));
+
+    expect(isHttpError(crossed) && crossed.status).toBe(404);
+    expect(JSON.stringify(crossed)).not.toContain("not expected");
+  });
+
+  it("leaves a dialog its own wording for a resource that is already gone", async () => {
+    const crossed = await crossTheBoundary(nswagApiException(404, ""));
+
+    expect(
+      describeSubmitError(crossed, "This data source is already gone.")
+    ).toBe("This data source is already gone.");
+    expect(
+      remoteErrorMessage(crossed, "This data source is already gone.")
+    ).toBe("This data source is already gone.");
   });
 
   it("still flattens a status it does not forward", async () => {

--- a/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
+++ b/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { transformWithEsbuild } from "vite";
 import { error, isHttpError } from "@sveltejs/kit";
 import config from "../../../../../remote-codegen.config";
-import { describeSubmitError, RATE_LIMITED_ERROR } from "../forms/submit-error";
+import {
+  describeSubmitError,
+  MISSING_ITEM_ERROR,
+  RATE_LIMITED_ERROR,
+} from "../forms/submit-error";
 import { remoteErrorMessage } from "./remote-error";
 
 /**
@@ -41,17 +45,28 @@ async function crossTheBoundary(thrown: unknown): Promise<unknown> {
 }
 
 /**
- * NSwag's ApiException, which is what it throws for a status the operation
- * declares no response type for — the rate limiter's 429 among them. The body
- * arrives as unparsed text on `response`, and the message is NSwag's own.
+ * The two messages the generated client puts on an `ApiException`: the first
+ * for a status the operation declares no response type for — the rate limiter's
+ * 429 among them — and the second for one it declares but whose body came back
+ * empty or unparsed, as a bare `NotFound()` does.
  */
-function nswagApiException(status: number, body: string) {
-  return Object.assign(
-    new Error(
-      `The HTTP status code of the response was not expected (${status}).`
-    ),
-    { status, response: body, result: null }
-  );
+const UNDECLARED_STATUS_MESSAGE = "An unexpected server error occurred.";
+const DECLARED_STATUS_MESSAGE = "A server side error occurred.";
+
+/**
+ * NSwag's ApiException. The body arrives as unparsed text on `response`, and
+ * the message is NSwag's own rather than anything the server wrote.
+ */
+function nswagApiException(
+  status: number,
+  body: string,
+  message = UNDECLARED_STATUS_MESSAGE
+) {
+  return Object.assign(new Error(message), {
+    status,
+    response: body,
+    result: null,
+  });
 }
 
 /**
@@ -84,7 +99,7 @@ describe("the status a generated remote function lets through", () => {
   it("keeps NSwag's boilerplate out of the message it carries", async () => {
     const crossed = await crossTheBoundary(nswagApiException(429, RATE_LIMIT_BODY));
 
-    expect(JSON.stringify(crossed)).not.toContain("not expected");
+    expect(JSON.stringify(crossed)).not.toContain("error occurred");
   });
 
   it("reads as throttled on the invite page, not as a dead invite", async () => {
@@ -115,21 +130,32 @@ describe("the status a generated remote function lets through", () => {
   });
 
   it("forwards a 404 whose body is empty, as `NotFound()` sends it", async () => {
-    const crossed = await crossTheBoundary(nswagApiException(404, ""));
+    const crossed = await crossTheBoundary(
+      nswagApiException(404, "", DECLARED_STATUS_MESSAGE)
+    );
 
     expect(isHttpError(crossed) && crossed.status).toBe(404);
-    expect(JSON.stringify(crossed)).not.toContain("not expected");
+    expect(JSON.stringify(crossed)).not.toContain("error occurred");
   });
 
   it("leaves a dialog its own wording for a resource that is already gone", async () => {
-    const crossed = await crossTheBoundary(nswagApiException(404, ""));
+    const crossed = await crossTheBoundary(
+      nswagApiException(404, "", DECLARED_STATUS_MESSAGE)
+    );
 
     expect(
       describeSubmitError(crossed, "This data source is already gone.")
     ).toBe("This data source is already gone.");
+  });
+
+  it("does not read as a missing permission when an id is stale", async () => {
+    const crossed = await crossTheBoundary(
+      nswagApiException(404, "", DECLARED_STATUS_MESSAGE)
+    );
+
     expect(
-      remoteErrorMessage(crossed, "This data source is already gone.")
-    ).toBe("This data source is already gone.");
+      remoteErrorMessage(crossed, "Changing alerts requires alerts.readwrite.")
+    ).toBe(MISSING_ITEM_ERROR);
   });
 
   it("still flattens a status it does not forward", async () => {

--- a/src/Web/packages/app/src/lib/api/remote-error.ts
+++ b/src/Web/packages/app/src/lib/api/remote-error.ts
@@ -1,4 +1,7 @@
-import { RATE_LIMITED_ERROR } from "$lib/forms/submit-error";
+import {
+  MISSING_ITEM_ERROR,
+  RATE_LIMITED_ERROR,
+} from "$lib/forms/submit-error";
 
 /**
  * Message to show for a rejected remote function call.
@@ -9,14 +12,19 @@ import { RATE_LIMITED_ERROR } from "$lib/forms/submit-error";
  * message is the HTTP client's own boilerplate; the caller's fallback names the
  * permission instead. A 429 is answered from the status for the same reason the
  * codegen forwards it with a fixed reason, and because a fallback naming the
- * permission the caller lacks describes the wrong refusal. A 404 is forwarded
- * with a fixed reason too, so its message names the status rather than what was
- * missing; see `describeSubmitError`.
+ * permission the caller lacks describes the wrong refusal.
+ *
+ * A 404 is answered from the status as well, but with {@link MISSING_ITEM_ERROR}
+ * rather than the fallback: the codegen forwards it with a fixed reason, so its
+ * message names the status, and every caller here passes a sentence about a
+ * missing permission — which a caller who holds the permission would be told
+ * they lack the moment they act on an id someone else deleted.
  */
 export function remoteErrorMessage(err: unknown, fallback: string): string {
   const e = err as { status?: number; body?: { message?: unknown } } | null;
   if (e?.status === 429) return RATE_LIMITED_ERROR;
-  if (e?.status === 403 || e?.status === 404) return fallback;
+  if (e?.status === 404) return MISSING_ITEM_ERROR;
+  if (e?.status === 403) return fallback;
 
   const message = e?.body?.message;
   return typeof message === "string" && message.trim() ? message : fallback;

--- a/src/Web/packages/app/src/lib/api/remote-error.ts
+++ b/src/Web/packages/app/src/lib/api/remote-error.ts
@@ -9,12 +9,14 @@ import { RATE_LIMITED_ERROR } from "$lib/forms/submit-error";
  * message is the HTTP client's own boilerplate; the caller's fallback names the
  * permission instead. A 429 is answered from the status for the same reason the
  * codegen forwards it with a fixed reason, and because a fallback naming the
- * permission the caller lacks describes the wrong refusal.
+ * permission the caller lacks describes the wrong refusal. A 404 is forwarded
+ * with a fixed reason too, so its message names the status rather than what was
+ * missing; see `describeSubmitError`.
  */
 export function remoteErrorMessage(err: unknown, fallback: string): string {
   const e = err as { status?: number; body?: { message?: unknown } } | null;
   if (e?.status === 429) return RATE_LIMITED_ERROR;
-  if (e?.status === 403) return fallback;
+  if (e?.status === 403 || e?.status === 404) return fallback;
 
   const message = e?.body?.message;
   return typeof message === "string" && message.trim() ? message : fallback;

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte
@@ -14,6 +14,7 @@
     Pencil,
     Trash2,
   } from "lucide-svelte";
+  import { describeSubmitError, errorStatus } from "$lib/forms";
   import { getCategoryIcon } from "$lib/utils/connector-display";
   import { lastSeen } from "$lib/utils/formatting";
 
@@ -34,6 +35,7 @@
     success?: boolean;
     totalDeleted?: number;
     error?: string;
+    alreadyGone?: boolean;
   } | null>(null);
 
   $effect(() => {
@@ -97,9 +99,19 @@
         }
       }
     } catch (e) {
+      // A rejected remote function throws SvelteKit's `HttpError` — a plain
+      // `{ status, body }` object, not an `Error` — so the status is what
+      // separates data that was already gone from a delete that failed.
+      const alreadyGone = errorStatus(e) === 404;
       deleteResult = {
         success: false,
-        error: e instanceof Error ? e.message : "Failed to delete data",
+        alreadyGone,
+        error: describeSubmitError(
+          e,
+          alreadyGone
+            ? "This data source has no data left to delete."
+            : "Failed to delete data"
+        ),
       };
     } finally {
       isDeletingDataSource = false;
@@ -254,7 +266,11 @@
                   class="flex items-center gap-2 text-red-800 dark:text-red-200"
                 >
                   <AlertCircle class="h-5 w-5" />
-                  <span class="font-medium">Failed to delete data</span>
+                  <span class="font-medium">
+                    {deleteResult.alreadyGone
+                      ? "Nothing left to delete"
+                      : "Failed to delete data"}
+                  </span>
                 </div>
                 <p class="text-sm text-red-700 dark:text-red-300 mt-1">
                   {deleteResult.error}

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte.test.ts
@@ -61,9 +61,10 @@ describe("DataSourceManageDialog", () => {
 
     await attemptDelete();
 
-    await expect
-      .element(page.getByText("Failed to delete data").first())
-      .toBeInTheDocument();
+    const failureWording = page.getByText("Failed to delete data");
+    await expect.element(failureWording.first()).toBeInTheDocument();
+    // the headline and the message below it each carry the wording
+    expect(failureWording.elements()).toHaveLength(2);
     await expect
       .element(page.getByText("Nothing left to delete"))
       .not.toBeInTheDocument();

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte.test.ts
@@ -1,0 +1,71 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { DataSourceInfo } from "$api-clients";
+
+let deleteImpl: () => Promise<unknown>;
+
+vi.mock("$api/generated/services.generated.remote", () => ({
+  deleteDataSourceData: () => deleteImpl(),
+}));
+
+import DataSourceManageDialog from "./DataSourceManageDialog.svelte";
+
+/**
+ * What a rejected remote function hands the dialog: SvelteKit's `HttpError` is
+ * a plain `{ status, body }` object and not an `Error`, so the status is the
+ * only part of it a caller can read.
+ */
+function httpError(status: number, message: string) {
+  return { status, body: { message } };
+}
+
+const dataSource: DataSourceInfo = {
+  id: "11111111-1111-1111-1111-111111111111",
+  name: "Dexcom G7",
+  category: "cgm",
+  status: "active",
+  totalEntries: 4200,
+};
+
+async function attemptDelete() {
+  render(DataSourceManageDialog, {
+    props: { open: true, selectedDataSource: dataSource },
+  });
+
+  await page.getByRole("button", { name: "Delete Data..." }).click();
+  await page.getByRole("textbox").fill("DELETE");
+  await page.getByRole("button", { name: "Delete All Data" }).click();
+}
+
+describe("DataSourceManageDialog", () => {
+  beforeEach(() => {
+    deleteImpl = () => Promise.resolve({ success: true, totalDeleted: 1 });
+  });
+
+  it("reports data that was already gone as nothing left to delete", async () => {
+    deleteImpl = () => Promise.reject(httpError(404, "Not found"));
+
+    await attemptDelete();
+
+    await expect
+      .element(page.getByText("Nothing left to delete"))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("This data source has no data left to delete."))
+      .toBeInTheDocument();
+  });
+
+  it("still reports a delete that failed as a failure", async () => {
+    deleteImpl = () => Promise.reject(httpError(500, "Failed to delete data"));
+
+    await attemptDelete();
+
+    await expect
+      .element(page.getByText("Failed to delete data").first())
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("Nothing left to delete"))
+      .not.toBeInTheDocument();
+  });
+});

--- a/src/Web/packages/app/src/lib/forms/submit-error.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.ts
@@ -44,6 +44,11 @@ export function errorMessage(err: unknown): string | undefined {
  * rate limiter's body carries no `message` and a caller's fallback describes
  * what it asked for — "this invite link is invalid" for a request the limiter
  * never let reach the invite.
+ *
+ * A 404 answers with the caller's fallback for the same reason: the codegen
+ * forwards it with a fixed reason, so its message names the status rather than
+ * what was missing. A caller that can say something better ("already removed")
+ * reads the status itself.
  */
 export function describeSubmitError(
   err: unknown,
@@ -51,6 +56,7 @@ export function describeSubmitError(
 ): string {
   const status = errorStatus(err);
   if (status === 429) return RATE_LIMITED_ERROR;
+  if (status === 404) return fallback;
 
   if (status !== undefined && status >= 400 && status < 500) {
     return errorMessage(err) ?? fallback;

--- a/src/Web/packages/app/src/lib/forms/submit-error.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.ts
@@ -6,6 +6,10 @@ export const GENERIC_SUBMIT_ERROR =
 export const RATE_LIMITED_ERROR =
   "Too many attempts. Please wait a few minutes and try again.";
 
+/** Shown when the thing an action referred to is no longer on the server. */
+export const MISSING_ITEM_ERROR =
+  "That item no longer exists. Refresh the page to see what's there now.";
+
 /** The HTTP status carried by a thrown value, if it has one. */
 export function errorStatus(err: unknown): number | undefined {
   if (err && typeof err === "object" && "status" in err) {

--- a/src/Web/remote-codegen.config.ts
+++ b/src/Web/remote-codegen.config.ts
@@ -38,12 +38,21 @@ export default {
     // message to the user. Falls through to a 500 with the extracted message
     // so the real error is still visible in dev.
     //
-    // 429 is forwarded too, and with a fixed reason rather than the extracted
-    // message: the rate limiter's body declares no typed schema, so NSwag
-    // supplies its own "status code was not expected" text, and flattened to a
-    // 500 the status a caller needs to tell "you were throttled" from "this
-    // failed" never reaches the browser. `describeSubmitError` and
-    // `remoteErrorMessage` resolve the wording from the status.
+    // 429 and 404 are forwarded too, and with a fixed reason rather than the
+    // extracted message: the rate limiter's body declares no typed schema, so
+    // NSwag supplies its own "status code was not expected" text, and a missing
+    // resource is answered with either an empty body (`NotFound()`) or an
+    // RFC-7807 body whose `title` is the status phrase — so the extracted
+    // message is boilerplate either way, while the status is what tells a caller
+    // "already gone"/"you were throttled" from "this failed".
+    // `describeSubmitError` and `remoteErrorMessage` resolve the wording from
+    // the status.
+    //
+    // A forwarded 404 reaches a query and a command differently, and both are
+    // wanted: a query awaited by a page load renders the not-found page, while a
+    // command or form rejects its caller with an `HttpError(404)` — SvelteKit
+    // renders an error page only for a failed load, so a dialog still gets to
+    // show its own "already gone" wording.
     //
     // NSwag throws ProblemDetails directly (not wrapped in ApiException) for
     // responses that declare a typed error schema, so the title/detail/errors
@@ -55,6 +64,7 @@ export default {
       `    const flat = errors ? Object.entries(errors).map(([, v]: [string, any]) => Array.isArray(v) ? v.join(', ') : v).join('; ') : undefined;\n` +
       `    const message = flat ?? body?.message ?? body?.title ?? body?.detail ?? e?.message ?? e?.title ?? e?.detail;\n` +
       `    if (status === 429) throw error(429, 'Too many requests');\n` +
+      `    if (status === 404) throw error(404, 'Not found');\n` +
       `    if (status === 400 || status === 409) throw error(status, message ?? 'Request rejected');\n` +
       `    throw error(500, message ?? 'Failed to ${functionName}')`,
   },


### PR DESCRIPTION
Closes #876.

Items 1, 2 and 4 of that issue are already fixed on main — the three `DataSourceService` catch blocks return generic text, every `ServicesController` 404 is RFC-7807 `Problem(...)`, and the narrating comments are gone. This closes item 3, which is broader than filed.

The generated remote-function wrappers special-cased 401/403/400/409/429 and funnelled everything else — including **404** — into `throw error(500, message)`. That is not one endpoint: the ladder is generated into **456 wrapper sites across 91 files**, none of which handled 404. So no "already gone" signal reached any dialog anywhere in the app, and `DataSourceManageDialog` could not tell a stale id from a failed delete.

## The template

One arm added to `remote-codegen.config.ts`, with a **fixed reason** rather than the server's message.

The template cannot vary by remote kind — `on500` is typed `(functionName: string) => string`, and `generateCatchBlock` passes `RemoteKind` only to `resolveOn401`. It also does not need to: a command's `error(404, …)` rejects the caller's `await` rather than rendering an error page, since SvelteKit renders one only for a failed *load*, and no `load`, `+page.server.ts`, `+layout.server.ts`, universal load or `handle` hook in the app consumes a generated remote function. All 100 importing files were enumerated to confirm.

A fixed reason because the message channel carries nothing usable: 121 of 163 `NotFound(...)` sites are bare, so the body is empty and NSwag throws its own boilerplate; and of the 182 operations that declare a 404, 179 declare `ProblemDetails`, whose `title` is the status phrase "Not Found" — which the extraction ladder prefers over `detail`. Forwarding would have pushed boilerplate and status phrases at users. See #937: fixing that ordering would make the fixed reason unnecessary for 179 of the 182, so this arm should be revisited once it lands.

## The helpers, and a regression caught at review

Adding the arm would have made all 456 indifferent call sites newly show "Not found" in place of their own wording, so both shared helpers gained a 404 arm.

For `describeSubmitError` that is behaviour-preserving — a 404 already arrived as `HttpError(500)` and already fell through to the caller's fallback. Every caller's fallback was checked: all are neutral submission sentences.

For `remoteErrorMessage` it was **not**, and the first revision of this branch regressed. It previously returned the extracted message; returning the caller's fallback was wrong because all nine call sites pass a *permission* sentence:

```
before  status=500 | toast => "A server side error occurred."
first   status=404 | toast => "Changing alerts requires the alerts.readwrite permission."
```

Two tabs on `/alerts`, one deletes a rule and the other toggles it, and an admin who holds the permission is told they lack it. The compression-lows delete loop iterates a stale array, so a double-click triggers it reliably. Trading a vague-but-neutral message for a confident wrong one is worse than the gap being fixed.

403 and 404 are now separate: a scope refusal genuinely is a permission refusal, so that arm keeps the caller's sentence; a 404 gets its own wording that states what happened without diagnosing why.

## The dialog

`DataSourceManageDialog` caught failures with `e instanceof Error ? e.message : "Failed to delete data"`. SvelteKit's `HttpError` is a plain `{ status, body }` object with no `Error` in its prototype chain — verified at runtime, `proto chain: HttpError -> Object` — so that check always took the else branch and discarded the status of *every* failure. Forwarding 404 through the template would have changed nothing visible without fixing the call site too.

It now reads the status once, which drives both the message and the result headline.

## A test harness that would have certified the bug

The repo's component-test stub aliases `@sveltejs/kit` and throws a real `Error` from `error()`. A test that built its rejection by calling it would have taken the true branch of `instanceof Error` and **passed against the broken code**. The dialog test constructs the plain object the framework actually throws. Filed as #934.

## Verification

Regeneration reproduced independently: 456 hunks, 91 files, exactly one distinct line, `api-client.generated.ts` unchanged, deterministic across runs, output still untracked.

Mutation-proved, each restored: deleting the template arm fails 3 tests; reverting either helper's 404 arm fails 1 each — the `remoteErrorMessage` failure being the false permission claim itself; changing the dialog's status check fails the browser test; and altering only the dialog's script fallback fails the failure-path assertion.

Two of this branch's own assertions were vacuous and are fixed. The test fixture invented an NSwag message (`"The HTTP status code of the response was not expected (…)"`) that appears **zero times** in the generated client, so an assertion forbidding it could never fire; the real messages are now used. Correcting it once was not enough — forbidding `"server error occurred"` still passed under mutation, because the declared-status message is "A server **side** error occurred" and that substring matches only the *undeclared* one. It now forbids `"error occurred"`, which both contain. The same flaw made the pre-existing 429 assertion vacuous on main; it is load-bearing now.

Node suite 851 passed (the one failure is `appearance-store.ssr.test.ts`, broken on main); dialog browser tests 2/2; `svelte-check` 64/10, the documented baseline; zero new lint errors.

## Filed while verifying

- **#933** — generated bulk-restore wrappers drop the required `ids` body, so they cannot work at runtime.
- **#934** — the component-test SvelteKit stub throws a real `Error`, so error-path tests can validate code that cannot work in production.
- **#937** — `body?.title` precedes `body?.detail`, so every `ProblemDetails` 400/409 reads as "Bad Request"/"Conflict" instead of the reason.
