### PR TITLE
fix(connectors): widen Nightscout's catch-up bounds instead of replacing them

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -386,24 +386,33 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
-    ///     The lower bound a family crawls from: whichever of the caller's bound and the family's
-    ///     own resume point reaches further back, where a null bound reaches back without limit.
+    ///     The lower bound a family crawls from, given the caller's bound and the family's own
+    ///     resume point: whichever of the two reaches further back, where an open resume point
+    ///     reaches back without limit and an absent caller bound leaves the resume point standing.
     /// </summary>
     /// <remarks>
-    ///     Neither may narrow the other. The resume point cannot narrow the caller's bound, because
+    ///     Neither bound may narrow the other. The resume point cannot narrow the caller's, because
     ///     an explicit <c>from</c> with no <c>to</c> is the shape an admin repairing a gap sends, and
     ///     answering that from the watermark returns nothing and reports it as a success. The
-    ///     caller's bound cannot narrow the resume point either, because on a background catch-up
-    ///     that bound is the glucose watermark, and honouring it alone is what strands the other
+    ///     caller's cannot narrow the resume point either, because on a background catch-up the
+    ///     caller's bound is the glucose watermark, and honouring it alone is what strands the other
     ///     families behind glucose — a resume point left open by an unbounded
-    ///     <see cref="InitialSyncFloor"/> included, since that one is a family with no history
-    ///     stored at all. A resume point that is absent rather than open is resolved by the caller
-    ///     before it gets here; <see cref="CalculateDeviceStatusCatchUpSinceAsync"/> and
-    ///     <see cref="CalculateActivityCatchUpSinceAsync"/> are the two that answer that way.
+    ///     <see cref="InitialSyncFloor"/> included, since that is a family with nothing stored at
+    ///     all asking for the source's whole history.
+    ///     <para>
+    ///     A caller that supplies no bound is not asking for everything: a background cycle whose
+    ///     glucose watermark is null reaches here, as does the tenant's own sync button, and a
+    ///     family with a resume point still stands on it. A resume point that is absent rather than
+    ///     open is resolved by the caller before it gets here — see
+    ///     <see cref="CalculateDeviceStatusCatchUpSinceAsync"/> for the two that answer that way.
+    ///     </para>
     /// </remarks>
     protected static DateTime? ResumeFrom(DateTime? requested, DateTime? resumePoint)
     {
-        if (requested is null || resumePoint is null)
+        if (requested is null)
+            return resumePoint;
+
+        if (resumePoint is null)
             return null;
 
         return requested < resumePoint ? requested : resumePoint;

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -386,6 +386,30 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
+    ///     The lower bound a family crawls from: whichever of the caller's bound and the family's
+    ///     own resume point reaches further back, where a null bound reaches back without limit.
+    /// </summary>
+    /// <remarks>
+    ///     Neither may narrow the other. The resume point cannot narrow the caller's bound, because
+    ///     an explicit <c>from</c> with no <c>to</c> is the shape an admin repairing a gap sends, and
+    ///     answering that from the watermark returns nothing and reports it as a success. The
+    ///     caller's bound cannot narrow the resume point either, because on a background catch-up
+    ///     that bound is the glucose watermark, and honouring it alone is what strands the other
+    ///     families behind glucose — a resume point left open by an unbounded
+    ///     <see cref="InitialSyncFloor"/> included, since that one is a family with no history
+    ///     stored at all. A resume point that is absent rather than open is resolved by the caller
+    ///     before it gets here; <see cref="CalculateDeviceStatusCatchUpSinceAsync"/> and
+    ///     <see cref="CalculateActivityCatchUpSinceAsync"/> are the two that answer that way.
+    /// </remarks>
+    protected static DateTime? ResumeFrom(DateTime? requested, DateTime? resumePoint)
+    {
+        if (requested is null || resumePoint is null)
+            return null;
+
+        return requested < resumePoint ? requested : resumePoint;
+    }
+
+    /// <summary>
     ///     Applies the catch-up overlap to a latest-record timestamp: returns the timestamp
     ///     minus a small overlap (to absorb clock drift), or <c>null</c> when there is no
     ///     usable prior timestamp.

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -157,10 +157,9 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
         var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
-        // For open-ended background catch-up (no explicit upper bound), each data type
-        // resolves its own "since" from its OWN latest stored record rather than reusing
-        // the glucose-derived request.From. Otherwise a single type that fell behind (or
-        // failed once) would be permanently stranded behind the glucose cursor. Explicit
+        // On an open-ended catch-up (no explicit upper bound) each data type below widens the
+        // glucose-derived request.From with its own resume point (see ResumeFrom), so a single type
+        // that fell behind — or failed once — is not stranded behind the glucose cursor. Explicit
         // ranged syncs (request.To set, e.g. a manual re-import) honour request.From/To as-is.
         var openEnded = request.To is null;
 
@@ -206,10 +205,11 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         {
             try
             {
-                // Treatments track their own cursor (latest treatment, else 6-month initial
-                // backfill) so historical boluses/carbs are filled even once glucose is current.
+                // Treatments track their own cursor (latest treatment, else this connector's
+                // unbounded initial backfill) so historical boluses/carbs are filled even once
+                // glucose is current.
                 var treatmentFrom = openEnded
-                    ? await CalculateTreatmentSinceTimestampAsync(config)
+                    ? ResumeFrom(request.From, await CalculateTreatmentSinceTimestampAsync(config))
                     : request.From;
 
                 var outcome = await CrawlAndPublishAsync(
@@ -250,10 +250,10 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             try
             {
                 // Device status tracks its own cursor when a watermark is available; if none
-                // exists yet it falls back to request.From (current behaviour) rather than
-                // re-fetching the full initial window of this high-volume telemetry every sync.
+                // exists yet it falls back to request.From rather than re-fetching the full
+                // initial window of this high-volume telemetry every sync.
                 var deviceStatusFrom = openEnded
-                    ? await CalculateDeviceStatusCatchUpSinceAsync(config) ?? request.From
+                    ? ResumeFrom(request.From, await CalculateDeviceStatusCatchUpSinceAsync(config) ?? request.From)
                     : request.From;
 
                 var outcome = await CrawlAndPublishAsync(
@@ -295,7 +295,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
                 // Activity tracks its own cursor when a watermark is available, else falls
                 // back to request.From.
                 var activityFrom = openEnded
-                    ? await CalculateActivityCatchUpSinceAsync(config) ?? request.From
+                    ? ResumeFrom(request.From, await CalculateActivityCatchUpSinceAsync(config) ?? request.From)
                     : request.From;
 
                 var outcome = await CrawlAndPublishAsync(

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -157,10 +157,9 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
         var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
 
-        // On an open-ended catch-up (no explicit upper bound) each data type below widens the
-        // glucose-derived request.From with its own resume point (see ResumeFrom), so a single type
-        // that fell behind — or failed once — is not stranded behind the glucose cursor. Explicit
-        // ranged syncs (request.To set, e.g. a manual re-import) honour request.From/To as-is.
+        // On an open-ended catch-up (no explicit upper bound) each data type below resolves its
+        // bound through ResumeFrom, from request.From and its own resume point. Explicit ranged
+        // syncs (request.To set, e.g. a manual re-import) honour request.From/To as-is.
         var openEnded = request.To is null;
 
         // Glucose keeps request.From — for background syncs the framework already derived
@@ -205,9 +204,8 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         {
             try
             {
-                // Treatments track their own cursor (latest treatment, else this connector's
-                // unbounded initial backfill) so historical boluses/carbs are filled even once
-                // glucose is current.
+                // The treatment cursor resolves to a bound rather than to an absent resume point:
+                // with none stored it is this connector's own open InitialSyncFloor.
                 var treatmentFrom = openEnded
                     ? ResumeFrom(request.From, await CalculateTreatmentSinceTimestampAsync(config))
                     : request.From;
@@ -249,9 +247,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         {
             try
             {
-                // Device status tracks its own cursor when a watermark is available; if none
-                // exists yet it falls back to request.From rather than re-fetching the full
-                // initial window of this high-volume telemetry every sync.
                 var deviceStatusFrom = openEnded
                     ? ResumeFrom(request.From, await CalculateDeviceStatusCatchUpSinceAsync(config) ?? request.From)
                     : request.From;
@@ -292,8 +287,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
         {
             try
             {
-                // Activity tracks its own cursor when a watermark is available, else falls
-                // back to request.From.
                 var activityFrom = openEnded
                     ? ResumeFrom(request.From, await CalculateActivityCatchUpSinceAsync(config) ?? request.From)
                     : request.From;

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -148,7 +148,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
             // A run carrying no glucose cursor imports the remote's full history here, which no
             // family's resume point may narrow — unlike ResumeFrom's own reading of an absent
-            // caller bound, which the remaining families keep.
+            // caller bound, which the other connectors keep.
             return request.From is null ? null : ResumeFrom(request.From, resume ?? request.From);
         }
 

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -137,8 +137,11 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         Task<DateTime?> ActivityFromAsync() =>
             activity ??= BoundAsync(() => CalculateActivityCatchUpSinceAsync(config));
 
+        // Device status and activity answer with no resume point at all when nothing of theirs is
+        // stored yet; taking the caller's bound there keeps a first sync off the whole initial
+        // window of collections this high-volume.
         async Task<DateTime?> BoundAsync(Func<Task<DateTime?>> resumePoint) =>
-            openEnded ? ResumeFrom(request.From, await resumePoint()) : request.From;
+            openEnded ? ResumeFrom(request.From, await resumePoint() ?? request.From) : request.From;
 
         foreach (var type in activeTypes)
         {
@@ -175,30 +178,6 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
         result.EndTime = DateTimeOffset.UtcNow;
         return result;
-    }
-
-    /// <summary>
-    ///     The lower bound a family crawls from: whichever of the caller's bound and the family's own
-    ///     resume point reaches further back.
-    /// </summary>
-    /// <remarks>
-    ///     Neither may narrow the other. The resume point cannot narrow the caller's bound, because
-    ///     an explicit <c>from</c> with no <c>to</c> is the shape an admin repairing a gap sends, and
-    ///     answering that from the watermark returns nothing and reports it as a success. The
-    ///     caller's bound cannot narrow the resume point either, because on a background catch-up
-    ///     that bound is the glucose watermark, and honouring it alone is what strands the other
-    ///     families behind glucose. A family with no resume point has nothing stored yet, so the
-    ///     caller's bound stands as given — a null one included, which imports the full history.
-    /// </remarks>
-    private static DateTime? ResumeFrom(DateTime? requested, DateTime? resumePoint)
-    {
-        if (resumePoint is null)
-            return requested;
-
-        if (requested is null)
-            return null;
-
-        return requested < resumePoint ? requested : resumePoint;
     }
 
     #region V4 Data Type Sync Methods

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -137,11 +137,20 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         Task<DateTime?> ActivityFromAsync() =>
             activity ??= BoundAsync(() => CalculateActivityCatchUpSinceAsync(config));
 
-        // Device status and activity answer with no resume point at all when nothing of theirs is
-        // stored yet; taking the caller's bound there keeps a first sync off the whole initial
-        // window of collections this high-volume.
-        async Task<DateTime?> BoundAsync(Func<Task<DateTime?>> resumePoint) =>
-            openEnded ? ResumeFrom(request.From, await resumePoint() ?? request.From) : request.From;
+        async Task<DateTime?> BoundAsync(Func<Task<DateTime?>> resumePoint)
+        {
+            if (!openEnded)
+                return request.From;
+
+            // Awaited before the bound is decided, so a watermark the publisher cannot answer
+            // fails this family whether or not the value is used.
+            var resume = await resumePoint();
+
+            // A run carrying no glucose cursor imports the remote's full history here, which no
+            // family's resume point may narrow — unlike ResumeFrom's own reading of an absent
+            // caller bound, which the remaining families keep.
+            return request.From is null ? null : ResumeFrom(request.From, resume ?? request.From);
+        }
 
         foreach (var type in activeTypes)
         {

--- a/tests/Unit/Nocturne.Connectors.Nightscout.Tests/Services/NightscoutConnectorServiceCatchUpBoundsTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Nightscout.Tests/Services/NightscoutConnectorServiceCatchUpBoundsTests.cs
@@ -69,6 +69,37 @@ public class NightscoutConnectorServiceCatchUpBoundsTests
     }
 
     /// <summary>
+    /// An explicit range is answered as asked, resume points and all: it is the shape a manual
+    /// re-import of one window sends, and a bound widened back to the watermark re-crawls
+    /// everything between — the whole source, for a family that has stored nothing.
+    /// </summary>
+    [Theory]
+    [InlineData(SyncDataType.Boluses, "treatments")]
+    [InlineData(SyncDataType.DeviceStatus, "devicestatus")]
+    [InlineData(SyncDataType.Activity, "activity")]
+    public async Task SyncDataAsync_WhenGivenAnExplicitRange_AsksForItAsGiven(
+        SyncDataType dataType, string collection)
+    {
+        var askedFrom = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var watermark = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new CollectingHandler();
+        var service = NewService(handler, watermarks: watermark);
+
+        await service.SyncDataAsync(
+            new SyncRequest
+            {
+                From = askedFrom,
+                To = new DateTime(2026, 6, 2, 0, 0, 0, DateTimeKind.Utc),
+                DataTypes = [dataType],
+            },
+            NewConfig(),
+            CancellationToken.None);
+
+        handler.CrawlOf(collection).Should()
+            .Contain(LowerBound(askedFrom), "the caller bounded the range at both ends");
+    }
+
+    /// <summary>
     /// A Nightscout instance is a full data export, so with no treatments stored the initial
     /// backfill has no lower bound at all — and the glucose cursor <c>request.From</c> carries on a
     /// background run must not narrow it to one. A treatments crawl that failed on the first sync

--- a/tests/Unit/Nocturne.Connectors.Nightscout.Tests/Services/NightscoutConnectorServiceCatchUpBoundsTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Nightscout.Tests/Services/NightscoutConnectorServiceCatchUpBoundsTests.cs
@@ -1,0 +1,204 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Nightscout.Configurations;
+using Nocturne.Connectors.Nightscout.Services;
+using Xunit;
+
+namespace Nocturne.Connectors.Nightscout.Tests.Services;
+
+public class NightscoutConnectorServiceCatchUpBoundsTests
+{
+    /// <summary>
+    /// A caller's lower bound is never narrowed by a family's resume point. An explicit <c>from</c>
+    /// with no <c>to</c> is a legitimate request shape and the one an admin repairing a months-old
+    /// gap sends; answering it from the watermark fetches nothing and reports the run as a success
+    /// with a zero count.
+    /// </summary>
+    [Theory]
+    [InlineData(SyncDataType.Boluses, "treatments")]
+    [InlineData(SyncDataType.DeviceStatus, "devicestatus")]
+    [InlineData(SyncDataType.Activity, "activity")]
+    public async Task SyncDataAsync_WhenGivenALowerBoundBelowTheResumePoint_HonoursTheCallersBound(
+        SyncDataType dataType, string collection)
+    {
+        var askedFrom = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var watermark = new DateTime(2026, 5, 31, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new CollectingHandler();
+        var service = NewService(handler, watermarks: watermark);
+
+        await service.SyncDataAsync(
+            new SyncRequest { From = askedFrom, To = null, DataTypes = [dataType] },
+            NewConfig(),
+            CancellationToken.None);
+
+        handler.CrawlOf(collection).Should()
+            .Contain(LowerBound(askedFrom), "the caller asked for this lower bound");
+    }
+
+    /// <summary>
+    /// On an open-ended catch-up a family that has fallen behind widens the bound back to its own
+    /// resume point. Leaving it on the glucose-derived bound strands it: this run's glucose publish
+    /// moves that bound past the range a failed crawl still owes, so the gap cannot be repaired
+    /// next cycle.
+    /// </summary>
+    [Theory]
+    [InlineData(SyncDataType.Boluses, "treatments")]
+    [InlineData(SyncDataType.DeviceStatus, "devicestatus")]
+    [InlineData(SyncDataType.Activity, "activity")]
+    public async Task SyncDataAsync_WhenAFamilyHasFallenBehind_WidensToItsOwnResumePoint(
+        SyncDataType dataType, string collection)
+    {
+        var watermark = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var glucoseFrom = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new CollectingHandler();
+        var service = NewService(handler, watermarks: watermark);
+
+        await service.SyncDataAsync(
+            new SyncRequest { From = glucoseFrom, To = null, DataTypes = [dataType] },
+            NewConfig(),
+            CancellationToken.None);
+
+        handler.CrawlOf(collection).Should()
+            .Contain(LowerBound(watermark - CatchUpOverlap),
+                "the family resumes from its own newest stored record, not glucose's");
+    }
+
+    /// <summary>
+    /// A Nightscout instance is a full data export, so with no treatments stored the initial
+    /// backfill has no lower bound at all — and the glucose cursor <c>request.From</c> carries on a
+    /// background run must not narrow it to one. A treatments crawl that failed on the first sync
+    /// after glucose landed is exactly that state, and bounding its retry at the glucose cursor
+    /// puts the history below permanently out of reach.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenNoTreatmentsAreStored_CrawlsTheFullHistory()
+    {
+        var handler = new CollectingHandler();
+        var service = NewService(handler, watermarks: null);
+
+        await service.SyncDataAsync(
+            new SyncRequest
+            {
+                From = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                To = null,
+                DataTypes = [SyncDataType.Boluses],
+            },
+            NewConfig(),
+            CancellationToken.None);
+
+        handler.CrawlOf("treatments").Should().NotContain("$gte");
+    }
+
+    /// <summary>
+    /// Device status and activity answer with no resume point rather than an open one, and take the
+    /// caller's bound instead: their initial window is high-volume telemetry that would otherwise
+    /// be re-fetched in full on every sync until the first page stored.
+    /// </summary>
+    [Theory]
+    [InlineData(SyncDataType.DeviceStatus, "devicestatus")]
+    [InlineData(SyncDataType.Activity, "activity")]
+    public async Task SyncDataAsync_WhenNoTelemetryIsStored_CrawlsFromTheCallersBound(
+        SyncDataType dataType, string collection)
+    {
+        var askedFrom = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new CollectingHandler();
+        var service = NewService(handler, watermarks: null);
+
+        await service.SyncDataAsync(
+            new SyncRequest { From = askedFrom, To = null, DataTypes = [dataType] },
+            NewConfig(),
+            CancellationToken.None);
+
+        handler.CrawlOf(collection).Should().Contain(LowerBound(askedFrom));
+    }
+
+    /// <summary>Overlap the shared catch-up calculation subtracts to absorb clock drift.</summary>
+    private static readonly TimeSpan CatchUpOverlap = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Envelope the created_at crawls widen their opening bounds by, to reach records an old
+    /// uploader wrote with a local offset.
+    /// </summary>
+    private static readonly TimeSpan WallClockEnvelope = TimeSpan.FromHours(14);
+
+    private static string LowerBound(DateTime from) =>
+        $"find[created_at][$gte]={from - WallClockEnvelope:o}";
+
+    private static NightscoutConnectorConfiguration NewConfig() => new()
+    {
+        Url = "https://ns.example",
+        ApiSecret = "secret",
+    };
+
+    private static NightscoutConnectorService NewService(
+        CollectingHandler handler,
+        DateTime? watermarks)
+    {
+        var treatments = new Mock<ITreatmentPublisher>();
+        treatments
+            .Setup(p => p.GetLatestTreatmentTimestampAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(watermarks);
+
+        var device = new Mock<IDevicePublisher>();
+        device
+            .Setup(p => p.GetLatestDeviceStatusTimestampAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(watermarks);
+
+        var metadata = new Mock<IMetadataPublisher>();
+        metadata
+            .Setup(p => p.GetLatestActivityTimestampAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(watermarks);
+
+        var publisher = new Mock<IConnectorPublisher>();
+        publisher.Setup(p => p.IsAvailable).Returns(true);
+        publisher.Setup(p => p.Glucose).Returns(Mock.Of<IGlucosePublisher>());
+        publisher.Setup(p => p.Treatments).Returns(treatments.Object);
+        publisher.Setup(p => p.Device).Returns(device.Object);
+        publisher.Setup(p => p.Metadata).Returns(metadata.Object);
+
+        var registration = new Mock<IConnectorRegistration<NightscoutConnectorConfiguration>>();
+        registration.Setup(r => r.Defaults).Returns(new NightscoutConnectorConfiguration());
+
+        return new NightscoutConnectorService(
+            new HttpClient(handler),
+            Mock.Of<IConnectorServerResolver<NightscoutConnectorConfiguration>>(),
+            NullLogger<NightscoutConnectorService>.Instance,
+            Mock.Of<IRetryDelayStrategy>(),
+            Mock.Of<IRateLimitingStrategy>(),
+            registration.Object,
+            publisher.Object);
+    }
+
+    /// <summary>
+    /// Records every request and answers each with an empty collection, so a crawl asks once per
+    /// collection and the range it asked for is what the test reads.
+    /// </summary>
+    private sealed class CollectingHandler : HttpMessageHandler
+    {
+        private readonly List<string> _requests = [];
+
+        /// <summary>The crawl request for <paramref name="collection"/>, as the source reads it.</summary>
+        internal string CrawlOf(string collection) =>
+            _requests.Single(u => u.Contains($"/api/v1/{collection}.json", StringComparison.Ordinal));
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // The bracket syntax Nightscout filters by is escaped on the wire.
+            _requests.Add(Uri.UnescapeDataString(request.RequestUri!.ToString()));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Nightscout.Tests/Services/NightscoutConnectorServiceCatchUpBoundsTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Nightscout.Tests/Services/NightscoutConnectorServiceCatchUpBoundsTests.cs
@@ -69,6 +69,34 @@ public class NightscoutConnectorServiceCatchUpBoundsTests
     }
 
     /// <summary>
+    /// A caller supplying no lower bound is not asking for everything, and each family stands on
+    /// its own resume point. This connector's glucose floor is open, so a background cycle for a
+    /// tenant with glucose switched off — or with none published yet — carries a null <c>from</c>
+    /// on every run, as do the tenant's own sync button and the dev-admin sweep. Reading that as a
+    /// request for the whole source re-crawls the entire history on every one of those runs.
+    /// </summary>
+    [Theory]
+    [InlineData(SyncDataType.Boluses, "treatments")]
+    [InlineData(SyncDataType.DeviceStatus, "devicestatus")]
+    [InlineData(SyncDataType.Activity, "activity")]
+    public async Task SyncDataAsync_WhenTheCallerSuppliesNoLowerBound_ResumesFromTheFamilysWatermark(
+        SyncDataType dataType, string collection)
+    {
+        var watermark = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var handler = new CollectingHandler();
+        var service = NewService(handler, watermarks: watermark);
+
+        await service.SyncDataAsync(
+            new SyncRequest { From = null, To = null, DataTypes = [dataType] },
+            NewConfig(),
+            CancellationToken.None);
+
+        handler.CrawlOf(collection).Should()
+            .Contain(LowerBound(watermark - CatchUpOverlap),
+                "the family has a resume point and the caller supplied nothing to widen it with");
+    }
+
+    /// <summary>
     /// An explicit range is answered as asked, resume points and all: it is the shape a manual
     /// re-import of one window sends, and a bound widened back to the watermark re-crawls
     /// everything between — the whole source, for a family that has stored nothing.

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
@@ -416,6 +416,26 @@ public class NocturneRemoteConnectorServiceCrawlTests
     }
 
     /// <summary>
+    /// A run carrying no lower bound imports this remote's full history, and no family's resume
+    /// point may narrow it back — the remote is another Nocturne instance, so the first sync is
+    /// meant to take everything it holds.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheCallerSuppliesNoLowerBound_AsksEveryFamilyForEverything()
+    {
+        var handler = new RemoteFakeHandler();
+        var fixture = new ServiceFixture(
+            handler, latestTreatment: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        await fixture.Service.SyncDataAsync(
+            new SyncRequest { From = null, To = null, DataTypes = [SyncDataType.Boluses] },
+            fixture.Config,
+            CancellationToken.None);
+
+        handler.CrawlOf(NocturneRemoteConstants.Boluses).Should().NotContain("from=");
+    }
+
+    /// <summary>
     /// The tenant's configured attempt budget governs, not the frozen startup defaults. Only the
     /// background entry point primes the field the defaults live in, so a manual sync or a cursor
     /// reset — the long full-history re-pull where the budget matters most — would otherwise run on


### PR DESCRIPTION
Closes #954.

## The defect

Nightscout's per-type catch-up cursors (treatments, device status, activity) gated on `openEnded = request.To is null` and **replaced** an explicit `request.From` with the family watermark. A repair request `{"from": "2026-01-01", "dataTypes": ["Boluses"]}` — a legitimate shape with `To` unset — therefore crawled the last few minutes instead of five months and reported `Success = true` with a zero count. The UI always sends both bounds and the cursor-reset path sets `To = UtcNow`, which is the only reason this wasn't hit routinely; anything driving the API directly hits it.

## The fix

`ResumeFrom` — introduced for NocturneRemote in #953 — is hoisted to `BaseConnectorService` as the one shared site, and Nightscout's three cursor sites resolve through it: **whichever bound reaches further back wins.** Gluroo inherits via the Nightscout base (verified: no overrides of the sync path or cursor calcs).

The hoisted helper's semantics are deliberately asymmetric, which round 2 of the hostile review forced (see below):

```
requested is null   → resumePoint   (an absent caller bound is absent, not "everything")
resumePoint is null → null          (an open resume point reaches back without limit)
otherwise           → min
```

`request.From == null` is a live production shape, not a theoretical one — the web Quick Sync button posts `{}`, and every scheduled cycle for a tenant whose glucose watermark is null (e.g. `SyncGlucose = false`; Nightscout's `InitialSyncFloor` is null) carries no `From`. Treating that as "crawl everything" would have re-crawled the source's entire history every cycle. NocturneRemote's "null From = unbounded" rule from #953 is its own semantics, so it now lives at its one call site (`BoundAsync`), keeping NocturneRemote **byte-identical to main across all four truth-table cells** — including the deliberately unconditional `await resumePoint()` so a watermark-read failure still fails that family.

## Declared behavioral delta

Nightscout/Gluroo differ from main in **exactly one cell**: `(From set, watermark set)` now takes the earlier of the two instead of the watermark — and only matters when `From` reaches further back. Every other cell, the ranged branch (`To` set → `From/To` honored as-is), and the cursor-reset path are unchanged and now pinned by tests.

## Review trail

Two-stage review (author-independent verification, then a fresh-context hostile gate), two rounds each. Round 1 of the gate caught a real blocker — the first version of the hoisted helper treated `requested null` as unbounded, regressing the Quick Sync/glucose-off paths above into full-history crawls (proven with a witness test red-on-branch/green-on-main) — which round 2 verified fixed, with Nightscout's divergence reduced to the single cell above.

Tests: 69 Nightscout (12 new in `NightscoutConnectorServiceCatchUpBoundsTests`, asserting at the HTTP-crawl-URL boundary), 21 NocturneRemote (1 new), 137 Connectors.Core; solution builds clean. Mutation evidence (each killed, run by author, reviewer, and gate independently; restored after):

| Mutation | Killed by |
|---|---|
| `<` → `>` in `ResumeFrom` | 6 Nightscout + 2 NocturneRemote direction cases |
| `requested null → null` (the round-1 regression) | `ResumesFromTheFamilysWatermark` ×3 |
| `resumePoint null → requested` (#953's cell, wrong for a full-export connector) | `WhenNoTreatmentsAreStored_CrawlsTheFullHistory` |
| drop `?? request.From` at the telemetry sites | `WhenNoTelemetryIsStored_CrawlsFromTheCallersBound` ×2 |
| `openEnded = true` / `= false` | ranged cases ×3 / catch-up cases ×7 |
| swap `ResumeFrom` argument order at a call site | 2 red (argument order is load-bearing) |
| drop NocturneRemote's local null-`From` guard | `AsksEveryFamilyForEverything` |
| make NocturneRemote's await conditional | `WhenAFamilysWatermarkCannotBeRead_FailsOnlyThatFamily` |

Follow-up (separate issue, verified independently): Tandem never reads the request window at all, MyLife's `defaultSince` pass-through bypasses the treatment watermark, and Glooko ignores `request.To` — the same story in three other connectors, each needing its own shape.

https://claude.ai/code/session_013JMfvQxpzTVwa27EBLJ2dZ
