### PR TITLE
test(data): one tenant-scoped table set, derived from the EF model

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Models.Authorization;
-using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Interceptors;
 using Nocturne.Infrastructure.Data.Security;
 using Npgsql;
@@ -269,17 +268,9 @@ public static class DatabaseInitializationExtensions
         var context = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
         var logger = scope.ServiceProvider.GetRequiredService<ILogger<NocturneDbContext>>();
 
-        var tenantScopedTables = context.Model.GetEntityTypes()
-            .Where(et => typeof(ITenantScoped).IsAssignableFrom(et.ClrType))
-            .Select(et => et.GetTableName())
-            .Where(name => !string.IsNullOrEmpty(name))
-            .Select(name => name!)
-            .Distinct()
-            .ToArray();
-
         await VerifyRlsAsync(
             context.Database.GetDbConnection(),
-            tenantScopedTables,
+            ShareRlsPolicy.TenantScopedTableNames(context.Model),
             logger,
             cancellationToken);
 
@@ -326,7 +317,7 @@ public static class DatabaseInitializationExtensions
     /// if it isn't already, and is left open on return.
     /// </summary>
     /// <param name="connection">Open or closed DbConnection to run the checks against. Opened if needed and left open.</param>
-    /// <param name="tenantScopedTables">Names of tables expected to have RLS configured (typically derived from the EF model walk for <see cref="ITenantScoped"/> entities).</param>
+    /// <param name="tenantScopedTables">Names of tables expected to have RLS configured — <see cref="ShareRlsPolicy.TenantScopedTableNames"/> in production.</param>
     /// <param name="logger">Logger for pass/warn/fail messages. Pass <see cref="Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance"/> to suppress.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task VerifyRlsAsync(

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
@@ -1,6 +1,8 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Interceptors;
+using Nocturne.Infrastructure.Data.Security;
 using Npgsql;
 using Testcontainers.PostgreSql;
 using Xunit;
@@ -32,6 +34,12 @@ public class RlsCompletenessFixture : IAsyncLifetime
 
     public string AppConnectionString { get; private set; } = string.Empty;
     public string MigratorConnectionString { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// <see cref="ShareRlsPolicy.TenantScopedTableNames"/> off the model this fixture migrated
+    /// and reconciled, so the tables asserted over and the tables policied cannot come apart.
+    /// </summary>
+    public IReadOnlyList<string> TenantScopedTableNames { get; private set; } = [];
 
     public async Task InitializeAsync()
     {
@@ -66,6 +74,10 @@ public class RlsCompletenessFixture : IAsyncLifetime
         await DatabaseInitializationExtensions.ReconcileShareRlsPoliciesAsync(
             MigratorConnectionString,
             NullLogger.Instance);
+
+        await using var context = new NocturneDbContext(
+            new DbContextOptionsBuilder<NocturneDbContext>().UseNpgsql(MigratorConnectionString).Options);
+        TenantScopedTableNames = ShareRlsPolicy.TenantScopedTableNames(context.Model);
     }
 
     public async Task DisposeAsync()

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Interceptors;
 using Nocturne.Infrastructure.Data.Security;
@@ -36,8 +37,12 @@ public class RlsCompletenessFixture : IAsyncLifetime
     public string MigratorConnectionString { get; private set; } = string.Empty;
 
     /// <summary>
-    /// <see cref="ShareRlsPolicy.TenantScopedTableNames"/> off the model this fixture migrated
-    /// and reconciled, so the tables asserted over and the tables policied cannot come apart.
+    /// Tables the suites in this collection expect the live database to have policied, cascaded
+    /// and forced. Deliberately NOT <see cref="ShareRlsPolicy.TenantScopedTableNames"/>: that
+    /// method produced the DDL under test, so asserting against it would only restate what the
+    /// reconciler was told to do. Walks <see cref="ITenantScoped"/> CLR types instead and asks
+    /// the model for each one's table, so a table dropped from the reconciler's set still
+    /// appears here and the database is caught missing it.
     /// </summary>
     public IReadOnlyList<string> TenantScopedTableNames { get; private set; } = [];
 
@@ -77,7 +82,15 @@ public class RlsCompletenessFixture : IAsyncLifetime
 
         await using var context = new NocturneDbContext(
             new DbContextOptionsBuilder<NocturneDbContext>().UseNpgsql(MigratorConnectionString).Options);
-        TenantScopedTableNames = ShareRlsPolicy.TenantScopedTableNames(context.Model);
+
+        TenantScopedTableNames = typeof(ITenantScoped).Assembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(ITenantScoped).IsAssignableFrom(t))
+            .Select(t => context.Model.FindEntityType(t)?.GetTableName())
+            .Where(n => n is not null)
+            .Select(n => n!)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
     }
 
     public async Task DisposeAsync()

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsEnforcementTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsEnforcementTests.cs
@@ -1,6 +1,5 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Extensions;
 using Npgsql;
 using Xunit;
@@ -33,7 +32,7 @@ public class RlsEnforcementTests
     [Fact]
     public async Task AllTenantScopedTables_HaveRlsEnabledAndForcedAndPolicied()
     {
-        var tenantScopedTables = TenantScopedTableNames().ToArray();
+        var tenantScopedTables = _fx.TenantScopedTableNames.ToArray();
         tenantScopedTables.Should().NotBeEmpty(
             "the EF model should declare at least one ITenantScoped entity");
 
@@ -147,18 +146,6 @@ public class RlsEnforcementTests
         reader.GetString(0).Should().Be("nocturne_app");
         reader.GetBoolean(1).Should().BeFalse("nocturne_app must not be a superuser");
         reader.GetBoolean(2).Should().BeFalse("nocturne_app must not have BYPASSRLS");
-    }
-
-    private static IEnumerable<string> TenantScopedTableNames()
-    {
-        return typeof(ITenantScoped).Assembly
-            .GetTypes()
-            .Where(t => typeof(ITenantScoped).IsAssignableFrom(t) && t is { IsAbstract: false, IsInterface: false })
-            .Select(t => (System.ComponentModel.DataAnnotations.Schema.TableAttribute?)
-                Attribute.GetCustomAttribute(t, typeof(System.ComponentModel.DataAnnotations.Schema.TableAttribute)))
-            .Where(attr => attr is not null)
-            .Select(attr => attr!.Name)
-            .Distinct(StringComparer.Ordinal);
     }
 
     private async Task SeedRowAsync(Guid tenantId)

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsShareCategoryTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsShareCategoryTests.cs
@@ -1,8 +1,6 @@
-using System.ComponentModel.DataAnnotations.Schema;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Core.Models.Authorization;
-using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Security;
 using Npgsql;
@@ -175,7 +173,7 @@ public class RlsShareCategoryTests
                 policied[reader.GetString(0)] = (reader.GetBoolean(1), reader.GetChar(2), reader.GetString(3));
         }
 
-        foreach (var table in TenantScopedTableNames())
+        foreach (var table in _fx.TenantScopedTableNames)
         {
             policied.Should().ContainKey(table,
                 $"the reconciler must apply '{ShareRlsPolicy.PolicyName}' to every tenant-scoped table");
@@ -314,12 +312,4 @@ public class RlsShareCategoryTests
         p.Value = value;
         cmd.Parameters.Add(p);
     }
-
-    private static IEnumerable<string> TenantScopedTableNames() =>
-        typeof(ITenantScoped).Assembly.GetTypes()
-            .Where(t => typeof(ITenantScoped).IsAssignableFrom(t) && t is { IsAbstract: false, IsInterface: false })
-            .Select(t => Attribute.GetCustomAttribute(t, typeof(TableAttribute)) as TableAttribute)
-            .Where(a => a is not null)
-            .Select(a => a!.Name)
-            .Distinct(StringComparer.Ordinal);
 }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/TenantDeleteCascadeTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/TenantDeleteCascadeTests.cs
@@ -1,5 +1,4 @@
 using FluentAssertions;
-using Nocturne.Infrastructure.Data.Security;
 
 namespace Nocturne.Infrastructure.Data.Tests.Rls;
 
@@ -27,12 +26,7 @@ public class TenantDeleteCascadeTests
     [Fact]
     public async Task EveryTenantScopedTable_CascadesFromTenantDelete()
     {
-        await using var context = new NocturneDbContext(
-            new DbContextOptionsBuilder<NocturneDbContext>()
-                .UseNpgsql(_fixture.MigratorConnectionString)
-                .Options);
-
-        var tenantScoped = ShareRlsPolicy.TenantScopedTableNames(context.Model);
+        var tenantScoped = _fixture.TenantScopedTableNames;
         tenantScoped.Should().NotBeEmpty("the model must expose tenant-scoped entities");
 
         var cascadeEdges = await LoadCascadeEdgesAsync();

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Authorization/ShareDataCategoriesGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Authorization/ShareDataCategoriesGuardTests.cs
@@ -1,6 +1,5 @@
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Reflection;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data.Security;
 
 namespace Nocturne.Infrastructure.Data.Tests.Authorization;
 
@@ -40,37 +39,18 @@ public class ShareDataCategoriesGuardTests
         "user_food_favorites",
     };
 
-    private static IReadOnlyList<Type> TenantScopedEntities() =>
-        typeof(ITenantScoped).Assembly.GetTypes()
-            .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(ITenantScoped).IsAssignableFrom(t))
-            .ToList();
-
-    private static string? TableName(Type entity) => entity.GetCustomAttribute<TableAttribute>()?.Name;
-
-    [Fact]
-    public void EveryTenantScopedEntity_HasATableAttribute()
+    private static IReadOnlySet<string> TenantScopedTables()
     {
-        // The coverage guard resolves table names from [Table] attributes; an entity
-        // without one would be silently skipped and therefore ungated.
-        var untabled = TenantScopedEntities()
-            .Where(t => TableName(t) is null)
-            .Select(t => t.Name)
-            .OrderBy(s => s, StringComparer.Ordinal)
-            .ToList();
-
-        untabled.Should().BeEmpty();
+        using var context = OfflineDbContext.Create();
+        return ShareRlsPolicy.TenantScopedTableNames(context.Model).ToHashSet(StringComparer.Ordinal);
     }
 
     [Fact]
     public void EveryTenantScopedTable_IsClassifiedShareableOrHidden()
     {
-        var unclassified = TenantScopedEntities()
-            .Select(t => new { Entity = t.Name, Table = TableName(t) })
-            .Where(x => x.Table is not null)
-            .Where(x => ShareDataCategories.GoverningScopeFor(x.Table!) is null
-                     && !KnownHiddenTables.Contains(x.Table!))
-            .Select(x => $"{x.Entity} -> {x.Table}")
-            .OrderBy(s => s, StringComparer.Ordinal)
+        var unclassified = TenantScopedTables()
+            .Where(t => ShareDataCategories.GoverningScopeFor(t) is null && !KnownHiddenTables.Contains(t))
+            .OrderBy(t => t, StringComparer.Ordinal)
             .ToList();
 
         unclassified.Should().BeEmpty(
@@ -81,7 +61,7 @@ public class ShareDataCategoriesGuardTests
     [Fact]
     public void GovernedTables_OnlyReferenceRealTenantScopedTables()
     {
-        var real = TenantScopedEntities().Select(TableName).Where(n => n is not null).ToHashSet(StringComparer.Ordinal);
+        var real = TenantScopedTables();
 
         ShareDataCategories.GovernedTables.Values.SelectMany(t => t)
             .Where(t => !real.Contains(t))
@@ -91,7 +71,7 @@ public class ShareDataCategoriesGuardTests
     [Fact]
     public void KnownHiddenTables_AreAllStillTenantScoped()
     {
-        var real = TenantScopedEntities().Select(TableName).Where(n => n is not null).ToHashSet(StringComparer.Ordinal);
+        var real = TenantScopedTables();
 
         KnownHiddenTables.Where(t => !real.Contains(t))
             .Should().BeEmpty("KnownHiddenTables must not list a stale, non-ITenantScoped table");

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Authorization/ShareDataCategoriesGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Authorization/ShareDataCategoriesGuardTests.cs
@@ -39,16 +39,16 @@ public class ShareDataCategoriesGuardTests
         "user_food_favorites",
     };
 
-    private static IReadOnlySet<string> TenantScopedTables()
+    private static readonly Lazy<IReadOnlySet<string>> TenantScopedTables = new(() =>
     {
         using var context = OfflineDbContext.Create();
         return ShareRlsPolicy.TenantScopedTableNames(context.Model).ToHashSet(StringComparer.Ordinal);
-    }
+    });
 
     [Fact]
     public void EveryTenantScopedTable_IsClassifiedShareableOrHidden()
     {
-        var unclassified = TenantScopedTables()
+        var unclassified = TenantScopedTables.Value
             .Where(t => ShareDataCategories.GoverningScopeFor(t) is null && !KnownHiddenTables.Contains(t))
             .OrderBy(t => t, StringComparer.Ordinal)
             .ToList();
@@ -61,7 +61,7 @@ public class ShareDataCategoriesGuardTests
     [Fact]
     public void GovernedTables_OnlyReferenceRealTenantScopedTables()
     {
-        var real = TenantScopedTables();
+        var real = TenantScopedTables.Value;
 
         ShareDataCategories.GovernedTables.Values.SelectMany(t => t)
             .Where(t => !real.Contains(t))
@@ -71,7 +71,7 @@ public class ShareDataCategoriesGuardTests
     [Fact]
     public void KnownHiddenTables_AreAllStillTenantScoped()
     {
-        var real = TenantScopedTables();
+        var real = TenantScopedTables.Value;
 
         KnownHiddenTables.Where(t => !real.Contains(t))
             .Should().BeEmpty("KnownHiddenTables must not list a stale, non-ITenantScoped table");

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/DeviceEventIndexTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/DeviceEventIndexTests.cs
@@ -19,11 +19,7 @@ public class DeviceEventIndexTests
     [Fact]
     public void LatestByEventTypeLookup_IsBackedByATenantEventTypeTimestampIndex()
     {
-        using var ctx = new NocturneDbContext(
-            new DbContextOptionsBuilder<NocturneDbContext>()
-                .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
-                .Options)
-        { TenantId = Guid.NewGuid() };
+        using var ctx = OfflineDbContext.Create();
 
         // Column sort direction only survives on the design-time model; the runtime model drops it.
         var index = ctx.GetService<IDesignTimeModel>().Model

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/JsonbStringComparerTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/JsonbStringComparerTests.cs
@@ -22,11 +22,7 @@ public class JsonbStringComparerTests
     private const string CompactJson = """[{"Time":"00:00","Value":1.5,"TimeAsSeconds":0}]""";
     private const string JsonbNormalizedJson = """[{"Time": "00:00", "Value": 1.5, "TimeAsSeconds": 0}]""";
 
-    private static NocturneDbContext NewContext() =>
-        new(new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
-            .Options)
-        { TenantId = Guid.NewGuid() };
+    private static NocturneDbContext NewContext() => OfflineDbContext.Create();
 
     [Fact]
     public void EveryJsonbStringColumn_UsesTheSemanticComparer()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/LegacyIdIndexFilterTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/LegacyIdIndexFilterTests.cs
@@ -49,11 +49,7 @@ public class LegacyIdIndexFilterTests
                 "a soft-deleted row must drop out of the index so a system-swept legacy id stays re-importable");
     }
 
-    private static NocturneDbContext CreateContext() =>
-        new(new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
-            .Options)
-        { TenantId = Guid.NewGuid() };
+    private static NocturneDbContext CreateContext() => OfflineDbContext.Create();
 
     /// <summary>
     /// Both facts pass vacuously if discovery drifts, so the count is asserted here rather than

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
@@ -54,10 +54,10 @@ public class DataMigrationTenantContextGuardTests
     [Fact]
     public void TheGuardCanSeeMigrationsAndTenantScopedTables()
     {
-        // A path or reflection regression would empty both sets and make the guard above pass
-        // vacuously.
+        // Either set going empty makes the guard above pass vacuously. A named table catches the
+        // narrower regression too: a set that still holds most tables but has quietly dropped some.
         MigrationSourceFiles.All().Should().NotBeEmpty();
-        MigrationSourceFiles.TenantScopedTableNames().Should().NotBeEmpty();
+        MigrationSourceFiles.TenantScopedTableNames().Should().Contain("sensor_glucose");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
@@ -1,6 +1,5 @@
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Reflection;
 using System.Text.RegularExpressions;
+using Nocturne.Infrastructure.Data.Security;
 using Match = System.Text.RegularExpressions.Match;
 
 namespace Nocturne.Infrastructure.Data.Tests.Migrations;
@@ -90,14 +89,20 @@ internal static class MigrationSourceFiles
         return new string(blanked);
     }
 
-    /// <summary>Table names of every <see cref="ITenantScoped"/> entity, lowercased.</summary>
-    public static IReadOnlySet<string> TenantScopedTableNames() =>
-        typeof(ITenantScoped).Assembly.GetTypes()
-            .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(ITenantScoped).IsAssignableFrom(t))
-            .Select(t => t.GetCustomAttribute<TableAttribute>()?.Name)
-            .Where(n => n is not null)
-            .Select(n => n!.ToLowerInvariant())
+    /// <summary>
+    /// <see cref="ShareRlsPolicy.TenantScopedTableNames"/> as a lowercased set, for comparison
+    /// against table names lifted out of SQL by <see cref="BareTableName"/>.
+    /// </summary>
+    public static IReadOnlySet<string> TenantScopedTableNames() => ScopedTables.Value;
+
+    private static readonly Lazy<IReadOnlySet<string>> ScopedTables = new(() =>
+    {
+        using var context = OfflineDbContext.Create();
+
+        return ShareRlsPolicy.TenantScopedTableNames(context.Model)
+            .Select(n => n.ToLowerInvariant())
             .ToHashSet(StringComparer.Ordinal);
+    });
 
     private static readonly Regex TimestampPrefixed = new(@"^\d{14}_", RegexOptions.Compiled);
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
@@ -187,11 +187,7 @@ public class ModelConventionTests
     /// </summary>
     private static IModel Model()
     {
-        using var ctx = new NocturneDbContext(
-            new DbContextOptionsBuilder<NocturneDbContext>()
-                .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
-                .Options)
-        { TenantId = Guid.NewGuid() };
+        using var ctx = OfflineDbContext.Create();
 
         return ctx.GetService<IDesignTimeModel>().Model;
     }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/OfflineDbContext.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/OfflineDbContext.cs
@@ -1,0 +1,18 @@
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// A <see cref="NocturneDbContext"/> for tests that only read model metadata.
+/// </summary>
+internal static class OfflineDbContext
+{
+    /// <summary>
+    /// The Npgsql provider is required — table names, index filters and column types exist only on
+    /// the relational mapping — but the model builds without a server, so nothing here is reachable
+    /// and the connection is never opened.
+    /// </summary>
+    public static NocturneDbContext Create() =>
+        new(new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
+            .Options)
+        { TenantId = Guid.NewGuid() };
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/OfflineDbContext.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/OfflineDbContext.cs
@@ -7,8 +7,9 @@ internal static class OfflineDbContext
 {
     /// <summary>
     /// The Npgsql provider is required — table names, index filters and column types exist only on
-    /// the relational mapping — but the model builds without a server, so nothing here is reachable
-    /// and the connection is never opened.
+    /// the relational mapping — but building the model opens no connection, so the host and
+    /// credentials are placeholders for as long as a caller touches nothing but
+    /// <see cref="DbContext.Model"/>.
     /// </summary>
     public static NocturneDbContext Create() =>
         new(new DbContextOptionsBuilder<NocturneDbContext>()

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Security/ShareRlsPolicyTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Security/ShareRlsPolicyTests.cs
@@ -98,9 +98,8 @@ public class ShareRlsPolicyTests
     [Fact]
     public void TenantScopedTableNames_CoversEveryTenantScopedEntity()
     {
-        // Every consumer — the startup reconciler, the share-category classification guard, the
-        // data-migration tenant-loop guard, the RLS integration suites — reads its table set from
-        // here, so an entity this misses is unpoliced and unguarded everywhere at once.
+        // Every caller takes its table set from here, so an entity this misses is unpoliced and
+        // unguarded everywhere at once.
         var model = Model();
         var tables = ShareRlsPolicy.TenantScopedTableNames(model).ToHashSet(StringComparer.Ordinal);
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Security/ShareRlsPolicyTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Security/ShareRlsPolicyTests.cs
@@ -1,6 +1,3 @@
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data.Security;
@@ -12,12 +9,7 @@ public class ShareRlsPolicyTests
 {
     private static IModel Model()
     {
-        // The EF model builds offline (no connection); UseNpgsql gives the relational mapping
-        // so GetTableName() resolves real table names, mirroring the reconciler at startup.
-        var options = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
-            .Options;
-        using var ctx = new NocturneDbContext(options);
+        using var ctx = OfflineDbContext.Create();
         return ctx.Model;
     }
 
@@ -104,21 +96,22 @@ public class ShareRlsPolicyTests
     }
 
     [Fact]
-    public void TenantScopedTableNames_MatchesTableAttributeReflection()
+    public void TenantScopedTableNames_CoversEveryTenantScopedEntity()
     {
-        // The reconciler resolves names from the EF model; the coverage guard resolves them from
-        // [Table] attributes. They must agree, or a table could be policied under one source and
-        // classified under the other. This fails the build if an entity ever maps its table via
-        // ToTable() without a matching [Table] attribute.
-        var fromModel = ShareRlsPolicy.TenantScopedTableNames(Model());
+        // Every consumer — the startup reconciler, the share-category classification guard, the
+        // data-migration tenant-loop guard, the RLS integration suites — reads its table set from
+        // here, so an entity this misses is unpoliced and unguarded everywhere at once.
+        var model = Model();
+        var tables = ShareRlsPolicy.TenantScopedTableNames(model).ToHashSet(StringComparer.Ordinal);
 
-        var fromAttributes = typeof(ITenantScoped).Assembly.GetTypes()
+        var uncovered = typeof(ITenantScoped).Assembly.GetTypes()
             .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(ITenantScoped).IsAssignableFrom(t))
-            .Select(t => t.GetCustomAttribute<TableAttribute>()?.Name)
-            .Where(n => n is not null)
-            .Select(n => n!)
-            .Distinct(StringComparer.Ordinal);
+            .Where(t => model.FindEntityType(t)?.GetTableName() is not { } table || !tables.Contains(table))
+            .Select(t => t.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
 
-        fromModel.Should().BeEquivalentTo(fromAttributes);
+        uncovered.Should().BeEmpty();
+        tables.Should().NotBeEmpty();
     }
 }


### PR DESCRIPTION
Closes #950.

## Verdict on the issue, then the fix

The issue is right about the structure and stale on the particulars: `entries` no longer exists (dropped in `20260425084256_DropEntriesTable`; `sensor_glucose` is the successor), and on today's tree the `[Table]`-attribute set and the EF-model set are identical — proven independently during review (74 `ITenantScoped` classes, 74 attribute names, 74 mapped names, zero divergence in either direction), so **no existing migration was a latent no-op**. What was real: the guard's table set was held closed only by a convention test in a different file, one attribute deletion away from going blind — and the tenant-scoped enumeration existed **six** times (the `ShareRlsPolicy` model walk used by the startup reconciler, an inlined copy in `DatabaseInitializationExtensions.VerifyRlsAsync`, and four `[Table]`-reflection copies across unit and integration tests).

All six now resolve through `ShareRlsPolicy.TenantScopedTableNames(IModel)` — except the integration fixture, deliberately (below). The migration guard therefore sees fluent-mapped tables by construction, and its vacuity pin is upgraded from `NotBeEmpty()` to `Contain("sensor_glucose")` — a named table that is also the driving table of an allowlisted no-op migration, so the pin is double-covered.

`TenantScopedTableNames_MatchesTableAttributeReflection` (which enshrined the attribute as a second source of truth) is replaced by `TenantScopedTableNames_CoversEveryTenantScopedEntity`: no `ITenantScoped` CLR type may be absent from the set regardless of mapping style. `EveryTenantScopedEntity_HasATableAttribute` is deleted — a repo-wide search finds nothing resolving table names via the attribute at runtime; it existed only to prop up attribute reflection. A copy-pasted offline-model pattern in five unit test files is extracted to `OfflineDbContext.Create()` (verified model-neutral: the tenant query filter parameterizes `TenantId` at query time, so the cached model cannot differ from production's).

## The one enumeration that must stay independent

The hostile review proved that pointing the integration fixture at `ShareRlsPolicy` made the live-DB policy-presence assertions tautological — the fixture would assert against the same list that produced the reconciler's DDL, and a table silently dropped from `ShareRlsPolicy` left the whole RLS integration suite green while the live database held an unpolicied tenant-scoped table (main's suite catches it). The fixture now derives its oracle in the opposite direction — assembly walk over `ITenantScoped` CLR types, each resolved through `model.FindEntityType(t).GetTableName()` — so at least one detector reads `pg_policy` against a list not produced by the code under test.

## Verification

- Unit suite: 678 passed / 0 failed. Integration RLS suites run under Docker: 24/24 (and again in CI's integration-db).
- Mutations (all restored, each run independently by author and reviewers):
  - remove `[Table]` from an entity, leaving only its fluent `ToTable` → suite stays green (the guard now sees it); with attribute-only reflection restored, 3 tests red — including `EveryAllowlistedMigrationStillExistsAndStillOffends` losing a migration that genuinely drives its tenant loop off that table, the exact in-the-wild failure mode;
  - silently drop `sensor_glucose` from the set → vacuity pin red;
  - silently drop `clock_faces` (a table no behavioral test names) from `ShareRlsPolicy` → unit coverage test red **and** the integration suite's independent oracle red against live `pg_policy` (`EveryTenantScopedTable_HasCorrectRestrictiveSelectSharePolicy`); before the fixture fix this mutation left integration 24/24 green.

## Follow-up (separate issue)

Found while proving the above, out of scope here: `VerifyRlsAsync` — the startup self-check — only counts policies per table, so a table missing `share_category_read` but still carrying `tenant_isolation` reads as fine; the startup check detects total RLS absence only. Filed together with two evasion shapes the migration guard's regex cannot see.

https://claude.ai/code/session_013JMfvQxpzTVwa27EBLJ2dZ
