### PR TITLE
fix(glooko): build the request window from the timezone timeline

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoTimeMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoTimeMapper.cs
@@ -41,6 +41,9 @@ public class GlookoTimeMapper
     /// </summary>
     public DateTime ToGlookoTime(DateTime utcTime)
     {
+        if (_timeline is { } timeline)
+            return timeline.ToLocal(utcTime);
+
         return utcTime.AddHours(_config.TimezoneOffset);
     }
 

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoTimeMapperTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoTimeMapperTests.cs
@@ -13,7 +13,13 @@ namespace Nocturne.Connectors.Glooko.Tests.Mappers;
 /// </summary>
 public class GlookoTimeMapperTests
 {
-    private static GlookoTimeMapper Mapper(TimezoneTimeline? timeline, double offset = 0)
+    /// <summary>
+    /// Timeline-bearing cases pass a non-zero static offset that matches no zone under test, so a
+    /// mapper that added the legacy offset to the timeline result instead of replacing it would fail.
+    /// </summary>
+    private const double DecoyOffset = 3;
+
+    private static GlookoTimeMapper Mapper(TimezoneTimeline? timeline, double offset = DecoyOffset)
     {
         var mapper = new GlookoTimeMapper(
             new GlookoConnectorConfiguration { TimezoneOffset = offset }, NullLogger.Instance);
@@ -44,18 +50,22 @@ public class GlookoTimeMapperTests
     }
 
     [Fact]
-    public void ToGlookoTime_AfterRelocation_UsesTheZoneInEffect()
+    public void ToGlookoTime_AcrossRelocation_UsesTheZoneInEffectAtEachInstant()
     {
-        var timeline = new TimezoneTimeline(
+        var mapper = Mapper(new TimezoneTimeline(
         [
             new TimezoneTimelineEntry { Timezone = "Australia/Sydney", EffectiveFrom = DateTime.MinValue },
             new TimezoneTimelineEntry { Timezone = "Europe/London", EffectiveFrom = new DateTime(2026, 3, 1) },
-        ]);
+        ]));
 
-        // 2026-06-10 09:00Z falls after the move, when London is BST (+1).
-        var result = Mapper(timeline).ToGlookoTime(new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc));
+        // Before the move: Sydney, AEDT (+11).
+        mapper.ToGlookoTime(new DateTime(2026, 2, 15, 13, 0, 0, DateTimeKind.Utc))
+            .Should().Be(new DateTime(2026, 2, 16, 0, 0, 0));
 
-        result.Should().Be(new DateTime(2026, 6, 10, 10, 0, 0));
+        // After the move: London, BST (+1). Picking the newest entry regardless of instant would
+        // return the London offset for both.
+        mapper.ToGlookoTime(new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc))
+            .Should().Be(new DateTime(2026, 6, 10, 10, 0, 0));
     }
 
     [Fact]
@@ -67,10 +77,16 @@ public class GlookoTimeMapperTests
         result.Should().Be(new DateTime(2026, 1, 9, 23, 0, 0));
     }
 
+    /// <summary>
+    /// Round-tripping is only lossless away from transition boundaries: <see cref="TimezoneTimeline.ToLocal"/>
+    /// resolves entries in wall-clock space, so near a relocation or a fall-back overlap the pair is off
+    /// by the zone delta. The request window is padded a day either side to absorb that.
+    /// </summary>
     [Theory]
     [InlineData(2026, 1, 9)]
     [InlineData(2026, 7, 9)]
-    public void ToGlookoTime_RoundTripsThroughGetCorrectedGlookoTime(int year, int month, int day)
+    public void ToGlookoTime_AwayFromTransitions_RoundTripsThroughGetCorrectedGlookoTime(
+        int year, int month, int day)
     {
         var mapper = Mapper(Sydney());
         var utc = new DateTime(year, month, day, 13, 0, 0, DateTimeKind.Utc);

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoTimeMapperTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoTimeMapperTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Mappers;
+using Nocturne.Core.Models.Timezones;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Mappers;
+
+/// <summary>
+/// Verifies both directions of the fake-UTC conversion honour the timezone timeline, so the request
+/// window sent to Glooko is built in the same wall-clock space the responses are interpreted in.
+/// </summary>
+public class GlookoTimeMapperTests
+{
+    private static GlookoTimeMapper Mapper(TimezoneTimeline? timeline, double offset = 0)
+    {
+        var mapper = new GlookoTimeMapper(
+            new GlookoConnectorConfiguration { TimezoneOffset = offset }, NullLogger.Instance);
+        if (timeline is not null)
+            mapper.UseTimeline(timeline);
+        return mapper;
+    }
+
+    private static TimezoneTimeline Sydney() =>
+        new([new TimezoneTimelineEntry { Timezone = "Australia/Sydney", EffectiveFrom = DateTime.MinValue }]);
+
+    [Fact]
+    public void ToGlookoTime_InDaylightSaving_UsesTheSummerOffset()
+    {
+        // 2026-01-09 13:00Z is AEDT (+11) -> local midnight on the 10th.
+        var result = Mapper(Sydney()).ToGlookoTime(new DateTime(2026, 1, 9, 13, 0, 0, DateTimeKind.Utc));
+
+        result.Should().Be(new DateTime(2026, 1, 10, 0, 0, 0));
+    }
+
+    [Fact]
+    public void ToGlookoTime_OutsideDaylightSaving_UsesTheWinterOffset()
+    {
+        // Same wall-clock target six months later, when Sydney is AEST (+10).
+        var result = Mapper(Sydney()).ToGlookoTime(new DateTime(2026, 7, 9, 14, 0, 0, DateTimeKind.Utc));
+
+        result.Should().Be(new DateTime(2026, 7, 10, 0, 0, 0));
+    }
+
+    [Fact]
+    public void ToGlookoTime_AfterRelocation_UsesTheZoneInEffect()
+    {
+        var timeline = new TimezoneTimeline(
+        [
+            new TimezoneTimelineEntry { Timezone = "Australia/Sydney", EffectiveFrom = DateTime.MinValue },
+            new TimezoneTimelineEntry { Timezone = "Europe/London", EffectiveFrom = new DateTime(2026, 3, 1) },
+        ]);
+
+        // 2026-06-10 09:00Z falls after the move, when London is BST (+1).
+        var result = Mapper(timeline).ToGlookoTime(new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc));
+
+        result.Should().Be(new DateTime(2026, 6, 10, 10, 0, 0));
+    }
+
+    [Fact]
+    public void ToGlookoTime_NoTimeline_FallsBackToStaticOffset()
+    {
+        var result = Mapper(timeline: null, offset: 10)
+            .ToGlookoTime(new DateTime(2026, 1, 9, 13, 0, 0, DateTimeKind.Utc));
+
+        result.Should().Be(new DateTime(2026, 1, 9, 23, 0, 0));
+    }
+
+    [Theory]
+    [InlineData(2026, 1, 9)]
+    [InlineData(2026, 7, 9)]
+    public void ToGlookoTime_RoundTripsThroughGetCorrectedGlookoTime(int year, int month, int day)
+    {
+        var mapper = Mapper(Sydney());
+        var utc = new DateTime(year, month, day, 13, 0, 0, DateTimeKind.Utc);
+
+        mapper.GetCorrectedGlookoTime(mapper.ToGlookoTime(utc)).Should().Be(utc);
+    }
+}


### PR DESCRIPTION
## What

`GlookoTimeMapper.GetCorrectedGlookoTime` resolves Glooko's fake-UTC timestamps (local wall clock stamped `Z`) through the tenant's timezone timeline, honouring DST and travel. Its inverse, `ToGlookoTime` — which builds the fake-UTC `?startDate`/`&endDate` window sent to Glooko — still applied only the legacy static `TimezoneOffset`.

So the read path was timeline-aware and the write path was not.

`TimezoneTimeline.ToLocal` is already the exact inverse of `ToUtc`, so this wires it up and keeps the static offset as the fallback when no timeline is present:

```csharp
public DateTime ToGlookoTime(DateTime utcTime)
{
    if (_timeline is { } timeline)
        return timeline.ToLocal(utcTime);

    return utcTime.AddHours(_config.TimezoneOffset);
}
```

## Impact

Low in practice — the request window is padded a day either side, so a one-hour discrepancy widens or narrows the fetch rather than corrupting anything stored. But the two directions have to agree; a request built in one wall-clock space and interpreted in another is a bug waiting for a wider offset.

Ordering was already correct: `ConfigureTimezoneTimelineAsync` runs before the window is built, so the timeline is installed by the time `ToGlookoTime` is called.

`ToLocal`'s documented caveat — entry lookup happens in wall-clock space, so it is off by the zone offset for a few hours either side of a relocation boundary — is harmless here given the padding.

## Tests

`GlookoTimeMapperTests` covers both directions:

- Sydney in January (AEDT +11) and July (AEST +10) — the pair a static offset cannot satisfy
- zone selection after a relocation entry
- static-offset fallback when no timeline is installed
- round-trip `ToGlookoTime` → `GetCorrectedGlookoTime` in both DST states

Mutation-checked: with the timeline branch removed, 5 of 6 fail. The survivor is the fallback test, which correctly does not depend on it. Full Glooko suite green at 105.

## Follow-ups

The reverse direction was found while auditing how the connector handles Glooko time end to end. Two larger pieces came out of the same audit and are filed separately: #968 (read the account UTC offset from `/api/v2/users`) and #969 (derive the device clock offset from `syncTimestamp` to maintain the timeline automatically).
