### PR TITLE
feat: dispatchable screenshot-regeneration workflow (phase 2)

### DIFF
--- a/.github/workflows/screenshot-regen.yml
+++ b/.github/workflows/screenshot-regen.yml
@@ -1,0 +1,188 @@
+name: Documentation screenshots
+
+# Re-shoots every screenshot the documentation embeds against a stack built from this ref, and
+# opens a PR when the images move. Dispatch-only: the seeded data is anchored to the calendar
+# date, so an unattended schedule would drift every time it ran and bury real UI changes in data
+# noise. A schedule becomes viable once seeding can replay identical data shapes across days.
+#
+# The PR is created with GITHUB_TOKEN, so GitHub deliberately does not run workflows on it —
+# reviewing it means closing and reopening the PR to get checks. Creating it at all requires
+# "Allow GitHub Actions to create and approve pull requests" under Settings > Actions > General.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: screenshot-regen
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_VERSION: "10.0"
+  NODE_VERSION: "24"
+  PNPM_VERSION: "11.5.0"
+  APPHOST_LOG: apphost.log
+  CAPTURE_LOG: capture.log
+  DIFF_TABLE: screenshot-diff.md
+  API_URL: http://localhost:1610
+  GATEWAY_URL: https://nocturne.localhost:1612
+  BOOT_TIMEOUT_SECONDS: "900"
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: src/Web/pnpm-lock.yaml
+
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+
+      - name: Install web dependencies
+        working-directory: src/Web
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium
+        working-directory: src/Web
+        run: pnpm --filter @nocturne/screenshots exec playwright install chromium --with-deps
+
+      # mkcert is not installed here, so the AppHost falls back to the ASP.NET developer
+      # certificate for the gateway the capture browses through. Untrusted is fine — the browser
+      # context sets ignoreHTTPSErrors — but it has to exist.
+      - name: Create the ASP.NET developer certificate
+        run: dotnet dev-certs https
+
+      # The `http` launch profile keeps the dashboard/OTLP/resource-service endpoints on plain
+      # HTTP; `dotnet run` would otherwise pick `https`, which wants an HTTPS dashboard endpoint.
+      - name: Start the stack
+        run: |
+          nohup dotnet run --project src/Aspire/Nocturne.Aspire.Host --launch-profile http \
+            > "$APPHOST_LOG" 2>&1 &
+          echo "APPHOST_PID=$!" >> "$GITHUB_ENV"
+
+      # The capture browses through the gateway to the web dev server, both of which come up well
+      # after the API, so waiting on the API alone would move a slow web boot's failure from here
+      # (where the AppHost log is dumped) into an opaque Playwright navigation timeout.
+      - name: Wait for the stack
+        run: |
+          deadline=$(( SECONDS + BOOT_TIMEOUT_SECONDS ))
+          wait_for() {
+            until curl -fkso /dev/null "$1"; do
+              if ! kill -0 "$APPHOST_PID" 2>/dev/null; then
+                echo "The AppHost exited before $1 came up."
+                tail -n 200 "$APPHOST_LOG"
+                exit 1
+              fi
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "$1 did not answer within ${BOOT_TIMEOUT_SECONDS}s."
+                tail -n 200 "$APPHOST_LOG"
+                exit 1
+              fi
+              sleep 5
+            done
+          }
+          wait_for "$API_URL/health"
+          wait_for "$GATEWAY_URL"
+
+      # A stale anchor or an unsettled route is the signal this workflow exists to raise, so a
+      # failure here stops the run rather than committing whatever it managed to shoot.
+      - name: Capture
+        working-directory: src/Web
+        env:
+          NOCTURNE_API_URL: ${{ env.API_URL }}
+        run: |
+          set -o pipefail
+          pnpm --filter @nocturne/screenshots run capture 2>&1 \
+            | tee "$GITHUB_WORKSPACE/$CAPTURE_LOG"
+
+      - name: Upload capture diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshot-capture-diagnostics
+          path: |
+            ${{ env.CAPTURE_LOG }}
+            ${{ env.APPHOST_LOG }}
+            src/Web/packages/screenshots/images
+          if-no-files-found: ignore
+
+      # --restore-identical puts committed bytes back for images whose pixels did not change, so
+      # an encoder version bump re-quantising every file cannot open a PR by itself. The byte-level
+      # gate below therefore only sees pixel-level drift (and manifest changes).
+      - name: Measure the drift
+        working-directory: src/Web
+        run: |
+          pnpm --filter @nocturne/screenshots run diff-stats \
+            --restore-identical --output "$GITHUB_WORKSPACE/$DIFF_TABLE"
+
+      - name: Detect drift
+        id: drift
+        run: |
+          if [ -z "$(git status --porcelain src/Web/packages/screenshots)" ]; then
+            echo "No drift: the captured screenshots match the committed ones."
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drifted=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compose the pull request body
+        if: steps.drift.outputs.drifted == 'true'
+        run: |
+          {
+            echo "Regenerated from a stack built at ${GITHUB_SHA}."
+            echo
+            echo "Read the table as a shortlist of what to look at rather than a verdict: the"
+            echo "percentage is pixels, and a small one can still be the label a documentation"
+            echo "page quotes. The seeded data ends on the capture date, so rows under about 1%"
+            echo "are usually clocks and axis labels; larger jumps are UI or data-shape changes."
+            echo
+            cat "$DIFF_TABLE"
+            echo
+            echo "[Workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+            echo
+            echo "Checks do not run on a pull request opened with \`GITHUB_TOKEN\`. Close and reopen"
+            echo "this one to start them."
+          } > pr-body.md
+
+      - name: Open or update the pull request
+        if: steps.drift.outputs.drifted == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: docs/screenshot-regen
+          base: main
+          add-paths: src/Web/packages/screenshots
+          commit-message: "docs: regenerate documentation screenshots"
+          title: "docs: regenerate documentation screenshots"
+          body-path: pr-body.md
+          delete-branch: true
+
+      - name: Stop the stack
+        if: always() && env.APPHOST_PID != ''
+        run: kill "$APPHOST_PID" || true

--- a/src/Web/packages/screenshots/README.md
+++ b/src/Web/packages/screenshots/README.md
@@ -19,7 +19,15 @@ pnpm --filter @nocturne/screenshots run capture                       # seed, sh
 pnpm --filter @nocturne/screenshots run validate                      # definitions only; no stack, no browser
 pnpm --filter @nocturne/screenshots run check-refs                    # markdown references vs images on disk
 pnpm --filter @nocturne/screenshots run check-embeds                  # docs <Screenshot> ids and anchors vs the manifest
+pnpm --filter @nocturne/screenshots run diff-stats                    # what a capture just changed, against HEAD
 ```
+
+`diff-stats` reads the working tree against the committed images and prints a markdown table of
+how much of each one moved, plus anything added, deleted, resized or unreadable. `--output <file>`
+writes the same table to disk; `--restore-identical` puts committed bytes back for images whose
+pixels did not change, so an encoder re-quantising the same render never shows up as drift. A
+percentage is a shortlist of what to look at, not a verdict: a fraction of a percent can still be
+the label a docs page quotes.
 
 A successful run tidies up after itself: images no manifest entry claims are deleted, and the
 tenants it seeded are removed. A failed one leaves both behind to be inspected.
@@ -29,6 +37,23 @@ ports, so read yours from `aspire describe`.
 
 Locale, timezone, viewport, device scale and the browser clock are pinned in `src/capture.ts` and
 must stay that way: a screenshot is only reviewable as a diff against the one it replaces.
+
+## Regeneration workflow
+
+`.github/workflows/screenshot-regen.yml` boots a stack on the runner, runs the capture, and opens
+a PR on `docs/screenshot-regen` with the `diff-stats` table in its body when the images move.
+Dispatch it from the Actions tab ("Documentation screenshots" → Run workflow) after a UI change
+you expect the docs to show. It is dispatch-only: the seeded data is anchored to the calendar
+date, so an unattended schedule would drift on every run and bury real UI changes in data noise —
+a schedule becomes viable once seeding can replay identical data shapes across days.
+
+A capture failure — a stale anchor, a route that will not settle — fails the run and opens
+nothing; the capture log and whatever images it managed to write are attached to the run as an
+artifact.
+
+Two GitHub settings caveats: creating the PR at all requires "Allow GitHub Actions to create and
+approve pull requests" (Settings → Actions → General), and GitHub does not run workflows on a PR
+opened with `GITHUB_TOKEN`, so it arrives with no checks — close and reopen it to start them.
 
 ## When a run fails to settle
 

--- a/src/Web/packages/screenshots/package.json
+++ b/src/Web/packages/screenshots/package.json
@@ -13,6 +13,7 @@
 	"scripts": {
 		"capture": "tsx src/capture.ts",
 		"validate": "tsx src/capture.ts --validate",
+		"diff-stats": "tsx src/diff-stats.ts",
 		"check-refs": "tsx src/check-refs.ts",
 		"check-embeds": "tsx src/check-embeds.ts",
 		"check": "tsc --noEmit"

--- a/src/Web/packages/screenshots/src/diff-stats.ts
+++ b/src/Web/packages/screenshots/src/diff-stats.ts
@@ -1,0 +1,215 @@
+import { execFileSync } from 'node:child_process';
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+import sharp from 'sharp';
+import { imagesDir, repoRoot } from './paths.js';
+
+/**
+ * Lossy WebP re-quantises a whole compression block around one changed glyph, so an exact
+ * comparison reads a clock ticking over as a rewritten screenshot. Calibrated against a real
+ * recapture: the counts collapse between 0 and 8 and then flatten, and 8 separates a shot whose
+ * data moved from one whose timestamp did by two orders of magnitude. Higher starts eating the
+ * anti-aliased edges of text that genuinely changed.
+ */
+const CHANNEL_TOLERANCE = 8;
+
+const BASE = 'HEAD';
+/** The images directory also carries a .gitkeep, which is not a capture. */
+const EXTENSION = '.webp';
+
+type Status = 'changed' | 'resized' | 'added' | 'deleted' | 'unreadable';
+
+interface Row {
+	file: string;
+	status: Status;
+	detail: string;
+	/** Structural findings have no percentage to sort on and belong above the ones that do. */
+	rank: number;
+}
+
+interface Totals {
+	changedPixels: number;
+	comparedPixels: number;
+	identical: number;
+}
+
+function git(args: string[]): Buffer {
+	return execFileSync('git', args, { cwd: repoRoot, maxBuffer: 256 * 1024 * 1024 });
+}
+
+async function decode(input: Buffer): Promise<{ data: Buffer; width: number; height: number }> {
+	const { data, info } = await sharp(input)
+		.ensureAlpha()
+		.raw()
+		.toBuffer({ resolveWithObject: true });
+	return { data, width: info.width, height: info.height };
+}
+
+function countChangedPixels(before: Buffer, after: Buffer): number {
+	let changed = 0;
+	for (let i = 0; i < before.length; i += 4) {
+		if (
+			Math.abs(before[i] - after[i]) > CHANNEL_TOLERANCE ||
+			Math.abs(before[i + 1] - after[i + 1]) > CHANNEL_TOLERANCE ||
+			Math.abs(before[i + 2] - after[i + 2]) > CHANNEL_TOLERANCE ||
+			Math.abs(before[i + 3] - after[i + 3]) > CHANNEL_TOLERANCE
+		) {
+			changed++;
+		}
+	}
+	return changed;
+}
+
+function percentage(changed: number, total: number): string {
+	if (total === 0) return '0%';
+	const value = (changed / total) * 100;
+	if (changed > 0 && value < 0.01) return '<0.01%';
+	return `${value.toFixed(2)}%`;
+}
+
+async function compare(
+	path: string,
+	file: string,
+	totals: Totals,
+	restoreIdentical: boolean,
+): Promise<Row | null> {
+	const committed = git(['show', `${BASE}:${path}`]);
+	const current = await readFile(join(imagesDir, file));
+	if (committed.equals(current)) {
+		const { width = 0, height = 0 } = await sharp(current).metadata();
+		totals.comparedPixels += width * height;
+		totals.identical++;
+		return null;
+	}
+
+	let before: Awaited<ReturnType<typeof decode>>;
+	let after: Awaited<ReturnType<typeof decode>>;
+	try {
+		[before, after] = await Promise.all([decode(committed), decode(current)]);
+	} catch (error) {
+		return {
+			file,
+			status: 'unreadable',
+			detail: error instanceof Error ? error.message : String(error),
+			rank: Number.POSITIVE_INFINITY,
+		};
+	}
+
+	if (before.width !== after.width || before.height !== after.height) {
+		return {
+			file,
+			status: 'resized',
+			detail: `${before.width}x${before.height} -> ${after.width}x${after.height}`,
+			rank: Number.POSITIVE_INFINITY,
+		};
+	}
+
+	const pixels = before.width * before.height;
+	const changed = countChangedPixels(before.data, after.data);
+	totals.changedPixels += changed;
+	totals.comparedPixels += pixels;
+	if (changed === 0) {
+		// Same pixels, different bytes — an encoder version re-quantised the file. Restoring the
+		// committed bytes keeps a pixel-noop out of git history and out of the drift gate.
+		if (restoreIdentical) await writeFile(join(imagesDir, file), committed);
+		totals.identical++;
+		return null;
+	}
+	return {
+		file,
+		status: 'changed',
+		detail: percentage(changed, pixels),
+		rank: changed / pixels,
+	};
+}
+
+async function collect(restoreIdentical: boolean): Promise<{ rows: Row[]; totals: Totals }> {
+	const prefix = relative(repoRoot, imagesDir).split(sep).join('/');
+	const committed = git(['ls-tree', '-r', '--name-only', BASE, '--', prefix])
+		.toString('utf8')
+		.split('\n')
+		.filter((path) => path.endsWith(EXTENSION));
+	const present = new Set(
+		(await readdir(imagesDir, { recursive: true }))
+			.map((file) => file.split(sep).join('/'))
+			.filter((file) => file.endsWith(EXTENSION)),
+	);
+
+	const totals: Totals = { changedPixels: 0, comparedPixels: 0, identical: 0 };
+	const rows: Row[] = [];
+
+	for (const path of committed) {
+		const file = path.slice(prefix.length + 1);
+		if (!present.delete(file)) {
+			rows.push({
+				file,
+				status: 'deleted',
+				detail: '-',
+				rank: Number.POSITIVE_INFINITY,
+			});
+			continue;
+		}
+		const row = await compare(path, file, totals, restoreIdentical);
+		if (row) rows.push(row);
+	}
+
+	for (const file of present) {
+		let detail: string;
+		let status: Status = 'added';
+		try {
+			const { width, height } = await decode(await readFile(join(imagesDir, file)));
+			detail = `${width}x${height}`;
+		} catch (error) {
+			status = 'unreadable';
+			detail = error instanceof Error ? error.message : String(error);
+		}
+		rows.push({
+			file,
+			status,
+			detail,
+			rank: Number.POSITIVE_INFINITY,
+		});
+	}
+
+	rows.sort((left, right) => right.rank - left.rank || left.file.localeCompare(right.file));
+	return { rows, totals };
+}
+
+function render(rows: Row[], totals: Totals): string {
+	const compared = rows.length + totals.identical;
+	if (rows.length === 0) {
+		return `No screenshot drift: all ${compared} images match ${BASE}.`;
+	}
+
+	const counts = new Map<Status, number>();
+	for (const row of rows) counts.set(row.status, (counts.get(row.status) ?? 0) + 1);
+	const summary = [...counts]
+		.map(([status, count]) => `${count} ${status}`)
+		.join(', ');
+
+	return [
+		'| Image | Status | Changed |',
+		'| --- | --- | --- |',
+		...rows.map((row) => `| \`${row.file}\` | ${row.status} | ${row.detail} |`),
+		'',
+		`Against ${BASE}: ${summary}, ${totals.identical} unchanged. `
+			+ `${percentage(totals.changedPixels, totals.comparedPixels)} of all compared pixels differ.`,
+	].join('\n');
+}
+
+async function main(): Promise<void> {
+	const flag = process.argv.indexOf('--output');
+	const output = flag === -1 ? null : process.argv[flag + 1];
+	if (flag !== -1 && !output) {
+		console.error('--output needs a file path.');
+		process.exit(1);
+	}
+	const restoreIdentical = process.argv.includes('--restore-identical');
+
+	const { rows, totals } = await collect(restoreIdentical);
+	const markdown = render(rows, totals);
+	console.log(markdown);
+	if (output) await writeFile(output, `${markdown}\n`);
+}
+
+await main();


### PR DESCRIPTION
Stacked on #996 (retarget to main after it merges, then close/reopen to trigger CI — stacked PRs get no runs otherwise).

## What this adds

- **`screenshot-regen.yml`** (`workflow_dispatch`): checks out, boots the full Aspire stack headlessly on the runner (`dotnet run --launch-profile http`; API pinned to :1610 and gateway to :1612 in a non-worktree checkout), waits on both the API health endpoint and the gateway, installs chromium, runs the capture, and — if pixels actually moved — opens/updates a PR on `docs/screenshot-regen` with a per-image diff table. Capture failures (stale anchor, unsettled route) fail the run, upload logs + images as an artifact, and open nothing. Serialized by a concurrency group.
- **`diff-stats`**: sharp-based changed-pixel percentages vs HEAD (per-channel tolerance 8, calibrated on real drift: a ticking clock reads ~0.4%, changed data ~20% — two orders of magnitude of separation). `--restore-identical` reverts byte-only drift (e.g. a libwebp version bump re-quantising identical pixels), so encoder churn can never open a PR — verified with a lossless re-encode round-trip.

## Design decision: dispatch-only, no schedule

The adversarial review demonstrated the monthly schedule's premise was false: seeded data is date-anchored (by phase-1 design), so a scheduled run drifts **every** time, with diff tables dominated by data noise — an alarm that always fires is worse than none. The schedule returns when seeding can replay identical data shapes across days (timestamp-rebasing import, the designated upgrade path).

## First-dispatch caveats (the real acceptance test)

Nothing in this repo has ever booted the Aspire stack on a hosted runner. Known risks, all diagnosable from the workflow's own log dumps: DCP orchestration has hung on runners before (tests.yml's E2E deferral note); the linux dev-cert path for the gateway is unverified; `*.nocturne.localhost` relies on Chromium's own loopback resolution. Also requires "Allow GitHub Actions to create and approve pull requests" in repo Actions settings, and the regen PRs it opens need the close/reopen dance for checks.

https://claude.ai/code/session_01GbRU9f6w1xX77bxsPVTPNt
