### PR TITLE
fix(auth): say why enrolling an authenticator was refused

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
@@ -81,6 +81,15 @@ public class TotpController : ControllerBase
     }
 
     /// <summary>
+    /// The 400 for a refused enrolment. <c>detail</c> carries the <see cref="TotpSetupFailure"/>
+    /// value rather than a sentence: the generated remote wrapper forwards <c>detail</c> and drops
+    /// the rest of the body, so it is the only channel to the browser, and the wording is the web
+    /// app's to choose.
+    /// </summary>
+    private ObjectResult Refused(TotpSetupFailure failure)
+        => Problem(detail: failure.ToString(), statusCode: 400, title: "Bad Request");
+
+    /// <summary>
     /// Generate TOTP setup data including provisioning URI and secret.
     /// </summary>
     /// <returns>A <see cref="TotpSetupResponse"/> containing the provisioning URI, base32 secret, and challenge token.</returns>
@@ -90,12 +99,13 @@ public class TotpController : ControllerBase
     /// <see cref="VerifySetup"/> along with a valid 6-digit code to complete setup.
     /// </remarks>
     /// <response code="200">TOTP setup data generated.</response>
-    /// <response code="400">No primary factor configured, or user account not found.</response>
+    /// <response code="400">Setup refused; <c>detail</c> is a <c>TotpSetupFailure</c> value.</response>
     /// <response code="401">Not authenticated.</response>
     [HttpPost("setup")]
     [DenyDemoSubject]
     [RemoteCommand]
     [ProducesResponseType(typeof(TotpSetupResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<TotpSetupResponse>> Setup()
     {
@@ -105,19 +115,13 @@ public class TotpController : ControllerBase
 
         var subject = await _subjectService.GetSubjectByIdAsync(auth.SubjectId.Value);
         if (subject == null)
-            return Problem(detail: "User account not found", statusCode: 400, title: "Bad Request");
+            return Refused(TotpSetupFailure.SubjectNotFound);
 
         // TOTP is a second factor; require at least one primary factor (passkey or OIDC link)
         // so a user cannot end up with only TOTP configured.
         var primaryFactorCount = await _subjectService.CountPrimaryAuthFactorsAsync(auth.SubjectId.Value);
         if (primaryFactorCount < 1)
-        {
-            return BadRequest(new
-            {
-                error = "no_primary_factor",
-                message = "Configure a passkey or linked sign-in method before enabling TOTP",
-            });
-        }
+            return Refused(TotpSetupFailure.NoPrimaryFactor);
 
         var result = await _totpService.GenerateSetupAsync(auth.SubjectId.Value, subject.Name);
 
@@ -162,10 +166,7 @@ public class TotpController : ControllerBase
         }
         catch (TotpSetupException ex)
         {
-            // detail carries the TotpSetupFailure value, not a sentence. The generated remote
-            // wrapper forwards detail and drops the rest of the body, so it is the only channel
-            // to the browser, and the wording is the web app's to choose.
-            return Problem(detail: ex.Failure.ToString(), statusCode: 400, title: "Bad Request");
+            return Refused(ex.Failure);
         }
     }
 

--- a/src/Core/Nocturne.Core.Contracts/Auth/ITotpService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/ITotpService.cs
@@ -75,8 +75,8 @@ public record TotpLoginResult(Guid SubjectId, string Username, string DisplayNam
 public record TotpCredentialInfo(Guid Id, string? Label, DateTime CreatedAt, DateTime? LastUsedAt);
 
 /// <summary>
-/// Why a TOTP setup attempt was refused. The wording belongs to whichever client is asking, so
-/// the service names the check that refused and nothing else.
+/// Why enrolling an authenticator was refused, at either end of the flow. The wording belongs to
+/// whichever client is asking, so the server names the check that refused and nothing else.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter<TotpSetupFailure>))]
 public enum TotpSetupFailure
@@ -89,10 +89,23 @@ public enum TotpSetupFailure
 
     /// <summary>The challenge token was readable but past its expiry.</summary>
     ChallengeExpired,
+
+    /// <summary>
+    /// No passkey or linked provider is configured, so TOTP would be the only factor. Raised when
+    /// setup starts, not when it completes.
+    /// </summary>
+    NoPrimaryFactor,
+
+    /// <summary>
+    /// The session names a subject the store no longer holds. Raised when setup starts, not when
+    /// it completes.
+    /// </summary>
+    SubjectNotFound,
 }
 
 /// <summary>
-/// Thrown when <see cref="ITotpService.CompleteSetupAsync"/> refuses an attempt.
+/// Thrown when <see cref="ITotpService.CompleteSetupAsync"/> refuses an attempt. It carries only
+/// the failures that completing can raise, not the ones that refuse setup before it starts.
 /// <see cref="Failure"/> is the whole answer; the message is for logs.
 /// </summary>
 public class TotpSetupException : Exception

--- a/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
+++ b/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
@@ -11,7 +11,9 @@ import { remoteErrorMessage } from "./remote-error";
 import { TotpSetupFailure } from "$api-clients";
 import {
   describeTotpSetupError,
+  describeTotpSetupStartError,
   TOTP_SETUP_FALLBACK,
+  TOTP_SETUP_START_FALLBACK,
 } from "../components/account/totp-errors";
 
 /**
@@ -285,5 +287,32 @@ describe("a refused authenticator setup", () => {
 
     expect(describeAsThePageDoes(crossed)).toBe(TOTP_SETUP_FALLBACK);
     expect(TOTP_SETUP_FALLBACK.trim()).not.toBe("");
+  });
+});
+
+describe("an authenticator setup that was refused before it started", () => {
+  it("says which primary factor to add rather than naming a server error", async () => {
+    const crossed = await crossTheBoundary(
+      problemDetails(400, TotpSetupFailure.NoPrimaryFactor, "Bad Request")
+    );
+
+    // What the endpoint sent before it declared a 400 response type.
+    expect(describeTotpSetupStartError(crossed)).not.toContain("error occurred");
+    expect(describeTotpSetupStartError(crossed)).toContain("passkey");
+  });
+
+  it("does not tell someone to check a code they were never asked for", async () => {
+    const crossed = await crossTheBoundary(
+      problemDetails(400, TotpSetupFailure.NoPrimaryFactor, "Bad Request")
+    );
+
+    expect(describeTotpSetupStartError(crossed)).not.toBe(TOTP_SETUP_FALLBACK);
+  });
+
+  it("falls back on its own wording, not the verify step's", async () => {
+    const crossed = await crossTheBoundary(nswagApiException(503, "unavailable"));
+
+    expect(describeTotpSetupStartError(crossed)).toBe(TOTP_SETUP_START_FALLBACK);
+    expect(TOTP_SETUP_START_FALLBACK.trim()).not.toBe("");
   });
 });

--- a/src/Web/packages/app/src/lib/components/account/totp-errors.ts
+++ b/src/Web/packages/app/src/lib/components/account/totp-errors.ts
@@ -2,9 +2,9 @@
  * Turns a refused authenticator setup into something a person can act on.
  *
  * The server names the check that refused — `TotpSetupFailure` — and never the
- * wording, so the copy lives here. `verify-setup` carries the value as the
- * `detail` of its 400, which the generated remote wrapper forwards as the
- * thrown `HttpError`'s `body.message`.
+ * wording, so the copy lives here. Both `setup` and `verify-setup` carry the
+ * value as the `detail` of their 400, which the generated remote wrapper
+ * forwards as the thrown `HttpError`'s `body.message`.
  */
 
 import { TotpSetupFailure } from "$api-clients";
@@ -18,6 +18,10 @@ const SETUP_FAILURES: Record<TotpSetupFailure, string> = {
     "That code wasn't accepted. Check your authenticator app and try again.",
   [TotpSetupFailure.ChallengeUnreadable]: `This two-factor setup is no longer valid. ${RESTART_SETUP}`,
   [TotpSetupFailure.ChallengeExpired]: `This two-factor setup took too long. ${RESTART_SETUP}`,
+  [TotpSetupFailure.NoPrimaryFactor]:
+    "Add a passkey or link a sign-in provider first. An authenticator app is a second step, not a way in on its own.",
+  [TotpSetupFailure.SubjectNotFound]:
+    "We couldn't load your account. Sign out and back in, then try again.",
 };
 
 function setupFailure(err: unknown): TotpSetupFailure | undefined {
@@ -29,9 +33,13 @@ function setupFailure(err: unknown): TotpSetupFailure | undefined {
     : undefined;
 }
 
-/** Shown when nothing more specific applies. */
+/** Shown when completing setup fails for a reason we can't name. */
 export const TOTP_SETUP_FALLBACK =
   "Verification failed. Check the code and try again.";
+
+/** Shown when starting setup fails for a reason we can't name. */
+export const TOTP_SETUP_START_FALLBACK =
+  "We couldn't start authenticator setup. Please try again.";
 
 /**
  * @param err The thrown value.
@@ -50,4 +58,14 @@ export function describeTotpSetupError(
   if (errorStatus(err) === 400) return fallback;
 
   return describeSubmitError(err, fallback);
+}
+
+/**
+ * The same map for the call that *starts* enrolment, which refuses for its own
+ * reasons and so carries its own fallback.
+ *
+ * @param err The thrown value.
+ */
+export function describeTotpSetupStartError(err: unknown): string {
+  return describeTotpSetupError(err, TOTP_SETUP_START_FALLBACK);
 }

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
@@ -48,7 +48,10 @@
     parseCeremonyOptions,
   } from "$lib/components/auth/passkey-errors";
   import { describeSubmitError } from "$lib/forms/submit-error";
-  import { describeTotpSetupError } from "$lib/components/account/totp-errors";
+  import {
+    describeTotpSetupError,
+    describeTotpSetupStartError,
+  } from "$lib/components/account/totp-errors";
   import { page } from "$app/state";
   import { copyToClipboard } from "$lib/utils";
 
@@ -285,7 +288,7 @@
 
       showTotpSetup = true;
     } catch (err) {
-      errorMessage = describeSubmitError(err, "Failed to start authenticator setup.");
+      errorMessage = describeTotpSetupStartError(err);
     } finally {
       totpSetupLoading = false;
     }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/TotpControllerSetupFailureTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/TotpControllerSetupFailureTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -8,6 +9,7 @@ using Nocturne.API.Controllers.Authentication;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
+using Subject = Nocturne.Core.Models.Authorization.Subject;
 using Nocturne.Core.Models.Configuration;
 using Xunit;
 
@@ -75,6 +77,80 @@ public class TotpControllerSetupFailureTests
         problem.Status.Should().Be(400);
         problem.Detail.Should().Be(failure.ToString(),
             "the web app matches this against the generated TotpSetupFailure enum");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Setup_WithNoPrimaryFactor_AnswersWithTheFailureValue()
+    {
+        _subjectService
+            .Setup(s => s.GetSubjectByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new Subject { Id = Guid.CreateVersion7(), Name = "rhys" });
+        _subjectService
+            .Setup(s => s.CountPrimaryAuthFactorsAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(0);
+
+        var result = await CreateController().Setup();
+
+        var problem = result.Result.Should().BeOfType<ObjectResult>()
+            .Which.Value.Should().BeOfType<ProblemDetails>(
+                "an anonymous body carries no detail, so nothing reaches the browser").Subject;
+
+        problem.Status.Should().Be(400);
+        problem.Detail.Should().Be(nameof(TotpSetupFailure.NoPrimaryFactor));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Setup_WhenTheSessionNamesNoSubject_AnswersWithTheFailureValue()
+    {
+        _subjectService
+            .Setup(s => s.GetSubjectByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((Subject?)null);
+
+        var result = await CreateController().Setup();
+
+        var problem = (ProblemDetails)((ObjectResult)result.Result!).Value!;
+
+        problem.Status.Should().Be(400);
+        problem.Detail.Should().Be(nameof(TotpSetupFailure.SubjectNotFound));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Setup_WithAPrimaryFactor_IsNotRefused()
+    {
+        _subjectService
+            .Setup(s => s.GetSubjectByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new Subject { Id = Guid.CreateVersion7(), Name = "rhys" });
+        _subjectService
+            .Setup(s => s.CountPrimaryAuthFactorsAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(1);
+        _totpService
+            .Setup(s => s.GenerateSetupAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .ReturnsAsync(new TotpSetupResult("otpauth://totp/x", "BASE32", "challenge"));
+
+        var result = await CreateController().Setup();
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    /// <summary>
+    /// A 400 the endpoint does not declare is not parsed by the generated client, which throws its
+    /// own "An unexpected server error occurred." instead — so the body would never be read no
+    /// matter what the controller put in it. Nothing else in CI regenerates the client to notice.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(TotpController.Setup))]
+    [InlineData(nameof(TotpController.VerifySetup))]
+    [Trait("Category", "Unit")]
+    public void RefusableEndpoints_DeclareTheirBadRequestBody(string action)
+    {
+        typeof(TotpController).GetMethod(action)!
+            .GetCustomAttributes<ProducesResponseTypeAttribute>()
+            .Should().Contain(
+                a => a.StatusCode == 400 && a.Type == typeof(ProblemDetails),
+                "an undeclared 400 reaches the user as NSwag boilerplate");
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #966, which found this while auditing the same controller.

## What a blocked enrolment said

`POST /api/auth/totp/setup` carried `[ProducesResponseType]` for 200 and 401 and nothing for 400. NSwag only parses a status the operation declares, so both of its refusals came back as a bare `ApiException` whose message is NSwag's own — and the generated wrapper's ladder (`flat ?? body.message ?? detail ?? title ?? message`) found nothing better to forward. Someone with no passkey and no linked provider, clicking "add authenticator", was shown:

> An unexpected server error occurred.

instead of being told to add a primary factor first. The sentence the controller wrote for them — "Configure a passkey or linked sign-in method before enabling TOTP" — never left the server.

The two refusals also disagreed on shape: `subject == null` returned `ProblemDetails`, `primaryFactorCount < 1` returned an anonymous `{ error = "no_primary_factor", message }`. Nothing in the repo reads that `error` discriminator — one grep, one hit, the definition itself — and an anonymous body carries no `detail`, so declaring the 400 alone would have fixed one arm and not the other.

## What it says now

Both answer the way `verify-setup` does after #966: `detail` carries a `TotpSetupFailure` value, which is the only field that reaches the browser. `TotpSetupFailure` gains `NoPrimaryFactor` and `SubjectNotFound`; `TotpSetupException` still carries only the three a *completion* can raise, and its doc comment says so.

The web app gains copy for both and a second entry point, `describeTotpSetupStartError`. That is not ceremony: the two calls share the map but not the fallback, and "Verification failed. Check the code and try again." is wrong for a call that never asked for a code. Both fallbacks are now the defaults their caller actually relies on, and both are asserted non-empty — #966's review found that half of this module was tested through a hand-copied literal the page never passes.

One `Refused(TotpSetupFailure)` helper serves all three sites, so the reason `detail` is the channel is written once.

## Evidence

- `Nocturne.API.Tests` **2493/2493**. New: both `Setup` refusals assert the `ProblemDetails` body *and* the value in it, an accepted case so the guards are not vacuously green, and a reflection guard pinning the declared 400 on both endpoints.
- Mutation-proofed: restoring the anonymous body and dropping the `ProducesResponseType` gives **2 red**. That guard matters more than usual here — the failure mode is invisible until the client is regenerated, and no CI job regenerates it against these tests.
- Web vitest **147 passed / 1 skipped**; svelte-check **53 errors**, unchanged from the post-#966 baseline.
- Verified end to end against the regenerated client: `processSetup` now parses the 400 into `ProblemDetails` and `nocturne-api-client.ts` no longer substitutes boilerplate for it.

## Note

`SubjectNotFound` means the session names a subject the store no longer holds, which is arguably a 500. Left as a 400 — changing the status is a separate decision from making the existing one legible.

_Agent-authored; reviewed with independent verification._
