### PR TITLE
fix(realtime): put colName and identifier on every storage delete event

### DIFF
--- a/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
+++ b/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
@@ -1,5 +1,6 @@
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Cache.Abstractions;
 using Nocturne.API.Services.Realtime;
 
@@ -211,7 +212,11 @@ public class WriteSideEffectsService : IWriteSideEffects
         {
             await _broadcast.BroadcastStorageDeleteAsync(
                 collectionName,
-                new { colName = collectionName, doc = deletedRecord }
+                StorageDeleteEvent.ForRecord(
+                    collectionName,
+                    (deletedRecord as IProcessableDocument)?.Id,
+                    deletedRecord
+                )
             );
         }
         catch (Exception ex)
@@ -243,7 +248,7 @@ public class WriteSideEffectsService : IWriteSideEffects
         {
             await _broadcast.BroadcastStorageDeleteAsync(
                 collectionName,
-                new { colName = collectionName, deletedCount }
+                StorageDeleteEvent.ForBulk(collectionName, deletedCount)
             );
         }
         catch (Exception ex)

--- a/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
+++ b/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
@@ -214,7 +214,7 @@ public class WriteSideEffectsService : IWriteSideEffects
                 collectionName,
                 StorageDeleteEvent.ForRecord(
                     collectionName,
-                    (deletedRecord as IProcessableDocument)?.Id,
+                    MongoObjectId.Coerce((deletedRecord as IProcessableDocument)?.Id),
                     deletedRecord
                 )
             );

--- a/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
+++ b/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
@@ -214,7 +214,7 @@ public class WriteSideEffectsService : IWriteSideEffects
                 collectionName,
                 StorageDeleteEvent.ForRecord(
                     collectionName,
-                    MongoObjectId.Coerce((deletedRecord as IProcessableDocument)?.Id),
+                    (deletedRecord as IProcessableDocument)?.Id,
                     deletedRecord
                 )
             );

--- a/src/API/Nocturne.API/Services/Health/ActivityService.cs
+++ b/src/API/Nocturne.API/Services/Health/ActivityService.cs
@@ -469,7 +469,7 @@ public class ActivityService : IActivityService
                 {
                     await _signalRBroadcastService.BroadcastStorageDeleteAsync(
                         "activity",
-                        new { collection = "activity", id }
+                        StorageDeleteEvent.ForRecord("activity", id)
                     );
                     await _events.OnDeletedAsync(null, cancellationToken);
                     _logger.LogDebug("Successfully deleted sleep session for activity ID: {Id}", id);
@@ -483,7 +483,7 @@ public class ActivityService : IActivityService
             {
                 await _signalRBroadcastService.BroadcastStorageDeleteAsync(
                     "activity",
-                    new { collection = "activity", id = id }
+                    StorageDeleteEvent.ForRecord("activity", id)
                 );
 
                 await _events.OnDeletedAsync(null, cancellationToken);
@@ -552,7 +552,7 @@ public class ActivityService : IActivityService
             {
                 await _signalRBroadcastService.BroadcastStorageDeleteAsync(
                     "activity",
-                    new { collection = "activity", count = deletedCount }
+                    StorageDeleteEvent.ForBulk("activity", deletedCount)
                 );
 
                 await _events.OnBulkDeletedAsync(deletedCount, cancellationToken);

--- a/src/API/Nocturne.API/Services/Legacy/SimpleEntityService.cs
+++ b/src/API/Nocturne.API/Services/Legacy/SimpleEntityService.cs
@@ -367,7 +367,7 @@ public abstract class SimpleEntityService<TDomain, TEntity>
 
             await SignalRBroadcastService.BroadcastStorageDeleteAsync(
                 CollectionName,
-                new { collection = CollectionName, id }
+                StorageDeleteEvent.ForRecord(CollectionName, id)
             );
 
             Logger.LogDebug(

--- a/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
+++ b/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Nocturne.API.Services.Realtime;
 
 /// <summary>
@@ -6,22 +8,24 @@ namespace Nocturne.API.Services.Realtime;
 /// <remarks>
 /// NS v3 socket clients read <c>colName</c> and <c>identifier</c> from the top level of the event and
 /// never look inside <c>doc</c>; the reference Nightscout server emits exactly those two keys
-/// (<c>lib/api3/generic/delete/operation.js</c>). Clients match the identifier against the id they
-/// already hold for the record, so it has to be byte-identical to the one the same collection's
-/// create broadcast emits — for the legacy collections that means the coerced form
-/// (<see cref="Nocturne.Core.Models.MongoObjectId"/>), for the Nocturne-native ones the uuid verbatim.
-/// Deciding that belongs to the producer, which knows its own collection.
+/// (<c>lib/api3/generic/delete/operation.js</c>). Clients match the identifier against the id their
+/// create event delivered, and the models disagree on what that is — <see cref="Nocturne.Core.Models.Treatment"/>
+/// coerces its id to a Mongo ObjectId on the wire, <see cref="Nocturne.Core.Models.Entry"/> and
+/// <see cref="Nocturne.Core.Models.DeviceStatus"/> emit the uuid. Reading the identifier back out of the
+/// serialized document keeps delete and create in step for any model rather than restating each model's
+/// choice at the call site.
 /// </remarks>
 internal static class StorageDeleteEvent
 {
     /// <summary>Builds the delete event for a single removed record.</summary>
-    /// <param name="identifier">The record id as this collection puts it on the wire.</param>
+    /// <param name="collectionName">The collection the record belonged to.</param>
+    /// <param name="id">The record id. Used only when there is no <paramref name="doc"/> to read it from.</param>
     /// <param name="doc">The removed record. Carried for clients that need the body; NS v3 clients ignore it.</param>
-    internal static object ForRecord(string collectionName, string? identifier, object? doc = null) =>
+    internal static object ForRecord(string collectionName, string? id, object? doc = null) =>
         new
         {
             colName = collectionName,
-            identifier,
+            identifier = doc is null ? id : WireIdentifier(doc) ?? id,
             doc,
         };
 
@@ -32,6 +36,26 @@ internal static class StorageDeleteEvent
     /// them, so fanning out would trade one event for a broadcast storm. Clients reconcile a bulk
     /// delete on their next catch-up load.
     /// </remarks>
+    /// <param name="collectionName">The collection the records belonged to.</param>
+    /// <param name="deletedCount">How many records were removed.</param>
     internal static object ForBulk(string collectionName, long deletedCount) =>
         new { colName = collectionName, deletedCount };
+
+    /// <summary>
+    /// The id as <paramref name="doc"/> itself puts it on the wire, preferring the v3 <c>identifier</c>
+    /// over the legacy <c>_id</c>. Returns null for a document that carries neither.
+    /// </summary>
+    private static string? WireIdentifier(object doc)
+    {
+        var root = JsonSerializer.SerializeToElement(doc);
+
+        return Read(root, "identifier") ?? Read(root, "_id");
+
+        static string? Read(JsonElement root, string property) =>
+            root.ValueKind == JsonValueKind.Object
+            && root.TryGetProperty(property, out var value)
+            && value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : null;
+    }
 }

--- a/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
+++ b/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
@@ -1,5 +1,3 @@
-using Nocturne.Core.Models;
-
 namespace Nocturne.API.Services.Realtime;
 
 /// <summary>
@@ -8,33 +6,32 @@ namespace Nocturne.API.Services.Realtime;
 /// <remarks>
 /// NS v3 socket clients read <c>colName</c> and <c>identifier</c> from the top level of the event and
 /// never look inside <c>doc</c>; the reference Nightscout server emits exactly those two keys
-/// (<c>lib/api3/generic/delete/operation.js</c>). <c>identifier</c> is matched against the record id
-/// the client stored, so it is coerced to the 24-hex form the legacy wire uses everywhere else —
-/// see <see cref="MongoObjectId.Coerce"/>, which is idempotent for real ObjectIds and reversible for
-/// Nocturne UUIDs.
+/// (<c>lib/api3/generic/delete/operation.js</c>). Clients match the identifier against the id they
+/// already hold for the record, so it has to be byte-identical to the one the same collection's
+/// create broadcast emits — for the legacy collections that means the coerced form
+/// (<see cref="Nocturne.Core.Models.MongoObjectId"/>), for the Nocturne-native ones the uuid verbatim.
+/// Deciding that belongs to the producer, which knows its own collection.
 /// </remarks>
 internal static class StorageDeleteEvent
 {
     /// <summary>Builds the delete event for a single removed record.</summary>
-    /// <param name="collectionName">The collection the record belonged to.</param>
-    /// <param name="id">The record id, in whatever form the producer holds it.</param>
+    /// <param name="identifier">The record id as this collection puts it on the wire.</param>
     /// <param name="doc">The removed record. Carried for clients that need the body; NS v3 clients ignore it.</param>
-    internal static object ForRecord(string collectionName, string? id, object? doc = null) =>
+    internal static object ForRecord(string collectionName, string? identifier, object? doc = null) =>
         new
         {
             colName = collectionName,
-            identifier = MongoObjectId.Coerce(id),
+            identifier,
             doc,
         };
 
     /// <summary>Builds the delete event for a range or predicate delete.</summary>
     /// <remarks>
-    /// There is no identifier to send: the removed ids are never materialised by any caller, and the
-    /// v3 socket contract has no bulk form because v3 DELETE addresses one identifier at a time.
-    /// Clients reconcile a bulk delete on their next catch-up load.
+    /// No identifier is sent. The v3 socket contract has no bulk form — v3 DELETE addresses one
+    /// identifier at a time — and the callers that do hold the removed ids hold an unbounded set of
+    /// them, so fanning out would trade one event for a broadcast storm. Clients reconcile a bulk
+    /// delete on their next catch-up load.
     /// </remarks>
-    /// <param name="collectionName">The collection the records belonged to.</param>
-    /// <param name="deletedCount">How many records were removed.</param>
     internal static object ForBulk(string collectionName, long deletedCount) =>
         new { colName = collectionName, deletedCount };
 }

--- a/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
+++ b/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
@@ -1,0 +1,40 @@
+using Nocturne.Core.Models;
+
+namespace Nocturne.API.Services.Realtime;
+
+/// <summary>
+/// Builds the payloads passed to <see cref="ISignalRBroadcastService.BroadcastStorageDeleteAsync"/>.
+/// </summary>
+/// <remarks>
+/// NS v3 socket clients read <c>colName</c> and <c>identifier</c> from the top level of the event and
+/// never look inside <c>doc</c>; the reference Nightscout server emits exactly those two keys
+/// (<c>lib/api3/generic/delete/operation.js</c>). <c>identifier</c> is matched against the record id
+/// the client stored, so it is coerced to the 24-hex form the legacy wire uses everywhere else —
+/// see <see cref="MongoObjectId.Coerce"/>, which is idempotent for real ObjectIds and reversible for
+/// Nocturne UUIDs.
+/// </remarks>
+internal static class StorageDeleteEvent
+{
+    /// <summary>Builds the delete event for a single removed record.</summary>
+    /// <param name="collectionName">The collection the record belonged to.</param>
+    /// <param name="id">The record id, in whatever form the producer holds it.</param>
+    /// <param name="doc">The removed record. Carried for clients that need the body; NS v3 clients ignore it.</param>
+    internal static object ForRecord(string collectionName, string? id, object? doc = null) =>
+        new
+        {
+            colName = collectionName,
+            identifier = MongoObjectId.Coerce(id),
+            doc,
+        };
+
+    /// <summary>Builds the delete event for a range or predicate delete.</summary>
+    /// <remarks>
+    /// There is no identifier to send: the removed ids are never materialised by any caller, and the
+    /// v3 socket contract has no bulk form because v3 DELETE addresses one identifier at a time.
+    /// Clients reconcile a bulk delete on their next catch-up load.
+    /// </remarks>
+    /// <param name="collectionName">The collection the records belonged to.</param>
+    /// <param name="deletedCount">How many records were removed.</param>
+    internal static object ForBulk(string collectionName, long deletedCount) =>
+        new { colName = collectionName, deletedCount };
+}

--- a/src/API/Nocturne.API/Services/Treatments/SignalRTreatmentEventSink.cs
+++ b/src/API/Nocturne.API/Services/Treatments/SignalRTreatmentEventSink.cs
@@ -75,7 +75,7 @@ public class SignalRTreatmentEventSink : IDataEventSink<Treatment>
         try
         {
             await _broadcast.BroadcastStorageDeleteAsync(
-                Collection, new { colName = Collection, doc = treatment });
+                Collection, StorageDeleteEvent.ForRecord(Collection, treatment?.Id, treatment));
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Services/Treatments/SignalRTreatmentEventSink.cs
+++ b/src/API/Nocturne.API/Services/Treatments/SignalRTreatmentEventSink.cs
@@ -75,7 +75,7 @@ public class SignalRTreatmentEventSink : IDataEventSink<Treatment>
         try
         {
             await _broadcast.BroadcastStorageDeleteAsync(
-                Collection, StorageDeleteEvent.ForRecord(Collection, treatment?.Id, treatment));
+                Collection, StorageDeleteEvent.ForRecord(Collection, MongoObjectId.Coerce(treatment?.Id), treatment));
         }
         catch (Exception ex)
         {

--- a/src/API/Nocturne.API/Services/Treatments/SignalRTreatmentEventSink.cs
+++ b/src/API/Nocturne.API/Services/Treatments/SignalRTreatmentEventSink.cs
@@ -75,7 +75,7 @@ public class SignalRTreatmentEventSink : IDataEventSink<Treatment>
         try
         {
             await _broadcast.BroadcastStorageDeleteAsync(
-                Collection, StorageDeleteEvent.ForRecord(Collection, MongoObjectId.Coerce(treatment?.Id), treatment));
+                Collection, StorageDeleteEvent.ForRecord(Collection, treatment?.Id, treatment));
         }
         catch (Exception ex)
         {

--- a/src/Core/Nocturne.Core.Models/Entry.cs
+++ b/src/Core/Nocturne.Core.Models/Entry.cs
@@ -24,7 +24,6 @@ public class Entry : ProcessableDocumentBase
     /// Gets or sets the MongoDB ObjectId
     /// </summary>
     [JsonPropertyName("_id")]
-    [JsonConverter(typeof(ObjectIdJsonConverter))]
     public override string? Id { get; set; }
 
     /// <summary>
@@ -376,7 +375,6 @@ public class Entry : ProcessableDocumentBase
     /// Gets the V3 API identifier - alias for <see cref="ProcessableDocumentBase.Id"/>.
     /// </summary>
     [JsonPropertyName("identifier")]
-    [JsonConverter(typeof(ObjectIdJsonConverter))]
     public string? Identifier => Id;
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Models/Entry.cs
+++ b/src/Core/Nocturne.Core.Models/Entry.cs
@@ -24,6 +24,7 @@ public class Entry : ProcessableDocumentBase
     /// Gets or sets the MongoDB ObjectId
     /// </summary>
     [JsonPropertyName("_id")]
+    [JsonConverter(typeof(ObjectIdJsonConverter))]
     public override string? Id { get; set; }
 
     /// <summary>
@@ -375,6 +376,7 @@ public class Entry : ProcessableDocumentBase
     /// Gets the V3 API identifier - alias for <see cref="ProcessableDocumentBase.Id"/>.
     /// </summary>
     [JsonPropertyName("identifier")]
+    [JsonConverter(typeof(ObjectIdJsonConverter))]
     public string? Identifier => Id;
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
@@ -36,40 +36,49 @@ public class StorageDeleteBroadcastContractTests
     private const string RecordGuid = "0198c2a4-1f3b-7c2d-9e55-6a1b2c3d4e5f";
     private static readonly Guid TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
+    /// <summary>
+    /// Records both arguments of every storage broadcast. The first argument selects the SignalR
+    /// tenant group; the bridge picks the socket.io room off the payload's <c>colName</c>. If the
+    /// two disagree the event is delivered to a room no client of that collection has joined.
+    /// </summary>
     private sealed class BroadcastCapture
     {
         public Mock<ISignalRBroadcastService> Broadcast { get; } = new();
-        private object? _payload;
+        private (string Group, object Data)? _delete;
+        private (string Group, object Data)? _create;
 
         public BroadcastCapture()
         {
             Broadcast
                 .Setup(b => b.BroadcastStorageDeleteAsync(It.IsAny<string>(), It.IsAny<object>()))
-                .Callback<string, object>((_, data) => _payload = data)
+                .Callback<string, object>((group, data) => _delete = (group, data))
+                .Returns(Task.CompletedTask);
+            Broadcast
+                .Setup(b => b.BroadcastStorageCreateAsync(It.IsAny<string>(), It.IsAny<object>()))
+                .Callback<string, object>((group, data) => _create = (group, data))
                 .Returns(Task.CompletedTask);
         }
 
-        public JsonElement Payload
-        {
-            get
-            {
-                _payload.Should().NotBeNull("the producer must broadcast a delete event");
-                return JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(_payload));
-            }
-        }
-    }
+        public JsonElement Delete => Read(_delete, "delete");
 
-    private static void AssertSingleRecordShape(JsonElement payload, string collection, string sourceId)
-    {
-        payload.GetProperty("colName").GetString().Should().Be(collection);
-        payload
-            .GetProperty("identifier")
-            .GetString()
-            .Should()
-            .Be(
-                MongoObjectId.Coerce(sourceId),
-                "clients match the identifier against the id the legacy wire gave them"
+        public JsonElement Create => Read(_create, "create");
+
+        private static JsonElement Read((string Group, object Data)? captured, string kind)
+        {
+            captured.Should().NotBeNull($"the producer must broadcast a {kind} event");
+            var payload = JsonSerializer.Deserialize<JsonElement>(
+                JsonSerializer.Serialize(captured!.Value.Data)
             );
+            payload
+                .GetProperty("colName")
+                .GetString()
+                .Should()
+                .Be(
+                    captured.Value.Group,
+                    "the SignalR group and the payload's colName select the same audience and must agree"
+                );
+            return payload;
+        }
     }
 
     private static WriteSideEffectsService CreateSideEffects(BroadcastCapture capture) =>
@@ -102,6 +111,9 @@ public class StorageDeleteBroadcastContractTests
             NullLogger<ActivityService>.Instance
         );
 
+    private static string? Identifier(JsonElement payload) =>
+        payload.GetProperty("identifier").GetString();
+
     [Theory]
     [InlineData("entries")]
     [InlineData("devicestatus")]
@@ -112,8 +124,8 @@ public class StorageDeleteBroadcastContractTests
         await CreateSideEffects(capture)
             .OnDeletedAsync(collection, new Entry { Id = RecordGuid, Sgv = 120 });
 
-        AssertSingleRecordShape(capture.Payload, collection, RecordGuid);
-        capture.Payload.GetProperty("doc").GetProperty("_id").GetString().Should().Be(RecordGuid);
+        Identifier(capture.Delete).Should().Be(MongoObjectId.Coerce(RecordGuid));
+        capture.Delete.GetProperty("doc").GetProperty("sgv").GetInt32().Should().Be(120);
     }
 
     [Fact]
@@ -123,47 +135,86 @@ public class StorageDeleteBroadcastContractTests
 
         await CreateSideEffects(capture).OnBulkDeletedAsync("entries", 17);
 
-        var payload = capture.Payload;
-        payload.GetProperty("colName").GetString().Should().Be("entries");
-        payload.GetProperty("deletedCount").GetInt64().Should().Be(17);
-        payload
-            .TryGetProperty("identifier", out _)
+        capture.Delete.GetProperty("deletedCount").GetInt64().Should().Be(17);
+        capture
+            .Delete.TryGetProperty("identifier", out _)
             .Should()
             .BeFalse("a range delete materialises no ids; clients reconcile it on catch-up");
     }
 
     [Fact]
-    public async Task TreatmentSink_Delete_CarriesColNameAndIdentifier()
+    public async Task TreatmentSink_Delete_CarriesColNameIdentifierAndDoc()
     {
         var capture = new BroadcastCapture();
 
         await CreateTreatmentSink(capture)
             .OnDeletedAsync(new Treatment { Id = RecordGuid, EventType = "Meal Bolus" }, CancellationToken.None);
 
-        AssertSingleRecordShape(capture.Payload, "treatments", RecordGuid);
+        Identifier(capture.Delete).Should().Be(MongoObjectId.Coerce(RecordGuid));
+        capture
+            .Delete.GetProperty("doc")
+            .GetProperty("eventType")
+            .GetString()
+            .Should()
+            .Be("Meal Bolus", "the web client reads the removed record out of doc");
     }
 
     /// <summary>
-    /// The identifier on the wire has to be the same string the v3 REST projection served, or the
-    /// client's lookup misses just as surely as it does on an empty one.
+    /// The invariant the whole fix rests on: a client only ever holds the identifier its create
+    /// event delivered, so a delete carrying any other spelling of the same id misses the lookup
+    /// exactly as an empty one does.
+    /// </summary>
+    [Fact]
+    public async Task DeleteIdentifier_EqualsTheCreateIdentifier_ForEntries()
+    {
+        var entry = new Entry { Id = RecordGuid, Sgv = 120 };
+        var capture = new BroadcastCapture();
+        var sideEffects = CreateSideEffects(capture);
+
+        await sideEffects.OnCreatedAsync("entries", new[] { entry });
+        await sideEffects.OnDeletedAsync("entries", entry);
+
+        var doc = capture.Create.GetProperty("doc");
+        doc.GetProperty("_id")
+            .GetString()
+            .Should()
+            .Be(doc.GetProperty("identifier").GetString(), "one record cannot ship two ids");
+        Identifier(capture.Delete).Should().Be(doc.GetProperty("identifier").GetString());
+    }
+
+    [Fact]
+    public async Task DeleteIdentifier_EqualsTheCreateIdentifier_ForTreatments()
+    {
+        var treatment = new Treatment { Id = RecordGuid, EventType = "Meal Bolus" };
+        var capture = new BroadcastCapture();
+        var sink = CreateTreatmentSink(capture);
+
+        await sink.OnCreatedAsync(treatment, CancellationToken.None);
+        await sink.OnDeletedAsync(treatment, CancellationToken.None);
+
+        Identifier(capture.Delete)
+            .Should()
+            .Be(capture.Create.GetProperty("doc").GetProperty("identifier").GetString());
+    }
+
+    /// <summary>
+    /// The same identifier also has to survive a client that loaded the record over REST rather
+    /// than over the socket.
     /// </summary>
     [Fact]
     public async Task DeleteIdentifier_MatchesTheV3RestProjection()
     {
-        var treatment = new Treatment { Id = RecordGuid, EventType = "Meal Bolus" };
         var entry = new Entry { Id = RecordGuid, Sgv = 120 };
-
-        var restTreatmentId = RestIdentifier(treatment);
-        var restEntryId = RestIdentifier(new EntryV3Response(entry));
-
-        var treatmentCapture = new BroadcastCapture();
-        await CreateTreatmentSink(treatmentCapture).OnDeletedAsync(treatment, CancellationToken.None);
+        var treatment = new Treatment { Id = RecordGuid, EventType = "Meal Bolus" };
 
         var entryCapture = new BroadcastCapture();
         await CreateSideEffects(entryCapture).OnDeletedAsync("entries", entry);
 
-        treatmentCapture.Payload.GetProperty("identifier").GetString().Should().Be(restTreatmentId);
-        entryCapture.Payload.GetProperty("identifier").GetString().Should().Be(restEntryId);
+        var treatmentCapture = new BroadcastCapture();
+        await CreateTreatmentSink(treatmentCapture).OnDeletedAsync(treatment, CancellationToken.None);
+
+        Identifier(entryCapture.Delete).Should().Be(RestIdentifier(new EntryV3Response(entry)));
+        Identifier(treatmentCapture.Delete).Should().Be(RestIdentifier(treatment));
 
         static string? RestIdentifier(object projection) =>
             JsonSerializer
@@ -172,8 +223,12 @@ public class StorageDeleteBroadcastContractTests
                 .GetString();
     }
 
+    /// <summary>
+    /// The Nocturne-native collections serve raw uuids on every surface they have, so coercing
+    /// their delete identifier would emit an id none of those surfaces produces.
+    /// </summary>
     [Fact]
-    public async Task SimpleEntityService_Delete_CarriesColNameAndIdentifier()
+    public async Task SimpleEntityService_Delete_SendsTheUuidVerbatim()
     {
         var options = new DbContextOptionsBuilder<NocturneDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -197,11 +252,12 @@ public class StorageDeleteBroadcastContractTests
         ).DeleteHeartRateAsync(RecordGuid);
 
         deleted.Should().BeTrue();
-        AssertSingleRecordShape(capture.Payload, "heartrate", RecordGuid);
+        capture.Delete.GetProperty("colName").GetString().Should().Be("heartrate");
+        Identifier(capture.Delete).Should().Be(RecordGuid);
     }
 
     [Fact]
-    public async Task ActivityService_SingleDelete_CarriesColNameAndIdentifier()
+    public async Task ActivityService_SingleDelete_SendsTheUuidVerbatim()
     {
         var stateSpans = new Mock<IStateSpanService>();
         stateSpans
@@ -212,11 +268,12 @@ public class StorageDeleteBroadcastContractTests
         await CreateActivityService(capture, stateSpans, new Mock<ISleepService>())
             .DeleteActivityAsync(RecordGuid, CancellationToken.None);
 
-        AssertSingleRecordShape(capture.Payload, "activity", RecordGuid);
+        capture.Delete.GetProperty("colName").GetString().Should().Be("activity");
+        Identifier(capture.Delete).Should().Be(RecordGuid);
     }
 
     [Fact]
-    public async Task ActivityService_SleepDelete_CarriesColNameAndIdentifier()
+    public async Task ActivityService_SleepDelete_SendsTheUuidVerbatim()
     {
         var sleep = new Mock<ISleepService>();
         sleep
@@ -227,7 +284,8 @@ public class StorageDeleteBroadcastContractTests
         await CreateActivityService(capture, new Mock<IStateSpanService>(), sleep)
             .DeleteActivityAsync(RecordGuid, CancellationToken.None);
 
-        AssertSingleRecordShape(capture.Payload, "activity", RecordGuid);
+        capture.Delete.GetProperty("colName").GetString().Should().Be("activity");
+        Identifier(capture.Delete).Should().Be(RecordGuid);
     }
 
     [Fact]
@@ -246,8 +304,7 @@ public class StorageDeleteBroadcastContractTests
         await CreateActivityService(capture, stateSpans, new Mock<ISleepService>())
             .DeleteMultipleActivitiesAsync("exercise", CancellationToken.None);
 
-        var payload = capture.Payload;
-        payload.GetProperty("colName").GetString().Should().Be("activity");
-        payload.GetProperty("deletedCount").GetInt64().Should().Be(1);
+        capture.Delete.GetProperty("colName").GetString().Should().Be("activity");
+        capture.Delete.GetProperty("deletedCount").GetInt64().Should().Be(1);
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
@@ -114,18 +114,30 @@ public class StorageDeleteBroadcastContractTests
     private static string? Identifier(JsonElement payload) =>
         payload.GetProperty("identifier").GetString();
 
+    /// <summary>
+    /// <see cref="Entry"/> carries an <c>identifier</c> of its own; <see cref="DeviceStatus"/> carries
+    /// none, so its delete falls back to <c>_id</c>. Neither model coerces, so both send the uuid.
+    /// </summary>
+    public static TheoryData<string, object> LegacyRecords =>
+        new()
+        {
+            { "entries", new Entry { Id = RecordGuid, Sgv = 120 } },
+            { "devicestatus", new DeviceStatus { Id = RecordGuid } },
+        };
+
     [Theory]
-    [InlineData("entries")]
-    [InlineData("devicestatus")]
-    public async Task WriteSideEffects_SingleDelete_CarriesColNameAndIdentifier(string collection)
+    [MemberData(nameof(LegacyRecords))]
+    public async Task WriteSideEffects_SingleDelete_CarriesColNameAndIdentifier(
+        string collection,
+        object record
+    )
     {
         var capture = new BroadcastCapture();
 
-        await CreateSideEffects(capture)
-            .OnDeletedAsync(collection, new Entry { Id = RecordGuid, Sgv = 120 });
+        await CreateSideEffects(capture).OnDeletedAsync(collection, record);
 
-        Identifier(capture.Delete).Should().Be(MongoObjectId.Coerce(RecordGuid));
-        capture.Delete.GetProperty("doc").GetProperty("sgv").GetInt32().Should().Be(120);
+        Identifier(capture.Delete).Should().Be(RecordGuid);
+        capture.Delete.GetProperty("doc").GetProperty("_id").GetString().Should().Be(RecordGuid);
     }
 
     [Fact]
@@ -198,29 +210,86 @@ public class StorageDeleteBroadcastContractTests
     }
 
     /// <summary>
-    /// The same identifier also has to survive a client that loaded the record over REST rather
-    /// than over the socket.
+    /// A treatment has one identifier everywhere, so a client that loaded it over REST resolves the
+    /// delete too.
     /// </summary>
     [Fact]
-    public async Task DeleteIdentifier_MatchesTheV3RestProjection()
+    public async Task DeleteIdentifier_MatchesTheV3RestProjection_ForTreatments()
     {
-        var entry = new Entry { Id = RecordGuid, Sgv = 120 };
         var treatment = new Treatment { Id = RecordGuid, EventType = "Meal Bolus" };
 
-        var entryCapture = new BroadcastCapture();
-        await CreateSideEffects(entryCapture).OnDeletedAsync("entries", entry);
+        var capture = new BroadcastCapture();
+        await CreateTreatmentSink(capture).OnDeletedAsync(treatment, CancellationToken.None);
 
-        var treatmentCapture = new BroadcastCapture();
-        await CreateTreatmentSink(treatmentCapture).OnDeletedAsync(treatment, CancellationToken.None);
+        Identifier(capture.Delete).Should().Be(RestIdentifier(treatment));
+    }
 
-        Identifier(entryCapture.Delete).Should().Be(RestIdentifier(new EntryV3Response(entry)));
-        Identifier(treatmentCapture.Delete).Should().Be(RestIdentifier(treatment));
+    /// <summary>
+    /// Entries do not have one identifier everywhere: the REST wrapper coerces its id to an ObjectId
+    /// and the model the socket serializes does not. Delete follows the socket, because that is the
+    /// half this event has to agree with, which leaves a client that only ever loaded the reading over
+    /// REST unable to resolve the delete. Pinned so the divergence is deliberate and so this test
+    /// fails the day the two are unified.
+    /// </summary>
+    [Fact]
+    public async Task DeleteIdentifier_DivergesFromTheV3RestProjection_ForEntries()
+    {
+        var entry = new Entry { Id = RecordGuid, Sgv = 120 };
 
-        static string? RestIdentifier(object projection) =>
-            JsonSerializer
-                .Deserialize<JsonElement>(JsonSerializer.Serialize(projection))
-                .GetProperty("identifier")
-                .GetString();
+        var capture = new BroadcastCapture();
+        await CreateSideEffects(capture).OnDeletedAsync("entries", entry);
+
+        Identifier(capture.Delete).Should().Be(RecordGuid);
+        RestIdentifier(new EntryV3Response(entry)).Should().Be(MongoObjectId.Coerce(RecordGuid));
+    }
+
+    private static string? RestIdentifier(object projection) =>
+        JsonSerializer
+            .Deserialize<JsonElement>(JsonSerializer.Serialize(projection))
+            .GetProperty("identifier")
+            .GetString();
+
+    /// <summary>
+    /// A record whose two id spellings disagree, to pin which one the delete follows. No shipping
+    /// model does this today — <see cref="Treatment"/> coerces both, <see cref="Entry"/> neither —
+    /// so the precedence is only observable here.
+    /// </summary>
+    private sealed class DisagreeingIds
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("identifier")]
+        public string Identifier => "from-identifier";
+
+        [System.Text.Json.Serialization.JsonPropertyName("_id")]
+        public string Id => "from-underscore-id";
+    }
+
+    [Fact]
+    public async Task DeleteIdentifier_PrefersTheV3IdentifierOverTheLegacyId()
+    {
+        var capture = new BroadcastCapture();
+
+        await CreateSideEffects(capture).OnDeletedAsync("entries", new DisagreeingIds());
+
+        Identifier(capture.Delete).Should().Be("from-identifier");
+    }
+
+    /// <summary>
+    /// The web app's realtime store matches a create against a delete on <c>doc._id</c> alone, and
+    /// the entries it holds come from the V4 REST DTO, whose <c>_id</c> is the record's full uuid.
+    /// A broadcast that shortens <c>_id</c> leaves a deleted reading on the chart until reload.
+    /// </summary>
+    [Fact]
+    public async Task EntriesBroadcastDocId_StaysTheFullUuid()
+    {
+        var entry = new Entry { Id = RecordGuid, Sgv = 120 };
+        var capture = new BroadcastCapture();
+        var sideEffects = CreateSideEffects(capture);
+
+        await sideEffects.OnCreatedAsync("entries", new[] { entry });
+        await sideEffects.OnDeletedAsync("entries", entry);
+
+        capture.Create.GetProperty("doc").GetProperty("_id").GetString().Should().Be(RecordGuid);
+        capture.Delete.GetProperty("doc").GetProperty("_id").GetString().Should().Be(RecordGuid);
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
@@ -1,0 +1,253 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Effects;
+using Nocturne.API.Services.Health;
+using Nocturne.API.Services.Realtime;
+using Nocturne.API.Services.Treatments;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Contracts.Sleep;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Extensions;
+using Nocturne.Infrastructure.Cache.Abstractions;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Mocks;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Realtime;
+
+/// <summary>
+/// NS v3 socket clients route a storage <c>delete</c> on the event's top-level <c>colName</c> and
+/// look the removed record up by its top-level <c>identifier</c> — AAPS's <c>onDataDelete</c> reads
+/// both with <c>JSONObject.optString</c>, which yields <c>""</c> rather than null for a missing key,
+/// so a payload carrying neither deletes nothing and reports no error. The reference Nightscout
+/// server emits exactly those two keys.
+/// </summary>
+[Trait("Category", "Unit")]
+public class StorageDeleteBroadcastContractTests
+{
+    private const string RecordGuid = "0198c2a4-1f3b-7c2d-9e55-6a1b2c3d4e5f";
+    private static readonly Guid TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private sealed class BroadcastCapture
+    {
+        public Mock<ISignalRBroadcastService> Broadcast { get; } = new();
+        private object? _payload;
+
+        public BroadcastCapture()
+        {
+            Broadcast
+                .Setup(b => b.BroadcastStorageDeleteAsync(It.IsAny<string>(), It.IsAny<object>()))
+                .Callback<string, object>((_, data) => _payload = data)
+                .Returns(Task.CompletedTask);
+        }
+
+        public JsonElement Payload
+        {
+            get
+            {
+                _payload.Should().NotBeNull("the producer must broadcast a delete event");
+                return JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(_payload));
+            }
+        }
+    }
+
+    private static void AssertSingleRecordShape(JsonElement payload, string collection, string sourceId)
+    {
+        payload.GetProperty("colName").GetString().Should().Be(collection);
+        payload
+            .GetProperty("identifier")
+            .GetString()
+            .Should()
+            .Be(
+                MongoObjectId.Coerce(sourceId),
+                "clients match the identifier against the id the legacy wire gave them"
+            );
+    }
+
+    private static WriteSideEffectsService CreateSideEffects(BroadcastCapture capture) =>
+        new(
+            Mock.Of<ICacheService>(),
+            capture.Broadcast.Object,
+            Mock.Of<IDecompositionPipeline>(),
+            MockTenantAccessor.Create().Object,
+            Enumerable.Empty<ICollectionEffectDescriptor>(),
+            NullLogger<WriteSideEffectsService>.Instance
+        );
+
+    private static SignalRTreatmentEventSink CreateTreatmentSink(BroadcastCapture capture) =>
+        new(capture.Broadcast.Object, NullLogger<SignalRTreatmentEventSink>.Instance);
+
+    private static ActivityService CreateActivityService(
+        BroadcastCapture capture,
+        Mock<IStateSpanService> stateSpans,
+        Mock<ISleepService> sleep
+    ) =>
+        new(
+            stateSpans.Object,
+            sleep.Object,
+            Mock.Of<IDocumentProcessingService>(),
+            capture.Broadcast.Object,
+            Mock.Of<IDataEventSink<Activity>>(),
+            Mock.Of<IActivityDecomposer>(),
+            Mock.Of<IHeartRateService>(),
+            Mock.Of<IStepCountService>(),
+            NullLogger<ActivityService>.Instance
+        );
+
+    [Theory]
+    [InlineData("entries")]
+    [InlineData("devicestatus")]
+    public async Task WriteSideEffects_SingleDelete_CarriesColNameAndIdentifier(string collection)
+    {
+        var capture = new BroadcastCapture();
+
+        await CreateSideEffects(capture)
+            .OnDeletedAsync(collection, new Entry { Id = RecordGuid, Sgv = 120 });
+
+        AssertSingleRecordShape(capture.Payload, collection, RecordGuid);
+        capture.Payload.GetProperty("doc").GetProperty("_id").GetString().Should().Be(RecordGuid);
+    }
+
+    [Fact]
+    public async Task WriteSideEffects_BulkDelete_CarriesColNameAndCountButNoIdentifier()
+    {
+        var capture = new BroadcastCapture();
+
+        await CreateSideEffects(capture).OnBulkDeletedAsync("entries", 17);
+
+        var payload = capture.Payload;
+        payload.GetProperty("colName").GetString().Should().Be("entries");
+        payload.GetProperty("deletedCount").GetInt64().Should().Be(17);
+        payload
+            .TryGetProperty("identifier", out _)
+            .Should()
+            .BeFalse("a range delete materialises no ids; clients reconcile it on catch-up");
+    }
+
+    [Fact]
+    public async Task TreatmentSink_Delete_CarriesColNameAndIdentifier()
+    {
+        var capture = new BroadcastCapture();
+
+        await CreateTreatmentSink(capture)
+            .OnDeletedAsync(new Treatment { Id = RecordGuid, EventType = "Meal Bolus" }, CancellationToken.None);
+
+        AssertSingleRecordShape(capture.Payload, "treatments", RecordGuid);
+    }
+
+    /// <summary>
+    /// The identifier on the wire has to be the same string the v3 REST projection served, or the
+    /// client's lookup misses just as surely as it does on an empty one.
+    /// </summary>
+    [Fact]
+    public async Task DeleteIdentifier_MatchesTheV3RestProjection()
+    {
+        var treatment = new Treatment { Id = RecordGuid, EventType = "Meal Bolus" };
+        var entry = new Entry { Id = RecordGuid, Sgv = 120 };
+
+        var restTreatmentId = RestIdentifier(treatment);
+        var restEntryId = RestIdentifier(new EntryV3Response(entry));
+
+        var treatmentCapture = new BroadcastCapture();
+        await CreateTreatmentSink(treatmentCapture).OnDeletedAsync(treatment, CancellationToken.None);
+
+        var entryCapture = new BroadcastCapture();
+        await CreateSideEffects(entryCapture).OnDeletedAsync("entries", entry);
+
+        treatmentCapture.Payload.GetProperty("identifier").GetString().Should().Be(restTreatmentId);
+        entryCapture.Payload.GetProperty("identifier").GetString().Should().Be(restEntryId);
+
+        static string? RestIdentifier(object projection) =>
+            JsonSerializer
+                .Deserialize<JsonElement>(JsonSerializer.Serialize(projection))
+                .GetProperty("identifier")
+                .GetString();
+    }
+
+    [Fact]
+    public async Task SimpleEntityService_Delete_CarriesColNameAndIdentifier()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new NocturneDbContext(options) { TenantId = TenantId };
+        context.HeartRates.Add(new HeartRateEntity
+        {
+            Id = Guid.Parse(RecordGuid),
+            TenantId = TenantId,
+            Timestamp = new DateTime(2026, 6, 16, 12, 0, 0, DateTimeKind.Utc),
+            Bpm = 60,
+        });
+        await context.SaveChangesAsync();
+
+        var capture = new BroadcastCapture();
+        var deleted = await new HeartRateService(
+            context,
+            Mock.Of<IDocumentProcessingService>(),
+            capture.Broadcast.Object,
+            NullLogger<HeartRateService>.Instance
+        ).DeleteHeartRateAsync(RecordGuid);
+
+        deleted.Should().BeTrue();
+        AssertSingleRecordShape(capture.Payload, "heartrate", RecordGuid);
+    }
+
+    [Fact]
+    public async Task ActivityService_SingleDelete_CarriesColNameAndIdentifier()
+    {
+        var stateSpans = new Mock<IStateSpanService>();
+        stateSpans
+            .Setup(s => s.DeleteActivityAsync(RecordGuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var capture = new BroadcastCapture();
+        await CreateActivityService(capture, stateSpans, new Mock<ISleepService>())
+            .DeleteActivityAsync(RecordGuid, CancellationToken.None);
+
+        AssertSingleRecordShape(capture.Payload, "activity", RecordGuid);
+    }
+
+    [Fact]
+    public async Task ActivityService_SleepDelete_CarriesColNameAndIdentifier()
+    {
+        var sleep = new Mock<ISleepService>();
+        sleep
+            .Setup(s => s.DeleteSessionAsync(Guid.Parse(RecordGuid), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var capture = new BroadcastCapture();
+        await CreateActivityService(capture, new Mock<IStateSpanService>(), sleep)
+            .DeleteActivityAsync(RecordGuid, CancellationToken.None);
+
+        AssertSingleRecordShape(capture.Payload, "activity", RecordGuid);
+    }
+
+    [Fact]
+    public async Task ActivityService_BulkDelete_CarriesColNameAndCount()
+    {
+        var stateSpans = new Mock<IStateSpanService>();
+        stateSpans
+            .Setup(s => s.GetActivitiesAsync(
+                It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new Activity { Id = RecordGuid, Type = "exercise", Mills = 1 }]);
+        stateSpans
+            .Setup(s => s.DeleteActivityAsync(RecordGuid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var capture = new BroadcastCapture();
+        await CreateActivityService(capture, stateSpans, new Mock<ISleepService>())
+            .DeleteMultipleActivitiesAsync("exercise", CancellationToken.None);
+
+        var payload = capture.Payload;
+        payload.GetProperty("colName").GetString().Should().Be("activity");
+        payload.GetProperty("deletedCount").GetInt64().Should().Be(1);
+    }
+}


### PR DESCRIPTION
Refs #1020. Follow-up tracked in #1022.

Deliberately **not** `Closes` — this fixes the payload shape and makes treatment deletes resolve, but entries deletes still cannot, for the reason in #1022.

## Status in one line

| Collection | Before | After |
|---|---|---|
| `treatments` | delete silently discarded | **resolves** |
| `entries` | delete silently discarded | still does not resolve — entries carry a different identifier on the socket than on REST (#1022) |
| `devicestatus`, `profile`, `foods` | n/a | AAPS's `onDataDelete` acts only on treatments and entries |

## What I verified first

The issue was filed by another agent, so I re-checked every claim against primary sources.

**1. AAPS reads both keys at the top level.** `plugins/sync/src/main/kotlin/app/aaps/plugins/sync/nsclientV3/services/NSClientV3Service.kt` on `master`:

```kotlin
private val onDataDelete = Emitter.Listener { args ->
    val response = args[0] as JSONObject
    val collection = response.optString("colName") ?: return@Listener
    val identifier = response.optString("identifier") ?: return@Listener
    ...
    if (collection == "treatments") { storeDataForDb.addToDeleteTreatment(identifier); ... }
    if (collection == "entries")    { storeDataForDb.addToDeleteGlucoseValue(identifier); ... }
}
```

Bound with `socket.on("delete", onDataDelete)` on the `/storage` socket, which subscribes to `["devicestatus","entries","profile","treatments","foods","settings"]`. `optString` returns `""` for a missing key, so the `?: return@Listener` guards are dead — confirmed.

**2. The identifier is an NSId lookup key.** `nsShared/StoreDataForDbImpl.kt`: `addToDeleteTreatment` feeds a list that `updateDeletedTreatmentsInDb()` drains through `persistenceLayer.getBolusByNSId(id)`, `getCarbsByNSId(id)`, and siblings; the entries leg drains through `getBgReadingByNSId(id)`. `nightscoutId` is set from the v3 document's `identifier` (`nsclientV3/extensions/GlucoseValueExtension.kt`, `BolusExtension.kt`).

So the requirement is not "send *an* identifier" but **send the same identifier the client already holds**. A wrong spelling misses exactly as an empty one does.

**3. The reference server's shape.** `nightscout/cgm-remote-monitor`, `lib/api3/generic/delete/operation.js`:

```js
ctx.bus.emit('storage-socket-delete', { colName: col.colName, identifier });
```

`lib/api3/storageSocket.js` `emitDelete` forwards it unchanged to the collection room. Canonical payload is exactly `{ colName, identifier }` — no `doc`, one event per identifier, no bulk form.

**4. The bridge is not already fixing this.** `message-translator.ts` `translateStorageEvent` returns `{ colName: data.colName || data.collection, doc: ..., ...data }` and `socketio-server.ts` fans out `{ ...data, colName: clientCollection }`. It normalises the collection spelling and nothing else — `identifier` was never added. **The issue is valid.**

**5. `SignalRV4RecordBroadcaster` is out of scope — verified, not assumed.** It still emits `{ recordType, id }` with no `colName` and no `collection`, so `broadcastStorageEvent`'s `/storage` fan-out finds no `broadcastCollection` and skips it entirely. Its categories (`glucose`/`care`/`device`) are also absent from AAPS's subscribe list. Unchanged here.

## What changed

`src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs` gives the five producers one payload shape:

- `ForRecord(collection, id, doc = null)` produces `{ colName, identifier, doc }`
- `ForBulk(collection, deletedCount)` produces `{ colName, deletedCount }`

**The identifier is read back out of the serialized document** (its `identifier`, else its `_id`), not coerced from a C# string at the call site. That is what keeps delete in step with create: the models disagree about their wire id — `Treatment` coerces to a Mongo ObjectId, `Entry` and `DeviceStatus` emit the uuid — and deriving from the document means neither producer has to know which. It holds for any model, present or future. Where there is no document (`SimpleEntityService`, `ActivityService`) the raw id is used.

| Site | Before | After | identifier |
|---|---|---|---|
| `WriteSideEffectsService.OnDeletedAsync` | `{ colName, doc }` | `{ colName, identifier, doc }` | from the doc |
| `WriteSideEffectsService.OnBulkDeletedAsync` | `{ colName, deletedCount }` | unchanged shape, via `ForBulk` | none |
| `SignalRTreatmentEventSink.OnDeletedAsync` | `{ colName, doc }` | `{ colName, identifier, doc }` | from the doc (coerced) |
| `SimpleEntityService.DeleteOneAsync` | `{ collection, id }` | `{ colName, identifier, doc: null }` | uuid verbatim |
| `ActivityService` single delete (x2) | `{ collection, id }` | `{ colName, identifier, doc: null }` | uuid verbatim |
| `ActivityService` bulk delete | `{ collection, count }` | `{ colName, deletedCount }` | none |

`doc` is kept where it was already sent — the web store's `handleDelete` filters on `doc._id`.

**The four Nocturne-native collections deliberately do not coerce.** `heartrate`, `stepcount`, `bodyweight` and `activity` appear in neither AAPS's subscribe list nor the bridge's `/storage` list and serve raw uuids on every surface they have, so coercing would emit an id none of their own surfaces produces — and `Coerce` is lossy for a uuid. Pinned by test.

**Bulk delete is not fanned out.** The v3 socket contract has no bulk form, and the callers that *do* hold the removed ids hold an unbounded set (`ActivityService.DeleteMultipleActivitiesAsync` loads with `count: int.MaxValue`), so fanning out would trade one event for a broadcast storm. `V4RepositoryBase` already fans out per-record where the set is capped (`BroadcastMaterializationCap`); unchanged.

## What this PR no longer does

An earlier commit put `[JsonConverter(typeof(ObjectIdJsonConverter))]` on `Entry.Id`/`Entry.Identifier` to give entries one wire id. **Reverted** — `Entry.cs` is byte-identical to `main` again. Review found it breaks a first-party client: `realtime-store.svelte.ts:623` (`handleDelete`) filters on `doc._id` with no fallback, `:604` (`handleUpdate`) matches the same way, and the store's entries come from the V4 REST DTO via `sensorGlucoseToEntry` (`:58`), which sets `_id = sg.id` — the full 36-char GUID. Shortening `_id` would leave a deleted reading on the chart until reload and silently drop updates to backfilled readings. `NightscoutWriteBackSink.cs:149` also serializes a raw `Entry` into a **third-party** Nightscout, and eleven other sites emit a raw `Entry`. It is the right direction but needs its consumers moved in lockstep — that is #1022.

`EntriesBroadcastDocId_StaysTheFullUuid` now guards the revert directly: it asserts the entries create *and* delete broadcasts both carry `doc._id` as the full uuid. Re-applying the converter fails it.

## Declarations

- **Connector-sourced entries cannot resolve a realtime delete either way.** Every connector sets a non-uuid `LegacyId` (`CareLinkSensorGlucoseMapper.cs:50` produces `carelink_…`, likewise Dexcom, Libre, Glooko, Eversense). `MongoObjectId.Coerce` takes its SHA-256 branch for those, which is not reversible, so `TryGetGuidPrefixRange` covers an unrelated key space and the lookup misses on all three branches of `EntryReadService.GetByIdAsync`. Pre-existing and unchanged by this PR.
- **Profile and food deletes broadcast no event at all.** #1020's table says they send `identifier: null`; in fact `WriteSideEffectsService.OnDeletedAsync` returns before broadcasting when the record is null, and `ProfileWriteService`/`FoodService` both pass null. Pre-existing, harmless for AAPS, but missing rather than malformed — a different fix.
- **`devicestatus` exercises the `_id` fallback.** `DeviceStatus` has no `identifier` property at all, so its delete identifier comes from `_id`. AAPS never deletes devicestatus by id, so this is inert; it is covered because the fallback branch is real.

## Mutation testing

`StorageDeleteBroadcastContractTests` has 14 tests. Each was proven by breaking the production code.

| # | Mutation | Result |
|---|---|---|
| 1 | Re-apply the reverted `Entry` converter | 3 failed — `EntriesBroadcastDocId_StaysTheFullUuid`, the entries theory case, `DeleteIdentifier_DivergesFromTheV3RestProjection_ForEntries` |
| 2 | Stop deriving from the doc; use the C# id | 4 failed — all three treatment tests + the precedence test |
| 3 | Read `_id` before `identifier` | 1 failed — `DeleteIdentifier_PrefersTheV3IdentifierOverTheLegacyId` |
| 4 | Coerce the derived identifier | 8 failed |
| 5 | Drop the `identifier` key | 11 failed / 3 passed (the bulk tests + the doc-only test) |
| 6 | Rename `colName` to `collection` | 12 failed / 2 passed |
| 7 | `ForBulk` adds `identifier = (string?)null` | 1 failed — the bulk test |
| 8 | Treatment sink broadcasts to the `devicestatus` SignalR group | 3 failed |
| 9 | Treatment sink drops `doc` | 3 failed |
| 10 | `SimpleEntityService` coerces | 1 failed |
| 11+12 | `ActivityService` coerces both single sites; bulk reverts to `{collection, count}` | 3 failed |
| 13 | `WriteSideEffectsService` stops passing `doc` | 4 failed |

Mutations 11 and 12 were applied in one run; the failing names are listed together.

Two are worth calling out. Mutation 8 is the wrong-SignalR-group case: the first version of these tests discarded the collection argument and passed against it. The capture now records **both** arguments of every broadcast and asserts the SignalR group equals the payload's `colName` — the group selects the audience in `SignalRBroadcastService`, the bridge picks the socket.io room off the payload, and a disagreement delivers to a room no client of that collection has joined. That is the same class of silent failure as #1020 itself. Mutation 3 is only observable through a purpose-built test double, because no shipping model's `identifier` and `_id` disagree; the test says so rather than implying broader coverage.

## Suites

- `tests/Unit/Nocturne.API.Tests` — `Passed! - Failed: 0, Passed: 6115, Skipped: 5, Total: 6120`
- `tests/Unit/Nocturne.Core.Models.Tests` — `Passed! - Failed: 0, Passed: 789, Skipped: 0, Total: 789`
- `tests/Unit/Nocturne.Infrastructure.Data.Tests` — `Passed! - Failed: 0, Passed: 678, Skipped: 0, Total: 678`
- `tests/Unit/Nocturne.Connectors.Nightscout.Tests` — `Passed! - Failed: 0, Passed: 69, Skipped: 0, Total: 69`

All with `-p:GenerateNSwagClient=false`. No bridge or web-app changes, so no `pnpm check` / `pnpm lint` delta. The `CS1573` warning on `StorageDeleteEvent` is fixed (all parameters documented now); the remaining `CS1573`s in the build are pre-existing in `Infrastructure.Data`.

## Not verified

I only read AAPS `master`, not the released build most users run. If `onDataDelete` changed between them the shape assumption should be re-checked. Both keys have been in the reference server's payload for the life of the v3 API, so the risk looks low.
