### PR TITLE
fix(web): keep the share host out of the sign-in gates it can never satisfy

### DIFF
--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -21,7 +21,7 @@ import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
 import { buildProxyHeaders } from "$lib/server/api-proxy-headers";
 import { clientAddressHeaders } from "$lib/server/client-address";
 import { getOriginalProto, getEffectiveHost, getOriginalHost, isShareHost } from "$lib/server/request-host";
-import { STATIC_ASSET_PREFIXES, isPublicRoute } from "$lib/server/public-routes";
+import { STATIC_ASSET_PREFIXES, requiresSignIn } from "$lib/server/public-routes";
 import {
   installRequestScopedBitsIdCounter,
   withFreshBitsIdCounter,
@@ -224,8 +224,14 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
       event.locals.siteSecurityChecked = true;
     }
 
-    // Only enforce requireAuthentication on non-public routes
-    if (!isPublicRoute(pathname) && event.locals.requireAuthentication && !event.locals.isAuthenticated) {
+    if (
+      requiresSignIn({
+        pathname,
+        requireAuthentication: event.locals.requireAuthentication ?? false,
+        isAuthenticated: event.locals.isAuthenticated,
+        isShareHost: event.locals.isShareHost,
+      })
+    ) {
       const returnUrl = encodeURIComponent(pathname + event.url.search);
       return new Response(null, {
         status: 303,

--- a/src/Web/packages/app/src/lib/server/public-routes.test.ts
+++ b/src/Web/packages/app/src/lib/server/public-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isPublicRoute, PUBLIC_PREFIXES } from "./public-routes";
+import { isPublicRoute, PUBLIC_PREFIXES, requiresSignIn } from "./public-routes";
 
 describe("isPublicRoute", () => {
   it("treats /join as public so an invitee without an account can accept an invite", () => {
@@ -43,5 +43,40 @@ describe("isPublicRoute", () => {
     ]) {
       expect(isPublicRoute(path), path).toBe(false);
     }
+  });
+});
+
+describe("requiresSignIn", () => {
+  /** A locked-down tenant with an anonymous visitor on a tenant-scoped route. */
+  const lockedDown = {
+    pathname: "/reports/agp",
+    requireAuthentication: true,
+    isAuthenticated: false,
+    isShareHost: false,
+  };
+
+  it("sends an anonymous visitor on a locked-down tenant host to sign in", () => {
+    expect(requiresSignIn(lockedDown)).toBe(true);
+  });
+
+  it("exempts the share host, whose visitors can never be authenticated", () => {
+    expect(requiresSignIn({ ...lockedDown, isShareHost: true })).toBe(false);
+  });
+
+  it("exempts the share host on the data requests the client router issues", () => {
+    // Not a public route by path, and the one the shared dashboard itself is re-fetched through.
+    expect(
+      requiresSignIn({ ...lockedDown, pathname: "/__data.json", isShareHost: true })
+    ).toBe(false);
+  });
+
+  it("leaves a signed-in visitor and an unlocked tenant alone", () => {
+    expect(requiresSignIn({ ...lockedDown, isAuthenticated: true })).toBe(false);
+    expect(requiresSignIn({ ...lockedDown, requireAuthentication: false })).toBe(false);
+  });
+
+  it("leaves the public routes alone on a locked-down tenant host", () => {
+    expect(requiresSignIn({ ...lockedDown, pathname: "/" })).toBe(false);
+    expect(requiresSignIn({ ...lockedDown, pathname: "/auth/login" })).toBe(false);
   });
 });

--- a/src/Web/packages/app/src/lib/server/public-routes.ts
+++ b/src/Web/packages/app/src/lib/server/public-routes.ts
@@ -29,3 +29,34 @@ export function isPublicRoute(pathname: string): boolean {
     STATIC_ASSET_PREFIXES.some((p) => pathname.startsWith(p))
   );
 }
+
+/** The request facts the site-wide requireAuthentication gate decides on. */
+export interface SignInGate {
+  pathname: string;
+  /** The tenant's site-level requireAuthentication setting. */
+  requireAuthentication: boolean;
+  isAuthenticated: boolean;
+  /** Whether the request arrived on a public share host ({token}.share.{base-domain}). */
+  isShareHost: boolean;
+}
+
+/**
+ * Whether the site-wide requireAuthentication gate should send this request to sign-in.
+ *
+ * A share host is exempt from the gate wholesale, not route by route: it never carries a session,
+ * because the auth handler leaves its cookies unread (see authHandle), so `isAuthenticated` is
+ * false there for the tenant's owner and for a stranger alike. Asking a host that cannot hold a
+ * session whether it holds one can only ever redirect, and the sign-in page it lands on is for an
+ * account the host would not honor either. The API applies the same setting itself and grants a
+ * share host only the public read the tenant published.
+ */
+export function requiresSignIn({
+  pathname,
+  requireAuthentication,
+  isAuthenticated,
+  isShareHost,
+}: SignInGate): boolean {
+  if (isShareHost) return false;
+  if (isPublicRoute(pathname)) return false;
+  return requireAuthentication && !isAuthenticated;
+}

--- a/src/Web/packages/app/src/lib/server/request-host.test.ts
+++ b/src/Web/packages/app/src/lib/server/request-host.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { extractTenantSlug, isShareHost } from "./request-host";
+import {
+  SETUP_TENANT_COOKIE,
+  extractTenantSlug,
+  getEffectiveHost,
+  isShareHost,
+} from "./request-host";
 
 describe("isShareHost", () => {
   it("matches the {token}.share.{baseDomain} form", () => {
@@ -86,5 +91,27 @@ describe("extractTenantSlug", () => {
     expect(extractTenantSlug("rhys.nocturne.run", null)).toBeNull();
     expect(extractTenantSlug("rhys.nocturne.run", "")).toBeNull();
     expect(extractTenantSlug(null, "nocturne.run")).toBeNull();
+  });
+});
+
+describe("getEffectiveHost", () => {
+  /** A request as it reaches the app behind the gateway, on `host`. */
+  function requestOn(host: string): Request {
+    return new Request("http://internal/", { headers: { "x-forwarded-host": host } });
+  }
+
+  /** A browser presenting the setup cookie left by whoever last ran the wizard here. */
+  const setupCookie = { get: (name: string) => (name === SETUP_TENANT_COOKIE ? "acme" : undefined) };
+
+  const noCookies = { get: () => undefined };
+
+  it("prepends the setup tenant slug on the apex, so the API resolves that tenant", () => {
+    expect(getEffectiveHost(requestOn("nocturne.run"), setupCookie)).toBe("acme.nocturne.run");
+  });
+
+  it("leaves a share host alone, whatever the browser carries", () => {
+    const share = "k7m2q9x4r3wt.share.nocturne.run";
+    expect(getEffectiveHost(requestOn(share), setupCookie)).toBe(share);
+    expect(getEffectiveHost(requestOn(share), noCookies)).toBe(share);
   });
 });

--- a/src/Web/packages/app/src/lib/server/request-host.ts
+++ b/src/Web/packages/app/src/lib/server/request-host.ts
@@ -7,6 +7,10 @@
  * (e.g. the realtime handshake-ticket endpoint).
  */
 
+// Imported from the shared (non-server) module, and re-exported below, so the client 401
+// interceptor and these server hooks share one definition of the share-host shape.
+import { isShareHost } from "$lib/share-host";
+
 /**
  * Get the original client-facing host from the request.
  * YARP suppresses the original Host header when transforms are configured,
@@ -68,17 +72,21 @@ export const SETUP_TENANT_COOKIE = "nocturne-setup-tenant";
 /**
  * Returns the effective host for API calls, prepending the setup tenant slug
  * when available so the apex domain resolves to the correct tenant.
+ *
+ * Never on a share host: the cookie is a leftover of whoever last ran setup in this browser, and
+ * prepending a slug to {token}.share.{baseDomain} yields a host the API resolves no share from,
+ * so a stale cookie would decide whether the shared view renders or the visitor is bounced to
+ * sign-in.
  */
 export function getEffectiveHost(
   request: Request,
   cookies: { get(name: string): string | undefined },
 ): string | null {
   const host = getOriginalHost(request);
+  if (isShareHost(host)) return host;
   const slug = cookies.get(SETUP_TENANT_COOKIE);
   if (slug && host && !host.startsWith(`${slug}.`)) return `${slug}.${host}`;
   return host;
 }
 
-// Re-exported from the shared (non-server) module so the client 401 interceptor and these server
-// hooks share one definition of the share-host shape. See $lib/share-host.
-export { isShareHost } from "$lib/share-host";
+export { isShareHost };

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -26,21 +26,6 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) =
   // first because it qualifies the setup redirect below as well as the route guard further down.
   const { tenantless } = await parent();
 
-  // Guest sessions bypass onboarding — the data owner's instance is already set up.
-  if (!locals.isGuestSession) {
-    // Check onboarding first — if the instance needs setup, redirect there
-    // regardless of auth state. This covers fresh installs where no tenant
-    // or credentials exist yet.
-    const onboarding = await checkOnboarding(
-      cookies,
-      locals.apiClient,
-      url.protocol === "https:",
-    );
-    if (!onboarding.isComplete) {
-      throw redirect(303, "/setup");
-    }
-  }
-
   // Tenant status drives the anonymous-access gate and the demo banner. Shared with the root
   // layout's tenantless check, and null on failure — default to no anonymous access then
   // (fail safe: require sign-in rather than over-expose).
@@ -53,7 +38,27 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) =
   // then bursting 401s on the bare host.
   // Security headers for the share host (Referrer-Policy, X-Robots-Tag) are applied for every
   // response in hooks.server.ts (shareHostSecurityHandle).
+  //
+  // Resolved before the setup redirects below because /setup is a sign-in destination for anyone
+  // without a session: it renders the wizard for an authenticated operator and redirects everyone
+  // else to /auth/login. A share host holds no session by construction, so sending one to /setup
+  // is a longer road to the sign-in page this view exists to avoid — and a share link only
+  // resolves a tenant on an instance that is past setup.
   const publicViewAllowed = locals.isShareHost && anonymousReadAccess;
+
+  // Guest sessions bypass onboarding — the data owner's instance is already set up.
+  if (!locals.isGuestSession && !publicViewAllowed) {
+    // If the instance needs setup, redirect there regardless of auth state.
+    // This covers fresh installs where no tenant or credentials exist yet.
+    const onboarding = await checkOnboarding(
+      cookies,
+      locals.apiClient,
+      url.protocol === "https:",
+    );
+    if (!onboarding.isComplete) {
+      throw redirect(303, "/setup");
+    }
+  }
 
   // A fresh instance with no resolved tenant reports "setup_required" — send it to setup rather
   // than bouncing an anonymous visitor to login.
@@ -64,7 +69,7 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) =
   // in front of a production deployment that already has tenants, and the dashboard would never
   // render at all. A genuinely fresh install is caught above instead: checkOnboarding reads the
   // 503 the API serves when no tenant exists.
-  if (!tenantless && status?.status === "setup_required") {
+  if (!tenantless && !publicViewAllowed && status?.status === "setup_required") {
     throw redirect(303, "/setup");
   }
 

--- a/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
@@ -25,30 +25,37 @@ interface Situation {
   /** Slugs the operator reserved for the dashboard (none by default). */
   dashboardSlugs?: string[];
   /** The /api/v4/status document. */
-  status: { status?: string; tenantSlug?: string | null };
+  status: { status?: string; tenantSlug?: string | null; anonymousReadAccess?: boolean };
   /** The passkey auth-status answer; a number rejects with that HTTP status. */
   authStatus: { onboardingCompleted?: boolean } | number;
   signedIn?: boolean;
   pathname?: string;
   /** The caller's effective permissions, as /api/v4/me/permissions reports them. */
   permissions?: string[];
+  /** The cookies the browser presents on this host. */
+  cookies?: Record<string, string>;
 }
 
 function runLoad(situation: Situation) {
   const { kind } = classifyHost(situation.host, BASE, situation.dashboardSlugs ?? []);
   const tenantless = isTenantlessHost(kind, situation.apexResolvesTenant ?? false);
+  const shareHost = kind === "share";
 
+  const jar = new Map(Object.entries(situation.cookies ?? {}));
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- a stub of the three Cookies methods this load touches; implementing the full interface would say nothing
   const cookies = {
-    get: () => undefined,
+    get: (name: string) => jar.get(name),
     set: () => {},
     delete: () => {},
   } as unknown as Cookies;
 
-  const signedIn = situation.signedIn ?? true;
+  // A share host is never authenticated whatever the browser presents: the auth handler leaves
+  // its cookies unread (hooks.server.ts, authHandle), so the owner of the data behind the link
+  // arrives on it as anonymously as a stranger does.
+  const signedIn = !shareHost && (situation.signedIn ?? true);
   const locals = {
     isGuestSession: false,
-    isShareHost: false,
+    isShareHost: shareHost,
     isAuthenticated: signedIn,
     user: signedIn ? { subjectId: "s1", name: "Sam" } : null,
     effectivePermissions: situation.permissions ?? ["*"],
@@ -75,9 +82,14 @@ function runLoad(situation: Situation) {
 }
 
 /** The page data the load returned, for situations that render rather than redirect. */
-async function loadedData(situation: Situation): Promise<{ canViewRealtimeData: boolean }> {
+async function loadedData(
+  situation: Situation
+): Promise<{ canViewRealtimeData: boolean; user: { name: string } | null }> {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the load's declared return includes void, for the paths that throw a redirect; these situations render
-  return (await runLoad(situation)) as { canViewRealtimeData: boolean };
+  return (await runLoad(situation)) as {
+    canViewRealtimeData: boolean;
+    user: { name: string } | null;
+  };
 }
 
 /** The Location of the redirect the load threw, or null if it returned page data. */
@@ -189,6 +201,84 @@ describe("(authenticated) layout load — where each host situation lands", () =
         ...populatedTenantless,
       })
     ).resolves.toBe("/auth/login?returnUrl=%2Fsettings%2Faccount");
+  });
+});
+
+describe("(authenticated) layout load — the public share host", () => {
+  const SHARE = `k7m2q9x4r3wt.share.${BASE}`;
+
+  /** The tenant behind a live share link: set up, resolved, and granting anonymous read. */
+  const sharedTenant = {
+    status: { status: "ok", tenantSlug: "acme", anonymousReadAccess: true },
+    authStatus: { onboardingCompleted: true },
+  } as const;
+
+  /** What the owner's browser carries on every host under the base domain after signing in. */
+  const ownerSession = {
+    IsAuthenticated: "true",
+    nocturne_access_token: "owner-access",
+    nocturne_refresh_token: "owner-refresh",
+  };
+
+  it("renders the shared view for a browser carrying the owner's session", async () => {
+    await expect(
+      redirectLocation({ host: SHARE, cookies: ownerSession, ...sharedTenant })
+    ).resolves.toBeNull();
+  });
+
+  it("gives the owner's browser the same anonymous view a stranger's gets", async () => {
+    const stranger = await loadedData({ host: SHARE, ...sharedTenant });
+    const owner = await loadedData({ host: SHARE, cookies: ownerSession, ...sharedTenant });
+
+    expect(owner).toEqual(stranger);
+    expect(owner.user).toBeNull();
+    expect(owner.canViewRealtimeData).toBe(true);
+  });
+
+  it("renders the shared view when the instance reports onboarding incomplete", async () => {
+    // /setup is a sign-in destination for anyone without a session, so a share host sent there
+    // lands on /auth/login by a longer road.
+    await expect(
+      redirectLocation({
+        host: SHARE,
+        cookies: ownerSession,
+        status: { status: "ok", tenantSlug: "acme", anonymousReadAccess: true },
+        authStatus: { onboardingCompleted: false },
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("renders the shared view when the status document says setup_required", async () => {
+    await expect(
+      redirectLocation({
+        host: SHARE,
+        status: { status: "setup_required", tenantSlug: "acme", anonymousReadAccess: true },
+        authStatus: { onboardingCompleted: true },
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("still sends a share host of a tenant that grants no anonymous read to login", async () => {
+    await expect(
+      redirectLocation({
+        host: SHARE,
+        cookies: ownerSession,
+        status: { status: "ok", tenantSlug: "acme", anonymousReadAccess: false },
+        authStatus: { onboardingCompleted: true },
+      })
+    ).resolves.toBe("/auth/login?returnUrl=%2F");
+  });
+
+  it("keeps the bare tenant host login-only even when the tenant shares publicly", async () => {
+    await expect(
+      redirectLocation({ host: `acme.${BASE}`, signedIn: false, ...sharedTenant })
+    ).resolves.toBe("/auth/login?returnUrl=%2F");
+  });
+
+  it("renders the tenant app for the owner on the bare tenant host", async () => {
+    await expect(
+      redirectLocation({ host: `acme.${BASE}`, cookies: ownerSession, ...sharedTenant })
+    ).resolves.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Symptom

A public share link (`{token}.share.{domain}`) serves `/auth/login` instead of the read-only shared dashboard.

## Root cause

A share host holds no session **by construction**. `authHandle` returns before it reads a single cookie there (`src/Web/packages/app/src/hooks.server.ts:66`), so `locals.isAuthenticated` is `false` on that host for the owner of the data and for a stranger alike — and it stays false no matter what the browser presents. Three decisions downstream still put session-shaped questions to it, and each one can only ever answer by serving the sign-in page for an account the host would not honour anyway.

**1. The site-security gate — `hooks.server.ts:228` on `main`: `if (!isPublicRoute(pathname) && event.locals.requireAuthentication && !event.locals.isAuthenticated)`.**
`requireAuthentication` is a tenant setting, and a tenant that shares publicly is otherwise private, so it is normally on. The gate exempts routes by path (`PUBLIC_PREFIXES`), and `"/"` is on that list — which is why the share landing page renders at all. Nothing else is: `/reports/*` on a share host redirects to `/auth/login`, and so does **every `__data.json` the client router fetches after hydration**, including the one for `"/"`. That last one is the shape that turns a rendered share view into a sign-in page in front of the visitor. (This is also the mechanism behind #1009's "clicking lands on the login page".)

**2. The layout's two `/setup` redirects — `src/routes/(authenticated)/+layout.server.ts:40` (`checkOnboarding`) and `:67` (`status.status === "setup_required"`).**
`/setup` is a sign-in destination for anyone without a session: `src/routes/(unauthenticated)/setup/+page.server.ts:42` redirects an unauthenticated visitor to `/auth/login?returnUrl=/setup` unconditionally. So on a share host, which is unauthenticated by construction, either signal took a longer road to the same sign-in page. Both signals sit **above** `publicViewAllowed`, so the share view never got a say.

**3. `getEffectiveHost` — `src/lib/server/request-host.ts:79`.** This is the one cookie read that reaches the share host's tenant resolution. It prepends the `nocturne-setup-tenant` cookie's slug to the request host, producing `{slug}.{token}.share.{base-domain}` — a host the API resolves no share from (`TenantResolutionMiddleware` only takes the share branch for `{token}.share.…`). The status document then carries no `anonymousReadAccess`, `publicViewAllowed` is false, and the layout falls through to `/auth/login`. A leftover cookie from whoever last ran the wizard in that browser had a vote on whether a share link renders.

## The fix

- **`public-routes.ts`** — widen the existing route classification into `requiresSignIn({ pathname, requireAuthentication, isAuthenticated, isShareHost })`, which exempts a share host **wholesale** rather than route by route, and use it in `siteSecurityHandle`. Same decision for every other host.
- **`(authenticated)/+layout.server.ts`** — resolve `publicViewAllowed` above the two `/setup` redirects and skip both when it holds. A share link only resolves a tenant on an instance that is already past setup, so nothing that could genuinely need the wizard is diverted.
- **`request-host.ts`** — `getEffectiveHost` returns a share host unchanged.

Nothing here starts honouring credentials on a share host: `apiClientHandle`, `buildProxyHeaders` and `authHandle` still send no cookies there, and `locals.user` is still null. Tenant hosts are untouched — all three changes are gated on `isShareHost`.

### Behavioural deltas a reviewer should weigh

- `getRequestStatus` now runs **before** `checkOnboarding` on every host. It is memoized on `locals` and swallows its own failures, so this is one extra round-trip on a genuinely fresh install (which then still redirects to `/setup`), not a new failure mode.
- A locked-down tenant's share host is no longer bounced from `/reports/*`. That is the intended reach of a share whose scopes include `reports.read`; the API still authorizes every endpoint, and RLS still narrows a share to its granted categories.

## Test evidence

`pnpm vitest run src/lib/server src/routes` — **21 files, 207 tests, all passing.**

New tests:

*`src/lib/server/public-routes.test.ts` — `requiresSignIn`*
- sends an anonymous visitor on a locked-down tenant host to sign in
- exempts the share host, whose visitors can never be authenticated
- exempts the share host on the data requests the client router issues (`/__data.json`)
- leaves a signed-in visitor and an unlocked tenant alone
- leaves the public routes alone on a locked-down tenant host

*`src/lib/server/request-host.test.ts` — `getEffectiveHost`*
- prepends the setup tenant slug on the apex, so the API resolves that tenant
- leaves a share host alone, whatever the browser carries

*`src/routes/(authenticated)/layout-server-load.test.ts` — the public share host*
The harness now derives `locals.isShareHost` from the host via the real `classifyHost`, forces `isAuthenticated: false` on a share host (the hook's contract), and models the browser's cookie jar.
- renders the shared view for a browser carrying the owner's session
- gives the owner's browser the same anonymous view a stranger's gets (asserts the two page-data objects are equal, `user` is null, `canViewRealtimeData` is true)
- renders the shared view when the instance reports onboarding incomplete
- renders the shared view when the status document says `setup_required`
- still sends a share host of a tenant that grants no anonymous read to login
- keeps the bare tenant host login-only even when the tenant shares publicly
- renders the tenant app for the owner on the bare tenant host

### Mutation proof

Each fix was flipped in turn and the new tests were confirmed to fail, then restored:

| Mutation | Result |
| --- | --- |
| `requiresSignIn`: `if (false && isShareHost) return false;` | 2 failed / 8 passed — "exempts the share host…" and the `/__data.json` case |
| `getEffectiveHost`: `if (false && isShareHost(host)) return host;` | 1 failed / 16 passed — expected `k7m2q9x4r3wt.share.nocturne.run`, received `acme.k7m2q9x4r3wt.share.nocturne.run` |
| layout: both `!publicViewAllowed` guards removed | 2 failed / 18 passed — the onboarding-incomplete and `setup_required` cases, both landing on `/setup` |

Lint delta on the changed files: **zero** (the 6 errors + 2 warnings in `hooks.server.ts` are pre-existing, on lines this PR does not touch). `pnpm check`: 53 errors, none in the changed files.

## Live verification outcome

An independent repro run against a full local stack (Aspire, seeded tenant, Playwright, the issue's exact recorded procedure) could not reproduce #1008's symptom on current main — including with production cookie scoping forced on (`Oidc:Cookie:SessionDomain=.{base}`), so the owner's session cookies demonstrably reached the share host and the shared dashboard still rendered identically to an anonymous context (`/`, `__data.json`, `/reports`, client-router navigation: all 200, no redirect, both contexts). The three defects fixed here are real but none is reachable in the configuration the issue describes: the `requireAuthentication` gate is instance-wide and off by default (and turning it on breaks sharing at the API before the web gate can matter), the setup cookies are host-only and never reach a share host, and `checkOnboarding` self-heals there. This PR therefore merged as hardening on its own merits and does not claim to fix #1008, which was reopened after the merge's `Fixes` keyword auto-closed it and stays open pending the reporter's environment details.

On this branch the same run confirmed: owner-session and anonymous contexts both render the share view, a signed-out tenant host still 303s to `/auth/login`, and the layout change is observably live (main leaks `nocturne-setup-complete` onto the share host via `checkOnboarding`; the branch does not).

## Follow-ups (declared, out of scope)

- `src/routes/realtime/ticket/+server.ts` reads and forwards cookies directly on every host including share hosts — verified unexploitable (`AuthenticationMiddleware` short-circuits to Unauthenticated under `IsShareAccess` before any handler), and required for share-host realtime, but it is the one exception to this PR's "no cookies on a share host" invariant.
- No test exercises the real hook chain: the layout test harness hard-codes authHandle's leave-share-cookies-unread contract rather than testing it. If authHandle ever changes, nothing fails.
- `Security:RequireAuthentication=true` kills public sharing at the API (`SiteSecurityMiddleware` has no share-host exemption) — this PR fixes only the web twin of that gate.
- An unresolvable or rotated-away share token serves the first-run setup wizard to a stranger (`/setup` redirect when the status document reports `setup_required`); `publicViewAllowed` is false there so this PR does not change it.

Refs #1008

https://claude.ai/code/session_01JbUirjgJ67Pe4s3e1doMir



