### PR TITLE
fix(oauth): complete DCR for pre-seeded known clients and unblock the consent page

### DIFF
--- a/src/API/Nocturne.API/Services/Auth/OAuthClientService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OAuthClientService.cs
@@ -170,14 +170,34 @@ public class OAuthClientService : IOAuthClientService
         string? createdFromIp,
         CancellationToken ct = default)
     {
-        // Idempotent on (tenant, software_id) when software_id is supplied:
-        // if a row already exists return it unchanged.
+        // Idempotent on (tenant, software_id) when software_id is supplied — but only for
+        // clients that completed a real registration. Known-directory seeds ship with an
+        // empty RedirectUris list (the real value is only knowable once the client
+        // registers), so returning such a seed unchanged would silently discard the
+        // submitted redirect_uris and permanently break /authorize for that client.
+        // A seed therefore adopts the incoming registration data instead.
         if (!string.IsNullOrEmpty(softwareId))
         {
             var existing = await _dbContext.OAuthClients
                 .FirstOrDefaultAsync(c => c.SoftwareId == softwareId, ct);
             if (existing != null)
             {
+                if (existing.IsKnown && DeserializeRedirectUris(existing.RedirectUris).Count == 0)
+                {
+                    existing.RedirectUris = JsonSerializer.Serialize(redirectUris);
+                    existing.ClientName = clientName ?? existing.ClientName;
+                    existing.ClientUri = clientUri ?? existing.ClientUri;
+                    existing.LogoUri = logoUri ?? existing.LogoUri;
+                    existing.DisplayName = clientName ?? existing.DisplayName;
+                    existing.UpdatedAt = DateTime.UtcNow;
+                    await _dbContext.SaveChangesAsync(ct);
+
+                    _logger.LogInformation(
+                        "DCR: known-directory seed {SoftwareId} adopted registration redirect_uris ({Count} URIs)",
+                        SanitizeForLog(softwareId), redirectUris.Count);
+                    return MapToInfo(existing);
+                }
+
                 _logger.LogDebug(
                     "DCR: returning existing client for software_id {SoftwareId} (tenant {TenantId})",
                     SanitizeForLog(softwareId), existing.TenantId);

--- a/src/Web/packages/app/src/routes/(authenticated)/oauth/consent/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/oauth/consent/+page.svelte
@@ -75,6 +75,11 @@
 
   // Get form-level issues for error display
   const formIssues = $derived(consentForm.fields.allIssues() ?? []);
+
+  // A SvelteKit remote form can only be bound to a single <form> element, so Deny
+  // and Approve each need their own keyed instance of the same remote function.
+  const denyForm = $derived(consentForm.for("deny"));
+  const approveForm = $derived(consentForm.for("approve"));
 </script>
 
 <svelte:head>
@@ -290,7 +295,7 @@
 
         <div class="flex gap-3">
           <form
-            {...consentForm.enhance(async ({ submit }) => {
+            {...denyForm.enhance(async ({ submit }) => {
               await submit();
             })}
             class="flex-1"
@@ -310,16 +315,16 @@
               type="submit"
               variant="outline"
               class="w-full"
-              disabled={!!consentForm.pending}
+              disabled={!!denyForm.pending}
             >
-              {#if consentForm.pending}
+              {#if denyForm.pending}
                 <Loader2 class="mr-2 h-4 w-4 animate-spin" />
               {/if}
               Deny
             </Button>
           </form>
           <form
-            {...consentForm.enhance(async ({ submit }) => {
+            {...approveForm.enhance(async ({ submit }) => {
               await submit();
             })}
             class="flex-1"
@@ -338,9 +343,9 @@
             <Button
               type="submit"
               class="w-full"
-              disabled={!!consentForm.pending}
+              disabled={!!approveForm.pending}
             >
-              {#if consentForm.pending}
+              {#if approveForm.pending}
                 <Loader2 class="mr-2 h-4 w-4 animate-spin" />
               {/if}
               Approve

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/OAuthClientServiceRegistrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/OAuthClientServiceRegistrationTests.cs
@@ -1,0 +1,131 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Services.Auth;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Regression tests for DCR against pre-seeded known-directory clients (#810 bug 1):
+/// a seed ships with an empty RedirectUris list, so returning it unchanged silently
+/// discarded the submitted redirect_uris and permanently broke /authorize for that client.
+/// </summary>
+public class OAuthClientServiceRegistrationTests : IDisposable
+{
+    private readonly DbContextOptions<NocturneDbContext> _options;
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+
+    public OAuthClientServiceRegistrationTests()
+    {
+        _options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = NewContext();
+        context.OAuthClients.Add(new OAuthClientEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = _tenantId,
+            ClientId = "seeded-client-id",
+            SoftwareId = "io.home-assistant.nocturne",
+            ClientName = "Home Assistant",
+            DisplayName = "Home Assistant",
+            IsKnown = true,
+            // The known directory cannot know a per-instance callback URL.
+            RedirectUris = "[]",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        context.SaveChanges();
+    }
+
+    private NocturneDbContext NewContext() =>
+        new(_options) { TenantId = _tenantId };
+
+    private OAuthClientService CreateService(NocturneDbContext context) =>
+        new(context, new RedirectUriValidator(), NullLogger<OAuthClientService>.Instance);
+
+    [Fact]
+    public async Task Register_WhenSoftwareIdMatchesEmptyKnownSeed_AdoptsSubmittedRedirectUris()
+    {
+        using var context = NewContext();
+        var service = CreateService(context);
+        var uris = new[] { "http://127.0.0.1:8123/auth/nocturne/callback" };
+
+        var info = await service.RegisterClientAsync(
+            "io.home-assistant.nocturne",
+            "Home Assistant",
+            "https://www.home-assistant.io",
+            null,
+            uris,
+            "glucose.read treatments.read",
+            null);
+
+        // The registration response must carry the submitted URIs so the client
+        // can immediately proceed to /authorize.
+        info.RedirectUris.Should().BeEquivalentTo(uris);
+
+        var stored = await context.OAuthClients
+            .SingleAsync(c => c.SoftwareId == "io.home-assistant.nocturne");
+        stored.RedirectUris.Should().Contain("127.0.0.1:8123");
+        stored.IsKnown.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Register_WhenSeedAlreadyCompletedRegistration_ReturnsItUnchanged()
+    {
+        using var context = NewContext();
+        // Complete the seed first, exactly like the first real DCR would.
+        var service = CreateService(context);
+        await service.RegisterClientAsync(
+            "io.home-assistant.nocturne",
+            "Home Assistant",
+            "https://www.home-assistant.io",
+            null,
+            new[] { "http://127.0.0.1:8123/auth/nocturne/callback" },
+            "glucose.read",
+            null);
+
+        // A second registration must be fully idempotent: the original URIs survive.
+        var second = await service.RegisterClientAsync(
+            "io.home-assistant.nocturne",
+            "Renamed Client",
+            "https://example.com",
+            null,
+            new[] { "https://evil.example.com/callback" },
+            "glucose.read",
+            null);
+
+        second.RedirectUris.Should().BeEquivalentTo(
+            new[] { "http://127.0.0.1:8123/auth/nocturne/callback" });
+
+        var stored = await context.OAuthClients
+            .SingleAsync(c => c.SoftwareId == "io.home-assistant.nocturne");
+        stored.RedirectUris.Should().NotContain("evil.example.com");
+        stored.DisplayName.Should().Be("Home Assistant");
+    }
+
+    [Fact]
+    public async Task Register_WithoutExistingRow_CreatesNewClientWithUris()
+    {
+        using var context = NewContext();
+        var service = CreateService(context);
+        var uris = new[] { "org.loopkit.loop://oauth/callback" };
+
+        var info = await service.RegisterClientAsync(
+            "org.loopkit.loop.newinstall", null, null, null, uris, "glucose.read", null);
+
+        info.RedirectUris.Should().BeEquivalentTo(uris);
+        info.IsKnown.Should().BeFalse();
+
+        (await context.OAuthClients.CountAsync(c => c.SoftwareId == "org.loopkit.loop.newinstall"))
+            .Should().Be(1);
+    }
+
+    public void Dispose()
+    {
+        using var context = NewContext();
+        context.Database.EnsureDeleted();
+    }
+}


### PR DESCRIPTION
# PR body — fix/oauth-dcr-seed-redirect-uris

Fixes #810 (bugs 1 and 2).

## Summary

Third-party OAuth clients (verified in the issue with Home Assistant's `io.home-assistant.nocturne` DCR) currently cannot complete the authorization-code flow at all. Two independent defects, both fixed here:

**1. DCR against a pre-seeded known client silently discarded `redirect_uris`** (`src/API/Nocturne.API/Services/Auth/OAuthClientService.cs`)

Every tenant is seeded with a known-clients directory whose entries ship with an empty `RedirectUris` list (the real callback URL is only knowable once that specific instance registers). When such a client then performed real DCR, `RegisterClientAsync` found the seed by `software_id` and returned it **unchanged** — the submitted URIs were dropped forever, so `/authorize` failed with "Invalid redirect_uri for this client" on every attempt.

Fix: a known-directory seed with an empty redirect list now **adopts the incoming registration data** (URIs plus optional name/homepage/logo overrides). Idempotency is preserved where it matters: once a client has completed registration (non-empty `RedirectUris`), repeat registrations keep returning it unchanged — including a regression test asserting a second registration cannot overwrite the stored URIs.

Note: the controller already RFC-8252-validates every submitted URI before the service call (`OAuthController.Register`, `invalid_redirect_uri` arm), so the adoption path only ever stores validated values.

**2. Consent page crashed before approval was possible** (`src/Web/packages/app/src/routes/(authenticated)/oauth/consent/+page.svelte`)

Deny and Approve were two `<form>` elements bound to the **same** SvelteKit remote-form instance (`consentForm.enhance(...)` twice). SvelteKit remote forms support exactly one `<form>` binding per instance, so the page threw *"A form object can only be attached to a single `<form>` element"* — no user could get past consent.

Fix: each button gets its own keyed instance via the pattern already used across the codebase (e.g. `TrackerEditorDialog.svelte`, `TrackerStartDialog.svelte`, `TrackerCompletionDialog.svelte`): `$derived(consentForm.for("deny"))` / `.for("approve")`, including their separate `pending` state.

## Test plan

- [x] New unit tests `tests/Unit/Nocturne.API.Tests/Services/Auth/OAuthClientServiceRegistrationTests.cs`:
  - empty known seed adopts submitted redirect_uris (the HA scenario)
  - already-completed registration stays fully idempotent (second DCR cannot rewrite URIs)
  - unknown software_id still creates a fresh client
- [x] `dotnet test --filter FullyQualifiedName~OAuthClientServiceRegistration` green locally (.NET SDK 10.0.400)
- [ ] CI for the Svelte side: local `pnpm check` is not runnable without generated NSwag clients (pre-existing repo state, cf. #760 discussion of the same limitation); the `.for(key)` usage mirrors the established call sites listed above.
