### PR TITLE
fix(connectors): headline a failed sync with the failure it hit

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -172,14 +172,14 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     ///     <see cref="SyncResult.Message"/>, standing in the failure that started it.
     /// </summary>
     /// <remarks>
-    ///     The tenant's sync card headlines <see cref="SyncResult.Message"/> and lists the errors
-    ///     beneath it, so a failure that recorded no message reads as unexplained with its reason
-    ///     buried in the list. Owned here because every connector's failure paths converge on this
-    ///     wrapper, unlike the per-type catch blocks that raise most of them: those sit in each
-    ///     connector separately and can hold no shared rule. A message an inner path chose stands,
-    ///     because <see cref="AuthenticationFailedResult"/> and <see cref="RecordFailure"/> both
-    ///     summarise what the raw error text only implies; as in the latter, the first recorded
-    ///     failure names the run.
+    ///     The manual-sync dialog shows <see cref="SyncResult.Message"/> and nothing else about a
+    ///     failure — not <see cref="SyncResult.Errors"/> — so a run that recorded its reason only in
+    ///     the errors puts that reason out of the tenant's reach entirely. Owned here because every
+    ///     connector's failure paths converge on this wrapper, unlike the per-type catch blocks that
+    ///     raise most of them: those sit in each connector separately and can hold no shared rule.
+    ///     A message an inner path chose stands, because <see cref="AuthenticationFailedResult"/>
+    ///     and <see cref="RecordFailure"/> both summarise what the raw error text only implies; as
+    ///     in the latter, the first recorded failure names the run.
     /// </remarks>
     private static void StandInFailureMessage(SyncResult result)
     {

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -144,6 +144,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         try
         {
             var result = await body();
+            StandInFailureMessage(result);
             await ReportSyncOutcomeAsync(result.Success, FailureMessage(result), cancellationToken);
             return result;
         }
@@ -165,6 +166,28 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         ReportSyncMessageAsync(
             success ? SyncMessageType.SyncComplete : SyncMessageType.SyncFailed,
             null, cancellationToken, errorMessage);
+
+    /// <summary>
+    ///     Gives a failed run that recorded only <see cref="SyncResult.Errors"/> a
+    ///     <see cref="SyncResult.Message"/>, standing in the failure that started it.
+    /// </summary>
+    /// <remarks>
+    ///     The tenant's sync card headlines <see cref="SyncResult.Message"/> and lists the errors
+    ///     beneath it, so a failure that recorded no message reads as unexplained with its reason
+    ///     buried in the list. Owned here because every connector's failure paths converge on this
+    ///     wrapper, unlike the per-type catch blocks that raise most of them: those sit in each
+    ///     connector separately and can hold no shared rule. A message an inner path chose stands,
+    ///     because <see cref="AuthenticationFailedResult"/> and <see cref="RecordFailure"/> both
+    ///     summarise what the raw error text only implies; as in the latter, the first recorded
+    ///     failure names the run.
+    /// </remarks>
+    private static void StandInFailureMessage(SyncResult result)
+    {
+        if (result.Success || result.Errors.Count == 0) return;
+
+        if (string.IsNullOrWhiteSpace(result.Message))
+            result.Message = result.Errors[0];
+    }
 
     private static string? FailureMessage(SyncResult result)
     {

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte
@@ -137,6 +137,16 @@
   }
 </script>
 
+<!--
+  A failed sync is usually a partial one, so this total is the only thing that says how much of the
+  run still landed.
+-->
+{#snippet syncedTotal(items: SyncResult["itemsSynced"])}
+  {#if items}
+    ({Object.values(items).reduce((a, b) => (a || 0) + (b || 0), 0)} items)
+  {/if}
+{/snippet}
+
 <Dialog.Root bind:open>
   <Dialog.Content class="max-w-md">
     {#if selectedConnector}
@@ -393,12 +403,11 @@
                 {#if granularSyncResult.success}
                   <CheckCircle class="inline h-3 w-3 mr-1" />
                   Sync initiated successfully
-                  {#if granularSyncResult.itemsSynced}
-                    ({Object.values(granularSyncResult.itemsSynced || {}).reduce((a, b) => (a || 0) + (b || 0), 0)} items)
-                  {/if}
+                  {@render syncedTotal(granularSyncResult.itemsSynced)}
                 {:else}
                   <AlertCircle class="inline h-3 w-3 mr-1" />
                   {granularSyncResult.message || "Sync failed"}
+                  {@render syncedTotal(granularSyncResult.itemsSynced)}
                 {/if}
               </div>
             {/if}

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte.test.ts
@@ -1,0 +1,78 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, vi } from "vitest";
+import type { SyncResult } from "$lib/api/generated/nocturne-api-client";
+
+let syncImpl: () => Promise<SyncResult>;
+
+vi.mock("$lib/api", () => ({
+  getApiClient: () => ({
+    services: { triggerConnectorSync: () => syncImpl() },
+  }),
+}));
+
+// The dialog uses Tooltip.Root, whose provider the app layout supplies; the wrapper stands in for it.
+import ConnectorDetailsDialog from "./connector-details-dialog-test-wrapper.svelte";
+
+async function syncReturning(result: SyncResult) {
+  syncImpl = async () => result;
+
+  render(ConnectorDetailsDialog, {
+    props: {
+      open: true,
+      selectedConnector: {
+        id: "nightscout",
+        name: "Nightscout",
+        status: "Active",
+        state: "Configured",
+        isHealthy: true,
+      },
+      selectedConnectorCapabilities: {
+        supportsManualSync: true,
+        supportsHistoricalSync: true,
+      },
+    },
+  });
+
+  await page.getByRole("button", { name: "Sync Now" }).click();
+}
+
+describe("ConnectorDetailsDialog", () => {
+  it("reports the count a failed sync still landed", async () => {
+    await syncReturning({
+      success: false,
+      message: "Failed to sync Notes: the source refused the request",
+      errors: ["Failed to sync Notes: the source refused the request"],
+      itemsSynced: { Glucose: 288, Boluses: 12 },
+    });
+
+    await expect
+      .element(
+        page.getByText("Failed to sync Notes: the source refused the request")
+      )
+      .toBeVisible();
+    await expect.element(page.getByText("(300 items)")).toBeVisible();
+  });
+
+  it("reports a zero count for a failed sync that landed nothing", async () => {
+    await syncReturning({
+      success: false,
+      message: "Sync failed while fetching data",
+      errors: ["Failed to fetch Glucose"],
+      itemsSynced: { Glucose: 0 },
+    });
+
+    await expect.element(page.getByText("(0 items)")).toBeVisible();
+  });
+
+  it("reports the count a successful sync landed", async () => {
+    await syncReturning({
+      success: true,
+      message: "",
+      errors: [],
+      itemsSynced: { Glucose: 288 },
+    });
+
+    await expect.element(page.getByText("(288 items)")).toBeVisible();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/connectors/SyncResultCard.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/SyncResultCard.svelte
@@ -18,6 +18,26 @@
     $props();
 </script>
 
+<!--
+  Rendered on both outcomes. A failed sync is usually a partial one — the connectors record a count
+  per type they reached and fail the run for the type they did not — so on a failure these counts
+  are the only thing that says how much of the run still landed.
+-->
+{#snippet syncedCounts(items: SyncResult["itemsSynced"])}
+  {#if items}
+    <div class="flex flex-wrap gap-3 mt-3">
+      {#each Object.entries(items) as [type, count] (type)}
+        {#if count != null}
+          <Badge variant="outline">
+            {count}
+            {type.toLowerCase()}
+          </Badge>
+        {/if}
+      {/each}
+    </div>
+  {/if}
+{/snippet}
+
 <div class="space-y-6">
   {#if syncResult && syncResult.success}
     <Card class="border-green-500">
@@ -31,25 +51,9 @@
           <div>
             <p class="font-medium text-lg">Sync completed</p>
             <p class="text-sm text-muted-foreground mt-1">
-              {syncResult.message ||
-                `${displayName} synced successfully.`}
+              {syncResult.message || `${displayName} synced successfully.`}
             </p>
-            {#if syncResult.itemsSynced}
-              {@const syncedItems = Object.keys(
-                syncResult.itemsSynced
-              ) as Array<keyof typeof syncResult.itemsSynced>}
-              <div class="flex flex-wrap gap-3 mt-3">
-                {#each syncedItems as key}
-                  {@const count = syncResult.itemsSynced?.[key]}
-                  {#if count != null}
-                    <Badge variant="outline">
-                      {count}
-                      {key.toLowerCase()}
-                    </Badge>
-                  {/if}
-                {/each}
-              </div>
-            {/if}
+            {@render syncedCounts(syncResult.itemsSynced)}
           </div>
         </div>
       </CardContent>
@@ -69,14 +73,13 @@
               {syncResult.message || "An error occurred during sync."}
             </p>
             {#if syncResult.errors && syncResult.errors.length > 0}
-              <ul
-                class="text-sm text-destructive mt-2 list-disc list-inside"
-              >
+              <ul class="text-sm text-destructive mt-2 list-disc list-inside">
                 {#each syncResult.errors as err}
                   <li>{err}</li>
                 {/each}
               </ul>
             {/if}
+            {@render syncedCounts(syncResult.itemsSynced)}
           </div>
         </div>
       </CardContent>

--- a/src/Web/packages/app/src/lib/components/connectors/SyncResultCard.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/SyncResultCard.svelte
@@ -19,9 +19,8 @@
 </script>
 
 <!--
-  Rendered on both outcomes. A failed sync is usually a partial one — the connectors record a count
-  per type they reached and fail the run for the type they did not — so on a failure these counts
-  are the only thing that says how much of the run still landed.
+  A count of zero still earns a badge: connectors record one per type they reached, so an absent
+  key means the type went unchecked where a zero means it was checked and held nothing.
 -->
 {#snippet syncedCounts(items: SyncResult["itemsSynced"])}
   {#if items}

--- a/src/Web/packages/app/src/lib/components/connectors/SyncResultCard.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/SyncResultCard.svelte.test.ts
@@ -1,0 +1,75 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect } from "vitest";
+import SyncResultCard from "./SyncResultCard.svelte";
+import type { SyncResult } from "$lib/api/generated/nocturne-api-client";
+
+function makeResult(overrides: Partial<SyncResult> = {}): SyncResult {
+  return {
+    success: true,
+    message: "",
+    itemsSynced: {},
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe("SyncResultCard", () => {
+  it("reports the counts a failed sync still landed", async () => {
+    render(SyncResultCard, {
+      syncResult: makeResult({
+        success: false,
+        message: "Failed to sync Notes: the source refused the request",
+        errors: ["Failed to sync Notes: the source refused the request"],
+        itemsSynced: { Glucose: 288, Boluses: 12 },
+      }),
+      displayName: "Nightscout",
+    });
+
+    await expect.element(page.getByText("Sync failed")).toBeVisible();
+    await expect.element(page.getByText("288 glucose")).toBeVisible();
+    await expect.element(page.getByText("12 boluses")).toBeVisible();
+  });
+
+  it("headlines the reason the sync reported rather than its own fallback", async () => {
+    render(SyncResultCard, {
+      syncResult: makeResult({
+        success: false,
+        message: "Sync failed while fetching data",
+        errors: ["Chunk 2/5 failed (2026-01-08 to 2026-01-15)"],
+      }),
+      displayName: "Nightscout",
+    });
+
+    await expect
+      .element(page.getByText("Sync failed while fetching data"))
+      .toBeVisible();
+    await expect
+      .element(page.getByText("An error occurred during sync."))
+      .not.toBeInTheDocument();
+  });
+
+  it("falls back to its own copy when the sync reported no message", async () => {
+    render(SyncResultCard, {
+      syncResult: makeResult({ success: false, errors: ["Sync error"] }),
+      displayName: "Nightscout",
+    });
+
+    await expect
+      .element(page.getByText("An error occurred during sync."))
+      .toBeVisible();
+  });
+
+  it("reports the counts a successful sync landed", async () => {
+    render(SyncResultCard, {
+      syncResult: makeResult({
+        success: true,
+        itemsSynced: { Glucose: 288 },
+      }),
+      displayName: "Nightscout",
+    });
+
+    await expect.element(page.getByText("Sync completed")).toBeVisible();
+    await expect.element(page.getByText("288 glucose")).toBeVisible();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/connectors/SyncResultCard.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/SyncResultCard.svelte.test.ts
@@ -31,6 +31,20 @@ describe("SyncResultCard", () => {
     await expect.element(page.getByText("12 boluses")).toBeVisible();
   });
 
+  it("badges a type the failed sync checked and found empty", async () => {
+    render(SyncResultCard, {
+      syncResult: makeResult({
+        success: false,
+        message: "Failed to sync Notes: the source refused the request",
+        errors: ["Failed to sync Notes: the source refused the request"],
+        itemsSynced: { Glucose: 0 },
+      }),
+      displayName: "Nightscout",
+    });
+
+    await expect.element(page.getByText("0 glucose")).toBeVisible();
+  });
+
   it("headlines the reason the sync reported rather than its own fallback", async () => {
     render(SyncResultCard, {
       syncResult: makeResult({

--- a/src/Web/packages/app/src/lib/components/connectors/connector-details-dialog-test-wrapper.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/connector-details-dialog-test-wrapper.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import * as Tooltip from "$lib/components/ui/tooltip";
+  import ConnectorDetailsDialog from "./ConnectorDetailsDialog.svelte";
+  import type { ConnectorCapabilities } from "$lib/api/generated/nocturne-api-client";
+  import type { ConnectorStatusWithDescription } from "./ServerConnectorsCard.svelte";
+
+  interface Props {
+    open?: boolean;
+    selectedConnector: ConnectorStatusWithDescription | null;
+    selectedConnectorCapabilities: ConnectorCapabilities | null;
+  }
+
+  let {
+    open = $bindable(false),
+    selectedConnector,
+    selectedConnectorCapabilities,
+  }: Props = $props();
+</script>
+
+<Tooltip.Provider>
+  <ConnectorDetailsDialog
+    bind:open
+    {selectedConnector}
+    {selectedConnectorCapabilities}
+  />
+</Tooltip.Provider>

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
@@ -9,10 +9,11 @@ using Xunit;
 namespace Nocturne.Connectors.Core.Tests.Services;
 
 /// <summary>
-///     Covers the terminal progress message every sync ends with. A run that never reports a
-///     terminal <see cref="SyncPhase"/> leaves the tenant's connector stuck on "syncing" until the
-///     page is reloaded, so the outcome is reported by the shared run wrapper rather than left to
-///     each connector.
+///     Covers what the shared run wrapper says about a finished sync: the terminal progress message
+///     every run ends with, and the failure message the tenant's sync card headlines. A run that
+///     never reports a terminal <see cref="SyncPhase"/> leaves the tenant's connector stuck on
+///     "syncing" until the page is reloaded, and one that reports no message headlines as an
+///     unexplained failure — so both are owned by the wrapper rather than left to each connector.
 /// </summary>
 public class SyncTerminalPhaseTests
 {
@@ -279,6 +280,85 @@ public class SyncTerminalPhaseTests
         // Assert
         service.AuthenticateCalls.Should().Be(1);
         service.EnsureAuthenticatedCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task FailedSyncRecordingOnlyErrors_HeadlinesTheFirstOne()
+    {
+        // Arrange: the shape a per-type catch block leaves behind — the type that failed is in the
+        // errors and nothing has named the run.
+        var (reporter, _) = BuildReporter();
+
+        // Act
+        var result = await RunAsync(result =>
+        {
+            result.Success = false;
+            result.Errors.Add("Failed to sync Boluses: upstream refused the request");
+            result.Errors.Add("Failed to sync Notes: upstream refused the request");
+            return Task.CompletedTask;
+        }, reporter.Object);
+
+        // Assert
+        result.Message.Should().Be("Failed to sync Boluses: upstream refused the request",
+            "the card headlines the message, so leaving it empty hides which type failed behind a "
+            + "generic fallback");
+    }
+
+    [Fact]
+    public async Task FailedSync_KeepsTheMessageTheRunAlreadyChose()
+    {
+        // Arrange: a summary an inner path chose says more than the raw error text does
+        var (reporter, _) = BuildReporter();
+
+        // Act
+        var result = await RunAsync(result =>
+        {
+            result.Success = false;
+            result.Message = "Sync failed while fetching data";
+            result.Errors.Add("Chunk 2/5 failed (2026-01-08 to 2026-01-15)");
+            return Task.CompletedTask;
+        }, reporter.Object);
+
+        // Assert
+        result.Message.Should().Be("Sync failed while fetching data");
+    }
+
+    [Fact]
+    public async Task AuthenticationFailure_KeepsItsOwnSummary()
+    {
+        // Arrange: the authentication result carries both halves already, and its message is the
+        // one the tenant can act on — not the source-qualified detail meant for the error list.
+        var (reporter, _) = BuildReporter();
+        var service = new TestConnectorService(_ => Task.CompletedTask) { AuthenticationSucceeds = false };
+
+        // Act
+        var result = await service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] },
+            new TestConfig(),
+            CancellationToken.None,
+            reporter.Object);
+
+        // Assert
+        result.Message.Should().Be("Authentication failed");
+    }
+
+    [Fact]
+    public async Task SuccessfulSyncCarryingAnError_IsNotHeadlinedAsAFailure()
+    {
+        // Arrange: the card falls back to its own success line when the message is empty, so a
+        // run that stayed green must not have an error text stood in for it.
+        var (reporter, _) = BuildReporter();
+
+        // Act
+        var result = await RunAsync(result =>
+        {
+            result.Errors.Add("Failed to sync Notes: upstream refused the request");
+            return Task.CompletedTask;
+        }, reporter.Object);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Message.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/SyncTerminalPhaseTests.cs
@@ -343,6 +343,22 @@ public class SyncTerminalPhaseTests
     }
 
     [Fact]
+    public async Task BackgroundSyncThatThrew_HeadlinesTheExceptionItSwallowed()
+    {
+        // Arrange: unlike the requested-range entry point, the background one converts an escaped
+        // exception into an errors-only result of its own, which no connector code can name.
+        var (reporter, _) = BuildReporter();
+        var service = new TestConnectorService(_ => throw new InvalidOperationException("upstream went away"));
+
+        // Act
+        var result = await service.SyncDataAsync(new TestConfig(), CancellationToken.None, null, reporter.Object);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.Message.Should().Be("upstream went away");
+    }
+
+    [Fact]
     public async Task SuccessfulSyncCarryingAnError_IsNotHeadlinedAsAFailure()
     {
         // Arrange: the card falls back to its own success line when the message is empty, so a


### PR DESCRIPTION
Closes #946.

## The defects

1. **A failed sync headlines generically.** The connectors record per-type failures into `SyncResult.Errors` but never set `SyncResult.Message`, and the manual-sync dialog (`ConnectorDetailsDialog`) renders *only* `Message` on failure — so every per-type failure shows "Sync failed" with the real reason unreachable, not merely buried. (`AuthenticationFailedResult` sets `Message`, which is why auth failures read correctly and this gap was easy to miss.)
2. **Successful counts vanish on a failed sync.** Since #783 a partial failure is the normal shape of a bad sync, but the counts rendered only in the success branch — a tenant saw a red box and couldn't tell that everything else synced.

## The fix

**Message, in the shared path.** New `StandInFailureMessage` on `BaseConnectorService`, called in `RunWithProgressAsync` — the one point both public `SyncDataAsync` overloads and all three overriding connectors converge on. If a run failed, recorded errors, and set no message, it headlines with the first recorded failure. A message an inner path already chose (`AuthenticationFailedResult`, `RecordFailure`, Glooko's per-path messages) is left standing. Every connector gains a real headline with no per-connector edits and nothing to drift.

**Counts, on the live surface.** `ConnectorDetailsDialog`'s failure branch now renders the item-count total it already showed on success (its own summed-total idiom, reused via a snippet — not the per-type badge card). `SyncResultCard` gained the same both-branches treatment for completeness, though a hostile review found that component is currently unreachable (its setup-flow steps never fire) — filed separately as a dead-flow issue; its changes are correct and dormant until that flow is decided.

## Verification

- `Nocturne.Connectors.Core.Tests` 142 green (incl. a new test through the background overload, whose catch-all produces an errors-only result no connector code names); Nightscout/Tidepool/NocturneRemote/CareLink/Glooko suites green. Browser component tests 8 green (2 files).
- Mutations killed (restored after): drop the `StandInFailureMessage` call; drop the not-clobber guard (auth + chosen-message tests red); drop the success short-circuit; `Errors[0]`→`Errors[^1]`; drop the count render from the dialog failure branch (both failure tests red, success survives); the absent-vs-zero snippet guard `count != null`→`count` (a checked-but-empty `0` must still render — the `RecordPublishOutcome` contract).
- `pnpm check` 54 errors before and after; no new lint errors on the touched files.
- Dialog component test uses a Tooltip-provider wrapper following the existing `tracker-notification-editor-test-wrapper` precedent.

## Follow-up (verified, not fixed here)

`ConnectorDetailsDialog`'s MyFitnessPal food-only block gates its count on `itemsSynced?.Food` (truthiness), so a legitimate `Food: 0` renders nothing — the same absent-vs-zero bug, in a branch left untouched to keep this minimal.

https://claude.ai/code/session_013JMfvQxpzTVwa27EBLJ2dZ
