### PR TITLE
test(web): make the SvelteKit component-test stub throw the shapes the framework throws

### DIFF
--- a/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
@@ -7,6 +7,7 @@
     update as updateDnd,
   } from "$api/generated/tenantAlertSettings.generated.remote";
   import type { TenantAlertSettingsResponse } from "$api-clients";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import { Bell, BellOff, Settings as SettingsIcon, Loader2 } from "lucide-svelte";
   import { isDndActiveNow, isDndScheduleConfigured } from "./dnd";
 
@@ -60,8 +61,11 @@
       });
       settings = r;
       expanded = false;
-    } catch {
-      errorMessage = "Couldn't change Do Not Disturb. Please try again.";
+    } catch (e) {
+      errorMessage = remoteErrorMessage(
+        e,
+        "Couldn't change Do Not Disturb. Please try again.",
+      );
     } finally {
       saving = false;
     }

--- a/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte.test.ts
@@ -1,6 +1,7 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { error } from "@sveltejs/kit";
 import { page as pageState } from "$app/state";
 import type { TenantAlertSettingsResponse } from "$api-clients";
 
@@ -56,7 +57,7 @@ describe("DndPanel", () => {
 
   it("surfaces an error when the update is rejected", async () => {
     pageState.data = { effectivePermissions: ["alerts.readwrite"] };
-    updateImpl = () => Promise.reject(new Error("Forbidden"));
+    updateImpl = async () => error(403, "Forbidden");
 
     render(DndPanel, {});
 

--- a/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte.test.ts
@@ -55,9 +55,9 @@ describe("DndPanel", () => {
     await expect.element(dndToggle()).toBeVisible();
   });
 
-  it("surfaces an error when the update is rejected", async () => {
+  it("surfaces the server's reason when the update is rejected", async () => {
     pageState.data = { effectivePermissions: ["alerts.readwrite"] };
-    updateImpl = async () => error(403, "Forbidden");
+    updateImpl = async () => error(409, "A scheduled quiet period is running.");
 
     render(DndPanel, {});
 
@@ -65,7 +65,7 @@ describe("DndPanel", () => {
     await page.getByRole("button", { name: "30 minutes" }).click();
 
     await expect
-      .element(page.getByText(/Couldn't change Do Not Disturb/i))
+      .element(page.getByText("A scheduled quiet period is running."))
       .toBeVisible();
   });
 });

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte.test.ts
@@ -48,8 +48,8 @@ describe("DataSourceManageDialog", () => {
       .toBeInTheDocument();
   });
 
-  it("still reports a delete that failed as a failure", async () => {
-    deleteImpl = async () => error(500, "Failed to delete data");
+  it("keeps a server fault behind the dialog's own wording", async () => {
+    deleteImpl = async () => error(500, "db connection reset");
 
     await attemptDelete();
 
@@ -57,6 +57,9 @@ describe("DataSourceManageDialog", () => {
     await expect.element(failureWording.first()).toBeInTheDocument();
     // the headline and the message below it each carry the wording
     expect(failureWording.elements()).toHaveLength(2);
+    await expect
+      .element(page.getByText("db connection reset"))
+      .not.toBeInTheDocument();
     await expect
       .element(page.getByText("Nothing left to delete"))
       .not.toBeInTheDocument();

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte.test.ts
@@ -1,6 +1,7 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { error } from "@sveltejs/kit";
 import type { DataSourceInfo } from "$api-clients";
 
 let deleteImpl: () => Promise<unknown>;
@@ -10,15 +11,6 @@ vi.mock("$api/generated/services.generated.remote", () => ({
 }));
 
 import DataSourceManageDialog from "./DataSourceManageDialog.svelte";
-
-/**
- * What a rejected remote function hands the dialog: SvelteKit's `HttpError` is
- * a plain `{ status, body }` object and not an `Error`, so the status is the
- * only part of it a caller can read.
- */
-function httpError(status: number, message: string) {
-  return { status, body: { message } };
-}
 
 const dataSource: DataSourceInfo = {
   id: "11111111-1111-1111-1111-111111111111",
@@ -44,7 +36,7 @@ describe("DataSourceManageDialog", () => {
   });
 
   it("reports data that was already gone as nothing left to delete", async () => {
-    deleteImpl = () => Promise.reject(httpError(404, "Not found"));
+    deleteImpl = async () => error(404, "Not found");
 
     await attemptDelete();
 
@@ -57,7 +49,7 @@ describe("DataSourceManageDialog", () => {
   });
 
   it("still reports a delete that failed as a failure", async () => {
-    deleteImpl = () => Promise.reject(httpError(500, "Failed to delete data"));
+    deleteImpl = async () => error(500, "Failed to delete data");
 
     await attemptDelete();
 

--- a/src/Web/packages/app/src/lib/test-stubs/sveltekit.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/sveltekit.svelte.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  error,
+  fail,
+  invalid,
+  isActionFailure,
+  isHttpError,
+  isRedirect,
+  isValidationError,
+  redirect,
+} from "@sveltejs/kit";
+
+/**
+ * Only `*.svelte.test.ts` runs under vitest.browser.config.ts, which is where
+ * the `@sveltejs/kit` alias to this directory's stub applies — under any other
+ * config the imports above resolve to the real framework and prove nothing
+ * about the stub.
+ */
+function thrownBy(fn: () => never): any {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected the call to throw");
+}
+
+describe("@sveltejs/kit stub", () => {
+  it("throws an error that is not an Error", () => {
+    const thrown = thrownBy(() => error(404, "Not found"));
+
+    expect(thrown).not.toBeInstanceOf(Error);
+    expect(isHttpError(thrown)).toBe(true);
+    expect(isHttpError(thrown, 404)).toBe(true);
+    expect(isHttpError(thrown, 500)).toBe(false);
+  });
+
+  it("wraps a string body as the framework does", () => {
+    const thrown = thrownBy(() => error(404, "Not found"));
+
+    expect(thrown.status).toBe(404);
+    expect(thrown.body).toEqual({ message: "Not found" });
+  });
+
+  it("passes an object body through untouched", () => {
+    const thrown = thrownBy(() => error(400, { message: "Bad", details: "d" }));
+
+    expect(thrown.body).toEqual({ message: "Bad", details: "d" });
+  });
+
+  it("names the status when there is no body", () => {
+    const thrown = thrownBy(() => error(500));
+
+    expect(thrown.body).toEqual({ message: "Error: 500" });
+  });
+
+  it("throws a redirect that is not an Error", () => {
+    const thrown = thrownBy(() => redirect(303, "/login"));
+
+    expect(thrown).not.toBeInstanceOf(Error);
+    expect(isRedirect(thrown)).toBe(true);
+    expect(isHttpError(thrown)).toBe(false);
+    expect(thrown.status).toBe(303);
+    expect(thrown.location).toBe("/login");
+  });
+
+  it("throws a validation error carrying its issues", () => {
+    const thrown = thrownBy(() => invalid("too short", { message: "taken" }));
+
+    expect(isValidationError(thrown)).toBe(true);
+    expect(thrown.issues).toEqual([
+      { message: "too short" },
+      { message: "taken" },
+    ]);
+  });
+
+  it("returns a failure the framework's guard recognises", () => {
+    const failure = fail(400, { field: "name" });
+
+    expect(isActionFailure(failure)).toBe(true);
+    expect(failure.status).toBe(400);
+    expect(failure.data).toEqual({ field: "name" });
+  });
+});

--- a/src/Web/packages/app/src/lib/test-stubs/sveltekit.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/sveltekit.ts
@@ -43,12 +43,28 @@ class ValidationError extends Error {
   }
 }
 
+class ActionFailure {
+  constructor(
+    public status: number,
+    public data?: any
+  ) {}
+}
+
 export function error(status: number, body?: App.Error | string): never {
   throw new HttpError(status, body);
 }
 
+export function isHttpError(e: unknown, status?: number): boolean {
+  if (!(e instanceof HttpError)) return false;
+  return !status || e.status === status;
+}
+
 export function redirect(status: number, location: string | URL): never {
   throw new Redirect(status, location.toString());
+}
+
+export function isRedirect(e: unknown): boolean {
+  return e instanceof Redirect;
 }
 
 export function json(data: any, init?: ResponseInit) {
@@ -56,7 +72,11 @@ export function json(data: any, init?: ResponseInit) {
 }
 
 export function fail(status: number, data?: any) {
-  return { status, data };
+  return new ActionFailure(status, data);
+}
+
+export function isActionFailure(e: unknown): boolean {
+  return e instanceof ActionFailure;
 }
 
 // Returns never in @sveltejs/kit: callers invoke it bare and rely on it aborting,
@@ -67,4 +87,8 @@ export function invalid(...issues: ({ message: string } | string)[]): never {
       typeof issue === "string" ? { message: issue } : issue
     )
   );
+}
+
+export function isValidationError(e: unknown): boolean {
+  return e instanceof ValidationError;
 }

--- a/src/Web/packages/app/src/lib/test-stubs/sveltekit.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/sveltekit.ts
@@ -1,13 +1,54 @@
 /**
  * Stub for @sveltejs/kit in browser test environment.
- * Remote functions import error/redirect but never call them in component tests.
+ *
+ * The thrown values mirror the framework's own: an `HttpError` is a plain
+ * `{ status, body }` object with no `Error` in its prototype chain, and so is a
+ * `Redirect`. A stub that threw an `Error` instead would let a component test
+ * pass against a handler that cannot read the rejection in production.
  */
-export function error(status: number, body?: any) {
-  throw new Error(`HTTP ${status}: ${body}`);
+class HttpError {
+  status: number;
+  body: App.Error;
+
+  constructor(status: number, body?: App.Error | string) {
+    this.status = status;
+    if (typeof body === "string") {
+      this.body = { message: body };
+    } else if (body) {
+      this.body = body;
+    } else {
+      this.body = { message: `Error: ${status}` };
+    }
+  }
+
+  toString() {
+    return JSON.stringify(this.body);
+  }
 }
 
-export function redirect(status: number, location: string) {
-  throw new Error(`Redirect ${status}: ${location}`);
+class Redirect {
+  constructor(
+    public status: number,
+    public location: string
+  ) {}
+}
+
+class ValidationError extends Error {
+  issues: { message: string }[];
+
+  constructor(issues: { message: string }[]) {
+    super("Validation failed");
+    this.name = "ValidationError";
+    this.issues = issues;
+  }
+}
+
+export function error(status: number, body?: App.Error | string): never {
+  throw new HttpError(status, body);
+}
+
+export function redirect(status: number, location: string | URL): never {
+  throw new Redirect(status, location.toString());
 }
 
 export function json(data: any, init?: ResponseInit) {
@@ -20,6 +61,10 @@ export function fail(status: number, data?: any) {
 
 // Returns never in @sveltejs/kit: callers invoke it bare and rely on it aborting,
 // so returning here would let a rejected validation fall through to the success path.
-export function invalid(...issues: any[]): never {
-  throw new Error(`Invalid: ${JSON.stringify(issues)}`);
+export function invalid(...issues: ({ message: string } | string)[]): never {
+  throw new ValidationError(
+    issues.map((issue) =>
+      typeof issue === "string" ? { message: issue } : issue
+    )
+  );
 }

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/alerts-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/alerts-page.svelte.test.ts
@@ -104,6 +104,26 @@ describe("alerts page", () => {
     await expect.element(enableSwitch()).toBeVisible();
     await enableSwitch().click();
 
-    await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
+    await vi.waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        "Changing alerts requires the alerts.readwrite permission."
+      )
+    );
+  });
+
+  it("surfaces a stale rule as gone rather than as a permission problem", async () => {
+    pageState.data = { effectivePermissions: ["alerts.readwrite"] };
+    toggleImpl = async () => error(404, "Not Found");
+
+    render(AlertsPage, {});
+
+    await expect.element(enableSwitch()).toBeVisible();
+    await enableSwitch().click();
+
+    await vi.waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        "That item no longer exists. Refresh the page to see what's there now."
+      )
+    );
   });
 });

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/alerts-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/alerts-page.svelte.test.ts
@@ -1,6 +1,7 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { error } from "@sveltejs/kit";
 import { page as pageState } from "$app/state";
 import type { AlertRuleResponse } from "$api-clients";
 
@@ -96,7 +97,7 @@ describe("alerts page", () => {
 
   it("surfaces a refused toggle instead of discarding it", async () => {
     pageState.data = { effectivePermissions: ["alerts.readwrite"] };
-    toggleImpl = () => Promise.reject({ status: 403, body: { message: "Forbidden" } });
+    toggleImpl = async () => error(403, "Forbidden");
 
     render(AlertsPage, {});
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/compression-lows-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/compression-lows-page.svelte.test.ts
@@ -89,6 +89,10 @@ describe("compression-lows page", () => {
     await expect.element(acceptButton()).toBeVisible();
     await acceptButton().click();
 
-    await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
+    await vi.waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        "Reviewing compression lows requires the glucose.readwrite permission."
+      )
+    );
   });
 });

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/compression-lows-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/compression-lows-page.svelte.test.ts
@@ -1,6 +1,7 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { error } from "@sveltejs/kit";
 import { page as pageState } from "$app/state";
 
 const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
@@ -81,7 +82,7 @@ describe("compression-lows page", () => {
 
   it("surfaces a refused accept instead of discarding it", async () => {
     pageState.data = { effectivePermissions: ["glucose.readwrite"] };
-    acceptImpl = () => Promise.reject({ status: 403, body: { message: "Forbidden" } });
+    acceptImpl = async () => error(403, "Forbidden");
 
     render(CompressionLowsPage, {});
 


### PR DESCRIPTION
Closes #934.

## Problem

The browser component-test stub for `@sveltejs/kit` threw a real `Error` where the framework throws an `HttpError` — a plain `{ status, body }` object with no `Error` in its prototype chain. A component test that built its rejection through the stub could therefore pass against a handler that cannot read the rejection in production (the exact defect class #876/#940 fixed in `DataSourceManageDialog`, whose test had to hand-roll the shape to avoid the trap).

## Change

- `error()` / `redirect()` / `invalid()` now throw `HttpError` / `Redirect` / `ValidationError` classes mirroring the shapes `@sveltejs/kit` 2.59.x throws (verified against the installed package source), including the string→`{message}` wrap, the `Error: {status}` empty-body default, and `toString()`. The stub mirrors the thrown shapes, not the framework's DEV-time status/location validation.
- `fail()` returns an `ActionFailure` instance; `isHttpError` / `isRedirect` / `isValidationError` / `isActionFailure` are exported so components adopting the framework's discriminators don't fail browser tests on a missing export.
- A stub-fidelity guard test (7 cases, `.svelte.test.ts` so the browser alias applies) pins that the throws are **not** `instanceof Error` and carry the right fields — the mutation `class HttpError extends Error` previously survived every test in the repo; it now fails this file.
- Four tests converted from hand-rolled rejection shapes to calling the stub; the dialog's `httpError()` workaround helper is deleted.
- `DndPanel.svelte`'s bare `catch` (which discarded the server's reason entirely) now routes through `remoteErrorMessage` with its existing sentence as fallback. `remoteErrorMessage` over `describeSubmitError` because this is a permission-gated surface and the latter forwards 403 boilerplate verbatim.
- The alerts and compression-lows page tests now assert the toast *argument* (both previously asserted only `toHaveBeenCalled()`, which a hardcoded toast satisfied); the alerts page gains a 404 case that is shape-sensitive.
- The dialog's 5xx fixture was confounded (its message equalled the component's fallback string); it now uses a distinct string and asserts that string is **not** rendered — the test now states what it proves: a server fault stays behind the dialog's own wording.

## Evidence

- Affected browser suites: 5 files / 20 tests green. `pnpm check`: 64 errors, byte-identical to main's baseline. Node vitest unchanged (its 1 failure is pre-existing and unrelated).
- Mutations, each run and reverted: `extends Error` → 1 red; combined shape corruption (drop string-wrap, drop empty-body default, revert redirect/invalid) → 4 red; `fail()` → plain object → 1 red; DndPanel reverted to bare catch → 1 red; hardcoded toast text → 3 red across two files; dialog forwarding 5xx body → 2 red; whole stub reverted to `throw new Error` → 3 red.
- Reintroducing the pre-#940 `e instanceof Error` defect in the dialog fails its test under this stub; under the old stub the same defect passed.

## Notes

- Correction to the issue text: only `vitest.browser.config.ts` aliases the stub; `vite.config.ts` does not, and node vitest uses real `@sveltejs/kit`, so non-browser tests were never affected.
- The two 403 page tests cannot be made shape-sensitive: `remoteErrorMessage` returns the caller's fallback for 403 by design, and a real `Error` falls through to the same fallback. Shape is pinned universally by the fidelity guard instead.
- The full browser suite has pre-existing local failures (`OidcProviderDialog` ×1, `CalendarHeader` ×2, 15s timeouts) byte-identical at main; CI runs no web vitest.

_Agent-authored; reviewed + gate-reviewed with independent verification and a fix round._
