### PR TITLE
fix(api): keep public share links working under site-wide lockdown

### DIFF
--- a/src/API/Nocturne.API/Middleware/SiteSecurityMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/SiteSecurityMiddleware.cs
@@ -64,6 +64,19 @@ public class SiteSecurityMiddleware
             return;
         }
 
+        // A public share link is a per-tenant grant of anonymous read the tenant owner minted
+        // deliberately; the site-wide lockdown governs who may reach the instance's own hosts, and
+        // applying it here would silently 401 every link already handed out. Safe because
+        // TenantResolutionMiddleware sets ShareAccess only once the token resolves to an active
+        // tenant, and AuthenticationMiddleware narrows the request to Scope.PublicShareScopes --
+        // the exemption cannot reach past what the tenant published. Mirrors requiresSignIn in the
+        // web layer's public-routes.ts.
+        if (context.IsShareAccess())
+        {
+            await _next(context);
+            return;
+        }
+
         // Site is locked down - check if the route should be protected
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
 

--- a/src/API/Nocturne.API/Middleware/SiteSecurityMiddleware.cs
+++ b/src/API/Nocturne.API/Middleware/SiteSecurityMiddleware.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Nocturne.API.Extensions;
 using Nocturne.Core.Models.Authorization;
 
@@ -64,24 +65,20 @@ public class SiteSecurityMiddleware
             return;
         }
 
-        // A public share link is a per-tenant grant of anonymous read the tenant owner minted
-        // deliberately; the site-wide lockdown governs who may reach the instance's own hosts, and
-        // applying it here would silently 401 every link already handed out. Safe because
-        // TenantResolutionMiddleware sets ShareAccess only once the token resolves to an active
-        // tenant, and AuthenticationMiddleware narrows the request to Scope.PublicShareScopes --
-        // the exemption cannot reach past what the tenant published. Mirrors requiresSignIn in the
-        // web layer's public-routes.ts.
-        if (context.IsShareAccess())
-        {
-            await _next(context);
-            return;
-        }
-
         // Site is locked down - check if the route should be protected
         var path = context.Request.Path.Value?.ToLowerInvariant() ?? "";
 
         // Allow certain routes without authentication even in lockdown mode
         if (IsPublicRoute(path))
+        {
+            await _next(context);
+            return;
+        }
+
+        // A public share link is a per-tenant grant of anonymous read the tenant owner minted
+        // deliberately, and the site-wide lockdown must not silently 401 every link already handed
+        // out. Mirrors requiresSignIn in the web layer's public-routes.ts.
+        if (context.IsShareAccess() && IsShareExempt(context, path))
         {
             await _next(context);
             return;
@@ -107,6 +104,39 @@ public class SiteSecurityMiddleware
 
         // User is authenticated, proceed
         await _next(context);
+    }
+
+    /// <summary>
+    /// Whether a share-resolved request may skip the lockdown gate for the endpoint it is routed to.
+    /// </summary>
+    /// <remarks>
+    /// The anonymous surface has two halves and only one of them re-authorizes. An endpoint gated by
+    /// the default-deny fallback policy (a non-empty <see cref="Core.Models.PermissionTrie"/>) is
+    /// re-derived per request from the share's <see cref="Scope.PublicShareScopes"/> grant, so this
+    /// gate adds nothing there and skipping it cannot reach past what the tenant published. An
+    /// <see cref="Microsoft.AspNetCore.Authorization.IAllowAnonymous"/> endpoint consults no policy
+    /// at all -- for the passkey ceremony, guest-link activation and the invite-token lookups this
+    /// gate is the only gate -- so a share host stays subject to lockdown there. The status document
+    /// is the one exception: it is <c>[AllowAnonymous]</c> and is how the shared view learns the
+    /// tenant grants anonymous read at all, so a lockdown that denied it would leave every share
+    /// link dead with nothing to say why.
+    /// <para>
+    /// Read off endpoint metadata rather than a path list because the two halves do not follow a
+    /// path shape. <c>UseRouting</c> runs earlier in the pipeline, so the endpoint is resolved by
+    /// now; a request that routed to none is not exempted, leaving it on the normal gate.
+    /// </para>
+    /// </remarks>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="path">The lowercased request path to evaluate.</param>
+    private static bool IsShareExempt(HttpContext context, string path)
+    {
+        if (path == "/api/v4/status")
+        {
+            return true;
+        }
+
+        var endpoint = context.GetEndpoint();
+        return endpoint != null && endpoint.Metadata.GetMetadata<IAllowAnonymous>() == null;
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Middleware/SiteSecurityMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/SiteSecurityMiddlewareTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.API.Extensions;
 using Nocturne.API.Middleware;
 using Xunit;
 
@@ -71,6 +72,46 @@ public sealed class SiteSecurityMiddlewareTests
         var ctx = new DefaultHttpContext();
         ctx.Response.Body = new MemoryStream();
         ctx.Request.Path = "/api/v4/entries";
+
+        await mw.InvokeAsync(ctx);
+
+        nextCalled.Should().BeFalse();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Theory]
+    [InlineData("/api/v4/status")]
+    [InlineData("/api/v4/entries")]
+    public async Task Share_host_is_served_under_lockdown(string path)
+    {
+        // A share link is an anonymous read the tenant owner granted; the site-wide lockdown
+        // must not revoke it, or every link already handed out 401s and the web layer never
+        // even learns the tenant allows anonymous read.
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        var ctx = new DefaultHttpContext();
+        ctx.Response.Body = new MemoryStream();
+        ctx.Request.Path = path;
+        ctx.SetShareAccess();
+
+        await mw.InvokeAsync(ctx);
+
+        nextCalled.Should().BeTrue();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public async Task Bare_tenant_host_is_still_denied_under_lockdown()
+    {
+        // The counterpart to the share-host exemption: without a resolved share token the
+        // lockdown still applies, so the exemption is not a hole for any anonymous request.
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        var ctx = new DefaultHttpContext();
+        ctx.Response.Body = new MemoryStream();
+        ctx.Request.Path = "/api/v4/status";
 
         await mw.InvokeAsync(ctx);
 

--- a/tests/Unit/Nocturne.API.Tests/Middleware/SiteSecurityMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/SiteSecurityMiddlewareTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -79,21 +80,42 @@ public sealed class SiteSecurityMiddlewareTests
         ctx.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
     }
 
-    [Theory]
-    [InlineData("/api/v4/status")]
-    [InlineData("/api/v4/entries")]
-    public async Task Share_host_is_served_under_lockdown(string path)
+    /// <summary>
+    /// A request as the pipeline presents it to this middleware: routed (UseRouting has run), and
+    /// optionally resolved through a share token.
+    /// </summary>
+    private static DefaultHttpContext Request(
+        string path, bool shareAccess = false, bool allowAnonymous = false, bool routed = true)
     {
-        // A share link is an anonymous read the tenant owner granted; the site-wide lockdown
-        // must not revoke it, or every link already handed out 401s and the web layer never
-        // even learns the tenant allows anonymous read.
-        var nextCalled = false;
-        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
-
         var ctx = new DefaultHttpContext();
         ctx.Response.Body = new MemoryStream();
         ctx.Request.Path = path;
-        ctx.SetShareAccess();
+
+        if (routed)
+        {
+            var metadata = allowAnonymous
+                ? new EndpointMetadataCollection(new AllowAnonymousAttribute())
+                : EndpointMetadataCollection.Empty;
+            ctx.SetEndpoint(new Endpoint(_ => Task.CompletedTask, metadata, path));
+        }
+
+        if (shareAccess)
+        {
+            ctx.SetShareAccess();
+        }
+
+        return ctx;
+    }
+
+    [Fact]
+    public async Task Share_host_reads_the_status_document_under_lockdown()
+    {
+        // The link is dead without this: the web layer learns a tenant grants anonymous read from
+        // /api/v4/status alone, and it is [AllowAnonymous], so lockdown was the only thing 401ing it.
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        var ctx = Request("/api/v4/status", shareAccess: true, allowAnonymous: true);
 
         await mw.InvokeAsync(ctx);
 
@@ -101,17 +123,75 @@ public sealed class SiteSecurityMiddlewareTests
         ctx.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
     }
 
-    [Fact]
-    public async Task Bare_tenant_host_is_still_denied_under_lockdown()
+    [Theory]
+    [InlineData("/api/v4/entries")]
+    [InlineData("/api/v4/me/permissions")]
+    public async Task Share_host_reads_the_shared_data_under_lockdown(string path)
     {
-        // The counterpart to the share-host exemption: without a resolved share token the
-        // lockdown still applies, so the exemption is not a hole for any anonymous request.
+        // These carry no [AllowAnonymous], so the default-deny fallback policy re-derives the
+        // share's PublicShareScopes trie for each of them -- lockdown adds nothing this gate needs
+        // to keep, and keeping it revoked a grant the tenant owner published deliberately.
         var nextCalled = false;
         var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
 
-        var ctx = new DefaultHttpContext();
-        ctx.Response.Body = new MemoryStream();
-        ctx.Request.Path = "/api/v4/status";
+        var ctx = Request(path, shareAccess: true);
+
+        await mw.InvokeAsync(ctx);
+
+        nextCalled.Should().BeTrue();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Theory]
+    [InlineData("/api/auth/passkey/login/options")]
+    [InlineData("/api/auth/passkey/recovery-mode/complete")]
+    [InlineData("/api/auth/totp/login")]
+    [InlineData("/api/v4/guest-links/activate")]
+    [InlineData("/api/v4/member-invites/tok/info")]
+    [InlineData("/hubs/data/negotiate")]
+    public async Task Share_host_stays_locked_down_on_the_anonymous_surface(string path)
+    {
+        // [AllowAnonymous] suppresses authorization evaluation, so nothing downstream narrows these
+        // to the share's scopes and this gate is their only gate. A share link is a public URL: if
+        // holding one exempted its bearer here, the operator's lockdown would leave the passkey
+        // ceremony and the token oracles open on the one host anybody can reach.
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        var ctx = Request(path, shareAccess: true, allowAnonymous: true);
+
+        await mw.InvokeAsync(ctx);
+
+        nextCalled.Should().BeFalse();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task Share_host_stays_locked_down_on_a_request_that_routed_nowhere()
+    {
+        // No endpoint means no metadata to read, so the exemption cannot establish that anything
+        // downstream would re-authorize. Fail closed rather than assume.
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        var ctx = Request("/api/v4/entries", shareAccess: true, routed: false);
+
+        await mw.InvokeAsync(ctx);
+
+        nextCalled.Should().BeFalse();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Theory]
+    [InlineData("/api/v4/status", true)]
+    [InlineData("/api/v4/entries", false)]
+    public async Task Bare_tenant_host_is_still_denied_under_lockdown(string path, bool allowAnonymous)
+    {
+        // Without a resolved share token the lockdown applies to both halves of the surface.
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        var ctx = Request(path, allowAnonymous: allowAnonymous);
 
         await mw.InvokeAsync(ctx);
 


### PR DESCRIPTION
Closes #1017

## What was wrong

With `Security:RequireAuthentication` enabled, `SiteSecurityMiddleware` 401s every anonymous request — including on a share host. `GET /api/v4/status` on `{token}.share.{base}` returns `authentication_required`, so the web layer never learns `anonymousReadAccess` and every public share link the tenant handed out is dead.

#1012 exempted the share host from the *web* twin of this gate (`requiresSignIn` in `public-routes.ts`), but the API half had no exemption, so on such an instance the feature stayed broken end to end.

## The fix

The anonymous surface has two halves and only one of them re-authorizes:

- An endpoint with **no** `[AllowAnonymous]` is gated by the default-deny fallback policy (a non-empty `PermissionTrie`), which `AuthenticationMiddleware` re-derives per request from the share's `Scope.PublicShareScopes` grant. The lockdown gate adds nothing there, so skipping it cannot reach past what the tenant published. This is the entire share read surface — entries, treatments, `/api/v4/me/permissions`, and the `/api/v1/entries` probe the realtime ticket replays.
- An `[AllowAnonymous]` endpoint suppresses authorization evaluation, so **this gate is its only gate**. A share host stays subject to lockdown there.

The single exception is `GET /api/v4/status`: it is `[AllowAnonymous]`, and it is how the shared view learns the tenant grants anonymous read at all, so a lockdown that denied it left every link dead with nothing to say why.

Read off the endpoint metadata `UseRouting` has already resolved rather than a path list, because the two halves do not follow a path shape. A request that routed to no endpoint proves nothing about what would re-authorize it, so it is not exempt. The check sits below `IsPublicRoute`, which already answers for everyone.

Provenance is unchanged and still narrow: `SetShareAccess()` has one production call site (`TenantResolutionMiddleware.cs:234`), after unknown-token→404 and inactive-tenant→403; `AuthContextKeys.ShareAccess` is written nowhere else.

### Why the first revision of this PR was wrong

The original commit exempted the whole request. A hostile review enumerated the surface by reflection and found **56 endpoints** newly opened to any share-URL holder on a locked-down instance — the entire passkey ceremony (`login/options`, `login/complete`, `recovery-mode/*`, `recovery/verify`, `register/*`, `invite/*`), `POST /api/auth/totp/login`, `POST /api/v4/guest-links/activate`, the member/alert invite token lookups, and `POST /hubs/data/negotiate`. Post-PR the share host would have been the only host on a locked-down instance where passkey sign-in worked at all.

It also confirmed that the defence-in-depth a reviewer would assume backstops this does **not** run: `src/API/Nocturne.API/Filters/SiteSecurityFilter.cs` reads `HttpContext.Items["SiteLockdownEnabled"]`, and a repo-wide grep finds exactly one hit for both that filter and that key — the file itself. It is registered nowhere. Its doc comment says it exists precisely to "respect `[AllowAnonymous]`". Pre-existing dead code, left alone here; worth deleting or wiring separately.

## Tests

`SiteSecurityMiddlewareTests`, now driving a routed context (endpoint + metadata) the way the pipeline presents one:

- `Share_host_reads_the_status_document_under_lockdown` — the `[AllowAnonymous]` status document passes.
- `Share_host_reads_the_shared_data_under_lockdown` — `/api/v4/entries` and `/api/v4/me/permissions` pass.
- `Share_host_stays_locked_down_on_the_anonymous_surface` — passkey login options, passkey recovery-mode complete, TOTP login, guest-link activation, member-invite info, and `/hubs/data/negotiate` all **401**.
- `Share_host_stays_locked_down_on_a_request_that_routed_nowhere` — no endpoint, no exemption.
- `Bare_tenant_host_is_still_denied_under_lockdown` — both halves, without a share token.

Mutation proof:

- Restore the original too-wide guard (`if (context.IsShareAccess())`) → **7 failed, 10 passed** — exactly the six anonymous-surface cases plus the unrouted one.
- Break the `/api/v4/status` exception → **1 failed, 16 passed**.

`Nocturne.API.Tests` middleware + authorization suites: **1067 passed, 0 failed**.

## Known limits of these tests

They call `SetShareAccess()` by hand on a `DefaultHttpContext`; they do not exercise `TenantResolutionMiddleware`'s token resolution or `AuthenticationMiddleware`'s narrowing. Those were read and reasoned about, not driven end to end here.

https://claude.ai/code/session_01BbK5W7zQy2xLHUzRkmj7n6
