### PR TITLE
feat(injections): Adding long-acting injections to basal statistics calculations

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -69,6 +69,7 @@ public class StatisticsController : ControllerBase
     private readonly IApsSnapshotRepository _apsSnapshotRepository;
     private readonly IDeviceEventRepository _deviceEventRepository;
     private readonly ITargetRangeScheduleRepository _targetRangeScheduleRepository;
+    private readonly IBasalInjectionRepository _basalInjectionRepository;
     private readonly IActiveProfileResolver _activeProfileResolver;
     private readonly ICanonicalGlucoseService _canonicalGlucose;
 
@@ -93,6 +94,7 @@ public class StatisticsController : ControllerBase
         IApsSnapshotRepository apsSnapshotRepository,
         IDeviceEventRepository deviceEventRepository,
         ITargetRangeScheduleRepository targetRangeScheduleRepository,
+        IBasalInjectionRepository basalInjectionRepository,
         IActiveProfileResolver activeProfileResolver,
         ICanonicalGlucoseService canonicalGlucose
     )
@@ -113,6 +115,7 @@ public class StatisticsController : ControllerBase
         _apsSnapshotRepository = apsSnapshotRepository;
         _deviceEventRepository = deviceEventRepository;
         _targetRangeScheduleRepository = targetRangeScheduleRepository;
+        _basalInjectionRepository = basalInjectionRepository;
         _activeProfileResolver = activeProfileResolver;
         _canonicalGlucose = canonicalGlucose;
     }
@@ -846,13 +849,11 @@ public class StatisticsController : ControllerBase
 
                     // Fetch TempBasals and algorithm boluses for basal data
                     // Deduplicate by 30s window + rate to eliminate duplicates from multiple connectors
-                    var tempBasalTask = _tempBasalRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
-                    var algoTask      = _bolusRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken);
-
-                    await Task.WhenAll(tempBasalTask, algoTask);
-
-                    var tempBasals       = (await tempBasalTask).ToList();
-                    var algorithmBoluses = (await algoTask).ToList();
+                    // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
+                    // which does not support concurrent operations.
+                    var tempBasals       = (await _tempBasalRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken)).ToList();
+                    var algorithmBoluses = (await _bolusRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken)).ToList();
+                    var basalInjections  = (await _basalInjectionRepository.GetAsync(startTimestamp, endTimestamp, null, null, int.MaxValue, 0, false, cancellationToken)).ToList();
 
                     insulinDelivery = _statisticsService.CalculateInsulinDeliveryStatistics(
                         filteredBoluses,
@@ -860,13 +861,15 @@ public class StatisticsController : ControllerBase
                         tempBasals,
                         filteredCarbs,
                         startDate,
-                        endDate
+                        endDate,
+                        basalInjections
                     );
 
-                    // If no TempBasals/algorithm boluses but we have profile data, augment with scheduled basal
+                    // If no TempBasals/algorithm boluses/basal injections but we have profile data, augment with scheduled basal
                     if (
                         tempBasals.Count == 0
                         && algorithmBoluses.Count == 0
+                        && basalInjections.Count == 0
                         && hasProfileData
                     )
                     {
@@ -1041,15 +1044,12 @@ public class StatisticsController : ControllerBase
             var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
             var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
 
-            var bolusesTask   = _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
-            var tempBasalTask = _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
-            var algoTask      = _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
-
-            await Task.WhenAll(bolusesTask, tempBasalTask, algoTask);
-
-            var boluses          = await bolusesTask;
-            var tempBasals       = (await tempBasalTask).ToList();
-            var algorithmBoluses = await algoTask;
+            // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
+            // which does not support concurrent operations.
+            var boluses          = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
+            var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false)).ToList();
+            var algorithmBoluses = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
+            var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10000, 0, false)).ToList();
 
             var tzId = await _therapySettingsResolver.GetTimezoneAsync();
             var tz = !string.IsNullOrEmpty(tzId)
@@ -1060,7 +1060,8 @@ public class StatisticsController : ControllerBase
                 boluses,
                 algorithmBoluses,
                 tempBasals,
-                tz
+                tz,
+                basalInjections
             );
             return Ok(result);
         }
@@ -1100,24 +1101,20 @@ public class StatisticsController : ControllerBase
             var startDt = TimeZoneInfo.ConvertTimeToUtc(startLocalDate, tz);
             var endDt = TimeZoneInfo.ConvertTimeToUtc(endLocalDate.AddDays(1).AddTicks(-1), tz);
 
-            var glucoseTask   = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, 100_000, descending: false, ct: cancellationToken);
-            var bolusTask     = _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
-            var carbTask      = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken);
-            var algoTask      = _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken);
-            var tempBasalTask = _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken);
-
-            await Task.WhenAll(glucoseTask, bolusTask, carbTask, algoTask, tempBasalTask);
-
-            var glucoseData      = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
-            var manualBoluses    = (await bolusTask).ToList();
-            var carbs            = (await carbTask).ToList();
-            var algorithmBoluses = (await algoTask).ToList();
-            var tempBasals       = (await tempBasalTask).ToList();
+            // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
+            // which does not support concurrent operations.
+            var rawGlucose       = (await _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, 100_000, descending: false, ct: cancellationToken)).ToList();
+            var glucoseData      = (await _canonicalGlucose.SelectAsync(rawGlucose, cancellationToken)).ToList();
+            var manualBoluses    = (await _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Manual, ct: cancellationToken)).ToList();
+            var carbs            = (await _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken)).ToList();
+            var algorithmBoluses = (await _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken)).ToList();
+            var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken)).ToList();
+            var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10_000, 0, false, ct: cancellationToken)).ToList();
 
             // Daily basal totals come from the existing service path so the calendar's "totalBasal"
             // matches what /daily-basal-bolus-ratios would return for the same window.
             var dailyBasalBolus = _statisticsService.CalculateDailyBasalBolusRatios(
-                manualBoluses, algorithmBoluses, tempBasals, tz);
+                manualBoluses, algorithmBoluses, tempBasals, tz, basalInjections);
             var dailyBasalMap = new Dictionary<string, double>(StringComparer.Ordinal);
             foreach (var d in dailyBasalBolus.DailyData)
             {
@@ -1307,19 +1304,14 @@ public class StatisticsController : ControllerBase
             var startMs = new DateTimeOffset(startDt, TimeSpan.Zero).ToUnixTimeMilliseconds();
             var endMs   = new DateTimeOffset(endDt,   TimeSpan.Zero).ToUnixTimeMilliseconds();
 
-            var bolusesTask    = _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
-            var tempBasalsTask = _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
-            var algoTask       = _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
-            var carbsTask      = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
-            var resolverTask   = _basalRateResolver.BuildResolverAsync(startMs, endMs);
-
-            await Task.WhenAll(bolusesTask, tempBasalsTask, algoTask, carbsTask, resolverTask);
-
-            var boluses          = await bolusesTask;
-            var tempBasals       = (await tempBasalsTask).ToList();
-            var algorithmBoluses = await algoTask;
-            var carbs            = await carbsTask;
-            var rateAt           = await resolverTask;
+            // These reads share the request-scoped NocturneDbContext, which is not safe for
+            // concurrent operations, so they are awaited sequentially rather than via Task.WhenAll.
+            var boluses          = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
+            var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false)).ToList();
+            var algorithmBoluses = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
+            var carbs            = await _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
+            var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10000, 0, false)).ToList();
+            var rateAt           = await _basalRateResolver.BuildResolverAsync(startMs, endMs);
 
             foreach (var tb in tempBasals)
             {
@@ -1333,7 +1325,8 @@ public class StatisticsController : ControllerBase
                 tempBasals,
                 carbs,
                 startDate,
-                endDate
+                endDate,
+                basalInjections
             );
             return Ok(result);
         }
@@ -1447,21 +1440,21 @@ public class StatisticsController : ControllerBase
             // SMB) every ~5 minutes, so 90 days is ~26k records per type — a
             // 10k cap would silently truncate to the oldest ~35 days and
             // understate every average.
-            var tempBasalTask = _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false);
-            var bolusTask     = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual);
-            var algoTask      = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
-
-            await Task.WhenAll(tempBasalTask, bolusTask, algoTask);
-
-            var tempBasals       = (await tempBasalTask).ToList();
-            var boluses          = await bolusTask;
-            var algorithmBoluses = await algoTask;
+            // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
+            // which does not support concurrent operations.
+            var tempBasals       = (await _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false)).ToList();
+            var boluses          = await _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual);
+            var algorithmBoluses = await _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
+            var basalInjections  = (await _basalInjectionRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, 0, false)).ToList();
 
             // Fall back to profile-based scheduled rates when no TempBasals exist,
             // mirroring GetBasalAnalysis: each segment becomes one synthetic
             // TempBasal that gets duration-weighted across the hours it overlaps.
+            // Skip the profile fallback when basal injections exist: MDI injections are the
+            // actual basal source, so synthesizing scheduled rates from the profile on top of
+            // them would double-count the day's baseline coverage.
             var hasTherapyData = await _therapySettingsResolver.HasDataAsync(HttpContext.RequestAborted);
-            if (tempBasals.Count == 0 && hasTherapyData)
+            if (tempBasals.Count == 0 && basalInjections.Count == 0 && hasTherapyData)
             {
                 var fromMs = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
                 var toMs = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
@@ -1486,7 +1479,8 @@ public class StatisticsController : ControllerBase
                 algorithmBoluses,
                 startUtc,
                 endUtc,
-                userTz
+                userTz,
+                basalInjections
             );
             return Ok(result);
         }

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -1968,7 +1968,8 @@ public class StatisticsService : IStatisticsService
         IEnumerable<TempBasal> tempBasals,
         IEnumerable<CarbIntake> carbIntakes,
         DateTime startDate,
-        DateTime endDate
+        DateTime endDate,
+        IEnumerable<BasalInjection>? basalInjections = null
     )
     {
         // Start with bolus-based calculation (includes carb stats)
@@ -2011,7 +2012,23 @@ public class StatisticsService : IStatisticsService
         // Algorithm (micro) boluses are additional basal above scheduled
         additionalBasalInsulin += algorithmBolusInsulin;
 
-        var totalBasal = tempBasalInsulin + algorithmBolusInsulin;
+        // Sum basal injections (MDI long-acting insulin) — these are scheduled baseline coverage
+        var basalInjectionInsulin = 0.0;
+        var basalInjectionCount = 0;
+        if (basalInjections != null)
+        {
+            foreach (var bi in basalInjections)
+            {
+                if (bi.Units > 0)
+                {
+                    basalInjectionInsulin += bi.Units;
+                    basalInjectionCount++;
+                }
+            }
+        }
+        scheduledBasalInsulin += basalInjectionInsulin;
+
+        var totalBasal = tempBasalInsulin + algorithmBolusInsulin + basalInjectionInsulin;
         var totalInsulin = stats.TotalBolus + totalBasal;
 
         stats.TotalBasal = Math.Round(totalBasal * 100) / 100;
@@ -2025,6 +2042,8 @@ public class StatisticsService : IStatisticsService
             totalInsulin > 0 ? Math.Round(stats.TotalBolus / totalInsulin * 100 * 10) / 10 : 0;
         stats.MicroBolusCount = algorithmBolusList.Count;
         stats.MicroBolusInsulin = Math.Round(algorithmBolusInsulin * 100) / 100;
+        stats.BasalInjectionInsulin = Math.Round(basalInjectionInsulin * 100) / 100;
+        stats.BasalInjectionCount = basalInjectionCount;
 
         return stats;
     }
@@ -2036,7 +2055,8 @@ public class StatisticsService : IStatisticsService
         IEnumerable<Bolus> boluses,
         IEnumerable<Bolus> algorithmBoluses,
         IEnumerable<TempBasal> tempBasals,
-        TimeZoneInfo? userTimeZone = null
+        TimeZoneInfo? userTimeZone = null,
+        IEnumerable<BasalInjection>? basalInjections = null
     )
     {
         var tz = userTimeZone ?? TimeZoneInfo.Utc;
@@ -2084,6 +2104,23 @@ public class StatisticsService : IStatisticsService
 
             var (currentBasal, currentBolus) = dailyData[dateKey];
             dailyData[dateKey] = (currentBasal + ab.Insulin, currentBolus);
+        }
+
+        // Process basal injections (MDI long-acting insulin — treated as basal)
+        if (basalInjections != null)
+        {
+            foreach (var bi in basalInjections)
+            {
+                if (bi.Units <= 0)
+                    continue;
+
+                var dateKey = MillsToLocalDateString(bi.Mills, tz);
+                if (!dailyData.ContainsKey(dateKey))
+                    dailyData[dateKey] = (0, 0);
+
+                var (currentBasal, currentBolus) = dailyData[dateKey];
+                dailyData[dateKey] = (currentBasal + bi.Units, currentBolus);
+            }
         }
 
         // Build response
@@ -2255,7 +2292,8 @@ public class StatisticsService : IStatisticsService
         IEnumerable<Bolus> algorithmBoluses,
         DateTime startDate,
         DateTime endDate,
-        TimeZoneInfo? userTimeZone = null)
+        TimeZoneInfo? userTimeZone = null,
+        IEnumerable<BasalInjection>? basalInjections = null)
     {
         var tz = userTimeZone ?? TimeZoneInfo.Utc;
 
@@ -2301,6 +2339,24 @@ public class StatisticsService : IStatisticsService
             tempBasal[hour] += ab.Insulin;
             counts[hour]++;
             basalDays.Add(LocalDay(ab.Mills, tz));
+        }
+
+        // Long-acting basal injections (MDI) provide baseline coverage across their duration
+        // of insulin action, so spread each dose evenly across that window as scheduled basal —
+        // the discrete-dose analogue of a pump's scheduled rate tiling the day. The coverage
+        // window is the injection's recorded DIA when present (e.g. ~42h for degludec), else 24h.
+        const long HourMs = 3_600_000L;
+        foreach (var bi in (basalInjections ?? Enumerable.Empty<BasalInjection>()).Where(bi => bi.Units > 0))
+        {
+            // Coverage window is the injection's recorded DIA when valid, else 24h.
+            // Clamp to a sane ceiling so a bad DIA can't smear one dose across days of buckets.
+            var dia = bi.InsulinContext?.Dia ?? 0.0;
+            var coverageHours = dia > 0 ? Math.Min(dia, 72.0) : 24.0;
+            var ratePerHour = bi.Units / coverageHours;
+            var endMills = bi.Mills + (long)(coverageHours * HourMs);
+            DistributeInsulinAcrossHourOfDay(
+                bi.Mills, endMills, ratePerHour, tz, scheduledBasal, basalDays);
+            counts[LocalHourOfDay(bi.Mills, tz)]++;
         }
 
         // Average each component over the days that actually have its data, not

--- a/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
@@ -298,7 +298,7 @@ public interface IStatisticsService
 
     /// <summary>
     /// Calculate comprehensive insulin delivery statistics.
-    /// Basal data comes from TempBasals and algorithmBoluses; pass empty collections if none are available.
+    /// Basal data comes from TempBasals, algorithmBoluses, and basalInjections (MDI); pass empty collections if none are available.
     /// </summary>
     InsulinDeliveryStatistics CalculateInsulinDeliveryStatistics(
         IEnumerable<Bolus> boluses,
@@ -306,7 +306,8 @@ public interface IStatisticsService
         IEnumerable<TempBasal> tempBasals,
         IEnumerable<CarbIntake> carbIntakes,
         DateTime startDate,
-        DateTime endDate
+        DateTime endDate,
+        IEnumerable<BasalInjection>? basalInjections = null
     );
 
     // Formatting Utilities
@@ -393,13 +394,14 @@ public interface IStatisticsService
 
     /// <summary>
     /// Calculate daily basal/bolus ratio breakdown.
-    /// Basal data comes from TempBasals and algorithm boluses; pass empty collections if none are available.
+    /// Basal data comes from TempBasals, algorithm boluses, and basalInjections (MDI); pass empty collections if none are available.
     /// </summary>
     DailyBasalBolusRatioResponse CalculateDailyBasalBolusRatios(
         IEnumerable<Bolus> boluses,
         IEnumerable<Bolus> algorithmBoluses,
         IEnumerable<TempBasal> tempBasals,
-        TimeZoneInfo? userTimeZone = null);
+        TimeZoneInfo? userTimeZone = null,
+        IEnumerable<BasalInjection>? basalInjections = null);
 
     /// <summary>
     /// Calculate comprehensive basal analysis statistics from TempBasals. Hourly percentiles are
@@ -420,6 +422,8 @@ public interface IStatisticsService
     /// divide by the number of distinct local days that have delivery data, so a
     /// period that extends beyond the available data does not distort the pattern.
     /// Defaults to UTC hour-of-day when <paramref name="userTimeZone"/> is null.
+    /// Long-acting basal injections (MDI) are spread evenly across the 24 hours
+    /// following each injection and counted as scheduled basal.
     /// </summary>
     HourlyInsulinDeliveryResponse CalculateHourlyInsulinDelivery(
         IEnumerable<TempBasal> tempBasals,
@@ -427,5 +431,6 @@ public interface IStatisticsService
         IEnumerable<Bolus> algorithmBoluses,
         DateTime startDate,
         DateTime endDate,
-        TimeZoneInfo? userTimeZone = null);
+        TimeZoneInfo? userTimeZone = null,
+        IEnumerable<BasalInjection>? basalInjections = null);
 }

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -1987,6 +1987,17 @@ public class InsulinDeliveryStatistics
     public double MicroBolusInsulin { get; set; }
 
     /// <summary>
+    /// Total insulin from discrete long-acting basal injections (MDI) in units.
+    /// Included in <see cref="TotalBasal"/> and <see cref="ScheduledBasal"/>.
+    /// </summary>
+    public double BasalInjectionInsulin { get; set; }
+
+    /// <summary>
+    /// Number of discrete long-acting basal injections (MDI) in the period.
+    /// </summary>
+    public int BasalInjectionCount { get; set; }
+
+    /// <summary>
     /// Reliability assessment for insulin delivery statistics
     /// </summary>
     public StatisticReliability? Reliability { get; set; }

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
@@ -48,7 +48,16 @@
     endDate: reportsParams.endDate.toISOString() as unknown as Date,
   });
 
-  const dailyRatiosResource = $derived(getDailyBasalBolusRatios(statisticsDates));
+  // Routed through contextResource (not a bare $derived query) so a resolved
+  // response is retained across superseded query instances. A raw
+  // $derived(getDailyBasalBolusRatios(...)) stranded the value on a superseded
+  // instance (sveltejs/kit#14915), leaving .current undefined and the chart
+  // permanently showing "no insulin data available" even though the endpoint
+  // returned full daily data.
+  const dailyRatiosResource = contextResource(
+    () => getDailyBasalBolusRatios(statisticsDates),
+    { errorTitle: "Error Loading Insulin Delivery Data" }
+  );
 
   // Headline insulin figures for the selected range. The fixed-bucket
   // multi-period endpoint was used here instead, so every number above the

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
@@ -25,6 +25,7 @@ public class StatisticsControllerTests
     private readonly Mock<ITempBasalRepository> _tempBasalRepoMock = new();
     private readonly Mock<ITherapySettingsResolver> _therapySettingsResolverMock = new();
     private readonly Mock<ITargetRangeScheduleRepository> _targetRangeScheduleRepoMock = new();
+    private readonly Mock<IBasalInjectionRepository> _basalInjectionRepoMock = new();
     private readonly Mock<IActiveProfileResolver> _activeProfileResolverMock = new();
 
     private StatisticsController CreateController()
@@ -46,6 +47,7 @@ public class StatisticsControllerTests
             Mock.Of<IApsSnapshotRepository>(),
             Mock.Of<IDeviceEventRepository>(),
             _targetRangeScheduleRepoMock.Object,
+            _basalInjectionRepoMock.Object,
             _activeProfileResolverMock.Object,
             TestDoubles.CanonicalGlucosePassThrough.Create());
 
@@ -95,12 +97,21 @@ public class StatisticsControllerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<TempBasal>());
 
+        _basalInjectionRepoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<BasalInjection>());
+
         _statsServiceMock
             .Setup(s => s.CalculateDailyBasalBolusRatios(
                 It.IsAny<IEnumerable<Bolus>>(),
                 It.IsAny<IEnumerable<Bolus>>(),
                 It.IsAny<IEnumerable<TempBasal>>(),
-                It.IsAny<TimeZoneInfo?>()))
+                It.IsAny<TimeZoneInfo?>(),
+                It.IsAny<IEnumerable<BasalInjection>?>()))
             .Returns(new DailyBasalBolusRatioResponse());
     }
 


### PR DESCRIPTION
Replaces previous PR https://github.com/nightscout/nocturne/pull/423 which became obsolete after changes to the underlying structures.

ong-acting injections were being imported and stored in a separate table, but were never counted towards the basal statistics. This adds these treatments to the TDD widget and insulin delivery.

Before:
<img width="463" height="305" alt="Screenshot 2026-08-25 at 3 56 37 PM" src="https://github.com/user-attachments/assets/91020ade-3d24-4d3b-84e4-ac127f6bf751" />
<img width="1289" height="173" alt="Screenshot 2026-08-25 at 3 56 03 PM" src="https://github.com/user-attachments/assets/8da64738-98c1-48fb-a9be-b46ff1cc3dc0" />
<img width="1299" height="504" alt="Screenshot 2026-08-25 at 3 56 12 PM" src="https://github.com/user-attachments/assets/1bb44ad8-0d58-43db-bf70-2c4ae525e335" />
<img width="1293" height="602" alt="Screenshot 2026-08-25 at 3 56 21 PM" src="https://github.com/user-attachments/assets/52fae99b-14ff-4d7b-8a06-6f55bdc09c44" />

After:
<img width="461" height="306" alt="Screenshot 2026-08-25 at 3 41 14 PM" src="https://github.com/user-attachments/assets/412873a9-0ae0-43a6-a827-424d02b244cd" />
<img width="1280" height="164" alt="Screenshot 2026-08-25 at 3 41 59 PM" src="https://github.com/user-attachments/assets/4ba7e408-92c4-49d1-9aef-ad018ff9242b" />
<img width="1278" height="505" alt="Screenshot 2026-08-25 at 3 42 06 PM" src="https://github.com/user-attachments/assets/010bd01c-75d8-421b-8919-f1a522d541ac" />
<img width="1296" height="601" alt="Screenshot 2026-08-25 at 3 42 18 PM" src="https://github.com/user-attachments/assets/6c3ac49e-9556-46e0-bd08-26b219d0c5c2" />
