### PR TITLE
test(data): guard that new unique indexes over existing data deduplicate first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,10 +149,35 @@ including the per-tenant `set_config` loop that FORCE ROW LEVEL SECURITY require
 A table created in the same migration is exempt — it holds no rows yet, and a
 cleanup there would be dead code.
 
-`UniqueIndexDeduplicationGuardTests` enforces this over migration sources. Older
-migrations that predate the rule are listed there by name; an instance whose chain
-fails on one of them never reaches a later migration, so nothing can repair them
-and nothing may be added to that list.
+`UniqueIndexDeduplicationGuardTests` is a backstop for this rule, not the rule.
+Know what it actually checks before trusting it:
+
+- **Presence and ordering per migration, not per index.** It wants one live
+  duplicate-ranking statement somewhere in `Up` ahead of the *first* unique index
+  over a table the migration did not create. A single cleanup — even one for an
+  unrelated table — clears every index in that migration. It runs no SQL and
+  proves nothing about correctness.
+- **Only the house idiom is recognised**: `row_number() OVER (PARTITION BY …)`
+  plus a soft delete or a delete. A correct cleanup written another way is a false
+  red. Widen the migration to the idiom, not the guard to the migration.
+- **Shapes it cannot see**, which review has to catch: `CREATE TABLE IF NOT
+  EXISTS` naming a table that already exists, which spoofs the new-table
+  exemption; an unnamed `CREATE UNIQUE INDEX ON …`; a primary key added by raw SQL
+  `ADD CONSTRAINT … PRIMARY KEY`, since only the `AddPrimaryKey` builder call is
+  matched — the rule above is deliberately broader than the guard; and a cleanup
+  that cannot run, e.g. wrapped in `IF false`.
+- **Three of its detection paths have no live example in the tree** — raw-SQL
+  `CREATE UNIQUE INDEX`, `AddUniqueConstraint`/`AddPrimaryKey`, and
+  `ALTER TABLE … ADD CONSTRAINT … UNIQUE`. A regression in those regexes reddens
+  nothing, so treat them as unexercised.
+
+An index whose table it cannot read off the call — an interpolated `{table}`, a
+loop variable, a schema qualifier — is reported rather than skipped, so the
+multi-table loop the worked example is written in stays visible.
+
+Older migrations that predate the rule are listed in the guard by name; an
+instance whose chain fails on one never reaches a later migration, so nothing can
+repair them and nothing may be added to that list.
 
 ### Row Level Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,27 @@ Domain models use **mills-first** timestamps. `Entry.Mills` (Unix milliseconds) 
 - UUID v7 for new records; `OriginalId` preserved for MongoDB migration compatibility
 - Row Level Security for multitenancy
 
+### Unique indexes over existing data
+
+Migrations run on API startup, so a `CREATE UNIQUE INDEX` (or `unique: true`
+`CreateIndex`, or an added unique constraint) that trips over rows the database
+already holds fails the whole chain and crash-loops the API — with no
+self-service way out for a self-hosted instance. The instances most likely to
+carry pre-index duplicates are the ones upgrading across several versions.
+
+**Every unique index over a table the migration did not create in that same
+migration ships with a loser-cleanup step earlier in the same `Up`.** Soft-delete
+(or delete) all but the winner of each duplicate key first;
+`20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots` is the worked example,
+including the per-tenant `set_config` loop that FORCE ROW LEVEL SECURITY requires.
+A table created in the same migration is exempt — it holds no rows yet, and a
+cleanup there would be dead code.
+
+`UniqueIndexDeduplicationGuardTests` enforces this over migration sources. Older
+migrations that predate the rule are listed there by name; an instance whose chain
+fails on one of them never reaches a later migration, so nothing can repair them
+and nothing may be added to that list.
+
 ### Row Level Security
 
 Tenant-scoped tables enforce isolation via PostgreSQL Row Level Security.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,14 +166,21 @@ Know what it actually checks before trusting it:
   `ADD CONSTRAINT … PRIMARY KEY`, since only the `AddPrimaryKey` builder call is
   matched — the rule above is deliberately broader than the guard; and a cleanup
   that cannot run, e.g. wrapped in `IF false`.
-- **Three of its detection paths have no live example in the tree** — raw-SQL
-  `CREATE UNIQUE INDEX`, `AddUniqueConstraint`/`AddPrimaryKey`, and
-  `ALTER TABLE … ADD CONSTRAINT … UNIQUE`. A regression in those regexes reddens
-  nothing, so treat them as unexercised.
+- **Three of its detection paths redden nothing if they break.** Raw-SQL
+  `CREATE UNIQUE INDEX` does fire on a shipped migration —
+  `20260424051736_AddReadAccessAudit` — but that migration is *exempt*, because it
+  creates the table in the same `Up`, so breaking the regex still leaves the suite
+  green. That migration's exact spacing is load-bearing for a regex nothing tests.
+  `AddUniqueConstraint`/`AddPrimaryKey` and `ALTER TABLE … ADD CONSTRAINT … UNIQUE`
+  have no live example at all. Treat all three as unexercised.
 
-An index whose table it cannot read off the call — an interpolated `{table}`, a
-loop variable, a schema qualifier — is reported rather than skipped, so the
-multi-table loop the worked example is written in stays visible.
+An index whose table it cannot read off the call — an interpolated `{table}` hole,
+or a loop variable — is reported rather than skipped, so the multi-table loop the
+worked example is written in stays visible. Clearing that report means unrolling
+the loop so both the `CREATE TABLE` and the index name the table literally; naming
+only the index still reports, because the exemption cannot match a create it also
+cannot read. A schema qualifier is not a cause — `public.x` resolves to `x` on
+both sides, so a schema-qualified new table is exempted like any other.
 
 Older migrations that predate the rule are listed in the guard by name; an
 instance whose chain fails on one never reaches a later migration, so nothing can

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
@@ -36,24 +36,15 @@ public class DataMigrationTenantContextGuardTests
         @"FOR\s+\w+\s+IN\s+SELECT\s+(?:(?!\bFROM\b).)*?\s+FROM\s+(\S+)",
         RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
 
+    private static readonly IReadOnlySet<string> ScopedTables = MigrationSourceFiles.TenantScopedTableNames();
+
     [Fact]
     public void NoDataMigrationDrivesItsTenantLoopOffATenantScopedTable()
     {
-        var scoped = MigrationSourceFiles.TenantScopedTableNames();
-        var offenders = new List<string>();
-
-        foreach (var file in MigrationSourceFiles.All())
-        {
-            var migration = Path.GetFileNameWithoutExtension(file);
-
-            foreach (System.Text.RegularExpressions.Match match in LoopHeader.Matches(File.ReadAllText(file)))
-            {
-                var source = LoopSourceTable(match.Groups[1].Value);
-
-                if (scoped.Contains(source) && !KnownNoOpMigrations.Contains(migration))
-                    offenders.Add($"{migration} -> FROM {source}");
-            }
-        }
+        var offenders = MigrationSourceFiles.All()
+            .Where(f => !KnownNoOpMigrations.Contains(MigrationSourceFiles.Name(f)))
+            .SelectMany(f => ScopedLoopSources(f).Select(t => $"{MigrationSourceFiles.Name(f)} -> FROM {t}"))
+            .ToList();
 
         offenders.Should().BeEmpty(
             "a tenant loop must be driven off the tenants table; reading its bounds from a "
@@ -72,17 +63,26 @@ public class DataMigrationTenantContextGuardTests
     [Fact]
     public void EveryAllowlistedMigrationStillExistsAndStillOffends()
     {
-        var scoped = MigrationSourceFiles.TenantScopedTableNames();
-
         var stillOffending = MigrationSourceFiles.All()
-            .Where(f => KnownNoOpMigrations.Contains(Path.GetFileNameWithoutExtension(f)))
-            .Where(f => LoopHeader.Matches(File.ReadAllText(f))
-                .Any(m => scoped.Contains(LoopSourceTable(m.Groups[1].Value))))
-            .Select(Path.GetFileNameWithoutExtension)
+            .Where(f => KnownNoOpMigrations.Contains(MigrationSourceFiles.Name(f)))
+            .Where(f => ScopedLoopSources(f).Count > 0)
+            .Select(MigrationSourceFiles.Name)
             .ToHashSet(StringComparer.Ordinal);
 
         stillOffending.Should().BeEquivalentTo(KnownNoOpMigrations,
             "an allowlist entry that no longer matches is stale and hides a regression");
+    }
+
+    /// <summary>Tenant-scoped tables the migration's live <c>Up</c> drives a tenant loop off.</summary>
+    private static IReadOnlyList<string> ScopedLoopSources(string file)
+    {
+        var up = MigrationSourceFiles.WithCommentsBlanked(
+            MigrationSourceFiles.UpBody(File.ReadAllText(file)));
+
+        return LoopHeader.Matches(up)
+            .Select(m => LoopSourceTable(m.Groups[1].Value))
+            .Where(ScopedTables.Contains)
+            .ToList();
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
@@ -73,11 +73,16 @@ public class DataMigrationTenantContextGuardTests
             "an allowlist entry that no longer matches is stale and hides a regression");
     }
 
-    /// <summary>Tenant-scoped tables the migration's live <c>Up</c> drives a tenant loop off.</summary>
+    /// <summary>
+    /// Tenant-scoped tables the migration's <c>Up</c> drives a tenant loop off. Scanned as raw
+    /// text: this detects offenders, and
+    /// <see cref="MigrationSourceFiles.WithCommentsBlanked"/> withholds evidence, so a stray
+    /// <c>/*</c> inside a SQL literal would blank a live loop out of view. A commented-out loop
+    /// is therefore reported — the cheap direction to be wrong in.
+    /// </summary>
     private static IReadOnlyList<string> ScopedLoopSources(string file)
     {
-        var up = MigrationSourceFiles.WithCommentsBlanked(
-            MigrationSourceFiles.UpBody(File.ReadAllText(file)));
+        var up = MigrationSourceFiles.UpBody(file);
 
         return LoopHeader.Matches(up)
             .Select(m => LoopSourceTable(m.Groups[1].Value))

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
@@ -85,16 +85,8 @@ public class DataMigrationTenantContextGuardTests
         var up = MigrationSourceFiles.UpBody(file);
 
         return LoopHeader.Matches(up)
-            .Select(m => LoopSourceTable(m.Groups[1].Value))
+            .Select(m => MigrationSourceFiles.BareTableName(m.Groups[1].Value))
             .Where(ScopedTables.Contains)
             .ToList();
     }
-
-    /// <summary>
-    /// Trims the captured FROM source to its bare table name, dropping an argument list,
-    /// alias, or trailing punctuation. A derived table yields an empty string, which matches
-    /// no table.
-    /// </summary>
-    private static string LoopSourceTable(string captured) =>
-        Regex.Split(captured, @"[(;,\s]")[0].Trim('"').ToLowerInvariant();
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
+using System.Text.RegularExpressions;
+using Match = System.Text.RegularExpressions.Match;
 
 namespace Nocturne.Infrastructure.Data.Tests.Migrations;
 
@@ -26,6 +28,47 @@ internal static class MigrationSourceFiles
         File.ReadAllText(All().Single(f =>
             Path.GetFileNameWithoutExtension(f).EndsWith("_" + name, StringComparison.Ordinal)));
 
+    /// <summary>Migration name — the file name a guard reports and an allowlist keys on.</summary>
+    public static string Name(string file) => Path.GetFileNameWithoutExtension(file);
+
+    /// <summary>
+    /// Text of the migration's <c>Up</c> method. Only <c>Up</c> runs on the startup migration
+    /// chain, and <c>Down</c> routinely recreates the very indexes <c>Up</c> replaced. Sliced at
+    /// the <c>Down</c> signature rather than by brace matching: migration SQL lives in
+    /// interpolated raw string literals whose <c>{table}</c> holes are not C# braces. A shape
+    /// this fails to recognise yields an empty body, which reports as a discovery regression
+    /// rather than as a pass.
+    /// </summary>
+    public static string UpBody(string source)
+    {
+        var start = source.IndexOf("void Up(", StringComparison.Ordinal);
+
+        if (start < 0)
+            return string.Empty;
+
+        var end = source.IndexOf("void Down(", start, StringComparison.Ordinal);
+
+        return end < 0 ? source[start..] : source[start..end];
+    }
+
+    /// <summary>
+    /// The same text with every C# and SQL comment overwritten by spaces, so a commented-out
+    /// statement cannot satisfy a guard while offsets stay comparable to the original. A comment
+    /// marker inside a string literal is blanked too, which can only withhold evidence from a
+    /// guard, never manufacture it.
+    /// </summary>
+    public static string WithCommentsBlanked(string source)
+    {
+        var blanked = source.ToCharArray();
+
+        foreach (Match match in Comment.Matches(source))
+            for (var i = match.Index; i < match.Index + match.Length; i++)
+                if (blanked[i] is not ('\r' or '\n'))
+                    blanked[i] = ' ';
+
+        return new string(blanked);
+    }
+
     /// <summary>Table names of every <see cref="ITenantScoped"/> entity, lowercased.</summary>
     public static IReadOnlySet<string> TenantScopedTableNames() =>
         typeof(ITenantScoped).Assembly.GetTypes()
@@ -34,6 +77,10 @@ internal static class MigrationSourceFiles
             .Where(n => n is not null)
             .Select(n => n!.ToLowerInvariant())
             .ToHashSet(StringComparer.Ordinal);
+
+    private static readonly Regex Comment = new(
+        @"/\*.*?\*/|//[^\r\n]*|--[^\r\n]*",
+        RegexOptions.Singleline | RegexOptions.Compiled);
 
     private static string Location()
     {

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
@@ -35,16 +35,20 @@ internal static class MigrationSourceFiles
     /// Text of the migration's <c>Up</c> method. Only <c>Up</c> runs on the startup migration
     /// chain, and <c>Down</c> routinely recreates the very indexes <c>Up</c> replaced. Sliced at
     /// the <c>Down</c> signature rather than by brace matching: migration SQL lives in
-    /// interpolated raw string literals whose <c>{table}</c> holes are not C# braces. A shape
-    /// this fails to recognise yields an empty body, which reports as a discovery regression
-    /// rather than as a pass.
+    /// interpolated raw string literals whose <c>{table}</c> holes are not C# braces.
     /// </summary>
-    public static string UpBody(string source)
+    /// <exception cref="InvalidOperationException">
+    /// The signature was not found. Returning an empty body instead would silently clear every
+    /// guard that scans it, so a shape this cannot parse has to stop the run.
+    /// </exception>
+    public static string UpBody(string file)
     {
+        var source = File.ReadAllText(file);
         var start = source.IndexOf("void Up(", StringComparison.Ordinal);
 
         if (start < 0)
-            return string.Empty;
+            throw new InvalidOperationException(
+                $"No 'void Up(' in {Name(file)}; a guard cannot scan a method it cannot find.");
 
         var end = source.IndexOf("void Down(", start, StringComparison.Ordinal);
 
@@ -53,9 +57,13 @@ internal static class MigrationSourceFiles
 
     /// <summary>
     /// The same text with every C# and SQL comment overwritten by spaces, so a commented-out
-    /// statement cannot satisfy a guard while offsets stay comparable to the original. A comment
-    /// marker inside a string literal is blanked too, which can only withhold evidence from a
-    /// guard, never manufacture it.
+    /// statement cannot satisfy a guard while offsets stay comparable to the original.
+    /// <para>
+    /// A comment marker inside a string literal is blanked too, so this withholds evidence rather
+    /// than manufacturing it. That direction is only safe on a path where missing evidence means
+    /// FAIL — recognising a cleanup, or recognising the new-table exemption. On a path that
+    /// detects offenders, withheld evidence is a false green, so scan raw text there instead.
+    /// </para>
     /// </summary>
     public static string WithCommentsBlanked(string source)
     {

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
@@ -12,11 +12,15 @@ namespace Nocturne.Infrastructure.Data.Tests.Migrations;
 /// </summary>
 internal static class MigrationSourceFiles
 {
-    /// <summary>Every migration source file, excluding Designer files and the model snapshot.</summary>
+    /// <summary>
+    /// Every migration source file. A migration is timestamp-prefixed, so anything else sharing
+    /// the folder — the model snapshot, a shared SQL-constants helper — is not one, and is skipped
+    /// rather than handed to a parser that would reject it.
+    /// </summary>
     public static IReadOnlyList<string> All() =>
         Directory.GetFiles(Location(), "*.cs")
             .Where(f => !f.EndsWith(".Designer.cs", StringComparison.Ordinal))
-            .Where(f => !Path.GetFileName(f).Contains("ModelSnapshot", StringComparison.Ordinal))
+            .Where(f => TimestampPrefixed.IsMatch(Path.GetFileNameWithoutExtension(f)))
             .OrderBy(f => f, StringComparer.Ordinal)
             .ToList();
 
@@ -27,6 +31,15 @@ internal static class MigrationSourceFiles
     public static string Text(string name) =>
         File.ReadAllText(All().Single(f =>
             Path.GetFileNameWithoutExtension(f).EndsWith("_" + name, StringComparison.Ordinal)));
+
+    /// <summary>
+    /// The bare table name in a captured SQL or builder reference: the leading segment, before any
+    /// argument list, alias or trailing punctuation, unquoted and lowercased. <c>tbl(col)</c>,
+    /// <c>"tbl"(col)</c> and <c>tbl (col)</c> all yield <c>tbl</c>. A derived table
+    /// (<c>(VALUES …)</c>) yields an empty string, which matches no table.
+    /// </summary>
+    public static string BareTableName(string captured) =>
+        Regex.Split(captured, @"[(;,\s]")[0].Trim('"').ToLowerInvariant();
 
     /// <summary>Migration name — the file name a guard reports and an allowlist keys on.</summary>
     public static string Name(string file) => Path.GetFileNameWithoutExtension(file);
@@ -85,6 +98,8 @@ internal static class MigrationSourceFiles
             .Where(n => n is not null)
             .Select(n => n!.ToLowerInvariant())
             .ToHashSet(StringComparer.Ordinal);
+
+    private static readonly Regex TimestampPrefixed = new(@"^\d{14}_", RegexOptions.Compiled);
 
     private static readonly Regex Comment = new(
         @"/\*.*?\*/|//[^\r\n]*|--[^\r\n]*",

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/UniqueIndexDeduplicationGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/UniqueIndexDeduplicationGuardTests.cs
@@ -1,0 +1,158 @@
+using System.Text.RegularExpressions;
+using Match = System.Text.RegularExpressions.Match;
+
+namespace Nocturne.Infrastructure.Data.Tests.Migrations;
+
+/// <summary>
+/// Migrations run on API startup, so a unique index that trips over rows an upgrading instance
+/// already holds fails the chain and crash-loops the API with no self-service recovery. A
+/// migration adding one to a table it did not create in the same migration must therefore remove
+/// the duplicate losers first.
+/// <para>
+/// The check is presence and ordering within <c>Up</c>: at least one live duplicate-ranking
+/// statement ahead of the first unique index. It does not prove the SQL is correct, and does not
+/// pair each index with its own cleanup — reviewers do that. It matches only the house idiom
+/// (<c>row_number() OVER (PARTITION BY …)</c> feeding a soft delete or a delete), so a cleanup
+/// written some other way reports as an offender; widen the migration to the idiom rather than
+/// the guard to the migration.
+/// </para>
+/// </summary>
+[Trait("Category", "Unit")]
+public class UniqueIndexDeduplicationGuardTests
+{
+    /// <summary>
+    /// Migrations that shipped before the rule. Their <c>Up</c> is history — an instance whose
+    /// chain fails here never reaches a later migration, so no new migration can repair them and
+    /// editing them would not re-run. Membership in this list is the only thing separating a
+    /// grandfathered migration from a new one; nothing may be added.
+    /// </summary>
+    private static readonly IReadOnlySet<string> GrandfatheredMigrations = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "20251126040528_AddTreatmentOriginalIdUniqueIndex",
+        "20251229020632_AddConnectorFoodEntries",
+        "20260217005635_MakeV4LegacyIdUnique",
+        "20260227230204_FixConnectorConfigUniqueIndex",
+        "20260228071347_AddRlsWithCheckAndCompositeIndexes",
+        "20260320105641_DeviceIdentityUnification",
+        "20260326215857_UnifyFollowerGrantsWithTenantMembers",
+        "20260405053007_MakePasskeysSubjectScoped",
+        "20260410002642_OAuthTenantScope",
+        "20260416103826_DropCarbIntakeBolusIdAndAddSyncIdentifierIndexes",
+        "20260424052011_AddTenantMemberUsername",
+        "20260514052027_AddSoftDeleteToV4Entities",
+        "20260603134703_MakeDevicesUniqueIndexTenantScoped",
+        "20260607084109_AddTenantShareToken",
+        "20260609093227_AddTimezoneTimelineAndSensorGlucoseSyncId",
+        "20260616124951_AddHealthMetricsSyncDedup",
+        "20260717133302_AddDeviceStatusSnapshotSyncIdentifiers",
+        "20260717141728_AddTempBasalSyncIdentifierAndCarbMacros",
+        "20260802073145_DurableJobRecords",
+        "20260817042048_RestoreUpdateTimestampWritesAndBasalInjectionSoftDeleteIndex",
+        "20260817064038_AddTenantScopedLegacyIdIndexesToMeterGlucoseAndCalibrations",
+    };
+
+    [Fact]
+    public void NoNewMigrationCreatesAUniqueIndexOverPreExistingDataWithoutDeduplicating()
+    {
+        var offenders = MigrationSourceFiles.All()
+            .Where(f => !GrandfatheredMigrations.Contains(MigrationSourceFiles.Name(f)))
+            .Select(f => (Migration: MigrationSourceFiles.Name(f), Tables: UndeduplicatedTables(f)))
+            .Where(x => x.Tables.Count > 0)
+            .Select(x => $"{x.Migration} -> {string.Join(", ", x.Tables)}")
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "migrations run on API startup, so a unique index that fails on data an upgrading "
+            + "instance already holds crash-loops the API with no self-service recovery; soft-delete "
+            + "the duplicate losers earlier in the same Up, as "
+            + "20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots does");
+    }
+
+    [Fact]
+    public void EveryGrandfatheredMigrationStillExistsAndStillLacksDeduplication()
+    {
+        // Also the discovery check: a moved directory, a changed glob or a detection regex that
+        // stopped matching empties this set, and an empty set is not the allowlist.
+        var stillOffending = MigrationSourceFiles.All()
+            .Where(f => UndeduplicatedTables(f).Count > 0)
+            .Select(MigrationSourceFiles.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        stillOffending.Should().BeEquivalentTo(GrandfatheredMigrations,
+            "an allowlist entry that no longer matches is stale and hides a regression");
+    }
+
+    /// <summary>
+    /// Tables the migration makes unique without an earlier cleanup, ignoring tables it creates
+    /// itself — those hold no rows yet, so a cleanup there would be dead code.
+    /// </summary>
+    private static IReadOnlyList<string> UndeduplicatedTables(string file)
+    {
+        var up = MigrationSourceFiles.UpBody(File.ReadAllText(file));
+        var created = TablesCreatedIn(up);
+
+        var indexed = UniqueIndexCreations(up)
+            .Where(x => !created.Contains(x.Table))
+            .ToList();
+
+        if (indexed.Count == 0)
+            return [];
+
+        var live = MigrationSourceFiles.WithCommentsBlanked(up);
+        var firstIndex = indexed.Min(x => x.Position);
+
+        var deduplicates =
+            RankedDuplicates.Matches(live).Any(m => m.Index < firstIndex)
+            && RemovesRows.Matches(live).Any(m => m.Index < firstIndex);
+
+        return deduplicates
+            ? []
+            : indexed.Select(x => x.Table).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
+    }
+
+    private static IEnumerable<(int Position, string Table)> UniqueIndexCreations(string up)
+    {
+        foreach (var regex in new[] { FluentUniqueIndex, FluentUniqueConstraint })
+            foreach (Match match in regex.Matches(up))
+                if (TableArgument.Match(match.Groups[1].Value) is { Success: true } table)
+                    yield return (match.Index, table.Groups[1].Value.ToLowerInvariant());
+
+        foreach (var regex in new[] { SqlUniqueIndex, SqlUniqueConstraint })
+            foreach (Match match in regex.Matches(up))
+                yield return (match.Index, match.Groups[1].Value.ToLowerInvariant());
+    }
+
+    private static IReadOnlySet<string> TablesCreatedIn(string up) =>
+        new[] { FluentCreateTable, SqlCreateTable }
+            .SelectMany(r => r.Matches(up).Select(m => m.Groups[1].Value.ToLowerInvariant()))
+            .ToHashSet(StringComparer.Ordinal);
+
+    private const RegexOptions Sql = RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled;
+
+    private static readonly Regex FluentUniqueIndex = new(
+        @"\.CreateIndex\s*\(([^;]*?\bunique\s*:\s*true[^;]*?)\)\s*;", RegexOptions.Compiled);
+
+    private static readonly Regex FluentUniqueConstraint = new(
+        @"\.(?:AddUniqueConstraint|AddPrimaryKey)\s*\(([^;]*?)\)\s*;", RegexOptions.Compiled);
+
+    private static readonly Regex FluentCreateTable = new(
+        @"\.CreateTable\s*\(\s*name\s*:\s*""([^""]+)""", RegexOptions.Compiled);
+
+    private static readonly Regex TableArgument = new(@"table\s*:\s*""([^""]+)""", RegexOptions.Compiled);
+
+    private static readonly Regex SqlUniqueIndex = new(
+        @"CREATE\s+UNIQUE\s+INDEX(?:\s+CONCURRENTLY)?(?:\s+IF\s+NOT\s+EXISTS)?\s+\S+\s+ON\s+(?:ONLY\s+)?""?(\w+)""?",
+        Sql);
+
+    private static readonly Regex SqlUniqueConstraint = new(
+        @"ALTER\s+TABLE\s+(?:ONLY\s+)?""?(\w+)""?[^;]*?\bADD\s+CONSTRAINT\b[^;]*?\bUNIQUE\b", Sql);
+
+    private static readonly Regex SqlCreateTable = new(
+        @"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?""?(\w+)""?", Sql);
+
+    private static readonly Regex RankedDuplicates = new(
+        @"row_number\s*\(\s*\)\s*over\s*\(\s*partition\s+by\b", Sql);
+
+    private static readonly Regex RemovesRows = new(
+        @"\bupdate\s+\S+\s+set\s+deleted_at\b|\bdelete\s+from\s+\S+", Sql);
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/UniqueIndexDeduplicationGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/UniqueIndexDeduplicationGuardTests.cs
@@ -67,8 +67,9 @@ public class UniqueIndexDeduplicationGuardTests
             + "instance already holds crash-loops the API with no self-service recovery; soft-delete "
             + "the duplicate losers earlier in the same Up, as "
             + "20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots does. A table reported as "
-            + $"'{UnresolvedTable}' is one the guard could not read off the call; name it as a "
-            + "literal so the exemption for a table created in this migration can apply to it");
+            + $"'{UnresolvedTable}' is one the guard could not read off the call; unroll the loop "
+            + "so both the CREATE TABLE and the index name it literally — naming only the index "
+            + "still reports, because the exemption cannot match a create it also cannot read");
     }
 
     [Fact]
@@ -125,25 +126,43 @@ public class UniqueIndexDeduplicationGuardTests
     {
         foreach (var regex in new[] { FluentUniqueIndex, FluentUniqueConstraint })
             foreach (Match match in regex.Matches(up))
-                yield return (match.Index, TableArgument.Match(match.Groups[1].Value) is { Success: true } table
-                    ? ResolveTable(table.Groups[1].Value)
-                    : UnresolvedTable);
+                yield return (match.Index, FluentTable(match.Groups[1].Value));
 
         foreach (var regex in new[] { SqlUniqueIndex, SqlUniqueConstraint })
             foreach (Match match in regex.Matches(up))
                 yield return (match.Index, ResolveTable(match.Groups[1].Value));
     }
 
+    /// <summary>
+    /// The table a builder call targets: the named <c>table:</c> argument, or for a positional
+    /// call the second string literal — <c>CreateIndex</c>, <c>AddUniqueConstraint</c> and
+    /// <c>AddPrimaryKey</c> all take (name, table, …).
+    /// </summary>
+    private static string FluentTable(string arguments) =>
+        TableArgument.Match(arguments) is { Success: true } named
+            ? ResolveTable(named.Groups[1].Value)
+            : PositionalTableArgument.Match(arguments) is { Success: true } positional
+                ? ResolveTable(positional.Groups[1].Value)
+                : UnresolvedTable;
+
+    /// <summary>
+    /// The table a captured reference names, or <see cref="UnresolvedTable"/> when it is not a
+    /// plain name — an interpolated <c>{table}</c> hole, or a loop variable. A schema qualifier is
+    /// dropped so <c>public.x</c> and <c>x</c> are one table on both the index and the
+    /// <c>CREATE TABLE</c> side; splitting them would red-build a schema-qualified new table.
+    /// </summary>
     private static string ResolveTable(string captured)
     {
-        var bare = captured.Trim('"', ';', ',', '(', ')').ToLowerInvariant();
+        var bare = MigrationSourceFiles.BareTableName(captured);
+        var unqualified = bare[(bare.LastIndexOf('.') + 1)..];
 
-        return PlainTableName.IsMatch(bare) ? bare : UnresolvedTable;
+        return PlainTableName.IsMatch(unqualified) ? unqualified : UnresolvedTable;
     }
 
     private static IReadOnlySet<string> TablesCreatedIn(string up) =>
         new[] { FluentCreateTable, SqlCreateTable }
-            .SelectMany(r => r.Matches(up).Select(m => m.Groups[1].Value.ToLowerInvariant()))
+            .SelectMany(r => r.Matches(up).Select(m => ResolveTable(m.Groups[1].Value)))
+            .Where(t => t != UnresolvedTable)
             .ToHashSet(StringComparer.Ordinal);
 
     private const string UnresolvedTable = "<table not resolvable to a literal name>";
@@ -163,6 +182,9 @@ public class UniqueIndexDeduplicationGuardTests
 
     private static readonly Regex TableArgument = new(@"table\s*:\s*""([^""]+)""", RegexOptions.Compiled);
 
+    private static readonly Regex PositionalTableArgument = new(
+        @"^\s*""[^""]*""\s*,\s*""([^""]+)""", RegexOptions.Compiled);
+
     private static readonly Regex SqlUniqueIndex = new(
         @"CREATE\s+UNIQUE\s+INDEX(?:\s+CONCURRENTLY)?(?:\s+IF\s+NOT\s+EXISTS)?\s+\S+\s+ON\s+(?:ONLY\s+)?(\S+)",
         Sql);
@@ -171,7 +193,7 @@ public class UniqueIndexDeduplicationGuardTests
         @"ALTER\s+TABLE\s+(?:ONLY\s+)?(\S+)[^;]*?\bADD\s+CONSTRAINT\b[^;]*?\bUNIQUE\b", Sql);
 
     private static readonly Regex SqlCreateTable = new(
-        @"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?""?(\w+)""?", Sql);
+        @"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)", Sql);
 
     private static readonly Regex RankedDuplicates = new(
         @"row_number\s*\(\s*\)\s*over\s*\(\s*partition\s+by\b", Sql);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/UniqueIndexDeduplicationGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/UniqueIndexDeduplicationGuardTests.cs
@@ -14,7 +14,8 @@ namespace Nocturne.Infrastructure.Data.Tests.Migrations;
 /// pair each index with its own cleanup — reviewers do that. It matches only the house idiom
 /// (<c>row_number() OVER (PARTITION BY …)</c> feeding a soft delete or a delete), so a cleanup
 /// written some other way reports as an offender; widen the migration to the idiom rather than
-/// the guard to the migration.
+/// the guard to the migration. The shapes it cannot see are listed under "Unique indexes over
+/// existing data" in CLAUDE.md, where the authors it is a backstop for will read them.
 /// </para>
 /// </summary>
 [Trait("Category", "Unit")]
@@ -65,7 +66,9 @@ public class UniqueIndexDeduplicationGuardTests
             "migrations run on API startup, so a unique index that fails on data an upgrading "
             + "instance already holds crash-loops the API with no self-service recovery; soft-delete "
             + "the duplicate losers earlier in the same Up, as "
-            + "20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots does");
+            + "20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots does. A table reported as "
+            + $"'{UnresolvedTable}' is one the guard could not read off the call; name it as a "
+            + "literal so the exemption for a table created in this migration can apply to it");
     }
 
     [Fact]
@@ -88,8 +91,9 @@ public class UniqueIndexDeduplicationGuardTests
     /// </summary>
     private static IReadOnlyList<string> UndeduplicatedTables(string file)
     {
-        var up = MigrationSourceFiles.UpBody(File.ReadAllText(file));
-        var created = TablesCreatedIn(up);
+        var up = MigrationSourceFiles.UpBody(file);
+        var live = MigrationSourceFiles.WithCommentsBlanked(up);
+        var created = TablesCreatedIn(live);
 
         var indexed = UniqueIndexCreations(up)
             .Where(x => !created.Contains(x.Table))
@@ -98,7 +102,6 @@ public class UniqueIndexDeduplicationGuardTests
         if (indexed.Count == 0)
             return [];
 
-        var live = MigrationSourceFiles.WithCommentsBlanked(up);
         var firstIndex = indexed.Min(x => x.Position);
 
         var deduplicates =
@@ -110,16 +113,32 @@ public class UniqueIndexDeduplicationGuardTests
             : indexed.Select(x => x.Table).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToList();
     }
 
+    /// <summary>
+    /// Every unique index the migration's <c>Up</c> creates, paired with its target table. A
+    /// target that is not a bare literal — a <c>{table}</c> hole in interpolated SQL, a loop
+    /// variable, a schema qualifier — resolves to <see cref="UnresolvedTable"/>, which no
+    /// <c>CreateTable</c> can match, so it can only ever be exempted by an actual cleanup.
+    /// Dropping it instead would blind the guard to the multi-table loop the rule's own worked
+    /// example is written in.
+    /// </summary>
     private static IEnumerable<(int Position, string Table)> UniqueIndexCreations(string up)
     {
         foreach (var regex in new[] { FluentUniqueIndex, FluentUniqueConstraint })
             foreach (Match match in regex.Matches(up))
-                if (TableArgument.Match(match.Groups[1].Value) is { Success: true } table)
-                    yield return (match.Index, table.Groups[1].Value.ToLowerInvariant());
+                yield return (match.Index, TableArgument.Match(match.Groups[1].Value) is { Success: true } table
+                    ? ResolveTable(table.Groups[1].Value)
+                    : UnresolvedTable);
 
         foreach (var regex in new[] { SqlUniqueIndex, SqlUniqueConstraint })
             foreach (Match match in regex.Matches(up))
-                yield return (match.Index, match.Groups[1].Value.ToLowerInvariant());
+                yield return (match.Index, ResolveTable(match.Groups[1].Value));
+    }
+
+    private static string ResolveTable(string captured)
+    {
+        var bare = captured.Trim('"', ';', ',', '(', ')').ToLowerInvariant();
+
+        return PlainTableName.IsMatch(bare) ? bare : UnresolvedTable;
     }
 
     private static IReadOnlySet<string> TablesCreatedIn(string up) =>
@@ -127,7 +146,11 @@ public class UniqueIndexDeduplicationGuardTests
             .SelectMany(r => r.Matches(up).Select(m => m.Groups[1].Value.ToLowerInvariant()))
             .ToHashSet(StringComparer.Ordinal);
 
+    private const string UnresolvedTable = "<table not resolvable to a literal name>";
+
     private const RegexOptions Sql = RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled;
+
+    private static readonly Regex PlainTableName = new(@"^\w+$", RegexOptions.Compiled);
 
     private static readonly Regex FluentUniqueIndex = new(
         @"\.CreateIndex\s*\(([^;]*?\bunique\s*:\s*true[^;]*?)\)\s*;", RegexOptions.Compiled);
@@ -141,11 +164,11 @@ public class UniqueIndexDeduplicationGuardTests
     private static readonly Regex TableArgument = new(@"table\s*:\s*""([^""]+)""", RegexOptions.Compiled);
 
     private static readonly Regex SqlUniqueIndex = new(
-        @"CREATE\s+UNIQUE\s+INDEX(?:\s+CONCURRENTLY)?(?:\s+IF\s+NOT\s+EXISTS)?\s+\S+\s+ON\s+(?:ONLY\s+)?""?(\w+)""?",
+        @"CREATE\s+UNIQUE\s+INDEX(?:\s+CONCURRENTLY)?(?:\s+IF\s+NOT\s+EXISTS)?\s+\S+\s+ON\s+(?:ONLY\s+)?(\S+)",
         Sql);
 
     private static readonly Regex SqlUniqueConstraint = new(
-        @"ALTER\s+TABLE\s+(?:ONLY\s+)?""?(\w+)""?[^;]*?\bADD\s+CONSTRAINT\b[^;]*?\bUNIQUE\b", Sql);
+        @"ALTER\s+TABLE\s+(?:ONLY\s+)?(\S+)[^;]*?\bADD\s+CONSTRAINT\b[^;]*?\bUNIQUE\b", Sql);
 
     private static readonly Regex SqlCreateTable = new(
         @"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?""?(\w+)""?", Sql);


### PR DESCRIPTION
Closes #828.

Migrations run at API startup, so a `CREATE UNIQUE INDEX` that fails on data an upgrading instance already holds crash-loops the API with no self-service recovery. #786's migration soft-deletes the duplicate losers first for exactly that reason.

Shipped migrations that create unique indexes with no such step cannot be retro-fixed — a new migration ordered later cannot help an instance whose chain fails earlier, and hand-editing migration history is forbidden. So this takes the option the issue itself lands on: grandfather what shipped, adopt the rule going forward, guard it, and write it down.

**The issue names three offenders. There are 21.** It found the three it was looking at; the sweep turns up eighteen more, including `AddRlsWithCheckAndCompositeIndexes` (21 tables in one migration). One correction: `20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots` is not a fourth offender — it *is* #786, the worked example, and the only migration in the tree that passes the guard on its own merits.

## The guard

`UniqueIndexDeduplicationGuardTests` flags a migration that creates a unique index over a pre-existing table with no duplicate-ranking statement earlier in the same `Up`.

Detection is deliberately **asymmetric**: the index side reads raw text, so nothing hides behind a comment, while the cleanup side reads comment-blanked text, so a commented-out cleanup cannot satisfy it. Blanking withholds evidence, which is safe only where missing evidence means *fail* — that is a property of the call site, not of the transform, and it is stated once where the transform lives.

Tables created in the same `Up` are exempt, so a unique index on a brand-new empty table demands no dead cleanup. That is structural rather than an exception list, and it is not hypothetical: `AddReadAccessAudit` creates `coach_mark_states` and indexes it in the same migration, and the guard correctly leaves it alone.

Grandfathering is a **named 21-entry allowlist** — no date cutoff. A cutoff makes the debt invisible and silently stops applying when the regexes widen; a named list is a diff-visible eyesore someone has to consciously grow. A second test asserts the allowlist equals the *whole* current offender set, so a new offender, a stale entry, and a discovery regression all go red. That equality is also what makes the vacuous case fail: any change that empties the offender set — a moved directory, a changed glob, a regex that stopped matching — collapses it to empty, and empty is not the allowlist.

## The rule

`CLAUDE.md` gains a subsection under Database, next to the RLS rule about setting the tenant context in data migrations, so migration authors read the two together. It states the rule, the reason, the new-table exemption, and — deliberately — **what the guard does not check**: presence and ordering per migration rather than per index, so one cleanup clears every index in that migration; only the house `row_number() OVER (PARTITION BY …)` idiom is recognised, so a correct cleanup written another way is a false red whose remedy is to widen the migration, not the guard; and four shapes it cannot see at all. The rule is deliberately broader than the guard, and the doc says so rather than implying enforcement it does not have.

## Two guards, one set of helpers

`MigrationSourceFiles` gains `Name`, `UpBody` (only `Up` runs on the startup chain; `Down` routinely recreates the indexes `Up` replaced), `WithCommentsBlanked` (length-preserving, so offsets stay comparable), and `BareTableName`.

`DataMigrationTenantContextGuardTests` now uses `UpBody` and shares `BareTableName`. Narrowing to `Up` is a real semantic change, so the delta was **measured** rather than assumed: every migration's loop matches were dumped under whole-file, `Up`-only and `Up`-blanked. Exactly four matches drop, all `Down()`-only loops on `FROM tenants`, which was never a flagged source — so no migration moves in or out of the flagged set.

That guard reads **raw** text on its offender-detection path. An earlier revision blanked it too, and review found a `/*` inside a SQL string literal blanking twenty lines including a live tenant loop that the pre-refactor guard caught. Reverted. The cost is that a commented-out loop is now reported; no shipped migration has one, and that is the cheap direction to be wrong in.

## Verification

Every fix was A/B proved — each arm run both with and without the fix, so the un-fixed run passing is what shows the hole was real rather than that the new test happens to pass.

| Case | Un-fixed | Fixed |
|---|---|---|
| Prose comment containing "create table entries" exempting a pre-existing table | passes | fails |
| Interpolated `{table}` and loop-variable table names | passes | fails |
| `void Up (` with a space yielding an empty body | passes 9/9 | fails, named |
| `/*` in a SQL literal blanking a live tenant loop | passes | fails |
| Commented-out cleanup | fails | fails |
| Unique index over a table created in the same `Up` | passes | passes |
| Vacuous discovery | fails | fails |

Three hostile fresh-context review rounds. The first reproduced ten ways past the guard; four were fixed and the rest documented. The second found that closing those had opened four ways to **red-build correct work** — the worst being `ON tbl(col)` with no space, which a shipped migration is one keystroke away from. That was a normaliser using `Trim` (ends only) where the sibling guard already had the correct split-on-delimiter version forty lines away; both now share one implementation, and schema qualification resolves to its last segment on both the index and create sides rather than being inconsistent between them.

Two `CLAUDE.md` claims were false of the code and are corrected: raw-SQL `CREATE UNIQUE INDEX` **does** have a live example (`AddReadAccessAudit`), so that path fires and is exempt rather than unmatched — meaning that migration's exact spacing is load-bearing for a regex nothing tests; and the unresolvable-table causes no longer include punctuation adjacency, because that is now fixed rather than tolerated.

679 passed. Allowlists stable at 21 and 3. No shipped migration modified.

## Noted, not fixed

`MigrationSourceFiles.TenantScopedTableNames()` reads only `[Table]` attributes, so fluent-mapped tables — **including `entries`** — are invisible to the tenant-context guard, making its coverage narrower than it looks. Filed as #950.
