### PR TITLE
fix(glooko): report failed fetches and count food imports

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -755,8 +755,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         if (!success)
         {
-            result.Success = false;
-            result.Errors.Add($"{dataType} publish failed");
+            RecordFailure(result, $"{dataType} publish failed", PublishFailedMessage);
         }
         else if (count > 0)
         {
@@ -791,8 +790,30 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             return;
         }
 
+        RecordFailure(result, $"Failed to fetch {dataType}", FetchFailedMessage);
+    }
+
+    /// <summary>
+    ///     What a run says for itself when it failed and the reader has no <see cref="SyncResult.Errors"/>
+    ///     to go on. The first recorded failure names the run, so a fetch that fell over followed by a
+    ///     publish rejection still reads as the fetch failure that started it.
+    /// </summary>
+    protected const string FetchFailedMessage = "Sync failed while fetching data";
+
+    /// <inheritdoc cref="FetchFailedMessage"/>
+    protected const string PublishFailedMessage = "Sync failed while publishing data";
+
+    private static void RecordFailure(SyncResult result, string error, string message)
+    {
+        if (result.Errors.Count == 0)
+            result.Message = message;
+
         result.Success = false;
-        result.Errors.Add($"Failed to fetch {dataType}");
+
+        // A windowed sync meets the same failure once per chunk, and the terminal progress message
+        // joins every entry, so the tenant reads one line per distinct failure rather than per chunk.
+        if (!result.Errors.Contains(error))
+            result.Errors.Add(error);
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -766,6 +766,36 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
+    ///     The counterpart of <see cref="RecordPublishOutcome"/> one level up: a fetch that came back
+    ///     with nothing because it failed, reported as a failure of the run but only for a type the
+    ///     tenant enabled. Records no count — the source was never reached, and a count is a claim it
+    ///     was (see the remarks on <see cref="RecordPublishOutcome"/>).
+    /// </summary>
+    /// <remarks>
+    ///     A failed run withholds the connector's last-successful-sync stamp and shows the tenant a
+    ///     red connector, so a fetch issued only to support another type — a bolus fetch feeding a
+    ///     carb correlation — must not be able to fail the sync. Losing it costs that correlation and
+    ///     nothing else. The failure is sticky rather than fatal: whatever the run already fetched
+    ///     still publishes.
+    /// </remarks>
+    protected void RecordFetchFailure(
+        SyncResult result,
+        SyncDataType dataType,
+        HashSet<SyncDataType> activeTypes)
+    {
+        if (!activeTypes.Contains(dataType))
+        {
+            _logger.LogDebug(
+                "[{ConnectorSource}] {DataType} fetch failed for a type that is switched off",
+                ConnectorSource, dataType);
+            return;
+        }
+
+        result.Success = false;
+        result.Errors.Add($"Failed to fetch {dataType}");
+    }
+
+    /// <summary>
     ///     Reports a sync-progress message to the reporter supplied for this run, if any. The
     ///     message type carries the phase, so a terminal message cannot be emitted as in-progress.
     /// </summary>

--- a/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Configurations/GlookoConnectorConfiguration.cs
@@ -27,6 +27,7 @@ namespace Nocturne.Connectors.Glooko.Configurations;
         SyncDataType.Boluses,
         SyncDataType.BasalInjections,
         SyncDataType.CarbIntake,
+        SyncDataType.Food,
         SyncDataType.TempBasals,
         SyncDataType.StateSpans,
         SyncDataType.DeviceEvents,

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -59,7 +59,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     protected override string ConnectorSource => DataSources.GlookoConnector;
 
     private const string SyncSucceededMessage = "Sync completed successfully";
-    private const string PublishFailedMessage = "Sync failed while publishing data";
 
 
     // ── Authentication ──────────────────────────────────────────────────
@@ -352,11 +351,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 }
             }
 
-            // Fetch and authentication failures name themselves; a publish rejection only flips
-            // Success, and Message is the documented fallback for consumers that have no Errors.
-            if (!result.Success && result.Message == SyncSucceededMessage)
-                result.Message = PublishFailedMessage;
-
             result.EndTime = DateTime.UtcNow;
             return result;
         }
@@ -406,7 +400,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                     "[{ConnectorSource}] Chunk {Chunk}/{Total} ({From:yyyy-MM-dd} to {To:yyyy-MM-dd}) failed, stopping sync",
                     ConnectorSource, i + 1, chunks.Count, chunkFrom, chunkTo);
                 result.Success = false;
-                result.Message = "Sync failed during data fetch";
+                result.Message = FetchFailedMessage;
                 result.Errors.Add($"Chunk {i + 1}/{chunks.Count} failed ({chunkFrom:yyyy-MM-dd} to {chunkTo:yyyy-MM-dd})");
                 return;
             }

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -425,7 +425,11 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             try
             {
                 var deviceSettings = await FetchV3DeviceSettingsAsync(context);
-                if (deviceSettings != null)
+                if (deviceSettings is null)
+                {
+                    RecordFetchFailure(result, SyncDataType.Profiles, activeTypes);
+                }
+                else
                 {
                     await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
                         context.ProfileMapper.TransformDeviceSettingsToProfiles(deviceSettings),
@@ -444,6 +448,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             catch (Exception profileEx)
             {
                 _logger.LogWarning(profileEx, "[{ConnectorSource}] Failed to fetch/publish profile data", ConnectorSource);
+                RecordFetchFailure(result, SyncDataType.Profiles, activeTypes);
             }
         }
     }
@@ -487,7 +492,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             ? context.V4TreatmentMapper.MapFoodsToConnectorEntries(batchData) : [];
         Func<string, string?> foodResolver = externalEntryId => $"glooko_food_{externalEntryId}";
         await PublishFoodEntriesAndAttributeAsync(
-            foodEntryImports, carbs, foodResolver, result, config, cancellationToken);
+            foodEntryImports, carbs, foodResolver, result, activeTypes, cancellationToken);
 
         await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
             context.StateSpanMapper.TransformV2ToStateSpans(batchData),
@@ -520,12 +525,11 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         var v3Data = await FetchV3GraphDataAsync(context, fromDate, toDate);
         if (v3Data == null) return false;
 
-        GlookoV3HistoriesResponse? v3Histories = null;
-        try { v3Histories = await FetchV3HistoriesAsync(context, fromDate, toDate); }
-        catch (Exception histEx)
-        {
-            _logger.LogWarning(histEx, "[{ConnectorSource}] V3 histories fetch failed, meal data will be unavailable", ConnectorSource);
-        }
+        // Histories carry the meals: without them carbs fall back to the coarser carbAll series and
+        // food entries have no source at all, so the run reports both types as unfetched.
+        var v3Histories = await FetchV3HistoriesAsync(context, fromDate, toDate);
+        if (v3Histories is null)
+            RecordFetchFailure(result, SyncDataType.CarbIntake, activeTypes);
 
         if (config.V3IncludeCgmBackfill)
         {
@@ -566,41 +570,47 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             manualBasalInjections, PublishBasalInjectionDataAsync, config, cancellationToken);
 
         // Food attribution resolves against the carbs published above.
-        GlookoFood[]? v2Foods = null;
-        if (historyMealCarbs.Count > 0)
+        if (v3Histories is null)
         {
-            try { v2Foods = await FetchV2FoodsAsync(context, fromDate, toDate); }
-            catch (Exception v2Ex)
-            {
-                _logger.LogWarning(v2Ex, "[{ConnectorSource}] V2 foods fetch failed, food entries will lack externalId/brand metadata", ConnectorSource);
-            }
+            RecordFetchFailure(result, SyncDataType.Food, activeTypes);
         }
-
-        var foodEntryImports = historyMealCarbs.Count > 0 && v3Histories?.Histories != null
-            ? context.V4TreatmentMapper.MapV3HistoryMealsToConnectorEntries(v3Histories, v2Foods) : [];
-
-        // Build food resolver
-        Func<string, string?>? foodResolver = null;
-        if (historyMealCarbs.Count > 0 && v3Histories?.Histories != null)
+        else
         {
-            var foodGuidToMealGuid = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var meal in GlookoV4TreatmentMapper.ExtractMeals(v3Histories))
+            GlookoFood[]? v2Foods = null;
+            if (historyMealCarbs.Count > 0 && activeTypes.Contains(SyncDataType.Food))
             {
-                if (meal.SoftDeleted == true || string.IsNullOrEmpty(meal.Guid) || meal.Foods == null) continue;
-                foreach (var food in meal.Foods)
+                // V2 foods only enrich the entries with externalId/brand, so a failure here is
+                // sticky rather than fatal: the entries below still publish without that metadata.
+                v2Foods = await FetchV2FoodsAsync(context, fromDate, toDate);
+                if (v2Foods is null)
+                    RecordFetchFailure(result, SyncDataType.Food, activeTypes);
+            }
+
+            var foodEntryImports = historyMealCarbs.Count > 0 && v3Histories.Histories != null
+                ? context.V4TreatmentMapper.MapV3HistoryMealsToConnectorEntries(v3Histories, v2Foods) : [];
+
+            Func<string, string?>? foodResolver = null;
+            if (historyMealCarbs.Count > 0 && v3Histories.Histories != null)
+            {
+                var foodGuidToMealGuid = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var meal in GlookoV4TreatmentMapper.ExtractMeals(v3Histories))
                 {
-                    if (food.SoftDeleted != true && !string.IsNullOrEmpty(food.Guid))
-                        foodGuidToMealGuid.TryAdd(food.Guid, meal.Guid!);
+                    if (meal.SoftDeleted == true || string.IsNullOrEmpty(meal.Guid) || meal.Foods == null) continue;
+                    foreach (var food in meal.Foods)
+                    {
+                        if (food.SoftDeleted != true && !string.IsNullOrEmpty(food.Guid))
+                            foodGuidToMealGuid.TryAdd(food.Guid, meal.Guid!);
+                    }
                 }
+
+                foodResolver = externalEntryId =>
+                    foodGuidToMealGuid.TryGetValue(externalEntryId, out var mealGuid)
+                        ? $"glooko_v3meal_{mealGuid}" : null;
             }
 
-            foodResolver = externalEntryId =>
-                foodGuidToMealGuid.TryGetValue(externalEntryId, out var mealGuid)
-                    ? $"glooko_v3meal_{mealGuid}" : null;
+            await PublishFoodEntriesAndAttributeAsync(
+                foodEntryImports, allCarbs, foodResolver, result, activeTypes, cancellationToken);
         }
-
-        await PublishFoodEntriesAndAttributeAsync(
-            foodEntryImports, allCarbs, foodResolver, result, config, cancellationToken);
 
         var stateSpans = context.StateSpanMapper.TransformV3ToStateSpans(v3Data);
         stateSpans.AddRange(context.StateSpanMapper.TransformV3PumpModeToStateSpans(v3Data));
@@ -634,30 +644,34 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
         List<CarbIntake> carbIntakes,
         Func<string, string?>? foodEntryToCarbLegacyId,
         SyncResult result,
-        GlookoConnectorConfiguration config,
+        HashSet<SyncDataType> activeTypes,
         CancellationToken cancellationToken)
     {
-        if (foodEntryImports.Count == 0 || _connectorPublisher is not { IsAvailable: true })
+        if (!activeTypes.Contains(SyncDataType.Food))
             return;
+
+        if (foodEntryImports.Count == 0)
+        {
+            RecordPublishOutcome(result, SyncDataType.Food, 0, success: true);
+            return;
+        }
+
+        if (_connectorPublisher is not { IsAvailable: true })
+        {
+            _logger.LogWarning("Publisher not available for food entry submission");
+            RecordPublishOutcome(result, SyncDataType.Food, foodEntryImports.Count, success: false);
+            return;
+        }
 
         var importedEntries = await _connectorPublisher.Metadata.PublishConnectorFoodEntriesAsync(
             foodEntryImports, ConnectorSource, WriteOrigin.Live, cancellationToken); // Food is a dormant broadcast category — origin irrelevant until wired.
 
         // The publisher returns null only from its own catch; an import that reached the catalog
-        // returns a list, empty when nothing was accepted. Food has no SyncDataType toggle on this
-        // connector, so the failure is reported rather than routed through PublishRecordTypeAsync.
-        if (importedEntries is null)
-        {
-            result.Success = false;
-            result.Errors.Add("Food entries publish failed");
-            return;
-        }
+        // returns a list, empty when nothing was accepted.
+        RecordPublishOutcome(result, SyncDataType.Food, foodEntryImports.Count, importedEntries is not null);
 
-        if (importedEntries.Count == 0)
+        if (importedEntries is null || importedEntries.Count == 0)
             return;
-
-        _logger.LogInformation("[{ConnectorSource}] Published {Count} food entries to connector food catalog",
-            ConnectorSource, importedEntries.Count);
 
         if (_mealMatchingService == null || carbIntakes.Count == 0 || foodEntryToCarbLegacyId == null)
             return;

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -93,7 +93,7 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
 
                 if (bgValues is null)
                 {
-                    ReportFailedFetch(result, SyncDataType.Glucose, activeTypes);
+                    RecordFetchFailure(result, SyncDataType.Glucose, activeTypes);
                 }
                 else
                 {
@@ -128,9 +128,9 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
                 // that pairs a carb intake with a bolus needs the boluses even when boluses
                 // themselves are not being synced.
                 if (boluses is null)
-                    ReportFailedFetch(result, SyncDataType.Boluses, activeTypes);
+                    RecordFetchFailure(result, SyncDataType.Boluses, activeTypes);
                 if (foods is null)
-                    ReportFailedFetch(result, SyncDataType.CarbIntake, activeTypes);
+                    RecordFetchFailure(result, SyncDataType.CarbIntake, activeTypes);
 
                 // Boluses come from the bolus fetch and carb intakes from the food fetch, so each
                 // type is reported only when its own fetch came back.
@@ -152,31 +152,6 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
 
         result.EndTime = DateTimeOffset.UtcNow;
         return result;
-    }
-
-    /// <summary>
-    ///     Reports a fetch that came back null (see <see cref="FetchDataAsync{T}"/>) as a failure of
-    ///     the run, but only for a type the tenant enabled.
-    /// </summary>
-    /// <remarks>
-    ///     A failed run withholds the connector's last-successful-sync stamp and shows the tenant a
-    ///     red connector, so a fetch issued only to support another type — the bolus fetch feeding
-    ///     the carb correlation — must not be able to fail the sync. Losing it costs that
-    ///     correlation and nothing else.
-    /// </remarks>
-    private void ReportFailedFetch(
-        SyncResult result, SyncDataType dataType, HashSet<SyncDataType> activeTypes)
-    {
-        if (!activeTypes.Contains(dataType))
-        {
-            _logger.LogDebug(
-                "[{ConnectorSource}] {DataType} fetch failed for a type that is switched off",
-                ConnectorSource, dataType);
-            return;
-        }
-
-        result.Success = false;
-        result.Errors.Add($"Failed to fetch {dataType}");
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceFetchFailureTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceFetchFailureTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+/// Glooko's supporting fetches each sit behind their own catch, so a Glooko endpoint that is down
+/// used to cost the tenant that data while the run still reported green. A failed fetch of a type
+/// the tenant enabled must reach <see cref="SyncResult.Success"/> and <see cref="SyncResult.Errors"/>,
+/// while whatever the run already fetched still publishes.
+/// </summary>
+public class GlookoConnectorServiceFetchFailureTests
+{
+    /// <summary>
+    /// Device settings are the only profile source in either fetch mode, so both modes must report
+    /// the loss — and both must still publish the chunk's own state spans.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SyncDataAsync_WhenTheDeviceSettingsFetchFails_ReportsFailureAndKeepsPublishing(
+        bool useV3Api)
+    {
+        var service = BuildService(GlookoConstants.V3DeviceSettingsPath);
+
+        var result = await service.SyncDataAsync(
+            Request(SyncDataType.Profiles, SyncDataType.StateSpans),
+            GlookoSyncHarness.Config(useV3Api), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Be("Failed to fetch Profiles");
+        service.Published.Should().NotContain(PublishKind.Profiles);
+        service.Published.Should().Contain(PublishKind.StateSpans);
+    }
+
+    /// <summary>
+    /// Histories carry the meals the V3 path draws carbs from; without them carbs silently fall back
+    /// to the coarser carbAll series.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheHistoriesFetchFails_ReportsFailure()
+    {
+        var service = BuildService(GlookoConstants.V3HistoriesPath);
+
+        var result = await service.SyncDataAsync(
+            Request(SyncDataType.CarbIntake), GlookoSyncHarness.Config(useV3Api: true),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Be("Failed to fetch CarbIntake");
+    }
+
+    /// <summary>
+    /// A failed run withholds the connector's last-successful-sync stamp, so a fetch that only feeds
+    /// a type the tenant switched off must not be able to fail the sync.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheHistoriesFetchFailsForSwitchedOffTypes_ReportsSuccess()
+    {
+        var service = BuildService(GlookoConstants.V3HistoriesPath);
+
+        var result = await service.SyncDataAsync(
+            Request(SyncDataType.StateSpans), GlookoSyncHarness.Config(useV3Api: true),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The V2 foods endpoint only enriches V3 food entries with externalId and brand, so its failure
+    /// is sticky rather than fatal: the entries still publish, and still count.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheFoodMetadataFetchFails_ReportsFailureAndStillPublishesFood()
+    {
+        var (publisher, metadata) = BuildFoodPublisher();
+        var service = GlookoSyncHarness.Service(
+            new GlookoEndpointHandler(
+                failingPaths: [GlookoConstants.FoodsPath], withHistoryMeals: true),
+            rejected: null, publisher);
+
+        var result = await service.SyncDataAsync(
+            Request(SyncDataType.Food), GlookoSyncHarness.Config(useV3Api: true),
+            CancellationToken.None);
+
+        metadata.Verify(
+            m => m.PublishConnectorFoodEntriesAsync(
+                It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(), It.IsAny<string>(),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the entries must still reach the catalog, or the assertions below prove nothing");
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Be("Failed to fetch Food");
+        result.ItemsSynced[SyncDataType.Food].Should().Be(1);
+    }
+
+    // ── Test infrastructure ─────────────────────────────────────────────
+
+    private static SyncRequest Request(params SyncDataType[] dataTypes) => new()
+    {
+        DataTypes = [.. dataTypes],
+        From = DateTime.UtcNow.AddDays(-3), // single chunk keeps one request per endpoint
+    };
+
+    private static RecordingGlookoConnectorService BuildService(params string[] failingPaths) =>
+        GlookoSyncHarness.Service(new GlookoEndpointHandler(failingPaths: failingPaths));
+
+    private static (IConnectorPublisher Publisher, Mock<IMetadataPublisher> Metadata) BuildFoodPublisher()
+    {
+        var metadata = new Mock<IMetadataPublisher>();
+        metadata
+            .Setup(m => m.PublishConnectorFoodEntriesAsync(
+                It.IsAny<IEnumerable<ConnectorFoodEntryImport>>(), It.IsAny<string>(),
+                It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var publisher = new Mock<IConnectorPublisher>();
+        publisher.SetupGet(p => p.IsAvailable).Returns(true);
+        publisher.SetupGet(p => p.Metadata).Returns(metadata.Object);
+
+        return (publisher.Object, metadata);
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceFetchFailureTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceFetchFailureTests.cs
@@ -42,10 +42,11 @@ public class GlookoConnectorServiceFetchFailureTests
 
     /// <summary>
     /// Histories carry the meals the V3 path draws carbs from; without them carbs silently fall back
-    /// to the coarser carbAll series.
+    /// to the coarser carbAll series. <see cref="SyncResult.Message"/> is what a reader with no
+    /// <see cref="SyncResult.Errors"/> is shown, so it must name the fetch and not a publish.
     /// </summary>
     [Fact]
-    public async Task SyncDataAsync_WhenTheHistoriesFetchFails_ReportsFailure()
+    public async Task SyncDataAsync_WhenTheHistoriesFetchFails_ReportsFailureAsAFetch()
     {
         var service = BuildService(GlookoConstants.V3HistoriesPath);
 
@@ -55,6 +56,7 @@ public class GlookoConnectorServiceFetchFailureTests
 
         result.Success.Should().BeFalse();
         result.Errors.Should().ContainSingle().Which.Should().Be("Failed to fetch CarbIntake");
+        result.Message.Should().Be("Sync failed while fetching data");
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceMultiChunkTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceMultiChunkTests.cs
@@ -80,6 +80,30 @@ public class GlookoConnectorServiceMultiChunkTests
     }
 
     /// <summary>
+    /// An endpoint that is down is down for every chunk, and the terminal progress message joins the
+    /// whole error list, so a six-month window would otherwise hand the tenant the same two sentences
+    /// thirteen times over.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_AcrossChunks_ReportsOneEntryPerDistinctFetchFailure()
+    {
+        var handler = new GlookoEndpointHandler(
+            RecordsInChunk, failingPaths: [GlookoConstants.V3HistoriesPath]);
+        var service = GlookoSyncHarness.Service(handler);
+        var request = BuildRequest();
+        request.DataTypes = [SyncDataType.CarbIntake, SyncDataType.Food];
+
+        var result = await service.SyncDataAsync(
+            request, GlookoSyncHarness.Config(useV3Api: true), CancellationToken.None);
+
+        handler.WindowCount.Should().Be(2,
+            "the window must actually span more than one chunk, or the assertions below prove nothing");
+        result.Success.Should().BeFalse();
+        result.Errors.Should().BeEquivalentTo(
+            ["Failed to fetch CarbIntake", "Failed to fetch Food"]);
+    }
+
+    /// <summary>
     /// A window one day wider than a chunk, padded a day each side by the sync itself, spans exactly
     /// two chunks.
     /// </summary>

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
@@ -129,26 +129,31 @@ public class GlookoConnectorServicePublishFailureTests
         var service = BuildService(rejected: null, publisher);
 
         var result = await service.SyncDataAsync(
-            BuildRequest(), BuildConfig(useV3Api: false), CancellationToken.None);
+            BuildFoodRequest(), BuildConfig(useV3Api: false), CancellationToken.None);
 
         VerifyFoodEntriesWerePublished(metadata);
         result.Success.Should().BeFalse();
         result.Errors.Should().ContainSingle()
-            .Which.Should().Contain("Food entries");
+            .Which.Should().Contain("Food");
     }
 
+    /// <summary>
+    /// An import the catalog accepted nothing from still counts what the sync handed over, so the
+    /// tenant's card shows a food badge rather than the blank that reads as "never checked".
+    /// </summary>
     [Fact]
-    public async Task SyncDataAsync_WhenTheFoodEntryPublishImportsNothing_ReportsSuccess()
+    public async Task SyncDataAsync_WhenTheFoodEntryPublishImportsNothing_ReportsSuccessAndCountsFood()
     {
         var (publisher, metadata) = BuildFoodPublisher(imported: []);
         var service = BuildService(rejected: null, publisher);
 
         var result = await service.SyncDataAsync(
-            BuildRequest(), BuildConfig(useV3Api: false), CancellationToken.None);
+            BuildFoodRequest(), BuildConfig(useV3Api: false), CancellationToken.None);
 
         VerifyFoodEntriesWerePublished(metadata);
         result.Success.Should().BeTrue();
         result.Errors.Should().BeEmpty();
+        result.ItemsSynced[SyncDataType.Food].Should().Be(1);
     }
 
     // ── Test infrastructure ─────────────────────────────────────────────
@@ -162,6 +167,17 @@ public class GlookoConnectorServicePublishFailureTests
         ],
         From = DateTime.UtcNow.AddDays(-3), // single chunk keeps one request per endpoint
     };
+
+    /// <summary>
+    /// Food is its own toggle, so a request that does not name it publishes no food at all — the
+    /// food cases have to ask for it.
+    /// </summary>
+    private static SyncRequest BuildFoodRequest()
+    {
+        var request = BuildRequest();
+        request.DataTypes = [.. request.DataTypes, SyncDataType.Food];
+        return request;
+    }
 
     private static GlookoConnectorConfiguration BuildConfig(bool useV3Api) =>
         GlookoSyncHarness.Config(useV3Api);

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
@@ -156,6 +156,27 @@ public class GlookoConnectorServicePublishFailureTests
         result.ItemsSynced[SyncDataType.Food].Should().Be(1);
     }
 
+    /// <summary>
+    /// The scheduled sync names no data types and is expanded to every supported one, so that — not
+    /// the hand-listed request the cases above use — is what a tenant's connector actually runs. A
+    /// window that held no food still owes the card the zero that reads as "checked, found nothing".
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheRequestNamesNoTypes_CountsFoodAsChecked()
+    {
+        var service = BuildService(rejected: null);
+        var request = new SyncRequest { From = DateTime.UtcNow.AddDays(-3) };
+
+        var result = await service.SyncDataAsync(
+            request, BuildConfig(useV3Api: true), CancellationToken.None);
+
+        request.DataTypes.Should().Contain(SyncDataType.Food,
+            "the expansion must actually reach food, or the assertions below prove nothing");
+        result.Success.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+        result.ItemsSynced[SyncDataType.Food].Should().Be(0);
+    }
+
     // ── Test infrastructure ─────────────────────────────────────────────
 
     private static SyncRequest BuildRequest() => new()

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
@@ -158,7 +158,18 @@ internal sealed class StaticGlookoTokenProvider : GlookoAuthTokenProvider
 ///     How many of each record type a request window carries, by the order in which the sync first
 ///     asks for that window. Defaults to one per window.
 /// </param>
-internal sealed class GlookoEndpointHandler(Func<int, int>? recordsPerWindow = null) : HttpMessageHandler
+/// <param name="failingPaths">
+///     Endpoint paths that answer 500 however often they are asked, standing in for a Glooko
+///     endpoint that is down while the rest of the account still serves.
+/// </param>
+/// <param name="withHistoryMeals">
+///     Whether the histories endpoint carries one meal (one food, 30g of carbs), which is what
+///     switches on the V3 path's meal carbs and food entries.
+/// </param>
+internal sealed class GlookoEndpointHandler(
+    Func<int, int>? recordsPerWindow = null,
+    IReadOnlyCollection<string>? failingPaths = null,
+    bool withHistoryMeals = false) : HttpMessageHandler
 {
     private readonly Func<int, int> _recordsPerWindow = recordsPerWindow ?? (_ => 1);
     private readonly List<string> _windows = [];
@@ -177,6 +188,9 @@ internal sealed class GlookoEndpointHandler(Func<int, int>? recordsPerWindow = n
     {
         var path = request.RequestUri?.PathAndQuery ?? string.Empty;
 
+        if (failingPaths?.Any(failing => Matches(path, failing)) == true)
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
         if (Matches(path, GlookoConstants.V3UsersPath))
             return Json("{\"currentUser\":{\"meterUnits\":\"mgdl\",\"timezone\":\"Australia/Sydney\"}}");
 
@@ -184,7 +198,7 @@ internal sealed class GlookoEndpointHandler(Func<int, int>? recordsPerWindow = n
             return Json(DeviceSettingsPayload());
 
         if (Matches(path, GlookoConstants.V3HistoriesPath))
-            return Json("{\"histories\":[]}");
+            return Json(withHistoryMeals ? HistoryMealsPayload : "{\"histories\":[]}");
 
         var window = ResolveWindow(request.RequestUri?.Query ?? string.Empty);
 
@@ -257,6 +271,16 @@ internal sealed class GlookoEndpointHandler(Func<int, int>? recordsPerWindow = n
 
         return $"{{\"series\":{{{series}}}}}";
     }
+
+    /// <summary>
+    /// One meal of one food, which the V3 path maps to a single carb intake and a single food entry.
+    /// </summary>
+    private const string HistoryMealsPayload =
+        """
+        {"histories":[{"type":"meals","guid":"meal-1","item":{
+          "guid":"meal-1","timestamp":"2026-01-10T08:00:00Z","type":"breakfast","carbs":30.0,
+          "foods":[{"guid":"food-1","name":"Toast","carbs":30.0}]}}]}
+        """;
 
     /// <summary>
     /// One settings snapshot carrying a basal segment (which maps to a single profile) and an active


### PR DESCRIPTION
Closes #922, closes #930.

## Problem

Glooko's three supporting fetches (V3 device settings, V3 histories, V2 foods enrichment) each swallowed failures internally and returned null, so a down Glooko endpoint cost the tenant that data while the sync still reported green. Food publishes reached the log but never `SyncResult.ItemsSynced`, so a tenant with food data saw no food badge — indistinguishable from "never checked". (One correction to #922's diagnosis: the three `catch` blocks it names were mostly unreachable; the swallow lived one level deeper, in the fetch helpers returning null.)

## Change

- **`BaseConnectorService.RecordFetchFailure`** — Tidepool's private `ReportFailedFetch` promoted to the base as the fetch-level counterpart of `RecordPublishOutcome` (Tidepool's three call sites repointed; pure move). Each Glooko supporting fetch now records a sticky failure against the type it serves, gated on the type being active. Nothing aborts: whatever the run already fetched still publishes.
- **Food routes through the shared bookkeeping** — count, failure, and explicit zero via `RecordPublishOutcome`; the hand-rolled `Success`/`Errors`/log trio is gone. Publisher-unavailable now records a failed food publish, matching every other type.
- **`SyncDataType.Food` added to Glooko's `SupportedDataTypes`** — this is what let the special-casing collapse. Safety of the default was verified four independent ways: the configuration binder is a key-present overlay (an absent `syncFood` falls through to the default `true`); the schema filter and the `SyncFood` property landed in the same commit, so no shipped build ever let a Glooko tenant write a `syncFood` key; the only `ConfigurationJson` writer stores client JSON verbatim; every `SyncRequest` site passes `[]` or `SupportedDataTypes`. Existing tenants keep food imports with no migration.
- **Honest failure copy** (from hostile review): both record helpers now set `SyncResult.Message` — first recorded failure names the run — so a fetch outage says "Sync failed while fetching data" instead of being mislabeled "Sync failed while publishing data". Tidepool data failures, which previously carried no `Message` at all, get this for free.
- **Error dedup** (from hostile review): a windowed sync met the same failure once per 14-day chunk (28 entries on a 180-day window); identical error strings are now recorded once. Covers the identical pre-existing defect in `RecordPublishOutcome`.

## Declared behavioural deltas

- `syncFood` (boolean, default `true`) appears in Glooko's connector schema and `/effective`; "Food" joins the capability badges. The frontend already has the `SyncFood` label — the toggle renders checked with no frontend change.
- `CONNECT_GLOOKO_SYNC_FOOD` was already bound but inert; it now has an effect.
- #922 said adding the toggle "is a wire-visible toggle-schema change — decide alongside the other connector toggle work". **This PR makes that call** (it's what removes the special-casing that produced both bugs); veto by dropping the `GlookoConnectorConfiguration` line and the gating if unwanted.
- `ItemsSynced[Food]` records the attempted count, consistent with every other type through `RecordPublishOutcome` (the old log line reported the accepted count). The only "N foods imported" UI string is MyFitnessPal-gated and unreachable for Glooko.
- A failed histories fetch reports `CarbIntake` (and `Food`) as failed while carbs may still publish from the coarser `carbAll` fallback — a red sync with a non-zero carb count is the honest "partial" signal, by design.
- The profile `catch` wraps fetch and publish, so a throwing profile publish reports as a fetch failure and now fails the sync (previously log-only). Net improvement, imperfect label; narrowing it would change abort behaviour, left as-is.

## Evidence

Glooko 106/106, Connectors.Core 137, Tidepool 14, plus CareLink/Dexcom/Nightscout/MyFitnessPal/MyLife/Twiist/Eversense/Tandem suites and `API.Tests --filter Connectors` (217) all green. Nine mutations killed across the two rounds, including the hostile gate's survivor (the explicit-zero food branch is now pinned by a test that runs the production default `DataTypes = []` → `SupportedDataTypes` expansion). The 403 re-auth path is intact: the forbidden exception still bubbles from device-settings and the retry still clears state before re-running.

_Agent-authored; reviewed + gate-reviewed with independent verification and a fix round._
