### PR TITLE
fix(web): stop a dead share link serving the first-run setup wizard

### DIFF
--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -21,7 +21,12 @@ import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
 import { buildProxyHeaders } from "$lib/server/api-proxy-headers";
 import { clientAddressHeaders } from "$lib/server/client-address";
 import { getOriginalProto, getEffectiveHost, getOriginalHost, isShareHost } from "$lib/server/request-host";
-import { STATIC_ASSET_PREFIXES, requiresSignIn } from "$lib/server/public-routes";
+import {
+  STATIC_ASSET_PREFIXES,
+  requiresSignIn,
+  shareLinkIsDeadEnd,
+} from "$lib/server/public-routes";
+import { SHARE_UNAVAILABLE_PATH } from "$lib/share-host";
 import {
   installRequestScopedBitsIdCounter,
   withFreshBitsIdCounter,
@@ -184,12 +189,13 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
   const pathname = event.url.pathname;
 
   // Skip the status probe entirely for static assets, for pages that ARE
-  // the setup/recovery/auth destinations (probing those would cause infinite
+  // the setup/recovery/auth/share-unavailable destinations (probing those would cause infinite
   // redirect loops), and for external webhook/bot endpoints that must respond
   // regardless of setup state — third-party services like Discord cannot
   // follow HTML redirects and will treat any non-2xx as a hard failure.
   const skipProbe =
     STATIC_ASSET_PREFIXES.some((p) => pathname.startsWith(p)) ||
+    pathname.startsWith(SHARE_UNAVAILABLE_PATH) ||
     pathname.startsWith("/setup") ||
     pathname.startsWith("/auth") ||
     pathname.startsWith("/api/v4/webhooks") ||
@@ -243,6 +249,13 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
   } catch (error) {
     if (error && typeof error === "object" && "status" in error) {
       const status = (error as any).status;
+
+      if (shareLinkIsDeadEnd(event.locals.isShareHost, status)) {
+        return new Response(null, {
+          status: 303,
+          headers: { Location: SHARE_UNAVAILABLE_PATH },
+        });
+      }
 
       if (status === 503) {
         let body: any = {};

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -24,7 +24,7 @@ import { getOriginalProto, getEffectiveHost, getOriginalHost, isShareHost } from
 import {
   STATIC_ASSET_PREFIXES,
   requiresSignIn,
-  shareLinkIsDeadEnd,
+  statusProbeRedirect,
 } from "$lib/server/public-routes";
 import { SHARE_UNAVAILABLE_PATH } from "$lib/share-host";
 import {
@@ -248,56 +248,24 @@ const siteSecurityHandle: Handle = async ({ event, resolve }) => {
     }
   } catch (error) {
     if (error && typeof error === "object" && "status" in error) {
-      const status = (error as any).status;
-
-      if (shareLinkIsDeadEnd(event.locals.isShareHost, status)) {
-        return new Response(null, {
-          status: 303,
-          headers: { Location: SHARE_UNAVAILABLE_PATH },
-        });
+      let body: any = {};
+      try {
+        body = JSON.parse((error as any).response ?? "{}");
+      } catch {
+        // Couldn't parse — leave recoveryMode unset, which reads as "not ready"
       }
 
-      if (status === 503) {
-        let body: any = {};
-        try {
-          body = JSON.parse((error as any).response ?? "{}");
-        } catch {
-          // Couldn't parse — treat as setup required (API isn't ready)
-        }
+      const redirect = statusProbeRedirect({
+        isShareHost: event.locals.isShareHost,
+        apiStatus: (error as any).status,
+        recoveryMode: body.recoveryMode === true,
+        marketingUrl: env.MARKETING_URL,
+      });
 
-        if (body.recoveryMode) {
-          return new Response(null, {
-            status: 303,
-            headers: { Location: "/auth/recovery" },
-          });
-        }
-
-        // Any 503 from the API (setup_required, no tenants, or unparseable)
-        // means the instance isn't ready — redirect to setup
+      if (redirect) {
         return new Response(null, {
-          status: 303,
-          headers: { Location: "/setup" },
-        });
-      }
-
-      // Tenant not found (404) — either no tenant for this subdomain,
-      // or apex domain with no tenants set up yet.
-      if (status === 404) {
-        // If a marketing site is configured, redirect there (SaaS apex landing)
-        const marketingUrl = env.MARKETING_URL;
-        if (marketingUrl) {
-          return new Response(null, {
-            status: 302,
-            headers: { Location: marketingUrl },
-          });
-        }
-
-        // No marketing site — this is likely a self-hosted install.
-        // Check if this is an apex domain request (no tenant subdomain).
-        // If so, redirect to setup so the user can create their first tenant.
-        return new Response(null, {
-          status: 303,
-          headers: { Location: "/setup" },
+          status: redirect.status,
+          headers: { Location: redirect.location },
         });
       }
     }

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
@@ -539,6 +539,7 @@ export function createChartDataEngine(
   // mills value must never appear twice — even if base or realtimeStore
   // emit duplicates.
   const glucoseData = $derived.by(() => {
+    $inspect.trace("glucoseData");
     const base = serverChartData?.glucoseData ?? [];
     if (!serverChartData) return base as GlucosePoint[];
 

--- a/src/Web/packages/app/src/lib/server/public-routes.test.ts
+++ b/src/Web/packages/app/src/lib/server/public-routes.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isPublicRoute, PUBLIC_PREFIXES, requiresSignIn } from "./public-routes";
+import {
+  isPublicRoute,
+  PUBLIC_PREFIXES,
+  requiresSignIn,
+  shareLinkIsDeadEnd,
+} from "./public-routes";
 
 describe("isPublicRoute", () => {
   it("treats /join as public so an invitee without an account can accept an invite", () => {
@@ -78,5 +83,25 @@ describe("requiresSignIn", () => {
   it("leaves the public routes alone on a locked-down tenant host", () => {
     expect(requiresSignIn({ ...lockedDown, pathname: "/" })).toBe(false);
     expect(requiresSignIn({ ...lockedDown, pathname: "/auth/login" })).toBe(false);
+  });
+});
+
+describe("shareLinkIsDeadEnd", () => {
+  it("claims the statuses a share host cannot act on", () => {
+    // 404 is the API's answer to a token it cannot resolve; 503 is setup/recovery mode, which a
+    // share host has no way to satisfy. Both otherwise steer to /setup or the marketing site.
+    expect(shareLinkIsDeadEnd(true, 404)).toBe(true);
+    expect(shareLinkIsDeadEnd(true, 503)).toBe(true);
+  });
+
+  it("leaves every other host on its own dead ends", () => {
+    expect(shareLinkIsDeadEnd(false, 404)).toBe(false);
+    expect(shareLinkIsDeadEnd(false, 503)).toBe(false);
+  });
+
+  it("does not claim a status that means something else on a share host", () => {
+    for (const status of [401, 403, 500, undefined, null, "404"]) {
+      expect(shareLinkIsDeadEnd(true, status), String(status)).toBe(false);
+    }
   });
 });

--- a/src/Web/packages/app/src/lib/server/public-routes.test.ts
+++ b/src/Web/packages/app/src/lib/server/public-routes.test.ts
@@ -3,8 +3,9 @@ import {
   isPublicRoute,
   PUBLIC_PREFIXES,
   requiresSignIn,
-  shareLinkIsDeadEnd,
+  statusProbeRedirect,
 } from "./public-routes";
+import { SHARE_UNAVAILABLE_PATH } from "$lib/share-host";
 
 describe("isPublicRoute", () => {
   it("treats /join as public so an invitee without an account can accept an invite", () => {
@@ -86,22 +87,62 @@ describe("requiresSignIn", () => {
   });
 });
 
-describe("shareLinkIsDeadEnd", () => {
-  it("claims the statuses a share host cannot act on", () => {
-    // 404 is the API's answer to a token it cannot resolve; 503 is setup/recovery mode, which a
-    // share host has no way to satisfy. Both otherwise steer to /setup or the marketing site.
-    expect(shareLinkIsDeadEnd(true, 404)).toBe(true);
-    expect(shareLinkIsDeadEnd(true, 503)).toBe(true);
+describe("statusProbeRedirect", () => {
+  /** A self-hosted install with no marketing site, on an ordinary tenant host. */
+  const selfHosted = {
+    isShareHost: false,
+    recoveryMode: false,
+    marketingUrl: undefined,
+  };
+
+  it("claims every status a share host cannot act on, ahead of the instance-wide ones", () => {
+    // 404 an unresolvable token, 403 a suspended tenant, 503 an API that is itself unready. Each
+    // would otherwise steer to /setup, /auth/recovery or the marketing site, none of which a
+    // share host can do anything with.
+    for (const apiStatus of [404, 403, 503]) {
+      expect(
+        statusProbeRedirect({
+          ...selfHosted,
+          isShareHost: true,
+          recoveryMode: true,
+          marketingUrl: "https://nocturne.run",
+          apiStatus,
+        }),
+        String(apiStatus)
+      ).toEqual({ location: SHARE_UNAVAILABLE_PATH, status: 303 });
+    }
   });
 
-  it("leaves every other host on its own dead ends", () => {
-    expect(shareLinkIsDeadEnd(false, 404)).toBe(false);
-    expect(shareLinkIsDeadEnd(false, 503)).toBe(false);
+  it("leaves every other host on its own destinations", () => {
+    expect(statusProbeRedirect({ ...selfHosted, apiStatus: 503 })).toEqual({
+      location: "/setup",
+      status: 303,
+    });
+    expect(
+      statusProbeRedirect({ ...selfHosted, apiStatus: 503, recoveryMode: true })
+    ).toEqual({ location: "/auth/recovery", status: 303 });
+    expect(statusProbeRedirect({ ...selfHosted, apiStatus: 404 })).toEqual({
+      location: "/setup",
+      status: 303,
+    });
+    expect(
+      statusProbeRedirect({ ...selfHosted, apiStatus: 404, marketingUrl: "https://nocturne.run" })
+    ).toEqual({ location: "https://nocturne.run", status: 302 });
   });
 
-  it("does not claim a status that means something else on a share host", () => {
-    for (const status of [401, 403, 500, undefined, null, "404"]) {
-      expect(shareLinkIsDeadEnd(true, status), String(status)).toBe(false);
+  it("sends nowhere on a status neither branch answers for", () => {
+    // 403 is among them: only a share host reads it as a suspended tenant.
+    for (const apiStatus of [401, 403, 500, undefined, null, "404"]) {
+      expect(statusProbeRedirect({ ...selfHosted, apiStatus }), String(apiStatus)).toBeNull();
+    }
+  });
+
+  it("sends a share host nowhere on a status that is not its dead end either", () => {
+    for (const apiStatus of [401, 500, undefined, "404"]) {
+      expect(
+        statusProbeRedirect({ ...selfHosted, isShareHost: true, apiStatus }),
+        String(apiStatus)
+      ).toBeNull();
     }
   });
 });

--- a/src/Web/packages/app/src/lib/server/public-routes.ts
+++ b/src/Web/packages/app/src/lib/server/public-routes.ts
@@ -1,3 +1,5 @@
+import { SHARE_UNAVAILABLE_PATH } from "$lib/share-host";
+
 /**
  * Route classification shared by the request hooks.
  *
@@ -61,17 +63,52 @@ export function requiresSignIn({
   return requireAuthentication && !isAuthenticated;
 }
 
+/** What the request hooks know about a status probe that failed. */
+export interface StatusProbeFailure {
+  /** Whether the request arrived on a public share host ({token}.share.{base-domain}). */
+  isShareHost: boolean;
+  /** The HTTP status the API answered with, if it answered at all. */
+  apiStatus: unknown;
+  /** Whether the API's 503 body declared recovery mode. */
+  recoveryMode: boolean;
+  /** The marketing site to land an unresolvable non-share host on, if one is configured. */
+  marketingUrl: string | undefined;
+}
+
 /**
- * Whether a failed status probe means the share link itself is the dead end, rather than the
- * instance-wide condition the same status means on any other host.
+ * Where a failed status probe sends the request, or null to let it render and decide for itself.
  *
- * A share host answers for one tenant's link and nothing else, so the destinations those statuses
- * otherwise carry are all wrong for it: a marketing site on another domain, a first-run wizard on
- * an instance a share link only resolves on once it is past setup, a recovery sign-in the host
- * holds no session for. The API 404s a token it cannot resolve — rotated, disabled, or never
- * valid — and 503s only when it is itself unready; either way the link is what the visitor came
- * for and is not working.
+ * A share host answers for one tenant's link and nothing else, so it is claimed ahead of every
+ * instance-wide destination below: it holds no session for the recovery sign-in, the marketing site
+ * belongs to a different domain, and /setup offers a first-run wizard on an instance a share link
+ * only resolves on once it is past setup. The three statuses it claims mean an unresolvable token
+ * (404), a suspended tenant (403) and an API that is itself unready (503) — the page it lands on
+ * names none of them, only that the link is not working, because from here they are indistinguishable
+ * to the visitor and only one of them is even permanent.
  */
-export function shareLinkIsDeadEnd(isShareHost: boolean, apiStatus: unknown): boolean {
-  return isShareHost && (apiStatus === 404 || apiStatus === 503);
+export function statusProbeRedirect({
+  isShareHost,
+  apiStatus,
+  recoveryMode,
+  marketingUrl,
+}: StatusProbeFailure): { location: string; status: 302 | 303 } | null {
+  if (isShareHost && (apiStatus === 404 || apiStatus === 403 || apiStatus === 503)) {
+    return { location: SHARE_UNAVAILABLE_PATH, status: 303 };
+  }
+
+  // Any 503 (setup_required, no tenants, or an unparseable body) means the instance isn't ready.
+  if (apiStatus === 503) {
+    return { location: recoveryMode ? "/auth/recovery" : "/setup", status: 303 };
+  }
+
+  // No tenant for this subdomain, or an apex with no tenants set up yet. A configured marketing
+  // site is the SaaS apex landing; without one this is likely a self-hosted install that has yet
+  // to create its first tenant.
+  if (apiStatus === 404) {
+    return marketingUrl
+      ? { location: marketingUrl, status: 302 }
+      : { location: "/setup", status: 303 };
+  }
+
+  return null;
 }

--- a/src/Web/packages/app/src/lib/server/public-routes.ts
+++ b/src/Web/packages/app/src/lib/server/public-routes.ts
@@ -60,3 +60,18 @@ export function requiresSignIn({
   if (isPublicRoute(pathname)) return false;
   return requireAuthentication && !isAuthenticated;
 }
+
+/**
+ * Whether a failed status probe means the share link itself is the dead end, rather than the
+ * instance-wide condition the same status means on any other host.
+ *
+ * A share host answers for one tenant's link and nothing else, so the destinations those statuses
+ * otherwise carry are all wrong for it: a marketing site on another domain, a first-run wizard on
+ * an instance a share link only resolves on once it is past setup, a recovery sign-in the host
+ * holds no session for. The API 404s a token it cannot resolve — rotated, disabled, or never
+ * valid — and 503s only when it is itself unready; either way the link is what the visitor came
+ * for and is not working.
+ */
+export function shareLinkIsDeadEnd(isShareHost: boolean, apiStatus: unknown): boolean {
+  return isShareHost && (apiStatus === 404 || apiStatus === 503);
+}

--- a/src/Web/packages/app/src/lib/share-host.ts
+++ b/src/Web/packages/app/src/lib/share-host.ts
@@ -9,3 +9,13 @@
 export function isShareHost(host: string | null | undefined): boolean {
   return host != null && /^[^.]+\.share\./i.test(host);
 }
+
+/**
+ * Where a share host goes when its link serves nothing — rotated, disabled, or never valid.
+ *
+ * A share host holds no session and answers for one link only, so every other dead end the app
+ * has (sign-in, the first-run wizard, the marketing site) either cannot be satisfied there or
+ * reads as "this deployment is broken". Its page says only that the link is not working, which
+ * is all a visitor can act on and all a stranger may learn.
+ */
+export const SHARE_UNAVAILABLE_PATH = "/share/unavailable";

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -39,18 +39,14 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) =
   // then bursting 401s on the bare host.
   // Security headers for the share host (Referrer-Policy, X-Robots-Tag) are applied for every
   // response in hooks.server.ts (shareHostSecurityHandle).
-  //
-  // Resolved before the setup redirects below because /setup is a sign-in destination for anyone
-  // without a session: it renders the wizard for an authenticated operator and redirects everyone
-  // else to /auth/login. A share host holds no session by construction, so sending one to /setup
-  // is a longer road to the sign-in page this view exists to avoid — and a share link only
-  // resolves a tenant on an instance that is past setup.
   const publicViewAllowed = locals.isShareHost && anonymousReadAccess;
 
-  // A share host that grants nothing is a link that was rotated, disabled, or never valid.
-  // Neither redirect below reaches anywhere it can act on — /auth/login for a host that holds no
-  // session, /setup for an instance a link only resolves on once it is past setup — and a
-  // first-run wizard reads as "this deployment is broken". Say the one actionable thing instead.
+  // Resolved above every redirect below, because none of them reaches anywhere a share host can
+  // act on: /auth/login wants a session this host holds none of by construction, and /setup offers
+  // a first-run wizard on an instance a share link only resolves on once it is past setup — which
+  // reads as "this deployment is broken" to whoever was handed the link. A share host that grants
+  // nothing has a link that was rotated, disabled, or never valid; it is also what a status call
+  // that simply failed looks like from here, so the page it lands on claims neither.
   if (locals.isShareHost && !publicViewAllowed) {
     throw redirect(303, SHARE_UNAVAILABLE_PATH);
   }

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.server.ts
@@ -3,6 +3,7 @@ import type { LayoutServerLoad } from "./$types";
 import { checkOnboarding } from "$lib/server/onboarding-check";
 import { getRequestStatus } from "$lib/server/request-status";
 import { isTenantlessRoute } from "$lib/navigation/tenantless-navigation";
+import { SHARE_UNAVAILABLE_PATH } from "$lib/share-host";
 import { toIsoString } from "$lib/utils/api-date";
 
 /** Permissions that grant read access to glucose data (mirrors API's CanRead + OAuth scopes). */
@@ -45,6 +46,14 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url, parent }) =
   // is a longer road to the sign-in page this view exists to avoid — and a share link only
   // resolves a tenant on an instance that is past setup.
   const publicViewAllowed = locals.isShareHost && anonymousReadAccess;
+
+  // A share host that grants nothing is a link that was rotated, disabled, or never valid.
+  // Neither redirect below reaches anywhere it can act on — /auth/login for a host that holds no
+  // session, /setup for an instance a link only resolves on once it is past setup — and a
+  // first-run wizard reads as "this deployment is broken". Say the one actionable thing instead.
+  if (locals.isShareHost && !publicViewAllowed) {
+    throw redirect(303, SHARE_UNAVAILABLE_PATH);
+  }
 
   // Guest sessions bypass onboarding — the data owner's instance is already set up.
   if (!locals.isGuestSession && !publicViewAllowed) {

--- a/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { isRedirect, type Cookies } from "@sveltejs/kit";
 import { classifyHost, isTenantlessHost } from "$lib/server/tenantless-host";
+import { SHARE_UNAVAILABLE_PATH } from "$lib/share-host";
 import { load } from "./+layout.server";
 
 /**
@@ -258,7 +259,9 @@ describe("(authenticated) layout load — the public share host", () => {
     ).resolves.toBeNull();
   });
 
-  it("still sends a share host of a tenant that grants no anonymous read to login", async () => {
+  it("tells a share host of a tenant that grants no anonymous read that the link is gone", async () => {
+    // Sign-in is not an option the visitor has: the host holds no session, and the account the
+    // login page would take belongs to a different host anyway.
     await expect(
       redirectLocation({
         host: SHARE,
@@ -266,7 +269,30 @@ describe("(authenticated) layout load — the public share host", () => {
         status: { status: "ok", tenantSlug: "acme", anonymousReadAccess: false },
         authStatus: { onboardingCompleted: true },
       })
-    ).resolves.toBe("/auth/login?returnUrl=%2F");
+    ).resolves.toBe(SHARE_UNAVAILABLE_PATH);
+  });
+
+  it("never serves the first-run wizard to a share host whose token resolves nothing", async () => {
+    // A token the API cannot parse as one leaves the host resolving no tenant, and the status
+    // endpoint reports "setup_required" for any request that resolves none — which put the
+    // "WELCOME TO NOCTURNE" wizard in front of whoever held a rotated link.
+    await expect(
+      redirectLocation({
+        host: SHARE,
+        status: { status: "setup_required", tenantSlug: null, anonymousReadAccess: false },
+        authStatus: 404,
+      })
+    ).resolves.toBe(SHARE_UNAVAILABLE_PATH);
+  });
+
+  it("never serves the first-run wizard to a share host reporting onboarding incomplete", async () => {
+    await expect(
+      redirectLocation({
+        host: SHARE,
+        status: { status: "ok", tenantSlug: "acme", anonymousReadAccess: false },
+        authStatus: { onboardingCompleted: false },
+      })
+    ).resolves.toBe(SHARE_UNAVAILABLE_PATH);
   });
 
   it("keeps the bare tenant host login-only even when the tenant shares publicly", async () => {

--- a/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/layout-server-load.test.ts
@@ -25,8 +25,10 @@ interface Situation {
   apexResolvesTenant?: boolean;
   /** Slugs the operator reserved for the dashboard (none by default). */
   dashboardSlugs?: string[];
-  /** The /api/v4/status document. */
-  status: { status?: string; tenantSlug?: string | null; anonymousReadAccess?: boolean };
+  /** The /api/v4/status document; a number rejects with that HTTP status. */
+  status:
+    | { status?: string; tenantSlug?: string | null; anonymousReadAccess?: boolean }
+    | number;
   /** The passkey auth-status answer; a number rejects with that HTTP status. */
   authStatus: { onboardingCompleted?: boolean } | number;
   signedIn?: boolean;
@@ -61,7 +63,12 @@ function runLoad(situation: Situation) {
     user: signedIn ? { subjectId: "s1", name: "Sam" } : null,
     effectivePermissions: situation.permissions ?? ["*"],
     apiClient: {
-      status: { getStatus: async () => situation.status },
+      status: {
+        getStatus: async () => {
+          if (typeof situation.status === "number") throw { status: situation.status };
+          return situation.status;
+        },
+      },
       passkey: {
         getAuthStatus: async () => {
           if (typeof situation.authStatus === "number") throw { status: situation.authStatus };
@@ -282,6 +289,16 @@ describe("(authenticated) layout load — the public share host", () => {
         status: { status: "setup_required", tenantSlug: null, anonymousReadAccess: false },
         authStatus: 404,
       })
+    ).resolves.toBe(SHARE_UNAVAILABLE_PATH);
+  });
+
+  it("does not claim a cause when the status call is what failed", async () => {
+    // getRequestStatus swallows any failure to null, so a live link during an API blip is
+    // indistinguishable here from one that was rotated. It lands on the same page, which is why
+    // that page says the link is not working rather than that it was replaced — telling a viewer
+    // to ask for a replacement would have the owner rotate, killing the link for everyone else.
+    await expect(
+      redirectLocation({ host: SHARE, status: 503, authStatus: 404 })
     ).resolves.toBe(SHARE_UNAVAILABLE_PATH);
   });
 

--- a/src/Web/packages/app/src/routes/(unauthenticated)/share/unavailable/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/share/unavailable/+page.svelte
@@ -4,22 +4,32 @@
 </script>
 
 <svelte:head>
-  <title>Share link unavailable</title>
+  <title>Share link not working</title>
   <meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
 <div class="container mx-auto px-4 py-16 flex justify-center">
   <Card.Root class="w-full max-w-md">
     <Card.Header class="items-center text-center">
-      <div class="mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+      <div
+        class="mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-muted"
+      >
         <Link2Off class="h-6 w-6 text-muted-foreground" />
       </div>
-      <Card.Title>This share link isn't available</Card.Title>
+      <Card.Title>This share link isn't working</Card.Title>
     </Card.Header>
-    <Card.Content class="text-center text-sm text-muted-foreground">
+    <Card.Content class="space-y-3 text-center text-sm text-muted-foreground">
+      <!-- A rotated link, a suspended tenant and an API that is briefly unready all land here and
+           are indistinguishable from the browser, so the page names none of them. Prompting for a
+           replacement link first would be actively harmful: rotating is how the owner would supply
+           one, and it permanently breaks the link for every other recipient. -->
       <p>
-        It may have been turned off or replaced with a new one. If someone was sharing their
-        glucose data with you, ask them for the current link.
+        It may have been turned off or replaced, or the service may be
+        temporarily unavailable.
+      </p>
+      <p>
+        Try again in a few minutes. If it still doesn't work, ask the person who
+        shared it to check the link.
       </p>
     </Card.Content>
   </Card.Root>

--- a/src/Web/packages/app/src/routes/(unauthenticated)/share/unavailable/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/share/unavailable/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import * as Card from "$lib/components/ui/card";
+  import { Link2Off } from "lucide-svelte";
+</script>
+
+<svelte:head>
+  <title>Share link unavailable</title>
+  <meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<div class="container mx-auto px-4 py-16 flex justify-center">
+  <Card.Root class="w-full max-w-md">
+    <Card.Header class="items-center text-center">
+      <div class="mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+        <Link2Off class="h-6 w-6 text-muted-foreground" />
+      </div>
+      <Card.Title>This share link isn't available</Card.Title>
+    </Card.Header>
+    <Card.Content class="text-center text-sm text-muted-foreground">
+      <p>
+        It may have been turned off or replaced with a new one. If someone was sharing their
+        glucose data with you, ask them for the current link.
+      </p>
+    </Card.Content>
+  </Card.Root>
+</div>


### PR DESCRIPTION
Closes #1018

## What was wrong

`https://{any-garbage-token}.share.{base}/` — including a formerly-valid token after `POST /api/v4/share/rotate` — 303s to `/setup` and renders the "WELCOME TO NOCTURNE" first-run wizard, signed in or not.

Two paths reach it, from opposite API answers:

- **A share host the API resolves no tenant for.** `TenantResolutionMiddleware` returns **404** for the whole request; `siteSecurityHandle`'s status probe catches it and its 404 branch redirects to `MARKETING_URL` if set, `/setup` otherwise.
- **A share host the API does not recognise as one.** `SubdomainParser.Extract` returns null (the API's `BASE_DOMAIN` not matching the forwarded host), the host falls through to slug resolution, and `/api/v4/status` is tenantless-allowed — so it answers **200 with `status: "setup_required"`**, which is what the `(authenticated)` layout redirects on (`publicViewAllowed` is false there, so #1012's skip does not apply).

Either way an owner who rotates their link hands the old URL's visitors a wizard that reads as "the deployment is broken", and invites strangers to poke at a setup flow. The second path is really a `BASE_DOMAIN` mismatch between the web and API layers — this PR gives it a sane landing page but does not diagnose it.

## The fix

A share host answers for one link and nothing else, so none of the instance-wide dead ends mean anything on it: it holds no session for `/auth/login` or `/auth/recovery`, the marketing site is a different domain, and a share link only resolves on an instance already past setup.

- **New route** `(unauthenticated)/share/unavailable`, `noindex, nofollow`, no sign-in offer, nothing about the tenant behind the link.
- **`(authenticated)/+layout.server.ts`** — `isShareHost && !publicViewAllowed` short-circuits above the onboarding, `setup_required` and login redirects.
- **`hooks.server.ts`** — the whole status-probe failure decision moved into `statusProbeRedirect`, which claims 404 (unresolvable token), 403 (suspended tenant) and 503 (API not ready) on a share host *before* the recovery / marketing / `/setup` branches. 403 already reached the same page via the layout, but only after `console.error`ing on every request from a suspended tenant's share host.
- The new path joins `skipProbe`, so probing it cannot loop.

No tenant-existence oracle: an unresolvable token, a rotated token, and a live token whose tenant granted no anonymous read all produce `303 → /share/unavailable` with the same page and the same `Referrer-Policy: no-referrer` / `X-Robots-Tag` headers.

### The page says less than it first did

The first revision said the link "has been turned off or replaced with a new one". That is an assertion the code cannot make. Three conditions land here and only one is permanent, and `getRequestStatus` swallows *any* failure to null — so a **live** link during a rolling API restart reached this page too. Worse, the remedy that copy prompts is the destructive one: the recipient asks for a replacement link, the owner rotates, and the link dies for every other recipient.

It now names no cause, suggests waiting first, and only then suggests asking the sender to check the link.

## Tests

- `public-routes.test.ts` — `statusProbeRedirect` claims 404/403/503 on a share host *even when* `recoveryMode` and `marketingUrl` are set (i.e. the ordering, not just the predicate); routes every other host to `/setup`, `/auth/recovery` and the marketing site with their existing 302/303 codes; and returns null for statuses neither branch answers for.
- `layout-server-load.test.ts` — a share host with `anonymousReadAccess: false`, one reporting `setup_required` with no resolved tenant, one reporting onboarding incomplete, and **one whose status call itself rejects** all land on the share page. The harness gained the ability to fail `getStatus`, which it previously could not do at all. The case that asserted `/auth/login` now asserts the new destination.

Mutation proof: with both guards forced to `false`, exactly the 5 new assertions fail and the other 32 pass. Full `src/lib/server` + `src/routes` run on the branch: **22 files, 219 tests, all passing**.

`pnpm check`: 25 errors, all pre-existing and none in the changed files. eslint on the changed files: 6 errors, all pre-existing `any` casts in `hooks.server.ts`, matching baseline.

## Known limits

- `siteSecurityHandle` itself has no test — no test in the repo imports `hooks.server.ts`, and it currently cannot be imported under `vitest.config.ts` because `$env/dynamic/public` is unstubbed. The extraction above is what makes its decision testable; wiring the hook itself is separate work.
- Prettier is not run on the web app in CI and the repo is broadly non-conformant. The changed files match their pre-change prettier state; the new page and route are clean.
- `share-host.ts`'s `isShareHost` is a pure regex with no `BASE_DOMAIN` check, so a `BASE_DOMAIN` that itself contains a `share.` label misclassifies a legitimate tenant host as a share host — which now terminates on this page instead of on `/auth/login`. Both are dead ends; pre-existing, and related to the known "BASE_DOMAIN is a suffix" hazard.

https://claude.ai/code/session_01BbK5W7zQy2xLHUzRkmj7n6
