### PR TITLE
test(web): return the framework's remote-function shapes from the $app/server stub

### DIFF
--- a/src/Web/packages/app/src/lib/components/alerts/FiringToast.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/alerts/FiringToast.svelte.test.ts
@@ -3,6 +3,7 @@ import { page } from "vitest/browser";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { flushSync } from "svelte";
 import type { ActiveExcursionResponse } from "$api-clients";
+import { remoteQuery } from "$lib/test-stubs/remote-resource";
 
 // Mock the generated remote surface before importing the component. The
 // component reads `getActiveAlerts().current` inside an effect, so the backing
@@ -10,11 +11,7 @@ import type { ActiveExcursionResponse } from "$api-clients";
 let activeAlerts = $state<ActiveExcursionResponse[]>([]);
 
 vi.mock("$api/generated/alerts.generated.remote", () => ({
-	getActiveAlerts: () => ({
-		get current() {
-			return activeAlerts;
-		},
-	}),
+	getActiveAlerts: () => remoteQuery(() => activeAlerts),
 	snoozeInstance: () => Promise.resolve(),
 	acknowledgeExcursion: () => Promise.resolve(),
 }));

--- a/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
@@ -295,7 +295,7 @@
             {/if}
           </div>
           <input type="hidden" name="b:isCurrent" value="on" />
-          {#each deviceList.createForm.fields.allIssues() as issue}
+          {#each deviceList.createForm.fields.allIssues() ?? [] as issue}
             <p class="text-sm text-destructive">{issue.message}</p>
           {/each}
         </Card.Content>
@@ -589,7 +589,7 @@
             />
           </div>
 
-          {#each activeForm.fields.allIssues() as issue}
+          {#each activeForm.fields.allIssues() ?? [] as issue}
             <p class="text-sm text-destructive">{issue.message}</p>
           {/each}
         </div>

--- a/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte.test.ts
@@ -1,31 +1,37 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { remoteQuery } from "$lib/test-stubs/remote-resource";
 
 // Mock the generated remote functions before importing the component. DeviceListState reads
 // getDevices()/getDiscoveredSources() as reactive queries (`.current`) and calls reorderDevices()
-// as a command.
-const createDevice = Object.assign((..._args: unknown[]) => Promise.resolve({}), {
-  enhance: () => ({}),
-  pending: 0,
-  result: undefined,
-  fields: { allIssues: () => [] },
-});
-const updateDevice = Object.assign((..._args: unknown[]) => Promise.resolve({}), {
-  enhance: () => ({}),
-  pending: 0,
-  result: undefined,
-  fields: { allIssues: () => [] },
-});
-const reorderDevices = vi.fn().mockResolvedValue([]);
-const deleteDevice = vi.fn().mockResolvedValue(undefined);
+// as a command. The stand-ins are hoisted with the `vi.mock` call that names them: the factory
+// runs while the component is imported, which is before a module-level `const` is initialised.
+const { createDevice, updateDevice, reorderDevices, deleteDevice } = vi.hoisted(
+  () => {
+    const formStub = () =>
+      Object.assign((..._args: unknown[]) => Promise.resolve({}), {
+        enhance: () => ({}),
+        pending: 0,
+        result: undefined,
+        fields: { allIssues: () => [] },
+      });
+
+    return {
+      createDevice: formStub(),
+      updateDevice: formStub(),
+      reorderDevices: vi.fn().mockResolvedValue([]),
+      deleteDevice: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+);
 
 let devicesCurrent: unknown[] = [];
 let discoveredCurrent: unknown[] = [];
 
 vi.mock("$api/generated/patientRecords.generated.remote", () => ({
-  getDevices: () => ({ get current() { return devicesCurrent; } }),
-  getDiscoveredSources: () => ({ get current() { return discoveredCurrent; } }),
+  getDevices: () => remoteQuery(() => devicesCurrent),
+  getDiscoveredSources: () => remoteQuery(() => discoveredCurrent),
   createDevice,
   updateDevice,
   deleteDevice: (...args: unknown[]) => deleteDevice(...args),

--- a/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte.test.ts
@@ -1,30 +1,16 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { remoteQuery } from "$lib/test-stubs/remote-resource";
+import { remoteForm, remoteQuery } from "$lib/test-stubs/remote-resource";
 
 // Mock the generated remote functions before importing the component. DeviceListState reads
 // getDevices()/getDiscoveredSources() as reactive queries (`.current`) and calls reorderDevices()
-// as a command. The stand-ins are hoisted with the `vi.mock` call that names them: the factory
-// runs while the component is imported, which is before a module-level `const` is initialised.
-const { createDevice, updateDevice, reorderDevices, deleteDevice } = vi.hoisted(
-  () => {
-    const formStub = () =>
-      Object.assign((..._args: unknown[]) => Promise.resolve({}), {
-        enhance: () => ({}),
-        pending: 0,
-        result: undefined,
-        fields: { allIssues: () => [] },
-      });
-
-    return {
-      createDevice: formStub(),
-      updateDevice: formStub(),
-      reorderDevices: vi.fn().mockResolvedValue([]),
-      deleteDevice: vi.fn().mockResolvedValue(undefined),
-    };
-  }
-);
+// as a command. The spies are hoisted with the `vi.mock` call that reaches them: the factory runs
+// while the component is imported, which is before a module-level `const` is initialised.
+const { reorderDevices, deleteDevice } = vi.hoisted(() => ({
+  reorderDevices: vi.fn().mockResolvedValue([]),
+  deleteDevice: vi.fn().mockResolvedValue(undefined),
+}));
 
 let devicesCurrent: unknown[] = [];
 let discoveredCurrent: unknown[] = [];
@@ -32,8 +18,8 @@ let discoveredCurrent: unknown[] = [];
 vi.mock("$api/generated/patientRecords.generated.remote", () => ({
   getDevices: () => remoteQuery(() => devicesCurrent),
   getDiscoveredSources: () => remoteQuery(() => discoveredCurrent),
-  createDevice,
-  updateDevice,
+  createDevice: remoteForm(),
+  updateDevice: remoteForm(),
   deleteDevice: (...args: unknown[]) => deleteDevice(...args),
   reorderDevices: (...args: unknown[]) => reorderDevices(...args),
 }));

--- a/src/Web/packages/app/src/lib/components/patient/PatientInsulinManager.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/PatientInsulinManager.svelte
@@ -298,7 +298,7 @@
             <input type="hidden" name="formulationId" value={inlineFormulationId} />
           {/if}
 
-          {#each insulinList.createForm.fields.allIssues() as issue}
+          {#each insulinList.createForm.fields.allIssues() ?? [] as issue}
             <p class="text-sm text-destructive">{issue.message}</p>
           {/each}
         </Card.Content>
@@ -458,7 +458,7 @@
             <input type="hidden" name="{namePrefix}formulationId" value={insulinFormulationId} />
           {/if}
 
-          {#each activeForm.fields.allIssues() as issue}
+          {#each activeForm.fields.allIssues() ?? [] as issue}
             <p class="text-sm text-destructive">{issue.message}</p>
           {/each}
         </div>

--- a/src/Web/packages/app/src/lib/components/settings/ClientDevices.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/settings/ClientDevices.svelte.test.ts
@@ -1,6 +1,7 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { remoteQuery } from "$lib/test-stubs/remote-resource";
 
 // Mock the generated remote functions before importing the component.
 // The component calls getDevices()/getCapabilityCatalog() as reactive queries
@@ -18,16 +19,8 @@ const catalogCurrent = {
 };
 
 vi.mock("$lib/api/generated/clientDevices.generated.remote", () => ({
-  getDevices: () => ({
-    get current() {
-      return devicesCurrent;
-    },
-  }),
-  getCapabilityCatalog: () => ({
-    get current() {
-      return catalogCurrent;
-    },
-  }),
+  getDevices: () => remoteQuery(() => devicesCurrent),
+  getCapabilityCatalog: () => remoteQuery(() => catalogCurrent),
   rename: (...args: unknown[]) => rename(...args),
   revoke: (...args: unknown[]) => revoke(...args),
 }));

--- a/src/Web/packages/app/src/lib/test-stubs/app-server.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/app-server.svelte.test.ts
@@ -10,10 +10,11 @@ import { remoteQuery } from "./remote-resource";
  * about the stub.
  *
  * What is pinned here is shape: that a query call is a resource and not the
- * implementation, that the `(schema, fn)` overloads reach `fn`, and that a
- * command call is a promise carrying `updates()`. Reactivity, per-argument
- * caching, schema validation and form submission are deliberately absent from
- * the stub, so nothing below asserts them.
+ * implementation, that the `(schema, fn)` overloads reach `fn`, that a command
+ * call is a promise carrying `updates()`, and that a form's fields answer
+ * `undefined` rather than `[]` when they have no issues. Reactivity,
+ * per-argument caching, schema validation and form submission are deliberately
+ * absent from the stub, so nothing below asserts them.
  */
 describe("$app/server stub", () => {
   it("hands back a resource rather than the implementation", async () => {
@@ -45,11 +46,41 @@ describe("$app/server stub", () => {
     });
     const resource = boom();
 
-    await expect(resource.run()).rejects.toThrow("nope");
+    // Awaited, not `run()`: awaiting is the path a template takes and the one
+    // that settles `error`. The framework's `run()` bypasses the instance, so
+    // asserting `error` after it would pin something production does not do.
+    await expect(async () => await resource).rejects.toThrow("nope");
 
     expect(resource.error).toBeInstanceOf(Error);
     expect(resource.loading).toBe(false);
     expect(resource.ready).toBe(false);
+  });
+
+  it("keeps a rejection nobody awaited off the unhandled-rejection channel", async () => {
+    const unhandled: unknown[] = [];
+    const record = (event: PromiseRejectionEvent) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener("unhandledrejection", record);
+
+    try {
+      const boom = query(async () => {
+        throw new Error("unobserved");
+      });
+      const resource = boom();
+
+      // Reading a getter starts the work. Nothing chains onto it, which is what
+      // a component reading only `error` does.
+      expect(resource.error).toBeUndefined();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(unhandled).toEqual([]);
+      expect(resource.error).toBeInstanceOf(Error);
+    } finally {
+      window.removeEventListener("unhandledrejection", record);
+    }
   });
 
   it("re-runs the implementation on refresh", async () => {
@@ -110,8 +141,23 @@ describe("$app/server stub", () => {
     expect(submit.pending).toBe(0);
     expect(submit.result).toBeUndefined();
     expect(submit.enhance(async () => {})).toMatchObject({ method: "POST" });
-    expect(submit.fields.allIssues()).toEqual([]);
-    expect(submit.fields.username.issues()).toEqual([]);
+  });
+
+  it("spreads only the attributes a <form> takes", () => {
+    const submit = form(z.object({ username: z.string() }), async () => ({
+      ok: true,
+    }));
+
+    expect(Object.keys(submit)).toEqual(["method", "action"]);
+  });
+
+  it("reports no issues as undefined, the way the framework's lookup does", () => {
+    const submit = form(z.object({ username: z.string() }), async () => ({
+      ok: true,
+    }));
+
+    expect(submit.fields.allIssues()).toBeUndefined();
+    expect(submit.fields.username.issues()).toBeUndefined();
   });
 
   it("refuses getRequestEvent rather than answering with a half-built event", () => {

--- a/src/Web/packages/app/src/lib/test-stubs/app-server.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/app-server.svelte.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { command, form, getRequestEvent, query } from "$app/server";
+import { z } from "zod";
+import { remoteQuery } from "./remote-resource";
+
+/**
+ * Only `*.svelte.test.ts` runs under vitest.browser.config.ts, which is where
+ * the `$app/server` alias to this directory's stub applies — under any other
+ * config the imports above resolve to the real framework and prove nothing
+ * about the stub.
+ *
+ * What is pinned here is shape: that a query call is a resource and not the
+ * implementation, that the `(schema, fn)` overloads reach `fn`, and that a
+ * command call is a promise carrying `updates()`. Reactivity, per-argument
+ * caching, schema validation and form submission are deliberately absent from
+ * the stub, so nothing below asserts them.
+ */
+describe("$app/server stub", () => {
+  it("hands back a resource rather than the implementation", async () => {
+    const getValue = query(async () => 42);
+    const resource = getValue();
+
+    expect(typeof resource).not.toBe("function");
+    expect(resource.loading).toBe(true);
+    expect(resource.current).toBeUndefined();
+    expect(resource.ready).toBe(false);
+
+    expect(await resource).toBe(42);
+
+    expect(resource.current).toBe(42);
+    expect(resource.ready).toBe(true);
+    expect(resource.loading).toBe(false);
+    expect(resource.error).toBeUndefined();
+  });
+
+  it("runs the second argument of a validated query, not the first", async () => {
+    const double = query("unchecked", async (n: number) => n * 2);
+
+    expect(await double(21)).toBe(42);
+  });
+
+  it("carries a rejection on error instead of leaving it unobservable", async () => {
+    const boom = query(async () => {
+      throw new Error("nope");
+    });
+    const resource = boom();
+
+    await expect(resource.run()).rejects.toThrow("nope");
+
+    expect(resource.error).toBeInstanceOf(Error);
+    expect(resource.loading).toBe(false);
+    expect(resource.ready).toBe(false);
+  });
+
+  it("re-runs the implementation on refresh", async () => {
+    let calls = 0;
+    const next = query(async () => ++calls);
+    const resource = next();
+
+    expect(await resource).toBe(1);
+
+    await resource.refresh();
+
+    expect(resource.current).toBe(2);
+  });
+
+  it("applies an override to the current value until it is released", async () => {
+    const getValue = query(async () => 1);
+    const resource = getValue();
+    await resource;
+
+    const release = resource.withOverride((value) => value + 10);
+    expect(resource.current).toBe(11);
+
+    release();
+    expect(resource.current).toBe(1);
+  });
+
+  it("takes a value pushed in with set", async () => {
+    const getValue = query(async () => 1);
+    const resource = getValue();
+    await resource;
+
+    resource.set(7);
+
+    expect(resource.current).toBe(7);
+    expect(await resource).toBe(7);
+  });
+
+  it("hands back a command call that is a promise carrying updates", async () => {
+    const send = command("unchecked", async (n: number) => n + 1);
+
+    expect(send.pending).toBe(0);
+
+    const call = send(1);
+    expect(send.pending).toBe(1);
+    expect(typeof call.updates).toBe("function");
+
+    expect(await call.updates()).toBe(2);
+    expect(send.pending).toBe(0);
+  });
+
+  it("hands back a form instance rather than the implementation", () => {
+    const submit = form(z.object({ username: z.string() }), async () => ({
+      ok: true,
+    }));
+
+    expect(typeof submit).not.toBe("function");
+    expect(submit.method).toBe("POST");
+    expect(submit.pending).toBe(0);
+    expect(submit.result).toBeUndefined();
+    expect(submit.enhance(async () => {})).toMatchObject({ method: "POST" });
+    expect(submit.fields.allIssues()).toEqual([]);
+    expect(submit.fields.username.issues()).toEqual([]);
+  });
+
+  it("refuses getRequestEvent rather than answering with a half-built event", () => {
+    expect(() => getRequestEvent()).toThrow();
+  });
+});
+
+describe("remoteQuery", () => {
+  it("is settled before the first read, and re-reads its source", () => {
+    let value = 1;
+    const resource = remoteQuery(() => value);
+
+    expect(resource.loading).toBe(false);
+    expect(resource.ready).toBe(true);
+    expect(resource.current).toBe(1);
+
+    value = 2;
+    expect(resource.current).toBe(2);
+  });
+
+  it("is awaitable, as a query is in a template", async () => {
+    const resource = remoteQuery(() => "ready");
+
+    expect(await resource).toBe("ready");
+  });
+});

--- a/src/Web/packages/app/src/lib/test-stubs/app-server.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/app-server.ts
@@ -1,19 +1,106 @@
 /**
  * Stub for $app/server in browser test environment.
- * Remote functions import this but are never called in component tests.
+ *
+ * `query`, `command` and `form` return what the framework returns — a wrapper
+ * whose call yields a query resource, a promise carrying `updates()`, and a
+ * form instance respectively — not the implementation handed in. A stub that
+ * returned the implementation would let a component test pass against a
+ * component reading `.current` or calling `.updates()`, neither of which exists
+ * on a bare function in production, and would drop the second argument of the
+ * `(schema, fn)` overloads entirely.
+ *
+ * See `./remote-resource` for what a query resource does and does not carry.
+ * Form submission is not plumbed: `enhance()` returns the attributes and no
+ * listener, so the implementation only ever runs for a query or a command.
  */
-export function getRequestEvent() {
+import { createQueryResource } from "./remote-resource";
+
+export function getRequestEvent(): never {
   throw new Error("getRequestEvent is not available in browser tests");
 }
 
-export function query(fn: any) {
-  return fn;
+type Implementation = (arg?: unknown) => unknown;
+type CommandCall = Promise<unknown> & { updates: () => CommandCall };
+
+// The framework's `(schema, fn)` and `(fn)` overloads both end at `fn`. Only
+// the vitest alias reaches this module, so the schema never needs a type here.
+function implementation(
+  validateOrFn: Implementation,
+  maybeFn?: Implementation
+): Implementation {
+  return maybeFn ?? validateOrFn;
 }
 
-export function command(fn: any) {
-  return fn;
+export function query(validateOrFn: Implementation, maybeFn?: Implementation) {
+  const fn = implementation(validateOrFn, maybeFn);
+
+  return (arg?: unknown) => createQueryResource(async () => fn(arg));
 }
 
-export function form(fn: any) {
-  return fn;
+export function command(
+  validateOrFn: Implementation,
+  maybeFn?: Implementation
+) {
+  const fn = implementation(validateOrFn, maybeFn);
+  let pending = 0;
+
+  const wrapper = (arg?: unknown): CommandCall => {
+    pending++;
+
+    const call: CommandCall = Object.assign(
+      (async () => {
+        try {
+          return await fn(arg);
+        } finally {
+          pending--;
+        }
+      })(),
+      { updates: () => call }
+    );
+
+    return call;
+  };
+
+  Object.defineProperty(wrapper, "pending", { get: () => pending });
+
+  return wrapper;
+}
+
+/**
+ * Every field reports no issues, because the stub runs no schema and has
+ * nothing to report. An unrecognised property nests, so a path of any depth
+ * answers.
+ */
+function fieldProxy(path: string[] = []): unknown {
+  const name = path.join(".");
+
+  return new Proxy(() => undefined, {
+    get(target, prop) {
+      if (typeof prop === "symbol") return Reflect.get(target, prop);
+      if (prop === "issues" || prop === "allIssues") return () => [];
+      if (prop === "value") return () => undefined;
+      if (prop === "set") return (value: unknown) => value;
+      if (prop === "as") return (type: string) => ({ name, type });
+      return fieldProxy([...path, prop]);
+    },
+  });
+}
+
+export function form() {
+  const action = "?/remote=stub";
+  const instance: Record<string, unknown> = { method: "POST", action };
+
+  // Only `method` and `action` are enumerable on the framework's instance, so
+  // only they land on the element when the form is spread onto one.
+  Object.defineProperties(instance, {
+    enhance: { value: () => ({ method: "POST", action }) },
+    fields: { get: () => fieldProxy() },
+    result: { get: () => undefined },
+    pending: { get: () => 0 },
+    preflight: { value: () => instance },
+    validate: { value: async () => {} },
+    for: { value: () => instance },
+  });
+
+  return instance;
 }

--- a/src/Web/packages/app/src/lib/test-stubs/app-server.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/app-server.ts
@@ -9,18 +9,25 @@
  * on a bare function in production, and would drop the second argument of the
  * `(schema, fn)` overloads entirely.
  *
- * See `./remote-resource` for what a query resource does and does not carry.
- * Form submission is not plumbed: `enhance()` returns the attributes and no
- * listener, so the implementation only ever runs for a query or a command.
+ * A remote module a test forgot to `vi.mock` no longer fails loudly: the
+ * implementation runs, reaches `getRequestEvent`, and that error settles on the
+ * resource's `error` instead of propagating, so a component reading only
+ * `current` renders empty. A query that never produces a value is the shape a
+ * missing `vi.mock` takes.
+ *
+ * See `./remote-resource` for what these shapes do and do not carry.
  */
-import { createQueryResource } from "./remote-resource";
+import {
+  createQueryResource,
+  remoteCommand,
+  remoteForm,
+} from "./remote-resource";
 
 export function getRequestEvent(): never {
   throw new Error("getRequestEvent is not available in browser tests");
 }
 
 type Implementation = (arg?: unknown) => unknown;
-type CommandCall = Promise<unknown> & { updates: () => CommandCall };
 
 // The framework's `(schema, fn)` and `(fn)` overloads both end at `fn`. Only
 // the vitest alias reaches this module, so the schema never needs a type here.
@@ -41,66 +48,7 @@ export function command(
   validateOrFn: Implementation,
   maybeFn?: Implementation
 ) {
-  const fn = implementation(validateOrFn, maybeFn);
-  let pending = 0;
-
-  const wrapper = (arg?: unknown): CommandCall => {
-    pending++;
-
-    const call: CommandCall = Object.assign(
-      (async () => {
-        try {
-          return await fn(arg);
-        } finally {
-          pending--;
-        }
-      })(),
-      { updates: () => call }
-    );
-
-    return call;
-  };
-
-  Object.defineProperty(wrapper, "pending", { get: () => pending });
-
-  return wrapper;
+  return remoteCommand(implementation(validateOrFn, maybeFn));
 }
 
-/**
- * Every field reports no issues, because the stub runs no schema and has
- * nothing to report. An unrecognised property nests, so a path of any depth
- * answers.
- */
-function fieldProxy(path: string[] = []): unknown {
-  const name = path.join(".");
-
-  return new Proxy(() => undefined, {
-    get(target, prop) {
-      if (typeof prop === "symbol") return Reflect.get(target, prop);
-      if (prop === "issues" || prop === "allIssues") return () => [];
-      if (prop === "value") return () => undefined;
-      if (prop === "set") return (value: unknown) => value;
-      if (prop === "as") return (type: string) => ({ name, type });
-      return fieldProxy([...path, prop]);
-    },
-  });
-}
-
-export function form() {
-  const action = "?/remote=stub";
-  const instance: Record<string, unknown> = { method: "POST", action };
-
-  // Only `method` and `action` are enumerable on the framework's instance, so
-  // only they land on the element when the form is spread onto one.
-  Object.defineProperties(instance, {
-    enhance: { value: () => ({ method: "POST", action }) },
-    fields: { get: () => fieldProxy() },
-    result: { get: () => undefined },
-    pending: { get: () => 0 },
-    preflight: { value: () => instance },
-    validate: { value: async () => {} },
-    for: { value: () => instance },
-  });
-
-  return instance;
-}
+export const form = remoteForm;

--- a/src/Web/packages/app/src/lib/test-stubs/remote-resource.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/remote-resource.ts
@@ -1,0 +1,162 @@
+/**
+ * The remote-function shapes `$app/server` hands back, for the browser test
+ * environment.
+ *
+ * Mirrored: the surface a component touches. A query is a thenable carrying
+ * `current`, `error`, `loading` and `ready` alongside `run`, `set`, `refresh`
+ * and `withOverride`, and reading any of those getters starts the work, as the
+ * framework's does.
+ *
+ * Not mirrored: reactivity, per-argument caching, and schema validation. The
+ * getters read a snapshot rather than a signal, so nothing re-renders when a
+ * pending resource settles. A test that needs a value on screen builds the
+ * resource with `remoteQuery`, which is settled before the first read.
+ */
+export interface RemoteQueryStub<T> extends PromiseLike<T> {
+  readonly current: T | undefined;
+  readonly error: unknown;
+  readonly loading: boolean;
+  readonly ready: boolean;
+  run(): Promise<T>;
+  set(value: T): void;
+  refresh(): Promise<void>;
+  withOverride(update: (current: T) => T): () => void;
+}
+
+class QueryResource<T> implements RemoteQueryStub<T> {
+  #run: () => Promise<T>;
+  #read: (() => T) | null = null;
+  #promise: Promise<void> | null = null;
+  #loading = false;
+  #error: unknown = undefined;
+  #overrides: ((current: T) => T)[] = [];
+
+  constructor(run: () => Promise<T>) {
+    this.#run = run;
+  }
+
+  #start(): Promise<void> {
+    if (this.#promise) return this.#promise;
+
+    this.#loading = true;
+
+    const promise = (async () => this.#run())().then(
+      (value) => {
+        this.#read = () => value;
+        this.#loading = false;
+        this.#error = undefined;
+      },
+      (reason) => {
+        this.#loading = false;
+        this.#error = reason;
+        throw reason;
+      }
+    );
+
+    // The framework keeps a handler on its own copy so a rejection a component
+    // reads off `error` is not also an unhandled rejection.
+    promise.catch(() => {});
+
+    this.#promise = promise;
+    return promise;
+  }
+
+  settle(read: () => T) {
+    this.#read = read;
+    this.#loading = false;
+    this.#error = undefined;
+    this.#promise = Promise.resolve();
+  }
+
+  #overridden(read: () => T): T {
+    return this.#overrides.reduce<T>((value, apply) => apply(value), read());
+  }
+
+  get current(): T | undefined {
+    void this.#start();
+    return this.#read ? this.#overridden(this.#read) : undefined;
+  }
+
+  get error(): unknown {
+    void this.#start();
+    return this.#error;
+  }
+
+  get loading(): boolean {
+    void this.#start();
+    return this.#loading;
+  }
+
+  get ready(): boolean {
+    void this.#start();
+    return this.#read !== null;
+  }
+
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?:
+      | ((value: T) => TResult1 | PromiseLike<TResult1>)
+      | null
+      | undefined,
+    onrejected?:
+      | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+      | null
+      | undefined
+  ): Promise<TResult1 | TResult2> {
+    return this.run().then(onfulfilled, onrejected);
+  }
+
+  catch<TResult = never>(
+    onrejected?:
+      | ((reason: unknown) => TResult | PromiseLike<TResult>)
+      | null
+      | undefined
+  ): Promise<T | TResult> {
+    return this.run().catch(onrejected);
+  }
+
+  finally(onfinally?: (() => void) | null | undefined): Promise<T> {
+    return this.run().finally(onfinally);
+  }
+
+  run(): Promise<T> {
+    return this.#start().then(() => {
+      if (!this.#read) throw new Error("the resource settled without a value");
+      return this.#overridden(this.#read);
+    });
+  }
+
+  set(value: T) {
+    this.settle(() => value);
+  }
+
+  refresh(): Promise<void> {
+    this.#promise = null;
+    return this.#start();
+  }
+
+  withOverride(update: (current: T) => T): () => void {
+    this.#overrides.push(update);
+
+    return () => {
+      const index = this.#overrides.indexOf(update);
+      if (index !== -1) this.#overrides.splice(index, 1);
+    };
+  }
+}
+
+export function createQueryResource<T>(
+  run: () => Promise<T>
+): RemoteQueryStub<T> {
+  return new QueryResource(run);
+}
+
+/**
+ * A query resource that is already settled, for tests standing in for a remote
+ * module. `read` is called on every access, so a test can move the value the
+ * component sees between renders.
+ */
+export function remoteQuery<T>(read: () => T): RemoteQueryStub<T> {
+  const resource = new QueryResource<T>(async () => read());
+  resource.settle(read);
+  return resource;
+}

--- a/src/Web/packages/app/src/lib/test-stubs/remote-resource.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/remote-resource.ts
@@ -1,16 +1,30 @@
 /**
  * The remote-function shapes `$app/server` hands back, for the browser test
- * environment.
+ * environment. `./app-server` builds its exports from these, and a test
+ * standing in for a generated remote module builds its stand-ins from the same
+ * ones, so there is one description of the shape rather than one per test.
  *
  * Mirrored: the surface a component touches. A query is a thenable carrying
  * `current`, `error`, `loading` and `ready` alongside `run`, `set`, `refresh`
  * and `withOverride`, and reading any of those getters starts the work, as the
- * framework's does.
+ * framework's does. A command call is a promise carrying `updates()`, behind a
+ * wrapper counting `pending`. `fields.issues()` and `fields.allIssues()` answer
+ * `undefined`, not `[]`, when there is nothing to report: the framework builds
+ * its issue map with `flatten_issues`, which yields `{}` for no issues, so the
+ * lookup misses and the `?.map` short-circuits. Callers have to be written
+ * against that.
  *
- * Not mirrored: reactivity, per-argument caching, and schema validation. The
- * getters read a snapshot rather than a signal, so nothing re-renders when a
- * pending resource settles. A test that needs a value on screen builds the
- * resource with `remoteQuery`, which is settled before the first read.
+ * Not mirrored: reactivity, per-argument caching, schema validation, and form
+ * submission. The getters read a snapshot rather than a signal, so nothing
+ * re-renders when a pending resource settles; a test that needs a value on
+ * screen builds the resource with `remoteQuery`, which is settled before the
+ * first read and re-reads its source on every access, keeping whatever
+ * reactivity that source has.
+ *
+ * Deliberately more permissive than production: the framework refuses `run()`
+ * inside an effect and refuses to be awaited outside a tracking context, and
+ * these resources allow both. Code that only a test exercises can rely on
+ * either and still fail in the browser.
  */
 export interface RemoteQueryStub<T> extends PromiseLike<T> {
   readonly current: T | undefined;
@@ -21,6 +35,17 @@ export interface RemoteQueryStub<T> extends PromiseLike<T> {
   set(value: T): void;
   refresh(): Promise<void>;
   withOverride(update: (current: T) => T): () => void;
+}
+
+export type RemoteCommandCall<T> = Promise<T> & {
+  updates: () => RemoteCommandCall<T>;
+};
+
+// `pending` is a getter on the framework's wrapper and a plain property here.
+// Nothing writes it from outside, so the count a component reads is the same.
+export interface RemoteCommandStub<T> {
+  (arg?: unknown): RemoteCommandCall<T>;
+  pending: number;
 }
 
 class QueryResource<T> implements RemoteQueryStub<T> {
@@ -54,7 +79,9 @@ class QueryResource<T> implements RemoteQueryStub<T> {
     );
 
     // The framework keeps a handler on its own copy so a rejection a component
-    // reads off `error` is not also an unhandled rejection.
+    // reads off `error` is not also an unhandled rejection. In the browser
+    // runner an unhandled rejection aborts the whole run, so a resource nobody
+    // awaits would take the suite down with it.
     promise.catch(() => {});
 
     this.#promise = promise;
@@ -159,4 +186,75 @@ export function remoteQuery<T>(read: () => T): RemoteQueryStub<T> {
   const resource = new QueryResource<T>(async () => read());
   resource.settle(read);
   return resource;
+}
+
+export function remoteCommand<T>(
+  fn: (arg?: unknown) => T | Promise<T>
+): RemoteCommandStub<T> {
+  function invoke(arg?: unknown): RemoteCommandCall<T> {
+    stub.pending++;
+
+    const call: RemoteCommandCall<T> = Object.assign(
+      (async () => {
+        try {
+          return await fn(arg);
+        } finally {
+          stub.pending--;
+        }
+      })(),
+      { updates: () => call }
+    );
+
+    return call;
+  }
+
+  const stub: RemoteCommandStub<T> = Object.assign(invoke, { pending: 0 });
+
+  return stub;
+}
+
+/**
+ * Every field reports no issues, because the stub runs no schema and has
+ * nothing to report. An unrecognised property nests, so a path of any depth
+ * answers.
+ */
+function fieldProxy(path: string[] = []): unknown {
+  const name = path.join(".");
+
+  return new Proxy(() => undefined, {
+    get(target, prop) {
+      if (typeof prop === "symbol") return Reflect.get(target, prop);
+      if (prop === "issues" || prop === "allIssues") return () => undefined;
+      if (prop === "value") return () => undefined;
+      if (prop === "set") return (value: unknown) => value;
+      if (prop === "as") return (type: string) => ({ name, type });
+      return fieldProxy([...path, prop]);
+    },
+  });
+}
+
+/**
+ * The instance the framework's server build returns, where `pending` is always
+ * 0 and `result` always undefined. Nothing here submits, so the client build's
+ * counting `pending` would have nothing to count.
+ */
+export function remoteForm() {
+  const action = "?/remote=stub";
+  const instance: Record<string, unknown> = { method: "POST", action };
+
+  // `method` and `action` are the framework's only enumerable own properties
+  // on the server instance, and the two the caller spreads onto a <form>. The
+  // client instance additionally carries an attachment under a symbol key,
+  // which drives submission the stub does not implement.
+  Object.defineProperties(instance, {
+    enhance: { value: () => ({ method: "POST", action }) },
+    fields: { get: () => fieldProxy() },
+    result: { get: () => undefined },
+    pending: { get: () => 0 },
+    preflight: { value: () => instance },
+    validate: { value: async () => {} },
+    for: { value: () => instance },
+  });
+
+  return instance;
 }

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/alerts-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/alerts-page.svelte.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { error } from "@sveltejs/kit";
 import { page as pageState } from "$app/state";
 import type { AlertRuleResponse } from "$api-clients";
+import { remoteCommand, remoteQuery } from "$lib/test-stubs/remote-resource";
 
 const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
 
@@ -19,34 +20,32 @@ const rules = [
   },
 ] as unknown as AlertRuleResponse[];
 
-/** Stands in for a remote query: awaitable in the template, plus its methods. */
-function remoteQuery<T>(value: T, extra: Record<string, unknown> = {}) {
-  return Object.assign(Promise.resolve(value), {
-    refresh: () => Promise.resolve(),
-    ...extra,
-  });
-}
+// The backing values are module-level so each read hands back the same object:
+// a resource that answered a fresh array every access would restart any effect
+// deriving from it.
+const activeAlerts: unknown[] = [];
+const alertHistory = { items: [], totalCount: 0 };
 
 // `toggleRule` is the shortest write path on the page (one click, no dialog), so
 // it stands in for the server's refusal.
 let toggleImpl: () => Promise<unknown>;
 
 vi.mock("$api/generated/alertRules.generated.remote", () => ({
-  getRules: () => remoteQuery(rules),
-  deleteRule: () => Promise.resolve(),
-  toggleRule: () => toggleImpl(),
-  testFire: () => Promise.resolve(),
+  getRules: () => remoteQuery(() => rules),
+  deleteRule: remoteCommand(() => undefined),
+  toggleRule: remoteCommand(() => toggleImpl()),
+  testFire: remoteCommand(() => undefined),
 }));
 
 vi.mock("$api/generated/alerts.generated.remote", () => ({
-  getActiveAlerts: () => remoteQuery([], { withOverride: () => undefined }),
-  getAlertHistory: () => remoteQuery({ items: [], totalCount: 0 }),
-  acknowledge: () => ({ updates: () => Promise.resolve() }),
+  getActiveAlerts: () => remoteQuery(() => activeAlerts),
+  getAlertHistory: () => remoteQuery(() => alertHistory),
+  acknowledge: remoteCommand(() => undefined),
 }));
 
 vi.mock("$api/generated/tenantAlertSettings.generated.remote", () => ({
-  get: () => remoteQuery(null),
-  update: () => Promise.resolve(),
+  get: () => remoteQuery(() => null),
+  update: remoteCommand(() => undefined),
 }));
 
 vi.mock("svelte-sonner", () => ({ toast: { error: toastError } }));

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/compression-lows-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/compression-lows-page.svelte.test.ts
@@ -3,6 +3,7 @@ import { page } from "vitest/browser";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { error } from "@sveltejs/kit";
 import { page as pageState } from "$app/state";
+import { remoteCommand, remoteQuery } from "$lib/test-stubs/remote-resource";
 
 const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
 
@@ -27,17 +28,12 @@ const suggestions = [suggestion];
 let acceptImpl: () => Promise<unknown>;
 
 vi.mock("$api/generated/compressionLows.generated.remote", () => ({
-  getSuggestions: () => ({
-    current: suggestions,
-    loading: false,
-    error: undefined,
-    refresh: () => {},
-  }),
-  getSuggestion: () => ({ run: () => Promise.resolve(detail) }),
-  acceptSuggestion: () => acceptImpl(),
-  dismissSuggestion: () => Promise.resolve(),
-  deleteSuggestion: () => Promise.resolve(),
-  triggerDetection: () => Promise.resolve({}),
+  getSuggestions: () => remoteQuery(() => suggestions),
+  getSuggestion: () => remoteQuery(() => detail),
+  acceptSuggestion: remoteCommand(() => acceptImpl()),
+  dismissSuggestion: remoteCommand(() => undefined),
+  deleteSuggestion: remoteCommand(() => undefined),
+  triggerDetection: remoteCommand(() => ({})),
 }));
 
 vi.mock("svelte-sonner", () => ({ toast: { error: toastError } }));


### PR DESCRIPTION
Closes #958.

## Problem

The `$app/server` browser-test stub returned bare functions — worse than the issue described: with the framework's `(schema, fn)` overload, `query(Schema, fn)` returned the **zod schema**, so every generated remote function was a schema or the string `"unchecked"` under test. Nothing noticed only because every component test `vi.mock`s the generated module; the tax showed up instead as hand-rolled `remoteQuery()` shapes per test file — the same "workaround exists because the stub lies" signature that produced #934. (The issue's `fail()` item was already fixed by #942 and is moot here — `app-server.ts` never had one.)

## Change

- New `remote-resource.ts` + rewritten `app-server.ts`: `query` calls yield a resource with the framework's shape (thenable, `current`/`error`/`loading`/`ready`, `run`/`set`/`refresh`/`withOverride`), `command` carries a counting `pending` and `updates()`, `form` returns the server-instance shape — enumerable `method`/`action` only (pinned by a guard case), non-enumerable `enhance`/`fields`/`result`/…, with `fields` a nesting proxy whose `issues()`/`allIssues()` return **`undefined`** when empty, as the framework's lookup does (the first fix-round draft returned `[]`; the hostile gate caught the divergence against kit's `flatten_issues`).
- **Deliberately not mirrored, declared in the module docs:** reactivity, per-argument caching, schema validation, form submission (incl. the client instance's attachment symbol), and production's refusal of `run()`-in-effect / bare `await` outside a tracking context — the stub is more permissive, on purpose, and says so. A forgotten `vi.mock` now yields a settled-error resource that renders empty rather than the old loud TypeError; also documented.
- 14-case fidelity guard (`app-server.svelte.test.ts`) — the old bare-fn stub fails 7 of them; every hostile-gate survivor (empty-issues shape, enumerability, the noop rejection-catch) now has a killing case, including an `unhandledrejection`-channel assertion for the catch.
- The per-test workaround shapes #958 names are gone: `alerts-page` and `compression-lows-page` (ownership re-verified — last touched by merged #942, not open #960) plus `FiringToast`, `ClientDevices`, and `PatientDeviceManager`'s hand-rolled form stand-ins all build from the shared `remoteQuery`/`remoteCommand`/`remoteForm`. Every assertion preserved verbatim.
- Type/pattern alignment at the four `{#each …issues()}` sites without `?? []` (`PatientDeviceManager`, `PatientInsulinManager`) — latent, not live (Svelte's `each` coerces null), but now consistent with the guarded oauth pages and safe against a future `.length`/`.map`.

## The incidental find that mattered most

`PatientDeviceManager.svelte.test.ts` was dead on main: its `vi.mock` factory referenced module-level consts still in the TDZ, threw on every run, and the unhandled rejection **aborted the entire browser suite before its summary printed** — the full `pnpm test:browser` never completed and roughly half the files never ran locally. Fixed via `vi.hoisted`; the full suite now completes: **50 files, 303 tests: 298 passed / 4 pre-existing failures / 1 skipped** (identical failure set on both sides — `OidcProviderDialog`, `CalendarHeader` ×2, `CurrentBGDisplay`; none touch remote modules). CI runs no web vitest, so this only ever bit locally — which is exactly why it survived.

## Evidence

- Guard 14/14; converted files green with assertions unchanged; node suite identical to main; `pnpm check` 64 errors, baseline-identical, none in touched files.
- Mutations, all killed and reverted: bare-fn `query` (7 red), bare-fn `command`+`form` (4), `[]`-issues (1), enumerable form members (1, plus 3 via `Object.assign`), captured-once `remoteQuery` (2, incl. FiringToast's mid-test state mutation), early-resolving thenable (5), dropped noop catch (1).
- One declared concession: `RemoteCommandStub.pending` is a plain property where the framework uses a getter (the getter form needed a banned type assertion); nothing external writes it.

## Follow-ups declared

- `failedQuery`/`pendingQuery`/`remoteForm`-with-issues siblings would subsume the remaining per-test error/loading shapes in `ChannelsSection`/`LoginForm` — not built speculatively.
- The node vitest config aliases no `$app/*` modules, so three node tests duplicate the old bare-fn lie inline (~40 lines); aliasing `vitest.config.ts` like the browser config would put the node suite behind the same fidelity gate.

_Agent-authored; reviewed + gate-reviewed with independent verification and a fix round._
