### PR TITLE
fix(nocturne-remote): tell a rejected credential apart from an unwell endpoint

### DIFF
--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
@@ -16,7 +17,6 @@ namespace Nocturne.Connectors.NocturneRemote.Services;
 public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemoteConnectorConfiguration>
 {
     private readonly IRetryDelayStrategy _retryDelayStrategy;
-    private NocturneRemoteConnectorConfiguration _config;
     private string? _resolvedBaseUrl;
     private Dictionary<string, string>? _authHeaders;
 
@@ -24,86 +24,98 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         HttpClient httpClient,
         IConnectorServerResolver<NocturneRemoteConnectorConfiguration> serverResolver,
         ILogger<NocturneRemoteConnectorService> logger,
-        IConnectorRegistration<NocturneRemoteConnectorConfiguration> registration,
         IRetryDelayStrategy retryDelayStrategy,
         IConnectorPublisher? publisher = null
     )
         : base(httpClient, serverResolver, logger, publisher)
     {
-        _config = registration?.Defaults ?? throw new ArgumentNullException(nameof(registration));
         _retryDelayStrategy = retryDelayStrategy ?? throw new ArgumentNullException(nameof(retryDelayStrategy));
     }
 
     protected override string ConnectorSource => DataSources.NocturneRemoteConnector;
     public override string ServiceName => "Nocturne Remote";
 
+    /// <summary>
+    ///     Legacy no-config overload, carrying no configuration to authenticate against. This
+    ///     connector resolves and checks the run's credential in
+    ///     <see cref="PerformSyncInternalAsync"/>, where both entry points supply their own.
+    /// </summary>
+    public override Task<bool> AuthenticateAsync() => Task.FromResult(true);
 
-    public override async Task<bool> AuthenticateAsync()
-    {
-        // Legacy no-config overload; uses the injected startup config.
-        return await AuthenticateWithConfigAsync(_config);
-    }
-
-    private async Task<bool> AuthenticateWithConfigAsync(NocturneRemoteConnectorConfiguration config)
+    /// <summary>
+    ///     Resolves the run's base URL and bearer header, then asks the remote whether it accepts the
+    ///     credential at all.
+    /// </summary>
+    /// <remarks>
+    ///     The question is put to a data endpoint, so only a 401 is this connector's to answer: a 403
+    ///     is a grant the tenant scoped deliberately, and anything else is that endpoint being
+    ///     unwell. Failing the run on either sends the tenant to re-authorize a credential that was
+    ///     never the problem and costs them every other type; both are left to the per-type crawls,
+    ///     which reach the same endpoint under the same retry budget and scope the failure to the
+    ///     types that asked for it.
+    /// </remarks>
+    private async Task<bool> AuthenticateWithConfigAsync(
+        NocturneRemoteConnectorConfiguration config,
+        CancellationToken cancellationToken)
     {
         ResolveConfiguration(config);
 
+        // Captured as in FetchOrFailAsync, and for the same reason: the retry loop answers with
+        // nothing rather than with the status it ended on.
+        HttpStatusCode? answered = null;
+
         try
         {
-            var url = BuildAbsoluteUrl($"{NocturneRemoteConstants.SensorGlucose}?limit=1");
-            var response = await GetWithHeadersAsync(url, _authHeaders);
+            await ExecuteWithRetryAsync<HttpStatusCode>(
+                async () =>
+                {
+                    var response = await GetWithHeadersAsync(
+                        BuildAbsoluteUrl($"{NocturneRemoteConstants.SensorGlucose}?limit=1"),
+                        _authHeaders,
+                        cancellationToken);
 
-            if (!response.IsSuccessStatusCode)
-            {
-                var body = await response.Content.ReadAsStringAsync();
-                _logger.LogError(
-                    "[{ConnectorSource}] Auth check returned HTTP {StatusCode}: {Body}",
-                    ConnectorSource,
-                    (int)response.StatusCode,
-                    body);
-                TrackFailedRequest($"Auth check failed: HTTP {(int)response.StatusCode}");
-                return false;
-            }
+                    answered = response.StatusCode;
 
-            TrackSuccessfulRequest();
-            _logger.LogInformation(
-                "[{ConnectorSource}] Successfully authenticated with remote Nocturne instance at {Url}",
-                ConnectorSource,
-                _resolvedBaseUrl);
-            return true;
+                    if (!response.IsSuccessStatusCode)
+                        throw new HttpRequestException(
+                            $"HTTP {(int)response.StatusCode} {response.StatusCode}: " +
+                            await ReadFailureBodyAsync(response, config, cancellationToken),
+                            null,
+                            response.StatusCode);
+
+                    return response.StatusCode;
+                },
+                _retryDelayStrategy,
+                maxRetries: config.MaxRetryAttempts,
+                operationName: "auth check",
+                cancellationToken: cancellationToken);
         }
-        catch (Exception ex)
+        catch (HttpRequestException)
         {
-            TrackFailedRequest($"Authentication failed: {ex.Message}");
-            _logger.LogError(ex,
-                "[{ConnectorSource}] Failed to connect to remote Nocturne instance at {Url}",
-                ConnectorSource,
-                _resolvedBaseUrl);
-            return false;
+            // A budget spent on a status the retry loop kept re-throwing; `answered` holds it.
         }
-    }
 
-    public override async Task<SyncResult> SyncDataAsync(
-        NocturneRemoteConnectorConfiguration config,
-        CancellationToken cancellationToken = default,
-        DateTime? since = null,
-        ISyncProgressReporter? progressReporter = null)
-    {
-        // Prime _config with the per-tenant config before base calls AuthenticateAsync(),
-        // which delegates to AuthenticateWithConfigAsync(_config).
-        _config = config;
-        return await base.SyncDataAsync(config, cancellationToken, since, progressReporter);
-    }
+        if (answered != HttpStatusCode.Unauthorized)
+            return true;
 
-    protected override Task<bool> EnsureAuthenticatedAsync(
-        NocturneRemoteConnectorConfiguration config,
-        CancellationToken cancellationToken) => AuthenticateWithConfigAsync(config);
+        _logger.LogError(
+            "[{ConnectorSource}] The remote Nocturne instance at {Url} rejected the connector's credential",
+            ConnectorSource,
+            _resolvedBaseUrl);
+        return false;
+    }
 
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         NocturneRemoteConnectorConfiguration config,
         CancellationToken cancellationToken)
     {
+        // Both entry points converge here, and this is the only one of them holding the run's own
+        // configuration — the background one authenticates through the parameterless overload above,
+        // which has none.
+        if (!await AuthenticateWithConfigAsync(config, cancellationToken))
+            return AuthenticationFailedResult();
+
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
         if (!request.DataTypes.Any())

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -44,17 +44,29 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
     /// <summary>
     ///     Resolves the run's base URL and bearer header, then asks the remote whether it accepts the
-    ///     credential at all.
+    ///     credential. Answers with the result that ends the run, or null for a run that may proceed.
     /// </summary>
     /// <remarks>
-    ///     The question is put to a data endpoint, so only a 401 is this connector's to answer: a 403
-    ///     is a grant the tenant scoped deliberately, and anything else is that endpoint being
-    ///     unwell. Failing the run on either sends the tenant to re-authorize a credential that was
-    ///     never the problem and costs them every other type; both are left to the per-type crawls,
-    ///     which reach the same endpoint under the same retry budget and scope the failure to the
-    ///     types that asked for it.
+    ///     The question is put to a data endpoint, so of the answers it can get only a 401 is this
+    ///     connector's to report: a 403 is a grant the tenant scoped deliberately, and any other
+    ///     status is that endpoint being unwell. Failing the run on either sends the tenant to
+    ///     re-authorize a credential that was never the problem and costs them every other type; both
+    ///     are left to the per-type crawls, which reach the same endpoint under the tenant's retry
+    ///     budget and scope the failure to the types that asked for it.
+    ///     <para>
+    ///     A remote that answers nothing at all is neither, and is not per-endpoint either: every
+    ///     enabled type reads the same silent host, so there is nothing for a crawl to scope and each
+    ///     of them would spend the client's whole timeout rediscovering it. That ends the run here
+    ///     instead, under its own message rather than the credential's.
+    ///     </para>
+    ///     <para>
+    ///     One attempt, not the tenant's budget: a 401 is terminal in
+    ///     <see cref="BaseConnectorService{TConfig}.ExecuteWithRetryAsync{T}"/> and never retried, and
+    ///     every other answer proceeds regardless, so a second attempt cannot change what this
+    ///     returns — it can only spend another request on a remote already known to be unwell.
+    ///     </para>
     /// </remarks>
-    private async Task<bool> AuthenticateWithConfigAsync(
+    private async Task<SyncResult?> AuthenticateWithConfigAsync(
         NocturneRemoteConnectorConfiguration config,
         CancellationToken cancellationToken)
     {
@@ -86,23 +98,53 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
                     return response.StatusCode;
                 },
                 _retryDelayStrategy,
-                maxRetries: config.MaxRetryAttempts,
+                maxRetries: 1,
                 operationName: "auth check",
                 cancellationToken: cancellationToken);
         }
         catch (HttpRequestException)
         {
-            // A budget spent on a status the retry loop kept re-throwing; `answered` holds it.
+            // A status the retry loop re-threw; `answered` holds it.
+        }
+        // The retry loop re-throws every cancellation, and a client timeout reaches it as one. Only
+        // the caller's own token means the run was withdrawn, and a withdrawn run has no outcome to
+        // report; the rest is the remote falling silent.
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return UnansweredResult();
         }
 
         if (answered != HttpStatusCode.Unauthorized)
-            return true;
+            return null;
 
         _logger.LogError(
             "[{ConnectorSource}] The remote Nocturne instance at {Url} rejected the connector's credential",
             ConnectorSource,
             _resolvedBaseUrl);
-        return false;
+        return AuthenticationFailedResult();
+    }
+
+    /// <summary>
+    ///     The result of a run whose remote accepted the connection and then said nothing. Carries
+    ///     the same two fields as
+    ///     <see cref="BaseConnectorService{TConfig}.AuthenticationFailedResult"/> and for the same
+    ///     reasons, but must not borrow its wording: the credential is not what failed.
+    /// </summary>
+    private SyncResult UnansweredResult()
+    {
+        var unanswered = $"The remote Nocturne instance at {_resolvedBaseUrl} did not answer";
+        var now = DateTimeOffset.UtcNow;
+
+        _logger.LogError("[{ConnectorSource}] {Detail}", ConnectorSource, unanswered);
+
+        return new SyncResult
+        {
+            Success = false,
+            StartTime = now,
+            EndTime = now,
+            Message = unanswered,
+            Errors = { unanswered },
+        };
     }
 
     protected override async Task<SyncResult> PerformSyncInternalAsync(
@@ -113,8 +155,8 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
         // Both entry points converge here, and this is the only one of them holding the run's own
         // configuration — the background one authenticates through the parameterless overload above,
         // which has none.
-        if (!await AuthenticateWithConfigAsync(config, cancellationToken))
-            return AuthenticationFailedResult();
+        if (await AuthenticateWithConfigAsync(config, cancellationToken) is { } refused)
+            return refused;
 
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
@@ -13,16 +13,13 @@ namespace Nocturne.API.Tests.Services.Connectors;
 
 public class NocturneRemoteBackgroundSyncAuthTests
 {
-    private static NocturneRemoteConnectorService CreateService(
-        HttpMessageHandler handler,
-        NocturneRemoteConnectorConfiguration startupDefaults)
+    private static NocturneRemoteConnectorService CreateService(HttpMessageHandler handler)
     {
         var httpClient = new HttpClient(handler);
         return new NocturneRemoteConnectorService(
             httpClient,
             new ConnectorServerResolver<NocturneRemoteConnectorConfiguration>(null, null, null),
             Mock.Of<ILogger<NocturneRemoteConnectorService>>(),
-            new ConnectorRegistration<NocturneRemoteConnectorConfiguration>(startupDefaults, "NocturneRemote"),
             Mock.Of<IRetryDelayStrategy>(),
             publisher: null);
     }
@@ -52,10 +49,8 @@ public class NocturneRemoteBackgroundSyncAuthTests
         });
 
     [Fact]
-    public async Task BackgroundSync_UsesTenantConfigUrl_NotStartupDefaults()
+    public async Task BackgroundSync_UsesTheTenantConfigUrl()
     {
-        var startupDefaults = new NocturneRemoteConnectorConfiguration();
-
         var tenantConfig = new NocturneRemoteConnectorConfiguration
         {
             Url = "https://remote.nocturne.example.com",
@@ -64,7 +59,7 @@ public class NocturneRemoteBackgroundSyncAuthTests
             SyncIntervalMinutes = 5,
         };
 
-        var service = CreateService(RespondOkJson(), startupDefaults);
+        var service = CreateService(RespondOkJson());
 
         var result = await service.SyncDataAsync(tenantConfig, CancellationToken.None, since: null);
 
@@ -75,10 +70,9 @@ public class NocturneRemoteBackgroundSyncAuthTests
     [Fact]
     public async Task BackgroundSync_WithEmptyTenantUrl_ReturnsFailure_NotException()
     {
-        var startupDefaults = new NocturneRemoteConnectorConfiguration();
         var tenantConfig = new NocturneRemoteConnectorConfiguration { Enabled = true, SyncIntervalMinutes = 5 };
 
-        var service = CreateService(RespondOkJson(), startupDefaults);
+        var service = CreateService(RespondOkJson());
 
         var act = async () => await service.SyncDataAsync(tenantConfig, CancellationToken.None, since: null);
 
@@ -103,7 +97,7 @@ public class NocturneRemoteBackgroundSyncAuthTests
             {
                 Content = new StringContent("unauthorized")
             });
-        var service = CreateService(handler, new NocturneRemoteConnectorConfiguration());
+        var service = CreateService(handler);
         var config = new NocturneRemoteConnectorConfiguration
         {
             Url = "https://remote.nocturne.example.com",

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
@@ -13,9 +13,12 @@ namespace Nocturne.API.Tests.Services.Connectors;
 
 public class NocturneRemoteBackgroundSyncAuthTests
 {
-    private static NocturneRemoteConnectorService CreateService(HttpMessageHandler handler)
+    private static NocturneRemoteConnectorService CreateService(
+        HttpMessageHandler handler, TimeSpan? timeout = null)
     {
         var httpClient = new HttpClient(handler);
+        if (timeout is { } budget)
+            httpClient.Timeout = budget;
         return new NocturneRemoteConnectorService(
             httpClient,
             new ConnectorServerResolver<NocturneRemoteConnectorConfiguration>(null, null, null),
@@ -98,25 +101,76 @@ public class NocturneRemoteBackgroundSyncAuthTests
                 Content = new StringContent("unauthorized")
             });
         var service = CreateService(handler);
-        var config = new NocturneRemoteConnectorConfiguration
-        {
-            Url = "https://remote.nocturne.example.com",
-            Token = "bearer-token",
-        };
-
         var reported = new List<SyncProgressEvent>();
-        var reporter = new Mock<ISyncProgressReporter>();
-        reporter
-            .Setup(r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()))
-            .Callback<SyncProgressEvent, CancellationToken>((e, _) => reported.Add(e))
-            .Returns(Task.CompletedTask);
 
-        await service.SyncDataAsync(
-            new SyncRequest { DataTypes = [SyncDataType.Glucose], From = DateTime.UtcNow.AddHours(-1) },
-            config, CancellationToken.None, reporter.Object);
+        await service.SyncDataAsync(GlucoseSince(), RemoteConfig, CancellationToken.None, Recording(reported));
 
         reported.Where(e => e.Phase != SyncPhase.Syncing)
             .Should().ContainSingle().Which.Phase.Should().Be(expectedPhase);
+    }
+
+    /// <summary>
+    ///     A remote that accepts the connection and then says nothing reaches the connector as a
+    ///     client timeout, which is an <see cref="OperationCanceledException"/> — the one exception
+    ///     the shared run wrapper deliberately does not convert into a reported outcome, because a
+    ///     withdrawn run has none to report. Letting it escape the credential check leaves the
+    ///     tenant's connector badge on "syncing" until the page is reloaded, so the check ends the
+    ///     run with a result of its own instead.
+    /// </summary>
+    [Fact]
+    public async Task RequestedSync_WhenTheRemoteStallsDuringTheCredentialCheck_FailsTheRunAndReportsATerminalMessage()
+    {
+        var service = CreateService(new StallingHandler(), timeout: TimeSpan.FromMilliseconds(200));
+        var reported = new List<SyncProgressEvent>();
+
+        var run = async () => await service.SyncDataAsync(
+            GlucoseSince(), RemoteConfig, CancellationToken.None, Recording(reported));
+
+        var result = (await run.Should().NotThrowAsync()).Subject;
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("did not answer")
+            .And.NotContain("Authentication", "the credential is not what failed");
+        result.Errors.Should().ContainSingle().Which.Should().Contain("did not answer");
+        reported.Where(e => e.Phase != SyncPhase.Syncing)
+            .Should().ContainSingle().Which.Phase.Should().Be(SyncPhase.Failed);
+    }
+
+    /// <summary>
+    ///     The distinction that must survive: a run the caller withdrew is genuinely cancelled, and
+    ///     owes no terminal message — unlike every other ending, which does.
+    /// </summary>
+    [Fact]
+    public async Task RequestedSync_WhenTheCallerWithdrawsDuringTheCredentialCheck_PropagatesTheCancellation()
+    {
+        using var withdrawal = new CancellationTokenSource();
+        var service = CreateService(new StallingHandler(withdrawal));
+        var reported = new List<SyncProgressEvent>();
+
+        var run = async () => await service.SyncDataAsync(
+            GlucoseSince(), RemoteConfig, withdrawal.Token, Recording(reported));
+
+        await run.Should().ThrowAsync<OperationCanceledException>();
+        reported.Should().NotContain(e => e.Phase == SyncPhase.Failed || e.Phase == SyncPhase.Completed);
+    }
+
+    private static NocturneRemoteConnectorConfiguration RemoteConfig => new()
+    {
+        Url = "https://remote.nocturne.example.com",
+        Token = "bearer-token",
+    };
+
+    private static SyncRequest GlucoseSince() =>
+        new() { DataTypes = [SyncDataType.Glucose], From = DateTime.UtcNow.AddHours(-1) };
+
+    private static ISyncProgressReporter Recording(List<SyncProgressEvent> into)
+    {
+        var reporter = new Mock<ISyncProgressReporter>();
+        reporter
+            .Setup(r => r.ReportProgressAsync(It.IsAny<SyncProgressEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<SyncProgressEvent, CancellationToken>((e, _) => into.Add(e))
+            .Returns(Task.CompletedTask);
+        return reporter.Object;
     }
 
     private sealed class FuncHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
@@ -124,5 +178,20 @@ public class NocturneRemoteBackgroundSyncAuthTests
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
             => Task.FromResult(respond(request));
+    }
+
+    /// <summary>
+    ///     A remote that accepts the connection and then never answers, ending only when the client's
+    ///     timeout or <paramref name="withdrawTheRun"/> cancels the request.
+    /// </summary>
+    private sealed class StallingHandler(CancellationTokenSource? withdrawTheRun = null) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            withdrawTheRun?.Cancel();
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
     }
 }

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
@@ -206,10 +206,7 @@ public class NocturneRemoteConnectorServiceCrawlTests
 
     /// <summary>
     /// A type the tenant switched off is never crawled, so a remote that rejects its endpoint cannot
-    /// mark the connector red while everything the tenant enabled synced. Activity rather than
-    /// glucose, because the auth probe reads the glucose endpoint and fails the whole run before the
-    /// per-type gate is reached — see
-    /// <see cref="SyncDataAsync_WhenTheGlucoseEndpointIsBroken_FailsBeforeAnyTypeIsConsidered"/>.
+    /// mark the connector red while everything the tenant enabled synced.
     /// </summary>
     [Fact]
     public async Task SyncDataAsync_WhenASwitchedOffTypesEndpointIsBroken_ReportsSuccess()
@@ -233,36 +230,6 @@ public class NocturneRemoteConnectorServiceCrawlTests
         });
         handler.Requests.Should().NotContain(url => url.Contains(NocturneRemoteConstants.Activity),
             "a switched-off type is not crawled at all, which is why its endpoint cannot fail the run");
-    }
-
-    /// <summary>
-    /// Characterises a limitation this change does not remove, so it is not mistaken for a property
-    /// the connector has. <c>AuthenticateWithConfigAsync</c> probes the sensor-glucose endpoint on
-    /// every run whatever the tenant enabled, and a rejected probe fails the run before any type is
-    /// considered. So a remote whose glucose endpoint alone is broken — or a grant without
-    /// <c>glucose.read</c> — costs the tenant every other type too, and is reported as a credential
-    /// problem. Per-type scoping begins after this gate, not before it.
-    /// </summary>
-    [Fact]
-    public async Task SyncDataAsync_WhenTheGlucoseEndpointIsBroken_FailsBeforeAnyTypeIsConsidered()
-    {
-        var handler = new RemoteFakeHandler()
-            .Break(NocturneRemoteConstants.SensorGlucose, HttpStatusCode.BadGateway)
-            .Serve(NocturneRemoteConstants.Boluses,
-                RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
-        var fixture = new ServiceFixture(handler, config: NewConfig(syncGlucose: false));
-
-        var result = await fixture.Service.SyncDataAsync(
-            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses] },
-            fixture.Config,
-            CancellationToken.None);
-
-        result.Success.Should().BeFalse();
-        result.Message.Should().Be("Authentication failed");
-        result.Errors.Should().ContainSingle()
-            .Which.Should().Be($"Authentication failed for {DataSources.NocturneRemoteConnector}");
-        handler.Requests.Should().NotContain(url => url.Contains(NocturneRemoteConstants.Boluses),
-            "the probe fails the run before the enabled types are reached");
     }
 
     /// <summary>
@@ -436,14 +403,11 @@ public class NocturneRemoteConnectorServiceCrawlTests
     }
 
     /// <summary>
-    /// The tenant's configured attempt budget governs, not the frozen startup defaults. Only the
-    /// background entry point primes the field the defaults live in, so a manual sync or a cursor
-    /// reset — the long full-history re-pull where the budget matters most — would otherwise run on
-    /// whatever the deployment shipped. A budget of three would reach the third scripted response
-    /// and complete the crawl.
+    /// The attempt budget the run was handed governs. A budget of three would reach the third
+    /// scripted response and complete the crawl; one stops at the 502.
     /// </summary>
     [Fact]
-    public async Task SyncDataAsync_SpendsTheTenantsRetryBudget_NotTheStartupDefaults()
+    public async Task SyncDataAsync_SpendsTheBudgetTheRunWasHanded()
     {
         var handler = new RemoteFakeHandler()
             .Serve(NocturneRemoteConstants.SensorGlucose,
@@ -457,14 +421,13 @@ public class NocturneRemoteConnectorServiceCrawlTests
             fixture.Config,
             CancellationToken.None);
 
-        result.Success.Should().BeFalse(
-            $"the tenant allowed one attempt, not the {StartupDefaultRetryAttempts} the defaults carry");
+        result.Success.Should().BeFalse("the run was allowed one attempt");
         result.ItemsSynced.Should().BeEmpty();
     }
 
-    /// <summary>The tenant's page size governs for the same reason, and on the same paths.</summary>
+    /// <summary>The page size the run was handed governs for the same reason, and on the same paths.</summary>
     [Fact]
-    public async Task SyncDataAsync_UsesTheTenantsPageSize_NotTheStartupDefaults()
+    public async Task SyncDataAsync_UsesThePageSizeTheRunWasHanded()
     {
         var handler = new RemoteFakeHandler();
         var fixture = new ServiceFixture(handler);
@@ -475,8 +438,124 @@ public class NocturneRemoteConnectorServiceCrawlTests
             CancellationToken.None);
 
         handler.CrawlOf(NocturneRemoteConstants.SensorGlucose).Should()
-            .Contain($"limit={RemoteFakeHandler.PageSize}")
-            .And.NotContain($"limit={StartupDefaultPageSize}");
+            .Contain($"limit={RemoteFakeHandler.PageSize}");
+    }
+
+    /// <summary>
+    /// One service instance serves both entry points in turn, and each run must be crawled with the
+    /// configuration that run was handed. Holding it on the service instead — a cached copy the
+    /// background entry point alone assigns — leaves a manual "sync now" pulling the previous run's
+    /// pages with the previous run's credential, and the pagination loop terminating against a page
+    /// size the request never asked for.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAManualRunFollowsABackgroundRun_CrawlsWithTheManualRunsConfiguration()
+    {
+        var handler = new RemoteFakeHandler();
+        var fixture = new ServiceFixture(handler);
+
+        await fixture.Service.SyncDataAsync(fixture.Config, CancellationToken.None);
+
+        var manual = NewConfig();
+        manual.MaxCount = ManualRunPageSize;
+        manual.Token = ManualRunToken;
+
+        await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            manual,
+            CancellationToken.None);
+
+        handler.LastCrawlOf(NocturneRemoteConstants.SensorGlucose).Should()
+            .Contain($"limit={ManualRunPageSize}");
+        handler.Tokens.Last().Should().Be($"Bearer {ManualRunToken}");
+    }
+
+    /// <summary>
+    /// The credential check reads the sensor-glucose endpoint, so a remote that is merely unwell
+    /// there must not be reported as a rejected credential: the tenant would be sent to re-authorize
+    /// a grant that was never the problem, and would lose every other type with it. A 403 is the same
+    /// answer by a different route — a grant scoped to treatments only, which is a configuration the
+    /// remote supports.
+    /// </summary>
+    [Theory]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public async Task SyncDataAsync_WhenTheProbedEndpointRefusesButTheTypeIsSwitchedOff_ReportsSuccess(
+        HttpStatusCode refusal)
+    {
+        var handler = new RemoteFakeHandler()
+            .Break(NocturneRemoteConstants.SensorGlucose, refusal)
+            .Serve(NocturneRemoteConstants.Boluses,
+                RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
+        var fixture = new ServiceFixture(handler, config: NewConfig(syncGlucose: false));
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue("no type the tenant enabled failed to sync");
+        result.Errors.Should().BeEmpty();
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Boluses] = 1,
+        });
+    }
+
+    /// <summary>
+    /// And when the tenant did enable the type, the refusal is still that type's rather than the
+    /// run's: the crawl reaches the same endpoint under the tenant's retry budget and reports what it
+    /// found, leaving every other type synced.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheProbedEndpointIsUnwell_CostsOnlyTheTypeThatReadsIt()
+    {
+        var handler = new RemoteFakeHandler()
+            .Break(NocturneRemoteConstants.SensorGlucose, HttpStatusCode.BadGateway)
+            .Serve(NocturneRemoteConstants.Boluses,
+                RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().StartWith($"Failed to sync {SyncDataType.Glucose}");
+        result.ItemsSynced.Should().BeEquivalentTo(new Dictionary<SyncDataType, int>
+        {
+            [SyncDataType.Boluses] = 1,
+        });
+        fixture.PublishedBoluses.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// The one answer that is the connector's own to report. A credential the remote rejects will be
+    /// rejected by every crawl too, so the run ends at the check rather than repeating the rejection
+    /// once per type, and the tenant is told the thing they can act on.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheRemoteRejectsTheCredential_FailsBeforeAnyTypeIsCrawled()
+    {
+        var handler = new RemoteFakeHandler()
+            .Break(NocturneRemoteConstants.SensorGlucose, HttpStatusCode.Unauthorized)
+            .Serve(NocturneRemoteConstants.Boluses,
+                RemoteFakeHandler.BolusPage(total: 1, "2026-01-03T09:00:00Z"));
+        var fixture = new ServiceFixture(handler);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses] },
+            fixture.Config,
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Be("Authentication failed");
+        result.Errors.Should().ContainSingle()
+            .Which.Should().Be($"Authentication failed for {DataSources.NocturneRemoteConnector}");
+        handler.Requests.Should().NotContain(url => url.Contains(NocturneRemoteConstants.Boluses),
+            "a rejected credential fails the run before the enabled types are reached");
     }
 
     /// <summary>
@@ -561,11 +640,14 @@ public class NocturneRemoteConnectorServiceCrawlTests
             .Which.Should().NotContain(config.Token).And.Contain("HTTP 502 BadGateway");
     }
 
-    /// <summary>Page size and budget carried by the frozen startup defaults, never by a tenant.</summary>
-    private const int StartupDefaultPageSize = 500;
+    /// <summary>
+    /// Page size and credential belonging to a second run only, so a run crawled with the first
+    /// run's configuration cannot answer to them.
+    /// </summary>
+    private const int ManualRunPageSize = 7;
 
-    /// <inheritdoc cref="StartupDefaultPageSize"/>
-    private const int StartupDefaultRetryAttempts = 3;
+    /// <inheritdoc cref="ManualRunPageSize"/>
+    private const string ManualRunToken = "manual-run-token";
 
     private static NocturneRemoteConnectorConfiguration NewConfig(
         bool syncGlucose = true,
@@ -629,23 +711,10 @@ public class NocturneRemoteConnectorServiceCrawlTests
             publisher.Setup(p => p.Device).Returns(Mock.Of<IDevicePublisher>());
             publisher.Setup(p => p.Metadata).Returns(Mock.Of<IMetadataPublisher>());
 
-            // Deliberately NOT the tenant's config. Production conflates the two — the frozen
-            // startup defaults are what the field holds on the manual path — so aliasing them here
-            // would hide every place the tenant's own value is meant to be read.
-            var registration = new Mock<IConnectorRegistration<NocturneRemoteConnectorConfiguration>>();
-            registration.Setup(r => r.Defaults).Returns(new NocturneRemoteConnectorConfiguration
-            {
-                Url = RemoteFakeHandler.BaseUrl,
-                Token = "startup-defaults-token",
-                MaxCount = StartupDefaultPageSize,
-                MaxRetryAttempts = StartupDefaultRetryAttempts,
-            });
-
             Service = new NocturneRemoteConnectorService(
                 new HttpClient(handler),
                 Mock.Of<IConnectorServerResolver<NocturneRemoteConnectorConfiguration>>(),
                 NullLogger<NocturneRemoteConnectorService>.Instance,
-                registration.Object,
                 Mock.Of<IRetryDelayStrategy>(),
                 publisher.Object);
         }
@@ -657,10 +726,10 @@ public class NocturneRemoteConnectorServiceCrawlTests
     /// </summary>
     /// <remarks>
     /// <see cref="Break"/> models an endpoint that is down and answers every request to it — the
-    /// auth probe included, because the probe reads the sensor-glucose endpoint like any other
-    /// caller. <see cref="Serve"/> models the responses to successive pages of a working endpoint,
-    /// which the probe is deliberately not served from: it asks for one record before the crawl
-    /// starts, so letting it consume the crawl's first page would misdescribe every script.
+    /// auth check included, because it reads the sensor-glucose endpoint like any other caller.
+    /// <see cref="Serve"/> models the responses to successive pages of a working endpoint, which the
+    /// auth check is deliberately not served from: it asks for one record before the crawl starts,
+    /// so letting it consume the crawl's first page would misdescribe every script.
     /// </remarks>
     private sealed class RemoteFakeHandler : HttpMessageHandler
     {
@@ -676,15 +745,26 @@ public class NocturneRemoteConnectorServiceCrawlTests
         /// <summary>Every request made, so a test can assert on the range each crawl asked for.</summary>
         internal List<string> Requests { get; } = [];
 
+        /// <summary>
+        /// The Authorization header each request carried, positionally aligned with
+        /// <see cref="Requests"/>.
+        /// </summary>
+        internal List<string?> Tokens { get; } = [];
+
         internal RemoteFakeHandler Serve(string path, params HttpResponseMessage[] responses)
         {
             _pages[path] = new Queue<HttpResponseMessage>(responses);
             return this;
         }
 
-        /// <summary>The first crawl request made to <paramref name="path"/>, excluding the auth probe.</summary>
-        internal string CrawlOf(string path) =>
-            Requests.First(u => u.Contains(path, StringComparison.Ordinal)
+        /// <summary>The first crawl request made to <paramref name="path"/>, excluding the auth check.</summary>
+        internal string CrawlOf(string path) => Crawls(path).First();
+
+        /// <inheritdoc cref="CrawlOf"/>
+        internal string LastCrawlOf(string path) => Crawls(path).Last();
+
+        private IEnumerable<string> Crawls(string path) =>
+            Requests.Where(u => u.Contains(path, StringComparison.Ordinal)
                                 && u.Contains("offset=", StringComparison.Ordinal));
 
         internal RemoteFakeHandler Break(string path, HttpStatusCode status)
@@ -720,11 +800,14 @@ public class NocturneRemoteConnectorServiceCrawlTests
         {
             var path = request.RequestUri!.AbsolutePath;
             Requests.Add(request.RequestUri.ToString());
+            Tokens.Add(request.Headers.TryGetValues("Authorization", out var authorization)
+                ? authorization.FirstOrDefault()
+                : null);
 
             if (_broken.TryGetValue(path, out var status))
                 return Task.FromResult(Status(status));
 
-            if (IsAuthProbe(request))
+            if (IsAuthCheck(request))
                 return Task.FromResult(GlucosePage(total: 0));
 
             if (_pages.TryGetValue(path, out var queue) && queue.Count > 0)
@@ -736,7 +819,7 @@ public class NocturneRemoteConnectorServiceCrawlTests
                     : GlucosePage(total: 0));
         }
 
-        private static bool IsAuthProbe(HttpRequestMessage request) =>
+        private static bool IsAuthCheck(HttpRequestMessage request) =>
             request.RequestUri!.AbsolutePath == NocturneRemoteConstants.SensorGlucose
             && !request.RequestUri.Query.Contains("offset=", StringComparison.Ordinal);
     }

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
@@ -176,7 +176,7 @@ public class NocturneRemoteConnectorServiceCrawlTests
     /// Each data type crawls its own endpoint, so one endpoint failing must cost only that type. A
     /// failed run withholds the connector's last-successful-sync stamp and shows the tenant a red
     /// connector, which has to name what actually broke. The glucose crawl fails on its second page,
-    /// so the failure is reached past the auth probe rather than by it.
+    /// so the failure is reached past the auth check rather than by it.
     /// </summary>
     [Fact]
     public async Task SyncDataAsync_WhenOneTypesCrawlFails_LeavesTheOtherTypeSynced()
@@ -442,11 +442,13 @@ public class NocturneRemoteConnectorServiceCrawlTests
     }
 
     /// <summary>
-    /// One service instance serves both entry points in turn, and each run must be crawled with the
-    /// configuration that run was handed. Holding it on the service instead — a cached copy the
-    /// background entry point alone assigns — leaves a manual "sync now" pulling the previous run's
-    /// pages with the previous run's credential, and the pagination loop terminating against a page
-    /// size the request never asked for.
+    /// A tripwire for the cached-configuration shape this connector used to carry: a field seeded at
+    /// construction from the frozen startup defaults and assigned by the background entry point
+    /// alone, so a run that never assigned it crawled with a page size and credential it had not
+    /// been given. That is no longer constructible — the service takes no registration, and the
+    /// registration is transient anyway, so each run resolves its own instance — which is why the
+    /// arrangement here is two runs through one instance: the cheapest one that still goes red the
+    /// moment any configuration starts outliving the run it belongs to.
     /// </summary>
     [Fact]
     public async Task SyncDataAsync_WhenAManualRunFollowsABackgroundRun_CrawlsWithTheManualRunsConfiguration()


### PR DESCRIPTION
Closes #945. Closes #952.

Both defects live in NocturneRemoteConnectorService's sync entry points, so they're fixed together.

## #952 — the auth probe conflated three conditions

`AuthenticateWithConfigAsync` probed `GET /api/v4/glucose/sensor?limit=1` (needs `glucose.read`) and failed the whole run on *any* non-2xx, unretried. A valid credential lacking `glucose.read` (a least-privilege treatments-only tenant), or a transient 502 on that one endpoint, both read as "Authentication failed" and sent the tenant to re-authorize a credential that was never the problem.

Now only a **401** fails the run as `AuthenticationFailedResult()` (which drives the re-authorize affordance). A 403 or 5xx returns "proceed" — the per-type crawls reach the same endpoints under the tenant's retry budget and scope the failure to the types that asked for it (the per-type scoping from #783). The probe runs inside `ExecuteWithRetryAsync` with the same token-redacting failure-body reader as the crawls.

A remote that **accepts the connection then falls silent** is neither a credential problem nor per-endpoint (every type reads the same silent host, so there's nothing to scope and each crawl would spend the full client timeout rediscovering it). That ends the run here with its own message — "The remote Nocturne instance at {url} did not answer" — not the credential's. Genuine caller cancellation still propagates untouched. **The retry budget is `maxRetries: 1`, deliberately**: `ExecuteWithRetryAsync` never retries a 401 (it's terminal), and every other answer proceeds regardless, so a second attempt cannot change the return — it can only spend another request on an already-unwell remote. This is a measured departure from #952's "carry the crawls' budget" suggestion.

#783's characterisation test `SyncDataAsync_WhenTheGlucoseEndpointIsBroken_FailsBeforeAnyTypeIsConsidered` pinned the old defect deliberately; it is **deleted**, as that issue's body sanctioned.

## #945 — mostly already fixed; the vestige removed

The reported symptom (manual sync reading a stale `MaxCount`) does not reproduce: config is already threaded as a parameter through every consumer #953 named. What remained was a vestigial `_config` field, read only by the parameterless `AuthenticateAsync()` and primed only by the background entry point. Both entry points converge on `PerformSyncInternalAsync`, which holds the run's own config, so authentication moved there (once per run) and `_config`, the `SyncDataAsync`/`EnsureAuthenticatedAsync` overrides, **and** the now-dead `IConnectorRegistration` constructor dependency are all removed. `AuthenticateAsync()` becomes the legacy no-config shim (Glooko's existing shape), making the class of bug structurally unreintroducible via that route.

## Verification

- `Nocturne.Connectors.NocturneRemote.Tests` 25 green; `Nocturne.API.Tests` (`~NocturneRemote`) 11 green (+2 new); `Nocturne.Connectors.Core.Tests` 137 green; full solution builds.
- Mutations killed (each restored): 401→NotFound comparison flip; any-non-success-fails restoration; reintroduced `_config ??=`; `_authHeaders ??=` caching; auth shim → false; **removing the `OperationCanceledException` catch** (the timeout-escapes-the-run regression a hostile review caught) → the stall test goes red while genuine cancellation stays green; dropping the cancellation-token filter → the cancellation test goes red. `maxRetries` deviation is documented at its one site.

## Follow-ups (verified, filed separately)

- `NightscoutConnectorService._currentConfig` has the genuine #945 shape (six fetch-layer read sites, primed on one entry point) — a real latent bug this connector's fix doesn't reach.
- `NocturneRemoteConnectorBackgroundService` builds the SignalR hub URL as raw `{config.Url}/hubs/data` while the REST path prepends `https://` for a bare host — a tenant entering a scheme-less URL gets working REST sync and a silently dead realtime listener.
- The background entry point authenticates through the parameterless `AuthenticateAsync()`, which by contract can't receive the run's config — the architectural reason connectors smuggle config on fields at all.

https://claude.ai/code/session_013JMfvQxpzTVwa27EBLJ2dZ
