### PR TITLE
fix(web): read rejected remote-function reasons through the message helpers

### DIFF
--- a/src/Web/packages/app/src/lib/api/remote-error.test.ts
+++ b/src/Web/packages/app/src/lib/api/remote-error.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { MISSING_ITEM_ERROR, RATE_LIMITED_ERROR } from "../forms/submit-error";
+import { remoteErrorMessage } from "./remote-error";
+
+const NEEDS_ALERTS_READWRITE =
+  "Changing alerts requires the alerts.readwrite permission.";
+
+describe("remoteErrorMessage", () => {
+  it("answers a scope refusal with the permission the caller named", () => {
+    expect(
+      remoteErrorMessage({ status: 403, body: { message: "Forbidden" } }, NEEDS_ALERTS_READWRITE)
+    ).toBe(NEEDS_ALERTS_READWRITE);
+  });
+
+  it("keeps naming the permission even when the 403 body reads like a sentence", () => {
+    expect(
+      remoteErrorMessage(
+        {
+          status: 403,
+          body: { message: "This operation requires the 'alerts.write' scope." },
+        },
+        NEEDS_ALERTS_READWRITE
+      )
+    ).toBe(NEEDS_ALERTS_READWRITE);
+  });
+
+  it("answers a throttled read as throttled", () => {
+    expect(remoteErrorMessage({ status: 429 }, NEEDS_ALERTS_READWRITE)).toBe(
+      RATE_LIMITED_ERROR
+    );
+  });
+
+  it("answers a stale id as a missing item, not a missing permission", () => {
+    expect(
+      remoteErrorMessage({ status: 404, body: { message: "Not found" } }, NEEDS_ALERTS_READWRITE)
+    ).toBe(MISSING_ITEM_ERROR);
+  });
+
+  it("forwards the reason a rejected read carried", () => {
+    expect(
+      remoteErrorMessage(
+        { status: 400, body: { message: "That date range is too wide." } },
+        NEEDS_ALERTS_READWRITE
+      )
+    ).toBe("That date range is too wide.");
+  });
+
+  it("forwards a 5xx body, which is the only clue why a panel is empty", () => {
+    expect(
+      remoteErrorMessage(
+        { status: 500, body: { message: "Failed to get alert rules" } },
+        NEEDS_ALERTS_READWRITE
+      )
+    ).toBe("Failed to get alert rules");
+  });
+
+  it("falls back for a thrown Error, a bare string and null", () => {
+    expect(remoteErrorMessage(new Error("fetch failed"), NEEDS_ALERTS_READWRITE)).toBe(
+      NEEDS_ALERTS_READWRITE
+    );
+    expect(remoteErrorMessage("string throw", NEEDS_ALERTS_READWRITE)).toBe(
+      NEEDS_ALERTS_READWRITE
+    );
+    expect(remoteErrorMessage(null, NEEDS_ALERTS_READWRITE)).toBe(
+      NEEDS_ALERTS_READWRITE
+    );
+  });
+});

--- a/src/Web/packages/app/src/lib/api/remote-error.ts
+++ b/src/Web/packages/app/src/lib/api/remote-error.ts
@@ -28,11 +28,14 @@ import {
  * - Use this one where the fallback names the permission or scope the call
  *   needs ("Changing alerts requires alerts.readwrite") — the reading surfaces,
  *   where a refusal is the expected failure and a 5xx body is the only clue why
- *   a panel is empty. It forwards a 5xx body and answers 403 with the fallback.
+ *   a panel is empty. It forwards a 5xx body, and always answers 403 with the
+ *   fallback, which names the missing permission more precisely than any body
+ *   the server could send.
  * - Use `describeSubmitError` where the fallback names the action the user took
  *   ("Failed to create invite") — the writing surfaces, where the person is
  *   mid-task and a server's internal 5xx text must not reach them. It suppresses
- *   a 5xx body, answers 404 with the fallback, and shows a 403 body.
+ *   a 5xx body, answers 404 with the fallback, and answers 403 with the fallback
+ *   unless the server wrote the body rather than the HTTP client.
  */
 export function remoteErrorMessage(err: unknown, fallback: string): string {
   const e = err as { status?: number; body?: { message?: unknown } } | null;

--- a/src/Web/packages/app/src/lib/api/remote-error.ts
+++ b/src/Web/packages/app/src/lib/api/remote-error.ts
@@ -19,6 +19,20 @@ import {
  * message names the status, and every caller here passes a sentence about a
  * missing permission — which a caller who holds the permission would be told
  * they lack the moment they act on an id someone else deleted.
+ *
+ * `describeSubmitError` (`$lib/forms/submit-error`) reads the same
+ * `HttpError` shape for the other
+ * half of the app, and the two differ on three points. Which one a call site
+ * wants follows from what its fallback sentence says:
+ *
+ * - Use this one where the fallback names the permission or scope the call
+ *   needs ("Changing alerts requires alerts.readwrite") — the reading surfaces,
+ *   where a refusal is the expected failure and a 5xx body is the only clue why
+ *   a panel is empty. It forwards a 5xx body and answers 403 with the fallback.
+ * - Use `describeSubmitError` where the fallback names the action the user took
+ *   ("Failed to create invite") — the writing surfaces, where the person is
+ *   mid-task and a server's internal 5xx text must not reach them. It suppresses
+ *   a 5xx body, answers 404 with the fallback, and shows a 403 body.
  */
 export function remoteErrorMessage(err: unknown, fallback: string): string {
   const e = err as { status?: number; body?: { message?: unknown } } | null;

--- a/src/Web/packages/app/src/lib/components/account/UserProfileCard.svelte
+++ b/src/Web/packages/app/src/lib/components/account/UserProfileCard.svelte
@@ -18,6 +18,7 @@
   import { formatSessionExpiry, getAuthStore } from "$lib/stores/auth-store.svelte";
   import { formatDate } from "$lib/utils/formatting";
   import { upload as uploadAvatar, remove as deleteAvatar } from "$lib/api/generated/avatars.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   interface User {
     name: string;
@@ -80,7 +81,7 @@
       localAvatarUrl = result.avatarUrl;
       authStore.updateAvatarUrl(result.avatarUrl);
     } catch (err) {
-      avatarError = err instanceof Error ? err.message : "Failed to upload avatar";
+      avatarError = describeSubmitError(err, "Failed to upload avatar");
     } finally {
       isUploading = false;
       if (fileInput) fileInput.value = "";
@@ -97,7 +98,7 @@
       localAvatarUrl = undefined;
       authStore.updateAvatarUrl(undefined);
     } catch (err) {
-      avatarError = err instanceof Error ? err.message : "Failed to delete avatar";
+      avatarError = describeSubmitError(err, "Failed to delete avatar");
     } finally {
       isDeleting = false;
     }

--- a/src/Web/packages/app/src/lib/components/admin/OidcProviderDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/admin/OidcProviderDialog.svelte
@@ -14,7 +14,7 @@
   } from "lucide-svelte";
   import { OidcProviderType } from "$api";
   import type { OidcProviderResponse, OidcProviderTestResult, TenantRoleDto } from "$api";
-  import { errorMessage } from "$lib/forms/submit-error";
+  import { describeSubmitError, errorMessage } from "$lib/forms/submit-error";
 
   const OIDC_SCOPES = "openid profile email";
 
@@ -152,7 +152,7 @@
     } catch (err: unknown) {
       testResult = {
         success: false,
-        error: err instanceof Error ? err.message : "Test failed",
+        error: describeSubmitError(err, "Test failed"),
       };
     } finally {
       testingProvider = false;

--- a/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
@@ -25,6 +25,7 @@
     replayDryRun,
   } from "$api/generated/alertReplays.generated.remote";
   import { getRules } from "$api/generated/alertRules.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import {
     AlertReplayEventKind,
     type AlertReplayResult,
@@ -326,10 +327,7 @@
       leafLog = new LeafTransitionLog(result?.leafTransitionsByRule ?? {});
       factLog = new FactSnapshotLog(result?.factTimelines ?? {});
     } catch (err) {
-      runError =
-        err instanceof Error
-          ? err.message
-          : "Failed to run replay. Please try again.";
+      runError = describeSubmitError(err, "Failed to run replay. Please try again.");
     } finally {
       running = false;
     }

--- a/src/Web/packages/app/src/lib/components/connectors/CareLinkConnectPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/CareLinkConnectPanel.svelte
@@ -9,6 +9,7 @@
     complete as completeCareLinkConnect,
     desktopToken as mintDesktopLinkCode,
   } from "$lib/api/generated/careLinkConnects.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import {
     Card,
     CardContent,
@@ -80,7 +81,7 @@
       // Open Medtronic's login in a new tab; the user signs in + solves the captcha there.
       window.open(res.authorizeUrl, "_blank", "noopener");
     } catch (e) {
-      error = e instanceof Error ? e.message : "Could not start CareLink sign-in.";
+      error = describeSubmitError(e, "Could not start CareLink sign-in.");
     } finally {
       busy = false;
     }
@@ -103,7 +104,7 @@
       phase = "done";
       onConnected?.({ server: region, username: res.username, country: res.country });
     } catch (e) {
-      error = e instanceof Error ? e.message : "Could not complete CareLink sign-in.";
+      error = describeSubmitError(e, "Could not complete CareLink sign-in.");
     } finally {
       busy = false;
     }
@@ -131,7 +132,7 @@
       desktopLinkCode = res.linkCode ?? null;
       desktopExpiresMinutes = Math.max(1, Math.round((res.expiresInSeconds ?? 600) / 60));
     } catch (e) {
-      error = e instanceof Error ? e.message : "Could not create a link code.";
+      error = describeSubmitError(e, "Could not create a link code.");
     } finally {
       busy = false;
     }

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorDangerZone.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorDangerZone.svelte
@@ -8,6 +8,7 @@
   import {
     deleteConnectorData,
   } from "$lib/api/generated/services.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import {
     Card,
     CardContent,
@@ -88,7 +89,7 @@
     } catch (e) {
       deleteConfigResult = {
         success: false,
-        error: e instanceof Error ? e.message : "Failed to delete configuration",
+        error: describeSubmitError(e, "Failed to delete configuration"),
       };
     }
   }
@@ -104,7 +105,7 @@
     } catch (e) {
       deleteDataResult = {
         success: false,
-        error: e instanceof Error ? e.message : "Failed to delete data",
+        error: describeSubmitError(e, "Failed to delete data"),
       };
     }
   }

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorDangerZone.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorDangerZone.svelte.test.ts
@@ -1,0 +1,102 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+let deleteConfigImpl: () => Promise<unknown>;
+let deleteDataImpl: () => Promise<unknown>;
+
+vi.mock("$lib/api/generated/configurations.generated.remote", () => ({
+  deleteConfiguration: () => deleteConfigImpl(),
+}));
+
+vi.mock("$lib/api/generated/services.generated.remote", () => ({
+  deleteConnectorData: () => deleteDataImpl(),
+}));
+
+import ConnectorDangerZone from "./ConnectorDangerZone.svelte";
+
+// A rejected generated remote function is SvelteKit's `HttpError`: a plain
+// `{ status, body }` with no `Error` in its prototype chain.
+function rejection(status: number, message: string) {
+  return Promise.reject({ status, body: { message } });
+}
+
+async function attemptDeleteConfiguration() {
+  render(ConnectorDangerZone, {
+    props: {
+      connectorId: "dexcom",
+      displayName: "Dexcom",
+      hasExistingConfig: true,
+      hasData: false,
+      dataSummary: null,
+    },
+  });
+
+  await page.getByRole("button", { name: "Delete Config", exact: true }).click();
+  await page.getByRole("textbox").fill("DELETE CONFIGURATION");
+  await page
+    .getByRole("button", { name: "Delete Configuration", exact: true })
+    .click();
+}
+
+async function attemptDeleteData() {
+  render(ConnectorDangerZone, {
+    props: {
+      connectorId: "dexcom",
+      displayName: "Dexcom",
+      hasExistingConfig: false,
+      hasData: true,
+      dataSummary: null,
+    },
+  });
+
+  await page.getByRole("button", { name: "Delete Data", exact: true }).click();
+  await page.getByRole("textbox").fill("DELETE DATA");
+  await page.getByRole("button", { name: "Delete All Data" }).click();
+}
+
+describe("ConnectorDangerZone", () => {
+  beforeEach(() => {
+    deleteConfigImpl = () => Promise.resolve({});
+    deleteDataImpl = () => Promise.resolve({ success: true, totalDeleted: 1 });
+  });
+
+  it("shows the server's reason when deleting the configuration is refused", async () => {
+    deleteConfigImpl = () =>
+      rejection(409, "Stop the running sync before deleting this connector.");
+
+    await attemptDeleteConfiguration();
+
+    await expect
+      .element(
+        page.getByText("Stop the running sync before deleting this connector.")
+      )
+      .toBeInTheDocument();
+  });
+
+  it("keeps a server fault behind the component's own wording", async () => {
+    deleteConfigImpl = () => rejection(500, "npgsql: connection reset");
+
+    await attemptDeleteConfiguration();
+
+    await expect
+      .element(page.getByText("Failed to delete configuration").first())
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("npgsql: connection reset"))
+      .not.toBeInTheDocument();
+  });
+
+  it("shows the server's reason when deleting synced data is refused", async () => {
+    deleteDataImpl = () =>
+      rejection(409, "A deduplication job is still running on this data.");
+
+    await attemptDeleteData();
+
+    await expect
+      .element(
+        page.getByText("A deduplication job is still running on this data.")
+      )
+      .toBeInTheDocument();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorSetup.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorSetup.svelte
@@ -25,6 +25,7 @@
     getConnectorCapabilities,
     getConnectorDataSummary,
   } from "$lib/api/generated/services.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import {
     Card,
     CardContent,
@@ -270,7 +271,7 @@
     } catch (e) {
       saveMessage = {
         type: "error",
-        text: e instanceof Error ? e.message : "Failed to save configuration",
+        text: describeSubmitError(e, "Failed to save configuration"),
       };
       throw e;
     }
@@ -296,7 +297,7 @@
     } catch (e) {
       saveMessage = {
         type: "error",
-        text: e instanceof Error ? e.message : "Failed to update connector state",
+        text: describeSubmitError(e, "Failed to update connector state"),
       };
     }
 

--- a/src/Web/packages/app/src/lib/components/connectors/DeduplicationDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DeduplicationDialog.svelte
@@ -15,6 +15,7 @@
     getJobStatus as getDeduplicationJobStatus,
     cancelJob as cancelDeduplicationJob,
   } from "$api/generated/deduplications.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import type { DeduplicationJobStatus } from "$lib/api/generated/nocturne-api-client";
 
   let { open = $bindable(false), isDeduplicating = $bindable(false) } = $props<{ open: boolean, isDeduplicating?: boolean }>();
@@ -46,7 +47,7 @@
         deduplicationStartTime = null;
       }
     } catch (e) {
-      deduplicationError = e instanceof Error ? e.message : "Failed to start deduplication";
+      deduplicationError = describeSubmitError(e, "Failed to start deduplication");
       isDeduplicating = false;
       deduplicationStartTime = null;
     }

--- a/src/Web/packages/app/src/lib/components/connectors/DemoDataSection.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DemoDataSection.svelte
@@ -3,6 +3,7 @@
   import { Button } from "$lib/components/ui/button";
   import { Sparkles, CheckCircle, AlertCircle, Loader2, Trash2 } from "lucide-svelte";
   import { deleteDemoData as deleteDemoDataRemote } from "$api/generated/services.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   let { open = $bindable(false), onDeleteComplete } = $props<{
     open: boolean;
@@ -40,7 +41,7 @@
     } catch (e) {
       demoDeleteResult = {
         success: false,
-        error: e instanceof Error ? e.message : "Failed to delete demo data",
+        error: describeSubmitError(e, "Failed to delete demo data"),
       };
     } finally {
       isDeletingDemo = false;

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
@@ -10,6 +10,7 @@ import {
 import { STALE_THRESHOLD_MS } from "$lib/constants/staleness";
 import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
 import { getChartData } from "$api/chart-data.remote";
+import { remoteErrorMessage } from "$lib/api/remote-error";
 import {
   getPredictions,
   getPredictionStatus,
@@ -432,7 +433,7 @@ export function createChartDataEngine(
       .catch((err) => {
         if (!cancelled) {
           console.error("Failed to fetch predictions:", err);
-          predictionError = err.message;
+          predictionError = remoteErrorMessage(err, "Predictions are unavailable right now.");
           predictionData = null;
         }
       });

--- a/src/Web/packages/app/src/lib/components/dashboard/widgets/TddWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/widgets/TddWidget.svelte
@@ -5,6 +5,7 @@
   import { getMultiPeriodStatistics } from "$api/generated/statistics.generated.remote";
   import { Button } from "$lib/components/ui/button";
   import ReliabilityBadge from "$lib/components/reports/ReliabilityBadge.svelte";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
 
   // Toggle between today and 90-day average
   let showAverage = $state(false);
@@ -151,7 +152,7 @@
     {:catch err}
       <div class="flex flex-col items-center justify-center text-muted-foreground py-4">
         <p class="text-xs">Failed to load data</p>
-        <p class="text-xs text-destructive">{err?.message ?? JSON.stringify(err)}</p>
+        <p class="text-xs text-destructive">{remoteErrorMessage(err, "Please try again.")}</p>
       </div>
     {/await}
   {/if}

--- a/src/Web/packages/app/src/lib/components/dashboard/widgets/TirChartWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/widgets/TirChartWidget.svelte
@@ -7,6 +7,7 @@
   import { MediaQuery } from "svelte/reactivity";
   import { Button } from "$lib/components/ui/button";
   import ReliabilityBadge from "$lib/components/reports/ReliabilityBadge.svelte";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
 
   // Toggle between today and 90-day average
   let showAverage = $state(false);
@@ -137,7 +138,7 @@
     {:catch err}
       <div class="flex flex-col items-center justify-center text-muted-foreground py-4">
         <p class="text-xs">Failed to load data</p>
-        <p class="text-xs text-destructive">{err?.message ?? JSON.stringify(err)}</p>
+        <p class="text-xs text-destructive">{remoteErrorMessage(err, "Please try again.")}</p>
       </div>
     {/await}
   {/if}

--- a/src/Web/packages/app/src/lib/components/reports/ResourceGuard.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ResourceGuard.svelte
@@ -8,13 +8,14 @@
     CardTitle,
   } from "$lib/components/ui/card";
   import ReportsSkeleton from "./ReportsSkeleton.svelte";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import type { Snippet } from "svelte";
 
   interface Props {
     /** Whether the resource is loading */
     loading: boolean;
-    /** Error object or message, if any */
-    error: Error | string | null | undefined;
+    /** Error object, message, or rejected remote-function value, if any */
+    error: unknown;
     /** Whether there is cached data to show (prevents skeleton flash) */
     hasData?: boolean;
     /** Whether a new value is loading while the previous one is still shown */
@@ -50,7 +51,9 @@
     error
       ? error instanceof Error
         ? error.message
-        : String(error)
+        : typeof error === "string"
+          ? error
+          : remoteErrorMessage(error, "Something went wrong. Please try again.")
       : null
   );
 

--- a/src/Web/packages/app/src/lib/components/reports/ResourceGuard.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/reports/ResourceGuard.svelte.test.ts
@@ -124,6 +124,23 @@ describe("ResourceGuard", () => {
 			.toBeVisible();
 	});
 
+	it("shows the reason a remote query was rejected", async () => {
+		// A rejected remote function is SvelteKit's `HttpError`: a plain
+		// `{ status, body }` with no `Error` in its prototype chain.
+		render(ResourceGuard, {
+			loading: false,
+			error: { status: 400, body: { message: "That date range is too wide." } },
+			compact: true,
+			children: createRawSnippet(() => ({
+				render: () => "<p>Content loaded</p>",
+			})),
+		});
+
+		await expect
+			.element(page.getByText("That date range is too wide."))
+			.toBeVisible();
+	});
+
 	it("shows content when loaded successfully", async () => {
 		render(ResourceGuard, {
 			loading: false,

--- a/src/Web/packages/app/src/lib/components/reports/RetrospectiveStats.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/RetrospectiveStats.svelte
@@ -14,6 +14,7 @@
   import { getDirectionInfo } from "$lib/utils";
   import { formatGlucoseValue, getUnitLabel } from "$lib/utils/formatting";
   import { getRetrospectiveData } from "$api/generated/retrospectives.generated.remote";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
 
   interface Props {
     /** Unix timestamp in milliseconds to fetch data for */
@@ -84,9 +85,7 @@
     <Card.Content>
       <div class="text-center space-y-3">
         <p class="text-sm text-muted-foreground">
-          {error instanceof Error
-            ? error.message
-            : "Failed to load retrospective data"}
+          {remoteErrorMessage(error, "Failed to load retrospective data")}
         </p>
         <Button
           variant="outline"

--- a/src/Web/packages/app/src/lib/components/reports/RetrospectiveStats.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/reports/RetrospectiveStats.svelte.test.ts
@@ -4,14 +4,17 @@ import { describe, it, expect, vi } from "vitest";
 import { Direction } from "$lib/api/generated/nocturne-api-client";
 
 let reportedDirection: string | undefined;
+let reportedError: unknown;
 
 vi.mock("$api/generated/retrospectives.generated.remote", () => ({
   getRetrospectiveData: () => ({
-    current: {
-      time: 0,
-      glucose: { value: 120, direction: reportedDirection, delta: 4 },
-    },
-    error: undefined,
+    current: reportedError
+      ? undefined
+      : {
+          time: 0,
+          glucose: { value: 120, direction: reportedDirection, delta: 4 },
+        },
+    error: reportedError,
     refresh: () => {},
   }),
 }));
@@ -20,10 +23,28 @@ import RetrospectiveStats from "./RetrospectiveStats.svelte";
 
 function renderWithDirection(direction: string | undefined) {
   reportedDirection = direction;
+  reportedError = undefined;
   render(RetrospectiveStats, { props: { time: 0 } });
 }
 
 describe("RetrospectiveStats", () => {
+  it("shows the reason a rejected query gave", async () => {
+    // A rejected remote function is SvelteKit's `HttpError`: a plain
+    // `{ status, body }` with no `Error` in its prototype chain.
+    reportedError = {
+      status: 400,
+      body: { message: "That timestamp is before this tenant had data." },
+    };
+
+    render(RetrospectiveStats, { props: { time: 0 } });
+
+    await expect
+      .element(
+        page.getByText("That timestamp is before this tenant had data.")
+      )
+      .toBeVisible();
+  });
+
   it("labels a reported trend", async () => {
     renderWithDirection(Direction.Flat);
 

--- a/src/Web/packages/app/src/lib/components/schedule/TargetRangeCard.svelte
+++ b/src/Web/packages/app/src/lib/components/schedule/TargetRangeCard.svelte
@@ -10,6 +10,7 @@
   import { Target, Pencil } from "lucide-svelte";
   import ScheduleView from "./ScheduleView.svelte";
   import { createTargetRangeSchedule } from "$api/generated/profiles.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
   import {
     bgLabel,
@@ -93,7 +94,7 @@
       });
       editing = false;
     } catch (err) {
-      saveError = err instanceof Error ? err.message : "Failed to save target range";
+      saveError = describeSubmitError(err, "Failed to save target range");
     } finally {
       saving = false;
     }

--- a/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
@@ -23,6 +23,7 @@
     create as createGrant,
     revoke as revokeGrant,
   } from "$lib/api/generated/directGrants.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import type { DirectGrantDto } from "$api";
   import { copyToClipboard } from "$lib/utils";
 
@@ -115,8 +116,7 @@
       createdToken = data.token ?? null;
       await loadGrants();
     } catch (err) {
-      errorMessage =
-        err instanceof Error ? err.message : "Failed to create token.";
+      errorMessage = describeSubmitError(err, "Failed to create token.");
       showCreateDialog = false;
     } finally {
       isCreating = false;

--- a/src/Web/packages/app/src/lib/components/settings/LinkedOidcIdentities.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/LinkedOidcIdentities.svelte
@@ -16,6 +16,7 @@
     getLinkedIdentities,
     unlinkIdentity,
   } from "$lib/api/generated/oidcs.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import { getProvidersInfo } from "$routes/(unauthenticated)/auth/auth.remote";
 
   interface Props {
@@ -88,8 +89,7 @@
         errorMessage =
           "Cannot remove your only sign-in method. Add another first.";
       } else {
-        errorMessage =
-          err instanceof Error ? err.message : "Failed to remove sign-in method.";
+        errorMessage = describeSubmitError(err, "Failed to remove sign-in method.");
       }
       clearMessagesSoon();
     } finally {

--- a/src/Web/packages/app/src/lib/components/trackers/ReservoirReportDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/trackers/ReservoirReportDialog.svelte
@@ -8,6 +8,7 @@
   import { Droplet } from "lucide-svelte";
   import { toast } from "svelte-sonner";
   import { create as createReservoirReport } from "$api/generated/reservoirReports.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   type ReportKind = "Reading" | "Fill";
 
@@ -70,7 +71,7 @@
       onReported?.();
     } catch (err) {
       console.error("Failed to report reservoir value:", err);
-      toast.error(err instanceof Error ? err.message : "Failed to record reservoir value");
+      toast.error(describeSubmitError(err, "Failed to record reservoir value"));
     } finally {
       isSubmitting = false;
     }

--- a/src/Web/packages/app/src/lib/forms/submit-error.test.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.test.ts
@@ -1,9 +1,69 @@
 import { describe, it, expect } from "vitest";
+import { transformWithEsbuild } from "vite";
+import { error } from "@sveltejs/kit";
+import config from "../../../../../remote-codegen.config";
 import {
   describeSubmitError,
   GENERIC_SUBMIT_ERROR,
   RATE_LIMITED_ERROR,
 } from "./submit-error";
+
+/**
+ * What a 403 looks like by the time a page sees it: the thrown value put
+ * through the generated client's own 403 arm, compiled from the codegen config
+ * the build reads, so the body is whichever field that arm picked.
+ */
+type ForbidArm = (
+  err: unknown,
+  error: typeof import("@sveltejs/kit").error
+) => never;
+
+function compileArm(source: string): ForbidArm {
+  return new Function(`return ${source}`)();
+}
+
+async function crossThe403Arm(thrown: unknown): Promise<unknown> {
+  const compiled = await transformWithEsbuild(
+    `(err, error) => { ${config.errorHandling.on403}; }`,
+    "on403.ts",
+    { loader: "ts" }
+  );
+
+  const forbid = compileArm(compiled.code.trim().replace(/;$/, ""));
+
+  try {
+    forbid(thrown, error);
+  } catch (crossed) {
+    return crossed;
+  }
+
+  throw new Error("the 403 arm returned without throwing");
+}
+
+/** The two messages the generated client puts on an `ApiException` itself. */
+const UNDECLARED_STATUS_MESSAGE = "An unexpected server error occurred.";
+const DECLARED_STATUS_MESSAGE = "A server side error occurred.";
+
+/** NSwag's ApiException, as a bare `ForbidResult` arrives. */
+function nswagApiException(status: number, message: string) {
+  return Object.assign(new Error(message), {
+    status,
+    response: "",
+    result: null,
+  });
+}
+
+/** An RFC-7807 body, thrown as the parsed object when the 403 is declared. */
+function problemDetails(status: number, detail: string) {
+  return {
+    type: `https://tools.ietf.org/html/rfc9110#status.${status}`,
+    title: "Forbidden",
+    status,
+    detail,
+  };
+}
+
+const NEEDS_SCOPE = "This operation requires the 'activity.write' scope.";
 
 describe("describeSubmitError", () => {
   it("uses the handler's message for a 4xx", () => {
@@ -40,6 +100,43 @@ describe("describeSubmitError", () => {
   it("uses the caller's fallback", () => {
     expect(describeSubmitError(new Error("x"), "Couldn't save.")).toBe(
       "Couldn't save."
+    );
+  });
+
+  it("keeps the caller's wording when a bare ForbidResult is all the server sent", async () => {
+    const crossed = await crossThe403Arm(
+      nswagApiException(403, UNDECLARED_STATUS_MESSAGE)
+    );
+
+    expect(describeSubmitError(crossed, "You can't change this setting.")).toBe(
+      "You can't change this setting."
+    );
+  });
+
+  it("keeps the caller's wording for a declared 403 that came back empty", async () => {
+    const crossed = await crossThe403Arm(
+      nswagApiException(403, DECLARED_STATUS_MESSAGE)
+    );
+
+    expect(describeSubmitError(crossed, "You can't change this setting.")).toBe(
+      "You can't change this setting."
+    );
+  });
+
+  it("keeps the caller's wording when the arm falls through to the status phrase", () => {
+    expect(
+      describeSubmitError(
+        { status: 403, body: { message: "Forbidden" } },
+        "You can't change this setting."
+      )
+    ).toBe("You can't change this setting.");
+  });
+
+  it("shows a refusal the server worded itself", async () => {
+    const crossed = await crossThe403Arm(problemDetails(403, NEEDS_SCOPE));
+
+    expect(describeSubmitError(crossed, "You can't change this setting.")).toBe(
+      NEEDS_SCOPE
     );
   });
 

--- a/src/Web/packages/app/src/lib/forms/submit-error.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.ts
@@ -36,6 +36,35 @@ export function errorMessage(err: unknown): string | undefined {
 }
 
 /**
+ * The 403 bodies the client wrote itself rather than carried from the server.
+ *
+ * A scope refusal is usually a bare `ForbidResult`, which NSwag reports with one
+ * of its own two `ApiException` messages, and the codegen's 403 arm falls back
+ * to the status phrase when the thrown value carries neither a message nor a
+ * detail. Only a `Problem(detail: …)` refusal — the per-record scope guards —
+ * puts a sentence written for a person in the body.
+ *
+ * Recognising the synthesized side is the only check that can be complete: these
+ * three strings are constants of a pinned client and of our own codegen, while
+ * what a server may write is unbounded and so cannot be matched positively.
+ */
+const CLIENT_WRITTEN_FORBIDDEN = new Set([
+  "an unexpected server error occurred.",
+  "a server side error occurred.",
+  "forbidden",
+]);
+
+/** The 403 body, when the server rather than the client wrote it. */
+function forbiddenReason(err: unknown): string | undefined {
+  const message = errorMessage(err);
+  if (message === undefined) return undefined;
+
+  return CLIENT_WRITTEN_FORBIDDEN.has(message.trim().toLowerCase())
+    ? undefined
+    : message;
+}
+
+/**
  * Turns a rejected form submission into a message for the user.
  *
  * A remote `form()` handler that throws `error(status, message)` rejects the
@@ -53,6 +82,11 @@ export function errorMessage(err: unknown): string | undefined {
  * forwards it with a fixed reason, so its message names the status rather than
  * what was missing. A caller that can say something better ("already removed")
  * reads the status itself.
+ *
+ * A 403 answers with the caller's fallback unless the server wrote the body —
+ * see {@link CLIENT_WRITTEN_FORBIDDEN}. "You don't have permission to save
+ * this" beats "A server side error occurred.", and loses only to a refusal that
+ * names the scope.
  */
 export function describeSubmitError(
   err: unknown,
@@ -61,6 +95,7 @@ export function describeSubmitError(
   const status = errorStatus(err);
   if (status === 429) return RATE_LIMITED_ERROR;
   if (status === 404) return fallback;
+  if (status === 403) return forbiddenReason(err) ?? fallback;
 
   if (status !== undefined && status >= 400 && status < 500) {
     return errorMessage(err) ?? fallback;

--- a/src/Web/packages/app/src/lib/hooks/resource-context.svelte.ts
+++ b/src/Web/packages/app/src/lib/hooks/resource-context.svelte.ts
@@ -36,7 +36,8 @@ const RESOURCE_CONTEXT_KEY = Symbol("resource-context");
 /** One panel's fetch state, as reported to the layout's ResourceGuard. */
 export interface ResourceRegistration {
   loading: boolean;
-  error: Error | string | null | undefined;
+  /** Whatever the query rejected with — an `HttpError`, an `Error`, or a string. */
+  error: unknown;
   hasData: boolean;
   /** Loading a new value while a previous one is still on screen. */
   refreshing: boolean;
@@ -78,7 +79,7 @@ export class ResourceContext {
   }
 
   /** First error across registered resources. */
-  get error(): Error | string | null | undefined {
+  get error(): unknown {
     return this.#failed?.error ?? null;
   }
 
@@ -161,7 +162,7 @@ function registerWith(
  */
 export function useResourceContext(config: {
   loading: () => boolean;
-  error: () => Error | string | null | undefined;
+  error: () => unknown;
   hasData: () => boolean;
   errorTitle?: string;
   refetch: () => void;
@@ -242,7 +243,7 @@ export function contextResource<T>(
     getResourceContext(),
     () => ({
       loading: query.loading,
-      error: query.error as Error | string | null | undefined,
+      error: query.error,
       hasData: current !== undefined && current !== null,
       refreshing: query.loading && current !== undefined && current !== null,
       errorTitle,

--- a/src/Web/packages/app/src/lib/stores/auth-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/auth-store.svelte.ts
@@ -17,6 +17,7 @@ import {
   refreshSession as refreshSessionRemote,
   logoutSession as logoutSessionRemote,
 } from "../../routes/(unauthenticated)/auth/auth.remote";
+import { remoteErrorMessage } from "$lib/api/remote-error";
 
 const AUTH_STORE_KEY = Symbol("auth-store");
 
@@ -190,7 +191,7 @@ export class AuthStore {
       }
     } catch (e) {
       console.error("Failed to load session:", e);
-      this._error = e instanceof Error ? e.message : "Failed to load session";
+      this._error = remoteErrorMessage(e, "Failed to load session");
       this._state = "unauthenticated";
       this._user = null;
       this._expiresAt = null;

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -3,6 +3,7 @@
   import { createSettingsStore } from "$lib/stores/settings-store.svelte";
   import { createAuthStore } from "$lib/stores/auth-store.svelte";
   import { authInterceptorState } from "$lib/api/auth-interceptor";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import { onMount, onDestroy } from "svelte";
   import * as Sidebar from "$lib/components/ui/sidebar";
   import { AppSidebar, MobileHeader } from "$lib/components/layout";
@@ -227,7 +228,7 @@
           {@render children()}
 
           {#snippet failed(e, reset)}
-            {@const message = e instanceof Error ? e.message : typeof e === 'string' ? e : 'An unexpected error occurred'}
+            {@const message = e instanceof Error ? e.message : typeof e === 'string' ? e : remoteErrorMessage(e, 'An unexpected error occurred')}
             {@const stack = dev && e instanceof Error ? e.stack : undefined}
             <Card.Root class="mx-auto mt-10 max-w-2xl">
               <Card.Header>

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -188,7 +188,7 @@
           <div>
             <p class="font-medium">Failed to load alerts</p>
             <p class="text-sm text-muted-foreground">
-              {error instanceof Error ? error.message : "Unknown error"}
+              {remoteErrorMessage(error, "Unknown error")}
             </p>
           </div>
         </CardContent>

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
@@ -10,6 +10,7 @@
     deleteRule,
     testFire,
   } from "$api/generated/alertRules.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import { getAlertHistory } from "$api/generated/alerts.generated.remote";
   import { AlertRuleSeverity, AlertConditionType } from "$api-clients";
   import type { HistoryExcursionResponse } from "$api-clients";
@@ -151,7 +152,7 @@
         savedBody = buildBody(state);
       }
     } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
+      error = describeSubmitError(e, "Failed to save the alert rule. Please try again.");
     } finally {
       saving = false;
     }
@@ -166,7 +167,7 @@
       await deleteRule(ruleId);
       await goto("/alerts");
     } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
+      error = describeSubmitError(e, "Failed to delete the alert rule. Please try again.");
     } finally {
       deleting = false;
     }
@@ -180,7 +181,7 @@
     try {
       await testFire(ruleId);
     } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
+      error = describeSubmitError(e, "Failed to send a test alert. Please try again.");
     } finally {
       testingSaved = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
@@ -6,7 +6,7 @@
     get as getDnd,
     update as updateDnd,
   } from "$api/generated/tenantAlertSettings.generated.remote";
-  import { remoteErrorMessage } from "$lib/api/remote-error";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import type { TenantAlertSettingsResponse } from "$api-clients";
 
   import { Button } from "$lib/components/ui/button";
@@ -94,7 +94,7 @@
       });
       applyResponse(r);
     } catch (e) {
-      error = remoteErrorMessage(e, "Failed to save DND settings");
+      error = describeSubmitError(e, "Failed to save DND settings");
     } finally {
       saving = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
@@ -6,6 +6,7 @@
     get as getDnd,
     update as updateDnd,
   } from "$api/generated/tenantAlertSettings.generated.remote";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import type { TenantAlertSettingsResponse } from "$api-clients";
 
   import { Button } from "$lib/components/ui/button";
@@ -93,7 +94,7 @@
       });
       applyResponse(r);
     } catch (e) {
-      error = e instanceof Error ? e.message : "Failed to save DND settings";
+      error = remoteErrorMessage(e, "Failed to save DND settings");
     } finally {
       saving = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/dnd-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/dnd-page.svelte.test.ts
@@ -67,4 +67,23 @@ describe("alerts/dnd page", () => {
       .element(page.getByText("The schedule must end after it starts."))
       .toBeVisible();
   });
+
+  it("keeps a server fault behind the page's own wording", async () => {
+    pageState.data = { effectivePermissions: ["alerts.readwrite"] };
+    updateImpl = () =>
+      Promise.reject({
+        status: 500,
+        body: { message: "npgsql: connection reset" },
+      });
+
+    render(DndPage, {});
+    await saveButton().click();
+
+    await expect
+      .element(page.getByText("Failed to save DND settings"))
+      .toBeVisible();
+    await expect
+      .element(page.getByText("npgsql: connection reset"))
+      .not.toBeInTheDocument();
+  });
 });

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/dnd-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/dnd-page.svelte.test.ts
@@ -11,9 +11,11 @@ const settings: TenantAlertSettingsResponse = {
   dndScheduleEnabled: false,
 } as TenantAlertSettingsResponse;
 
+let updateImpl: () => Promise<TenantAlertSettingsResponse>;
+
 vi.mock("$api/generated/tenantAlertSettings.generated.remote", () => ({
   get: () => ({ current: settings }),
-  update: () => Promise.resolve(settings),
+  update: () => updateImpl(),
 }));
 
 import DndPage from "./+page.svelte";
@@ -24,6 +26,7 @@ const accessDenied = () => page.getByText("Access Denied");
 describe("alerts/dnd page", () => {
   beforeEach(() => {
     pageState.data = {};
+    updateImpl = () => Promise.resolve(settings);
   });
 
   it("shows the access-denied card for a member without alerts.readwrite", async () => {
@@ -45,5 +48,23 @@ describe("alerts/dnd page", () => {
       .element(page.getByText("Do Not Disturb is currently"))
       .toBeVisible();
     await expect.element(accessDenied()).not.toBeInTheDocument();
+  });
+
+  it("shows the server's reason when the save is refused", async () => {
+    pageState.data = { effectivePermissions: ["alerts.readwrite"] };
+    // A rejected generated remote function is SvelteKit's `HttpError`: a plain
+    // `{ status, body }` with no `Error` in its prototype chain.
+    updateImpl = () =>
+      Promise.reject({
+        status: 400,
+        body: { message: "The schedule must end after it starts." },
+      });
+
+    render(DndPage, {});
+    await saveButton().click();
+
+    await expect
+      .element(page.getByText("The schedule must end after it starts."))
+      .toBeVisible();
   });
 });

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/history/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { getAlertHistory } from "$api/generated/alerts.generated.remote";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import type { HistoryExcursionResponse } from "$api-clients";
   import { Button } from "$lib/components/ui/button";
   import { Badge } from "$lib/components/ui/badge";
@@ -56,7 +57,7 @@
 
     {#snippet failed(error)}
       <div class="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
-        {error instanceof Error ? error.message : "Failed to load history"}
+        {remoteErrorMessage(error, "Failed to load history")}
       </div>
     {/snippet}
 

--- a/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/calendar/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from "$app/state";
   import * as Card from "$lib/components/ui/card";
   import { getPunchCardData } from "$api/generated/statistics.generated.remote";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import { getActiveInstances, getDefinitions, getInstanceHistory } from "$api/generated/trackers.generated.remote";
   import type { TrackerInstanceDto, TrackerDefinitionDto } from "$api";
   import { NotificationUrgency as NotificationUrgencyEnum } from "$api";
@@ -379,7 +380,7 @@
             Failed to load calendar data
           </p>
           <p class="text-sm text-muted-foreground mt-1">
-            {punchCardError instanceof Error ? punchCardError.message : "An error occurred"}
+            {remoteErrorMessage(punchCardError, "An error occurred")}
           </p>
           <Button class="mt-4" onclick={() => window.location.reload()}>
             Try Again

--- a/src/Web/packages/app/src/routes/(authenticated)/clock/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/clock/+page.svelte
@@ -10,6 +10,7 @@
     Loader2,
   } from "lucide-svelte";
   import { toast } from "svelte-sonner";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import {
     list as listClockFaces,
     create as createClockFace,
@@ -164,7 +165,7 @@
         <Card.Root class="border-destructive">
           <Card.Content class="py-8 text-center space-y-3">
             <p class="text-destructive">
-              {error instanceof Error ? error.message : "Failed to load clock faces"}
+              {remoteErrorMessage(error, "Failed to load clock faces")}
             </p>
             <Button variant="outline" onclick={reset}>Retry</Button>
           </Card.Content>

--- a/src/Web/packages/app/src/routes/(authenticated)/compatibility/test/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/compatibility/test/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { runCompatibilityTest } from "./data.remote";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import { createPatch } from "diff";
 
   // UI Components
@@ -375,7 +376,7 @@
         requestBody: requestBody || undefined,
       });
     } catch (err) {
-      error = err instanceof Error ? err.message : "An error occurred";
+      error = remoteErrorMessage(err, "An error occurred");
     } finally {
       isLoading = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/notifications/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/notifications/+page.svelte
@@ -24,6 +24,7 @@
   import { cn } from "$lib/utils";
   import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import * as trackersRemote from "$api/generated/trackers.generated.remote";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import {
     CompletionReason,
     type TrackerInstanceDto,
@@ -317,7 +318,7 @@
               <div class="py-6 text-center">
                 <AlertTriangle class="h-8 w-8 text-destructive mx-auto mb-2" />
                 <p class="text-destructive">
-                  {error instanceof Error ? error.message : "Failed to load notification data"}
+                  {remoteErrorMessage(error, "Failed to load notification data")}
                 </p>
                 <Button variant="outline" class="mt-4" onclick={reset}>Retry</Button>
               </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
@@ -77,6 +77,7 @@
   } from "$lib/utils/formatting";
   import ReportsSkeleton from "$lib/components/reports/ReportsSkeleton.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import { coachmark } from "@nocturne/coach";
   import { fly, fade, scale } from "svelte/transition";
   import { cubicOut, elasticOut } from "svelte/easing";
@@ -158,9 +159,7 @@
       </div>
       <h2 class="text-xl font-semibold">Unable to load reports</h2>
       <p class="text-muted-foreground">
-        {reportsResource.error instanceof Error
-          ? reportsResource.error.message
-          : "Something went wrong"}
+        {remoteErrorMessage(reportsResource.error, "Something went wrong")}
       </p>
       <Button variant="outline" onclick={() => reportsResource.refresh()}>
         Try again

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
@@ -187,8 +187,7 @@
       successMessage = "Passkey added successfully.";
       clearMessages();
     } catch (err) {
-      console.error("Passkey registration failed:", err);
-      errorMessage = describePasskeyError(err, "register", "Failed to register passkey.");
+      errorMessage = describeSubmitError(err, "Failed to register passkey.");
     } finally {
       isSavingPasskey = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
@@ -21,7 +21,10 @@
   } from "lucide-svelte";
   import QRCode from "qrcode";
   import type { PageData } from "./$types";
-  import { startRegistration } from "@simplewebauthn/browser";
+  import {
+    startRegistration,
+    type PublicKeyCredentialCreationOptionsJSON,
+  } from "@simplewebauthn/browser";
   import {
     registerOptions,
     registerComplete,
@@ -40,6 +43,11 @@
   import UserProfileCard from "$lib/components/account/UserProfileCard.svelte";
   import SecurityCredentialCard from "$lib/components/account/SecurityCredentialCard.svelte";
   import TotpSetupDialog from "$lib/components/account/TotpSetupDialog.svelte";
+  import {
+    describePasskeyError,
+    parseCeremonyOptions,
+  } from "$lib/components/auth/passkey-errors";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import { page } from "$app/state";
   import { copyToClipboard } from "$lib/utils";
 
@@ -135,7 +143,10 @@
     try {
       // The account the passkey is added to comes from the session, not this call.
       const response = await registerOptions({ username: user.name });
-      const options = JSON.parse(response.options ?? "");
+      const options =
+        parseCeremonyOptions<PublicKeyCredentialCreationOptionsJSON>(
+          response.options
+        );
       const challengeToken = response.challengeToken ?? "";
 
       const attestation = await startRegistration({ optionsJSON: options });
@@ -150,7 +161,8 @@
       newPasskeyLabel = "";
       showLabelDialog = true;
     } catch (err) {
-      errorMessage = err instanceof Error ? err.message : "Failed to register passkey.";
+      console.error("Passkey registration failed:", err);
+      errorMessage = describePasskeyError(err, "register", "Failed to register passkey.");
     } finally {
       isRegistering = false;
     }
@@ -175,7 +187,8 @@
       successMessage = "Passkey added successfully.";
       clearMessages();
     } catch (err) {
-      errorMessage = err instanceof Error ? err.message : "Failed to register passkey.";
+      console.error("Passkey registration failed:", err);
+      errorMessage = describePasskeyError(err, "register", "Failed to register passkey.");
     } finally {
       isSavingPasskey = false;
     }
@@ -206,8 +219,7 @@
       successMessage = "Passkey removed.";
       clearMessages();
     } catch (err) {
-      errorMessage =
-        err instanceof Error ? err.message : "Failed to remove passkey.";
+      errorMessage = describeSubmitError(err, "Failed to remove passkey.");
     } finally {
       isRemoving = null;
       removeTarget = null;
@@ -273,7 +285,7 @@
 
       showTotpSetup = true;
     } catch (err) {
-      errorMessage = err instanceof Error ? err.message : "Failed to start authenticator setup.";
+      errorMessage = describeSubmitError(err, "Failed to start authenticator setup.");
     } finally {
       totpSetupLoading = false;
     }
@@ -300,7 +312,7 @@
       successMessage = "Authenticator app added successfully.";
       clearMessages();
     } catch (err) {
-      totpSetupError = err instanceof Error ? err.message : "Verification failed. Check the code and try again.";
+      totpSetupError = describeSubmitError(err, "Verification failed. Check the code and try again.");
     } finally {
       totpSetupLoading = false;
     }
@@ -322,7 +334,7 @@
       successMessage = "Authenticator removed.";
       clearMessages();
     } catch (err) {
-      errorMessage = err instanceof Error ? err.message : "Failed to remove authenticator.";
+      errorMessage = describeSubmitError(err, "Failed to remove authenticator.");
     } finally {
       totpRemovingId = null;
       totpRemoveTarget = null;

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/+page.svelte
@@ -20,6 +20,7 @@
   import OidcProvidersTabContent from "$lib/components/admin/OidcProvidersTabContent.svelte";
   import OidcProviderDialog from "$lib/components/admin/OidcProviderDialog.svelte";
   import { errorMessage } from "$lib/forms/submit-error";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import type {
     TenantRoleDto,
     OidcProviderResponse,
@@ -72,11 +73,7 @@
       }
     } catch (err) {
       console.error("Failed to load OIDC providers:", err);
-      const body = (err as { body?: { message?: string; detail?: string } })?.body;
-      oidcError =
-        body?.message ??
-        body?.detail ??
-        (err instanceof Error ? err.message : "Failed to load identity providers");
+      oidcError = remoteErrorMessage(err, "Failed to load identity providers");
     } finally {
       oidcLoading = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/tenants/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/tenants/+page.svelte
@@ -33,7 +33,7 @@
   import type { TenantDetailDto, TenantMemberDto } from "$api";
   import { getCurrentTenantId } from "../../current-tenant.remote";
   import { getTransitionStatus } from "$api/generated/platforms.generated.remote";
-  import { errorMessage } from "$lib/forms/submit-error";
+  import { describeSubmitError, errorMessage } from "$lib/forms/submit-error";
 
   const tenantIdQuery = getCurrentTenantId();
   const currentTenantId = $derived(tenantIdQuery.current ?? undefined);
@@ -228,8 +228,10 @@
       createdSlug = normalizedSlug;
       isCreateDialogOpen = false;
     } catch (err) {
-      createError =
-        (err as Error)?.message ?? "Failed to create tenant. Please try again.";
+      createError = describeSubmitError(
+        err,
+        "Failed to create tenant. Please try again."
+      );
     } finally {
       creating = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
@@ -30,6 +30,7 @@
     Info,
   } from "lucide-svelte";
   import * as migrationRemote from "$api/generated/migrations.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import {
     type MigrationJobInfo,
     type MigrationJobStatus,
@@ -171,7 +172,7 @@
       pollingActive = false;
       await loadData();
     } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to cancel migration";
+      error = describeSubmitError(err, "Failed to cancel migration");
     } finally {
       cancellingMigration = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/profile/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/profile/+page.svelte
@@ -22,6 +22,7 @@
   import * as Alert from "$lib/components/ui/alert";
   import { bgLabel } from "$lib/utils/formatting";
   import { getProfileSummary, setDefaultProfile } from "$api/generated/profiles.generated.remote";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import { coachmark } from "@nocturne/coach";
   import ScheduleView from "$lib/components/schedule/ScheduleView.svelte";
   import TargetRangeCard from "$lib/components/schedule/TargetRangeCard.svelte";
@@ -131,7 +132,7 @@
         <div class="text-center space-y-2">
           <p class="text-destructive font-medium">Failed to load profiles</p>
           <p class="text-sm text-muted-foreground">
-            {loadError instanceof Error ? loadError.message : "An error occurred"}
+            {remoteErrorMessage(loadError, "An error occurred")}
           </p>
           <Button variant="outline" onclick={() => window.location.reload()}>
             Try again

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/timezone/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/timezone/+page.svelte
@@ -6,6 +6,7 @@
   import * as AlertDialog from "$lib/components/ui/alert-dialog";
   import { Globe, Plus, Trash2, Loader2, RefreshCw } from "lucide-svelte";
   import * as tz from "$api/generated/timezoneTimelines.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import type { TimezoneTimelineEntry } from "$api";
 
   const timelineQuery = tz.getTimeline();
@@ -52,7 +53,7 @@
       await tz.upsert({ effectiveFrom: toWallClockIso(newDate), timezone: newZone });
       newDate = "";
     } catch (e) {
-      errorMessage = (e as { message?: string })?.message ?? "Failed to add entry";
+      errorMessage = describeSubmitError(e, "Failed to add entry");
     } finally {
       saving = false;
     }
@@ -65,7 +66,7 @@
     try {
       await tz.remove(entry.id);
     } catch (e) {
-      errorMessage = (e as { message?: string })?.message ?? "Failed to delete entry";
+      errorMessage = describeSubmitError(e, "Failed to delete entry");
     }
   }
 
@@ -76,7 +77,7 @@
       const result = await tz.recorrect({});
       recorrectMessage = result.message ?? (result.success ? "Re-import started." : "Re-import failed.");
     } catch (e) {
-      recorrectMessage = (e as { message?: string })?.message ?? "Re-import failed.";
+      recorrectMessage = describeSubmitError(e, "Re-import failed.");
     } finally {
       recorrecting = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
@@ -36,6 +36,7 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
   import * as trackersRemote from "$api/generated/trackers.generated.remote";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import {
     NotificationUrgency,
     TrackerCategory,
@@ -489,7 +490,7 @@
         <CardContent class="py-6 text-center">
           <AlertTriangle class="h-8 w-8 text-destructive mx-auto mb-2" />
           <p class="text-destructive">
-            {error instanceof Error ? error.message : "Failed to load tracker data"}
+            {remoteErrorMessage(error, "Failed to load tracker data")}
           </p>
           <Button variant="outline" class="mt-4" onclick={reset}>Retry</Button>
         </CardContent>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/weight/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/weight/+page.svelte
@@ -6,6 +6,7 @@
   import * as AlertDialog from "$lib/components/ui/alert-dialog";
   import { Weight, Plus, Trash2, Loader2 } from "lucide-svelte";
   import * as bw from "$api/generated/bodyWeights.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import type { BodyWeight } from "$api";
 
   // create/deleteBodyWeight declare a GetBodyWeights invalidation, but it refreshes
@@ -46,7 +47,7 @@
       newWeightKg = "";
       newDate = "";
     } catch (e) {
-      errorMessage = (e as { message?: string })?.message ?? "Failed to add entry";
+      errorMessage = describeSubmitError(e, "Failed to add entry");
     } finally {
       saving = false;
     }
@@ -60,7 +61,7 @@
       await bw.deleteBodyWeight(entry.id);
       await weightsQuery.refresh();
     } catch (e) {
-      errorMessage = (e as { message?: string })?.message ?? "Failed to delete entry";
+      errorMessage = describeSubmitError(e, "Failed to delete entry");
     }
   }
 </script>

--- a/src/Web/packages/app/src/routes/(fullscreen)/setup/connect/+page.svelte
+++ b/src/Web/packages/app/src/routes/(fullscreen)/setup/connect/+page.svelte
@@ -7,6 +7,7 @@
     getActiveDataSources,
     getServicesOverview,
   } from "$api/generated/services.generated.remote";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import type {
     UploaderApp,
     UploaderSetupResponse,
@@ -110,7 +111,7 @@
           uploaderApps={[]}
           dataSources={[]}
           isLoading={false}
-          loadError={error instanceof Error ? error.message : "Failed to load data sources"}
+          loadError={remoteErrorMessage(error, "Failed to load data sources")}
           onSelectConnector={() => {}}
           onSelectUploader={() => {}}
           onSkip={handleSkip}

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/account/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import * as Card from "$lib/components/ui/card";
   import { AlertTriangle, Loader2, UserPlus } from "lucide-svelte";
-  import { startRegistration } from "@simplewebauthn/browser";
+  import {
+    startRegistration,
+    type PublicKeyCredentialCreationOptionsJSON,
+  } from "@simplewebauthn/browser";
   import { goto } from "$app/navigation";
   import {
     setupOwnerOptions,
@@ -15,6 +18,10 @@
   import RecoveryCodes from "$lib/components/auth/RecoveryCodes.svelte";
   import OidcProviderButtons from "$lib/components/auth/OidcProviderButtons.svelte";
   import PasskeyRegistrationForm from "$lib/components/auth/PasskeyRegistrationForm.svelte";
+  import {
+    describePasskeyError,
+    parseCeremonyOptions,
+  } from "$lib/components/auth/passkey-errors";
 
   // ── Remote data ───────────────────────────────────────────────────
   const authStateQuery = getAuthState();
@@ -67,7 +74,10 @@
         username,
         displayName,
       });
-      const options = JSON.parse(response.options ?? "");
+      const options =
+        parseCeremonyOptions<PublicKeyCredentialCreationOptionsJSON>(
+          response.options
+        );
       const challengeToken = response.challengeToken ?? "";
 
       const attestation = await startRegistration({ optionsJSON: options });
@@ -88,8 +98,8 @@
       registrationComplete = true;
       recoveryCodes = result.recoveryCodes ?? [];
     } catch (err) {
-      passkeyError =
-        err instanceof Error ? err.message : "Failed to create account.";
+      console.error("Owner passkey registration failed:", err);
+      passkeyError = describePasskeyError(err, "register", "Failed to create account.");
     } finally {
       isRegistering = false;
     }


### PR DESCRIPTION
Addresses the sweep and the helper-layering decision from #956 (its items 1–2 — the `on403` ordering in the codegen config and the two no-`status` error DTOs — stay in the issue; the first is owned by #955's file and is a small follow-up once that lands).

## Problem

A rejected generated remote function throws SvelteKit's `HttpError` — `{status, body}`, not an `Error` — so `e instanceof Error ? e.message : fallback` always takes the fallback, discarding the server's reason. The class was fixed for two components in #940/#942 and survived everywhere else, including two sites that rendered raw internals instead (`String(error)` → `[object Object]` in `ResourceGuard`; `JSON.stringify(err)` in two dashboard widgets) and one that silently disabled UI (`chart-data-engine` set `predictionError = err.message` = `undefined`, so the chart's "Prediction unavailable" label could never render).

## Change

- **52 call sites across 41 files converted** — 33 to `describeSubmitError` (write surfaces), 17 to `remoteErrorMessage` (read surfaces), 2 passkey ceremonies to `describePasskeyError` + `parseCeremonyOptions` (killing an "Unexpected end of JSON input" leak and raw platform error text on cancel).
- **The read/write layering is now documented at one site** (`remote-error.ts`): choose by what the fallback sentence names — the permission a read needs vs the action the user took. The split was judged deliberate; a single unified helper is sketched in the review trail but deferred (it would touch 33+ call sites and conflict with in-flight PRs).
- **403 policy made explicit** (hostile-gate finding): almost every real 403 is a bare `ForbidResult`, which reaches the helpers as NSwag/codegen boilerplate — so the naive conversion would have shown "A server side error occurred." on ~30 write surfaces where a curated fallback used to show. `describeSubmitError` now answers 403 with the fallback unless the server worded the body, recognising the *client-written* strings (a closed three-string set from a pinned NSwag + our codegen arm) rather than trying to allowlist the unbounded server side. The genuine per-record scope refusals (`ForbiddenForScope`'s "This operation requires the 'x' scope.") still come through. Fail-open if a dependency rewords its boilerplate — the pre-existing behaviour, and the strings are pinned by existing tests.
- Deliberately left as `instanceof Error` (each verified): NSwag `ApiClient` call sites (`ApiException extends Error`), IndexedDB-only audio code, framework hooks, a chart boundary with no remote call inside.

## Evidence

- New/extended tests: `remote-error.test.ts` (7 — pins the full status table incl. 403→fallback, previously deletable with the whole suite green), `submit-error.test.ts` (+4, fixtures compiled through the **real** `on403` arm from the codegen config), `ConnectorDangerZone` (3), `ResourceGuard`/`RetrospectiveStats`/dnd-page (+1 each incl. a 500-suppression case pinning helper choice).
- Mutations, all killed and reverted: both hostile-gate survivors (helper-swap on the dnd page; deleting `remoteErrorMessage`'s 403 branch), the 403 arm reverted to `errorMessage(err) ?? fallback` (3 red), 403 arm to unconditional fallback (1 red), plus the round-1 set re-verified.
- `pnpm check` 64 errors — baseline-identical, none in touched files; eslint 0 findings on changed lines; node suite 862 passed (1 pre-existing unrelated failure, confirmed on main); affected browser files 43 tests green.

## Follow-ups declared

- `DndPanel.svelte` (owned by #942, untouched here) is now the one call site contradicting the documented criterion — one-line move to `describeSubmitError`, behaviour-preserving.
- Three more readers worth folding in the eventual unification: `errorMessage(err) ?? fallback` at 4 admin sites (not status-aware), and `GuestLinksSection`'s hand-rolled `body?.message` read.
- `ConnectorDetailsDialog` / `settings/connectors` / `settings-store` call the NSwag `ApiClient` directly against the "always use remote functions" rule and render `ApiException.message` — a multi-line dump including the raw response body — straight into the UI. Separate issue-worthy defect.

_Agent-authored; reviewed + gate-reviewed with independent verification and a fix round._
