### PR TITLE
fix(tls): issue certificates for public share hosts

### DIFF
--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -321,6 +321,10 @@ configs:
       #                       request via HTTP-01. The on_demand "ask" endpoint lets
       #                       the API confirm a hostname is a real tenant before Caddy
       #                       requests a certificate, so only valid subdomains issue.
+      #   - *.share.{$$BASE_DOMAIN}
+      #                       public share links, one label deeper. A Caddy site-address
+      #                       wildcard matches exactly one label, so this needs naming
+      #                       separately or share links never get a certificate.
       #
       # To front Nocturne with your own reverse proxy instead, disable this service
       # (see docker-compose.byo-proxy.yaml) and the gateway is exposed on plain HTTP.
@@ -335,6 +339,13 @@ configs:
       }
 
       *.{$$BASE_DOMAIN} {
+      	tls {
+      		on_demand
+      	}
+      	reverse_proxy gateway:5000
+      }
+
+      *.share.{$$BASE_DOMAIN} {
       	tls {
       		on_demand
       	}

--- a/src/API/Nocturne.API/Controllers/V4/TlsAuthorizationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TlsAuthorizationController.cs
@@ -79,10 +79,11 @@ public class TlsAuthorizationController : ControllerBase
         // Resolving the token rather than accepting any well-formed share host is what stops a
         // stranger with DNS pointed here from driving issuance for names of their choosing; a
         // caller must already hold the token to get a 200, and the token is the secret the link
-        // hands out anyway.
+        // hands out anyway. Resolved without recording an access: asking whether to mint a
+        // certificate is not someone opening the link.
         if (SubdomainParser.TryExtractShareToken(slug, out var shareToken))
         {
-            var shareTenant = await _shareTokens.ResolveByTokenAsync(shareToken);
+            var shareTenant = await _shareTokens.ResolveWithoutRecordingAccessAsync(shareToken, ct);
             return shareTenant is { IsActive: true } ? Ok() : NotFound();
         }
 

--- a/src/API/Nocturne.API/Controllers/V4/TlsAuthorizationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TlsAuthorizationController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Multitenancy;
+using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 
 namespace Nocturne.API.Controllers.V4;
@@ -10,8 +11,8 @@ namespace Nocturne.API.Controllers.V4;
 /// On-demand TLS authorization for the bundled Caddy reverse proxy.
 /// Caddy calls this before requesting a certificate for a hostname (its
 /// <c>on_demand_tls.ask</c> endpoint) so that certificates are only issued for
-/// the apex domain and real tenant subdomains — preventing unbounded issuance
-/// for arbitrary hostnames pointed at the server.
+/// the apex domain, real tenant subdomains, and live public share hosts —
+/// preventing unbounded issuance for arbitrary hostnames pointed at the server.
 /// </summary>
 /// <remarks>
 /// Anonymous and tenantless by design: it lives under the <c>/api/v4/platform/</c>
@@ -35,19 +36,23 @@ namespace Nocturne.API.Controllers.V4;
 public class TlsAuthorizationController : ControllerBase
 {
     private readonly ITenantService _tenantService;
+    private readonly IShareTokenResolver _shareTokens;
     private readonly BaseDomainOptions _baseDomain;
 
     public TlsAuthorizationController(
         ITenantService tenantService,
+        IShareTokenResolver shareTokens,
         IOptions<BaseDomainOptions> baseDomain)
     {
         _tenantService = tenantService;
+        _shareTokens = shareTokens;
         _baseDomain = baseDomain.Value;
     }
 
     /// <summary>
     /// Returns 200 when a certificate should be issued for <paramref name="domain"/>
-    /// (the apex domain or an active tenant subdomain), 404 otherwise.
+    /// (the apex domain, an active tenant subdomain, or a share host whose token is live),
+    /// 404 otherwise.
     /// </summary>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -66,12 +71,23 @@ public class TlsAuthorizationController : ControllerBase
         if (string.Equals(host, baseHost, StringComparison.OrdinalIgnoreCase))
             return Ok();
 
-        // Tenant subdomain — only issue for an existing, active tenant.
         var slug = SubdomainParser.Extract(host, baseDomain);
         if (slug is null)
             return NotFound();
 
-        // Match slugs the same way TenantResolutionMiddleware does (ordinal,
+        // Public share host — {token}.share.{baseDomain}, one label deeper than a tenant.
+        // Resolving the token rather than accepting any well-formed share host is what stops a
+        // stranger with DNS pointed here from driving issuance for names of their choosing; a
+        // caller must already hold the token to get a 200, and the token is the secret the link
+        // hands out anyway.
+        if (SubdomainParser.TryExtractShareToken(slug, out var shareToken))
+        {
+            var shareTenant = await _shareTokens.ResolveByTokenAsync(shareToken);
+            return shareTenant is { IsActive: true } ? Ok() : NotFound();
+        }
+
+        // Tenant subdomain — only issue for an existing, active tenant. Match slugs the same
+        // way TenantResolutionMiddleware does (ordinal,
         // case-sensitive) so we never authorize a cert for a host that would
         // then fail to resolve to a tenant.
         var tenants = await _tenantService.GetAllAsync(ct);

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -295,6 +295,8 @@ public static class ServiceRegistrationExtensions
         services.AddSingleton<GuestSessionCacheService>();
         services.AddSingleton<PublicAccessCacheService>();
         services.AddSingleton<ShareTokenCacheService>();
+        // Same instance behind the seam, so the cache is shared rather than duplicated.
+        services.AddSingleton<IShareTokenResolver>(sp => sp.GetRequiredService<ShareTokenCacheService>());
         services.AddSingleton<IShareTokenGenerator, ShareTokenGenerator>();
         services.AddScoped<IShareLinkService, ShareLinkService>();
         // Singleton because its consumer runs at startup outside any request scope; it creates its

--- a/src/API/Nocturne.API/Services/Auth/IShareTokenResolver.cs
+++ b/src/API/Nocturne.API/Services/Auth/IShareTokenResolver.cs
@@ -1,0 +1,20 @@
+using Nocturne.Core.Contracts.Multitenancy;
+
+namespace Nocturne.API.Services.Auth;
+
+/// <summary>
+/// Resolves the tenant behind a public share token.
+/// </summary>
+/// <remarks>
+/// A seam over <see cref="ShareTokenCacheService"/> for callers that only need the lookup and
+/// should not have to stand up its cache and database factory — the TLS authorization endpoint
+/// is one, and it is reached before any tenant is resolved.
+/// </remarks>
+public interface IShareTokenResolver
+{
+    /// <summary>
+    /// Resolves the tenant owning the given share token, or <see langword="null"/> when no
+    /// tenant holds it.
+    /// </summary>
+    Task<TenantContext?> ResolveByTokenAsync(string token);
+}

--- a/src/API/Nocturne.API/Services/Auth/IShareTokenResolver.cs
+++ b/src/API/Nocturne.API/Services/Auth/IShareTokenResolver.cs
@@ -3,18 +3,25 @@ using Nocturne.Core.Contracts.Multitenancy;
 namespace Nocturne.API.Services.Auth;
 
 /// <summary>
-/// Resolves the tenant behind a public share token.
+/// Resolves the tenant behind a public share token, without recording a view.
 /// </summary>
 /// <remarks>
 /// A seam over <see cref="ShareTokenCacheService"/> for callers that only need the lookup and
 /// should not have to stand up its cache and database factory — the TLS authorization endpoint
 /// is one, and it is reached before any tenant is resolved.
+/// <para>
+/// Deliberately narrower than <see cref="ShareTokenCacheService.ResolveByTokenAsync"/>, which
+/// also stamps <c>share_last_accessed_at</c>. That value is shown to the tenant owner as "Last
+/// viewed", so only a caller actually serving the share may set it: a certificate-issuance probe
+/// is not a view, and recording one would tell an owner their link had been opened when it had
+/// not.
+/// </para>
 /// </remarks>
 public interface IShareTokenResolver
 {
     /// <summary>
     /// Resolves the tenant owning the given share token, or <see langword="null"/> when no
-    /// tenant holds it.
+    /// tenant holds it. Does not record an access.
     /// </summary>
-    Task<TenantContext?> ResolveByTokenAsync(string token);
+    Task<TenantContext?> ResolveWithoutRecordingAccessAsync(string token, CancellationToken ct);
 }

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
@@ -42,7 +42,14 @@ public sealed class ShareTokenCacheService : IShareTokenResolver
     /// Resolves the tenant owning the given share token, or <see langword="null"/> if no
     /// active or inactive tenant holds it.
     /// </summary>
-    public async Task<TenantContext?> ResolveByTokenAsync(string token)
+    public Task<TenantContext?> ResolveByTokenAsync(string token) =>
+        ResolveAsync(token, recordAccess: true, CancellationToken.None);
+
+    /// <inheritdoc />
+    public Task<TenantContext?> ResolveWithoutRecordingAccessAsync(string token, CancellationToken ct) =>
+        ResolveAsync(token, recordAccess: false, ct);
+
+    private async Task<TenantContext?> ResolveAsync(string token, bool recordAccess, CancellationToken ct)
     {
         var tokenHash = CredentialHash.ShareToken(token);
         var cacheKey = CacheKey(tokenHash);
@@ -50,28 +57,30 @@ public sealed class ShareTokenCacheService : IShareTokenResolver
         if (_cache.TryGetValue(cacheKey, out TenantContext? cached))
             return cached;
 
-        await using var dbContext = await _dbContextFactory.CreateDbContextAsync();
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(ct);
 
         var tenant = await dbContext.Tenants
             .AsNoTracking()
             .Where(t => t.ShareToken == tokenHash)
             .Select(t => new { t.Id, t.Slug, t.DisplayName, t.IsActive, t.IsDemo })
-            .FirstOrDefaultAsync();
+            .FirstOrDefaultAsync(ct);
 
         if (tenant == null)
             return null;
 
         // Stamp last-accessed on the database-hit path only: successful resolutions are
         // cached for CacheTtl, so the write is debounced to at most once per TTL per token.
-        // Skipped for inactive tenants (the middleware rejects those requests, so nothing was
-        // accessed), and non-fatal: the stamp is bookkeeping and must not fail the resolve.
-        if (tenant.IsActive)
+        // Skipped for inactive tenants, whose requests are refused before anything is served,
+        // and non-fatal: the stamp is bookkeeping and must not fail the resolve. Callers that
+        // are not serving the share pass recordAccess: false — the value is shown to the owner
+        // as "Last viewed", so anything other than a real view is a lie about who opened a link.
+        if (recordAccess && tenant.IsActive)
         {
             try
             {
                 await dbContext.Tenants
                     .Where(t => t.Id == tenant.Id)
-                    .ExecuteUpdateAsync(s => s.SetProperty(t => t.ShareLastAccessedAt, DateTime.UtcNow));
+                    .ExecuteUpdateAsync(s => s.SetProperty(t => t.ShareLastAccessedAt, DateTime.UtcNow), ct);
             }
             catch (DbUpdateException ex)
             {

--- a/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareTokenCacheService.cs
@@ -20,7 +20,7 @@ namespace Nocturne.API.Services.Auth;
 /// The token is only ever stored and cached as its SHA-256 digest, so neither the database nor the
 /// cache holds a value that can be replayed as a share link.
 /// </remarks>
-public sealed class ShareTokenCacheService
+public sealed class ShareTokenCacheService : IShareTokenResolver
 {
     private readonly IMemoryCache _cache;
     private readonly IDbContextFactory<NocturneDbContext> _dbContextFactory;

--- a/src/Aspire/Nocturne.Aspire.Host/caddy/Caddyfile
+++ b/src/Aspire/Nocturne.Aspire.Host/caddy/Caddyfile
@@ -10,6 +10,11 @@
 #                       request via HTTP-01. The on_demand "ask" endpoint lets
 #                       the API confirm a hostname is a real tenant before Caddy
 #                       requests a certificate, so only valid subdomains issue.
+#   - *.share.{$BASE_DOMAIN}
+#                       public share links, which are one label deeper. A Caddy
+#                       site-address wildcard matches exactly one label, so this
+#                       needs naming separately or share links never get a cert.
+#                       The ask endpoint resolves the token before authorizing.
 #
 # To front Nocturne with your own reverse proxy instead, disable this service
 # (see docker-compose.byo-proxy.yaml) and the gateway is exposed on plain HTTP.
@@ -51,6 +56,13 @@
 }
 
 *.{$BASE_DOMAIN} {
+	tls {
+		on_demand
+	}
+	import to_gateway
+}
+
+*.share.{$BASE_DOMAIN} {
 	tls {
 		on_demand
 	}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/TlsAuthorizationControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/TlsAuthorizationControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Nocturne.API.Controllers.V4;
 using Nocturne.API.Multitenancy;
+using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Xunit;
 
@@ -12,23 +13,42 @@ namespace Nocturne.API.Tests.Controllers.V4;
 /// <summary>
 /// Verifies the on-demand TLS authorization endpoint that Caddy's
 /// <c>on_demand_tls.ask</c> calls before issuing a certificate: only the apex
-/// domain and active tenant subdomains are authorized.
+/// domain, active tenant subdomains, and share hosts whose token is live.
 /// </summary>
 public sealed class TlsAuthorizationControllerTests
 {
     private const string BaseDomain = "nocturne.run";
 
-    private static TlsAuthorizationController Build(params TenantDto[] tenants)
+    private static TlsAuthorizationController Build(params TenantDto[] tenants) =>
+        Build(shares: null, tenants);
+
+    private static TlsAuthorizationController Build(
+        IReadOnlyDictionary<string, TenantContext>? shares,
+        params TenantDto[] tenants)
     {
         var tenantService = new Mock<ITenantService>();
         tenantService
             .Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(tenants.ToList());
 
+        var shareTokens = new Mock<IShareTokenResolver>();
+        shareTokens
+            .Setup(s => s.ResolveByTokenAsync(It.IsAny<string>()))
+            .ReturnsAsync((string token) =>
+            {
+                if (shares is not null && shares.TryGetValue(token, out var tenant))
+                    return tenant;
+                return null;
+            });
+
         return new TlsAuthorizationController(
             tenantService.Object,
+            shareTokens.Object,
             Options.Create(new BaseDomainOptions { BaseDomain = BaseDomain }));
     }
+
+    private static TenantContext ShareTenant(bool isActive) =>
+        new(Guid.CreateVersion7(), "acme", "Acme", isActive, IsDemo: false);
 
     private static TenantDto Tenant(string slug, bool isActive) =>
         new(Guid.CreateVersion7(), slug, slug, isActive, DateTime.UtcNow);
@@ -80,6 +100,67 @@ public sealed class TlsAuthorizationControllerTests
     {
         var controller = Build();
         var result = await controller.Authorize(domain, default);
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    // ── Public share hosts, one label deeper than a tenant ───────────────────
+
+    [Fact]
+    public async Task Authorizes_a_share_host_whose_token_is_live()
+    {
+        // Without this the host reaches the tenant branch as the slug "tok3n.share",
+        // which no slug can equal, and Caddy never issues a certificate for a share link.
+        var controller = Build(
+            shares: new Dictionary<string, TenantContext> { ["tok3n"] = ShareTenant(isActive: true) });
+
+        var result = await controller.Authorize("tok3n.share.nocturne.run", default);
+
+        result.Should().BeOfType<OkResult>();
+    }
+
+    [Fact]
+    public async Task Rejects_a_share_host_whose_token_resolves_to_nothing()
+    {
+        // Accepting any well-formed share host would let a stranger with DNS pointed here
+        // drive unbounded issuance, so the token has to resolve.
+        var controller = Build(shares: new Dictionary<string, TenantContext>());
+
+        var result = await controller.Authorize("madeup.share.nocturne.run", default);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Rejects_a_share_host_of_an_inactive_tenant()
+    {
+        var controller = Build(
+            shares: new Dictionary<string, TenantContext> { ["tok3n"] = ShareTenant(isActive: false) });
+
+        var result = await controller.Authorize("tok3n.share.nocturne.run", default);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Does_not_treat_the_bare_share_label_as_a_share_host()
+    {
+        // "share.nocturne.run" carries no token; it is an ordinary subdomain and only
+        // authorizes if a tenant is actually called "share".
+        var controller = Build(Tenant("share", isActive: true));
+
+        var result = await controller.Authorize("share.nocturne.run", default);
+
+        result.Should().BeOfType<OkResult>();
+    }
+
+    [Fact]
+    public async Task Rejects_a_host_nested_below_a_share_host()
+    {
+        var controller = Build(
+            shares: new Dictionary<string, TenantContext> { ["tok3n"] = ShareTenant(isActive: true) });
+
+        var result = await controller.Authorize("deeper.tok3n.share.nocturne.run", default);
+
         result.Should().BeOfType<NotFoundResult>();
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/TlsAuthorizationControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/TlsAuthorizationControllerTests.cs
@@ -33,8 +33,8 @@ public sealed class TlsAuthorizationControllerTests
 
         var shareTokens = new Mock<IShareTokenResolver>();
         shareTokens
-            .Setup(s => s.ResolveByTokenAsync(It.IsAny<string>()))
-            .ReturnsAsync((string token) =>
+            .Setup(s => s.ResolveWithoutRecordingAccessAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string token, CancellationToken _) =>
             {
                 if (shares is not null && shares.TryGetValue(token, out var tenant))
                     return tenant;
@@ -144,13 +144,16 @@ public sealed class TlsAuthorizationControllerTests
     [Fact]
     public async Task Does_not_treat_the_bare_share_label_as_a_share_host()
     {
-        // "share.nocturne.run" carries no token; it is an ordinary subdomain and only
-        // authorizes if a tenant is actually called "share".
-        var controller = Build(Tenant("share", isActive: true));
+        // "share.nocturne.run" carries no token, so it takes the tenant branch rather than the
+        // share one. It can never authorize: "share" is in TenantService.ReservedSlugs, so no
+        // tenant holds that slug and nothing matches.
+        var controller = Build(
+            shares: new Dictionary<string, TenantContext> { ["tok3n"] = ShareTenant(isActive: true) },
+            Tenant("acme", isActive: true));
 
         var result = await controller.Authorize("share.nocturne.run", default);
 
-        result.Should().BeOfType<OkResult>();
+        result.Should().BeOfType<NotFoundResult>();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
@@ -116,6 +116,21 @@ public sealed class ShareTokenCacheServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveWithoutRecordingAccessAsync_resolves_but_does_not_stamp()
+    {
+        // The TLS authorization endpoint asks whether to mint a certificate for a share host.
+        // That is not somebody opening the link, and the value is shown to the tenant owner as
+        // "Last viewed", so a probe must not move it.
+        var tenant = await Service().ResolveWithoutRecordingAccessAsync(Token, CancellationToken.None);
+
+        tenant.Should().NotBeNull();
+
+        using var db = _factory.CreateDbContext();
+        db.Tenants.Single(t => t.Id == _tenantId).ShareLastAccessedAt.Should().BeNull(
+            "asking whether to issue a certificate is not a view of the share");
+    }
+
+    [Fact]
     public async Task EvictByHash_makes_a_rotated_token_stop_resolving()
     {
         var service = Service();


### PR DESCRIPTION
Closes #1004.

## Why

A public share link is served at `{token}.share.{BASE_DOMAIN}` — one label deeper than a tenant subdomain. The bundled Caddy could not get a certificate for one, so every share link failed TLS on a stock Compose deployment. The link is generated and handed out, and the app resolves the host correctly; only issuance was broken.

Two independent causes:

- `caddy/Caddyfile` declared only `*.{$BASE_DOMAIN}`. A Caddy site-address wildcard matches exactly one label, so a share host matched no site at all. Confirmed against `caddy:2`: with sites `*.example.com` and a catch-all, `a.example.com` hit the wildcard and `tok.share.example.com` fell through.
- Even widened, `tls-authorize` would refuse it. `SubdomainParser.Extract` strips the base domain and hands the tenant branch the slug `"{token}.share"`, which no slug can equal — slugs cannot contain dots.

## What

**Caddyfile** — `*.share.{$BASE_DOMAIN}` as its own site block, on-demand like the tenant wildcard. Caddy resolves the more specific address first, so bare `share.{BASE_DOMAIN}` still routes as an ordinary tenant.

**`TlsAuthorizationController`** — recognises the share form via the existing `SubdomainParser.TryExtractShareToken` and authorizes only when the token resolves to an **active** tenant. Accepting any well-formed share host would let anyone pointing DNS here drive unbounded issuance; requiring the token to resolve means a caller must already hold the secret the link hands out. The endpoint stays internal-only (`INTERNAL_ONLY_API_PATHS`), so only the compose network can ask.

**`IShareTokenResolver`** — a seam over the sealed `ShareTokenCacheService`, registered to the same singleton so the cache is shared rather than duplicated. The endpoint runs before any tenant is resolved and shouldn't have to stand up a cache and a DbContext factory to be tested.

## Verification

- `TlsAuthorizationControllerTests` — 12 pass, covering a live token, an unknown token, an inactive tenant, the bare `share` label, and a host nested below a share host.
- Mutation-proved: removing the share branch fails the authorize test; dropping the token check fails the unknown-token and inactive-tenant tests.
- Full `Nocturne.API.Tests` — 6100 passed, 0 failed.
- `caddy validate` on the updated Caddyfile → *Valid configuration*.

## Note

`deploy/docker-compose/docker-compose.yaml` embeds its own copy of the Caddyfile and had **already** drifted from the AppHost's. That drift is not cosmetic: the bundle is missing all of #924's client-IP hardening (`trusted_proxies_strict`, `client_ip_headers`, the `to_gateway` snippet), so self-hosters resolve a client address from the leftmost `X-Forwarded-For` entry, which a caller can prepend.

The share site block is added here in that file's own idiom, so this PR stays about share certificates. But the reasoning that this "avoids" a regeneration does not hold: `publish-release.cs` inlines the AppHost Caddyfile verbatim before tagging, so the next release sweeps the whole delta in as an unreviewed artefact anyway, along with a `TRUSTED_PROXIES` variable that `.env.example` never declares. Filed separately as #1006; #755 covers the missing drift check.
