### PR TITLE
fix(nocturne-remote): fail a truncated crawl instead of reporting a partial sync as complete

### DIFF
--- a/nocturne.sln
+++ b/nocturne.sln
@@ -190,6 +190,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{07C2787E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Tools.DiagramGen", "tools\Nocturne.Tools.DiagramGen\Nocturne.Tools.DiagramGen.csproj", "{3AA294CD-171F-4F5D-8103-8399CAC253B9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nocturne.Connectors.NocturneRemote.Tests", "tests\Unit\Nocturne.Connectors.NocturneRemote.Tests\Nocturne.Connectors.NocturneRemote.Tests.csproj", "{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -992,6 +994,18 @@ Global
 		{3AA294CD-171F-4F5D-8103-8399CAC253B9}.Release|x64.Build.0 = Release|Any CPU
 		{3AA294CD-171F-4F5D-8103-8399CAC253B9}.Release|x86.ActiveCfg = Release|Any CPU
 		{3AA294CD-171F-4F5D-8103-8399CAC253B9}.Release|x86.Build.0 = Release|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Debug|x64.Build.0 = Debug|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Debug|x86.Build.0 = Debug|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Release|x64.ActiveCfg = Release|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Release|x64.Build.0 = Release|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Release|x86.ActiveCfg = Release|Any CPU
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1075,5 +1089,6 @@ Global
 		{7209E189-D47B-4351-B82F-527F9B502E72} = {52BF7FB6-37FF-5100-EFD1-124EFF302675}
 		{5507B435-56A8-48A7-A917-B8EFB65F8196} = {F25A9213-C080-46DC-93A8-09D96E2C55A1}
 		{3AA294CD-171F-4F5D-8103-8399CAC253B9} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
+		{645DCDBB-21E8-4EDC-960C-1B24D50D5E6A} = {F25A9213-C080-46DC-93A8-09D96E2C55A1}
 	EndGlobalSection
 EndGlobal

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -805,8 +805,14 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     ///     that was never read, so the gap outlives the failure instead of being repaired. A source
     ///     with nothing left to give answers with an empty payload; that is what ends a crawl.
     /// </remarks>
-    protected static Exception FetchFailed(string operationName) =>
-        new HttpRequestException($"{operationName} fetch failed; see preceding connector logs");
+    /// <param name="detail">
+    ///     What the source did, when the caller knows it and the reader would otherwise have to read
+    ///     the connector logs to find out — which a hosted tenant cannot do.
+    /// </param>
+    protected static Exception FetchFailed(string operationName, string? detail = null) =>
+        new HttpRequestException(detail is null
+            ? $"{operationName} fetch failed; see preceding connector logs"
+            : $"{operationName} fetch failed: {detail}");
 
     /// <summary>
     ///     What a run says for itself when it failed and the reader has no <see cref="SyncResult.Errors"/>

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -794,6 +794,21 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
+    ///     The failure a connector raises when the source did not answer, for the fetches whose
+    ///     caller cannot tell a failure from a result by its shape.
+    /// </summary>
+    /// <remarks>
+    ///     A fetch that failed is not an answer, and must never be read as one. Standing in an empty
+    ///     result ends a paginated crawl at the page that broke and reports the truncation as a
+    ///     successful sync, and it advances whatever the connector resumes from next cycle — a
+    ///     persisted backfill low-water mark, or the newest record now stored locally — past history
+    ///     that was never read, so the gap outlives the failure instead of being repaired. A source
+    ///     with nothing left to give answers with an empty payload; that is what ends a crawl.
+    /// </remarks>
+    protected static Exception FetchFailed(string operationName) =>
+        new HttpRequestException($"{operationName} fetch failed; see preceding connector logs");
+
+    /// <summary>
     ///     What a run says for itself when it failed and the reader has no <see cref="SyncResult.Errors"/>
     ///     to go on. The first recorded failure names the run, so a fetch that fell over followed by a
     ///     publish rejection still reads as the fetch failure that started it.

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -487,12 +487,11 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         {
             var page = await FetchDataAsync<T[]>(buildUrl(from, currentTo), operationName);
 
-            // FetchDataAsync reports failure (retries exhausted, non-retryable HTTP, bad JSON)
-            // as null. That is not the end of the range — treating it as one silently truncated
-            // crawls into "successful" partial syncs, and would wrongly clear a backfill
-            // low-water mark. A genuinely exhausted range answers an empty array.
+            // FetchDataAsync reports failure (retries exhausted, non-retryable HTTP, bad JSON) as
+            // null rather than throwing; <see cref="BaseConnectorService{TConfig}.FetchFailed"/> is
+            // why that is not the end of the range.
             if (page == null)
-                throw new HttpRequestException($"{operationName} fetch failed; see preceding connector logs");
+                throw FetchFailed(operationName);
 
             if (page.Length == 0)
                 yield break;

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -15,6 +15,7 @@ namespace Nocturne.Connectors.NocturneRemote.Services;
 /// </summary>
 public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemoteConnectorConfiguration>
 {
+    private readonly IRetryDelayStrategy _retryDelayStrategy;
     private NocturneRemoteConnectorConfiguration _config;
     private string? _resolvedBaseUrl;
     private Dictionary<string, string>? _authHeaders;
@@ -24,11 +25,13 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         IConnectorServerResolver<NocturneRemoteConnectorConfiguration> serverResolver,
         ILogger<NocturneRemoteConnectorService> logger,
         IConnectorRegistration<NocturneRemoteConnectorConfiguration> registration,
+        IRetryDelayStrategy retryDelayStrategy,
         IConnectorPublisher? publisher = null
     )
         : base(httpClient, serverResolver, logger, publisher)
     {
         _config = registration?.Defaults ?? throw new ArgumentNullException(nameof(registration));
+        _retryDelayStrategy = retryDelayStrategy ?? throw new ArgumentNullException(nameof(retryDelayStrategy));
     }
 
     protected override string ConnectorSource => DataSources.NocturneRemoteConnector;
@@ -109,6 +112,23 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
         var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
+        // Glucose keeps request.From: the framework derived it from the newest stored glucose
+        // record, so it already is glucose's own cursor. Every other family resolves its own the
+        // same way instead of inheriting that one. Sharing it strands a family that fell behind —
+        // this run's glucose publish moves the shared cursor past the very range a failed crawl
+        // still owes, which is what turns a repairable gap into a permanent one. An explicit range
+        // (request.To set, as a cursor reset sends) is honoured as given.
+        var openEnded = request.To is null;
+        var treatmentFrom = openEnded && activeTypes.Overlaps(TreatmentFamily)
+            ? await CalculateTreatmentSinceTimestampAsync(config)
+            : request.From;
+        var deviceStatusFrom = openEnded && activeTypes.Contains(SyncDataType.DeviceStatus)
+            ? await CalculateDeviceStatusCatchUpSinceAsync(config) ?? request.From
+            : request.From;
+        var activityFrom = openEnded && activeTypes.Contains(SyncDataType.Activity)
+            ? await CalculateActivityCatchUpSinceAsync(config) ?? request.From
+            : request.From;
+
         foreach (var type in activeTypes)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -117,17 +137,19 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             {
                 await (type switch
                 {
-                    SyncDataType.Glucose => SyncSensorGlucoseAsync(request, config, result, activeTypes, cancellationToken),
-                    SyncDataType.ManualBG => SyncBGChecksAsync(request, config, result, activeTypes, cancellationToken),
-                    SyncDataType.Boluses => SyncBolusesAsync(request, config, result, activeTypes, cancellationToken),
-                    SyncDataType.CarbIntake => SyncCarbIntakeAsync(request, config, result, activeTypes, cancellationToken),
-                    SyncDataType.BolusCalculations => SyncBolusCalculationsAsync(request, config, result, activeTypes, cancellationToken),
-                    SyncDataType.Notes => SyncNotesAsync(request, config, result, activeTypes, cancellationToken),
-                    SyncDataType.DeviceEvents => SyncDeviceEventsAsync(request, config, result, activeTypes, cancellationToken),
-                    SyncDataType.StateSpans => SyncStateSpansAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Glucose => SyncSensorGlucoseAsync(request.From, request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.ManualBG => SyncBGChecksAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Boluses => SyncBolusesAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.CarbIntake => SyncCarbIntakeAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.BolusCalculations => SyncBolusCalculationsAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Notes => SyncNotesAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.DeviceEvents => SyncDeviceEventsAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
+                    // State spans have no resume watermark of their own, so they stay on the
+                    // glucose cursor and keep the exposure described above.
+                    SyncDataType.StateSpans => SyncStateSpansAsync(request.From, request.To, config, result, activeTypes, cancellationToken),
                     SyncDataType.Profiles => SyncProfilesAsync(config, result, activeTypes, cancellationToken),
-                    SyncDataType.DeviceStatus => SyncDeviceStatusAsync(request, config, result, activeTypes, cancellationToken),
-                    SyncDataType.Activity => SyncActivityAsync(request, config, result, activeTypes, cancellationToken),
+                    SyncDataType.DeviceStatus => SyncDeviceStatusAsync(deviceStatusFrom, request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Activity => SyncActivityAsync(activityFrom, request.To, config, result, activeTypes, cancellationToken),
                     SyncDataType.Food => SyncFoodAsync(config, result, activeTypes, cancellationToken),
                     _ => Task.CompletedTask
                 });
@@ -144,80 +166,97 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         return result;
     }
 
+    /// <summary>
+    ///     The types whose records all land in the v1 treatments collection, and so all resume from
+    ///     the one watermark <see cref="BaseConnectorService{TConfig}.CalculateTreatmentSinceTimestampAsync"/>
+    ///     reports for this source.
+    /// </summary>
+    /// <remarks>
+    ///     That watermark is the newest record of any of them, so these six do not resume
+    ///     independently of one another: a sibling that published in the same run still carries the
+    ///     bound past a range one of them failed to read. Separating them needs a per-type watermark
+    ///     the publisher does not expose.
+    /// </remarks>
+    private static readonly SyncDataType[] TreatmentFamily =
+    [
+        SyncDataType.ManualBG, SyncDataType.Boluses, SyncDataType.CarbIntake,
+        SyncDataType.BolusCalculations, SyncDataType.Notes, SyncDataType.DeviceEvents
+    ];
+
     #region V4 Data Type Sync Methods
 
     private async Task SyncSensorGlucoseAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<SensorGlucose>(
-            NocturneRemoteConstants.SensorGlucose, request.From, request.To, ct);
+            NocturneRemoteConstants.SensorGlucose, from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
             ImportHelper.PrepareForImport(records), PublishSensorGlucoseDataAsync, config, ct);
     }
 
     private async Task SyncBGChecksAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<BGCheck>(
-            NocturneRemoteConstants.BGChecks, request.From, request.To, ct);
+            NocturneRemoteConstants.BGChecks, from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
             ImportHelper.PrepareForImport(records), PublishBGCheckDataAsync, config, ct);
     }
 
     private async Task SyncBolusesAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<Bolus>(
-            NocturneRemoteConstants.Boluses, request.From, request.To, ct);
+            NocturneRemoteConstants.Boluses, from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
             ImportHelper.PrepareForImport(records), PublishBolusDataAsync, config, ct);
     }
 
     private async Task SyncCarbIntakeAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<CarbIntake>(
-            NocturneRemoteConstants.CarbIntake, request.From, request.To, ct);
+            NocturneRemoteConstants.CarbIntake, from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
             ImportHelper.PrepareForImport(records), PublishCarbIntakeDataAsync, config, ct);
     }
 
     private async Task SyncBolusCalculationsAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<BolusCalculation>(
-            NocturneRemoteConstants.BolusCalculations, request.From, request.To, ct);
+            NocturneRemoteConstants.BolusCalculations, from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, activeTypes,
             ImportHelper.PrepareForImport(records), PublishBolusCalculationDataAsync, config, ct);
     }
 
     private async Task SyncNotesAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<Note>(
-            NocturneRemoteConstants.Notes, request.From, request.To, ct);
+            NocturneRemoteConstants.Notes, from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Notes, activeTypes,
             ImportHelper.PrepareForImport(records), PublishNoteDataAsync, config, ct);
     }
 
     private async Task SyncDeviceEventsAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<DeviceEvent>(
-            NocturneRemoteConstants.DeviceEvents, request.From, request.To, ct);
+            NocturneRemoteConstants.DeviceEvents, from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
             ImportHelper.PrepareForImport(records), PublishDeviceEventDataAsync, config, ct);
@@ -228,11 +267,11 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     #region Legacy Model Sync Methods
 
     private async Task SyncStateSpansAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<StateSpan>(
-            NocturneRemoteConstants.StateSpans, request.From, request.To, ct);
+            NocturneRemoteConstants.StateSpans, from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
             records, PublishStateSpanDataAsync, config, ct);
@@ -250,23 +289,23 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     }
 
     private async Task SyncDeviceStatusAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         // DeviceStatus uses the v1 API because the publisher only supports the legacy model.
         // The remote instance exposes v1 compatibility endpoints.
-        var records = await FetchV1DeviceStatusAsync(request.From, request.To, ct);
+        var records = await FetchV1DeviceStatusAsync(from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, activeTypes,
             records, PublishDeviceStatusAsync, config, ct);
     }
 
     private async Task SyncActivityAsync(
-        SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<Activity>(
-            NocturneRemoteConstants.Activity, request.From, request.To, ct);
+            NocturneRemoteConstants.Activity, from, to, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Activity, activeTypes,
             records, PublishActivityDataAsync, config, ct);
@@ -277,30 +316,56 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         // Foods endpoint returns a flat array, not PaginatedResponse
-        var url = BuildAbsoluteUrl($"{NocturneRemoteConstants.Foods}?count={_config.MaxCount}");
-        var response = await GetWithHeadersAsync(url, _authHeaders, ct);
+        var foods = await FetchWithRetryAsync<Food[]>(
+            $"{NocturneRemoteConstants.Foods}?count={_config.MaxCount}",
+            NocturneRemoteConstants.Foods, ct);
 
-        if (!response.IsSuccessStatusCode)
-        {
-            _logger.LogWarning(
-                "[{ConnectorSource}] Failed to fetch foods: HTTP {StatusCode}",
-                ConnectorSource,
-                (int)response.StatusCode);
-            throw FetchFailed(NocturneRemoteConstants.Foods);
-        }
-
-        var foods = await DeserializeResponseAsync<Food[]>(response, ct);
         if (foods == null)
-        {
-            _logger.LogWarning(
-                "[{ConnectorSource}] Failed to fetch foods: response carried no records",
-                ConnectorSource);
             throw FetchFailed(NocturneRemoteConstants.Foods);
-        }
 
         // Food carries no per-record time, so no timestamp selector is supplied.
         await PublishRecordTypeAsync(result, SyncDataType.Food, activeTypes,
             foods.ToList(), PublishFoodDataAsync, config, ct);
+    }
+
+    #endregion
+
+    #region Fetch Helpers
+
+    /// <summary>
+    ///     One request to the remote instance under the connector retry budget, answering
+    ///     <c>null</c> when it did not survive it. Callers turn that into
+    ///     <see cref="BaseConnectorService{TConfig}.FetchFailed"/>; the two steps are separate
+    ///     because only the caller knows what the missing payload was for.
+    /// </summary>
+    /// <remarks>
+    ///     Mirrors the Nightscout connector's fetch layer so both crawls raise on the same
+    ///     condition: a transient status is retried, and a status the remote will keep returning,
+    ///     an unparseable body, or an exhausted budget all report the same <c>null</c>.
+    /// </remarks>
+    private Task<T?> FetchWithRetryAsync<T>(string relativeUrl, string operationName, CancellationToken ct)
+        where T : class =>
+        ExecuteWithRetryAsync(
+            async () => await FetchCoreAsync<T>(relativeUrl, ct),
+            _retryDelayStrategy,
+            maxRetries: _config.MaxRetryAttempts,
+            operationName: operationName,
+            cancellationToken: ct);
+
+    private async Task<T?> FetchCoreAsync<T>(string relativeUrl, CancellationToken ct) where T : class
+    {
+        var response = await GetWithHeadersAsync(BuildAbsoluteUrl(relativeUrl), _authHeaders, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException(
+                $"HTTP {(int)response.StatusCode} {response.StatusCode}: {body}",
+                null,
+                response.StatusCode);
+        }
+
+        return await DeserializeResponseAsync<T>(response, ct);
     }
 
     #endregion
@@ -313,10 +378,12 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     /// </summary>
     /// <remarks>
     ///     The crawl accumulates the whole range before its caller publishes any of it, so a page
-    ///     that never arrives costs the range rather than truncating it: pages arrive newest-first
-    ///     and the next sync's lower bound is derived from the newest record stored locally, so
-    ///     publishing the pages either side of a failure would put the ones in between permanently
-    ///     out of reach. See <see cref="BaseConnectorService{TConfig}.FetchFailed"/>.
+    ///     the remote never delivers costs the range rather than truncating it: pages arrive
+    ///     newest-first and the family's next lower bound comes from its newest stored record, so
+    ///     publishing the pages either side of a failure would put the ones in between out of reach.
+    ///     Each page is fetched under the retry budget, so a raised failure means the page did not
+    ///     survive <see cref="BaseConnectorConfiguration.MaxRetryAttempts"/> attempts rather than one
+    ///     unlucky moment. See <see cref="BaseConnectorService{TConfig}.FetchFailed"/>.
     /// </remarks>
     private async Task<List<T>> FetchPaginatedAsync<T>(
         string endpoint, DateTime? from, DateTime? to, CancellationToken ct) where T : class
@@ -328,30 +395,11 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         {
             ct.ThrowIfCancellationRequested();
 
-            var url = BuildAbsoluteUrl(BuildPaginatedUrl(endpoint, from, to, _config.MaxCount, offset));
-            var response = await GetWithHeadersAsync(url, _authHeaders, ct);
+            var page = await FetchWithRetryAsync<PaginatedResponse<T>>(
+                BuildPaginatedUrl(endpoint, from, to, _config.MaxCount, offset), endpoint, ct);
 
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogWarning(
-                    "[{ConnectorSource}] Failed to fetch {Endpoint} at offset {Offset}: HTTP {StatusCode}",
-                    ConnectorSource,
-                    endpoint,
-                    offset,
-                    (int)response.StatusCode);
-                throw FetchFailed(endpoint);
-            }
-
-            var page = await DeserializeResponseAsync<PaginatedResponse<T>>(response, ct);
             if (page?.Data == null)
-            {
-                _logger.LogWarning(
-                    "[{ConnectorSource}] Failed to fetch {Endpoint} at offset {Offset}: response carried no page",
-                    ConnectorSource,
-                    endpoint,
-                    offset);
                 throw FetchFailed(endpoint);
-            }
 
             var items = page.Data.ToList();
             if (items.Count == 0)
@@ -389,26 +437,11 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         {
             ct.ThrowIfCancellationRequested();
 
-            var url = BuildAbsoluteUrl(BuildV1DeviceStatusUrl(from, currentTo));
-            var response = await GetWithHeadersAsync(url, _authHeaders, ct);
+            var statuses = await FetchWithRetryAsync<DeviceStatus[]>(
+                BuildV1DeviceStatusUrl(from, currentTo), V1DeviceStatusEndpoint, ct);
 
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogWarning(
-                    "[{ConnectorSource}] Failed to fetch device statuses: HTTP {StatusCode}",
-                    ConnectorSource,
-                    (int)response.StatusCode);
-                throw FetchFailed(V1DeviceStatusEndpoint);
-            }
-
-            var statuses = await DeserializeResponseAsync<DeviceStatus[]>(response, ct);
             if (statuses == null)
-            {
-                _logger.LogWarning(
-                    "[{ConnectorSource}] Failed to fetch device statuses: response carried no records",
-                    ConnectorSource);
                 throw FetchFailed(V1DeviceStatusEndpoint);
-            }
 
             if (statuses.Length == 0)
                 break;

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -113,21 +113,32 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
         // Glucose keeps request.From: the framework derived it from the newest stored glucose
-        // record, so it already is glucose's own cursor. Every other family resolves its own the
-        // same way instead of inheriting that one. Sharing it strands a family that fell behind —
-        // this run's glucose publish moves the shared cursor past the very range a failed crawl
-        // still owes, which is what turns a repairable gap into a permanent one. An explicit range
-        // (request.To set, as a cursor reset sends) is honoured as given.
+        // record, so it already is glucose's own cursor. Every other family widens it with its own
+        // resume point (see ResumeFrom) rather than inheriting it alone. An explicit range
+        // (request.To set, as a cursor reset sends) bypasses the catch-up bounds entirely.
         var openEnded = request.To is null;
-        var treatmentFrom = openEnded && activeTypes.Overlaps(TreatmentFamily)
-            ? await CalculateTreatmentSinceTimestampAsync(config)
-            : request.From;
-        var deviceStatusFrom = openEnded && activeTypes.Contains(SyncDataType.DeviceStatus)
-            ? await CalculateDeviceStatusCatchUpSinceAsync(config) ?? request.From
-            : request.From;
-        var activityFrom = openEnded && activeTypes.Contains(SyncDataType.Activity)
-            ? await CalculateActivityCatchUpSinceAsync(config) ?? request.From
-            : request.From;
+
+        // Resolved at most once per run and awaited inside the loop's error boundary, so a publisher
+        // that cannot answer fails only the families whose bound it was: a faulted task re-throws on
+        // every await, which attributes it to each of them and leaves the rest of the run alone.
+        Task<DateTime?>? treatment = null;
+        Task<DateTime?>? deviceStatus = null;
+        Task<DateTime?>? activity = null;
+
+        // The six types below all land in the v1 treatments collection, so they share one watermark:
+        // its newest record of any of them. They therefore do not resume independently of each
+        // other — a sibling that published in the same run still carries the bound past a range one
+        // of them failed to read. Separating them needs a per-type watermark the publisher does not
+        // expose.
+        Task<DateTime?> TreatmentFromAsync() =>
+            treatment ??= BoundAsync(() => CalculateTreatmentSinceTimestampAsync(config));
+        Task<DateTime?> DeviceStatusFromAsync() =>
+            deviceStatus ??= BoundAsync(() => CalculateDeviceStatusCatchUpSinceAsync(config));
+        Task<DateTime?> ActivityFromAsync() =>
+            activity ??= BoundAsync(() => CalculateActivityCatchUpSinceAsync(config));
+
+        async Task<DateTime?> BoundAsync(Func<Task<DateTime?>> resumePoint) =>
+            openEnded ? ResumeFrom(request.From, await resumePoint()) : request.From;
 
         foreach (var type in activeTypes)
         {
@@ -138,18 +149,18 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
                 await (type switch
                 {
                     SyncDataType.Glucose => SyncSensorGlucoseAsync(request.From, request.To, config, result, activeTypes, cancellationToken),
-                    SyncDataType.ManualBG => SyncBGChecksAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
-                    SyncDataType.Boluses => SyncBolusesAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
-                    SyncDataType.CarbIntake => SyncCarbIntakeAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
-                    SyncDataType.BolusCalculations => SyncBolusCalculationsAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
-                    SyncDataType.Notes => SyncNotesAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
-                    SyncDataType.DeviceEvents => SyncDeviceEventsAsync(treatmentFrom, request.To, config, result, activeTypes, cancellationToken),
-                    // State spans have no resume watermark of their own, so they stay on the
-                    // glucose cursor and keep the exposure described above.
+                    SyncDataType.ManualBG => SyncBGChecksAsync(await TreatmentFromAsync(), request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Boluses => SyncBolusesAsync(await TreatmentFromAsync(), request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.CarbIntake => SyncCarbIntakeAsync(await TreatmentFromAsync(), request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.BolusCalculations => SyncBolusCalculationsAsync(await TreatmentFromAsync(), request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Notes => SyncNotesAsync(await TreatmentFromAsync(), request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.DeviceEvents => SyncDeviceEventsAsync(await TreatmentFromAsync(), request.To, config, result, activeTypes, cancellationToken),
+                    // State spans have no resume watermark to widen with, so they alone still
+                    // resume from wherever the glucose cursor reached.
                     SyncDataType.StateSpans => SyncStateSpansAsync(request.From, request.To, config, result, activeTypes, cancellationToken),
                     SyncDataType.Profiles => SyncProfilesAsync(config, result, activeTypes, cancellationToken),
-                    SyncDataType.DeviceStatus => SyncDeviceStatusAsync(deviceStatusFrom, request.To, config, result, activeTypes, cancellationToken),
-                    SyncDataType.Activity => SyncActivityAsync(activityFrom, request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.DeviceStatus => SyncDeviceStatusAsync(await DeviceStatusFromAsync(), request.To, config, result, activeTypes, cancellationToken),
+                    SyncDataType.Activity => SyncActivityAsync(await ActivityFromAsync(), request.To, config, result, activeTypes, cancellationToken),
                     SyncDataType.Food => SyncFoodAsync(config, result, activeTypes, cancellationToken),
                     _ => Task.CompletedTask
                 });
@@ -167,21 +178,28 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     }
 
     /// <summary>
-    ///     The types whose records all land in the v1 treatments collection, and so all resume from
-    ///     the one watermark <see cref="BaseConnectorService{TConfig}.CalculateTreatmentSinceTimestampAsync"/>
-    ///     reports for this source.
+    ///     The lower bound a family crawls from: whichever of the caller's bound and the family's own
+    ///     resume point reaches further back.
     /// </summary>
     /// <remarks>
-    ///     That watermark is the newest record of any of them, so these six do not resume
-    ///     independently of one another: a sibling that published in the same run still carries the
-    ///     bound past a range one of them failed to read. Separating them needs a per-type watermark
-    ///     the publisher does not expose.
+    ///     Neither may narrow the other. The resume point cannot narrow the caller's bound, because
+    ///     an explicit <c>from</c> with no <c>to</c> is the shape an admin repairing a gap sends, and
+    ///     answering that from the watermark returns nothing and reports it as a success. The
+    ///     caller's bound cannot narrow the resume point either, because on a background catch-up
+    ///     that bound is the glucose watermark, and honouring it alone is what strands the other
+    ///     families behind glucose. A family with no resume point has nothing stored yet, so the
+    ///     caller's bound stands as given — a null one included, which imports the full history.
     /// </remarks>
-    private static readonly SyncDataType[] TreatmentFamily =
-    [
-        SyncDataType.ManualBG, SyncDataType.Boluses, SyncDataType.CarbIntake,
-        SyncDataType.BolusCalculations, SyncDataType.Notes, SyncDataType.DeviceEvents
-    ];
+    private static DateTime? ResumeFrom(DateTime? requested, DateTime? resumePoint)
+    {
+        if (resumePoint is null)
+            return requested;
+
+        if (requested is null)
+            return null;
+
+        return requested < resumePoint ? requested : resumePoint;
+    }
 
     #region V4 Data Type Sync Methods
 
@@ -190,7 +208,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<SensorGlucose>(
-            NocturneRemoteConstants.SensorGlucose, from, to, ct);
+            NocturneRemoteConstants.SensorGlucose, from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
             ImportHelper.PrepareForImport(records), PublishSensorGlucoseDataAsync, config, ct);
@@ -201,7 +219,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<BGCheck>(
-            NocturneRemoteConstants.BGChecks, from, to, ct);
+            NocturneRemoteConstants.BGChecks, from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
             ImportHelper.PrepareForImport(records), PublishBGCheckDataAsync, config, ct);
@@ -212,7 +230,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<Bolus>(
-            NocturneRemoteConstants.Boluses, from, to, ct);
+            NocturneRemoteConstants.Boluses, from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
             ImportHelper.PrepareForImport(records), PublishBolusDataAsync, config, ct);
@@ -223,7 +241,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<CarbIntake>(
-            NocturneRemoteConstants.CarbIntake, from, to, ct);
+            NocturneRemoteConstants.CarbIntake, from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
             ImportHelper.PrepareForImport(records), PublishCarbIntakeDataAsync, config, ct);
@@ -234,7 +252,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<BolusCalculation>(
-            NocturneRemoteConstants.BolusCalculations, from, to, ct);
+            NocturneRemoteConstants.BolusCalculations, from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, activeTypes,
             ImportHelper.PrepareForImport(records), PublishBolusCalculationDataAsync, config, ct);
@@ -245,7 +263,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<Note>(
-            NocturneRemoteConstants.Notes, from, to, ct);
+            NocturneRemoteConstants.Notes, from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Notes, activeTypes,
             ImportHelper.PrepareForImport(records), PublishNoteDataAsync, config, ct);
@@ -256,7 +274,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<DeviceEvent>(
-            NocturneRemoteConstants.DeviceEvents, from, to, ct);
+            NocturneRemoteConstants.DeviceEvents, from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
             ImportHelper.PrepareForImport(records), PublishDeviceEventDataAsync, config, ct);
@@ -271,7 +289,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<StateSpan>(
-            NocturneRemoteConstants.StateSpans, from, to, ct);
+            NocturneRemoteConstants.StateSpans, from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
             records, PublishStateSpanDataAsync, config, ct);
@@ -282,7 +300,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<Profile>(
-            NocturneRemoteConstants.ProfileRecords, null, null, ct);
+            NocturneRemoteConstants.ProfileRecords, null, null, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
             records, PublishProfileDataAsync, config, ct);
@@ -294,7 +312,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     {
         // DeviceStatus uses the v1 API because the publisher only supports the legacy model.
         // The remote instance exposes v1 compatibility endpoints.
-        var records = await FetchV1DeviceStatusAsync(from, to, ct);
+        var records = await FetchV1DeviceStatusAsync(from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, activeTypes,
             records, PublishDeviceStatusAsync, config, ct);
@@ -305,7 +323,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         var records = await FetchPaginatedAsync<Activity>(
-            NocturneRemoteConstants.Activity, from, to, ct);
+            NocturneRemoteConstants.Activity, from, to, config, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Activity, activeTypes,
             records, PublishActivityDataAsync, config, ct);
@@ -316,12 +334,9 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
         // Foods endpoint returns a flat array, not PaginatedResponse
-        var foods = await FetchWithRetryAsync<Food[]>(
-            $"{NocturneRemoteConstants.Foods}?count={_config.MaxCount}",
-            NocturneRemoteConstants.Foods, ct);
-
-        if (foods == null)
-            throw FetchFailed(NocturneRemoteConstants.Foods);
+        var foods = await FetchOrFailAsync<Food[]>(
+            $"{NocturneRemoteConstants.Foods}?count={config.MaxCount}",
+            NocturneRemoteConstants.Foods, config, ct);
 
         // Food carries no per-record time, so no timestamp selector is supplied.
         await PublishRecordTypeAsync(result, SyncDataType.Food, activeTypes,
@@ -333,39 +348,70 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     #region Fetch Helpers
 
     /// <summary>
-    ///     One request to the remote instance under the connector retry budget, answering
-    ///     <c>null</c> when it did not survive it. Callers turn that into
-    ///     <see cref="BaseConnectorService{TConfig}.FetchFailed"/>; the two steps are separate
-    ///     because only the caller knows what the missing payload was for.
+    ///     One payload from the remote instance, fetched under the tenant's retry budget, raising
+    ///     <see cref="BaseConnectorService{TConfig}.FetchFailed"/> rather than answering with nothing.
     /// </summary>
     /// <remarks>
-    ///     Mirrors the Nightscout connector's fetch layer so both crawls raise on the same
-    ///     condition: a transient status is retried, and a status the remote will keep returning,
-    ///     an unparseable body, or an exhausted budget all report the same <c>null</c>.
+    ///     Mirrors the Nightscout connector's fetch layer so both crawls give up on the same
+    ///     condition. A transient status is retried; a status the remote keeps returning and a body
+    ///     that will not parse are reported as no payload, which becomes the raised failure here. An
+    ///     exhausted budget does not reach that point — the retry loop re-throws the last transient
+    ///     exception, which already names the status.
     /// </remarks>
-    private Task<T?> FetchWithRetryAsync<T>(string relativeUrl, string operationName, CancellationToken ct)
-        where T : class =>
-        ExecuteWithRetryAsync(
-            async () => await FetchCoreAsync<T>(relativeUrl, ct),
+    private async Task<T> FetchOrFailAsync<T>(
+        string relativeUrl,
+        string operationName,
+        NocturneRemoteConnectorConfiguration config,
+        CancellationToken ct) where T : class
+    {
+        // Captured rather than logged alone, because the tenant reads the sync card and not the
+        // connector logs, and a refused scope is the failure they can actually act on.
+        string? refusal = null;
+
+        var payload = await ExecuteWithRetryAsync(
+            async () =>
+            {
+                var response = await GetWithHeadersAsync(BuildAbsoluteUrl(relativeUrl), _authHeaders, ct);
+
+                if (response.IsSuccessStatusCode)
+                    return await DeserializeResponseAsync<T>(response, ct);
+
+                refusal = $"HTTP {(int)response.StatusCode} {response.StatusCode}";
+                throw new HttpRequestException(
+                    $"{refusal}: {await ReadFailureBodyAsync(response, config, ct)}",
+                    null,
+                    response.StatusCode);
+            },
             _retryDelayStrategy,
-            maxRetries: _config.MaxRetryAttempts,
+            maxRetries: config.MaxRetryAttempts,
             operationName: operationName,
             cancellationToken: ct);
 
-    private async Task<T?> FetchCoreAsync<T>(string relativeUrl, CancellationToken ct) where T : class
+        return payload ?? throw FetchFailed(operationName, refusal);
+    }
+
+    /// <summary>
+    ///     As much of a failed response's body as is worth quoting back to the tenant.
+    /// </summary>
+    /// <remarks>
+    ///     The body ends up in the connector's last-error message and its logs, and the remote is the
+    ///     tenant's own instance behind their own proxy — an error page that echoes the request would
+    ///     otherwise put the bearer token there. The token is removed and the rest is clamped, since
+    ///     what identifies the failure is at the front of the body.
+    /// </remarks>
+    private static async Task<string> ReadFailureBodyAsync(
+        HttpResponseMessage response,
+        NocturneRemoteConnectorConfiguration config,
+        CancellationToken ct)
     {
-        var response = await GetWithHeadersAsync(BuildAbsoluteUrl(relativeUrl), _authHeaders, ct);
+        const int maxQuotedBody = 200;
 
-        if (!response.IsSuccessStatusCode)
-        {
-            var body = await response.Content.ReadAsStringAsync(ct);
-            throw new HttpRequestException(
-                $"HTTP {(int)response.StatusCode} {response.StatusCode}: {body}",
-                null,
-                response.StatusCode);
-        }
+        var body = await response.Content.ReadAsStringAsync(ct);
 
-        return await DeserializeResponseAsync<T>(response, ct);
+        if (!string.IsNullOrEmpty(config.Token))
+            body = body.Replace(config.Token, "[redacted]", StringComparison.Ordinal);
+
+        return body.Length <= maxQuotedBody ? body : body[..maxQuotedBody] + "...";
     }
 
     #endregion
@@ -386,7 +432,8 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     ///     unlucky moment. See <see cref="BaseConnectorService{TConfig}.FetchFailed"/>.
     /// </remarks>
     private async Task<List<T>> FetchPaginatedAsync<T>(
-        string endpoint, DateTime? from, DateTime? to, CancellationToken ct) where T : class
+        string endpoint, DateTime? from, DateTime? to,
+        NocturneRemoteConnectorConfiguration config, CancellationToken ct) where T : class
     {
         var all = new List<T>();
         var offset = 0;
@@ -395,11 +442,13 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         {
             ct.ThrowIfCancellationRequested();
 
-            var page = await FetchWithRetryAsync<PaginatedResponse<T>>(
-                BuildPaginatedUrl(endpoint, from, to, _config.MaxCount, offset), endpoint, ct);
+            var page = await FetchOrFailAsync<PaginatedResponse<T>>(
+                BuildPaginatedUrl(endpoint, from, to, config.MaxCount, offset), endpoint, config, ct);
 
-            if (page?.Data == null)
-                throw FetchFailed(endpoint);
+            // An envelope that parses supplies an empty page rather than a null one, so this is a
+            // remote answering with the envelope and no page in it.
+            if (page.Data == null)
+                throw FetchFailed(endpoint, "response carried no page");
 
             var items = page.Data.ToList();
             if (items.Count == 0)
@@ -407,7 +456,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
             all.AddRange(items);
 
-            if (all.Count >= page.Pagination.Total || items.Count < _config.MaxCount)
+            if (all.Count >= page.Pagination.Total || items.Count < config.MaxCount)
                 break;
 
             offset += items.Count;
@@ -428,7 +477,8 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     /// <remarks>A page that never arrives costs the range, for the reason given on
     /// <see cref="FetchPaginatedAsync{T}"/>.</remarks>
     private async Task<List<DeviceStatus>> FetchV1DeviceStatusAsync(
-        DateTime? from, DateTime? to, CancellationToken ct)
+        DateTime? from, DateTime? to,
+        NocturneRemoteConnectorConfiguration config, CancellationToken ct)
     {
         var allStatuses = new List<DeviceStatus>();
         var currentTo = to;
@@ -437,18 +487,15 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         {
             ct.ThrowIfCancellationRequested();
 
-            var statuses = await FetchWithRetryAsync<DeviceStatus[]>(
-                BuildV1DeviceStatusUrl(from, currentTo), V1DeviceStatusEndpoint, ct);
-
-            if (statuses == null)
-                throw FetchFailed(V1DeviceStatusEndpoint);
+            var statuses = await FetchOrFailAsync<DeviceStatus[]>(
+                BuildV1DeviceStatusUrl(from, currentTo, config), V1DeviceStatusEndpoint, config, ct);
 
             if (statuses.Length == 0)
                 break;
 
             allStatuses.AddRange(statuses);
 
-            if (statuses.Length < _config.MaxCount)
+            if (statuses.Length < config.MaxCount)
                 break;
 
             var oldestDate = statuses
@@ -496,9 +543,10 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
     private const string V1DeviceStatusEndpoint = "/api/v1/devicestatus.json";
 
-    private string BuildV1DeviceStatusUrl(DateTime? from, DateTime? to)
+    private static string BuildV1DeviceStatusUrl(
+        DateTime? from, DateTime? to, NocturneRemoteConnectorConfiguration config)
     {
-        var url = $"{V1DeviceStatusEndpoint}?count={_config.MaxCount}";
+        var url = $"{V1DeviceStatusEndpoint}?count={config.MaxCount}";
 
         if (from.HasValue)
             url += $"&find[created_at][$gte]={from.Value.ToUniversalTime():o}";

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -150,7 +150,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedV4Async<SensorGlucose>(
+        var records = await FetchPaginatedAsync<SensorGlucose>(
             NocturneRemoteConstants.SensorGlucose, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
@@ -161,7 +161,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedV4Async<BGCheck>(
+        var records = await FetchPaginatedAsync<BGCheck>(
             NocturneRemoteConstants.BGChecks, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.ManualBG, activeTypes,
@@ -172,7 +172,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedV4Async<Bolus>(
+        var records = await FetchPaginatedAsync<Bolus>(
             NocturneRemoteConstants.Boluses, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
@@ -183,7 +183,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedV4Async<CarbIntake>(
+        var records = await FetchPaginatedAsync<CarbIntake>(
             NocturneRemoteConstants.CarbIntake, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
@@ -194,7 +194,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedV4Async<BolusCalculation>(
+        var records = await FetchPaginatedAsync<BolusCalculation>(
             NocturneRemoteConstants.BolusCalculations, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, activeTypes,
@@ -205,7 +205,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedV4Async<Note>(
+        var records = await FetchPaginatedAsync<Note>(
             NocturneRemoteConstants.Notes, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Notes, activeTypes,
@@ -216,7 +216,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedV4Async<DeviceEvent>(
+        var records = await FetchPaginatedAsync<DeviceEvent>(
             NocturneRemoteConstants.DeviceEvents, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
@@ -231,7 +231,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedLegacyAsync<StateSpan>(
+        var records = await FetchPaginatedAsync<StateSpan>(
             NocturneRemoteConstants.StateSpans, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
@@ -242,7 +242,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedLegacyAsync<Profile>(
+        var records = await FetchPaginatedAsync<Profile>(
             NocturneRemoteConstants.ProfileRecords, null, null, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Profiles, activeTypes,
@@ -265,7 +265,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         SyncRequest request, NocturneRemoteConnectorConfiguration config, SyncResult result,
         HashSet<SyncDataType> activeTypes, CancellationToken ct)
     {
-        var records = await FetchPaginatedLegacyAsync<Activity>(
+        var records = await FetchPaginatedAsync<Activity>(
             NocturneRemoteConstants.Activity, request.From, request.To, ct);
 
         await PublishRecordTypeAsync(result, SyncDataType.Activity, activeTypes,
@@ -286,14 +286,21 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
                 "[{ConnectorSource}] Failed to fetch foods: HTTP {StatusCode}",
                 ConnectorSource,
                 (int)response.StatusCode);
-            return;
+            throw FetchFailed(NocturneRemoteConstants.Foods);
         }
 
         var foods = await DeserializeResponseAsync<Food[]>(response, ct);
+        if (foods == null)
+        {
+            _logger.LogWarning(
+                "[{ConnectorSource}] Failed to fetch foods: response carried no records",
+                ConnectorSource);
+            throw FetchFailed(NocturneRemoteConstants.Foods);
+        }
 
         // Food carries no per-record time, so no timestamp selector is supplied.
         await PublishRecordTypeAsync(result, SyncDataType.Food, activeTypes,
-            foods?.ToList() ?? [], PublishFoodDataAsync, config, ct);
+            foods.ToList(), PublishFoodDataAsync, config, ct);
     }
 
     #endregion
@@ -301,61 +308,17 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     #region Pagination Helpers
 
     /// <summary>
-    ///     Fetches all pages of V4 records from a paginated endpoint.
+    ///     Fetches every page of a V4 paginated endpoint. <typeparamref name="T"/> spans both the V4
+    ///     records and the legacy models the publishers still take, which page identically.
     /// </summary>
-    private async Task<List<T>> FetchPaginatedV4Async<T>(
-        string endpoint, DateTime? from, DateTime? to, CancellationToken ct) where T : IV4Record
-    {
-        var all = new List<T>();
-        var offset = 0;
-
-        while (true)
-        {
-            ct.ThrowIfCancellationRequested();
-
-            var url = BuildAbsoluteUrl(BuildPaginatedUrl(endpoint, from, to, _config.MaxCount, offset));
-            var response = await GetWithHeadersAsync(url, _authHeaders, ct);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogWarning(
-                    "[{ConnectorSource}] Failed to fetch {Endpoint}: HTTP {StatusCode}",
-                    ConnectorSource,
-                    endpoint,
-                    (int)response.StatusCode);
-                break;
-            }
-
-            var page = await DeserializeResponseAsync<PaginatedResponse<T>>(response, ct);
-            if (page?.Data == null)
-                break;
-
-            var items = page.Data.ToList();
-            if (items.Count == 0)
-                break;
-
-            all.AddRange(items);
-
-            // Stop if we've fetched all records or got a partial page
-            if (all.Count >= page.Pagination.Total || items.Count < _config.MaxCount)
-                break;
-
-            offset += items.Count;
-        }
-
-        _logger.LogInformation(
-            "[{ConnectorSource}] Fetched {Count} {Type} records from remote",
-            ConnectorSource,
-            all.Count,
-            typeof(T).Name);
-
-        return all;
-    }
-
-    /// <summary>
-    ///     Fetches all pages of legacy model records from a V4 paginated endpoint.
-    /// </summary>
-    private async Task<List<T>> FetchPaginatedLegacyAsync<T>(
+    /// <remarks>
+    ///     The crawl accumulates the whole range before its caller publishes any of it, so a page
+    ///     that never arrives costs the range rather than truncating it: pages arrive newest-first
+    ///     and the next sync's lower bound is derived from the newest record stored locally, so
+    ///     publishing the pages either side of a failure would put the ones in between permanently
+    ///     out of reach. See <see cref="BaseConnectorService{TConfig}.FetchFailed"/>.
+    /// </remarks>
+    private async Task<List<T>> FetchPaginatedAsync<T>(
         string endpoint, DateTime? from, DateTime? to, CancellationToken ct) where T : class
     {
         var all = new List<T>();
@@ -371,16 +334,24 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning(
-                    "[{ConnectorSource}] Failed to fetch {Endpoint}: HTTP {StatusCode}",
+                    "[{ConnectorSource}] Failed to fetch {Endpoint} at offset {Offset}: HTTP {StatusCode}",
                     ConnectorSource,
                     endpoint,
+                    offset,
                     (int)response.StatusCode);
-                break;
+                throw FetchFailed(endpoint);
             }
 
             var page = await DeserializeResponseAsync<PaginatedResponse<T>>(response, ct);
             if (page?.Data == null)
-                break;
+            {
+                _logger.LogWarning(
+                    "[{ConnectorSource}] Failed to fetch {Endpoint} at offset {Offset}: response carried no page",
+                    ConnectorSource,
+                    endpoint,
+                    offset);
+                throw FetchFailed(endpoint);
+            }
 
             var items = page.Data.ToList();
             if (items.Count == 0)
@@ -406,6 +377,8 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     /// <summary>
     ///     Fetches legacy DeviceStatus records from the v1 API of the remote instance.
     /// </summary>
+    /// <remarks>A page that never arrives costs the range, for the reason given on
+    /// <see cref="FetchPaginatedAsync{T}"/>.</remarks>
     private async Task<List<DeviceStatus>> FetchV1DeviceStatusAsync(
         DateTime? from, DateTime? to, CancellationToken ct)
     {
@@ -425,11 +398,19 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
                     "[{ConnectorSource}] Failed to fetch device statuses: HTTP {StatusCode}",
                     ConnectorSource,
                     (int)response.StatusCode);
-                break;
+                throw FetchFailed(V1DeviceStatusEndpoint);
             }
 
             var statuses = await DeserializeResponseAsync<DeviceStatus[]>(response, ct);
-            if (statuses == null || statuses.Length == 0)
+            if (statuses == null)
+            {
+                _logger.LogWarning(
+                    "[{ConnectorSource}] Failed to fetch device statuses: response carried no records",
+                    ConnectorSource);
+                throw FetchFailed(V1DeviceStatusEndpoint);
+            }
+
+            if (statuses.Length == 0)
                 break;
 
             allStatuses.AddRange(statuses);
@@ -480,9 +461,11 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         return url;
     }
 
+    private const string V1DeviceStatusEndpoint = "/api/v1/devicestatus.json";
+
     private string BuildV1DeviceStatusUrl(DateTime? from, DateTime? to)
     {
-        var url = $"/api/v1/devicestatus.json?count={_config.MaxCount}";
+        var url = $"{V1DeviceStatusEndpoint}?count={_config.MaxCount}";
 
         if (from.HasValue)
             url += $"&find[created_at][$gte]={from.Value.ToUniversalTime():o}";

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
@@ -23,6 +23,7 @@ public class NocturneRemoteBackgroundSyncAuthTests
             new ConnectorServerResolver<NocturneRemoteConnectorConfiguration>(null, null, null),
             Mock.Of<ILogger<NocturneRemoteConnectorService>>(),
             new ConnectorRegistration<NocturneRemoteConnectorConfiguration>(startupDefaults, "NocturneRemote"),
+            Mock.Of<IRetryDelayStrategy>(),
             publisher: null);
     }
 

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Nocturne.Connectors.NocturneRemote.Tests.csproj
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Nocturne.Connectors.NocturneRemote.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Moq" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Connectors/Nocturne.Connectors.NocturneRemote/Nocturne.Connectors.NocturneRemote.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
@@ -7,6 +7,7 @@ using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.NocturneRemote.Configurations;
 using Nocturne.Connectors.NocturneRemote.Services;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models.V4;
 using Xunit;
@@ -18,7 +19,7 @@ public class NocturneRemoteConnectorServiceCrawlTests
     /// <summary>
     /// A page that never arrives is not the end of the range. Ending the crawl there publishes the
     /// newest pages and reports a green sync, and because the next lower bound is derived from the
-    /// newest record now stored locally, the pages below the failure are never asked for again.
+    /// newest record then stored locally, the pages below the failure are never asked for again.
     /// </summary>
     [Fact]
     public async Task SyncDataAsync_WhenAPageMidCrawlIsRejected_FailsTheRunAndPublishesNothing()
@@ -54,6 +55,31 @@ public class NocturneRemoteConnectorServiceCrawlTests
             .Serve(NocturneRemoteConstants.SensorGlucose,
                 RemoteFakeHandler.GlucosePage(total: 6, "2026-01-03T08:00:00Z", "2026-01-03T08:05:00Z"),
                 RemoteFakeHandler.Json("""{"data":null,"pagination":{"limit":2,"offset":2,"total":6}}"""));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ItemsSynced.Should().BeEmpty();
+        fixture.PublishedGlucose.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A body that will not parse — a captive portal's HTML, a truncated response — reaches the
+    /// crawl as an exception rather than a null, and has to reach the same conclusion. This is the
+    /// route by which most "carried no page" failures actually arrive: an envelope that parses at
+    /// all supplies an empty <c>Data</c> rather than a null one.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAPageIsUnparseable_FailsTheRunAndPublishesNothing()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose,
+                RemoteFakeHandler.GlucosePage(total: 6, "2026-01-03T08:00:00Z", "2026-01-03T08:05:00Z"),
+                RemoteFakeHandler.Json("<html>upstream is down</html>"));
         var fixture = new ServiceFixture(handler);
 
         var result = await fixture.Service.SyncDataAsync(
@@ -117,16 +143,50 @@ public class NocturneRemoteConnectorServiceCrawlTests
     }
 
     /// <summary>
+    /// Discarding the range is only the right trade because the page was asked for until the retry
+    /// budget ran out. Failing on one unlucky 502 would leave a remote with ordinary page-level
+    /// flakiness permanently red and syncing nothing for that type — worse than the truncation this
+    /// change exists to remove.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenATransientFailureClearsWithinTheRetryBudget_CompletesTheCrawl()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose,
+                RemoteFakeHandler.GlucosePage(total: 3, "2026-01-03T08:00:00Z", "2026-01-03T08:05:00Z"),
+                RemoteFakeHandler.Status(HttpStatusCode.BadGateway),
+                RemoteFakeHandler.Status(HttpStatusCode.ServiceUnavailable),
+                RemoteFakeHandler.GlucosePage(total: 3, "2026-01-03T08:10:00Z"));
+        var fixture = new ServiceFixture(handler, config: NewConfig(maxRetryAttempts: 3));
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue("the page arrived within the attempt budget");
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Glucose] = 3,
+        });
+        fixture.PublishedGlucose.Should().HaveCount(3);
+    }
+
+    /// <summary>
     /// Each data type crawls its own endpoint, so one endpoint failing must cost only that type. A
     /// failed run withholds the connector's last-successful-sync stamp and shows the tenant a red
-    /// connector, which has to name what actually broke.
+    /// connector, which has to name what actually broke. The glucose crawl fails on its second page,
+    /// so the failure is reached past the auth probe rather than by it.
     /// </summary>
     [Fact]
     public async Task SyncDataAsync_WhenOneTypesCrawlFails_LeavesTheOtherTypeSynced()
     {
         var handler = new RemoteFakeHandler()
-            .Serve(NocturneRemoteConstants.SensorGlucose, RemoteFakeHandler.Status(HttpStatusCode.BadGateway))
-            .Serve(NocturneRemoteConstants.Boluses, RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
+            .Serve(NocturneRemoteConstants.SensorGlucose,
+                RemoteFakeHandler.GlucosePage(total: 6, "2026-01-03T08:00:00Z", "2026-01-03T08:05:00Z"),
+                RemoteFakeHandler.Status(HttpStatusCode.BadGateway))
+            .Serve(NocturneRemoteConstants.Boluses,
+                RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
         var fixture = new ServiceFixture(handler);
 
         var result = await fixture.Service.SyncDataAsync(
@@ -146,18 +206,22 @@ public class NocturneRemoteConnectorServiceCrawlTests
 
     /// <summary>
     /// A type the tenant switched off is never crawled, so a remote that rejects its endpoint cannot
-    /// mark the connector red while everything the tenant enabled synced.
+    /// mark the connector red while everything the tenant enabled synced. Activity rather than
+    /// glucose, because the auth probe reads the glucose endpoint and fails the whole run before the
+    /// per-type gate is reached — see
+    /// <see cref="SyncDataAsync_WhenTheGlucoseEndpointIsBroken_FailsBeforeAnyTypeIsConsidered"/>.
     /// </summary>
     [Fact]
-    public async Task SyncDataAsync_WhenASwitchedOffTypesEndpointWouldFail_ReportsSuccess()
+    public async Task SyncDataAsync_WhenASwitchedOffTypesEndpointIsBroken_ReportsSuccess()
     {
         var handler = new RemoteFakeHandler()
-            .Serve(NocturneRemoteConstants.SensorGlucose, RemoteFakeHandler.Status(HttpStatusCode.BadGateway))
-            .Serve(NocturneRemoteConstants.Boluses, RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
-        var fixture = new ServiceFixture(handler, config: NewConfig(syncGlucose: false));
+            .Break(NocturneRemoteConstants.Activity, HttpStatusCode.BadGateway)
+            .Serve(NocturneRemoteConstants.Boluses,
+                RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
+        var fixture = new ServiceFixture(handler, config: NewConfig(syncActivity: false));
 
         var result = await fixture.Service.SyncDataAsync(
-            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses] },
+            new SyncRequest { DataTypes = [SyncDataType.Activity, SyncDataType.Boluses] },
             fixture.Config,
             CancellationToken.None);
 
@@ -167,14 +231,198 @@ public class NocturneRemoteConnectorServiceCrawlTests
         {
             [SyncDataType.Boluses] = 1,
         });
+        handler.Requests.Should().NotContain(url => url.Contains(NocturneRemoteConstants.Activity),
+            "a switched-off type is not crawled at all, which is why its endpoint cannot fail the run");
     }
 
-    private static NocturneRemoteConnectorConfiguration NewConfig(bool syncGlucose = true) => new()
+    /// <summary>
+    /// Characterises a limitation this change does not remove, so it is not mistaken for a property
+    /// the connector has. <c>AuthenticateWithConfigAsync</c> probes the sensor-glucose endpoint on
+    /// every run whatever the tenant enabled, and a rejected probe fails the run before any type is
+    /// considered. So a remote whose glucose endpoint alone is broken — or a grant without
+    /// <c>glucose.read</c> — costs the tenant every other type too, and is reported as a credential
+    /// problem. Per-type scoping begins after this gate, not before it.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheGlucoseEndpointIsBroken_FailsBeforeAnyTypeIsConsidered()
+    {
+        var handler = new RemoteFakeHandler()
+            .Break(NocturneRemoteConstants.SensorGlucose, HttpStatusCode.BadGateway)
+            .Serve(NocturneRemoteConstants.Boluses,
+                RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
+        var fixture = new ServiceFixture(handler, config: NewConfig(syncGlucose: false));
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Be("Authentication failed");
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Be($"Authentication failed for {DataSources.NocturneRemoteConnector}");
+        handler.Requests.Should().NotContain(url => url.Contains(NocturneRemoteConstants.Boluses),
+            "the probe fails the run before the enabled types are reached");
+    }
+
+    /// <summary>
+    /// Foods are a single flat fetch rather than a crawl, and used to answer a rejection with an
+    /// empty list — which <c>RecordPublishOutcome</c> records as a confident zero, telling the
+    /// tenant in green that the remote was reached and had no foods.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheFoodsFetchIsRejected_FailsTheRunAndRecordsNoCount()
+    {
+        var handler = new RemoteFakeHandler().Break(NocturneRemoteConstants.Foods, HttpStatusCode.Forbidden);
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Food] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().StartWith($"Failed to sync {SyncDataType.Food}");
+        result.ItemsSynced.Should().BeEmpty(
+            "a rejected fetch never reached the remote, so it cannot report that there were no foods");
+    }
+
+    /// <summary>The foods equivalent of an exhausted range: a remote with no foods is still a success.</summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheRemoteHasNoFoods_ReportsAnExplicitZero()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.Foods, RemoteFakeHandler.Json("[]"));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Food] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Food] = 0,
+        });
+    }
+
+    /// <summary>
+    /// Device status crawls the remote's v1 endpoint on a time cursor rather than an offset, and
+    /// carried the same swallow — worse, it read a rejected page and a range with nothing left in it
+    /// through one condition. A grant the remote will keep refusing is not retried, so it arrives as
+    /// the empty result the walk backwards through history used to stop on.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheDeviceStatusCrawlIsRejectedMidRange_FailsTheRun()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(RemoteFakeHandler.V1DeviceStatus,
+                RemoteFakeHandler.DeviceStatusPage("2026-01-03T08:05:00Z", "2026-01-03T08:00:00Z"),
+                RemoteFakeHandler.Status(HttpStatusCode.Forbidden));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.DeviceStatus] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().StartWith($"Failed to sync {SyncDataType.DeviceStatus}");
+        result.ItemsSynced.Should().BeEmpty();
+    }
+
+    /// <summary>A remote with no device statuses in range answers an empty array, and that succeeds.</summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheRemoteHasNoDeviceStatuses_ReportsAnExplicitZero()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(RemoteFakeHandler.V1DeviceStatus, RemoteFakeHandler.Json("[]"));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.DeviceStatus] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.DeviceStatus] = 0,
+        });
+    }
+
+    /// <summary>
+    /// On an open-ended catch-up each family asks for its own range. Sharing the glucose-derived
+    /// bound strands every other family: this run's glucose publish moves that bound past the range
+    /// a failed treatment crawl still owes, so the gap it left cannot be repaired next cycle.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenOpenEnded_AsksEachFamilyForItsOwnRange()
+    {
+        var latestTreatment = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var glucoseFrom = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new RemoteFakeHandler();
+        var fixture = new ServiceFixture(handler, latestTreatment: latestTreatment);
+
+        await fixture.Service.SyncDataAsync(
+            new SyncRequest
+            {
+                From = glucoseFrom,
+                To = null,
+                DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses],
+            },
+            fixture.Config,
+            CancellationToken.None);
+
+        handler.CrawlOf(NocturneRemoteConstants.SensorGlucose).Should()
+            .Contain($"from={glucoseFrom:o}");
+        handler.CrawlOf(NocturneRemoteConstants.Boluses).Should()
+            .Contain($"from={latestTreatment.AddMinutes(-5):o}",
+                "the treatment family resumes from its own newest stored record, not glucose's");
+    }
+
+    /// <summary>
+    /// An explicit range is honoured as given for every family — that is how a cursor reset re-pulls
+    /// history the per-family catch-up bounds would otherwise skip.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenGivenAnExplicitRange_AsksEveryFamilyForIt()
+    {
+        var from = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new RemoteFakeHandler();
+        var fixture = new ServiceFixture(
+            handler, latestTreatment: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        await fixture.Service.SyncDataAsync(
+            new SyncRequest
+            {
+                From = from,
+                To = new DateTime(2026, 6, 2, 0, 0, 0, DateTimeKind.Utc),
+                DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses],
+            },
+            fixture.Config,
+            CancellationToken.None);
+
+        handler.CrawlOf(NocturneRemoteConstants.SensorGlucose).Should().Contain($"from={from:o}");
+        handler.CrawlOf(NocturneRemoteConstants.Boluses).Should().Contain($"from={from:o}");
+    }
+
+    private static NocturneRemoteConnectorConfiguration NewConfig(
+        bool syncGlucose = true,
+        bool syncActivity = true,
+        int maxRetryAttempts = 1) => new()
     {
         Url = RemoteFakeHandler.BaseUrl,
         Token = "direct-grant-token",
         MaxCount = RemoteFakeHandler.PageSize,
+        // One attempt unless a test is about the budget, so each scripted response answers exactly
+        // one request and a crawl script reads in the order the crawl makes them.
+        MaxRetryAttempts = maxRetryAttempts,
         SyncGlucose = syncGlucose,
+        SyncActivity = syncActivity,
     };
 
     /// <summary>Wires the connector service and a recording publisher onto one fake handler.</summary>
@@ -187,7 +435,8 @@ public class NocturneRemoteConnectorServiceCrawlTests
 
         internal ServiceFixture(
             RemoteFakeHandler handler,
-            NocturneRemoteConnectorConfiguration? config = null)
+            NocturneRemoteConnectorConfiguration? config = null,
+            DateTime? latestTreatment = null)
         {
             Config = config ?? NewConfig();
 
@@ -201,6 +450,10 @@ public class NocturneRemoteConnectorServiceCrawlTests
                 .ReturnsAsync(true);
 
             var treatments = new Mock<ITreatmentPublisher>();
+            treatments
+                .Setup(p => p.GetLatestTreatmentTimestampAsync(
+                    It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(latestTreatment);
             treatments
                 .Setup(p => p.PublishBolusesAsync(
                     It.IsAny<IEnumerable<Bolus>>(), It.IsAny<string>(),
@@ -224,27 +477,50 @@ public class NocturneRemoteConnectorServiceCrawlTests
                 Mock.Of<IConnectorServerResolver<NocturneRemoteConnectorConfiguration>>(),
                 NullLogger<NocturneRemoteConnectorService>.Instance,
                 registration.Object,
+                Mock.Of<IRetryDelayStrategy>(),
                 publisher.Object);
         }
     }
 
     /// <summary>
-    /// Serves the remote instance's V4 paginated endpoints, one scripted response per page in the
-    /// order the crawl asks for them. The auth probe carries no offset, so it is answered separately
-    /// and a rejected data endpoint does not read as a rejected credential.
+    /// Serves the remote instance's endpoints, one scripted response per request in the order the
+    /// connector makes them.
     /// </summary>
+    /// <remarks>
+    /// <see cref="Break"/> models an endpoint that is down and answers every request to it — the
+    /// auth probe included, because the probe reads the sensor-glucose endpoint like any other
+    /// caller. <see cref="Serve"/> models the responses to successive pages of a working endpoint,
+    /// which the probe is deliberately not served from: it asks for one record before the crawl
+    /// starts, so letting it consume the crawl's first page would misdescribe every script.
+    /// </remarks>
     private sealed class RemoteFakeHandler : HttpMessageHandler
     {
         internal const string BaseUrl = "https://remote.example";
+        internal const string V1DeviceStatus = "/api/v1/devicestatus.json";
 
         /// <summary>Page size the fixture configures, small enough to script a multi-page crawl.</summary>
         internal const int PageSize = 2;
 
         private readonly Dictionary<string, Queue<HttpResponseMessage>> _pages = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, HttpStatusCode> _broken = new(StringComparer.Ordinal);
+
+        /// <summary>Every request made, so a test can assert on the range each crawl asked for.</summary>
+        internal List<string> Requests { get; } = [];
 
         internal RemoteFakeHandler Serve(string path, params HttpResponseMessage[] responses)
         {
             _pages[path] = new Queue<HttpResponseMessage>(responses);
+            return this;
+        }
+
+        /// <summary>The first crawl request made to <paramref name="path"/>, excluding the auth probe.</summary>
+        internal string CrawlOf(string path) =>
+            Requests.First(u => u.Contains(path, StringComparison.Ordinal)
+                                && u.Contains("offset=", StringComparison.Ordinal));
+
+        internal RemoteFakeHandler Break(string path, HttpStatusCode status)
+        {
+            _broken[path] = status;
             return this;
         }
 
@@ -261,6 +537,10 @@ public class NocturneRemoteConnectorServiceCrawlTests
             Page(total, timestamps.Select(t =>
                 $$"""{"id":"{{Guid.NewGuid()}}","timestamp":"{{t}}","insulin":1.5}"""));
 
+        internal static HttpResponseMessage DeviceStatusPage(params string[] createdAt) =>
+            Json("[" + string.Join(",", createdAt.Select(t =>
+                $$"""{"_id":"{{Guid.NewGuid()}}","created_at":"{{t}}"}""")) + "]");
+
         private static HttpResponseMessage Page(int total, IEnumerable<string> records) =>
             Json("{\"data\":[" + string.Join(",", records)
                  + "],\"pagination\":{\"limit\":" + PageSize
@@ -270,14 +550,25 @@ public class NocturneRemoteConnectorServiceCrawlTests
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var path = request.RequestUri!.AbsolutePath;
+            Requests.Add(request.RequestUri.ToString());
 
-            if (!request.RequestUri.Query.Contains("offset=", StringComparison.Ordinal))
+            if (_broken.TryGetValue(path, out var status))
+                return Task.FromResult(Status(status));
+
+            if (IsAuthProbe(request))
                 return Task.FromResult(GlucosePage(total: 0));
 
             if (_pages.TryGetValue(path, out var queue) && queue.Count > 0)
                 return Task.FromResult(queue.Dequeue());
 
-            return Task.FromResult(GlucosePage(total: 0));
+            return Task.FromResult(
+                path == V1DeviceStatus || path == NocturneRemoteConstants.Foods
+                    ? Json("[]")
+                    : GlucosePage(total: 0));
         }
+
+        private static bool IsAuthProbe(HttpRequestMessage request) =>
+            request.RequestUri!.AbsolutePath == NocturneRemoteConstants.SensorGlucose
+            && !request.RequestUri.Query.Contains("offset=", StringComparison.Ordinal);
     }
 }

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
@@ -1,0 +1,283 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.NocturneRemote.Configurations;
+using Nocturne.Connectors.NocturneRemote.Services;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Connectors.NocturneRemote.Tests.Services;
+
+public class NocturneRemoteConnectorServiceCrawlTests
+{
+    /// <summary>
+    /// A page that never arrives is not the end of the range. Ending the crawl there publishes the
+    /// newest pages and reports a green sync, and because the next lower bound is derived from the
+    /// newest record now stored locally, the pages below the failure are never asked for again.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAPageMidCrawlIsRejected_FailsTheRunAndPublishesNothing()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose,
+                RemoteFakeHandler.GlucosePage(total: 6, "2026-01-03T08:00:00Z", "2026-01-03T08:05:00Z"),
+                RemoteFakeHandler.Status(HttpStatusCode.BadGateway));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse("a crawl that lost a page has not synced the range");
+        result.Errors.Should().ContainSingle()
+            .Which.Should().StartWith($"Failed to sync {SyncDataType.Glucose}");
+        result.ItemsSynced.Should().BeEmpty(
+            "a range the sync could not read through must stay unreported rather than claim a count");
+        fixture.PublishedGlucose.Should().BeEmpty(
+            "publishing the pages above the failure would put the ones below it out of reach");
+    }
+
+    /// <summary>
+    /// The same swallow by a different route: a 200 whose envelope carries no page is a fetch that
+    /// failed, not a range that ran out. A range that ran out answers an empty array.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAPageCarriesNoData_FailsTheRunAndPublishesNothing()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose,
+                RemoteFakeHandler.GlucosePage(total: 6, "2026-01-03T08:00:00Z", "2026-01-03T08:05:00Z"),
+                RemoteFakeHandler.Json("""{"data":null,"pagination":{"limit":2,"offset":2,"total":6}}"""));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ItemsSynced.Should().BeEmpty();
+        fixture.PublishedGlucose.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The distinction the failure path must not erase: a range the remote genuinely has nothing
+    /// left in answers with a short page, and that is a successful sync of everything there was.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheRangeIsExhausted_ReportsSuccessAndPublishesEveryPage()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose,
+                RemoteFakeHandler.GlucosePage(total: 3, "2026-01-03T08:00:00Z", "2026-01-03T08:05:00Z"),
+                RemoteFakeHandler.GlucosePage(total: 3, "2026-01-03T08:10:00Z"));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Glucose] = 3,
+        });
+        fixture.PublishedGlucose.Should().HaveCount(3);
+    }
+
+    /// <summary>
+    /// A window the remote holds nothing for still records a count: the tenant's sync card renders a
+    /// badge per key, so "checked, found nothing" must not be reported the way "could not check" is.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheRemoteHasNoRecords_ReportsAnExplicitZero()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose, RemoteFakeHandler.GlucosePage(total: 0));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Glucose] = 0,
+        });
+    }
+
+    /// <summary>
+    /// Each data type crawls its own endpoint, so one endpoint failing must cost only that type. A
+    /// failed run withholds the connector's last-successful-sync stamp and shows the tenant a red
+    /// connector, which has to name what actually broke.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenOneTypesCrawlFails_LeavesTheOtherTypeSynced()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose, RemoteFakeHandler.Status(HttpStatusCode.BadGateway))
+            .Serve(NocturneRemoteConstants.Boluses, RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().StartWith($"Failed to sync {SyncDataType.Glucose}");
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Boluses] = 1,
+        }, "a rejected glucose crawl must not cost the boluses, nor claim a glucose count");
+        fixture.PublishedBoluses.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A type the tenant switched off is never crawled, so a remote that rejects its endpoint cannot
+    /// mark the connector red while everything the tenant enabled synced.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenASwitchedOffTypesEndpointWouldFail_ReportsSuccess()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose, RemoteFakeHandler.Status(HttpStatusCode.BadGateway))
+            .Serve(NocturneRemoteConstants.Boluses, RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
+        var fixture = new ServiceFixture(handler, config: NewConfig(syncGlucose: false));
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue("no type the tenant enabled failed to sync");
+        result.Errors.Should().BeEmpty();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Boluses] = 1,
+        });
+    }
+
+    private static NocturneRemoteConnectorConfiguration NewConfig(bool syncGlucose = true) => new()
+    {
+        Url = RemoteFakeHandler.BaseUrl,
+        Token = "direct-grant-token",
+        MaxCount = RemoteFakeHandler.PageSize,
+        SyncGlucose = syncGlucose,
+    };
+
+    /// <summary>Wires the connector service and a recording publisher onto one fake handler.</summary>
+    private sealed class ServiceFixture
+    {
+        internal NocturneRemoteConnectorService Service { get; }
+        internal NocturneRemoteConnectorConfiguration Config { get; }
+        internal List<SensorGlucose> PublishedGlucose { get; } = [];
+        internal List<Bolus> PublishedBoluses { get; } = [];
+
+        internal ServiceFixture(
+            RemoteFakeHandler handler,
+            NocturneRemoteConnectorConfiguration? config = null)
+        {
+            Config = config ?? NewConfig();
+
+            var glucose = new Mock<IGlucosePublisher>();
+            glucose
+                .Setup(p => p.PublishSensorGlucoseAsync(
+                    It.IsAny<IEnumerable<SensorGlucose>>(), It.IsAny<string>(),
+                    It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+                .Callback<IEnumerable<SensorGlucose>, string, WriteOrigin, CancellationToken>(
+                    (batch, _, _, _) => PublishedGlucose.AddRange(batch))
+                .ReturnsAsync(true);
+
+            var treatments = new Mock<ITreatmentPublisher>();
+            treatments
+                .Setup(p => p.PublishBolusesAsync(
+                    It.IsAny<IEnumerable<Bolus>>(), It.IsAny<string>(),
+                    It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+                .Callback<IEnumerable<Bolus>, string, WriteOrigin, CancellationToken>(
+                    (batch, _, _, _) => PublishedBoluses.AddRange(batch))
+                .ReturnsAsync(true);
+
+            var publisher = new Mock<IConnectorPublisher>();
+            publisher.Setup(p => p.IsAvailable).Returns(true);
+            publisher.Setup(p => p.Glucose).Returns(glucose.Object);
+            publisher.Setup(p => p.Treatments).Returns(treatments.Object);
+            publisher.Setup(p => p.Device).Returns(Mock.Of<IDevicePublisher>());
+            publisher.Setup(p => p.Metadata).Returns(Mock.Of<IMetadataPublisher>());
+
+            var registration = new Mock<IConnectorRegistration<NocturneRemoteConnectorConfiguration>>();
+            registration.Setup(r => r.Defaults).Returns(Config);
+
+            Service = new NocturneRemoteConnectorService(
+                new HttpClient(handler),
+                Mock.Of<IConnectorServerResolver<NocturneRemoteConnectorConfiguration>>(),
+                NullLogger<NocturneRemoteConnectorService>.Instance,
+                registration.Object,
+                publisher.Object);
+        }
+    }
+
+    /// <summary>
+    /// Serves the remote instance's V4 paginated endpoints, one scripted response per page in the
+    /// order the crawl asks for them. The auth probe carries no offset, so it is answered separately
+    /// and a rejected data endpoint does not read as a rejected credential.
+    /// </summary>
+    private sealed class RemoteFakeHandler : HttpMessageHandler
+    {
+        internal const string BaseUrl = "https://remote.example";
+
+        /// <summary>Page size the fixture configures, small enough to script a multi-page crawl.</summary>
+        internal const int PageSize = 2;
+
+        private readonly Dictionary<string, Queue<HttpResponseMessage>> _pages = new(StringComparer.Ordinal);
+
+        internal RemoteFakeHandler Serve(string path, params HttpResponseMessage[] responses)
+        {
+            _pages[path] = new Queue<HttpResponseMessage>(responses);
+            return this;
+        }
+
+        internal static HttpResponseMessage Status(HttpStatusCode status) => new(status);
+
+        internal static HttpResponseMessage Json(string body) =>
+            new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+        internal static HttpResponseMessage GlucosePage(int total, params string[] timestamps) =>
+            Page(total, timestamps.Select(t =>
+                $$"""{"id":"{{Guid.NewGuid()}}","timestamp":"{{t}}","mgdl":120}"""));
+
+        internal static HttpResponseMessage BolusPage(int total, params string[] timestamps) =>
+            Page(total, timestamps.Select(t =>
+                $$"""{"id":"{{Guid.NewGuid()}}","timestamp":"{{t}}","insulin":1.5}"""));
+
+        private static HttpResponseMessage Page(int total, IEnumerable<string> records) =>
+            Json("{\"data\":[" + string.Join(",", records)
+                 + "],\"pagination\":{\"limit\":" + PageSize
+                 + ",\"offset\":0,\"total\":" + total + "}}");
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (!request.RequestUri.Query.Contains("offset=", StringComparison.Ordinal))
+                return Task.FromResult(GlucosePage(total: 0));
+
+            if (_pages.TryGetValue(path, out var queue) && queue.Count > 0)
+                return Task.FromResult(queue.Dequeue());
+
+            return Task.FromResult(GlucosePage(total: 0));
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
@@ -283,7 +283,9 @@ public class NocturneRemoteConnectorServiceCrawlTests
 
         result.Success.Should().BeFalse();
         result.Errors.Should().ContainSingle()
-            .Which.Should().StartWith($"Failed to sync {SyncDataType.Food}");
+            .Which.Should().StartWith($"Failed to sync {SyncDataType.Food}")
+            .And.Contain("HTTP 403 Forbidden",
+                "a refused scope is the failure a tenant can act on, and they cannot read the logs");
         result.ItemsSynced.Should().BeEmpty(
             "a rejected fetch never reached the remote, so it cannot report that there were no foods");
     }
@@ -355,12 +357,13 @@ public class NocturneRemoteConnectorServiceCrawlTests
     }
 
     /// <summary>
-    /// On an open-ended catch-up each family asks for its own range. Sharing the glucose-derived
-    /// bound strands every other family: this run's glucose publish moves that bound past the range
-    /// a failed treatment crawl still owes, so the gap it left cannot be repaired next cycle.
+    /// On an open-ended catch-up a family that has fallen behind widens the bound back to its own
+    /// resume point. Leaving it on the glucose-derived bound strands it: this run's glucose publish
+    /// moves that bound past the range a failed treatment crawl still owes, so the gap cannot be
+    /// repaired next cycle.
     /// </summary>
     [Fact]
-    public async Task SyncDataAsync_WhenOpenEnded_AsksEachFamilyForItsOwnRange()
+    public async Task SyncDataAsync_WhenAFamilyHasFallenBehind_WidensToItsOwnResumePoint()
     {
         var latestTreatment = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var glucoseFrom = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -382,6 +385,78 @@ public class NocturneRemoteConnectorServiceCrawlTests
         handler.CrawlOf(NocturneRemoteConstants.Boluses).Should()
             .Contain($"from={latestTreatment.AddMinutes(-5):o}",
                 "the treatment family resumes from its own newest stored record, not glucose's");
+    }
+
+    /// <summary>
+    /// A caller's lower bound is never narrowed by a family's resume point. An explicit <c>from</c>
+    /// with no <c>to</c> is a legitimate request shape and the one an admin repairing a months-old
+    /// gap sends; answering it from the watermark fetches nothing and reports the run as a success
+    /// with a zero count, which is the failure this branch exists to stop.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenGivenALowerBoundBelowTheResumePoint_HonoursTheCallersBound()
+    {
+        var askedFrom = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new RemoteFakeHandler();
+        var fixture = new ServiceFixture(
+            handler, latestTreatment: new DateTime(2026, 5, 31, 0, 0, 0, DateTimeKind.Utc));
+
+        await fixture.Service.SyncDataAsync(
+            new SyncRequest
+            {
+                From = askedFrom,
+                To = null,
+                DataTypes = [SyncDataType.Boluses],
+            },
+            fixture.Config,
+            CancellationToken.None);
+
+        handler.CrawlOf(NocturneRemoteConstants.Boluses).Should()
+            .Contain($"from={askedFrom:o}", "the caller asked for this lower bound");
+    }
+
+    /// <summary>
+    /// The tenant's configured attempt budget governs, not the frozen startup defaults. Only the
+    /// background entry point primes the field the defaults live in, so a manual sync or a cursor
+    /// reset — the long full-history re-pull where the budget matters most — would otherwise run on
+    /// whatever the deployment shipped. A budget of three would reach the third scripted response
+    /// and complete the crawl.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_SpendsTheTenantsRetryBudget_NotTheStartupDefaults()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose,
+                RemoteFakeHandler.GlucosePage(total: 6, "2026-01-03T08:00:00Z", "2026-01-03T08:05:00Z"),
+                RemoteFakeHandler.Status(HttpStatusCode.BadGateway),
+                RemoteFakeHandler.GlucosePage(total: 6, "2026-01-03T08:10:00Z"));
+        var fixture = new ServiceFixture(handler, config: NewConfig(maxRetryAttempts: 1));
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse(
+            $"the tenant allowed one attempt, not the {StartupDefaultRetryAttempts} the defaults carry");
+        result.ItemsSynced.Should().BeEmpty();
+    }
+
+    /// <summary>The tenant's page size governs for the same reason, and on the same paths.</summary>
+    [Fact]
+    public async Task SyncDataAsync_UsesTheTenantsPageSize_NotTheStartupDefaults()
+    {
+        var handler = new RemoteFakeHandler();
+        var fixture = new ServiceFixture(handler);
+
+        await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
+
+        handler.CrawlOf(NocturneRemoteConstants.SensorGlucose).Should()
+            .Contain($"limit={RemoteFakeHandler.PageSize}")
+            .And.NotContain($"limit={StartupDefaultPageSize}");
     }
 
     /// <summary>
@@ -410,6 +485,68 @@ public class NocturneRemoteConnectorServiceCrawlTests
         handler.CrawlOf(NocturneRemoteConstants.Boluses).Should().Contain($"from={from:o}");
     }
 
+    /// <summary>
+    /// A watermark the publisher cannot answer fails only the families it would have bounded. It is
+    /// resolved inside the per-type error boundary for that reason: resolving it up front would take
+    /// down glucose, profiles and food as well, none of which needed it.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAFamilysWatermarkCannotBeRead_FailsOnlyThatFamily()
+    {
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose,
+                RemoteFakeHandler.GlucosePage(total: 1, "2026-01-03T08:00:00Z"));
+        var fixture = new ServiceFixture(handler, treatmentWatermarkFails: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().StartWith($"Failed to sync {SyncDataType.Boluses}");
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Glucose] = 1,
+        }, "glucose never needed the treatment watermark");
+    }
+
+    /// <summary>
+    /// The remote is the tenant's own instance behind their own proxy, and the failed response's
+    /// body is quoted into the connector's last-error message and its logs. A proxy error page that
+    /// echoes the request would otherwise put the tenant's bearer token in both.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAFailedResponseEchoesTheRequest_KeepsTheTokenOutOfTheError()
+    {
+        var config = NewConfig();
+        var handler = new RemoteFakeHandler()
+            .Serve(NocturneRemoteConstants.SensorGlucose,
+                RemoteFakeHandler.GlucosePage(total: 6, "2026-01-03T08:00:00Z", "2026-01-03T08:05:00Z"),
+                new HttpResponseMessage(HttpStatusCode.BadGateway)
+                {
+                    Content = new StringContent(
+                        $"upstream refused; sent authorization: Bearer {config.Token}"),
+                });
+        var fixture = new ServiceFixture(handler, config: config);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().NotContain(config.Token).And.Contain("HTTP 502 BadGateway");
+    }
+
+    /// <summary>Page size and budget carried by the frozen startup defaults, never by a tenant.</summary>
+    private const int StartupDefaultPageSize = 500;
+
+    /// <inheritdoc cref="StartupDefaultPageSize"/>
+    private const int StartupDefaultRetryAttempts = 3;
+
     private static NocturneRemoteConnectorConfiguration NewConfig(
         bool syncGlucose = true,
         bool syncActivity = true,
@@ -436,7 +573,8 @@ public class NocturneRemoteConnectorServiceCrawlTests
         internal ServiceFixture(
             RemoteFakeHandler handler,
             NocturneRemoteConnectorConfiguration? config = null,
-            DateTime? latestTreatment = null)
+            DateTime? latestTreatment = null,
+            bool treatmentWatermarkFails = false)
         {
             Config = config ?? NewConfig();
 
@@ -450,10 +588,12 @@ public class NocturneRemoteConnectorServiceCrawlTests
                 .ReturnsAsync(true);
 
             var treatments = new Mock<ITreatmentPublisher>();
-            treatments
-                .Setup(p => p.GetLatestTreatmentTimestampAsync(
-                    It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(latestTreatment);
+            var watermark = treatments.Setup(p => p.GetLatestTreatmentTimestampAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()));
+            if (treatmentWatermarkFails)
+                watermark.ThrowsAsync(new HttpRequestException("the API did not answer"));
+            else
+                watermark.ReturnsAsync(latestTreatment);
             treatments
                 .Setup(p => p.PublishBolusesAsync(
                     It.IsAny<IEnumerable<Bolus>>(), It.IsAny<string>(),
@@ -469,8 +609,17 @@ public class NocturneRemoteConnectorServiceCrawlTests
             publisher.Setup(p => p.Device).Returns(Mock.Of<IDevicePublisher>());
             publisher.Setup(p => p.Metadata).Returns(Mock.Of<IMetadataPublisher>());
 
+            // Deliberately NOT the tenant's config. Production conflates the two — the frozen
+            // startup defaults are what the field holds on the manual path — so aliasing them here
+            // would hide every place the tenant's own value is meant to be read.
             var registration = new Mock<IConnectorRegistration<NocturneRemoteConnectorConfiguration>>();
-            registration.Setup(r => r.Defaults).Returns(Config);
+            registration.Setup(r => r.Defaults).Returns(new NocturneRemoteConnectorConfiguration
+            {
+                Url = RemoteFakeHandler.BaseUrl,
+                Token = "startup-defaults-token",
+                MaxCount = StartupDefaultPageSize,
+                MaxRetryAttempts = StartupDefaultRetryAttempts,
+            });
 
             Service = new NocturneRemoteConnectorService(
                 new HttpClient(handler),


### PR DESCRIPTION
Closes #783.

`NocturneRemoteConnectorService` logged a warning and stopped paginating on a non-success HTTP status, returning the partial list. The caller published it and reported `Success = true`. A page-3-of-40 failure produced a green sync card with 37 pages missing, indistinguishable from a genuinely exhausted range.

`NightscoutConnectorService` deliberately does the opposite, and its comment already spells out why: treating a failed page as the end of the range "silently truncated crawls into 'successful' partial syncs, and would wrongly clear a backfill low-water mark."

## Why throwing is right here specifically, not just consistent

NocturneRemote's V4 pages arrive **newest-first** — `PrepareListQuery` sets `descending = true` and `BuildPaginatedUrl` never passes `sort`; the same holds for state spans and device events, and no call site asks for `timestamp_asc`. And the connector accumulates the whole range before publishing once.

So "publish what we got, mark the run failed" is actively harmful here rather than merely incomplete: publishing the newest pages advances the local watermark, which is where the next cycle's lower bound comes from. Throwing before any publish leaves the window unchanged so the next cycle retries the same range.

NocturneRemote maintains no persisted backfill low-water mark — `Get/SetBackfillLowWaterMarkAsync` are Nightscout's alone — so the local watermark *is* the whole resume mechanism, which is what makes a truncated crawl permanent.

## Per-type resume points

One glucose-derived bound previously drove all twelve types, so a failed bolus crawl was stranded behind an advancing glucose cursor — the same permanence in a second form, and throwing alone would have bought honesty without recoverability for eleven of twelve types.

The connector now resolves per-family resume points using the helpers Nightscout already uses. Recoverability after a failed crawl goes from **1 of 12** to:

| | resumes from | repaired next cycle? |
|---|---|---|
| Glucose, DeviceStatus, Activity | own source-scoped watermark | yes |
| Profiles, Food | no bounds (full re-fetch) | yes |
| ManualBG, Boluses, CarbIntake, BolusCalculations, Notes, DeviceEvents | shared treatment watermark | only if no sibling published in the same run |
| StateSpans | glucose bound | no |

The remaining two limits are recorded in code at the one site each applies to: `GetLatestTreatmentTimestampAsync` is a `Max()` across the family, so separating the six needs per-type watermarks the publisher does not expose; and state spans have no watermark at all. Both belong to #944.

**A resume point widens, it never narrows.** `ResumeFrom` takes whichever bound reaches further back, because either direction of narrowing is a real bug: a resume point that overrode the caller's bound discarded an explicit `from` sent with no `to` — silently returning a green zero-count result to an admin repairing a five-month gap, which is precisely the repair this issue exists to make possible — and a caller's bound that overrode the resume point reinstates the shared-cursor stranding above. `openEnded` still gates the whole thing, so a cursor reset's explicit range bypasses catch-up bounds as `ConnectorCursorResetService` documents.

## Retry, and why not `addResilience`

Throwing on the *first* transient 502 would not have been parity — Nightscout throws only after `ExecuteWithRetryAsync` exhausts its budget. Review initially suggested `addResilience: true`; **no call site in the repo sets it, including Nightscout**, so that would have given one connector a novel path with a hardcoded count, a circuit breaker nothing else has, and a 10-minute timeout.

Instead all three fetch sites route through `ExecuteWithRetryAsync` with the **tenant's** configured `MaxRetryAttempts`, matching Nightscout's `FetchDataAsync`/`FetchDataCoreAsync` structure. That collapsed two crawl guards into one, since a non-success status, an unparseable body and an exhausted budget now arrive the same way.

Threading the per-tenant `config` through the fetch path also fixed the page size: both `MaxRetryAttempts` and `MaxCount` previously came from `_config`, which only the background overload primes — so on "Sync now" and cursor reset, the two paths a human uses to repair a gap, the tenant's configured values were silently replaced by the startup defaults. `_config` is no longer read anywhere on the fetch path. The test fixture aliased `registration.Defaults` to the tenant config, which is why nothing could catch it; the two are now distinct objects.

## What a tenant sees

For a glucose crawl that loses page 3 while boluses sync fine:

| | Before | After |
|---|---|---|
| `Success` | `true` | `false` |
| `Errors` | empty | `["Failed to sync Glucose: …"]` — Boluses absent |
| `ItemsSynced` | `{Glucose: 37 of 40 pages, Boluses: 1}` | `{Boluses: 1}` — no Glucose key |
| Health state | `isHealthy: true`, `lastSuccessfulSync` advanced | `isHealthy: false`, not advanced |

The three states stay distinct: no key = "couldn't check", key with `0` = "checked, found nothing", key with `n` = "checked, found data".

Failure is scoped to the affected type — each type's crawl is its own `try` inside the loop over `activeTypes`, and this connector has no cross-type fetches. Family resume points are resolved lazily *inside* that boundary, so a publisher that cannot answer one watermark fails only the families it bounded.

Errors now name the status on the path a tenant can act on (`HTTP 403 Forbidden` rather than "see preceding connector logs", which a hosted tenant cannot read). The echoed remote body has the tenant's token redacted and is clamped to 200 characters — the remote is the tenant's own instance behind their own proxy, and a proxy error page that dumps request headers would otherwise put their bearer token into `LastErrorMessage`.

## Also fixed in the same file

`FetchV1DeviceStatusAsync` conflated "couldn't parse" with "range exhausted"; `SyncFoodAsync` published an empty list after an unparseable body, recording a confident zero — the same trap fixed in Tidepool recently.

## Verification

Ten mutations, each applied, run and reverted — including: a resume point that replaces rather than widens (fails with the admin-repair case); `config.` → `_config.` for both the retry budget and the page size; eager watermark resolution (escapes the run unhandled); and disabled token redaction (the recorded error carries `Bearer direct-grant-token`).

Two hostile fresh-context rounds. The first found that two tests were certifying a property production lacks — the auth probe hits the glucose endpoint unconditionally, and the fake short-circuited it, so a scripted glucose failure was never served. Those are now split into a positive test using a type the probe does not touch, and a **characterisation test** pinning the probe defect as-is. That defect is filed as **#952**, and deleting that test is the correct move when it is fixed.

The second round found the explicit-`from` and stale-`_config` defects above.

Tests: NocturneRemote 20/20 · Nightscout 54/54 · Tidepool 14/14 · Glooko 106/106 · CareLink 89/89 · Connectors.Core 137/137.

## A divergence this introduces

`NightscoutConnectorService` has the same replace-instead-of-widen defect, so `{"from": X}` with no `to` is discarded there too for treatments, device status and activity. Changing cursor semantics on the busier connector did not belong in this branch, but "make the two agree" was the original ask, so NocturneRemote is now ahead. `ResumeFrom` would port verbatim.

## Filed while verifying

**#944** (one cursor for all types — the across-cycle half), **#945** (stale `_config`), **#946** (the sync card's generic headline and hidden partial counts), **#952** (the auth probe). Also still open: `page.Pagination` NREs on `"pagination": null`.
