### PR TITLE
fix(auth): one bearer-credential chain, and stop expired grants being exchangeable

### DIFF
--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -281,6 +281,7 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IOAuthClientService, OAuthClientService>();
         services.AddSingleton<RedirectUriValidator>();
         services.AddScoped<IOAuthGrantService, OAuthGrantService>();
+        services.AddScoped<IJwtCredentialValidator, JwtCredentialValidator>();
         services.AddScoped<IOAuthTokenService, OAuthTokenService>();
         services.AddScoped<IOAuthDeviceCodeService, OAuthDeviceCodeService>();
         services.AddScoped<IMemberInviteService, MemberInviteService>();

--- a/src/API/Nocturne.API/Hubs/OverviewHub.cs
+++ b/src/API/Nocturne.API/Hubs/OverviewHub.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Nocturne.API.Extensions;
+using Nocturne.API.Services.Auth;
 using Nocturne.API.Services.Identity;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Authorization;
@@ -42,19 +43,16 @@ public class OverviewHub : Hub
 
     private readonly ILogger<OverviewHub> _logger;
     private readonly ITenantOverviewService _overviewService;
-    private readonly IJwtService _jwtService;
-    private readonly IOAuthTokenRevocationCache _revocationCache;
+    private readonly IJwtCredentialValidator _credentialValidator;
 
     public OverviewHub(
         ILogger<OverviewHub> logger,
         ITenantOverviewService overviewService,
-        IJwtService jwtService,
-        IOAuthTokenRevocationCache revocationCache)
+        IJwtCredentialValidator credentialValidator)
     {
         _logger = logger;
         _overviewService = overviewService;
-        _jwtService = jwtService;
-        _revocationCache = revocationCache;
+        _credentialValidator = credentialValidator;
     }
 
     /// <summary>
@@ -110,20 +108,16 @@ public class OverviewHub : Hub
                         + "the connection request, or send an OAuth JWT.");
                 }
 
-                var validation = _jwtService.ValidateAccessToken(request.Token);
-                if (!validation.IsValid || validation.Claims is null)
+                var validation = await _credentialValidator.ValidateAsync(request.Token);
+                if (!validation.IsValid)
                 {
-                    _logger.LogDebug("Overview hub JWT validation failed: {Error}", validation.Error);
+                    _logger.LogDebug(
+                        "Overview hub token refused ({Rejection}): {Error}",
+                        validation.Rejection, validation.Error);
                     return OverviewAuthorizeResponse.Failed("Invalid token.");
                 }
 
-                var claims = validation.Claims;
-                if (!string.IsNullOrEmpty(claims.JwtId)
-                    && await _revocationCache.IsRevokedAsync(claims.JwtId))
-                {
-                    _logger.LogDebug("Overview hub JWT has been revoked (jti: {Jti})", claims.JwtId);
-                    return OverviewAuthorizeResponse.Failed("Invalid token.");
-                }
+                var claims = validation.Claims!;
 
                 // A tenant-pinned JWT is only valid on the tenant that issued it
                 // (HubTokenAuthorizer enforces the pin strictly); accepting it here would

--- a/src/API/Nocturne.API/Middleware/Handlers/DirectGrantTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/DirectGrantTokenHandler.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
@@ -145,11 +146,25 @@ public class DirectGrantTokenHandler : IAuthHandler
     {
         return grants
             .IgnoreQueryFilters()
-            .Where(g => g.TenantId == tenantId
-                     && g.GrantType == OAuthGrantTypes.Direct
-                     && g.RevokedAt == null
-                     && (g.ExpiresAt == null || g.ExpiresAt > now));
+            .Where(g => g.TenantId == tenantId)
+            .Where(IsLiveDirectGrant(now));
     }
+
+    /// <summary>
+    /// What makes a direct grant usable, independent of how the caller scopes it to a tenant.
+    /// </summary>
+    /// <remarks>
+    /// Shared with the <c>/api/v2/authorization/request/{token}</c> exchange, which scopes by the
+    /// global query filter rather than an explicit tenant id and so cannot reuse
+    /// <see cref="ActiveDirectGrants"/> wholesale. It previously restated the predicate and omitted
+    /// the expiry term, so a grant this handler and the hubs both refused could still be exchanged
+    /// for a one-hour JWT.
+    /// </remarks>
+    /// <param name="now">The instant to judge expiry against.</param>
+    internal static Expression<Func<OAuthGrantEntity, bool>> IsLiveDirectGrant(DateTime now) =>
+        g => g.GrantType == OAuthGrantTypes.Direct
+             && g.RevokedAt == null
+             && (g.ExpiresAt == null || g.ExpiresAt > now);
 
     /// <summary>
     /// Extracts a direct grant token from the request. Accepts the <c>Authorization: Bearer</c>

--- a/src/API/Nocturne.API/Middleware/Handlers/OAuthAccessTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/OAuthAccessTokenHandler.cs
@@ -79,10 +79,7 @@ public class OAuthAccessTokenHandler : IAuthHandler
             return AuthResult.Skip();
         }
 
-        // Validate using IJwtService (uses the correct Jwt:SecretKey, issuer, audience)
         using var scope = _scopeFactory.CreateScope();
-        var jwtService = scope.ServiceProvider.GetRequiredService<IJwtService>();
-
         var credentialValidator = scope.ServiceProvider.GetRequiredService<IJwtCredentialValidator>();
         var validationResult = await credentialValidator.ValidateAsync(token);
 

--- a/src/API/Nocturne.API/Middleware/Handlers/OAuthAccessTokenHandler.cs
+++ b/src/API/Nocturne.API/Middleware/Handlers/OAuthAccessTokenHandler.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.API.Services.Auth;
 
 namespace Nocturne.API.Middleware.Handlers;
 
@@ -82,18 +83,18 @@ public class OAuthAccessTokenHandler : IAuthHandler
         using var scope = _scopeFactory.CreateScope();
         var jwtService = scope.ServiceProvider.GetRequiredService<IJwtService>();
 
-        var validationResult = jwtService.ValidateAccessToken(token);
+        var credentialValidator = scope.ServiceProvider.GetRequiredService<IJwtCredentialValidator>();
+        var validationResult = await credentialValidator.ValidateAsync(token);
 
-        if (!validationResult.IsValid || validationResult.Claims is null)
+        if (!validationResult.IsValid)
         {
             _logger.LogDebug(
-                "OAuth access token validation failed: {Error}",
-                validationResult.Error
-            );
+                "OAuth access token refused ({Rejection}): {Error}",
+                validationResult.Rejection, validationResult.Error);
             return AuthResult.Failure(validationResult.Error ?? "Invalid OAuth access token");
         }
 
-        var claims = validationResult.Claims;
+        var claims = validationResult.Claims!;
 
         // Enforce tenant pin: reject tokens issued for a different tenant
         if (claims.TenantId.HasValue)
@@ -105,40 +106,6 @@ public class OAuthAccessTokenHandler : IAuthHandler
                     "OAuth access token tenant mismatch: token tenant {TokenTenant}, request tenant {RequestTenant}",
                     claims.TenantId, tenantCtx?.TenantId);
                 return AuthResult.Failure("Token is not valid for this tenant");
-            }
-        }
-
-        // Reject tokens whose grant has been revoked. Access tokens are stateless, so a
-        // "Disconnect" on a connected app can only reach them through the grant id they carry.
-        if (claims.GrantId.HasValue)
-        {
-            if (!claims.TenantId.HasValue)
-            {
-                // Grant-bound tokens are always minted with their grant's tenant pin; one without
-                // a pin cannot have its grant checked, so it is not accepted.
-                _logger.LogWarning(
-                    "OAuth access token carries grant {GrantId} without a tenant pin", claims.GrantId);
-                return AuthResult.Failure("Token has been revoked");
-            }
-
-            var grantService = scope.ServiceProvider.GetRequiredService<IOAuthGrantService>();
-            if (await grantService.IsGrantRevokedAsync(claims.GrantId.Value, claims.TenantId.Value))
-            {
-                _logger.LogDebug(
-                    "OAuth access token's grant has been revoked (grant: {GrantId})", claims.GrantId);
-                return AuthResult.Failure("Token has been revoked");
-            }
-        }
-
-        // Check revocation cache
-        if (!string.IsNullOrEmpty(claims.JwtId))
-        {
-            var revocationCache =
-                scope.ServiceProvider.GetRequiredService<IOAuthTokenRevocationCache>();
-            if (await revocationCache.IsRevokedAsync(claims.JwtId))
-            {
-                _logger.LogDebug("OAuth access token has been revoked (jti: {Jti})", claims.JwtId);
-                return AuthResult.Failure("Token has been revoked");
             }
         }
 

--- a/src/API/Nocturne.API/Services/Auth/JwtCredentialValidator.cs
+++ b/src/API/Nocturne.API/Services/Auth/JwtCredentialValidator.cs
@@ -1,0 +1,132 @@
+using Nocturne.Core.Contracts.Auth;
+
+namespace Nocturne.API.Services.Auth;
+
+/// <summary>
+/// Validates a bearer JWT down to the point where a transport has to decide for itself.
+///
+/// Four call sites used to run this chain independently — the HTTP handler, the SignalR hub
+/// authorizer, the overview hub's in-band authorize, and token introspection — and they had
+/// drifted: the overview hub checked the revocation cache but never asked whether the token's
+/// GRANT had been revoked, so disconnecting a connected app left its hub connections authorized
+/// until the access token expired.
+///
+/// The tenant pin is deliberately NOT decided here. The three transports disagree on purpose: an
+/// HTTP request accepts an unpinned token because <c>MemberScopeMiddleware</c> re-resolves
+/// membership per request, a tenant hub requires the pin to match its connection because nothing
+/// re-checks after the handshake, and the overview hub requires the token to be unpinned because
+/// it spans every tenant the subject belongs to. Folding those into one rule would erase a
+/// distinction each site chose. Callers read <see cref="JwtClaims.TenantId"/> off the result and
+/// apply their own.
+/// </summary>
+public interface IJwtCredentialValidator
+{
+    /// <summary>
+    /// Validates <paramref name="token"/>'s signature and lifetime, then checks that neither the
+    /// token nor the grant behind it has been revoked.
+    /// </summary>
+    Task<JwtCredentialResult> ValidateAsync(string token, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Why a JWT credential was refused.</summary>
+public enum JwtCredentialRejection
+{
+    /// <summary>Signature, lifetime, issuer or audience did not hold up.</summary>
+    Invalid,
+
+    /// <summary>The token, or the grant it was minted against, has been revoked.</summary>
+    Revoked,
+}
+
+/// <summary>
+/// The outcome of <see cref="IJwtCredentialValidator.ValidateAsync"/>. A valid result carries the
+/// claims; the caller still owes the tenant-pin decision.
+/// </summary>
+public sealed record JwtCredentialResult
+{
+    private JwtCredentialResult() { }
+
+    /// <summary>The validated claims, or <see langword="null"/> when the credential was refused.</summary>
+    public JwtClaims? Claims { get; private init; }
+
+    /// <summary>Why it was refused, or <see langword="null"/> when it was not.</summary>
+    public JwtCredentialRejection? Rejection { get; private init; }
+
+    /// <summary>Diagnostic detail for logging. Never surfaced to the caller of the API.</summary>
+    public string? Error { get; private init; }
+
+    /// <summary>Whether the credential survived validation.</summary>
+    public bool IsValid => Claims is not null;
+
+    internal static JwtCredentialResult Valid(JwtClaims claims) => new() { Claims = claims };
+
+    internal static JwtCredentialResult Refused(JwtCredentialRejection rejection, string error) =>
+        new() { Rejection = rejection, Error = error };
+}
+
+/// <inheritdoc cref="IJwtCredentialValidator"/>
+public sealed class JwtCredentialValidator : IJwtCredentialValidator
+{
+    private readonly IJwtService _jwtService;
+    private readonly IOAuthGrantService _grantService;
+    private readonly IOAuthTokenRevocationCache _revocationCache;
+    private readonly ILogger<JwtCredentialValidator> _logger;
+
+    public JwtCredentialValidator(
+        IJwtService jwtService,
+        IOAuthGrantService grantService,
+        IOAuthTokenRevocationCache revocationCache,
+        ILogger<JwtCredentialValidator> logger)
+    {
+        _jwtService = jwtService;
+        _grantService = grantService;
+        _revocationCache = revocationCache;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<JwtCredentialResult> ValidateAsync(
+        string token, CancellationToken cancellationToken = default)
+    {
+        var validation = _jwtService.ValidateAccessToken(token);
+        if (!validation.IsValid || validation.Claims is null)
+        {
+            _logger.LogDebug("JWT validation failed: {Error}", validation.Error);
+            return JwtCredentialResult.Refused(
+                JwtCredentialRejection.Invalid, validation.Error ?? "Invalid token");
+        }
+
+        var claims = validation.Claims;
+
+        if (claims.GrantId.HasValue)
+        {
+            // A grant-bound token is always minted with its grant's tenant pin. One arriving
+            // without a pin cannot have its grant looked up, so it cannot be shown to be live.
+            if (!claims.TenantId.HasValue)
+            {
+                _logger.LogWarning(
+                    "Access token carries grant {GrantId} without a tenant pin", claims.GrantId);
+                return JwtCredentialResult.Refused(
+                    JwtCredentialRejection.Revoked, "Token has been revoked");
+            }
+
+            if (await _grantService.IsGrantRevokedAsync(claims.GrantId.Value, claims.TenantId.Value))
+            {
+                _logger.LogDebug(
+                    "Access token's grant has been revoked (grant: {GrantId})", claims.GrantId);
+                return JwtCredentialResult.Refused(
+                    JwtCredentialRejection.Revoked, "Token has been revoked");
+            }
+        }
+
+        if (!string.IsNullOrEmpty(claims.JwtId)
+            && await _revocationCache.IsRevokedAsync(claims.JwtId))
+        {
+            _logger.LogDebug("Access token has been revoked (jti: {Jti})", claims.JwtId);
+            return JwtCredentialResult.Refused(
+                JwtCredentialRejection.Revoked, "Token has been revoked");
+        }
+
+        return JwtCredentialResult.Valid(claims);
+    }
+}

--- a/src/API/Nocturne.API/Services/Auth/JwtCredentialValidator.cs
+++ b/src/API/Nocturne.API/Services/Auth/JwtCredentialValidator.cs
@@ -5,11 +5,13 @@ namespace Nocturne.API.Services.Auth;
 /// <summary>
 /// Validates a bearer JWT down to the point where a transport has to decide for itself.
 ///
-/// Four call sites used to run this chain independently — the HTTP handler, the SignalR hub
-/// authorizer, the overview hub's in-band authorize, and token introspection — and they had
-/// drifted: the overview hub checked the revocation cache but never asked whether the token's
-/// GRANT had been revoked, so disconnecting a connected app left its hub connections authorized
-/// until the access token expired.
+/// The HTTP handler, the SignalR hub authorizer and the overview hub's in-band authorize each ran
+/// this chain independently, in three different orders, and had drifted: the overview hub checked
+/// the revocation cache but never asked whether the token's GRANT had been revoked. Nothing
+/// reachable got past it — every grant-bound token is minted with its grant's tenant pin and that
+/// hub refuses pinned tokens — but the divergence was invisible and free to widen. Token
+/// introspection still carries its own copy; it answers a different question (describing a token
+/// rather than admitting one) and is left for a follow-up.
 ///
 /// The tenant pin is deliberately NOT decided here. The three transports disagree on purpose: an
 /// HTTP request accepts an unpinned token because <c>MemberScopeMiddleware</c> re-resolves
@@ -110,7 +112,7 @@ public sealed class JwtCredentialValidator : IJwtCredentialValidator
                     JwtCredentialRejection.Revoked, "Token has been revoked");
             }
 
-            if (await _grantService.IsGrantRevokedAsync(claims.GrantId.Value, claims.TenantId.Value))
+            if (await _grantService.IsGrantRevokedAsync(claims.GrantId.Value, claims.TenantId.Value, cancellationToken))
             {
                 _logger.LogDebug(
                     "Access token's grant has been revoked (grant: {GrantId})", claims.GrantId);
@@ -120,7 +122,7 @@ public sealed class JwtCredentialValidator : IJwtCredentialValidator
         }
 
         if (!string.IsNullOrEmpty(claims.JwtId)
-            && await _revocationCache.IsRevokedAsync(claims.JwtId))
+            && await _revocationCache.IsRevokedAsync(claims.JwtId, cancellationToken))
         {
             _logger.LogDebug("Access token has been revoked (jti: {Jti})", claims.JwtId);
             return JwtCredentialResult.Refused(

--- a/src/API/Nocturne.API/Services/Identity/AuthorizationService.cs
+++ b/src/API/Nocturne.API/Services/Identity/AuthorizationService.cs
@@ -153,9 +153,8 @@ public class AuthorizationService : IAuthorizationService, IDisposable
 
         var grant = await _dbContext.OAuthGrants
             .AsNoTracking()
-            .Where(g => g.TokenHash == tokenHash
-                     && g.GrantType == OAuthGrantTypes.Direct
-                     && g.RevokedAt == null)
+            .Where(g => g.TokenHash == tokenHash)
+            .Where(DirectGrantTokenHandler.IsLiveDirectGrant(DateTime.UtcNow))
             .FirstOrDefaultAsync();
 
         if (grant == null)

--- a/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
+++ b/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
@@ -59,7 +59,6 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
 {
     private readonly IJwtService _jwtService;
     private readonly IJwtCredentialValidator _credentialValidator;
-    private readonly IOAuthGrantService _grantService;
     private readonly IAuthorizationService _authorizationService;
     private readonly ITenantMemberService _memberService;
     private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;
@@ -70,7 +69,6 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
     public HubTokenAuthorizer(
         IJwtService jwtService,
         IJwtCredentialValidator credentialValidator,
-        IOAuthGrantService grantService,
         IAuthorizationService authorizationService,
         ITenantMemberService memberService,
         IDbContextFactory<NocturneDbContext> dbContextFactory,
@@ -80,7 +78,6 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
     {
         _jwtService = jwtService;
         _credentialValidator = credentialValidator;
-        _grantService = grantService;
         _authorizationService = authorizationService;
         _memberService = memberService;
         _dbContextFactory = dbContextFactory;

--- a/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
+++ b/src/API/Nocturne.API/Services/Identity/HubTokenAuthorizer.cs
@@ -8,6 +8,7 @@ using Nocturne.Core.Contracts.Identity;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
+using Nocturne.API.Services.Auth;
 
 namespace Nocturne.API.Services.Identity;
 
@@ -57,7 +58,7 @@ public interface IHubTokenAuthorizer
 public class HubTokenAuthorizer : IHubTokenAuthorizer
 {
     private readonly IJwtService _jwtService;
-    private readonly IOAuthTokenRevocationCache _revocationCache;
+    private readonly IJwtCredentialValidator _credentialValidator;
     private readonly IOAuthGrantService _grantService;
     private readonly IAuthorizationService _authorizationService;
     private readonly ITenantMemberService _memberService;
@@ -68,7 +69,7 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
 
     public HubTokenAuthorizer(
         IJwtService jwtService,
-        IOAuthTokenRevocationCache revocationCache,
+        IJwtCredentialValidator credentialValidator,
         IOAuthGrantService grantService,
         IAuthorizationService authorizationService,
         ITenantMemberService memberService,
@@ -78,7 +79,7 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
         ILogger<HubTokenAuthorizer> logger)
     {
         _jwtService = jwtService;
-        _revocationCache = revocationCache;
+        _credentialValidator = credentialValidator;
         _grantService = grantService;
         _authorizationService = authorizationService;
         _memberService = memberService;
@@ -152,14 +153,15 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
     private async Task<HubAuthorization?> AuthorizeJwtAsync(
         string token, Guid connectionTenantId, string requiredScope)
     {
-        var validation = _jwtService.ValidateAccessToken(token);
-        if (!validation.IsValid || validation.Claims is null)
+        var validation = await _credentialValidator.ValidateAsync(token);
+        if (!validation.IsValid)
         {
-            _logger.LogDebug("Hub JWT validation failed: {Error}", validation.Error);
+            _logger.LogDebug(
+                "Hub token refused ({Rejection}): {Error}", validation.Rejection, validation.Error);
             return null;
         }
 
-        var claims = validation.Claims;
+        var claims = validation.Claims!;
 
         // Unlike the HTTP handler, an unpinned (null-tenant) JWT is rejected outright: the hub
         // group is tenant-scoped and there is no per-request middleware to re-check access.
@@ -168,21 +170,6 @@ public class HubTokenAuthorizer : IHubTokenAuthorizer
             _logger.LogWarning(
                 "Hub JWT tenant mismatch: token tenant {TokenTenant}, connection tenant {ConnectionTenant}",
                 claims.TenantId, connectionTenantId);
-            return null;
-        }
-
-        if (!string.IsNullOrEmpty(claims.JwtId)
-            && await _revocationCache.IsRevokedAsync(claims.JwtId))
-        {
-            _logger.LogDebug("Hub JWT has been revoked (jti: {Jti})", claims.JwtId);
-            return null;
-        }
-
-        // A grant revocation reaches outstanding access tokens through the grant id they carry.
-        if (claims.GrantId.HasValue
-            && await _grantService.IsGrantRevokedAsync(claims.GrantId.Value, connectionTenantId))
-        {
-            _logger.LogDebug("Hub JWT's grant has been revoked (grant: {GrantId})", claims.GrantId);
             return null;
         }
 

--- a/tests/Unit/Nocturne.API.Tests/Hubs/OverviewHubAuthorizeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Hubs/OverviewHubAuthorizeTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Hubs;
+using Nocturne.API.Services.Auth;
 using Nocturne.API.Services.Identity;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -44,14 +45,27 @@ public class OverviewHubAuthorizeTests
         Mock<ITenantOverviewService> overview,
         Mock<IJwtService> jwt,
         Mock<IOAuthTokenRevocationCache> revocation,
+        Mock<IOAuthGrantService> grants,
         DefaultHttpContext httpContext) CreateHub()
     {
         var overview = new Mock<ITenantOverviewService>();
         var jwt = new Mock<IJwtService>();
         var revocation = new Mock<IOAuthTokenRevocationCache>();
+        var grants = new Mock<IOAuthGrantService>();
+
+        // The real validator, not a stub: these tests are the coverage for the hub's credential
+        // chain, and stubbing it would stop them seeing the grant-revocation check the hub used to
+        // skip. Unrevoked is the default so existing cases read unchanged.
+        grants
+            .Setup(g => g.IsGrantRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>()))
+            .ReturnsAsync(false);
+
+        var validator = new JwtCredentialValidator(
+            jwt.Object, grants.Object, revocation.Object,
+            NullLogger<JwtCredentialValidator>.Instance);
 
         var hub = new OverviewHub(
-            NullLogger<OverviewHub>.Instance, overview.Object, jwt.Object, revocation.Object);
+            NullLogger<OverviewHub>.Instance, overview.Object, validator);
 
         var httpContext = new DefaultHttpContext();
 
@@ -67,7 +81,7 @@ public class OverviewHubAuthorizeTests
 
         hub.Context = callerContext.Object;
         hub.Groups = groups.Object;
-        return (hub, groups, overview, jwt, revocation, httpContext);
+        return (hub, groups, overview, jwt, revocation, grants, httpContext);
     }
 
     private static JwtValidationResult ValidJwt(
@@ -85,7 +99,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_session_authcontext_joins_per_tenant_overview_groups()
     {
-        var (hub, groups, overview, _, _, httpContext) = CreateHub();
+        var (hub, groups, overview, _, _, _, httpContext) = CreateHub();
         httpContext.Items["AuthContext"] = new AuthContext
         {
             IsAuthenticated = true,
@@ -121,7 +135,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_session_authcontext_passes_the_credential_type_to_the_seam()
     {
-        var (hub, _, overview, _, _, httpContext) = CreateHub();
+        var (hub, _, overview, _, _, _, httpContext) = CreateHub();
         httpContext.Items["AuthContext"] = new AuthContext
         {
             IsAuthenticated = true,
@@ -145,7 +159,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_jwt_payload_passes_the_oauth_credential_type_to_the_seam()
     {
-        var (hub, _, overview, jwt, revocation, _) = CreateHub();
+        var (hub, _, overview, jwt, revocation, _, _) = CreateHub();
         jwt.Setup(j => j.ValidateAccessToken(JwtShapedToken))
             .Returns(ValidJwt(Subject, Scope.GlucoseRead));
         revocation.Setup(r => r.IsRevokedAsync("jti-1")).ReturnsAsync(false);
@@ -168,7 +182,7 @@ public class OverviewHubAuthorizeTests
         // The seam treats these as the credential's ceiling, so they have to arrive expanded the way
         // every other JWT-claims consumer expands them: the health.read alias becomes the concrete
         // scopes it stands for, and an unrecognized scope is dropped.
-        var (hub, _, overview, jwt, revocation, _) = CreateHub();
+        var (hub, _, overview, jwt, revocation, _, _) = CreateHub();
         jwt.Setup(j => j.ValidateAccessToken(JwtShapedToken))
             .Returns(ValidJwt(Subject, Scope.HealthRead, "not.a.scope"));
         revocation.Setup(r => r.IsRevokedAsync("jti-1")).ReturnsAsync(false);
@@ -202,7 +216,7 @@ public class OverviewHubAuthorizeTests
     [InlineData(AuthType.InstanceKey)]
     public async Task Authorize_with_tenant_bound_credential_type_is_rejected(AuthType authType)
     {
-        var (hub, groups, overview, _, _, httpContext) = CreateHub();
+        var (hub, groups, overview, _, _, _, httpContext) = CreateHub();
         httpContext.Items["AuthContext"] = new AuthContext
         {
             IsAuthenticated = true,
@@ -238,7 +252,7 @@ public class OverviewHubAuthorizeTests
         // A member browsing a tenant subdomain has a resolved TenantContext on the upgrade
         // request; the guard keys on the credential type, not on a resolved tenant, so their
         // ordinary session still opens the cross-tenant overview.
-        var (hub, groups, overview, _, _, httpContext) = CreateHub();
+        var (hub, groups, overview, _, _, _, httpContext) = CreateHub();
         httpContext.Items["TenantContext"] =
             new TenantContext(TenantA, "tenant-a", "Tenant A", true, false);
         httpContext.Items["AuthContext"] = new AuthContext
@@ -263,7 +277,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_valid_jwt_joins_groups_using_subject_and_scopes_from_claims()
     {
-        var (hub, groups, overview, jwt, revocation, _) = CreateHub();
+        var (hub, groups, overview, jwt, revocation, _, _) = CreateHub();
         jwt.Setup(j => j.ValidateAccessToken(JwtShapedToken))
             .Returns(ValidJwt(Subject, Scope.GlucoseRead));
         revocation.Setup(r => r.IsRevokedAsync("jti-1")).ReturnsAsync(false);
@@ -289,7 +303,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_revoked_jwt_is_rejected()
     {
-        var (hub, groups, _, jwt, revocation, _) = CreateHub();
+        var (hub, groups, _, jwt, revocation, _, _) = CreateHub();
         jwt.Setup(j => j.ValidateAccessToken(JwtShapedToken))
             .Returns(ValidJwt(Subject, Scope.GlucoseRead));
         revocation.Setup(r => r.IsRevokedAsync("jti-1")).ReturnsAsync(true);
@@ -305,7 +319,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_invalid_jwt_is_rejected()
     {
-        var (hub, groups, _, jwt, _, _) = CreateHub();
+        var (hub, groups, _, jwt, _, _, _) = CreateHub();
         jwt.Setup(j => j.ValidateAccessToken(JwtShapedToken))
             .Returns(JwtValidationResult.Failure("expired", JwtValidationError.Expired));
 
@@ -320,7 +334,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_opaque_token_is_rejected_without_jwt_validation()
     {
-        var (hub, groups, _, jwt, _, _) = CreateHub();
+        var (hub, groups, _, jwt, _, _, _) = CreateHub();
 
         var result = await hub.Authorize(new OverviewAuthorizeRequest { Token = "opaque-legacy-token" });
 
@@ -335,7 +349,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_without_session_or_token_is_rejected()
     {
-        var (hub, groups, _, _, _, _) = CreateHub();
+        var (hub, groups, _, _, _, _, _) = CreateHub();
 
         var result = await hub.Authorize(new OverviewAuthorizeRequest());
 
@@ -348,7 +362,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_no_qualifying_tenants_succeeds_with_empty_list_and_no_groups()
     {
-        var (hub, groups, overview, jwt, revocation, _) = CreateHub();
+        var (hub, groups, overview, jwt, revocation, _, _) = CreateHub();
         jwt.Setup(j => j.ValidateAccessToken(JwtShapedToken))
             .Returns(ValidJwt(Subject /* no glucose scope */));
         revocation.Setup(r => r.IsRevokedAsync("jti-1")).ReturnsAsync(false);
@@ -368,7 +382,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_tenant_pinned_jwt_is_rejected()
     {
-        var (hub, groups, overview, jwt, revocation, _) = CreateHub();
+        var (hub, groups, overview, jwt, revocation, _, _) = CreateHub();
         var validation = ValidJwt(Subject, Scope.GlucoseRead);
         validation.Claims!.TenantId = TenantA;
         jwt.Setup(j => j.ValidateAccessToken(JwtShapedToken)).Returns(validation);
@@ -390,7 +404,7 @@ public class OverviewHubAuthorizeTests
     public async Task Authorize_with_unauthenticated_authcontext_carrying_subject_is_rejected()
     {
         // The public-share pseudo-context shape: IsAuthenticated = false but a non-null SubjectId.
-        var (hub, groups, overview, _, _, httpContext) = CreateHub();
+        var (hub, groups, overview, _, _, _, httpContext) = CreateHub();
         httpContext.Items["AuthContext"] = new AuthContext
         {
             IsAuthenticated = false,
@@ -412,7 +426,7 @@ public class OverviewHubAuthorizeTests
     [Fact]
     public async Task Authorize_with_jwt_lacking_subject_is_rejected()
     {
-        var (hub, groups, _, jwt, revocation, _) = CreateHub();
+        var (hub, groups, _, jwt, revocation, _, _) = CreateHub();
         jwt.Setup(j => j.ValidateAccessToken(JwtShapedToken))
             .Returns(ValidJwt(Guid.Empty, Scope.GlucoseRead));
         revocation.Setup(r => r.IsRevokedAsync("jti-1")).ReturnsAsync(false);

--- a/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/OAuthAccessTokenHandlerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/Handlers/OAuthAccessTokenHandlerTests.cs
@@ -15,6 +15,7 @@ using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Xunit;
+using Microsoft.Extensions.Logging;
 
 namespace Nocturne.API.Tests.Middleware.Handlers;
 
@@ -56,6 +57,11 @@ public class OAuthAccessTokenHandlerTests
         services.AddSingleton(_jwt);
         services.AddSingleton(revocationCache.Object);
         services.AddSingleton(_grantService.Object);
+        // The real chain, matching the composition root: stubbing it here would stop these tests
+        // covering the grant and revocation links the handler now delegates.
+        services.AddScoped<IJwtCredentialValidator, JwtCredentialValidator>();
+        services.AddSingleton<ILogger<JwtCredentialValidator>>(
+            NullLogger<JwtCredentialValidator>.Instance);
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
         _handler = new OAuthAccessTokenHandler(scopeFactory, NullLogger<OAuthAccessTokenHandler>.Instance);

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/JwtCredentialValidatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/JwtCredentialValidatorTests.cs
@@ -180,4 +180,24 @@ public class JwtCredentialValidatorTests
         result.IsValid.Should().BeTrue();
         _revocation.Verify(r => r.IsRevokedAsync(It.IsAny<string>()), Times.Never);
     }
+
+    /// <summary>
+    /// Both downstream calls accept a token and a caller can abandon a request mid-chain; the
+    /// forwarding is otherwise invisible, since a mock matching any token cannot tell whether one
+    /// was passed.
+    /// </summary>
+    [Fact]
+    public async Task The_caller_s_cancellation_token_reaches_both_downstream_lookups()
+    {
+        TokenValidatesAs(TenantId, GrantId);
+        var validator = CreateValidator();
+        using var cts = new CancellationTokenSource();
+
+        await validator.ValidateAsync(Token, cts.Token);
+
+        _grants.Verify(
+            g => g.IsGrantRevokedAsync(GrantId, TenantId, cts.Token), Times.Once);
+        _revocation.Verify(
+            r => r.IsRevokedAsync("jti-1", cts.Token), Times.Once);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/JwtCredentialValidatorTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/JwtCredentialValidatorTests.cs
@@ -1,0 +1,183 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// The chain exists so the transports cannot drift apart on what makes a bearer JWT usable. That
+/// only holds while each link is pinned: the overview hub lost its grant-revocation check once
+/// already, and nothing failed.
+/// </summary>
+[Trait("Category", "Unit")]
+public class JwtCredentialValidatorTests
+{
+    private static readonly Guid TenantId = Guid.CreateVersion7();
+    private static readonly Guid GrantId = Guid.CreateVersion7();
+    private static readonly Guid SubjectId = Guid.CreateVersion7();
+
+    private readonly Mock<IJwtService> _jwt = new();
+    private readonly Mock<IOAuthGrantService> _grants = new();
+    private readonly Mock<IOAuthTokenRevocationCache> _revocation = new();
+
+    private const string Token = "aaa.bbb.ccc";
+
+    private JwtCredentialValidator CreateValidator()
+    {
+        _grants
+            .Setup(g => g.IsGrantRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>()))
+            .ReturnsAsync(false);
+        _revocation
+            .Setup(r => r.IsRevokedAsync(It.IsAny<string>()))
+            .ReturnsAsync(false);
+
+        return new JwtCredentialValidator(
+            _jwt.Object, _grants.Object, _revocation.Object,
+            NullLogger<JwtCredentialValidator>.Instance);
+    }
+
+    private void TokenValidatesAs(Guid? tenantId, Guid? grantId, string? jwtId = "jti-1")
+    {
+        _jwt.Setup(j => j.ValidateAccessToken(Token))
+            .Returns(JwtValidationResult.Success(new JwtClaims
+            {
+                SubjectId = SubjectId,
+                Scopes = [Scope.GlucoseRead],
+                TenantId = tenantId,
+                GrantId = grantId,
+                JwtId = jwtId,
+            }));
+    }
+
+    [Fact]
+    public async Task A_live_token_is_accepted_and_carries_its_claims()
+    {
+        TokenValidatesAs(TenantId, GrantId);
+
+        var result = await CreateValidator().ValidateAsync(Token);
+
+        result.IsValid.Should().BeTrue();
+        result.Claims!.SubjectId.Should().Be(SubjectId);
+        result.Rejection.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_token_that_fails_signature_validation_is_refused_as_invalid()
+    {
+        _jwt.Setup(j => j.ValidateAccessToken(Token))
+            .Returns(JwtValidationResult.Failure("bad signature", JwtValidationError.InvalidSignature));
+
+        var result = await CreateValidator().ValidateAsync(Token);
+
+        result.IsValid.Should().BeFalse();
+        result.Rejection.Should().Be(JwtCredentialRejection.Invalid);
+    }
+
+    /// <summary>
+    /// Disconnecting a connected app can only reach its outstanding access tokens through the grant
+    /// id they carry, because the tokens themselves are stateless.
+    /// </summary>
+    [Fact]
+    public async Task A_token_whose_grant_has_been_revoked_is_refused()
+    {
+        TokenValidatesAs(TenantId, GrantId);
+        var validator = CreateValidator();
+        _grants.Setup(g => g.IsGrantRevokedAsync(GrantId, TenantId)).ReturnsAsync(true);
+
+        var result = await validator.ValidateAsync(Token);
+
+        result.IsValid.Should().BeFalse("a revoked grant must not keep authorizing its tokens");
+        result.Rejection.Should().Be(JwtCredentialRejection.Revoked);
+    }
+
+    /// <summary>
+    /// A grant-bound token is always minted with its grant's tenant pin, so one arriving without a
+    /// pin cannot have its grant looked up — and therefore cannot be shown to still be live.
+    /// </summary>
+    [Fact]
+    public async Task A_grant_bound_token_without_a_tenant_pin_is_refused()
+    {
+        TokenValidatesAs(tenantId: null, grantId: GrantId);
+
+        var result = await CreateValidator().ValidateAsync(Token);
+
+        result.IsValid.Should().BeFalse("its grant cannot be checked, so it cannot be trusted");
+        result.Rejection.Should().Be(JwtCredentialRejection.Revoked);
+    }
+
+    [Fact]
+    public async Task A_grant_bound_token_without_a_tenant_pin_is_refused_without_a_grant_lookup()
+    {
+        TokenValidatesAs(tenantId: null, grantId: GrantId);
+        var validator = CreateValidator();
+
+        await validator.ValidateAsync(Token);
+
+        _grants.Verify(
+            g => g.IsGrantRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>()),
+            Times.Never,
+            "there is no tenant to look the grant up on");
+    }
+
+    [Fact]
+    public async Task A_token_in_the_revocation_cache_is_refused()
+    {
+        TokenValidatesAs(TenantId, grantId: null);
+        var validator = CreateValidator();
+        _revocation.Setup(r => r.IsRevokedAsync("jti-1")).ReturnsAsync(true);
+
+        var result = await validator.ValidateAsync(Token);
+
+        result.IsValid.Should().BeFalse();
+        result.Rejection.Should().Be(JwtCredentialRejection.Revoked);
+    }
+
+    /// <summary>
+    /// A token with no grant behind it is the ordinary subject-scoped case and must not be refused
+    /// for want of one.
+    /// </summary>
+    [Fact]
+    public async Task A_token_with_no_grant_is_accepted_without_a_grant_lookup()
+    {
+        TokenValidatesAs(TenantId, grantId: null);
+        var validator = CreateValidator();
+
+        var result = await validator.ValidateAsync(Token);
+
+        result.IsValid.Should().BeTrue();
+        _grants.Verify(
+            g => g.IsGrantRevokedAsync(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Never);
+    }
+
+    /// <summary>
+    /// The tenant pin is the caller's decision, not the chain's — the transports disagree on it by
+    /// design, so a pinned token must survive validation and leave the pin to be judged upstream.
+    /// </summary>
+    [Fact]
+    public async Task The_tenant_pin_is_left_for_the_caller_to_judge()
+    {
+        TokenValidatesAs(TenantId, grantId: null);
+
+        var result = await CreateValidator().ValidateAsync(Token);
+
+        result.IsValid.Should().BeTrue();
+        result.Claims!.TenantId.Should().Be(TenantId,
+            "the caller applies its own pin policy against this");
+    }
+
+    [Fact]
+    public async Task A_token_with_no_jti_is_not_looked_up_in_the_revocation_cache()
+    {
+        TokenValidatesAs(TenantId, grantId: null, jwtId: null);
+        var validator = CreateValidator();
+
+        var result = await validator.ValidateAsync(Token);
+
+        result.IsValid.Should().BeTrue();
+        _revocation.Verify(r => r.IsRevokedAsync(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/AuthorizationServiceTokenExchangeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/AuthorizationServiceTokenExchangeTests.cs
@@ -77,7 +77,11 @@ public class AuthorizationServiceTokenExchangeTests : IDisposable
         _connection.Dispose();
     }
 
-    private void SeedGrant(string token, DateTime? revokedAt = null, List<string>? scopes = null)
+    private void SeedGrant(
+        string token,
+        DateTime? revokedAt = null,
+        List<string>? scopes = null,
+        DateTime? expiresAt = null)
     {
         _dbContext.OAuthGrants.Add(new OAuthGrantEntity
         {
@@ -89,6 +93,7 @@ public class AuthorizationServiceTokenExchangeTests : IDisposable
             Scopes = scopes ?? ["glucose.read", "treatments.readwrite"],
             CreatedAt = DateTime.UtcNow,
             RevokedAt = revokedAt,
+            ExpiresAt = expiresAt,
         });
         _dbContext.SaveChanges();
     }
@@ -222,5 +227,36 @@ public class AuthorizationServiceTokenExchangeTests : IDisposable
         Assert.NotNull(result);
         Assert.Equal("legacy.jwt.token", result!.Token);
         Assert.Equal("aaps-uploader", result.Sub);
+    }
+
+    /// <summary>
+    /// The exchange restated the "usable grant" predicate and left the expiry term out, so a grant
+    /// the bearer handler and both hubs refused could still be traded here for a fresh one-hour
+    /// JWT — outliving its own expiry by the lifetime of whatever it minted.
+    /// </summary>
+    [Fact]
+    public async Task Expired_direct_grant_is_not_exchangeable()
+    {
+        const string token = "noc_expired";
+        SeedGrant(token, expiresAt: DateTime.UtcNow.AddMinutes(-1));
+        SetupActiveSubject();
+        SetupMintedJwt();
+
+        var result = await _authorizationService.GenerateJwtFromAccessTokenAsync(token);
+
+        result.Should().BeNull("an expired grant must not mint a token that outlives it");
+    }
+
+    [Fact]
+    public async Task Direct_grant_expiring_in_the_future_is_still_exchangeable()
+    {
+        const string token = "noc_live";
+        SeedGrant(token, expiresAt: DateTime.UtcNow.AddHours(1));
+        SetupActiveSubject();
+        SetupMintedJwt();
+
+        var result = await _authorizationService.GenerateJwtFromAccessTokenAsync(token);
+
+        result.Should().NotBeNull("an unexpired grant is still usable");
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
@@ -16,6 +16,7 @@ using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Xunit;
+using Nocturne.API.Services.Auth;
 
 namespace Nocturne.API.Tests.Services.Identity;
 
@@ -52,9 +53,17 @@ public class HubTokenAuthorizerTests
             .BuildServiceProvider()
             .GetRequiredService<IDbContextFactory<NocturneDbContext>>();
 
+    // The real validator, not a stub: these tests are this path's coverage for the shared credential
+    // chain, and stubbing it would hide the grant and revocation links behind a mock.
+    private JwtCredentialValidator CreateCredentialValidator() => new(
+        _jwtService.Object,
+        _grantService.Object,
+        _revocationCache.Object,
+        NullLogger<JwtCredentialValidator>.Instance);
+
     private HubTokenAuthorizer CreateAuthorizer(IConfiguration? configuration = null) => new(
         _jwtService.Object,
-        _revocationCache.Object,
+        CreateCredentialValidator(),
         _grantService.Object,
         _authorizationService.Object,
         _memberService.Object,

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/HubTokenAuthorizerTests.cs
@@ -64,7 +64,6 @@ public class HubTokenAuthorizerTests
     private HubTokenAuthorizer CreateAuthorizer(IConfiguration? configuration = null) => new(
         _jwtService.Object,
         CreateCredentialValidator(),
-        _grantService.Object,
         _authorizationService.Object,
         _memberService.Object,
         _dbContextFactory,


### PR DESCRIPTION
The bearer-JWT chain — validate, refuse a grant-bound token with no tenant pin, check grant revocation, check the jti cache — ran independently at three call sites in three different internal orders, and had drifted. `JwtCredentialValidator` holds it once.

## The tenant pin stays with the caller

Deliberately not folded in. The three transports disagree on purpose:

- **HTTP** accepts an unpinned token, because `MemberScopeMiddleware` re-resolves membership on every request.
- **A tenant hub** requires the pin to match its connection, because nothing re-checks after the handshake.
- **The overview hub** requires the token to be *unpinned*, because it spans every tenant the subject belongs to.

Folding those into one rule would erase a distinction each site chose. Callers read `TenantId` off the result and apply their own.

## The reachable bug

`/api/v2/authorization/request/{token}` restated the "usable direct grant" predicate and left out the expiry term, so a grant the bearer handler and both hubs all refused could still be traded for a fresh one-hour JWT — outliving its own expiry by the lifetime of whatever it minted. Both paths now share `IsLiveDirectGrant`.

Reproduced before fixing: reverting just that predicate reddens `Expired_direct_grant_is_not_exchangeable`.

## What is *not* a bug

`OverviewHub` gains a grant-revocation check it never had, but nothing reachable got past it. Every grant-bound token is minted with its grant's tenant pin (`OAuthGrantEntity.TenantId` is non-nullable, and all three mint sites pass it), and that hub refuses pinned tokens. This is hardening plus drift-prevention, not a fix.

Token introspection keeps its own copy. It answers a different question — describing a token rather than admitting one — so folding it in on a guess would be the wrong move.

## Tests

`JwtCredentialValidatorTests` pins each link. That matters more than usual here: on the first pass the module's own grant-revocation and grant-without-pin checks could both be **deleted with the entire 6,034-test suite still green**, because no test's claims carried a grant id. Both mutations now redden tests that name the property, across all three call sites.

The handler and hub tests build the real validator rather than stubbing it, so the links stay covered where they are actually reached.

## Follow-ups, not here

- The exchange's tenant scoping rests on the global query filter and no test covers a cross-tenant case — adding `IgnoreQueryFilters()` there passes everything. Pre-existing, and this diff only narrows what is exchangeable.
- Still duplicated and deferred: 7 copies of bearer-token extraction, 6 private SHA-256 helpers, 4 `UpdateLastUsedAsync` implementations, 3 different "is this a JWT?" predicates.