### PR TITLE
refactor: one declaration per target-range concept across the C# backend

### DIFF
--- a/src/API/Nocturne.API/Services/Alerts/SensorContextEnricher.cs
+++ b/src/API/Nocturne.API/Services/Alerts/SensorContextEnricher.cs
@@ -3,6 +3,7 @@ using Nocturne.API.Configuration;
 using Nocturne.API.Controllers.V4.Analytics;
 using Nocturne.API.Services.Alerts.Evaluators;
 using Nocturne.API.Services.Glucose;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Models;
@@ -368,10 +369,16 @@ internal sealed class SensorContextEnricher : ISensorContextEnricher
         var profileName = await _deps.ActiveProfileResolver.GetActiveProfileNameAsync(atMills, ct) ?? "Default";
         var schedule = await _deps.TargetRangeSchedules.GetActiveAtAsync(profileName, at, ct);
 
-        // No schedule at all — fall back to fully default (low=70, high=180) and clinical bucket defaults.
+        // No schedule at all — fall back to the consensus in-range band and clinical bucket defaults.
         if (schedule is null || schedule.Entries.Count == 0)
         {
-            return GlucoseBucketResolver.Compute(glucoseMgdl, 70m, 180m, null, null, null);
+            return GlucoseBucketResolver.Compute(
+                glucoseMgdl,
+                (decimal)GlucoseConstants.TargetBottomMgdl,
+                (decimal)GlucoseConstants.TargetTopMgdl,
+                null,
+                null,
+                null);
         }
 
         // Pick the entry active at the tenant's local time-of-day. `at` is always UTC; the

--- a/src/API/Nocturne.API/Services/Analytics/ActogramReportService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/ActogramReportService.cs
@@ -1,3 +1,4 @@
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Analytics;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Health;
@@ -16,16 +17,16 @@ namespace Nocturne.API.Services.Analytics;
 /// <c>ConcurrencyDetector</c> rejects parallel operations on a single
 /// context with <c>InvalidOperationException</c>. Threshold resolution
 /// mirrors <c>ProfileLoadStage</c>: very-low/very-high are fixed, low/high
-/// come from the active profile at the requested end time, with 70/180
-/// fallbacks when no therapy settings exist yet.
+/// come from the active profile at the requested end time, falling back to
+/// the consensus in-range band when no therapy settings exist yet.
 /// </remarks>
 public sealed class ActogramReportService : IActogramReportService
 {
     // Match ProfileLoadStage so the actogram and dashboard agree on band edges.
     private const double DefaultVeryLow = 54;
     private const double DefaultVeryHigh = 250;
-    private const double DefaultLow = 70;
-    private const double DefaultHigh = 180;
+    private const double DefaultLow = GlucoseConstants.TargetBottomMgdl;
+    private const double DefaultHigh = GlucoseConstants.TargetTopMgdl;
 
     // Sleep spans are sparse (≤ a few per day). Cap is generous but bounded.
     private const int SleepSpanLimit = 10000;

--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Analytics;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Models;
@@ -685,9 +686,10 @@ public class DataOverviewService : IDataOverviewService
         // Bucket readings into TIR zones
         var totalCount = glucoseReadings.Count;
         var veryLowCount = glucoseReadings.Count(v => v < 54);
-        var lowCount = glucoseReadings.Count(v => v >= 54 && v < 70);
-        var targetCount = glucoseReadings.Count(v => v >= 70 && v <= 180);
-        var highCount = glucoseReadings.Count(v => v > 180 && v <= 250);
+        var lowCount = glucoseReadings.Count(v => v >= 54 && v < GlucoseConstants.TargetBottomMgdl);
+        var targetCount = glucoseReadings.Count(
+            v => v >= GlucoseConstants.TargetBottomMgdl && v <= GlucoseConstants.TargetTopMgdl);
+        var highCount = glucoseReadings.Count(v => v > GlucoseConstants.TargetTopMgdl && v <= 250);
         var veryHighCount = glucoseReadings.Count(v => v > 250);
 
         var percentages = new TimeInRangePercentages
@@ -934,7 +936,8 @@ public class DataOverviewService : IDataOverviewService
             {
                 var readings = g.ToList();
                 var total = readings.Count;
-                var inRange = readings.Count(r => r.Mgdl >= 70 && r.Mgdl <= 180);
+                var inRange = readings.Count(
+                    r => r.Mgdl >= GlucoseConstants.TargetBottomMgdl && r.Mgdl <= GlucoseConstants.TargetTopMgdl);
                 return new
                 {
                     Date = g.Key,

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -2935,9 +2935,9 @@ public class StatisticsService : IStatisticsService
 
             // Calculate time in range
             var tirBefore =
-                (double)beforeValues.Count(v => v >= 70 && v <= 180) / beforeValues.Count * 100;
+                (double)beforeValues.Count(v => v >= GlucoseConstants.TargetBottomMgdl && v <= GlucoseConstants.TargetTopMgdl) / beforeValues.Count * 100;
             var tirAfter =
-                (double)afterValues.Count(v => v >= 70 && v <= 180) / afterValues.Count * 100;
+                (double)afterValues.Count(v => v >= GlucoseConstants.TargetBottomMgdl && v <= GlucoseConstants.TargetTopMgdl) / afterValues.Count * 100;
 
             // Calculate CV (coefficient of variation)
             var stdDevBefore = Math.Sqrt(

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -1179,8 +1179,8 @@ public class StatisticsService : IStatisticsService
             return 0;
         }
 
-        const double targetLow = 70;
-        const double targetHigh = 180;
+        const double targetLow = GlucoseConstants.TargetBottomMgdl;
+        const double targetHigh = GlucoseConstants.TargetTopMgdl;
 
         var inRangeCount = valuesList.Count(val => val >= targetLow && val <= targetHigh);
         var percentTimeInRange = (double)inRangeCount / valuesList.Count;

--- a/src/API/Nocturne.API/Services/ChartData/Stages/ProfileLoadStage.cs
+++ b/src/API/Nocturne.API/Services/ChartData/Stages/ProfileLoadStage.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Models;
 
@@ -28,8 +29,8 @@ internal sealed class ProfileLoadStage(
 ) : IChartDataStage
 {
     private const double DefaultVeryLow = 54;
-    private const double DefaultLow = 70;
-    private const double DefaultHigh = 180;
+    private const double DefaultLow = GlucoseConstants.TargetBottomMgdl;
+    private const double DefaultHigh = GlucoseConstants.TargetTopMgdl;
     private const double DefaultVeryHigh = 250;
 
     public async Task<ChartDataContext> ExecuteAsync(ChartDataContext context, CancellationToken cancellationToken)

--- a/src/API/Nocturne.API/Services/Glucose/Ar2Service.cs
+++ b/src/API/Nocturne.API/Services/Glucose/Ar2Service.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Models;
 
@@ -312,8 +313,8 @@ public class Ar2Service : IAr2Service
             var in20mins = properties.Forecast.Predicted[3].Mgdl;
 
             // Get thresholds from settings
-            var bgTargetTop = GetNumericValue(settings, "bgTargetTop", 180);
-            var bgTargetBottom = GetNumericValue(settings, "bgTargetBottom", 80);
+            var bgTargetTop = GetNumericValue(settings, "bgTargetTop", ApplicationConstants.Web.Thresholds.BgTargetTop);
+            var bgTargetBottom = GetNumericValue(settings, "bgTargetBottom", ApplicationConstants.Web.Thresholds.BgTargetBottom);
             var alarmHigh = GetBooleanValue(settings, "alarmHigh", true);
             var alarmLow = GetBooleanValue(settings, "alarmLow", true);
 

--- a/src/API/Nocturne.API/Services/Identity/TenantOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantOverviewService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Nocturne.API.Services.Alerts.Evaluators;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Glucose;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
@@ -48,10 +49,10 @@ public class TenantOverviewService : ITenantOverviewService
         var glucoseReadTenants = await GetGlucoseReadTenantsAsync(subjectId, tokenScopes, authType, ct);
 
         var defaults = new TenantOverviewThresholds(
-            UrgentLow: _configuration.GetValue("Thresholds:BgLow", 55),
-            Low: _configuration.GetValue("Thresholds:BgTargetBottom", 80),
-            High: _configuration.GetValue("Thresholds:BgTargetTop", 180),
-            UrgentHigh: _configuration.GetValue("Thresholds:BgHigh", 260));
+            UrgentLow: _configuration.GetValue("Thresholds:BgLow", ApplicationConstants.Web.Thresholds.BgLow),
+            Low: _configuration.GetValue("Thresholds:BgTargetBottom", ApplicationConstants.Web.Thresholds.BgTargetBottom),
+            High: _configuration.GetValue("Thresholds:BgTargetTop", ApplicationConstants.Web.Thresholds.BgTargetTop),
+            UrgentHigh: _configuration.GetValue("Thresholds:BgHigh", ApplicationConstants.Web.Thresholds.BgHigh));
         var staleAfter = TimeSpan.FromMinutes(_configuration.GetValue("Overview:StaleAfterMinutes", 25));
 
         var items = new List<TenantOverviewItem>();

--- a/src/API/Nocturne.API/Services/Platform/StatusService.cs
+++ b/src/API/Nocturne.API/Services/Platform/StatusService.cs
@@ -439,10 +439,10 @@ public class StatusService : IStatusService
         // Threshold values
         settings["thresholds"] = new Dictionary<string, object>
         {
-            ["bgHigh"] = _configuration.GetValue<int>("Thresholds:BgHigh", 260),
-            ["bgTargetTop"] = _configuration.GetValue<int>("Thresholds:BgTargetTop", 180),
-            ["bgTargetBottom"] = _configuration.GetValue<int>("Thresholds:BgTargetBottom", 80),
-            ["bgLow"] = _configuration.GetValue<int>("Thresholds:BgLow", 55),
+            ["bgHigh"] = _configuration.GetValue("Thresholds:BgHigh", ApplicationConstants.Web.Thresholds.BgHigh),
+            ["bgTargetTop"] = _configuration.GetValue("Thresholds:BgTargetTop", ApplicationConstants.Web.Thresholds.BgTargetTop),
+            ["bgTargetBottom"] = _configuration.GetValue("Thresholds:BgTargetBottom", ApplicationConstants.Web.Thresholds.BgTargetBottom),
+            ["bgLow"] = _configuration.GetValue("Thresholds:BgLow", ApplicationConstants.Web.Thresholds.BgLow),
         };
 
         // Security settings

--- a/src/API/Nocturne.API/Services/Profiles/PropertiesService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/PropertiesService.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Legacy;
 using Nocturne.Core.Contracts.Profiles;
@@ -446,8 +447,8 @@ public class PropertiesService : IPropertiesService
             // Get settings for thresholds (use defaults if not available)
             var settings = new Dictionary<string, object>
             {
-                ["bgTargetTop"] = 180,
-                ["bgTargetBottom"] = 80,
+                ["bgTargetTop"] = ApplicationConstants.Web.Thresholds.BgTargetTop,
+                ["bgTargetBottom"] = ApplicationConstants.Web.Thresholds.BgTargetBottom,
                 ["alarmHigh"] = true,
                 ["alarmLow"] = true,
             };

--- a/src/API/Nocturne.API/Services/Profiles/Resolvers/TargetRangeResolver.cs
+++ b/src/API/Nocturne.API/Services/Profiles/Resolvers/TargetRangeResolver.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.V4.Repositories;
@@ -21,8 +22,8 @@ internal sealed class TargetRangeResolver : ITargetRangeResolver
     private readonly ILogger<TargetRangeResolver> _logger;
 
     private const int CacheTtlSeconds = 5;
-    private const double DefaultLow = 70.0;
-    private const double DefaultHigh = 180.0;
+    private const double DefaultLow = GlucoseConstants.TargetBottomMgdl;
+    private const double DefaultHigh = GlucoseConstants.TargetTopMgdl;
 
     public TargetRangeResolver(
         ITargetRangeScheduleRepository repo,

--- a/src/API/Nocturne.API/Services/Sleep/SleepReportService.cs
+++ b/src/API/Nocturne.API/Services/Sleep/SleepReportService.cs
@@ -74,8 +74,8 @@ public class SleepReportService : ISleepReportService
     /// <summary>
     /// Resolves glycemic thresholds at <paramref name="timeMills"/> the same way
     /// <c>ProfileLoadStage</c> does: very-low/very-high are fixed; low and high come
-    /// from the active profile's target range, falling back to 70/180 when no therapy
-    /// settings exist for the tenant.
+    /// from the active profile's target range, falling back to the consensus in-range
+    /// band when no therapy settings exist for the tenant.
     /// </summary>
     private async Task<GlycemicThresholds> ResolveThresholdsAsync(long timeMills, CancellationToken ct)
     {

--- a/src/API/Nocturne.API/Services/Sleep/SleepReportService.cs
+++ b/src/API/Nocturne.API/Services/Sleep/SleepReportService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.Repositories;
 using Nocturne.Core.Contracts.Sleep;
@@ -16,14 +17,14 @@ namespace Nocturne.API.Services.Sleep;
 /// <remarks>
 /// Glycemic thresholds mirror <c>ProfileLoadStage</c>: very-low (54 mg/dL) and
 /// very-high (250 mg/dL) are fixed; low/target-bottom and high/target-top come from
-/// the active profile's target range, with 70/180 fallbacks when no therapy
-/// settings exist.
+/// the active profile's target range, falling back to the consensus in-range band
+/// when no therapy settings exist.
 /// </remarks>
 public class SleepReportService : ISleepReportService
 {
     private const double DefaultVeryLow  = 54;
-    private const double DefaultLow      = 70;
-    private const double DefaultHigh     = 180;
+    private const double DefaultLow      = GlucoseConstants.TargetBottomMgdl;
+    private const double DefaultHigh     = GlucoseConstants.TargetTopMgdl;
     private const double DefaultVeryHigh = 250;
 
     private readonly ISleepSessionRepository _sessions;

--- a/src/Core/Nocturne.Core.Constants/ApplicationConstants.cs
+++ b/src/Core/Nocturne.Core.Constants/ApplicationConstants.cs
@@ -299,8 +299,11 @@ public static class ApplicationConstants
         }
 
         /// <summary>
-        /// Defaults for the four legacy Nightscout <c>bg*</c> threshold settings, in mg/dL, supplied
-        /// wherever a <c>Thresholds:Bg*</c> configuration key is absent. They are client alarm
+        /// Defaults for the four legacy Nightscout <c>bg*</c> threshold settings, in mg/dL. They are
+        /// what ships when nothing else supplies a value: the status and tenant-overview services
+        /// fall back to them when the matching <c>Thresholds:Bg*</c> configuration key is absent, and
+        /// the properties and AR2 services use them for the <c>bgTarget*</c> entries of the settings
+        /// map they build and read, which never consults configuration at all. They are client alarm
         /// settings, not a clinical range — <see cref="GlucoseConstants.TargetBottomMgdl"/> and
         /// <see cref="GlucoseConstants.TargetTopMgdl"/> are the consensus in-range boundaries, and
         /// <see cref="BgTargetBottom"/> deliberately differs from the former. Collapsing the two

--- a/src/Core/Nocturne.Core.Constants/ApplicationConstants.cs
+++ b/src/Core/Nocturne.Core.Constants/ApplicationConstants.cs
@@ -299,13 +299,13 @@ public static class ApplicationConstants
         }
 
         /// <summary>
-        /// Defaults for the four legacy Nightscout <c>bg*</c> threshold settings, in mg/dL. Nothing
-        /// reads these: the values that ship are literals against the <c>Thresholds:Bg*</c>
-        /// configuration keys in the status and tenant-overview services, and this class records
-        /// what they are rather than supplying them. They are client alarm settings, not a clinical
-        /// range — <see cref="GlucoseConstants.TargetBottomMgdl"/> and
+        /// Defaults for the four legacy Nightscout <c>bg*</c> threshold settings, in mg/dL, supplied
+        /// wherever a <c>Thresholds:Bg*</c> configuration key is absent. They are client alarm
+        /// settings, not a clinical range — <see cref="GlucoseConstants.TargetBottomMgdl"/> and
         /// <see cref="GlucoseConstants.TargetTopMgdl"/> are the consensus in-range boundaries, and
-        /// <see cref="BgTargetBottom"/> deliberately differs from the former.
+        /// <see cref="BgTargetBottom"/> deliberately differs from the former. Collapsing the two
+        /// families onto each other moves either every tenant's default alarm threshold or every
+        /// time-in-range denominator.
         /// </summary>
         public static class Thresholds
         {

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -179,9 +179,9 @@ public class GlycemicThresholds
     public double VeryLow { get; set; } = 54;
 
     /// <summary>
-    /// Threshold for low glucose (default: 70 mg/dL)
+    /// Threshold for low glucose (defaults to <see cref="GlucoseConstants.TargetBottomMgdl"/>)
     /// </summary>
-    public double Low { get; set; } = 70;
+    public double Low { get; set; } = GlucoseConstants.TargetBottomMgdl;
 
     /// <summary>
     /// Target range bottom threshold (defaults to <see cref="GlucoseConstants.TargetBottomMgdl"/>)
@@ -194,9 +194,10 @@ public class GlycemicThresholds
     public double TargetTop { get; set; } = GlucoseConstants.TargetTopMgdl;
 
     /// <summary>
-    /// Tight target range bottom threshold (default: 70 mg/dL)
+    /// Tight target range bottom threshold. The tight band narrows the top only; its bottom is the
+    /// same hypoglycaemia boundary as <see cref="GlucoseConstants.TargetBottomMgdl"/>.
     /// </summary>
-    public double TightTargetBottom { get; set; } = 70;
+    public double TightTargetBottom { get; set; } = GlucoseConstants.TargetBottomMgdl;
 
     /// <summary>
     /// Tight target range top threshold (default: 140 mg/dL)
@@ -204,9 +205,9 @@ public class GlycemicThresholds
     public double TightTargetTop { get; set; } = 140;
 
     /// <summary>
-    /// Threshold for high glucose (default: 180 mg/dL)
+    /// Threshold for high glucose (defaults to <see cref="GlucoseConstants.TargetTopMgdl"/>)
     /// </summary>
-    public double High { get; set; } = 180;
+    public double High { get; set; } = GlucoseConstants.TargetTopMgdl;
 
     /// <summary>
     /// Threshold for very high glucose (default: 250 mg/dL)
@@ -974,8 +975,8 @@ public class ClinicalTargets
                 MaxTAR = 25,
                 MaxTARVeryHigh = 5,
                 TargetCV = 36,
-                TargetLow = 70,
-                TargetHigh = 180,
+                TargetLow = GlucoseConstants.TargetBottomMgdl,
+                TargetHigh = GlucoseConstants.TargetTopMgdl,
             },
             DiabetesPopulation.Type1Pediatric => new ClinicalTargets
             {
@@ -985,8 +986,8 @@ public class ClinicalTargets
                 MaxTAR = 25,
                 MaxTARVeryHigh = 5,
                 TargetCV = 36,
-                TargetLow = 70,
-                TargetHigh = 180,
+                TargetLow = GlucoseConstants.TargetBottomMgdl,
+                TargetHigh = GlucoseConstants.TargetTopMgdl,
             },
             DiabetesPopulation.Elderly => new ClinicalTargets
             {
@@ -996,8 +997,8 @@ public class ClinicalTargets
                 MaxTAR = 50,
                 MaxTARVeryHigh = 10,
                 TargetCV = 36,
-                TargetLow = 70,
-                TargetHigh = 180,
+                TargetLow = GlucoseConstants.TargetBottomMgdl,
+                TargetHigh = GlucoseConstants.TargetTopMgdl,
             },
             DiabetesPopulation.Pregnancy => new ClinicalTargets
             {

--- a/src/Tools/Nocturne.Tools.McpServer/Tools/EntryTools.cs
+++ b/src/Tools/Nocturne.Tools.McpServer/Tools/EntryTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Server;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
 using Nocturne.Tools.McpServer.Services;
 
@@ -188,6 +189,9 @@ public static class EntryTools
                 return "No valid glucose values found";
             }
 
+            const double targetLow = GlucoseConstants.TargetBottomMgdl;
+            const double targetHigh = GlucoseConstants.TargetTopMgdl;
+
             var stats = new
             {
                 Period = $"Last {hours} hours",
@@ -200,9 +204,9 @@ public static class EntryTools
                 TimeInRange = new
                 {
                     VeryLow = glucoseValues.Count(g => g < 54),
-                    Low = glucoseValues.Count(g => g >= 54 && g < 70),
-                    InRange = glucoseValues.Count(g => g >= 70 && g <= 180),
-                    High = glucoseValues.Count(g => g > 180 && g <= 250),
+                    Low = glucoseValues.Count(g => g >= 54 && g < targetLow),
+                    InRange = glucoseValues.Count(g => g >= targetLow && g <= targetHigh),
+                    High = glucoseValues.Count(g => g > targetHigh && g <= 250),
                     VeryHigh = glucoseValues.Count(g => g > 250),
                 },
                 TimeInRangePercentages = new
@@ -212,19 +216,19 @@ public static class EntryTools
                         1
                     ),
                     Low = Math.Round(
-                        (double)glucoseValues.Count(g => g >= 54 && g < 70)
+                        (double)glucoseValues.Count(g => g >= 54 && g < targetLow)
                             / glucoseValues.Length
                             * 100,
                         1
                     ),
                     InRange = Math.Round(
-                        (double)glucoseValues.Count(g => g >= 70 && g <= 180)
+                        (double)glucoseValues.Count(g => g >= targetLow && g <= targetHigh)
                             / glucoseValues.Length
                             * 100,
                         1
                     ),
                     High = Math.Round(
-                        (double)glucoseValues.Count(g => g > 180 && g <= 250)
+                        (double)glucoseValues.Count(g => g > targetHigh && g <= 250)
                             / glucoseValues.Length
                             * 100,
                         1

--- a/src/Tools/Nocturne.Tools.McpServer/Tools/GlucoseTools.cs
+++ b/src/Tools/Nocturne.Tools.McpServer/Tools/GlucoseTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text.Json;
 using ModelContextProtocol.Server;
+using Nocturne.Core.Constants;
 
 namespace Nocturne.Tools.McpServer.Tools;
 
@@ -106,6 +107,9 @@ public static class GlucoseTools
             var variance = sorted.Select(x => Math.Pow(x - mean, 2)).Average();
             var stdDev = Math.Sqrt(variance);
 
+            const double targetLow = GlucoseConstants.TargetBottomMgdl;
+            const double targetHigh = GlucoseConstants.TargetTopMgdl;
+
             var stats = new
             {
                 Period = $"Last {hours} hours",
@@ -119,17 +123,17 @@ public static class GlucoseTools
                 TimeInRange = new
                 {
                     VeryLow = sorted.Count(g => g < 54),
-                    Low = sorted.Count(g => g >= 54 && g < 70),
-                    InRange = sorted.Count(g => g >= 70 && g <= 180),
-                    High = sorted.Count(g => g > 180 && g <= 250),
+                    Low = sorted.Count(g => g >= 54 && g < targetLow),
+                    InRange = sorted.Count(g => g >= targetLow && g <= targetHigh),
+                    High = sorted.Count(g => g > targetHigh && g <= 250),
                     VeryHigh = sorted.Count(g => g > 250),
                 },
                 TimeInRangePercent = new
                 {
                     VeryLow = Math.Round((double)sorted.Count(g => g < 54) / values.Count * 100, 1),
-                    Low = Math.Round((double)sorted.Count(g => g >= 54 && g < 70) / values.Count * 100, 1),
-                    InRange = Math.Round((double)sorted.Count(g => g >= 70 && g <= 180) / values.Count * 100, 1),
-                    High = Math.Round((double)sorted.Count(g => g > 180 && g <= 250) / values.Count * 100, 1),
+                    Low = Math.Round((double)sorted.Count(g => g >= 54 && g < targetLow) / values.Count * 100, 1),
+                    InRange = Math.Round((double)sorted.Count(g => g >= targetLow && g <= targetHigh) / values.Count * 100, 1),
+                    High = Math.Round((double)sorted.Count(g => g > targetHigh && g <= 250) / values.Count * 100, 1),
                     VeryHigh = Math.Round((double)sorted.Count(g => g > 250) / values.Count * 100, 1),
                 },
             };


### PR DESCRIPTION
Addresses the target-range half of #928 (the palette half remains — see the closing note).

## What remained of #928 after #932

#932 guarded the surfaces but unified nothing: all four C# palettes are still distinct on main, and the issue's target-range list (7 sites) undercounted — this pass found 20 sites across 15 files declaring 70/180 (or 80/180/55/260) as bare literals.

## Change — one declaration per concept, zero value changes

Onto `GlucoseConstants.TargetBottomMgdl` / `TargetTopMgdl` (the consensus clinical in-range band, 70/180):
`GlycemicThresholds` (Low/High/TightTargetBottom), the three `ClinicalTargets` pairs, `StatisticsService` (PGS + intervention before/after TIR), `ActogramReportService`, `ProfileLoadStage`, `TargetRangeResolver`, `SleepReportService` (four "mirror ProfileLoadStage" default pairs), `DataOverviewService` bucketing, both MCP tools' bucketing, and `SensorContextEnricher`'s no-schedule fallback.

Onto `ApplicationConstants.Web.Thresholds.Bg*` (the legacy Nightscout `bg*` client alarm defaults, 80/180/55/260 — a **different concept** that #820 documented): `StatusService`, `TenantOverviewService`, `PropertiesService`, `Ar2Service`. That class's doc is the single site stating the two-families distinction and now describes both supply mechanisms accurately (config-key fallback vs the settings map the AR2 path builds).

The trap #928 warns about — collapsing 80 onto 70 (moves every default alarm threshold) or 70 onto 80 (moves every TIR denominator) — was the review focus: the hostile gate independently classified all sites from surrounding code and legacy Nightscout semantics and found zero mix-ups, including the two nearby decoys (`ClinicalTargets.TargetTIR = 70` is a percentage; pregnancy populations use 63/140).

Deliberately left, with reasons: `UISettingsController` alarm-rule defaults (70/180 — a third family, ambiguous), sensor-integrity/compression-low hypo detection params, `GlucoseBucketResolver.DefaultTightLow` (`const short`), `BolusWizardService`'s simplified threshold, histogram bin edges, and `TightTargetTop = 140` (declared once, duplicates nothing — tight range is 70–140, so only its bottom shares the standard boundary).

## Evidence

- Full solution 0 errors; `Nocturne.API.Tests` 5997, `Core.Models` 676, `Core.Constants` 29, `Widget.Contracts` 32 — all green; no test file touched.
- **Mutation A** (`TargetBottomMgdl` 70→71): 7 failures — 6 in API.Tests (clinical accuracy, ProfileLoadStage ×3, actogram, TargetRangeResolver) plus `GlucoseMirrorTests`' desktop-tray row. Honest sensitivity note: the taskbar-mod rows survive a 1 mg/dL move (3.94 still rounds to 3.9 at the mod's single decimal) — they kill ~2 mg/dL or larger, a documented limit of that guard, not a regression.
- **Mutation B** (`BgTargetBottom` 80→81): 6 failures — V1/V3 status golden tests and TenantOverviewService ×3, proving the wire shape (integers, unchanged) is pinned.
- Type audit: `Bg*` are `const int`, so `StatusService`'s dropped `GetValue<int>` infers identically; the V1 golden output is byte-identical.

## Residual finding from the hostile gate (test suite, not this diff)

Cross-linking the two families at a *use site* compiles silently and mostly survives the suite: swapping the AR2/PropertiesService alarm defaults to the clinical constant is caught by **nothing**, and the clinical→alarm direction is caught only via `GlycemicThresholds.Low` consumers. The invariant is enforced by prose at most sites. Noted on #928 for the follow-up pass, along with the adjacent duplications this pass surfaced (54/250 very-low/very-high declared 6×, 140 twice, and `DataOverviewService`/MCP tools hand-rolling TIR against a hardcoded band instead of tenant thresholds — the #561 shape).

## Closing note

This does not close #928: the palette table (four disagreeing C# palettes, `StatusPalette` with no production consumer) needs a product decision on which palette wins, because unifying changes rendered output on the Win11 widget and tray tile — the same reason #820 and #932 both left it. Suggest narrowing #928 to the palette question.

_Agent-authored; reviewed + gate-reviewed with independent verification and a fix round._
