### PR TITLE
test(auth): audit the whole tenantless demo surface, not just the bare-[Authorize] slice

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -316,6 +316,7 @@ public class OidcController : ControllerBase
     /// Does NOT issue new session cookies.
     /// </summary>
     [HttpGet("link/callback")]
+    [DenyDemoSubject]
     [ProducesResponseType(StatusCodes.Status302Found)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> LinkCallback(

--- a/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
@@ -49,6 +49,7 @@ public class DemoSubjectGatedEndpointsTests
 
         // Accumulating an external identity on the shared subject.
         { typeof(OidcController), nameof(OidcController.Link) },
+        { typeof(OidcController), nameof(OidcController.LinkCallback) },
         { typeof(OidcController), nameof(OidcController.GetLinkedIdentities) },
         { typeof(OidcController), nameof(OidcController.UnlinkIdentity) },
 
@@ -96,9 +97,7 @@ public class DemoSubjectGatedEndpointsTests
 
         // Sign-in factors on the shared subject. Enrolling binds a visitor's own authenticator to
         // the account every other visitor uses; listing shows them each other's credential labels;
-        // revoking and regenerating destroy factors and recovery codes they did not create. The
-        // enrolment pair is [AllowAnonymous] for the recovery flow, so the coverage sweep — which
-        // reads bare [Authorize] as the surface — cannot see it; these entries are the only guard.
+        // revoking and regenerating destroy factors and recovery codes they did not create.
         { typeof(PasskeyController), nameof(PasskeyController.RegisterOptions) },
         { typeof(PasskeyController), nameof(PasskeyController.RegisterComplete) },
         { typeof(PasskeyController), nameof(PasskeyController.ListCredentials) },

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Authorization;
 using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
+using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Controllers.V4;
 using Nocturne.API.Multitenancy;
 using Xunit;
@@ -15,23 +16,32 @@ namespace Nocturne.API.Tests.Authorization;
 /// <summary>
 /// Discovers the endpoints an anonymous visitor holding a demo session can reach off the demo
 /// tenant, and requires each to be gated with <see cref="DenyDemoSubjectAttribute"/> or named in
-/// <see cref="Exempt"/>.
+/// its bucket's exemption list with a reason.
 /// </summary>
 /// <remarks>
 /// <para>
 /// The surface is the paths <see cref="TenantResolutionMiddleware.IsTenantlessAllowed"/> admits
-/// with no resolved tenant, intersected with the endpoints whose only gate is <em>bare</em>
+/// with no resolved tenant, in two buckets.
+/// </para>
+/// <para>
+/// <see cref="AuthenticationOnly"/> is the endpoints whose only gate is <em>bare</em>
 /// <c>[Authorize]</c> — not "endpoints with no attribute". An attribute-less endpoint falls to the
 /// fallback policy (<see cref="HasPermissionsRequirement"/>), which the demo subject fails off a
 /// tenant: its permissions come from a tenant membership while the fallback reads only global
 /// <c>subject_roles</c>, which is empty for it. A bare <c>[Authorize]</c> drops that to the
 /// framework's "is authenticated", which every demo session is. Widening the predicate would
-/// pull in endpoints the demo subject cannot reach anyway.
+/// pull in endpoints the demo subject cannot reach anyway: one gated by roles, a policy, or a
+/// Nocturne <c>[Require*]</c> filter asks for more than authentication.
 /// </para>
 /// <para>
-/// An endpoint gated by roles, a policy, or a Nocturne <c>[Require*]</c> filter asks for more than
-/// authentication; one carrying <c>[AllowAnonymous]</c> was never gated by a session at all. This
-/// discovers, so anything added to the surface later must be classified before it ships —
+/// <see cref="Anonymous"/> is the endpoints carrying <c>[AllowAnonymous]</c>. That attribute says
+/// several kinds of caller reach the endpoint, not that no caller is identified — a body reading
+/// <c>GetAuthContext()</c> resolves a demo session like any other, and such a call is invisible to
+/// metadata. So the whole slice is classified by hand rather than narrowed by reflection: a
+/// heuristic that missed one would read as protection while providing none.
+/// </para>
+/// <para>
+/// This discovers, so an endpoint joining either bucket later must be classified before it ships —
 /// <see cref="DemoSubjectGatedEndpointsTests"/> pins what is already decided and cannot see a new
 /// endpoint.
 /// </para>
@@ -39,10 +49,10 @@ namespace Nocturne.API.Tests.Authorization;
 public class TenantlessDemoSubjectCoverageTests
 {
     /// <summary>
-    /// Endpoints on this surface deliberately left reachable by a demo visitor, keyed by
-    /// <c>Controller.Action</c> with the reason.
+    /// Endpoints on the bare-<c>[Authorize]</c> surface deliberately left reachable by a demo
+    /// visitor, keyed by <c>Controller.Action</c> with the reason.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> Exempt =
+    private static readonly IReadOnlyDictionary<string, string> AuthenticationOnlyExempt =
         new Dictionary<string, string>(StringComparer.Ordinal)
         {
             // A demo subject holds the demo tenant's membership and nothing else — the reset
@@ -57,40 +67,108 @@ public class TenantlessDemoSubjectCoverageTests
             ["UserPreferencesController.GetPreferences"] = "returns the caller's own units and formats, which for the demo subject are the demo account's public display defaults",
         };
 
+    private const string DevOnly =
+        "lives in the .DevOnly namespace, which DevOnlyExcludingControllerFeatureProvider drops "
+        + "from controller discovery outside Development, so it is on no deployed surface";
+
+    private const string FirstRunOnly =
+        "refuses once the instance has an owner, and an instance serving a demo tenant has one";
+
+    /// <summary>
+    /// Endpoints on the <c>[AllowAnonymous]</c> surface deliberately left reachable by a demo
+    /// visitor, keyed by <c>Controller.Action</c> with the reason.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> AnonymousExempt =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["AvatarController.Get"] = "serves any subject's picture by id to anyone; with no id it falls back to the caller's own subject, which for a demo session is the demo account's own picture",
+
+            ["DevAdminController.CreateTenant"] = DevOnly,
+            ["DevAdminController.DeleteTenant"] = DevOnly,
+            ["DevAdminController.EnterRecoveryMode"] = DevOnly,
+            ["DevAdminController.ExportSnapshot"] = DevOnly,
+            ["DevAdminController.ImportScopedSnapshot"] = DevOnly,
+            ["DevAdminController.ImportSnapshot"] = DevOnly,
+            ["DevAdminController.ListTenants"] = DevOnly,
+            ["DevAdminController.SeedSampleData"] = DevOnly,
+            ["DevAdminController.SeedTenant"] = DevOnly,
+            ["DevAdminController.SyncAll"] = DevOnly,
+            ["DevAuthController.ExportPasskeyFixture"] = DevOnly,
+            ["DevAuthController.Login"] = DevOnly,
+            ["DevAuthController.LoginJson"] = DevOnly,
+
+            ["OidcController.GetProviders"] = "lists the deployment's enabled identity providers so the sign-in page can render its buttons; reads no session",
+            ["OidcController.Login"] = "starts the identity-provider sign-in and redirects to the provider; reads no session",
+            ["OidcController.Callback"] = "mints the session; the subject comes from the provider's token response, not from any session on the request",
+            ["OidcController.Refresh"] = "mints the session; the subject comes from the refresh token presented, not from any session on the request",
+            ["OidcController.GetSession"] = "reports the caller's own session back to the caller, which for a demo session is the demo account the demo UI is already signed in as",
+
+            ["PlatformAccessController.Access"] = "resolves the caller's subject but mints the grant only for one holding the global subjects.is_platform_admin flag, which no demo subject does; the refusal is audited",
+
+            ["SetupController.CreateTenant"] = FirstRunOnly,
+            ["SetupController.OwnerOptions"] = FirstRunOnly,
+            ["SetupController.OwnerComplete"] = FirstRunOnly,
+            ["SetupController.OwnerOidc"] = FirstRunOnly,
+            ["SetupController.OidcCallback"] = FirstRunOnly,
+
+            ["StatusController.GetStatus"] = "reports the deployment's version, settings and setup state to any caller, signed in or not; reads no session",
+            ["TlsAuthorizationController.Authorize"] = "answers the edge's on-demand-TLS ask for a hostname; it takes no credential and reads no session",
+            ["TotpController.Login"] = "mints the session; the subject comes from the passkey step-up token, and it additionally requires membership of the resolved tenant, which a tenantless host has none of",
+        };
+
     [Fact]
-    public void EveryTenantlessAuthenticationOnlyEndpoint_RefusesTheDemoSubjectOrIsExempt()
+    public void EveryTenantlessAuthenticationOnlyEndpoint_RefusesTheDemoSubjectOrIsExempt() =>
+        AssertEveryEndpointIsGatedOrExempt(AuthenticationOnly);
+
+    [Fact]
+    public void EveryTenantlessAnonymousEndpoint_RefusesTheDemoSubjectOrIsExempt() =>
+        AssertEveryEndpointIsGatedOrExempt(Anonymous);
+
+    [Fact]
+    public void TheAuthenticationOnlyDiscoveryFindsItsSurface() =>
+        AssertTheDiscoveryFindsTheSurface(AuthenticationOnly);
+
+    [Fact]
+    public void TheAnonymousDiscoveryFindsItsSurface() =>
+        AssertTheDiscoveryFindsTheSurface(Anonymous);
+
+    [Fact]
+    public void EveryAuthenticationOnlyExemptionNamesADiscoveredUngatedEndpoint() =>
+        AssertEveryExemptionIsLive(AuthenticationOnly);
+
+    [Fact]
+    public void EveryAnonymousExemptionNamesADiscoveredUngatedEndpoint() =>
+        AssertEveryExemptionIsLive(Anonymous);
+
+    private static void AssertEveryEndpointIsGatedOrExempt(Surface surface)
     {
-        var ungated = Discover()
+        var ungated = surface.Discover()
             .Where(e => !ControllerActionReflection.DeniesTheDemoSubject(e.Action, e.Controller))
             .Select(e => Key(e.Controller, e.Action))
-            .Where(k => !Exempt.ContainsKey(k))
+            .Where(k => !surface.Exempt.ContainsKey(k))
             .Distinct()
             .OrderBy(k => k, StringComparer.Ordinal)
             .ToList();
 
         ungated.Should().BeEmpty(
-            "an anonymous caller can obtain a demo session, and off a tenant nothing but "
-            + "authentication stands in front of these — gate them with [DenyDemoSubject] or add "
-            + "them to Exempt with a reason. Ungated:\n  " + string.Join("\n  ", ungated));
+            "an anonymous caller can obtain a demo session, and off a tenant " + surface.Reachability
+            + " — gate them with [DenyDemoSubject] or add them to the " + surface.Name
+            + " exemptions with a reason. Ungated:\n  " + string.Join("\n  ", ungated));
     }
 
     /// <summary>
     /// Non-vacuity: a discovery that enumerates nothing passes the guard above while checking
     /// nothing, so pin that the surface is found and that a known member of it is on it.
     /// </summary>
-    [Fact]
-    public void TheDiscoveryFindsTheTenantlessSurface()
+    private static void AssertTheDiscoveryFindsTheSurface(Surface surface)
     {
-        var discovered = Discover().Select(e => Key(e.Controller, e.Action)).Distinct().ToList();
+        var discovered = surface.Discover().Select(e => Key(e.Controller, e.Action)).Distinct().ToList();
 
         discovered.Should().NotBeEmpty(
-            "the tenantless surface has authentication-only endpoints on it, so a discovery that "
-            + "returns nothing has stopped matching routes rather than found the surface clean");
+            "the tenantless {0} surface has endpoints on it, so a discovery that returns nothing "
+            + "has stopped matching routes rather than found the surface clean", surface.Name);
 
-        discovered.Should().Contain(
-            $"{nameof(PlatformController)}.{nameof(PlatformController.CreateTenant)}",
-            "tenant creation is served off the apex under a bare [Authorize] and is the endpoint "
-            + "this surface was gated for");
+        discovered.Should().Contain(surface.Witness, surface.WitnessReason);
     }
 
     /// <summary>
@@ -98,49 +176,82 @@ public class TenantlessDemoSubjectCoverageTests
     /// that is still discovered and still ungated, so the guard above cannot be passing because
     /// everything reads as gated.
     /// </summary>
-    [Fact]
-    public void EveryExemptionNamesADiscoveredUngatedEndpoint()
+    private static void AssertEveryExemptionIsLive(Surface surface)
     {
-        var discovered = Discover().ToDictionary(e => Key(e.Controller, e.Action), e => e);
+        var ungatedByKey = surface.Discover()
+            .GroupBy(e => Key(e.Controller, e.Action), StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Any(e => !ControllerActionReflection.DeniesTheDemoSubject(e.Action, e.Controller)),
+                StringComparer.Ordinal);
 
-        foreach (var (key, reason) in Exempt)
+        foreach (var (key, reason) in surface.Exempt)
         {
-            discovered.Should().ContainKey(key,
-                "{0} is exempted with the reason \"{1}\" but is no longer on the tenantless "
-                + "authentication-only surface — drop the entry", key, reason);
+            ungatedByKey.Should().ContainKey(key,
+                "{0} is exempted with the reason \"{1}\" but is no longer on the tenantless {2} "
+                + "surface — drop the entry", key, reason, surface.Name);
 
-            var endpoint = discovered[key];
-            ControllerActionReflection.DeniesTheDemoSubject(endpoint.Action, endpoint.Controller)
-                .Should().BeFalse(
-                    "{0} now carries [DenyDemoSubject], so its exemption is dead — drop the entry",
-                    key);
+            ungatedByKey[key].Should().BeTrue(
+                "{0} now carries [DenyDemoSubject], so its exemption is dead — drop the entry", key);
         }
     }
 
     private static string Key(Type controller, MethodInfo action) => $"{controller.Name}.{action.Name}";
 
-    private static IEnumerable<(Type Controller, MethodInfo Action)> Discover()
+    /// <summary>One bucket of the tenantless surface, and what a failure on it should say.</summary>
+    /// <param name="Name">Names the bucket in failure messages.</param>
+    /// <param name="OnTheSurface">Whether an action belongs to this bucket, before route matching.</param>
+    /// <param name="Reachability">What stands between an anonymous caller and these endpoints.</param>
+    /// <param name="Witness">An endpoint whose absence means discovery has stopped working.</param>
+    private sealed record Surface(
+        string Name,
+        Func<MethodInfo, Type, bool> OnTheSurface,
+        IReadOnlyDictionary<string, string> Exempt,
+        string Reachability,
+        string Witness,
+        string WitnessReason)
     {
-        foreach (var controller in ControllerActionReflection.GetControllers())
+        public IEnumerable<(Type Controller, MethodInfo Action)> Discover()
         {
-            foreach (var action in ControllerActionReflection.GetActionMethods(controller))
+            foreach (var controller in ControllerActionReflection.GetControllers())
             {
-                if (ControllerActionReflection.HasAnonymous(action, controller))
-                    continue;
+                foreach (var action in ControllerActionReflection.GetActionMethods(controller))
+                {
+                    if (!OnTheSurface(action, controller))
+                        continue;
 
-                if (!AuthenticationIsTheOnlyGate(action, controller))
-                    continue;
+                    // No method: this sweeps the whole tenantless surface, so a path reachable
+                    // under any method has to be covered.
+                    if (!ControllerActionReflection.GetRoutes(controller, action)
+                            .Any(route => TenantResolutionMiddleware.IsTenantlessAllowed(route)))
+                        continue;
 
-                // No method: this sweeps the whole tenantless surface, so a path reachable under
-                // any method has to be covered.
-                if (!ControllerActionReflection.GetRoutes(controller, action)
-                        .Any(route => TenantResolutionMiddleware.IsTenantlessAllowed(route)))
-                    continue;
-
-                yield return (controller, action);
+                    yield return (controller, action);
+                }
             }
         }
     }
+
+    private static readonly Surface AuthenticationOnly = new(
+        "authentication-only",
+        (action, controller) => !ControllerActionReflection.HasAnonymous(action, controller)
+                                && AuthenticationIsTheOnlyGate(action, controller),
+        AuthenticationOnlyExempt,
+        "nothing but authentication stands in front of these",
+        $"{nameof(PlatformController)}.{nameof(PlatformController.CreateTenant)}",
+        "tenant creation is served off the apex under a bare [Authorize] and is the endpoint this "
+        + "surface was gated for");
+
+    private static readonly Surface Anonymous = new(
+        "[AllowAnonymous]",
+        ControllerActionReflection.HasAnonymous,
+        AnonymousExempt,
+        "these are reachable with no session at all, and one that resolves a subject from the "
+        + "session anyway resolves a demo session",
+        $"{nameof(PasskeyController)}.{nameof(PasskeyController.RegisterOptions)}",
+        "passkey enrolment is [AllowAnonymous] for the recovery flow yet binds an authenticator to "
+        + "whichever subject the caller's session resolves to, which is the shape this bucket "
+        + "exists to catch");
 
     private static bool AuthenticationIsTheOnlyGate(MethodInfo action, Type controller)
     {

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
@@ -21,17 +21,12 @@ namespace Nocturne.API.Tests.Authorization;
 /// <remarks>
 /// <para>
 /// The surface is the paths <see cref="TenantResolutionMiddleware.IsTenantlessAllowed"/> admits
-/// with no resolved tenant, in two buckets.
+/// with no resolved tenant, in three buckets.
 /// </para>
 /// <para>
 /// <see cref="AuthenticationOnly"/> is the endpoints whose only gate is <em>bare</em>
-/// <c>[Authorize]</c> — not "endpoints with no attribute". An attribute-less endpoint falls to the
-/// fallback policy (<see cref="HasPermissionsRequirement"/>), which the demo subject fails off a
-/// tenant: its permissions come from a tenant membership while the fallback reads only global
-/// <c>subject_roles</c>, which is empty for it. A bare <c>[Authorize]</c> drops that to the
-/// framework's "is authenticated", which every demo session is. Widening the predicate would
-/// pull in endpoints the demo subject cannot reach anyway: one gated by roles, a policy, or a
-/// Nocturne <c>[Require*]</c> filter asks for more than authentication.
+/// <c>[Authorize]</c>, which drops authorization to the framework's "is authenticated" — and every
+/// demo session is.
 /// </para>
 /// <para>
 /// <see cref="Anonymous"/> is the endpoints carrying <c>[AllowAnonymous]</c>. That attribute says
@@ -41,7 +36,22 @@ namespace Nocturne.API.Tests.Authorization;
 /// heuristic that missed one would read as protection while providing none.
 /// </para>
 /// <para>
-/// This discovers, so an endpoint joining either bucket later must be classified before it ships —
+/// <see cref="FallbackPolicy"/> is the endpoints carrying no authorization attribute at all. They
+/// fall to <see cref="HasPermissionsRequirement"/>, which the demo subject fails off a tenant
+/// because its permissions come from a tenant membership while the fallback reads only global
+/// <c>subject_roles</c>, empty for it. That refusal is real but it lives two layers away and holds
+/// for a reason about the demo subject's provenance rather than about the endpoint, so these are
+/// classified here too — most already carry the gate, and the sign-in-factor endpoints among them
+/// are the ones that would matter if the fallback ever loosened.
+/// </para>
+/// <para>
+/// What this cannot see is an endpoint gated by roles, a policy, or a Nocturne <c>[Require*]</c>
+/// filter: those ask for more than authentication, and the demo subject holds no global role or
+/// scope off a tenant, so it fails them on the endpoint's own terms. That is the one deliberate
+/// exclusion.
+/// </para>
+/// <para>
+/// This discovers, so an endpoint joining any bucket later must be classified before it ships —
 /// <see cref="DemoSubjectGatedEndpointsTests"/> pins what is already decided and cannot see a new
 /// endpoint.
 /// </para>
@@ -116,6 +126,16 @@ public class TenantlessDemoSubjectCoverageTests
             ["TotpController.Login"] = "mints the session; the subject comes from the passkey step-up token, and it additionally requires membership of the resolved tenant, which a tenantless host has none of",
         };
 
+    /// <summary>
+    /// Endpoints on the fallback-policy surface deliberately left reachable by a demo visitor,
+    /// keyed by <c>Controller.Action</c> with the reason.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> FallbackPolicyExempt =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["OidcController.Logout"] = "revokes the refresh token the caller presented and clears the caller's own cookies; it reads the subject only to attribute the audit row, so a demo visitor signing themselves out reaches nothing another visitor holds",
+        };
+
     [Fact]
     public void EveryTenantlessAuthenticationOnlyEndpoint_RefusesTheDemoSubjectOrIsExempt() =>
         AssertEveryEndpointIsGatedOrExempt(AuthenticationOnly);
@@ -139,6 +159,18 @@ public class TenantlessDemoSubjectCoverageTests
     [Fact]
     public void EveryAnonymousExemptionNamesADiscoveredUngatedEndpoint() =>
         AssertEveryExemptionIsLive(Anonymous);
+
+    [Fact]
+    public void EveryTenantlessFallbackPolicyEndpoint_RefusesTheDemoSubjectOrIsExempt() =>
+        AssertEveryEndpointIsGatedOrExempt(FallbackPolicy);
+
+    [Fact]
+    public void TheFallbackPolicyDiscoveryFindsItsSurface() =>
+        AssertTheDiscoveryFindsTheSurface(FallbackPolicy);
+
+    [Fact]
+    public void EveryFallbackPolicyExemptionNamesADiscoveredUngatedEndpoint() =>
+        AssertEveryExemptionIsLive(FallbackPolicy);
 
     private static void AssertEveryEndpointIsGatedOrExempt(Surface surface)
     {
@@ -252,6 +284,18 @@ public class TenantlessDemoSubjectCoverageTests
         "passkey enrolment is [AllowAnonymous] for the recovery flow yet binds an authenticator to "
         + "whichever subject the caller's session resolves to, which is the shape this bucket "
         + "exists to catch");
+
+    private static readonly Surface FallbackPolicy = new(
+        "fallback-policy",
+        (action, controller) => !ControllerActionReflection.HasAnonymous(action, controller)
+                                && !ControllerActionReflection.HasAuthorizationGate(action, controller),
+        FallbackPolicyExempt,
+        "nothing on the endpoint itself stands in front of these — they are held off the demo "
+        + "subject by the fallback policy alone, which refuses it only because its permissions "
+        + "come from a tenant membership and no tenant is resolved here",
+        $"{nameof(PasskeyController)}.{nameof(PasskeyController.ListCredentials)}",
+        "the caller's own sign-in factors are served off the apex with no authorization attribute "
+        + "at all, and are the largest part of this surface");
 
     private static bool AuthenticationIsTheOnlyGate(MethodInfo action, Type controller)
     {


### PR DESCRIPTION
Closes #759.

An instance can host a public demo tenant, so any anonymous visitor can obtain a demo session — "authenticated" does not mean "signed up", and the demo subject is a *shared* row every visitor uses. `TenantlessDemoSubjectCoverageTests` exists to force each endpoint reachable off a tenant with such a session to be gated with `[DenyDemoSubject]` or exempted with a stated reason.

It skipped `[AllowAnonymous]` endpoints outright, on the premise that such an endpoint "was never gated by a session at all". That premise is false for the case that matters: an endpoint can carry `[AllowAnonymous]` and still resolve the caller from the session. `PasskeyController.RegisterOptions`/`RegisterComplete` are that shape — anonymous so the recovery flow can reach them, but accepting an ordinary authenticated caller first. Before #758 a demo visitor could bind their own authenticator to the shared demo subject and then sign in as it, and **the sweep reported the surface clean throughout**, because it had skipped both endpoints before ever looking at the gate.

## Three buckets, not one

- **`AuthenticationOnly`** — the original surface: endpoints whose only gate is bare authentication.
- **`Anonymous`** — 28 endpoints carrying `[AllowAnonymous]`. All 28 exempted with a reason; 13 are the dev-only controllers, which `DevOnlyExcludingControllerFeatureProvider` drops from discovery outside Development, and 5 are setup endpoints that refuse once the instance has an owner.
- **`FallbackPolicy`** — endpoints carrying no authorization attribute at all, relying on the default-deny fallback.

That third bucket was measured before being decided on, and the measurement is the interesting part: **13 endpoints, 12 already `[DenyDemoSubject]`-gated, 1 open.** Its membership is the sign-in-factor surface — passkey credentials, TOTP, linked identities — precisely what #758 widened. The codebase already treated these as demo-sensitive; nothing enforced it, and the fallback policy was doing the work by accident.

Reflection is deliberately not used to narrow the anonymous slice. A body-level `GetAuthContext()` call is not visible in metadata, so classifying by hand is both simpler and stricter than a heuristic that reads as protection while missing one.

## The audit

The issue's real question was whether any `[AllowAnonymous]` endpoint on the surface reads the caller's subject. Three do:

- `AvatarController.Get` — serves the caller's own avatar when no id is given. Read-only, and the same image is already served to anyone by `?id=`. POST and DELETE both carry `[DenyDemoSubject]`.
- `OidcController.GetSession` — reports the caller's own session back to the caller. Off a tenant, roles are empty.
- `PlatformAccessController.Access` — mints a 30-minute tenant-pinned cookie with `permissions: ["*"]` for **any tenant by slug**, guarded only by a body-level `if (!auth.IsPlatformAdmin)`.

The third is the one that justifies the issue: its entire barrier is a check the metadata cannot see, so nothing forced anyone to look at it. It is safe — `IsPlatformAdmin` is read from `subjects.is_platform_admin` on every request rather than carried in the JWT, the demo subject's row defaults it false and holds only the tenant-scoped `demo-visitor` role, and the only production writers grant it to configured admin ids or to the owner of the sole/oldest tenant, which the demo subject never is. But it was safe by nobody having checked, and it is now pinned by an exemption that states why.

## One production change

`[DenyDemoSubject]` on `OidcController.LinkCallback`.

It was invisible to every bucket — no `[AllowAnonymous]`, no authorization attribute, no gate — while its sibling `Link` carried one. And `LinkCallback` is the endpoint that actually attaches the external identity to the caller's subject; `Link` only initiates. Gating the initiator and not the effecting endpoint is backwards, and it was safe only via a fallback policy two layers away that nobody had reviewed against this threat.

Removing the attribute now reddens **two** guards — the coverage sweep and the pin list — which is the point of pinning it in both.

## Two false premises removed

The sweep's own class remarks stated the premise this issue disproves. They now describe all three buckets and the single deliberate exclusion: endpoints gated by a role, a policy or a `[Require*]` filter, which ask for more than authentication and which the demo subject fails on the endpoint's own terms, holding no global role, scope or permission off a tenant.

`DemoSubjectGatedEndpointsTests` carried a second one — that the enrolment pair is `[AllowAnonymous]` and so "the coverage sweep ... cannot see it; these entries are the only guard". This change makes that false, so it is deleted.

## Verification

Six mutations, each restored:

| Mutation | Result |
|---|---|
| New unclassified `[AllowAnonymous]` endpoint on the surface | red |
| Remove `[DenyDemoSubject]` from `PasskeyController.RegisterOptions` | red |
| New unclassified attribute-less endpoint on the surface | red |
| Remove `[DenyDemoSubject]` from `PasskeyController.ListCredentials` | red |
| Remove `[DenyDemoSubject]` from `OidcController.LinkCallback` | red in **both** guards |
| Empty discovery (assembly scan stops matching) | **6 of 9 red** |

The vacuous case is the one that matters: the three `BeEmpty` assertions would pass on an empty set, but the three discovery-witness tests and the three exemption-is-discovered tests all go red, so a renamed base type, a route-filter regression or a narrowed allowlist cannot quietly empty the surface.

A hostile fresh-context security review traced every write path to `subjects.is_platform_admin` independently and could not reach the `["*"]` grant from a demo session; verified the dev-only exclusion is registered unconditionally and nothing re-adds those controllers; confirmed a demo-serving instance necessarily has ≥2 tenants and a credentialed owner, so the setup exemptions hold; and confirmed the three bucket predicates are mutually exclusive and jointly exhaustive with no fourth category. It found no reachable escalation.

Tests: 5997 passed, 0 failed.

## Noted, not fixed

- `TenantResolutionMiddleware`'s `/api/metadata` entry is an exact match for a path no action serves — filed as #947. Harmless here (an unreachable allow entry, not an over-grant), and it is why `MetadataController` correctly does not appear in the anonymous bucket despite the issue listing it.
- If an operator deleted every real tenant and left the demo tenant as the sole one, the first-owner setup flow would become reachable against it. Not attacker-reachable on a normally-operated instance, which always retains the operator's owner tenant — it requires the operator to destroy their own instance first. Worth a hardening pass (refuse setup while a demo tenant exists) rather than a fix here.
