### PR TITLE
fix(web): set BODY_SIZE_LIMIT=44M in release Dockerfile.web

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -65,6 +65,10 @@ RUN node -e "import('zod'); import('@nocturne/bridge')"
 
 ENV NODE_ENV=production
 ENV PORT=5173
+# adapter-node caps request bodies at 512K by default, which rejects support
+# issue screenshot uploads (up to 4 x 10 MB) before they reach the app. Keep in
+# sync with src/Web/Dockerfile.
+ENV BODY_SIZE_LIMIT=44M
 EXPOSE 5173
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

The release image (`Dockerfile.web`) does not set `BODY_SIZE_LIMIT`, so adapter-node caps request bodies at its 512 KB default. The support issue form allows up to 4 × 10 MB screenshots and submits them through the `submitIssue` remote `form(...)` — anything larger than 512 KB is rejected with 413 before it reaches the app.

The dev/local image already handles this: #510 set `ENV BODY_SIZE_LIMIT=44M` in `src/Web/Dockerfile`, but the release image at the repo root was missed.

This PR adds the same env var (with a comment referencing the dev Dockerfile) to the runtime stage of `Dockerfile.web`.

## Changes
- `Dockerfile.web`: `ENV BODY_SIZE_LIMIT=44M` in the runtime stage

## Context
- Upload limit in UI: `IssueCreatorDialog.svelte` (`maxSize = 10 * 1024 * 1024`, 4 files)
- Dev image reference: `src/Web/Dockerfile` line 37
- Follow-up to #510 / #509