### PR TITLE
fix(glooko): report V2 batch endpoint failures and let a mid-batch 403 re-auth

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -462,7 +462,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     {
         var config = context.Config;
 
-        var batchData = await FetchBatchDataAsync(context, fromDate, toDate);
+        var batchData = await FetchBatchDataAsync(context, fromDate, toDate, activeTypes, result);
         if (batchData == null) return false;
 
         var sensorGlucose = context.SensorGlucoseMapper.TransformBatchDataToSensorGlucose(batchData).ToList();
@@ -711,8 +711,17 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
     /// <summary>
     ///     Fetches comprehensive batch data from all v2 Glooko endpoints.
     /// </summary>
+    /// <remarks>
+    ///     One endpoint being down costs only the types it carries, so each is recorded through
+    ///     <see cref="BaseConnectorService{TConfig}.RecordFetchFailure"/> and the rest of the batch
+    ///     still fetches and publishes.
+    /// </remarks>
     private async Task<GlookoBatchData?> FetchBatchDataAsync(
-        GlookoSyncContext context, DateTime fromDate, DateTime toDate)
+        GlookoSyncContext context,
+        DateTime fromDate,
+        DateTime toDate,
+        HashSet<SyncDataType> activeTypes,
+        SyncResult result)
     {
         try
         {
@@ -723,39 +732,43 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             var batchData = new GlookoBatchData();
 
-            var endpointDefinitions = new (string Endpoint, Action<JsonElement> Handler)[]
+            // An endpoint's types are what its payload feeds downstream in FetchAndMapViaV2Async, not
+            // what the endpoint is named: foods become carb intakes as well as catalog entries, a bolus
+            // carries its own wizard carbs, and all three basal endpoints map to temp basals (suspends
+            // additionally to a pump-mode span).
+            var endpointDefinitions = new (string Endpoint, SyncDataType[] Types, Action<JsonElement> Handler)[]
             {
-                (GlookoConstants.FoodsPath, json =>
+                (GlookoConstants.FoodsPath, [SyncDataType.CarbIntake, SyncDataType.Food], json =>
                 {
                     if (json.TryGetProperty("foods", out var el))
                         batchData.Foods = JsonSerializer.Deserialize<GlookoFood[]>(el.GetRawText()) ?? [];
                 }),
-                (GlookoConstants.ScheduledBasalsPath, json =>
+                (GlookoConstants.ScheduledBasalsPath, [SyncDataType.TempBasals], json =>
                 {
                     if (json.TryGetProperty("scheduledBasals", out var el))
                         batchData.ScheduledBasals = JsonSerializer.Deserialize<GlookoBasal[]>(el.GetRawText()) ?? [];
                 }),
-                (GlookoConstants.NormalBolusesPath, json =>
+                (GlookoConstants.NormalBolusesPath, [SyncDataType.Boluses, SyncDataType.CarbIntake], json =>
                 {
                     if (json.TryGetProperty("normalBoluses", out var el))
                         batchData.NormalBoluses = JsonSerializer.Deserialize<GlookoBolus[]>(el.GetRawText()) ?? [];
                 }),
-                (GlookoConstants.CgmReadingsPath, json =>
+                (GlookoConstants.CgmReadingsPath, [SyncDataType.Glucose], json =>
                 {
                     if (json.TryGetProperty("readings", out var el))
                         batchData.Readings = JsonSerializer.Deserialize<GlookoCgmReading[]>(el.GetRawText()) ?? [];
                 }),
-                (GlookoConstants.MeterReadingsPath, json =>
+                (GlookoConstants.MeterReadingsPath, [SyncDataType.ManualBG], json =>
                 {
                     if (json.TryGetProperty("readings", out var el))
                         batchData.MeterReadings = JsonSerializer.Deserialize<GlookoMeterReading[]>(el.GetRawText()) ?? [];
                 }),
-                (GlookoConstants.SuspendBasalsPath, json =>
+                (GlookoConstants.SuspendBasalsPath, [SyncDataType.StateSpans, SyncDataType.TempBasals], json =>
                 {
                     if (json.TryGetProperty("suspendBasals", out var el))
                         batchData.SuspendBasals = JsonSerializer.Deserialize<GlookoSuspendBasal[]>(el.GetRawText()) ?? [];
                 }),
-                (GlookoConstants.TemporaryBasalsPath, json =>
+                (GlookoConstants.TemporaryBasalsPath, [SyncDataType.TempBasals], json =>
                 {
                     if (json.TryGetProperty("temporaryBasals", out var el))
                         batchData.TempBasals = JsonSerializer.Deserialize<GlookoTempBasal[]>(el.GetRawText()) ?? [];
@@ -764,7 +777,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             for (var i = 0; i < endpointDefinitions.Length; i++)
             {
-                var (endpoint, handler) = endpointDefinitions[i];
+                var (endpoint, types, handler) = endpointDefinitions[i];
                 var url = ConstructV2Url(context, endpoint, fromDate, toDate);
 
                 await _rateLimitingStrategy.ApplyDelayAsync(i);
@@ -773,14 +786,18 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 {
                     var fetchResult = await FetchFromGlookoEndpointWithRetry(context, url);
                     if (fetchResult.HasValue)
-                    {
-                        try { handler(fetchResult.Value); }
-                        catch (Exception ex) { _logger.LogWarning(ex, "Error parsing data from {Endpoint}", endpoint); }
-                    }
+                        handler(fetchResult.Value);
                 }
+                catch (GlookoDataForbiddenException) { throw; }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Failed to fetch from {Endpoint}. Continuing with other endpoints.", endpoint);
+                    // A payload that arrived but would not parse loses the same data as one that never
+                    // arrived, so both land here.
+                    _logger.LogWarning(ex,
+                        "Failed to fetch or parse {Endpoint}. Continuing with other endpoints.", endpoint);
+
+                    foreach (var type in types)
+                        RecordFetchFailure(result, type, activeTypes);
                 }
             }
 
@@ -1041,6 +1058,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
             return historiesData;
         }
+        catch (GlookoDataForbiddenException) { throw; }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error fetching Glooko v3 histories");

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceFetchFailureTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceFetchFailureTests.cs
@@ -20,39 +20,40 @@ namespace Nocturne.Connectors.Glooko.Tests.Services;
 public class GlookoConnectorServiceFetchFailureTests
 {
     /// <summary>
-    /// Glucose is the connector's primary type and has one V2 source, so a dead CGM endpoint reporting
-    /// green was indistinguishable from a quiet day. The rest of the batch is unaffected by it.
+    /// Every V2 batch endpoint against the types its payload feeds, so a row that stops matching what
+    /// the mappers actually read off that payload ships red. Glucose is the connector's primary type
+    /// and has one V2 source, so a dead CGM endpoint reporting green was indistinguishable from a
+    /// quiet day; a bolus carries the wizard's carbs alongside its insulin, foods become carb intakes
+    /// as well as catalog entries, and all three basal endpoints feed temp basals.
     /// </summary>
-    [Fact]
-    public async Task SyncDataAsync_WhenAV2BatchEndpointFails_ReportsItsTypeAndPublishesTheRest()
+    /// <param name="stillPublished">
+    ///     A publish the failing endpoint has no part in, which must still be reached — the failure is
+    ///     sticky, not an abort.
+    /// </param>
+    [Theory]
+    [InlineData(GlookoConstants.CgmReadingsPath, "Glucose", PublishKind.StateSpans)]
+    [InlineData(GlookoConstants.MeterReadingsPath, "ManualBG", PublishKind.StateSpans)]
+    [InlineData(GlookoConstants.NormalBolusesPath, "Boluses,CarbIntake", PublishKind.StateSpans)]
+    [InlineData(GlookoConstants.FoodsPath, "CarbIntake,Food", PublishKind.StateSpans)]
+    [InlineData(GlookoConstants.ScheduledBasalsPath, "TempBasals", PublishKind.StateSpans)]
+    [InlineData(GlookoConstants.TemporaryBasalsPath, "TempBasals", PublishKind.StateSpans)]
+    [InlineData(GlookoConstants.SuspendBasalsPath, "StateSpans,TempBasals", PublishKind.TempBasals)]
+    public async Task SyncDataAsync_WhenAV2BatchEndpointFails_ReportsEveryTypeItServes(
+        string failingPath, string expectedTypes, PublishKind stillPublished)
     {
-        var service = BuildService(GlookoConstants.CgmReadingsPath);
+        var service = BuildService(failingPath);
 
         var result = await service.SyncDataAsync(
-            Request(SyncDataType.Glucose, SyncDataType.StateSpans, SyncDataType.TempBasals),
-            GlookoSyncHarness.Config(useV3Api: false), CancellationToken.None);
+            Request(V2BatchTypes), GlookoSyncHarness.Config(useV3Api: false), CancellationToken.None);
 
-        result.Success.Should().BeFalse();
-        result.Errors.Should().ContainSingle().Which.Should().Be("Failed to fetch Glucose");
+        // The whole batch is fetched before anything publishes, so a publish rejection can never be
+        // the failure that named the run.
         result.Message.Should().Be("Sync failed while fetching data");
-        service.Published.Should().Contain([PublishKind.StateSpans, PublishKind.TempBasals]);
-    }
-
-    /// <summary>
-    /// One endpoint can carry several types — a normal bolus carries the wizard's carbs alongside the
-    /// insulin — and losing the endpoint loses every one of them.
-    /// </summary>
-    [Fact]
-    public async Task SyncDataAsync_WhenAV2BatchEndpointServingSeveralTypesFails_ReportsEachType()
-    {
-        var service = BuildService(GlookoConstants.NormalBolusesPath);
-
-        var result = await service.SyncDataAsync(
-            Request(SyncDataType.Boluses, SyncDataType.CarbIntake),
-            GlookoSyncHarness.Config(useV3Api: false), CancellationToken.None);
-
-        result.Success.Should().BeFalse();
-        result.Errors.Should().Contain(["Failed to fetch Boluses", "Failed to fetch CarbIntake"]);
+        result.Errors
+            .Where(error => error.StartsWith("Failed to fetch ", StringComparison.Ordinal))
+            .Should().BeEquivalentTo(
+                expectedTypes.Split(',').Select(type => $"Failed to fetch {type}"));
+        service.Published.Should().Contain(stillPublished);
     }
 
     /// <summary>
@@ -179,6 +180,13 @@ public class GlookoConnectorServiceFetchFailureTests
     }
 
     // ── Test infrastructure ─────────────────────────────────────────────
+
+    /// <summary>Every type the V2 batch endpoints serve, so no row is gated off by an inactive type.</summary>
+    private static readonly SyncDataType[] V2BatchTypes =
+    [
+        SyncDataType.Glucose, SyncDataType.ManualBG, SyncDataType.Boluses, SyncDataType.CarbIntake,
+        SyncDataType.Food, SyncDataType.StateSpans, SyncDataType.TempBasals,
+    ];
 
     private static SyncRequest Request(params SyncDataType[] dataTypes) => new()
     {

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceFetchFailureTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceFetchFailureTests.cs
@@ -11,13 +11,87 @@ using Xunit;
 namespace Nocturne.Connectors.Glooko.Tests.Services;
 
 /// <summary>
-/// Glooko's supporting fetches each sit behind their own catch, so a Glooko endpoint that is down
-/// used to cost the tenant that data while the run still reported green. A failed fetch of a type
-/// the tenant enabled must reach <see cref="SyncResult.Success"/> and <see cref="SyncResult.Errors"/>,
-/// while whatever the run already fetched still publishes.
+/// Glooko's fetches each sit behind their own catch — the supporting ones singly, the V2 batch's
+/// endpoints in a loop — so a Glooko endpoint that is down used to cost the tenant that data while
+/// the run still reported green. A failed fetch of a type the tenant enabled must reach
+/// <see cref="SyncResult.Success"/> and <see cref="SyncResult.Errors"/>, while whatever the run
+/// already fetched still publishes.
 /// </summary>
 public class GlookoConnectorServiceFetchFailureTests
 {
+    /// <summary>
+    /// Glucose is the connector's primary type and has one V2 source, so a dead CGM endpoint reporting
+    /// green was indistinguishable from a quiet day. The rest of the batch is unaffected by it.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAV2BatchEndpointFails_ReportsItsTypeAndPublishesTheRest()
+    {
+        var service = BuildService(GlookoConstants.CgmReadingsPath);
+
+        var result = await service.SyncDataAsync(
+            Request(SyncDataType.Glucose, SyncDataType.StateSpans, SyncDataType.TempBasals),
+            GlookoSyncHarness.Config(useV3Api: false), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Be("Failed to fetch Glucose");
+        result.Message.Should().Be("Sync failed while fetching data");
+        service.Published.Should().Contain([PublishKind.StateSpans, PublishKind.TempBasals]);
+    }
+
+    /// <summary>
+    /// One endpoint can carry several types — a normal bolus carries the wizard's carbs alongside the
+    /// insulin — and losing the endpoint loses every one of them.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAV2BatchEndpointServingSeveralTypesFails_ReportsEachType()
+    {
+        var service = BuildService(GlookoConstants.NormalBolusesPath);
+
+        var result = await service.SyncDataAsync(
+            Request(SyncDataType.Boluses, SyncDataType.CarbIntake),
+            GlookoSyncHarness.Config(useV3Api: false), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().Contain(["Failed to fetch Boluses", "Failed to fetch CarbIntake"]);
+    }
+
+    /// <summary>
+    /// A payload that arrived but would not map loses the tenant exactly what one that never arrived
+    /// does, so the two report alike.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAV2BatchEndpointServesUnmappablePayload_ReportsItsType()
+    {
+        var service = GlookoSyncHarness.Service(
+            new GlookoEndpointHandler(malformedPaths: [GlookoConstants.CgmReadingsPath]));
+
+        var result = await service.SyncDataAsync(
+            Request(SyncDataType.Glucose, SyncDataType.StateSpans),
+            GlookoSyncHarness.Config(useV3Api: false), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Be("Failed to fetch Glucose");
+        service.Published.Should().Contain(PublishKind.StateSpans);
+    }
+
+    /// <summary>
+    /// A failed run withholds the connector's last-successful-sync stamp, so a batch endpoint whose
+    /// types the tenant switched off must not be able to fail the sync.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAV2BatchEndpointFailsForSwitchedOffTypes_ReportsSuccess()
+    {
+        var service = BuildService(GlookoConstants.CgmReadingsPath);
+
+        var result = await service.SyncDataAsync(
+            Request(SyncDataType.StateSpans), GlookoSyncHarness.Config(useV3Api: false),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+        service.Published.Should().Contain(PublishKind.StateSpans);
+    }
+
     /// <summary>
     /// Device settings are the only profile source in either fetch mode, so both modes must report
     /// the loss — and both must still publish the chunk's own state spans.

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
@@ -102,7 +102,61 @@ public class GlookoConnectorServiceReauthTests
             .Should().ContainSingle().Which.Phase.Should().Be(expectedPhase);
     }
 
+    /// <summary>
+    /// The V2 batch loop and the V3 histories fetch each swallowed every exception per endpoint,
+    /// including the 403 the whole recovery turns on: a code that went stale mid-batch logged a
+    /// warning and the run carried on querying the stale one.
+    /// </summary>
+    [Theory]
+    [InlineData(false, GlookoConstants.CgmReadingsPath)]
+    [InlineData(true, GlookoConstants.V3HistoriesPath)]
+    public async Task SyncDataAsync_WhenAForbiddenEndpointIsReachedMidPass_Reauthenticates(
+        bool useV3Api, string forbiddenPath)
+    {
+        var tokenProvider = new StaticGlookoTokenProvider();
+        var handler = new GlookoEndpointHandler(forbiddenPaths: [forbiddenPath]);
+        var service = GlookoSyncHarness.Service(handler, tokenProvider: tokenProvider);
+
+        var result = await service.SyncDataAsync(
+            SingleChunkRequest(SyncDataType.Glucose, SyncDataType.CarbIntake),
+            GlookoSyncHarness.Config(useV3Api), CancellationToken.None);
+
+        tokenProvider.AcquireCount.Should().Be(2, "the 403 must reach the re-authentication retry");
+        handler.RequestsFor(forbiddenPath).Should().Be(2, "the retried pass must re-run the fetch");
+        result.Success.Should().BeFalse("the code never refreshes, so the retried pass is forbidden too");
+    }
+
+    /// <summary>
+    /// The retry re-syncs from scratch, so the abandoned pass's recorded fetch failure must not
+    /// survive into the retried pass's result and redden a run that went on to fetch everything.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheRetriedPassSucceeds_DropsTheAbandonedPassFailures()
+    {
+        var tokenProvider = new StaticGlookoTokenProvider();
+        var handler = new GlookoEndpointHandler(
+            failingPaths: [GlookoConstants.ScheduledBasalsPath],
+            forbiddenPaths: [GlookoConstants.CgmReadingsPath],
+            recoversAfterForbidden: true);
+        var service = GlookoSyncHarness.Service(handler, tokenProvider: tokenProvider);
+
+        var result = await service.SyncDataAsync(
+            SingleChunkRequest(SyncDataType.Glucose, SyncDataType.TempBasals),
+            GlookoSyncHarness.Config(useV3Api: false), CancellationToken.None);
+
+        tokenProvider.AcquireCount.Should().Be(2,
+            "the abandoned pass's basal failure is only abandoned if a retry actually happened");
+        result.Errors.Should().BeEmpty();
+        result.Success.Should().BeTrue();
+    }
+
     // ── Test infrastructure ─────────────────────────────────────────────
+
+    private static SyncRequest SingleChunkRequest(params SyncDataType[] dataTypes) => new()
+    {
+        DataTypes = [.. dataTypes],
+        From = DateTime.UtcNow.AddDays(-3),
+    };
 
     private static GlookoConnectorConfiguration BuildConfig() => new()
     {

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
@@ -127,27 +127,35 @@ public class GlookoConnectorServiceReauthTests
     }
 
     /// <summary>
-    /// The retry re-syncs from scratch, so the abandoned pass's recorded fetch failure must not
-    /// survive into the retried pass's result and redden a run that went on to fetch everything.
+    /// The retry re-syncs from scratch, so neither the abandoned pass's recorded fetch failure nor
+    /// the records it already published may survive into the retried pass's result — the first would
+    /// redden a run that went on to fetch everything, the second would count the same records twice.
+    /// The 403 lands on the device settings, which are fetched after the chunks have published, so
+    /// the abandoned pass has both to leave behind.
     /// </summary>
     [Fact]
-    public async Task SyncDataAsync_WhenTheRetriedPassSucceeds_DropsTheAbandonedPassFailures()
+    public async Task SyncDataAsync_WhenTheRetriedPassSucceeds_DropsTheAbandonedPassResults()
     {
         var tokenProvider = new StaticGlookoTokenProvider();
         var handler = new GlookoEndpointHandler(
             failingPaths: [GlookoConstants.ScheduledBasalsPath],
-            forbiddenPaths: [GlookoConstants.CgmReadingsPath],
+            forbiddenPaths: [GlookoConstants.V3DeviceSettingsPath],
             recoversAfterForbidden: true);
         var service = GlookoSyncHarness.Service(handler, tokenProvider: tokenProvider);
 
         var result = await service.SyncDataAsync(
-            SingleChunkRequest(SyncDataType.Glucose, SyncDataType.TempBasals),
+            SingleChunkRequest(SyncDataType.StateSpans, SyncDataType.TempBasals, SyncDataType.Profiles),
             GlookoSyncHarness.Config(useV3Api: false), CancellationToken.None);
 
         tokenProvider.AcquireCount.Should().Be(2,
-            "the abandoned pass's basal failure is only abandoned if a retry actually happened");
-        result.Errors.Should().BeEmpty();
+            "the abandoned pass's results are only abandoned if a retry actually happened");
         result.Success.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+
+        // One suspended basal and one temporary basal per chunk; one pump-mode span from that
+        // suspend, plus the active-basal-program span the device settings carry.
+        result.ItemsSynced[SyncDataType.TempBasals].Should().Be(2);
+        result.ItemsSynced[SyncDataType.StateSpans].Should().Be(2);
     }
 
     // ── Test infrastructure ─────────────────────────────────────────────

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
@@ -239,7 +239,7 @@ internal sealed class GlookoEndpointHandler(
         if (!healed && failingPaths?.Any(failing => Matches(path, failing)) == true)
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
 
-        if (malformedPaths?.Any(malformed => Matches(path, malformed)) == true)
+        if (!healed && malformedPaths?.Any(malformed => Matches(path, malformed)) == true)
             return Json(MalformedPayload);
 
         if (Matches(path, GlookoConstants.V3UsersPath))

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
@@ -35,8 +35,9 @@ internal static class GlookoSyncHarness
     public static RecordingGlookoConnectorService Service(
         GlookoEndpointHandler handler,
         PublishKind? rejected = null,
-        IConnectorPublisher? publisher = null) =>
-        new(new HttpClient(handler), new StaticGlookoTokenProvider(), rejected, publisher);
+        IConnectorPublisher? publisher = null,
+        StaticGlookoTokenProvider? tokenProvider = null) =>
+        new(new HttpClient(handler), tokenProvider ?? new StaticGlookoTokenProvider(), rejected, publisher);
 }
 
 /// <summary>
@@ -115,6 +116,9 @@ internal sealed class RecordingGlookoConnectorService : GlookoConnectorService
 /// </summary>
 internal sealed class StaticGlookoTokenProvider : GlookoAuthTokenProvider
 {
+    /// <summary>How many logins the sync has driven; a second one is a re-authentication.</summary>
+    public int AcquireCount { get; private set; }
+
     public StaticGlookoTokenProvider()
         : base(
             new HttpClient(),
@@ -128,6 +132,8 @@ internal sealed class StaticGlookoTokenProvider : GlookoAuthTokenProvider
     protected override Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
         GlookoConnectorConfiguration config, CancellationToken cancellationToken)
     {
+        AcquireCount++;
+
         const string cookie = "_logbook-web_session=sess";
         var userData = JsonSerializer.Serialize(
             new GlookoUserData { User = new GlookoUserLogin { GlookoCode = GlookoSyncHarness.PatientCode } });
@@ -162,6 +168,18 @@ internal sealed class StaticGlookoTokenProvider : GlookoAuthTokenProvider
 ///     Endpoint paths that answer 500 however often they are asked, standing in for a Glooko
 ///     endpoint that is down while the rest of the account still serves.
 /// </param>
+/// <param name="forbiddenPaths">
+///     Endpoint paths that answer 403 <c>data_cant_view</c>, standing in for a patient code Glooko no
+///     longer authorizes.
+/// </param>
+/// <param name="malformedPaths">
+///     Endpoint paths that answer 200 with a well-formed envelope whose every record array is a bare
+///     number, so the response arrives and only the record mapping fails.
+/// </param>
+/// <param name="recoversAfterForbidden">
+///     Whether every broken path starts serving normally once a 403 has been issued — the account
+///     state a re-authentication repairs, and what tells a retried pass apart from the first.
+/// </param>
 /// <param name="withHistoryMeals">
 ///     Whether the histories endpoint carries one meal (one food, 30g of carbs), which is what
 ///     switches on the V3 path's meal carbs and food entries.
@@ -169,11 +187,16 @@ internal sealed class StaticGlookoTokenProvider : GlookoAuthTokenProvider
 internal sealed class GlookoEndpointHandler(
     Func<int, int>? recordsPerWindow = null,
     IReadOnlyCollection<string>? failingPaths = null,
+    IReadOnlyCollection<string>? forbiddenPaths = null,
+    IReadOnlyCollection<string>? malformedPaths = null,
+    bool recoversAfterForbidden = false,
     bool withHistoryMeals = false) : HttpMessageHandler
 {
     private readonly Func<int, int> _recordsPerWindow = recordsPerWindow ?? (_ => 1);
     private readonly List<string> _windows = [];
+    private readonly List<string> _requested = [];
     private readonly Lock _gate = new();
+    private bool _forbiddenIssued;
 
     private const string DeviceSettingsTimestamp = "2026-01-10T00:00:00Z";
 
@@ -183,13 +206,41 @@ internal sealed class GlookoEndpointHandler(
         get { lock (_gate) return _windows.Count; }
     }
 
+    /// <summary>How many times an endpoint was asked, over every date window and sync pass.</summary>
+    public int RequestsFor(string endpoint)
+    {
+        lock (_gate) return _requested.Count(path => Matches(path, endpoint));
+    }
+
     protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var path = request.RequestUri?.PathAndQuery ?? string.Empty;
 
-        if (failingPaths?.Any(failing => Matches(path, failing)) == true)
+        bool healed;
+        lock (_gate)
+        {
+            _requested.Add(path);
+            healed = recoversAfterForbidden && _forbiddenIssued;
+        }
+
+        if (!healed && forbiddenPaths?.Any(forbidden => Matches(path, forbidden)) == true)
+        {
+            lock (_gate) _forbiddenIssued = true;
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden)
+            {
+                Content = new StringContent(
+                    "{\"status\":403,\"code\":\"data_cant_view\",\"message\":\"user is not authorized to view data\"}",
+                    Encoding.UTF8, "application/json"),
+            });
+        }
+
+        if (!healed && failingPaths?.Any(failing => Matches(path, failing)) == true)
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        if (malformedPaths?.Any(malformed => Matches(path, malformed)) == true)
+            return Json(MalformedPayload);
 
         if (Matches(path, GlookoConstants.V3UsersPath))
             return Json("{\"currentUser\":{\"meterUnits\":\"mgdl\",\"timezone\":\"Australia/Sydney\"}}");
@@ -271,6 +322,16 @@ internal sealed class GlookoEndpointHandler(
 
         return $"{{\"series\":{{{series}}}}}";
     }
+
+    /// <summary>
+    /// Every V2 envelope property at once, each holding a number where an array belongs, so whichever
+    /// endpoint serves it the response parses and only the records do not.
+    /// </summary>
+    private const string MalformedPayload =
+        """
+        {"foods":0,"scheduledBasals":0,"normalBoluses":0,"readings":0,"suspendBasals":0,
+         "temporaryBasals":0}
+        """;
 
     /// <summary>
     /// One meal of one food, which the V3 path maps to a single carb intake and a single food entry.


### PR DESCRIPTION
Closes #957.

## Problem

Glooko's V2 batch fetch wrapped each endpoint in a catch-log-continue, so a dead `/api/v2/cgm/readings` produced a green sync with zero glucose — indistinguishable from a quiet day, on the connector's primary type. The same catch ate `GlookoDataForbiddenException`, so a mid-batch 403 never reached the re-auth retry the connector was designed around; `FetchV3HistoriesAsync`'s unfiltered internal catch did the same for meal histories.

## Change

- **Each V2 endpoint declares the `SyncDataType`s its payload feeds**, and a per-endpoint failure records through `RecordFetchFailure` against exactly those types — active-type gated, sticky, deduped, non-aborting (the rest of the batch still fetches and publishes, unchanged). The map was derived by tracing which `GlookoBatchData` field each handler writes and which mapper consumes it — not from endpoint names — and the hostile review re-derived all 7 rows independently and confirmed them, including the three non-obvious ones: foods also yield carb intakes, boluses carry their own wizard carbs, and suspends are the *only* V2 state-span source.
- **`catch (GlookoDataForbiddenException) { throw; }`** ahead of the batch loop's general catch and in `FetchV3HistoriesAsync`, matching the fetch helper's established pattern — a mid-batch or histories 403 now reaches the re-auth retry (token invalidated, session cleared, one clean second pass; a second-pass 403 fails cleanly with no loop, pinned by `AcquireCount`/request-count assertions).
- **The inner parse catch folded into the outer one**: a payload that arrived but won't map loses the tenant the same data as one that never arrived, and now records the same way.

## Evidence

- Glooko 118/118, Connectors.Core 137/137.
- **13 mutations, all killed** (each applied, shown red, restored): every one of the 7 map rows individually (a table `[Theory]` drives all rows with every type active and asserts the exact error set, the honest `Message`, and that an unrelated type still publishes), the `RecordFetchFailure` loop, the active-type gate, both 403 rethrows, and the retry reset's `Errors.Clear()` **and** `ItemsSynced.Clear()` — the latter pinned via a device-settings 403 (fetched after the chunks publish, so the abandoned pass genuinely leaves counts behind; a retried pass that failed to drop them would double-count).
- Test harness drives the real `SyncDataAsync` end to end; gained `forbiddenPaths` / `malformedPaths` (now heal-gated like the rest) / `recoversAfterForbidden` / per-endpoint request counts.

## Declared / follow-ups

- `FetchV2FoodsAsync` and `FetchV3UserProfileAsync` still swallow 403 unfiltered — deliberate: V2-foods is documented sticky-not-fatal and rethrow would convert an enrichment failure into a whole-run resync; the profile path is shielded by the graph fetch 403ing first. Each needs its own decision if ever revisited.
- Pre-existing, surface slightly widened: a *second*-pass 403's exception message (full Glooko URL incl. the tenant's own patient code + raw response body) lands in the tenant-visible `Errors`. Low severity (tenant sees their own identifiers); worth a tidy-up when that message is next touched.
- Pre-existing convention tension: a type whose fetch failed still gets an explicit `ItemsSynced = 0` from the publish path's empty-batch branch, so the card can show "checked, found nothing" beside "Failed to fetch". The two conventions want reconciling in one place.

_Agent-authored; reviewed + gate-reviewed with independent verification and a fix round._
