### PR TITLE
fix(web): make local report day boundaries DST-safe

### DIFF
--- a/src/Web/packages/app/src/lib/utils/timezone.test.ts
+++ b/src/Web/packages/app/src/lib/utils/timezone.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { localDayStart, localDayEnd } from "./timezone";
+import { localDayStart, localDayEnd, getLocalDayBoundariesUtc } from "./timezone";
 
 describe("localDayStart", () => {
 	it("returns local midnight, not UTC midnight", () => {
@@ -34,6 +34,75 @@ describe("localDayEnd", () => {
 			const nextDay = new Date(end.getTime() + 1);
 			expect(nextDay.getDate()).not.toBe(start.getDate());
 			expect(nextDay.getHours()).toBe(0);
+		}
+	});
+});
+
+describe("getLocalDayBoundariesUtc", () => {
+	/** First instant of a local calendar day, found by brute-force Intl scan. */
+	function firstInstantOfDay(dateStr: string, timeZone: string): number {
+		const utcNoon = Date.parse(dateStr + "T12:00:00Z");
+		for (let t = utcNoon - 24 * 60 * 60 * 1000; t <= utcNoon; t += 60 * 1000) {
+			if (new Intl.DateTimeFormat("en-CA", { timeZone }).format(new Date(t)) === dateStr) return t;
+		}
+		throw new Error(`no instant found for ${dateStr} in ${timeZone}`);
+	}
+
+	function expectDayBoundaries(dateStr: string, timeZone: string) {
+		const { start, end } = getLocalDayBoundariesUtc(dateStr, timeZone);
+		expect(start.getTime()).toBe(firstInstantOfDay(dateStr, timeZone));
+
+		const [y, m, d] = dateStr.split("-").map(Number);
+		const nextDateStr = new Date(Date.UTC(y, m - 1, d + 1)).toISOString().slice(0, 10);
+		const nextStart = getLocalDayBoundariesUtc(nextDateStr, timeZone).start;
+		expect(end.getTime()).toBe(nextStart.getTime() - 1);
+
+		// The whole window must display as the requested local date.
+		for (const probe of [start, end]) {
+			expect(
+				new Intl.DateTimeFormat("en-CA", { timeZone }).format(probe)
+			).toBe(dateStr);
+		}
+	}
+
+	it("handles an ordinary day", () => {
+		expectDayBoundaries("2026-06-15", "Europe/Berlin");
+	});
+
+	it("starts at the first instant of the local day when DST begins at midnight (Chile)", () => {
+		// America/Santiago: clocks jump 2026-09-06 00:00 -> 01:00 (-04 -> -03),
+		// i.e. the local day begins at 2026-09-06T04:00:00Z. The buggy
+		// string-roundtrip computed the offset from the *previous* day's
+		// instant and produced the same 04:00Z only by accident on the start,
+		// but derived end as start+24h, overlapping into the next day.
+		const { start } = getLocalDayBoundariesUtc("2026-09-06", "America/Santiago");
+		expect(start.toISOString()).toBe("2026-09-06T04:00:00.000Z");
+		// Sanity via Intl: that instant is the earliest one displaying as Sep 6.
+		expect(new Intl.DateTimeFormat("en-US", { timeZone: "America/Santiago" })
+			.format(new Date(start.getTime() - 1))).toMatch(/9\/5/);
+		expectDayBoundaries("2026-09-06", "America/Santiago");
+	});
+
+	it("yields a 23-hour day on the spring-forward date and a 25-hour day on the fall-back date", () => {
+		const spring = getLocalDayBoundariesUtc("2026-09-06", "America/Santiago");
+		expect(spring.end.getTime() - spring.start.getTime() + 1).toBe(23 * 60 * 60 * 1000);
+
+		// Chile falls back 2027-04-04 01:00 -> 00:00 (-03 -> -04); the extra
+		// hour repeats at the END of Apr 3, so the 25-hour day is Apr 3.
+		const fall = getLocalDayBoundariesUtc("2027-04-03", "America/Santiago");
+		expect(fall.end.getTime() - fall.start.getTime() + 1).toBe(25 * 60 * 60 * 1000);
+		expect(
+			getLocalDayBoundariesUtc("2027-04-04", "America/Santiago").end.getTime() -
+				getLocalDayBoundariesUtc("2027-04-04", "America/Santiago").start.getTime() +
+				1
+		).toBe(24 * 60 * 60 * 1000);
+	});
+
+	it("keeps boundaries inside the requested local day across European DST changes", () => {
+		// Spring forward / fall back in Berlin (transitions at 02:00/03:00 local,
+		// not midnight — but the end must still land before the next midnight).
+		for (const date of ["2026-03-29", "2026-10-25"]) {
+			expectDayBoundaries(date, "Europe/Berlin");
 		}
 	});
 });

--- a/src/Web/packages/app/src/lib/utils/timezone.test.ts
+++ b/src/Web/packages/app/src/lib/utils/timezone.test.ts
@@ -87,7 +87,7 @@ describe("getLocalDayBoundariesUtc", () => {
 		const spring = getLocalDayBoundariesUtc("2026-09-06", "America/Santiago");
 		expect(spring.end.getTime() - spring.start.getTime() + 1).toBe(23 * 60 * 60 * 1000);
 
-		// Chile falls back on 2027-04-03 at 01:00 -> 00:00 (-03 -> -04); the extra
+		// Chile falls back on 2027-04-03 at 00:00 -> 23:00 (-03 -> -04); the extra
 		// hour repeats at the END of Apr 3, so the 25-hour day is Apr 3.
 		const fall = getLocalDayBoundariesUtc("2027-04-03", "America/Santiago");
 		expect(fall.end.getTime() - fall.start.getTime() + 1).toBe(25 * 60 * 60 * 1000);

--- a/src/Web/packages/app/src/lib/utils/timezone.test.ts
+++ b/src/Web/packages/app/src/lib/utils/timezone.test.ts
@@ -87,7 +87,7 @@ describe("getLocalDayBoundariesUtc", () => {
 		const spring = getLocalDayBoundariesUtc("2026-09-06", "America/Santiago");
 		expect(spring.end.getTime() - spring.start.getTime() + 1).toBe(23 * 60 * 60 * 1000);
 
-		// Chile falls back 2027-04-04 01:00 -> 00:00 (-03 -> -04); the extra
+		// Chile falls back on 2027-04-03 at 01:00 -> 00:00 (-03 -> -04); the extra
 		// hour repeats at the END of Apr 3, so the 25-hour day is Apr 3.
 		const fall = getLocalDayBoundariesUtc("2027-04-03", "America/Santiago");
 		expect(fall.end.getTime() - fall.start.getTime() + 1).toBe(25 * 60 * 60 * 1000);

--- a/src/Web/packages/app/src/lib/utils/timezone.ts
+++ b/src/Web/packages/app/src/lib/utils/timezone.ts
@@ -23,6 +23,48 @@ export function localDayEnd(dateStr: string): Date {
 }
 
 /**
+ * Offset of `timeZone` at an instant, in ms (positive east of UTC), derived via
+ * formatToParts so no locale-dependent string parsing is involved.
+ */
+function tzOffsetMs(timeZone: string, at: Date): number {
+	const parts = new Intl.DateTimeFormat('en-US', {
+		timeZone,
+		hourCycle: 'h23',
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit'
+	}).formatToParts(at);
+	const get = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+	return (
+		Date.UTC(get('year'), get('month') - 1, get('day'), get('hour'), get('minute'), get('second')) -
+		at.getTime()
+	);
+}
+
+/** Local calendar date (`YYYY-MM-DD`) of an instant in `timeZone`. */
+function tzDateStr(timeZone: string, at: Date): string {
+	return new Intl.DateTimeFormat('en-CA', { timeZone }).format(at);
+}
+
+/**
+ * First instant of the local calendar day `dateStr` in `timeZone`, as a UTC
+ * instant. Around a DST transition at midnight the naive guess
+ * `utcMidnight - offsetAt(utcMidnight)` carries whichever offset the guess
+ * itself lands on, so compute the two candidates and keep the earliest one
+ * whose local calendar date actually equals `dateStr`.
+ */
+function localMidnightUtc(dateStr: string, timeZone: string): number {
+	const utcMidnight = Date.parse(dateStr + 'T00:00:00Z');
+	const c1 = utcMidnight - tzOffsetMs(timeZone, new Date(utcMidnight));
+	const candidates = [c1, utcMidnight - tzOffsetMs(timeZone, new Date(c1))];
+	const valid = candidates.filter((ms) => tzDateStr(timeZone, new Date(ms)) === dateStr);
+	return valid.length > 0 ? Math.min(...valid) : c1;
+}
+
+/**
  * Compute UTC start/end of a local day for a given IANA timezone.
  * Falls back to UTC if timezone is not provided.
  */
@@ -36,14 +78,13 @@ export function getLocalDayBoundariesUtc(
 		return { start, end };
 	}
 
-	// Use Intl to determine the UTC offset at local midnight for the given timezone
-	const utcMidnight = new Date(dateStr + 'T00:00:00Z');
-	const utcStr = utcMidnight.toLocaleString('en-US', { timeZone: 'UTC' });
-	const localStr = utcMidnight.toLocaleString('en-US', { timeZone });
-	const offsetMs = new Date(localStr).getTime() - new Date(utcStr).getTime();
+	const startMs = localMidnightUtc(dateStr, timeZone);
 
-	// Local midnight = UTC midnight minus the timezone offset
-	const start = new Date(utcMidnight.getTime() - offsetMs);
-	const end = new Date(start.getTime() + 24 * 60 * 60 * 1000 - 1);
-	return { start, end };
+	// End = last millisecond before the following local midnight, so 23- and
+	// 25-hour days come out the right length instead of a fixed 24 hours.
+	const [y, m, d] = dateStr.split('-').map(Number);
+	const nextDateStr = new Date(Date.UTC(y, m - 1, d + 1)).toISOString().slice(0, 10);
+	const end = new Date(localMidnightUtc(nextDateStr, timeZone) - 1);
+
+	return { start: new Date(startMs), end };
 }


### PR DESCRIPTION
## Summary
- computes UTC report boundaries from actual local calendar midnights
- derives the end from the following local midnight instead of assuming 24 hours
- covers midnight transitions and 23/25-hour days

## Problem
`getLocalDayBoundariesUtc` used locale-string parsing and always added 24 hours. In zones with DST transitions, report windows could overlap the next local day or omit part of a 25-hour day.

## Tests
- `pnpm vitest run src/lib/utils/timezone.test.ts`: 7 passed
- sabotage run with the previous implementation: 3 new DST tests failed
- `pnpm run check`: remaining generated-module errors were also present on the upstream baseline

## Scope
Only the timezone helper and its focused tests are changed. Related profile-unit and bridge-CORS findings are intentionally excluded.