### PR TITLE
test: retire the host-measuring unit tests so an unfiltered run is green

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
             csproj=$(find "$proj" -maxdepth 1 -name "*.csproj" | head -1)
             [ -z "$csproj" ] && continue
             dotnet test "$csproj" \
-              --filter "Category!=Integration&Category!=Performance&Category!=E2E" \
+              --filter "Category!=Integration&Category!=E2E" \
               --logger "trx;LogFileName=unit.trx" \
               -p:GenerateNSwagClient=false \
               || exit 1
@@ -232,7 +232,7 @@ jobs:
       - name: Integration tests (Infrastructure.Data — RLS + DataProtection)
         run: |
           dotnet test tests/Integration/Nocturne.Infrastructure.Data.Tests/Nocturne.Infrastructure.Data.Tests.csproj \
-            --filter "Category!=Performance&Category!=E2E" \
+            --filter "Category!=E2E" \
             --logger "trx;LogFileName=integration-db.trx" \
             -p:GenerateNSwagClient=false \
             || exit 1

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/README.md
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/README.md
@@ -331,19 +331,11 @@ Enhanced health check system with better diagnostics:
 ```bash
 # Run cache-specific tests
 dotnet test --filter "Category=Cache"
-
-# Run performance benchmarks
-dotnet test --filter "Category=Performance"
 ```
 
-### Performance Benchmarks
-
-The system includes comprehensive performance tests:
-
-- **Cache Retrieval Performance**: Validates sub-10ms targets
-- **Hit Rate Performance**: Ensures >80% hit rates
-- **Throughput Testing**: Concurrent operation handling
-- **Memory Usage**: Resource consumption analysis
+`tests/Unit/Nocturne.Infrastructure.Cache.Tests` covers hit rate over a seeded access pattern and
+concurrent read-modify-write. The sub-10ms retrieval target above is a production goal, not a test
+assertion: a wall-clock budget on a shared runner measures the runner.
 
 ## Monitoring & Observability
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,9 +38,8 @@ dotnet test
 # One category (also solution-scoped)
 dotnet test --filter "Category=Integration"
 
-# One project, on any OS. Unit projects carry a few Category=Performance tests with
-# machine-dependent thresholds, so the default filter belongs here too
-dotnet test tests/Unit/Nocturne.API.Tests --filter "Category!=Integration&Category!=Performance&Category!=E2E"
+# One project, on any OS
+dotnet test tests/Unit/Nocturne.API.Tests --filter "Category!=Integration&Category!=E2E"
 
 # Run the end-to-end suite (stands up the whole Aspire stack)
 dotnet test tests/E2E/Nocturne.E2E.Tests -p:RunE2E=true
@@ -101,12 +100,13 @@ dotnet test --filter "Category!=Integration&Category!=Performance&Category!=E2E"
 
 ### Performance Tests
 
-```bash
-# Run only performance/benchmark tests
-dotnet test --filter "Category=Performance"
+`Category=Performance` marks the BenchmarkDotNet runners under `tests/Performance` and nothing else;
+the whole-solution filters above exist to skip them. Nothing under `tests/Unit` carries the trait, so
+a per-project unit run needs no `Category!=Performance` (`TestCategoryTraitTests` enforces both).
 
-# Run cache performance tests specifically
-dotnet test --filter "FullyQualifiedName~CachePerformanceBenchmarks"
+```bash
+# Run only the benchmark runners
+dotnet test --filter "Category=Performance"
 ```
 
 ### Integration Tests

--- a/tests/Unit/Nocturne.API.Tests/README.md
+++ b/tests/Unit/Nocturne.API.Tests/README.md
@@ -6,9 +6,8 @@ live in `tests/Integration/Nocturne.API.Tests`.
 ## Running Tests
 
 ```bash
-# The whole project. Five tests here are Category=Performance — memory and throughput thresholds
-# that depend on the machine — and the standard filter is what keeps them out
-dotnet test tests/Unit/Nocturne.API.Tests --filter "Category!=Integration&Category!=Performance&Category!=E2E"
+# The whole project
+dotnet test tests/Unit/Nocturne.API.Tests --filter "Category!=Integration&Category!=E2E"
 
 # One class
 dotnet test tests/Unit/Nocturne.API.Tests --filter "FullyQualifiedName~EntryServiceTests"

--- a/tests/Unit/Nocturne.API.Tests/Services/Legacy/DataFormatServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Legacy/DataFormatServiceTests.cs
@@ -746,12 +746,11 @@ public class DataFormatServiceTests
 
     #endregion
 
-    #region Large Dataset Performance Tests
+    #region Large Dataset Tests
 
     [Fact]
     [Trait("Category", "Unit")]
-    [Trait("Category", "Performance")]
-    public void FormatEntries_WithLargeDataset_ShouldPerformReasonably()
+    public void FormatEntries_WithLargeDataset_ShouldEmitEveryRow()
     {
         // Arrange
         var entries = new Entry[1000];
@@ -771,21 +770,17 @@ public class DataFormatServiceTests
         var format = "csv";
 
         // Act
-        var startTime = DateTime.UtcNow;
         var result = DataFormatService.FormatEntries(entries, format);
-        var endTime = DateTime.UtcNow;
 
         // Assert
         result.Should().NotBeNullOrEmpty();
         var lines = result.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
         lines.Length.Should().Be(1001); // Header + 1000 data rows
-        (endTime - startTime).Should().BeLessThan(TimeSpan.FromSeconds(5)); // Should complete within 5 seconds
     }
 
     [Fact]
     [Trait("Category", "Unit")]
-    [Trait("Category", "Performance")]
-    public void FormatTreatments_WithLargeDataset_ShouldPerformReasonably()
+    public void FormatTreatments_WithLargeDataset_ShouldEmitEveryRow()
     {
         // Arrange
         var treatments = new Treatment[1000];
@@ -803,15 +798,12 @@ public class DataFormatServiceTests
         var format = "csv";
 
         // Act
-        var startTime = DateTime.UtcNow;
         var result = DataFormatService.FormatTreatments(treatments, format);
-        var endTime = DateTime.UtcNow;
 
         // Assert
         result.Should().NotBeNullOrEmpty();
         var lines = result.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
         lines.Length.Should().Be(1001); // Header + 1000 data rows
-        (endTime - startTime).Should().BeLessThan(TimeSpan.FromSeconds(5)); // Should complete within 5 seconds
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/Legacy/DocumentProcessingServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Legacy/DocumentProcessingServiceTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Services.Legacy;
@@ -562,10 +561,10 @@ public class DocumentProcessingServiceTests
 
     #endregion
 
-    #region Memory Management and Large Documents
+    #region Large Documents
 
     [Fact]
-    public void ProcessDocuments_WithLargeDocumentBatch_HandlesMemoryEfficiently()
+    public void ProcessDocuments_WithLargeDocumentBatch_SanitizesEveryDocument()
     {
         // Arrange - Create a large batch of documents
         const int batchSize = 1000;
@@ -587,21 +586,12 @@ public class DocumentProcessingServiceTests
             );
         }
 
-        var stopwatch = Stopwatch.StartNew();
-
         // Act
         var result = _service.ProcessDocuments(largeBatch).ToArray();
 
-        stopwatch.Stop();
-
         // Assert
         Assert.Equal(batchSize, result.Length);
-
-        // Verify processing completed in reasonable time (should be under 5 seconds for 1000 documents)
-        Assert.True(
-            stopwatch.ElapsedMilliseconds < 5000,
-            $"Large batch processing took {stopwatch.ElapsedMilliseconds}ms, expected < 5000ms"
-        );
+        Assert.All(result, doc => Assert.DoesNotContain("<script>", doc.Notes));
 
         // Spot check some processed documents
         var firstDoc = result[0];
@@ -616,7 +606,7 @@ public class DocumentProcessingServiceTests
     }
 
     [Fact]
-    public void ProcessDocuments_WithLargeTextFields_SanitizesEfficiently()
+    public void ProcessDocuments_WithLargeTextFields_SanitizesTheWholeField()
     {
         // Arrange - Create documents with very large text fields
         var largeTextBuilder = new System.Text.StringBuilder();
@@ -639,27 +629,17 @@ public class DocumentProcessingServiceTests
             },
         };
 
-        var stopwatch = Stopwatch.StartNew();
-
         // Act
         var result = _service.ProcessDocuments(documentsWithLargeText).ToArray();
-
-        stopwatch.Stop();
 
         // Assert
         Assert.Single(result);
         var processed = result[0];
 
-        // Should complete in reasonable time (under 1 second for large text sanitization)
-        Assert.True(
-            stopwatch.ElapsedMilliseconds < 1000,
-            $"Large text sanitization took {stopwatch.ElapsedMilliseconds}ms, expected < 1000ms"
-        );
-
-        // All script tags should be removed but paragraphs and bold text should remain
+        // Sanitization covers the whole field, not just its opening paragraphs
         Assert.DoesNotContain("<script>", processed.Notes!);
-        Assert.Contains("<p>", processed.Notes!);
-        Assert.Contains("<b>bold text", processed.Notes!);
+        Assert.Equal(1000, processed.Notes!.Split("<p>").Length - 1);
+        Assert.Contains("<b>bold text 999</b>", processed.Notes!);
 
         // Content should be significantly shorter due to script removal
         Assert.True(processed.Notes!.Length < largeText.Length);
@@ -687,21 +667,11 @@ public class DocumentProcessingServiceTests
             );
         }
 
-        var stopwatch = Stopwatch.StartNew();
-
         // Act
         var result = _service.ProcessDocuments(veryLargeBatch).ToArray();
 
-        stopwatch.Stop();
-
         // Assert
         Assert.Equal(largeBatchSize, result.Length);
-
-        // Should handle large batches efficiently (under 15 seconds)
-        Assert.True(
-            stopwatch.ElapsedMilliseconds < 15000,
-            $"Very large batch processing took {stopwatch.ElapsedMilliseconds}ms, expected < 15000ms"
-        );
 
         // Verify random sampling of processed documents
         var sampleIndices = new[] { 0, largeBatchSize / 4, largeBatchSize / 2, largeBatchSize - 1 };
@@ -1036,186 +1006,53 @@ public class DocumentProcessingServiceTests
 
     #endregion
 
-    #region Performance Benchmark Tests
+    #region Scaling
 
     [Fact]
-    [Trait("Category", "Performance")]
-    public void ProcessDocuments_PerformanceBenchmark_LargeDocumentStressTesting()
+    public void ProcessDocuments_AllocatesInProportionToBatchSize()
     {
-        // Arrange - Create a very large batch for stress testing
-        const int stressTestSize = 10000;
-        var stressTestBatch = new List<Treatment>(stressTestSize);
+        const int smallBatch = 100;
+        const int largeBatch = 2000;
 
-        for (int i = 0; i < stressTestSize; i++)
+        // A first pass pays for JIT and the sanitizer's one-off setup; charging that to the
+        // small batch would flatter the ratio.
+        MeasureAllocations(smallBatch);
+
+        var smallBatchBytes = MeasureAllocations(smallBatch);
+        var largeBatchBytes = MeasureAllocations(largeBatch);
+
+        var ratio = (double)largeBatchBytes / smallBatchBytes;
+        Assert.InRange(ratio, 10.0, 40.0);
+    }
+
+    /// <summary>
+    /// Bytes allocated on this thread by processing <paramref name="batchSize"/> entries. Thread-local
+    /// and exact, so it reads the same on a loaded machine as on an idle one — unlike a wall clock.
+    /// </summary>
+    private long MeasureAllocations(int batchSize)
+    {
+        var batch = new List<Entry>(batchSize);
+        for (int i = 0; i < batchSize; i++)
         {
-            stressTestBatch.Add(
-                new Treatment
+            batch.Add(
+                new Entry
                 {
-                    Id = $"stress_test_{i}",
-                    Mills = DateTimeOffset.UtcNow.AddMinutes(-i).ToUnixTimeMilliseconds(),
-                    EventType = i % 5 == 0 ? "Meal Bolus" : "Correction Bolus",
-                    Insulin = (i % 20) * 0.5 + 1.0,
-                    Carbs = i % 3 == 0 ? (i % 100) + 5.0 : null,
-                    Notes =
-                        $"<p>Stress test treatment {i}</p><script>alert('stress{i}')</script><b>Performance test</b>",
-                    BolusCalc =
-                        i % 10 == 0
-                            ? new Dictionary<string, object>
-                            {
-                                ["estimate"] = (i % 20) * 0.25,
-                                ["foodEstimate"] = (i % 15) * 0.33,
-                                ["correction"] = (i % 8) * 0.125,
-                            }
-                            : null,
+                    Id = $"perf_entry_{i}",
+                    Mills = DateTimeOffset.UtcNow.AddSeconds(-i).ToUnixTimeMilliseconds(),
+                    Type = "sgv",
+                    Sgv = 80 + (i % 200),
+                    Device = $"<span>PerfDevice_{i % 5}</span>",
+                    Notes = i % 50 == 0 ? $"<b>Performance note {i}</b>" : null,
                 }
             );
         }
 
-        var stopwatch = Stopwatch.StartNew();
-        var memoryBefore = GC.GetTotalMemory(false);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var processed = _service.ProcessDocuments(batch).ToArray();
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
-        // Act
-        var result = _service.ProcessDocuments(stressTestBatch).ToArray();
-
-        stopwatch.Stop();
-        var memoryAfter = GC.GetTotalMemory(true); // Force GC to get accurate measurement
-
-        // Assert
-        Assert.Equal(stressTestSize, result.Length);
-
-        // Performance assertions - should handle 10k documents in reasonable time
-        Assert.True(
-            stopwatch.ElapsedMilliseconds < 30000,
-            $"Stress test took {stopwatch.ElapsedMilliseconds}ms, expected < 30000ms"
-        );
-
-        // Memory usage should be reasonable (allow for 100MB increase)
-        var memoryIncrease = memoryAfter - memoryBefore;
-        Assert.True(
-            memoryIncrease < 100_000_000,
-            $"Memory increase was {memoryIncrease} bytes, expected < 100MB"
-        );
-
-        // Spot check results
-        var firstResult = result[0];
-        Assert.DoesNotContain("<script>", firstResult.Notes!);
-        Assert.Contains("<p>Stress test treatment 0</p>", firstResult.Notes!);
-        Assert.Contains("<b>Performance test</b>", firstResult.Notes!);
-
-        var lastResult = result[stressTestSize - 1];
-        Assert.Equal($"stress_test_{stressTestSize - 1}", lastResult.Id);
-        Assert.NotNull(lastResult.CreatedAt);
-    }
-
-    [Fact]
-    [Trait("Category", "Performance")]
-    public void ProcessDocuments_BatchProcessingPerformance_ScalesLinearly()
-    {
-        // Arrange - Test different batch sizes to verify linear scaling
-        var batchSizes = new[] { 100, 500, 1000, 2000 };
-        var results = new List<(int Size, long ElapsedMs)>();
-
-        foreach (var batchSize in batchSizes)
-        {
-            var batch = new List<Entry>(batchSize);
-            for (int i = 0; i < batchSize; i++)
-            {
-                batch.Add(
-                    new Entry
-                    {
-                        Id = $"perf_entry_{i}",
-                        Mills = DateTimeOffset.UtcNow.AddSeconds(-i).ToUnixTimeMilliseconds(),
-                        Type = "sgv",
-                        Sgv = 80 + (i % 200),
-                        Device = $"<span>PerfDevice_{i % 5}</span>",
-                        Notes = i % 50 == 0 ? $"<b>Performance note {i}</b>" : null,
-                    }
-                );
-            }
-
-            var stopwatch = Stopwatch.StartNew();
-
-            // Act
-            var processed = _service.ProcessDocuments(batch).ToArray();
-
-            stopwatch.Stop();
-            results.Add((batchSize, stopwatch.ElapsedMilliseconds));
-
-            // Verify processing completed correctly
-            Assert.Equal(batchSize, processed.Length);
-        }
-
-        // Assert - Processing time should scale roughly linearly
-        // Allow for some variance due to system factors
-        var smallBatchTime = results[0].ElapsedMs;
-        var largeBatchTime = results[3].ElapsedMs; // 2000 vs 100 items = 20x
-        var scalingRatio = (double)largeBatchTime / smallBatchTime;
-
-        // Should scale between 5x and 50x (allowing for overhead)
-        Assert.True(
-            scalingRatio >= 5 && scalingRatio <= 50,
-            $"Scaling ratio was {scalingRatio:F2}, expected between 5 and 50"
-        );
-    }
-
-    [Fact]
-    [Trait("Category", "Performance")]
-    public void ProcessDocuments_MemoryUsageBenchmarks_EfficientMemoryManagement()
-    {
-        // Arrange - Test memory efficiency with document reuse patterns
-        const int iterations = 100;
-        const int documentsPerIteration = 50;
-
-        var memoryMeasurements = new List<long>();
-
-        for (int iteration = 0; iteration < iterations; iteration++)
-        {
-            var batch = new List<DeviceStatus>(documentsPerIteration);
-            for (int i = 0; i < documentsPerIteration; i++)
-            {
-                batch.Add(
-                    new DeviceStatus
-                    {
-                        Id = $"memory_test_{iteration}_{i}",
-                        Mills = DateTimeOffset
-                            .UtcNow.AddSeconds(-(iteration * documentsPerIteration + i))
-                            .ToUnixTimeMilliseconds(),
-                        Device = $"<div>MemoryTestDevice_{i % 3}</div>",
-                        IsCharging = (i % 2) == 0,
-                    }
-                );
-            }
-
-            var memoryBefore = GC.GetTotalMemory(false);
-
-            // Act
-            var result = _service.ProcessDocuments(batch).ToArray();
-
-            // Force garbage collection to measure actual retention
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-
-            var memoryAfter = GC.GetTotalMemory(false);
-            memoryMeasurements.Add(memoryAfter - memoryBefore);
-
-            // Verify processing worked
-            Assert.Equal(documentsPerIteration, result.Length);
-        }
-
-        // Assert - Memory usage should be consistent and not grow significantly
-        var averageMemoryIncrease = memoryMeasurements.Average();
-        var maxMemoryIncrease = memoryMeasurements.Max();
-
-        // Memory increase per iteration should be reasonable (under 5MB per iteration)
-        Assert.True(
-            averageMemoryIncrease < 5_000_000,
-            $"Average memory increase was {averageMemoryIncrease} bytes, expected < 5MB"
-        );
-        Assert.True(
-            maxMemoryIncrease < 10_000_000,
-            $"Max memory increase was {maxMemoryIncrease} bytes, expected < 10MB"
-        );
+        Assert.Equal(batchSize, processed.Length);
+        return allocated;
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/Platform/XmlDocumentationServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Platform/XmlDocumentationServiceTests.cs
@@ -394,10 +394,10 @@ public class XmlDocumentationServiceTests
 
     #endregion
 
-    #region Performance Tests
+    #region Large Document Tests
 
     [Fact]
-    public void GetMethodSummary_WithLargeXmlDocument_ShouldPerformWell()
+    public void GetMethodSummary_WithLargeXmlDocument_FindsTheMatchingMember()
     {
         // Arrange
         var largeXmlContent = GenerateLargeXmlDocument(1000); // 1000 methods
@@ -407,13 +407,10 @@ public class XmlDocumentationServiceTests
         );
 
         // Act
-        var startTime = DateTime.UtcNow;
         var result = service.GetMethodSummary(method!);
-        var endTime = DateTime.UtcNow;
 
         // Assert
-        var duration = endTime - startTime;
-        duration.Should().BeLessThan(TimeSpan.FromMilliseconds(100)); // Should complete within 100ms
+        result.Should().Be("A simple method with documentation");
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/TestSuite/TestCategoryTraitTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/TestSuite/TestCategoryTraitTests.cs
@@ -6,18 +6,21 @@ using Xunit;
 namespace Nocturne.API.Tests.TestSuite;
 
 /// <summary>
-/// CI runs its suites under <c>Category!=Integration</c>, <c>Category!=Performance</c> and
-/// <c>Category!=E2E</c>, so any of those traits removes a test from a run. A test that wears one
-/// without needing it runs nowhere on CI and can rot to red locally while CI stays green.
-/// (E2E needs no sweep here: <c>Nocturne.E2E.Tests</c> is the only project that carries the trait
-/// and it is excluded from collection outright — see the "End-to-end tests" section of AGENTS.md.)
+/// CI runs its suites under <c>Category!=Integration</c> and <c>Category!=E2E</c>, and the
+/// whole-solution commands add <c>Category!=Performance</c> to keep the BenchmarkDotNet runners in
+/// <c>tests/Performance</c> out of an ordinary run. Any of those traits removes a test from a run,
+/// so a test that wears one without needing it runs nowhere on CI and can rot to red locally while
+/// CI stays green. (E2E needs no sweep here: <c>Nocturne.E2E.Tests</c> is the only project that
+/// carries the trait and it is excluded from collection outright — see the "End-to-end tests"
+/// section of AGENTS.md.)
 /// </summary>
 /// <remarks>
 /// The Integration trait is earned by binding to an xUnit fixture — <c>[Collection]</c>,
 /// <c>IClassFixture&lt;&gt;</c> or <c>ICollectionFixture&lt;&gt;</c>, on the class or on a base
 /// class — which is what makes the container, host or database it needs a real reason to sit out a
-/// CI run. The Performance trait is earned by measuring a resource the runner cannot promise: a
-/// wall-clock duration, allocated bytes, or a BenchmarkDotNet run.
+/// CI run. The Performance trait is earned by measuring a resource the runner cannot promise — a
+/// wall-clock duration, allocated bytes, or a BenchmarkDotNet run — and only in
+/// <c>tests/Performance</c>, the tree the whole-solution filter exists to skip.
 /// <para>
 /// A source scan rather than a reflection one: each test project builds its own assembly and no test
 /// process loads the others, so reflection can only ever see the project it runs in.
@@ -63,10 +66,32 @@ public class TestCategoryTraitTests
             .ToList();
 
         offenders.Should().BeEmpty(
-            "every CI suite filters on Category!=Performance, so the trait drops a test from every " +
-            "run; it is earned by asserting a budget on a measured resource — elapsed wall-clock, " +
-            "allocated bytes, or a BenchmarkDotNet run — which is what a shared runner cannot " +
-            "promise, and a test that measures nothing is an ordinary test that CI should run");
+            "the whole-solution test commands filter on Category!=Performance, so the trait drops a " +
+            "test from those runs; it is earned by asserting a budget on a measured resource — " +
+            "elapsed wall-clock, allocated bytes, or a BenchmarkDotNet run — which is what a shared " +
+            "runner cannot promise, and a test that measures nothing is an ordinary test that CI " +
+            "should run");
+    }
+
+    [Fact]
+    public void ThePerformanceTraitLivesOnlyUnderTestsPerformance()
+    {
+        var offenders = Files
+            .Where(file => file.Tree != "Performance")
+            .SelectMany(file => file.Types)
+            .Where(type =>
+                type.Traits.Contains(PerformanceTrait)
+                || type.Methods.Any(method => method.Traits.Contains(PerformanceTrait)))
+            .Select(type => $"{type.Name} ({type.Path})")
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "the filter that skips this trait is only on the whole-solution commands, and it is " +
+            "there to skip the BenchmarkDotNet runners under tests/Performance; wearing it anywhere " +
+            "else hides a test from those commands while the per-project and CI runs still execute " +
+            "it, which is how a host-measuring assertion ends up red on a contributor's machine and " +
+            "green on CI — a suite that needs a benchmark's variance handling belongs in " +
+            "tests/Performance, and one that does not belongs untagged");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Cache.Tests/MemoryCacheServiceTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Cache.Tests/MemoryCacheServiceTests.cs
@@ -1,22 +1,17 @@
-using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Infrastructure.Cache.Abstractions;
 using Nocturne.Infrastructure.Cache.Extensions;
 using Xunit;
 
-namespace Nocturne.Infrastructure.Cache.Tests.Performance;
+namespace Nocturne.Infrastructure.Cache.Tests;
 
-/// <summary>
-/// Performance benchmarks for cache operations to validate performance targets
-/// Target: Sub-10ms cache retrieval times, >80% hit rates
-/// </summary>
-public class CachePerformanceBenchmarks : IDisposable
+public class MemoryCacheServiceTests : IDisposable
 {
     private readonly ITestOutputHelper _output;
     private readonly ICacheService _cacheService;
     private readonly ServiceProvider _serviceProvider;
 
-    public CachePerformanceBenchmarks(ITestOutputHelper output)
+    public MemoryCacheServiceTests(ITestOutputHelper output)
     {
         _output = output;
 
@@ -30,74 +25,8 @@ public class CachePerformanceBenchmarks : IDisposable
     }
 
     [Fact]
-    [Trait("Category", "Performance")]
     [Trait("Category", "Cache")]
-    public async Task CacheRetrievalPerformance_Should_BeSubTenMilliseconds()
-    {
-        // Arrange
-        const int iterations = 1000;
-        var testData = new TestCacheData
-        {
-            Id = Guid.NewGuid().ToString(),
-            Value = "Performance test data",
-            Timestamp = DateTimeOffset.UtcNow,
-        };
-
-        // Pre-populate cache
-        await _cacheService.SetAsync(
-            "perf-test",
-            testData,
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-
-        var retrievalTimes = new List<TimeSpan>();
-        var stopwatch = new Stopwatch();
-
-        // Act - Measure cache retrieval performance
-        for (int i = 0; i < iterations; i++)
-        {
-            stopwatch.Restart();
-            var result = await _cacheService.GetAsync<TestCacheData>(
-                "perf-test",
-                TestContext.Current.CancellationToken
-            );
-            stopwatch.Stop();
-
-            retrievalTimes.Add(stopwatch.Elapsed);
-            Assert.NotNull(result);
-        }
-
-        // Assert - Performance targets
-        var averageMs = retrievalTimes.Average(t => t.TotalMilliseconds);
-        var medianMs = retrievalTimes
-            .OrderBy(t => t.TotalMilliseconds)
-            .Skip(iterations / 2)
-            .First()
-            .TotalMilliseconds;
-        var maxMs = retrievalTimes.Max(t => t.TotalMilliseconds);
-
-        _output.WriteLine($"Cache Retrieval Performance Results:");
-        _output.WriteLine($"  Average: {averageMs:F2}ms");
-        _output.WriteLine($"  Median: {medianMs:F2}ms");
-        _output.WriteLine($"  Max: {maxMs:F2}ms");
-        _output.WriteLine($"  Iterations: {iterations}");
-
-        // Performance target: Sub-10ms average retrieval time
-        Assert.True(
-            averageMs < 10.0,
-            $"Average cache retrieval time {averageMs:F2}ms exceeds target of 10ms"
-        );
-
-        // Additional checks
-        Assert.True(
-            medianMs < 10.0,
-            $"Median cache retrieval time {medianMs:F2}ms exceeds target of 10ms"
-        );
-    }
-
-    [Fact]
-    [Trait("Category", "Cache")]
-    public async Task CacheHitRatePerformance_Should_ExceedEightyPercent()
+    public async Task CacheHitRate_Should_ExceedEightyPercent()
     {
         // Arrange
         const int totalRequests = 1000;
@@ -162,17 +91,17 @@ public class CachePerformanceBenchmarks : IDisposable
             }
         }
 
-        // Assert - Hit rate performance
+        // Assert - Hit rate behaviour
         var hitRate = (double)cacheHits / totalRequests;
         var hitRatePercentage = hitRate * 100;
 
-        _output.WriteLine($"Cache Hit Rate Performance Results:");
+        _output.WriteLine($"Cache Hit Rate Results:");
         _output.WriteLine($"  Cache Hits: {cacheHits}");
         _output.WriteLine($"  Cache Misses: {cacheMisses}");
         _output.WriteLine($"  Hit Rate: {hitRatePercentage:F1}%");
         _output.WriteLine($"  Total Requests: {totalRequests}");
 
-        // Performance target: >80% hit rate
+        // Target: >80% hit rate
         Assert.True(
             hitRate > 0.80,
             $"Cache hit rate {hitRatePercentage:F1}% is below target of 80%"
@@ -180,64 +109,8 @@ public class CachePerformanceBenchmarks : IDisposable
     }
 
     [Fact]
-    [Trait("Category", "Performance")]
     [Trait("Category", "Cache")]
-    public async Task CacheSetPerformance_Should_BeReasonablyFast()
-    {
-        // Arrange
-        const int iterations = 500;
-        var testData = new TestCacheData
-        {
-            Id = Guid.NewGuid().ToString(),
-            Value = "Performance test data for set operations",
-            Timestamp = DateTimeOffset.UtcNow,
-        };
-
-        var setTimes = new List<TimeSpan>();
-        var stopwatch = new Stopwatch();
-
-        // Act - Measure cache set performance
-        for (int i = 0; i < iterations; i++)
-        {
-            var key = $"set-perf-test-{i}";
-
-            stopwatch.Restart();
-            await _cacheService.SetAsync(
-                key,
-                testData,
-                cancellationToken: TestContext.Current.CancellationToken
-            );
-            stopwatch.Stop();
-
-            setTimes.Add(stopwatch.Elapsed);
-        }
-
-        // Assert - Performance analysis
-        var averageMs = setTimes.Average(t => t.TotalMilliseconds);
-        var medianMs = setTimes
-            .OrderBy(t => t.TotalMilliseconds)
-            .Skip(iterations / 2)
-            .First()
-            .TotalMilliseconds;
-        var maxMs = setTimes.Max(t => t.TotalMilliseconds);
-
-        _output.WriteLine($"Cache Set Performance Results:");
-        _output.WriteLine($"  Average: {averageMs:F2}ms");
-        _output.WriteLine($"  Median: {medianMs:F2}ms");
-        _output.WriteLine($"  Max: {maxMs:F2}ms");
-        _output.WriteLine($"  Iterations: {iterations}");
-
-        // Reasonable performance expectation for set operations
-        Assert.True(
-            averageMs < 50.0,
-            $"Average cache set time {averageMs:F2}ms exceeds reasonable threshold of 50ms"
-        );
-    }
-
-    [Fact]
-    [Trait("Category", "Performance")]
-    [Trait("Category", "Cache")]
-    public async Task BulkOperationPerformance_Should_HandleHighThroughput()
+    public async Task ConcurrentReadModifyWrite_Should_LeaveEveryKeyAtItsUpdatedValue()
     {
         // Arrange
         const int concurrentOperations = 100;
@@ -248,8 +121,6 @@ public class CachePerformanceBenchmarks : IDisposable
             Value = "Bulk operation test data",
             Timestamp = DateTimeOffset.UtcNow,
         };
-
-        var stopwatch = Stopwatch.StartNew();
 
         // Act - Concurrent cache operations
         for (int i = 0; i < concurrentOperations; i++)
@@ -294,23 +165,18 @@ public class CachePerformanceBenchmarks : IDisposable
         }
 
         await Task.WhenAll(tasks);
-        stopwatch.Stop();
 
-        // Assert - Throughput performance
-        var totalOperations = concurrentOperations * 3; // Set + Get + Update
-        var operationsPerSecond = totalOperations / stopwatch.Elapsed.TotalSeconds;
+        // Assert - every worker's own key survived the others' traffic
+        for (int i = 0; i < concurrentOperations; i++)
+        {
+            var stored = await _cacheService.GetAsync<TestCacheData>(
+                $"bulk-test-{i}",
+                TestContext.Current.CancellationToken
+            );
 
-        _output.WriteLine($"Bulk Operation Performance Results:");
-        _output.WriteLine($"  Total Operations: {totalOperations}");
-        _output.WriteLine($"  Total Time: {stopwatch.Elapsed.TotalMilliseconds:F0}ms");
-        _output.WriteLine($"  Operations/Second: {operationsPerSecond:F0}");
-        _output.WriteLine($"  Concurrent Workers: {concurrentOperations}");
-
-        // Performance expectation: Should handle reasonable throughput
-        Assert.True(
-            operationsPerSecond > 100,
-            $"Operations per second {operationsPerSecond:F0} is below reasonable threshold"
-        );
+            Assert.NotNull(stored);
+            Assert.Equal($"Updated {testData.Value}", stored.Value);
+        }
     }
 
     public void Dispose()
@@ -320,7 +186,7 @@ public class CachePerformanceBenchmarks : IDisposable
 }
 
 /// <summary>
-/// Test data class for performance benchmarks
+/// Test data class for cache tests
 /// </summary>
 public class TestCacheData
 {


### PR DESCRIPTION
Closes #938.

## Problem

`Category=Performance` was filtered out of every CI job and every documented command, so the unit tests wearing it ran nowhere — and two failed on a clean tree (an absolute 10MB retention budget; a 1s wall-clock budget that flips under concurrent build load). A contributor running the obvious unfiltered `dotnet test` got a red suite that was nobody's fault and invisible to CI. Three *untagged* siblings carried the same host-measuring budgets and did run in CI, which is worse — they flap under load in real runs.

## Change — decided per test, not blanket

Full disposition table in the commit message. The shape:

- **Kept, budget dropped, answer-asserted:** the sanitization batch tests now assert what they were always about (whole batch covered, whole field covered — the large-text case counts surviving paragraphs); `GetMethodSummary_WithLargeXmlDocument` previously asserted *only* a 100ms budget and could not fail on a wrong answer — it now asserts the summary resolves from the right member of a 1000-member document (the hostile review confirmed: its wrong-answer mutation is green on main, red here).
- **Kept, re-expressed machine-independently:** the linear-scaling claim is real, so it's measured in bytes allocated on the test's own thread — exact and load-independent (the code path is verified fully synchronous; ten runs measured 20.00x–20.02x against a 10x–40x window; quadratic and constant-dominated mutations both go red).
- **Kept as a concurrency test:** the cache bulk-operation test loses its throughput floor and now checks every key holds its own worker's update.
- **Deleted:** the stress test (a 10× costlier duplicate of the batch test — every non-budget assertion survives elsewhere, verified one by one), the memory benchmark (no retention invariant exists — the service holds no state), and two millisecond budgets on an in-memory dictionary that measured the runner and nothing else. Nothing moved to `tests/Performance`: BenchmarkDotNet runs there are manual, and nobody tracks sanitizer or IMemoryCache throughput.
- **The trait can't come back:** `TestCategoryTraitTests` gains the rule that `Category=Performance` may only appear under `tests/Performance` — the guard scans all test trees (cross-project kill verified) and is anchored non-vacuous.
- **Dead filter clauses removed** from the per-project CI unit loop and the integration-db job (zero Performance traits ever existed under `tests/Integration`) and from the per-project documented commands. Whole-solution commands keep the filter — that's what excludes the BenchmarkDotNet runner, whose only `[Fact]` wears the trait (verified).

## Evidence

- The deliverable: unfiltered `Nocturne.API.Tests` green **6001/6006 twice, once under a concurrent solution build** — the configuration that previously failed 2. `Infrastructure.Cache.Tests` unfiltered green.
- Hostile review: MERGE-SAFE, no confirmed findings — deletions checked assertion-by-assertion against main for orphaned invariants (none; the deleted stress test never actually asserted on the BolusCalc data it built), allocation-test thread-affinity verified sound, both its mutations red, guard kills cross-project, filter blast radius clean including the docs.
- Honest limits, declared: the allocation test guards *scaling* only (a fixed +2MB per-call regression stays green by design); the guard is one-directional (a future untagged runner under `tests/Performance` would run inside `dotnet test nocturne.sln` — a second rule could pin that later).

_Agent-authored; reviewed + gate-reviewed with independent verification (the load-stability runs are mine)._
