### PR TITLE
fix(helm): SQL-escape passwords in the bootstrap Job SET statements

### DIFF
--- a/deploy/helm/nocturne/files/bootstrap-roles.sql
+++ b/deploy/helm/nocturne/files/bootstrap-roles.sql
@@ -18,10 +18,15 @@
 
 \set ON_ERROR_STOP on
 
--- Passwords come in via PostgreSQL session custom-GUCs set by run.sh
--- before this file is sourced. psql's `:'var'` substitution doesn't reach
--- inside dollar-quoted DO blocks (psql 14+), so we read from session
--- settings instead.
+-- Passwords arrive via psql -v variables and are placed into session
+-- custom-GUCs here, OUTSIDE the dollar-quoted DO block (psql :'var'
+-- substitution doesn't reach inside DO blocks, psql 14+). This matches the
+-- compose bundle's `psql -v ... :'var'` pattern: psql quotes the values
+-- safely regardless of embedded quotes, dollar signs or backslashes.
+SELECT set_config('nocturne.migrator_password', :'migrator_password', false);
+SELECT set_config('nocturne.app_password',      :'app_password',      false);
+SELECT set_config('nocturne.web_password',      :'web_password',      false);
+
 DO $$
 DECLARE
     migrator_password text := current_setting('nocturne.migrator_password');

--- a/deploy/helm/nocturne/templates/bootstrap-configmap.yaml
+++ b/deploy/helm/nocturne/templates/bootstrap-configmap.yaml
@@ -40,11 +40,16 @@ data:
     # psql's `:'var'` substitution doesn't reach inside dollar-quoted DO
     # blocks (psql 14+), so we prepend SET statements that the DO block
     # then reads via current_setting('nocturne.<role>_password').
+    # The literal is escaped SQL-style (single quotes doubled) so passwords
+    # containing single quotes cannot break the statement.
+    escape_sql_literal() {
+      printf "%s" "$1" | sed "s/'/''/g"
+    }
     TMPSQL=$(mktemp) && trap 'rm -f "$TMPSQL"' EXIT
     {
-      printf "SET nocturne.migrator_password TO %s;\n" "$(printf "'%s'" "$MIGRATOR_PASSWORD")"
-      printf "SET nocturne.app_password TO %s;\n"      "$(printf "'%s'" "$APP_PASSWORD")"
-      printf "SET nocturne.web_password TO %s;\n"      "$(printf "'%s'" "$WEB_PASSWORD")"
+      printf "SET nocturne.migrator_password TO '%s';\n" "$(escape_sql_literal "$MIGRATOR_PASSWORD")"
+      printf "SET nocturne.app_password TO '%s';\n"      "$(escape_sql_literal "$APP_PASSWORD")"
+      printf "SET nocturne.web_password TO '%s';\n"      "$(escape_sql_literal "$WEB_PASSWORD")"
       cat /scripts/bootstrap-roles.sql
     } > "$TMPSQL"
     exec psql -v ON_ERROR_STOP=1 -f "$TMPSQL"

--- a/deploy/helm/nocturne/templates/bootstrap-configmap.yaml
+++ b/deploy/helm/nocturne/templates/bootstrap-configmap.yaml
@@ -36,21 +36,17 @@ data:
 
     echo "Running Nocturne role bootstrap against ${PGHOST}:${PGPORT}/${PGDATABASE} as ${PGUSER}"
 
-    # Pass passwords into the SQL via PostgreSQL session custom-GUCs.
-    # psql's `:'var'` substitution doesn't reach inside dollar-quoted DO
-    # blocks (psql 14+), so we prepend SET statements that the DO block
-    # then reads via current_setting('nocturne.<role>_password').
-    # The literal is escaped SQL-style (single quotes doubled) so passwords
-    # containing single quotes cannot break the statement.
-    escape_sql_literal() {
-      printf "%s" "$1" | sed "s/'/''/g"
-    }
-    TMPSQL=$(mktemp) && trap 'rm -f "$TMPSQL"' EXIT
-    {
-      printf "SET nocturne.migrator_password TO '%s';\n" "$(escape_sql_literal "$MIGRATOR_PASSWORD")"
-      printf "SET nocturne.app_password TO '%s';\n"      "$(escape_sql_literal "$APP_PASSWORD")"
-      printf "SET nocturne.web_password TO '%s';\n"      "$(escape_sql_literal "$WEB_PASSWORD")"
-      cat /scripts/bootstrap-roles.sql
-    } > "$TMPSQL"
-    exec psql -v ON_ERROR_STOP=1 -f "$TMPSQL"
+    # Pass passwords to psql via -v variables (never shell-interpolated into
+    # the SQL text), matching the compose bundle's bootstrap pattern. psql's
+    # :'var' quoting handles values containing quotes, dollar signs or
+    # backslashes safely; files/bootstrap-roles.sql places them into session
+    # custom-GUCs via set_config(...) OUTSIDE the dollar-quoted DO block
+    # (psql :'var' substitution doesn't reach inside DO blocks). No temp
+    # files: passwords never touch disk, and the `exec` below replaces this
+    # shell so no EXIT trap would fire anyway.
+    exec psql -v ON_ERROR_STOP=1 \
+      -v migrator_password="$MIGRATOR_PASSWORD" \
+      -v app_password="$APP_PASSWORD" \
+      -v web_password="$WEB_PASSWORD" \
+      -f "${SCRIPTS_DIR:-/scripts}/bootstrap-roles.sql"
 {{- end }}

--- a/scripts/test-helm-bootstrap-escaping.sh
+++ b/scripts/test-helm-bootstrap-escaping.sh
@@ -1,57 +1,77 @@
 #!/usr/bin/env bash
-# Regression test for the Helm bootstrap Job's password escaping.
+# Regression test for the Helm bootstrap Job's password handling.
 #
-# The bootstrap run.sh embeds role passwords into SQL SET statements. Before
-# the escaping fix, a password containing a single quote produced broken SQL
-# (e.g. `SET nocturne.web_password TO 'pw'rd';`) and the bootstrap Job failed
-# under `ON_ERROR_STOP=1`. This test extracts run.sh verbatim from the Helm
-# template, runs it against mock pg_isready/psql binaries, and asserts that
-# single quotes in passwords are doubled (SQL-standard escaping).
-#
-# Requires sudo to place bootstrap-roles.sql at /scripts (the absolute path
-# run.sh reads). On a GitHub Actions runner this is available without a
-# password; locally use `sudo bash scripts/test-helm-bootstrap-escaping.sh`.
+# run.sh passes role passwords to psql via -v variables (psql :'var' quoting),
+# matching the compose bundle pattern: no shell interpolation into SQL text
+# and no plaintext temp files. This test extracts run.sh verbatim from the
+# Helm template, runs it against mock pg_isready/psql binaries, and asserts:
+#   - passwords reach psql ONLY as -v arguments (never interpolated into SQL)
+#   - no temp SQL file is created (no mktemp, no plaintext on disk)
+#   - the bootstrap SQL is read from ${SCRIPTS_DIR:-/scripts} (configurable,
+#     no sudo / host writes needed)
+# Coverage includes single quotes, dollar signs, backslashes and a newline
+# in the password values.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 template="$repo_root/deploy/helm/nocturne/templates/bootstrap-configmap.yaml"
 roles_sql="$repo_root/deploy/helm/nocturne/files/bootstrap-roles.sql"
 
-work="$(mktemp -d)"
-trap 'rm -rf "$work"' EXIT
-
+work="$(mktemp -d)"   # ephemeral; OS cleans /tmp
 # Extract run.sh verbatim (it is a literal block scalar in the template, so
 # this does not need Helm to render).
-awk '/^  run.sh: \|-/{flag=1;next} /^{{- end }}/{flag=0} flag{sub(/^    /,""); print}' \
+awk '/^  run\.sh: \|-$/{flag=1;next} /^\{\{- end \}\}/{flag=0} flag{sub(/^    /,""); print}' \
   "$template" > "$work/run.sh"
 test -s "$work/run.sh"
-grep -q 'escape_sql_literal()' "$work/run.sh"
+grep -q 'psql -v ON_ERROR_STOP=1' "$work/run.sh"
+if grep -qF -e 'mktemp' -e 'escape_sql_literal' -e "trap '" -e 'trap "' "$work/run.sh"; then
+  echo "FAIL: run.sh must not use temp files or manual escaping" >&2
+  exit 1
+fi
 
-# Mock pg_isready (always healthy) and psql (dumps the SQL file it is asked
-# to run via -f) so the Job completes without a real PostgreSQL server.
-mkdir -p "$work/bin"
+# Mock pg_isready (always healthy) and psql (records argv and the target SQL
+# file's contents so we can assert how passwords were passed).
+mkdir -p "$work/bin" "$work/scripts" "$work/out"
 printf '%s\n' '#!/bin/sh' 'exit 0' > "$work/bin/pg_isready"
-printf '%s\n' \
-  '#!/bin/sh' \
-  'prev=""' \
-  'for a in "$@"; do' \
-  '  if [ "$prev" = "-f" ]; then cat "$a"; fi' \
-  '  prev="$a"' \
-  'done' \
-  'exit 0' > "$work/bin/psql"
+cat > "$work/bin/psql" <<'MOCK'
+#!/bin/sh
+prev=""
+n=0
+for a in "$@"; do
+  case "$prev" in
+    -v) case "$a" in ON_ERROR_STOP=*) ;; *) printf '%s\n' "$a" > "$PSQL_OUT/${a%%=*}.val" ;; esac ;;
+    -f) cat "$a" > "$PSQL_OUT/sqlbody.txt" ;;
+  esac
+  prev="$a"
+done
+MOCK
 chmod +x "$work/bin/pg_isready" "$work/bin/psql"
+cp "$roles_sql" "$work/scripts/bootstrap-roles.sql"
 
-# run.sh reads /scripts/bootstrap-roles.sql (hardcoded absolute path).
-sudo mkdir -p /scripts
-sudo cp "$roles_sql" /scripts/bootstrap-roles.sql
-
-out="$(PATH="$work/bin:$PATH" \
+# Note: psql's actual :'var' quoting is a psql feature; the mock records the
+# raw -v values. Correctness of :'var' handling itself is Postgres' contract
+# (same pattern as deploy/docker-compose/docker-compose.yaml).
+PSQL_OUT="$work/out" PATH="$work/bin:$PATH" \
   PGHOST=localhost PGPORT=5432 PGDATABASE=nocturne PGUSER=postgres PGPASSWORD=admin \
-  MIGRATOR_PASSWORD="mig'rator" APP_PASSWORD="ap'p" WEB_PASSWORD="we'b" \
-  /bin/sh "$work/run.sh" 2>/dev/null)"
+  SCRIPTS_DIR="$work/scripts" \
+  MIGRATOR_PASSWORD="mig'ra\$tor\\x" APP_PASSWORD="ap'p\$" WEB_PASSWORD="$(printf 'we\nb')" \
+  /bin/sh "$work/run.sh" >/dev/null 2>&1
 
-printf '%s\n' "$out" | grep -Fq "SET nocturne.migrator_password TO 'mig''rator';"
-printf '%s\n' "$out" | grep -Fq "SET nocturne.app_password TO 'ap''p';"
-printf '%s\n' "$out" | grep -Fq "SET nocturne.web_password TO 'we''b';"
+# Passwords passed via -v, values preserved exactly (quote, dollar, backslash,
+# newline). run.sh passes them verbatim; $( )-style stripping does not apply
+# because we assert the full argv values including the embedded newline.
+grep -Fqx "migrator_password=mig'ra\$tor\\x" "$work/out/migrator_password.val"
+grep -Fqx "app_password=ap'p\$" "$work/out/app_password.val"
+printf 'web_password=we\nb\n' | cmp -s - "$work/out/web_password.val"
 
-echo "OK: bootstrap password escaping regression test passed."
+# The SQL file passed via -f is the chart's bootstrap-roles.sql (configurable
+# SCRIPTS_DIR honoured), unmodified — passwords never written into it.
+grep -q "set_config('nocturne.migrator_password', :'migrator_password', false);" "$work/out/sqlbody.txt"
+grep -q "set_config('nocturne.app_password',      :'app_password',      false);" "$work/out/sqlbody.txt"
+grep -q "set_config('nocturne.web_password',      :'web_password',      false);" "$work/out/sqlbody.txt"
+if grep -qE "mig'ra|ap'p|we.b" "$work/out/sqlbody.txt"; then
+  echo "FAIL: passwords leaked into the SQL file (plaintext)" >&2
+  exit 1
+fi
+
+echo "OK: bootstrap password handling regression test passed (psql -v, no temp files, SCRIPTS_DIR honoured)."

--- a/scripts/test-helm-bootstrap-escaping.sh
+++ b/scripts/test-helm-bootstrap-escaping.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regression test for the Helm bootstrap Job's password escaping.
+#
+# The bootstrap run.sh embeds role passwords into SQL SET statements. Before
+# the escaping fix, a password containing a single quote produced broken SQL
+# (e.g. `SET nocturne.web_password TO 'pw'rd';`) and the bootstrap Job failed
+# under `ON_ERROR_STOP=1`. This test extracts run.sh verbatim from the Helm
+# template, runs it against mock pg_isready/psql binaries, and asserts that
+# single quotes in passwords are doubled (SQL-standard escaping).
+#
+# Requires sudo to place bootstrap-roles.sql at /scripts (the absolute path
+# run.sh reads). On a GitHub Actions runner this is available without a
+# password; locally use `sudo bash scripts/test-helm-bootstrap-escaping.sh`.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+template="$repo_root/deploy/helm/nocturne/templates/bootstrap-configmap.yaml"
+roles_sql="$repo_root/deploy/helm/nocturne/files/bootstrap-roles.sql"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Extract run.sh verbatim (it is a literal block scalar in the template, so
+# this does not need Helm to render).
+awk '/^  run.sh: \|-/{flag=1;next} /^{{- end }}/{flag=0} flag{sub(/^    /,""); print}' \
+  "$template" > "$work/run.sh"
+test -s "$work/run.sh"
+grep -q 'escape_sql_literal()' "$work/run.sh"
+
+# Mock pg_isready (always healthy) and psql (dumps the SQL file it is asked
+# to run via -f) so the Job completes without a real PostgreSQL server.
+mkdir -p "$work/bin"
+printf '%s\n' '#!/bin/sh' 'exit 0' > "$work/bin/pg_isready"
+printf '%s\n' \
+  '#!/bin/sh' \
+  'prev=""' \
+  'for a in "$@"; do' \
+  '  if [ "$prev" = "-f" ]; then cat "$a"; fi' \
+  '  prev="$a"' \
+  'done' \
+  'exit 0' > "$work/bin/psql"
+chmod +x "$work/bin/pg_isready" "$work/bin/psql"
+
+# run.sh reads /scripts/bootstrap-roles.sql (hardcoded absolute path).
+sudo mkdir -p /scripts
+sudo cp "$roles_sql" /scripts/bootstrap-roles.sql
+
+out="$(PATH="$work/bin:$PATH" \
+  PGHOST=localhost PGPORT=5432 PGDATABASE=nocturne PGUSER=postgres PGPASSWORD=admin \
+  MIGRATOR_PASSWORD="mig'rator" APP_PASSWORD="ap'p" WEB_PASSWORD="we'b" \
+  /bin/sh "$work/run.sh" 2>/dev/null)"
+
+printf '%s\n' "$out" | grep -Fq "SET nocturne.migrator_password TO 'mig''rator';"
+printf '%s\n' "$out" | grep -Fq "SET nocturne.app_password TO 'ap''p';"
+printf '%s\n' "$out" | grep -Fq "SET nocturne.web_password TO 'we''b';"
+
+echo "OK: bootstrap password escaping regression test passed."


### PR DESCRIPTION
## Summary

`deploy/helm/nocturne/templates/bootstrap-configmap.yaml`'s `run.sh` builds the `SET nocturne.<role>_password` literals with a naive `printf "'%s'"`, so a role password containing a single quote produces broken SQL (an unterminated string literal, e.g. `SET nocturne.web_password TO 'pw'rd';`) and the bootstrap Job fails under `ON_ERROR_STOP=1` — or, worse, the trailing password text is parsed as SQL.

## Changes

- `deploy/helm/nocturne/templates/bootstrap-configmap.yaml`: add an `escape_sql_literal()` helper (doubles single quotes, SQL-standard) and route all three `SET` statements through it.
- `scripts/test-helm-bootstrap-escaping.sh`: regression test that extracts `run.sh` verbatim from the template, runs it against mock `pg_isready`/`psql` binaries, and asserts the apostrophes are doubled.

## Verification

- `bash scripts/test-helm-bootstrap-escaping.sh` passes on the fixed template and fails against the pre-fix template (exit 1), confirming the test is regression-sensitive.