### PR TITLE
fix(chat-identity): close the default-link lifecycle gaps

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityController.cs
@@ -41,28 +41,49 @@ public class ChatIdentityController : ControllerBase
         _tenantAccessor = tenantAccessor;
     }
 
+    /// <summary>The authenticated subject, or <c>null</c> for a credential that carries none.</summary>
+    private Guid? SubjectId => (HttpContext.Items["AuthContext"] as AuthContext)?.SubjectId;
+
     /// <summary>
     /// Resolves the authenticated user's subject ID or throws if unavailable.
     /// </summary>
     /// <returns>The authenticated subject's <see cref="Guid"/>.</returns>
     /// <exception cref="InvalidOperationException">Thrown when <see cref="AuthContext"/> is missing or has no subject ID.</exception>
     private Guid GetUserIdOrThrow()
-    {
-        var authContext = HttpContext.Items["AuthContext"] as AuthContext
-            ?? throw new InvalidOperationException("AuthContext not available");
-        return authContext.SubjectId
-            ?? throw new InvalidOperationException("Authenticated request has no subject id");
-    }
+        => SubjectId ?? throw new InvalidOperationException(
+            "Authenticated request has no subject id");
 
     /// <summary>List active chat identity links for the current tenant.</summary>
+    /// <remarks>
+    /// The list stays tenant-scoped, so a chat account linked to several tenants shows a
+    /// non-default row here while its default sits on a row this tenant cannot see. Naming that
+    /// row's label closes the gap without widening the list, and it is filled in only for the
+    /// caller's own links: a co-member's chat account may be linked to tenants the caller has no
+    /// part in, and its label is that tenant's slug.
+    /// </remarks>
     [HttpGet]
     [RemoteQuery]
     [ProducesResponseType(typeof(List<ChatIdentityLinkResponse>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<ChatIdentityLinkResponse>>> GetLinks(CancellationToken ct)
     {
         var tenantId = _tenantAccessor.TenantId;
+        var subjectId = SubjectId;
         var links = await _service.GetByTenantAsync(tenantId, ct);
-        return Ok(links.Select(MapResponse).ToList());
+
+        var responses = new List<ChatIdentityLinkResponse>(links.Count);
+        foreach (var link in links)
+        {
+            var response = MapResponse(link);
+            if (link.NocturneUserId == subjectId)
+            {
+                var holder = await _service.GetDefaultAsync(link.Platform, link.PlatformUserId, ct);
+                response.DefaultLabel = holder?.Label;
+            }
+
+            responses.Add(response);
+        }
+
+        return Ok(responses);
     }
 
     /// <summary>Claim a pending link token after /connect slash command auth.</summary>
@@ -206,6 +227,14 @@ public class ChatIdentityLinkResponse
     public string Label { get; set; } = string.Empty;
     public string DisplayName { get; set; } = string.Empty;
     public bool IsDefault { get; set; }
+
+    /// <summary>
+    /// Label of the link a bare bot invocation from this chat account resolves to, which may be a
+    /// link in another tenant. Null when the chat account has no default, and on links belonging to
+    /// another subject.
+    /// </summary>
+    public string? DefaultLabel { get; set; }
+
     public string DisplayUnit { get; set; } = "mg/dL";
     public bool IsActive { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/src/API/Nocturne.API/Services/Chat/ChatIdentityDirectoryService.cs
+++ b/src/API/Nocturne.API/Services/Chat/ChatIdentityDirectoryService.cs
@@ -26,6 +26,12 @@ namespace Nocturne.API.Services.Chat;
 /// (<c>IsDefault = true</c>). Subsequent calls to <see cref="SetDefaultAsync"/> clear the
 /// previous default and set the new one atomically inside a user-initiated transaction wrapped
 /// by the Npgsql retry execution strategy, enabling safe replay on transient failures.
+/// <see cref="RevokeAsync"/> closes the same loop: a platform user left holding a single link has
+/// no choice to make, so that survivor becomes the default — the same unambiguous call the
+/// first-link rule makes, and what stops deleting the default from leaving none. Two or more
+/// survivors is a real choice between tenants, which the bot asks the user to make rather than
+/// guessing for them. That promotion is unscoped because one link per tenant per platform user
+/// puts every survivor in a different tenant from the revoked link.
 /// </para>
 /// <para>
 /// Each method opens its own <see cref="Microsoft.EntityFrameworkCore.DbContext"/> from the
@@ -59,29 +65,14 @@ public sealed class ChatIdentityDirectoryService(
             .ToListAsync(ct);
     }
 
-    /// <summary>Resolves a single directory entry by platform user and optional label, falling back to the default link.</summary>
-    public async Task<ChatIdentityDirectoryEntry?> GetByPlatformAndUserAsync(
-        string platform, string platformUserId, string? labelArg, CancellationToken ct)
-    {
-        var candidates = await GetCandidatesAsync(platform, platformUserId, ct);
-        if (candidates.Count == 0)
-        {
-            return null;
-        }
-
-        if (labelArg is not null)
-        {
-            return candidates.FirstOrDefault(c => c.Label == labelArg);
-        }
-
-        if (candidates.Count == 1)
-        {
-            return candidates[0];
-        }
-
-        var defaults = candidates.Where(c => c.IsDefault).ToList();
-        return defaults.Count == 1 ? defaults[0] : null;
-    }
+    /// <summary>
+    /// Returns the active entry a bare bot invocation resolves to for a platform user, or
+    /// <c>null</c> when that platform user has no default. The entry may belong to any tenant.
+    /// </summary>
+    public async Task<ChatIdentityDirectoryEntry?> GetDefaultAsync(
+        string platform, string platformUserId, CancellationToken ct)
+        => (await GetCandidatesAsync(platform, platformUserId, ct))
+            .FirstOrDefault(d => d.IsDefault);
 
     /// <summary>Returns all active directory entries for a tenant.</summary>
     public async Task<IReadOnlyList<ChatIdentityDirectoryEntry>> GetByTenantAsync(
@@ -261,7 +252,10 @@ public sealed class ChatIdentityDirectoryService(
         await db.SaveChangesAsync(ct);
     }
 
-    /// <summary>Permanently deletes a directory link.</summary>
+    /// <summary>
+    /// Permanently deletes a directory link, promoting the platform user's sole surviving link to
+    /// default.
+    /// </summary>
     /// <param name="linkId">The directory entry to delete.</param>
     /// <param name="tenantScope">Tenant the entry must belong to, or <c>null</c> for a cross-tenant caller.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -269,9 +263,29 @@ public sealed class ChatIdentityDirectoryService(
     public async Task<int> RevokeAsync(Guid linkId, Guid? tenantScope, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
-        return await db.ChatIdentityDirectory
+        var target = await db.ChatIdentityDirectory.AsNoTracking()
+            .Where(ScopedToId(linkId, tenantScope))
+            .FirstOrDefaultAsync(ct);
+        if (target is null)
+        {
+            return 0;
+        }
+
+        var deleted = await db.ChatIdentityDirectory
             .Where(ScopedToId(linkId, tenantScope))
             .ExecuteDeleteAsync(ct);
+        if (deleted == 0)
+        {
+            return deleted;
+        }
+
+        var survivors = await GetCandidatesAsync(target.Platform, target.PlatformUserId, ct);
+        if (survivors is [{ IsDefault: false } survivor])
+        {
+            await SetDefaultAsync(survivor.Id, tenantScope: null, ct);
+        }
+
+        return deleted;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Chat/ChatIdentityService.cs
+++ b/src/API/Nocturne.API/Services/Chat/ChatIdentityService.cs
@@ -38,6 +38,11 @@ public sealed class ChatIdentityService(
         Guid tenantId, CancellationToken ct)
         => directory.GetByTenantAsync(tenantId, ct);
 
+    /// <inheritdoc cref="ChatIdentityDirectoryService.GetDefaultAsync"/>
+    public Task<ChatIdentityDirectoryEntry?> GetDefaultAsync(
+        string platform, string platformUserId, CancellationToken ct)
+        => directory.GetDefaultAsync(platform, platformUserId, ct);
+
     /// <summary>Consumes a pending link token and creates a directory entry linking the chat platform user to the tenant.</summary>
     public async Task<ChatIdentityDirectoryEntry> ClaimPendingLinkAsync(
         Guid tenantId, Guid userId, string token, CancellationToken ct)

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/+page.svelte
@@ -141,7 +141,7 @@
 		<Card.Header>
 			<Card.Title>Linked accounts</Card.Title>
 			<Card.Description>
-				Discord accounts linked to <strong>this Nocturne instance</strong>. Each one can be
+				Discord accounts linked to <strong>this Nocturne account</strong>. Each one can be
 				queried from Discord with <code>/bg &lt;label&gt;</code>.
 			</Card.Description>
 		</Card.Header>
@@ -206,6 +206,12 @@
 												· Discord <code>{link.platformUserId}</code>
 											{/if}
 										</div>
+										{#if !link.isDefault && link.defaultLabel}
+											<div class="text-xs text-muted-foreground truncate">
+												<code>/bg</code> without a label goes to <code>{link.defaultLabel}</code> on
+												another Nocturne account.
+											</div>
+										{/if}
 									</div>
 								</div>
 								<div class="flex gap-1 shrink-0">

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ChatIdentityControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ChatIdentityControllerTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.API.Services.Chat;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Identity;
+
+/// <summary>
+/// Covers what the tenant-scoped link list tells a member about a chat account whose default sits
+/// on a link in a tenant this list does not show.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ChatIdentityControllerTests
+{
+    private const string Platform = "discord";
+    private const string ChatUser = "discord-user-a";
+
+    private readonly Guid _tenantId = Guid.NewGuid();
+    private readonly Guid _otherTenantId = Guid.NewGuid();
+    private readonly Guid _callerSubjectId = Guid.NewGuid();
+    private readonly DbContextOptions<NocturneDbContext> _dbOptions =
+        new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+    private NocturneDbContext CreateDbContext() => new(_dbOptions);
+
+    private void InsertLink(Guid tenantId, Guid subjectId, string label, bool isDefault)
+    {
+        using var db = CreateDbContext();
+        db.ChatIdentityDirectory.Add(new ChatIdentityDirectoryEntry
+        {
+            Id = Guid.CreateVersion7(),
+            Platform = Platform,
+            PlatformUserId = ChatUser,
+            TenantId = tenantId,
+            NocturneUserId = subjectId,
+            Label = label,
+            DisplayName = label,
+            IsDefault = isDefault,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+        });
+        db.SaveChanges();
+    }
+
+    private ChatIdentityController CreateController(bool withSubject = true)
+    {
+        var factory = new Mock<IDbContextFactory<NocturneDbContext>>();
+        factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateDbContext);
+
+        var service = new ChatIdentityService(
+            new ChatIdentityDirectoryService(
+                factory.Object, Mock.Of<ILogger<ChatIdentityDirectoryService>>()),
+            new ChatIdentityPendingLinkService(
+                factory.Object, Mock.Of<ILogger<ChatIdentityPendingLinkService>>()),
+            factory.Object,
+            Mock.Of<ILogger<ChatIdentityService>>());
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.SetupGet(t => t.TenantId).Returns(_tenantId);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            SubjectId = withSubject ? _callerSubjectId : null,
+            TenantId = _tenantId,
+        };
+
+        return new ChatIdentityController(service, tenantAccessor.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+
+    private static ChatIdentityLinkResponse SingleLink(ActionResult<List<ChatIdentityLinkResponse>> result)
+        => result.Result.Should().BeOfType<OkObjectResult>().Subject
+            .Value.Should().BeOfType<List<ChatIdentityLinkResponse>>().Subject
+            .Should().ContainSingle().Subject;
+
+    [Fact]
+    public async Task GetLinks_names_the_link_holding_the_default_when_it_belongs_to_another_tenant()
+    {
+        InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: false);
+        InsertLink(_otherTenantId, _callerSubjectId, "oliver", isDefault: true);
+
+        var link = SingleLink(await CreateController().GetLinks(CancellationToken.None));
+
+        link.Label.Should().Be("lily");
+        link.IsDefault.Should().BeFalse();
+        link.DefaultLabel.Should().Be("oliver");
+    }
+
+    [Fact]
+    public async Task GetLinks_leaves_the_default_label_off_a_link_belonging_to_another_subject()
+    {
+        InsertLink(_tenantId, Guid.NewGuid(), "lily", isDefault: false);
+        InsertLink(_otherTenantId, Guid.NewGuid(), "oliver", isDefault: true);
+
+        var link = SingleLink(await CreateController().GetLinks(CancellationToken.None));
+
+        link.DefaultLabel.Should().BeNull(
+            "the label is the slug of a tenant the caller may have no part in");
+    }
+
+    [Fact]
+    public async Task GetLinks_reports_no_default_label_when_no_link_holds_the_default()
+    {
+        InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: false);
+        InsertLink(_otherTenantId, _callerSubjectId, "oliver", isDefault: false);
+
+        var link = SingleLink(await CreateController().GetLinks(CancellationToken.None));
+
+        link.DefaultLabel.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetLinks_still_lists_for_a_credential_that_carries_no_subject()
+    {
+        InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: false);
+        InsertLink(_otherTenantId, _callerSubjectId, "oliver", isDefault: true);
+
+        var link = SingleLink(await CreateController(withSubject: false).GetLinks(CancellationToken.None));
+
+        link.Label.Should().Be("lily");
+        link.DefaultLabel.Should().BeNull();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Chat/ChatIdentityDirectoryServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Chat/ChatIdentityDirectoryServiceTests.cs
@@ -523,6 +523,53 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
         after.Should().BeNull();
     }
 
+    [Fact]
+    public async Task RevokeAsync_promotes_the_sole_survivor_when_the_default_is_deleted()
+    {
+        var tenantA = NewTenant();
+        var a = await _service.CreateLinkAsync(Platform, UserA, tenantA, NewSubject(), "lily", "Lily", default);
+        var b = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
+        var elsewhere = await _service.CreateLinkAsync(Platform, UserB, NewTenant(), NewSubject(), "rose", "Rose", default);
+        a.IsDefault.Should().BeTrue();
+        b.IsDefault.Should().BeFalse();
+
+        await _service.RevokeAsync(a.Id, tenantScope: tenantA, ct: default);
+
+        var bAfter = await _service.GetByIdAsync(b.Id, tenantScope: null, ct: default);
+        bAfter!.IsDefault.Should().BeTrue(
+            "the survivor is in another tenant than the revoked link, so a tenant-scoped promotion would miss it");
+        var elsewhereAfter = await _service.GetByIdAsync(elsewhere.Id, tenantScope: null, ct: default);
+        elsewhereAfter!.IsDefault.Should().BeTrue("another chat account's links are not survivors of this one");
+    }
+
+    [Fact]
+    public async Task RevokeAsync_promotes_the_sole_survivor_of_an_account_that_held_no_default()
+    {
+        InsertLink(UserA, NewTenant(), "lily", isDefault: false);
+        InsertLink(UserA, NewTenant(), "oliver", isDefault: false);
+        var before = await _service.GetCandidatesAsync(Platform, UserA, default);
+
+        await _service.RevokeAsync(before.Single(d => d.Label == "lily").Id, tenantScope: null, ct: default);
+
+        var survivors = await _service.GetCandidatesAsync(Platform, UserA, default);
+        survivors.Should().ContainSingle().Which.IsDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RevokeAsync_leaves_no_default_when_more_than_one_link_survives()
+    {
+        var tenantA = NewTenant();
+        var a = await _service.CreateLinkAsync(Platform, UserA, tenantA, NewSubject(), "lily", "Lily", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
+        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "rose", "Rose", default);
+
+        await _service.RevokeAsync(a.Id, tenantScope: tenantA, ct: default);
+
+        var survivors = await _service.GetCandidatesAsync(Platform, UserA, default);
+        survivors.Should().HaveCount(2);
+        survivors.Should().OnlyContain(d => !d.IsDefault, "choosing between two tenants belongs to the user");
+    }
+
     // ---- GetByTenantAsync ----
 
     [Fact]
@@ -538,61 +585,31 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
         result[0].TenantId.Should().Be(t1);
     }
 
-    // ---- GetByPlatformAndUserAsync ----
+    // ---- GetDefaultAsync ----
 
     [Fact]
-    public async Task GetByPlatformAndUserAsync_returns_exact_match_when_label_provided()
+    public async Task GetDefaultAsync_returns_the_holder_from_whichever_tenant_holds_it()
     {
-        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
-        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
+        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
+        var b = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
+        await _service.SetDefaultAsync(b.Id, tenantScope: null, ct: default);
+        await _service.CreateLinkAsync(Platform, UserB, NewTenant(), NewSubject(), "rose", "Rose", default);
 
-        var result = await _service.GetByPlatformAndUserAsync(Platform, UserA, "oliver", default);
+        var result = await _service.GetDefaultAsync(Platform, UserA, default);
+
         result.Should().NotBeNull();
-        result!.Label.Should().Be("oliver");
+        result!.Id.Should().Be(b.Id);
+        result.TenantId.Should().NotBe(a.TenantId);
     }
 
     [Fact]
-    public async Task GetByPlatformAndUserAsync_returns_default_when_label_null_and_multiple_exist()
+    public async Task GetDefaultAsync_returns_null_when_no_link_holds_the_default()
     {
-        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
-        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
+        InsertLink(UserA, NewTenant(), "lily", isDefault: false);
+        await _service.CreateLinkAsync(Platform, UserB, NewTenant(), NewSubject(), "rose", "Rose", default);
 
-        var result = await _service.GetByPlatformAndUserAsync(Platform, UserA, null, default);
-        result.Should().NotBeNull();
-        result!.Id.Should().Be(a.Id);
-    }
+        var result = await _service.GetDefaultAsync(Platform, UserA, default);
 
-    [Fact]
-    public async Task GetByPlatformAndUserAsync_returns_single_when_only_one_exists()
-    {
-        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
-        // Force IsDefault=false to simulate "no default"
-        using (var db = _factory.CreateDbContext())
-        {
-            var entity = await db.ChatIdentityDirectory.FirstAsync(d => d.Id == a.Id);
-            entity.IsDefault = false;
-            await db.SaveChangesAsync();
-        }
-
-        var result = await _service.GetByPlatformAndUserAsync(Platform, UserA, null, default);
-        result.Should().NotBeNull();
-        result!.Id.Should().Be(a.Id);
-    }
-
-    [Fact]
-    public async Task GetByPlatformAndUserAsync_returns_null_when_label_null_and_ambiguous()
-    {
-        var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
-        await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
-        // Clear default flag without setting another
-        using (var db = _factory.CreateDbContext())
-        {
-            var entity = await db.ChatIdentityDirectory.FirstAsync(d => d.Id == a.Id);
-            entity.IsDefault = false;
-            await db.SaveChangesAsync();
-        }
-
-        var result = await _service.GetByPlatformAndUserAsync(Platform, UserA, null, default);
         result.Should().BeNull();
     }
 


### PR DESCRIPTION
Closes #858.

Three lifecycle gaps around the default chat-identity link.

## 1. A multi-tenant user couldn't see where their default is

`GetLinks` is tenant-scoped, so a chat account linked to several tenants showed a non-default row at one tenant with nothing indicating the default sits on a row this tenant can't see — and offered "Set as default", sending the user to change state the page couldn't show them.

Fix keyed on the **chat account**, not the subject: each row belonging to the caller's own subject now carries `DefaultLabel`, the label a bare bot invocation from that chat account resolves to (which may be another tenant's). The list stays tenant-scoped. Rejected the cross-tenant-by-subject list because `CreateLinkAsync` doesn't require the same subject across a chat account's links, so a subject-keyed query wouldn't answer the question and would surface rows the tenant-scoped write endpoints can't act on. `DefaultLabel` is filled **only for the caller's own rows** — a co-member's chat account may be linked to tenants the caller has no part in, and its label is that tenant's slug. Disclosure is strictly less than the bot's existing ambiguity message, and only to the link's owner.

## 2. Revoking the default left no default

`RevokeAsync` hard-deleted and nothing promoted, so a user who removed their default was prompted on every bare invocation forever. Now a **sole surviving link** is promoted to default (the same unambiguous call the first-link rule makes); two-or-more survivors is a real choice between tenants, which the bot already asks the user to make. The promotion is tenantless because the one-link-per-tenant invariant puts every survivor in a different tenant from the revoked one, and it self-heals an already-defaultless account.

## 3. The resolution ladder existed twice

`GetByPlatformAndUserAsync` duplicated the bot's `pickCandidate` ladder (label → single → sole-default) and had **zero production callers** with no interface to hide behind — deleted. A narrow `GetDefaultAsync` (built on the existing `GetCandidatesAsync`) serves item 1; the bot's `pickCandidate` is now the only ladder.

## Verification

- Full API unit suite green (6033+); `pnpm check` within the pre-existing band, nothing new on the discord page.
- Mutations killed (restored after): promotion never fires; promote regardless of survivor count; tenant-scoped promotion (misses every survivor); `GetDefaultAsync` predicate flip and drop; owner-guard flip and removal; `GetUserIdOrThrow` in `GetLinks` (a subjectless credential must still list). A hostile review additionally confirmed both DB unique indexes (`ux_directory_user_one_default`, `ux_directory_user_tenant`) make "two defaults" and "a non-default row naming the caller's own tenant" impossible below the code.

## Security follow-ups (found during this work, verified, filed separately)

- `CreateDirectLink` (`links/direct`) accepts a `platformUserId` from the body under bare `[Authorize]` with no proof the caller controls that chat account, and has no frontend caller — a chat-account takeover vector.
- `GetLinks` maps `PlatformUserId` for every row in the tenant, letting any member enumerate co-members' platform ids.
- `RevokeLink` scopes only to tenant with no per-subject ownership check, so a member can revoke another member's link (and now trigger the cross-tenant promotion on their account).

https://claude.ai/code/session_013JMfvQxpzTVwa27EBLJ2dZ
