### PR TITLE
fix(multitenancy): drop the tenantless entries no route answers

### DIFF
--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -46,7 +46,7 @@ public class TenantResolutionMiddleware
     /// Whether <paramref name="Path"/> admits everything beneath it. Needed by controllers whose
     /// routes carry an id segment; prefer an exact entry, which cannot admit a route added later.
     /// </param>
-    private readonly record struct TenantlessPath(
+    public readonly record struct TenantlessPath(
         string Path, string? Method = null, bool Prefix = false)
     {
         /// <summary>Admit every method on a path, which is the case for most of the list.</summary>
@@ -66,13 +66,11 @@ public class TenantResolutionMiddleware
     /// </summary>
     private static readonly TenantlessPath[] TenantlessAllowedPaths =
     [
-        // Aspire ServiceDefaults health endpoints — must never be tenant-gated;
-        // they are used by Kubernetes liveness/readiness probes and external
-        // monitoring. Returning 503 on these when no tenant exists causes
-        // liveness probes to kill the pod, preventing first-time setup.
+        // The two paths MapDefaultEndpoints maps, and the only two the deployment probes.
+        // Returning 503 on these when no tenant exists causes liveness probes to kill the pod,
+        // preventing first-time setup.
         "/health",
         "/alive",
-        "/ready",
         "/api/v4/status",
         "/api/v4/me/tenants/validate-slug",
         // Cross-tenant caregiver overview: aggregates across the subject's tenants,
@@ -95,8 +93,6 @@ public class TenantResolutionMiddleware
         // only presentation: the dashboard tiles render glucose in the units held here, so a 404
         // shows an mmol/L user their children's readings in mg/dL.
         "/api/v4/user/preferences",
-        "/api/v4/admin/tenants/validate-slug",
-        "/api/metadata",
         "/api/v4/chat-identity/directory/resolve",
         "/api/v4/chat-identity/directory/pending-links",
         // OIDC login can be initiated from the apex (no subdomain) — e.g. the
@@ -184,6 +180,11 @@ public class TenantResolutionMiddleware
         // exact path: SignalR appends /negotiate to the hub path.
         new TenantlessPath("/hubs/overview", Prefix: true),
     ];
+
+    /// <summary>
+    /// The entries themselves, for the guard that asserts each one still names a routed endpoint.
+    /// </summary>
+    public static IReadOnlyList<TenantlessPath> TenantlessPaths => TenantlessAllowedPaths;
 
     /// <summary>
     /// Whether a request is served without a resolved tenant. Public so the authorization

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerActionReflection.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerActionReflection.cs
@@ -59,6 +59,13 @@ internal static class ControllerActionReflection
         return templates.Select(t => Combine(prefix, t)).Distinct(StringComparer.OrdinalIgnoreCase);
     }
 
+    /// <summary>The HTTP methods an action answers, empty when its attribute constrains none.</summary>
+    public static IEnumerable<string> GetHttpMethods(MethodInfo action) =>
+        action.GetCustomAttributes()
+            .OfType<IActionHttpMethodProvider>()
+            .SelectMany(p => p.HttpMethods)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
     public static bool HasAnonymous(MethodInfo action, Type controller) =>
         action.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any()
         || controller.GetCustomAttributes(inherit: true).OfType<IAllowAnonymous>().Any();

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessAllowedPathsCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantlessAllowedPathsCoverageTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Nocturne.API.Multitenancy;
+using Nocturne.API.Tests.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Multitenancy;
+
+/// <summary>
+/// Every tenantless entry must name an endpoint that is actually served, under a method it is
+/// actually served on. An entry nothing answers reads as permission while granting none: the
+/// paths a caller does ask for stay tenant-gated, and the 404 or <c>503 setup_required</c> they
+/// get back appears to come from a path the list plainly admits.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class TenantlessAllowedPathsCoverageTests
+{
+    /// <summary>
+    /// Entries served outside MVC routing, which <see cref="ControllerActionReflection"/> cannot
+    /// see, keyed by path with where each is mapped.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> NonControllerEntries =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["/health"] = "MapHealthChecks in Nocturne.Aspire.ServiceDefaults",
+            ["/alive"] = "MapHealthChecks in Nocturne.Aspire.ServiceDefaults",
+            ["/hubs/overview"] = "MapHub<OverviewHub> in Program.cs",
+        };
+
+    private static readonly IReadOnlyList<(string Route, string Method)> RoutedEndpoints =
+        (from controller in ControllerActionReflection.GetControllers()
+         from action in ControllerActionReflection.GetActionMethods(controller)
+         from route in ControllerActionReflection.GetRoutes(controller, action)
+         from method in ControllerActionReflection.GetHttpMethods(action)
+         select (route, method))
+        .Distinct()
+        .ToList();
+
+    [Fact]
+    public void EveryTenantlessEntryNamesARoutedEndpoint()
+    {
+        var dead = TenantResolutionMiddleware.TenantlessPaths
+            .Where(entry => !NonControllerEntries.ContainsKey(entry.Path))
+            .Where(entry => !RoutedEndpoints.Any(e => entry.Matches(e.Route, e.Method)))
+            .Select(Describe)
+            .OrderBy(d => d, StringComparer.Ordinal)
+            .ToList();
+
+        dead.Should().BeEmpty(
+            "a tenantless entry no route answers admits nothing, while making the paths a caller "
+            + "does ask for look permitted — point each at the route it meant, or drop it. Dead:\n  "
+            + string.Join("\n  ", dead));
+    }
+
+    /// <summary>
+    /// Staleness on the hand-kept list: an entry named there and then removed from the middleware
+    /// would leave a name the guard silently skips.
+    /// </summary>
+    [Fact]
+    public void EveryNonControllerEntryIsStillOnTheAllowList()
+    {
+        var paths = TenantResolutionMiddleware.TenantlessPaths
+            .Select(p => p.Path)
+            .ToList();
+
+        foreach (var (path, mappedAt) in NonControllerEntries)
+        {
+            paths.Should().Contain(
+                p => string.Equals(p, path, StringComparison.OrdinalIgnoreCase),
+                "{0} is skipped as mapped by {1} but is no longer tenantless-allowed — drop the entry",
+                path, mappedAt);
+        }
+    }
+
+    /// <summary>
+    /// Non-vacuity: a route enumeration that returns nothing passes the guard above only because
+    /// every entry would then be reported, so pin that it finds the surface and that an entry is
+    /// proven by a discovered route rather than by the skip list.
+    /// </summary>
+    [Fact]
+    public void TheRouteDiscoveryFindsTheControllerSurface()
+    {
+        RoutedEndpoints.Should().Contain(("/api/v4/me/tenants", "GET"),
+            "the subject's tenant list is served off the apex and is the entry whose exact-match "
+            + "shape this guard exists to keep honest");
+
+        TenantResolutionMiddleware.TenantlessPaths
+            .Count(entry => RoutedEndpoints.Any(e => entry.Matches(e.Route, e.Method)))
+            .Should().BeGreaterThan(NonControllerEntries.Count,
+                "most of the list is served by controllers, so a run where only the skip list "
+                + "resolves means route matching has stopped working");
+    }
+
+    private static string Describe(TenantResolutionMiddleware.TenantlessPath entry) =>
+        entry.Path
+        + (entry.Prefix ? " (prefix)" : " (exact)")
+        + (entry.Method is null ? "" : $" {entry.Method}");
+}


### PR DESCRIPTION
Closes #947.

## What this does

Removes the three `TenantlessAllowedPaths` entries that no route answers, and adds a guard test asserting every entry on the list resolves to at least one real `(route, method)` pair — so a dead entry (or a method-mismatched one) can never be added again.

Issue #947 proposed widening `/api/metadata` to a prefix match. Investigation went the other way: **nothing calls any `/api/metadata/*` path.** A repo-wide search (web app, portal, bot, bridge, scripts, and the nocturne-cloud provisioner) finds zero consumers — the web app reads `BaseDomain` from `process.env.BASE_DOMAIN`, not from the API, and `MetadataController` is class-level `[ApiExplorerSettings(IgnoreApi = true)]`: it exists as an NSwag type-anchor, not a live surface. Widening would have dropped its 12 `[AllowAnonymous]` actions onto the anonymous tenantless surface for zero callers. If a real tenantless consumer appears later, the narrow move is one exact entry for the route it calls — and the new guard forces that entry to name a real route.

## The removed entries

| Entry | Why it was dead |
|---|---|
| `/api/metadata` (exact) | `MetadataController` routes `api/[controller]` and all 12 actions carry sub-templates; nothing serves the bare path. Dead since it was introduced (5c46ffb39, never matched a request). |
| `/ready` | `MapDefaultEndpoints` maps only `/health` and `/alive`; the API never maps `/ready`. The API helm chart probes `/alive` + `/health`. |
| `/api/v4/admin/tenants/validate-slug` | No such route exists (the only `validate-slug` action is under `/api/v4/me/tenants`, already listed) — and the surviving `/api/v4/admin/tenants` prefix entry would have covered it anyway. |

## Behavioral delta

The removals are strict narrowings of paths nothing serves. The only observable shape change: `/ready` and `/api/metadata` on a **zero-tenant apex** now answer `503 setup_required` instead of 404. Single-tenant, multi-tenant, and subdomain requests: 404 before and after. Nothing probes either path in any deployment artifact (helm, compose, cloud infra, CI).

## The guard

`TenantlessAllowedPathsCoverageTests` cross-joins the shared `ControllerActionReflection` enumeration (extended with HTTP-method discovery) against the middleware's own `Matches`, with a 3-entry skip list for the non-MVC paths (`/health`, `/alive` via `MapHealthChecks`; `/hubs/overview` via `MapHub`) — verified to be exactly the API's non-MVC surface on the allow-list. Two companion facts guard the skip list against staleness and pin non-vacuity of the route discovery.

**Declared limitation:** the guard is one-directional. It proves every entry is *live*; it does not prove an entry is no *wider* than needed (an exact entry silently widened to `Prefix: true` passes until a future route lands beneath it). Method-narrowing is defended per-entry by `TenantlessDashboardPathsTests`, not systematically.

## Verification

- Full `Nocturne.API.Tests` unit suite: 6032 passed / 0 failed.
- Mutations, all killed unless noted:
  - re-adding each removed entry → guard red, all reported independently;
  - a method-mismatch mutant (existing path, wrong verb) → guard red (verb-sensitive);
  - bogus skip-list entry → staleness fact red;
  - collapsing HTTP-method discovery to empty → 2 of 3 facts red (non-vacuous);
  - `Matches` `OrdinalIgnoreCase` → `Ordinal` → guard + demo-subject coverage red;
  - stripping the `POST` constraint from `/api/auth/oidc/refresh` → caught by the companion suite;
  - exact → `Prefix: true` on an entry → **survives** (the declared one-directional limitation above).
- `[AllowDuringSetup]`/`TenantSetupMiddleware` interplay verified unchanged (it gates on endpoint metadata after tenant resolution and never consults this list).

https://claude.ai/code/session_013JMfvQxpzTVwa27EBLJ2dZ
