### PR TITLE
fix(realtime): derive the storage delete identifier from the hub's own serializer

### DIFF
--- a/src/API/Nocturne.API/Services/Devices/DeviceStatusProjectionService.cs
+++ b/src/API/Nocturne.API/Services/Devices/DeviceStatusProjectionService.cs
@@ -534,6 +534,12 @@ public class DeviceStatusProjectionService
                 case "srvCreated":
                     ds.SrvCreated = CoerceLong(value);
                     break;
+                // An NS v3 uploader sends its own identifier and it is stored verbatim.
+                // DeviceStatus has no member to absorb it, so re-emitting it would put a
+                // client-supplied value where every reader takes the record's identity from —
+                // including the id of its delete event (see StorageDeleteEvent).
+                case "identifier":
+                    break;
                 default:
                     // Unknown keys go into ExtensionData
                     var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(value, JsonOptions);

--- a/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
+++ b/src/API/Nocturne.API/Services/Effects/WriteSideEffectsService.cs
@@ -212,7 +212,7 @@ public class WriteSideEffectsService : IWriteSideEffects
         {
             await _broadcast.BroadcastStorageDeleteAsync(
                 collectionName,
-                StorageDeleteEvent.ForRecord(
+                new StorageDeleteEvent(
                     collectionName,
                     (deletedRecord as IProcessableDocument)?.Id,
                     deletedRecord
@@ -248,7 +248,7 @@ public class WriteSideEffectsService : IWriteSideEffects
         {
             await _broadcast.BroadcastStorageDeleteAsync(
                 collectionName,
-                StorageDeleteEvent.ForBulk(collectionName, deletedCount)
+                new StorageBulkDeleteEvent(collectionName, deletedCount)
             );
         }
         catch (Exception ex)

--- a/src/API/Nocturne.API/Services/Health/ActivityService.cs
+++ b/src/API/Nocturne.API/Services/Health/ActivityService.cs
@@ -469,7 +469,7 @@ public class ActivityService : IActivityService
                 {
                     await _signalRBroadcastService.BroadcastStorageDeleteAsync(
                         "activity",
-                        StorageDeleteEvent.ForRecord("activity", id)
+                        new StorageDeleteEvent("activity", id)
                     );
                     await _events.OnDeletedAsync(null, cancellationToken);
                     _logger.LogDebug("Successfully deleted sleep session for activity ID: {Id}", id);
@@ -483,7 +483,7 @@ public class ActivityService : IActivityService
             {
                 await _signalRBroadcastService.BroadcastStorageDeleteAsync(
                     "activity",
-                    StorageDeleteEvent.ForRecord("activity", id)
+                    new StorageDeleteEvent("activity", id)
                 );
 
                 await _events.OnDeletedAsync(null, cancellationToken);
@@ -552,7 +552,7 @@ public class ActivityService : IActivityService
             {
                 await _signalRBroadcastService.BroadcastStorageDeleteAsync(
                     "activity",
-                    StorageDeleteEvent.ForBulk("activity", deletedCount)
+                    new StorageBulkDeleteEvent("activity", deletedCount)
                 );
 
                 await _events.OnBulkDeletedAsync(deletedCount, cancellationToken);

--- a/src/API/Nocturne.API/Services/Legacy/SimpleEntityService.cs
+++ b/src/API/Nocturne.API/Services/Legacy/SimpleEntityService.cs
@@ -367,7 +367,7 @@ public abstract class SimpleEntityService<TDomain, TEntity>
 
             await SignalRBroadcastService.BroadcastStorageDeleteAsync(
                 CollectionName,
-                StorageDeleteEvent.ForRecord(CollectionName, id)
+                new StorageDeleteEvent(CollectionName, id)
             );
 
             Logger.LogDebug(

--- a/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
+++ b/src/API/Nocturne.API/Services/Realtime/SignalRBroadcastService.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
 using Nocturne.API.Hubs;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -163,6 +164,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
     private readonly IHubContext<HomeAssistantHub> _homeAssistantHubContext;
     private readonly IHubContext<OverviewHub> _overviewHubContext;
     private readonly ITenantAccessor _tenantAccessor;
+    private readonly IOptions<JsonHubProtocolOptions> _hubProtocolOptions;
     private readonly ILogger<SignalRBroadcastService> _logger;
 
     /// <summary>
@@ -175,6 +177,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
     /// <param name="homeAssistantHubContext">Hub context for <see cref="HomeAssistantHub"/> — glucose relay and alert event relay to Home Assistant instances.</param>
     /// <param name="overviewHubContext">Hub context for <see cref="OverviewHub"/> — cross-tenant overview pings.</param>
     /// <param name="tenantAccessor">Provides the current tenant context for scoping group names.</param>
+    /// <param name="hubProtocolOptions">The serializer the hubs write payloads with — see <see cref="WithWireIdentifier"/>.</param>
     /// <param name="logger">The logger instance.</param>
     public SignalRBroadcastService(
         IHubContext<DataHub> dataHubContext,
@@ -184,6 +187,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
         IHubContext<HomeAssistantHub> homeAssistantHubContext,
         IHubContext<OverviewHub> overviewHubContext,
         ITenantAccessor tenantAccessor,
+        IOptions<JsonHubProtocolOptions> hubProtocolOptions,
         ILogger<SignalRBroadcastService> logger
     )
     {
@@ -194,6 +198,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
         _homeAssistantHubContext = homeAssistantHubContext;
         _overviewHubContext = overviewHubContext;
         _tenantAccessor = tenantAccessor;
+        _hubProtocolOptions = hubProtocolOptions;
         _logger = logger;
     }
 
@@ -410,7 +415,7 @@ public class SignalRBroadcastService : ISignalRBroadcastService
             );
             await _dataHubContext
                 .Clients.Group(TenantGroup(collectionName))
-                .SendCoreAsync("delete", new[] { data });
+                .SendCoreAsync("delete", new[] { WithWireIdentifier(data) });
         }
         catch (Exception ex)
         {
@@ -420,6 +425,26 @@ public class SignalRBroadcastService : ISignalRBroadcastService
                 collectionName
             );
         }
+    }
+
+    /// <summary>
+    /// Resolves a <see cref="StorageDeleteEvent"/> against the payload serializer this hub sends with,
+    /// which is the only serializer whose output a client ever sees. Any other payload passes through.
+    /// </summary>
+    private object WithWireIdentifier(object data)
+    {
+        if (data is not StorageDeleteEvent delete)
+            return data;
+
+        var resolved = delete.OnWire(_hubProtocolOptions.Value.PayloadSerializerOptions);
+
+        if (resolved.Identifier is null)
+            _logger.LogWarning(
+                "Storage delete for {Collection} carries no identifier; no client can resolve it",
+                resolved.ColName
+            );
+
+        return resolved;
     }
 
     /// <inheritdoc />

--- a/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
+++ b/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
@@ -1,61 +1,83 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Nocturne.API.Services.Realtime;
 
 /// <summary>
-/// Builds the payloads passed to <see cref="ISignalRBroadcastService.BroadcastStorageDeleteAsync"/>.
+/// The storage <c>delete</c> event for a single removed record, as
+/// <see cref="ISignalRBroadcastService.BroadcastStorageDeleteAsync"/> sends it. Five of the six
+/// delete producers use it; <see cref="SignalRV4RecordBroadcaster"/> sends its own shape, which the
+/// socket.io bridge skips for want of a <c>colName</c>.
 /// </summary>
 /// <remarks>
-/// NS v3 socket clients read <c>colName</c> and <c>identifier</c> from the top level of the event and
-/// never look inside <c>doc</c>; the reference Nightscout server emits exactly those two keys
-/// (<c>lib/api3/generic/delete/operation.js</c>). Clients match the identifier against the id their
-/// create event delivered, and the models disagree on what that is — <see cref="Nocturne.Core.Models.Treatment"/>
-/// coerces its id to a Mongo ObjectId on the wire, <see cref="Nocturne.Core.Models.Entry"/> and
-/// <see cref="Nocturne.Core.Models.DeviceStatus"/> emit the uuid. Reading the identifier back out of the
-/// serialized document keeps delete and create in step for any model rather than restating each model's
-/// choice at the call site.
+/// NS v3 socket clients route on the top-level <c>colName</c> and look the removed record up by the
+/// top-level <c>identifier</c>; they never look inside <c>doc</c>. The reference Nightscout server
+/// emits exactly those two keys (<c>lib/api3/generic/delete/operation.js</c>), so they are a wire
+/// contract rather than a naming convention and are spelled out here instead of being left to the
+/// payload serializer's naming policy.
+/// <para>
+/// A client only ever holds the identifier its create event delivered, and the models disagree on
+/// what that is — <see cref="Nocturne.Core.Models.Treatment"/> coerces its id to a Mongo ObjectId on
+/// the wire, <see cref="Nocturne.Core.Models.Entry"/> and <see cref="Nocturne.Core.Models.DeviceStatus"/>
+/// emit the uuid. <see cref="OnWire"/> reads the identifier back out of the serialized document so the
+/// two stay in step for any model rather than restating each model's choice at the call site.
+/// </para>
 /// </remarks>
-internal static class StorageDeleteEvent
+/// <param name="ColName">The collection the record belonged to.</param>
+/// <param name="Identifier">The record id. Superseded by the document's own id where it has one.</param>
+/// <param name="Doc">The removed record. Carried for clients that need the body; NS v3 clients ignore it.</param>
+internal sealed record StorageDeleteEvent(
+    [property: JsonPropertyName("colName")] string ColName,
+    [property: JsonPropertyName("identifier")] string? Identifier,
+    [property: JsonPropertyName("doc")] object? Doc = null
+)
 {
-    /// <summary>Builds the delete event for a single removed record.</summary>
-    /// <param name="collectionName">The collection the record belonged to.</param>
-    /// <param name="id">The record id. Used only when there is no <paramref name="doc"/> to read it from.</param>
-    /// <param name="doc">The removed record. Carried for clients that need the body; NS v3 clients ignore it.</param>
-    internal static object ForRecord(string collectionName, string? id, object? doc = null) =>
-        new
-        {
-            colName = collectionName,
-            identifier = doc is null ? id : WireIdentifier(doc) ?? id,
-            doc,
-        };
-
-    /// <summary>Builds the delete event for a range or predicate delete.</summary>
-    /// <remarks>
-    /// No identifier is sent. The v3 socket contract has no bulk form — v3 DELETE addresses one
-    /// identifier at a time — and the callers that do hold the removed ids hold an unbounded set of
-    /// them, so fanning out would trade one event for a broadcast storm. Clients reconcile a bulk
-    /// delete on their next catch-up load.
-    /// </remarks>
-    /// <param name="collectionName">The collection the records belonged to.</param>
-    /// <param name="deletedCount">How many records were removed.</param>
-    internal static object ForBulk(string collectionName, long deletedCount) =>
-        new { colName = collectionName, deletedCount };
-
     /// <summary>
-    /// The id as <paramref name="doc"/> itself puts it on the wire, preferring the v3 <c>identifier</c>
-    /// over the legacy <c>_id</c>. Returns null for a document that carries neither.
+    /// The event resolved against the serializer the hub sends payloads with, so the identifier is
+    /// the id the document itself puts on the wire. Prefers the v3 <c>identifier</c> over the legacy
+    /// <c>_id</c>, and keeps the supplied <see cref="Identifier"/> for a document carrying neither.
+    /// Serializing the document here rather than at the call site also lets the hub write the result
+    /// verbatim instead of reflecting over it a second time.
     /// </summary>
-    private static string? WireIdentifier(object doc)
+    /// <param name="payloadOptions">
+    /// <see cref="Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions.PayloadSerializerOptions"/>.
+    /// </param>
+    internal StorageDeleteEvent OnWire(JsonSerializerOptions payloadOptions)
     {
-        var root = JsonSerializer.SerializeToElement(doc);
+        if (Doc is null)
+            return this;
 
-        return Read(root, "identifier") ?? Read(root, "_id");
+        var doc = JsonSerializer.SerializeToElement(Doc, payloadOptions);
 
-        static string? Read(JsonElement root, string property) =>
-            root.ValueKind == JsonValueKind.Object
-            && root.TryGetProperty(property, out var value)
-            && value.ValueKind == JsonValueKind.String
-                ? value.GetString()
-                : null;
+        return this with { Identifier = Read(doc, "identifier") ?? Read(doc, "_id") ?? Identifier, Doc = doc };
     }
+
+    private static string? Read(JsonElement doc, string property) =>
+        doc.ValueKind == JsonValueKind.Object && doc.TryGetProperty(property, out var value)
+            ? value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString(),
+                JsonValueKind.Number => value.GetRawText(),
+                _ => null,
+            }
+            : null;
 }
+
+/// <summary>
+/// The storage <c>delete</c> event for a range or predicate delete. See <see cref="StorageDeleteEvent"/>
+/// for the wire contract these keys belong to.
+/// </summary>
+/// <remarks>
+/// No identifier is sent. The v3 socket contract has no bulk form — v3 DELETE addresses one identifier
+/// at a time — and the callers that do hold the removed ids hold an unbounded set of them, so fanning
+/// out would trade one event for a broadcast storm. An AAPS client reads the missing key as <c>""</c>
+/// (<c>JSONObject.optString</c>) and enqueues it; the lookup it then runs
+/// (<c>SELECT … WHERE nightscoutId = ''</c>, <c>GlucoseValueDao.findByNSId</c>) matches no record we
+/// delivered, so the event neither removes anything nor errors.
+/// </remarks>
+/// <param name="ColName">The collection the records belonged to.</param>
+/// <param name="DeletedCount">How many records were removed.</param>
+internal sealed record StorageBulkDeleteEvent(
+    [property: JsonPropertyName("colName")] string ColName,
+    [property: JsonPropertyName("deletedCount")] long DeletedCount
+);

--- a/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
+++ b/src/API/Nocturne.API/Services/Realtime/StorageDeleteEvent.cs
@@ -6,7 +6,7 @@ namespace Nocturne.API.Services.Realtime;
 /// <summary>
 /// The storage <c>delete</c> event for a single removed record, as
 /// <see cref="ISignalRBroadcastService.BroadcastStorageDeleteAsync"/> sends it. Five of the six
-/// delete producers use it; <see cref="SignalRV4RecordBroadcaster"/> sends its own shape, which the
+/// delete producers use it; <see cref="SignalRV4RecordBroadcaster{TModel}"/> sends its own shape, which the
 /// socket.io bridge skips for want of a <c>colName</c>.
 /// </summary>
 /// <remarks>
@@ -38,6 +38,11 @@ internal sealed record StorageDeleteEvent(
     /// <c>_id</c>, and keeps the supplied <see cref="Identifier"/> for a document carrying neither.
     /// Serializing the document here rather than at the call site also lets the hub write the result
     /// verbatim instead of reflecting over it a second time.
+    /// <para>
+    /// One serializer this cannot follow: <see cref="System.Text.Json.Serialization.ReferenceHandler.Preserve"/>
+    /// gives the pre-serialized document its own <c>$id</c> namespace, so the envelope emits <c>$id</c>
+    /// twice and a sibling <c>$ref</c> would dangle. Nothing configures it today.
+    /// </para>
     /// </summary>
     /// <param name="payloadOptions">
     /// <see cref="Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions.PayloadSerializerOptions"/>.

--- a/src/API/Nocturne.API/Services/Treatments/SignalRTreatmentEventSink.cs
+++ b/src/API/Nocturne.API/Services/Treatments/SignalRTreatmentEventSink.cs
@@ -75,7 +75,7 @@ public class SignalRTreatmentEventSink : IDataEventSink<Treatment>
         try
         {
             await _broadcast.BroadcastStorageDeleteAsync(
-                Collection, StorageDeleteEvent.ForRecord(Collection, treatment?.Id, treatment));
+                Collection, new StorageDeleteEvent(Collection, treatment?.Id, treatment));
         }
         catch (Exception ex)
         {

--- a/tests/Unit/Nocturne.API.Tests/Hubs/HubCredentialKindTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Hubs/HubCredentialKindTests.cs
@@ -359,6 +359,7 @@ public class HubCredentialKindTests
             Mock.Of<IHubContext<HomeAssistantHub>>(),
             Mock.Of<IHubContext<OverviewHub>>(),
             tenantAccessor.Object,
+            Options.Create(new JsonHubProtocolOptions()),
             Mock.Of<ILogger<SignalRBroadcastService>>());
 
         return (service, sends);

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantIsolationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantIsolationTests.cs
@@ -313,7 +313,8 @@ public class TenantIsolationTests
 
         var service = new SignalRBroadcastService(
             mockDataHub.Object, mockAlarmHub.Object, mockConfigHub.Object, mockAlertHub.Object,
-            mockHaHub.Object, mockOverviewHub.Object, mockAccessor.Object, mockLogger.Object);
+            mockHaHub.Object, mockOverviewHub.Object, mockAccessor.Object,
+            Options.Create(new JsonHubProtocolOptions()), mockLogger.Object);
 
         return (service, dataClients, alarmClients, configClients, dataProxy, alarmProxy, configProxy);
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceStatusProjectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceStatusProjectionServiceTests.cs
@@ -363,6 +363,31 @@ public class DeviceStatusProjectionServiceTests
         result.ExtensionData.Should().NotContainKey("srvCreated");
     }
 
+    [Fact]
+    public void ProjectAsync_WithClientIdentifierInExtras_DoesNotReEmitIt()
+    {
+        // An NS v3 uploader sends its own identifier; DeviceStatus has no member to absorb it, so it
+        // is stored as an extra. Splatting it back would make the record's id — and the identifier of
+        // its realtime delete event — client-controlled.
+        var aps = CreateApsSnapshot(AidAlgorithm.OpenAps);
+        aps.SuggestedJson = JsonSerializer.Serialize(new OpenApsSuggested { Bg = 120 }, JsonOptions);
+
+        var extras = new DeviceStatusExtras
+        {
+            Id = Guid.NewGuid(),
+            CorrelationId = aps.CorrelationId!.Value,
+            Timestamp = ReferenceTime,
+            Extras = new Dictionary<string, object?>
+            {
+                ["identifier"] = JsonSerializer.SerializeToElement("CLIENT-SUPPLIED", JsonOptions),
+            },
+        };
+
+        var result = DeviceStatusProjectionService.ProjectFromSnapshots(aps, null, null, null, extras);
+
+        result.ExtensionData.Should().NotContainKey("identifier");
+    }
+
     #endregion
 
     #region Correlation

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceStatusProjectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/DeviceStatusProjectionServiceTests.cs
@@ -366,9 +366,6 @@ public class DeviceStatusProjectionServiceTests
     [Fact]
     public void ProjectAsync_WithClientIdentifierInExtras_DoesNotReEmitIt()
     {
-        // An NS v3 uploader sends its own identifier; DeviceStatus has no member to absorb it, so it
-        // is stored as an extra. Splatting it back would make the record's id — and the identifier of
-        // its realtime delete event — client-controlled.
         var aps = CreateApsSnapshot(AidAlgorithm.OpenAps);
         aps.SuggestedJson = JsonSerializer.Serialize(new OpenApsSuggested { Bg = 120 }, JsonOptions);
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/SignalRBroadcastServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/SignalRBroadcastServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Nocturne.API.Hubs;
 using Nocturne.API.Services.Realtime;
@@ -89,6 +90,7 @@ public class SignalRBroadcastServiceTests
             _mockHomeAssistantHubContext.Object,
             _mockOverviewHubContext.Object,
             MockTenantAccessor.Create().Object,
+            Options.Create(new JsonHubProtocolOptions()),
             _mockLogger.Object
         );
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
@@ -377,6 +377,44 @@ public class StorageDeleteBroadcastContractTests
             );
     }
 
+    /// <summary>
+    /// The bulk keys are the same wire contract as the single-record ones, so a reconfigured
+    /// payload serializer must not be able to rename them either.
+    /// </summary>
+    [Fact]
+    public async Task BulkDeleteKeys_SurviveAReconfiguredPayloadSerializer()
+    {
+        var capture = new BroadcastCapture(o => o.PropertyNamingPolicy = null);
+
+        await CreateSideEffects(capture).OnBulkDeletedAsync("entries", 17);
+
+        capture.Delete.GetProperty("colName").GetString().Should().Be("entries");
+        capture.Delete.GetProperty("deletedCount").GetInt64().Should().Be(17);
+    }
+
+    /// <summary>
+    /// The identifier a client reads and the document id it would match against are the same string
+    /// on the wire, under a serializer that is not the default.
+    /// </summary>
+    [Fact]
+    public async Task WireIdentifier_MatchesTheDocumentIdOnTheWire()
+    {
+        var capture = new BroadcastCapture(o => o.PropertyNamingPolicy = null);
+
+        await CreateSideEffects(capture).OnDeletedAsync("entries", new LegacyIdOnly());
+
+        var doc = capture.Delete.GetProperty("doc");
+        doc.ValueKind.Should().Be(JsonValueKind.Object);
+        capture
+            .Delete.GetProperty("identifier")
+            .GetString()
+            .Should()
+            .Be(
+                doc.GetProperty("_id").GetString(),
+                "an identifier that does not match the document's own id resolves nothing"
+            );
+    }
+
     /// <summary>A document carrying only the legacy id, and no record behind it to fall back on.</summary>
     private sealed class LegacyIdOnly
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Realtime/StorageDeleteBroadcastContractTests.cs
@@ -1,8 +1,13 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
+using Nocturne.API.Hubs;
 using Nocturne.API.Services.Effects;
 using Nocturne.API.Services.Health;
 using Nocturne.API.Services.Realtime;
@@ -37,44 +42,97 @@ public class StorageDeleteBroadcastContractTests
     private static readonly Guid TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
     /// <summary>
-    /// Records both arguments of every storage broadcast. The first argument selects the SignalR
-    /// tenant group; the bridge picks the socket.io room off the payload's <c>colName</c>. If the
-    /// two disagree the event is delivered to a room no client of that collection has joined.
+    /// Runs the producers against a real <see cref="SignalRBroadcastService"/> and reads the events
+    /// back as <see cref="JsonHubProtocol"/> writes them. Asserting on anything else — a fresh
+    /// <see cref="JsonSerializer"/> call over the captured object, say — validates a serialization
+    /// no client ever sees.
     /// </summary>
     private sealed class BroadcastCapture
     {
-        public Mock<ISignalRBroadcastService> Broadcast { get; } = new();
-        private (string Group, object Data)? _delete;
-        private (string Group, object Data)? _create;
+        private readonly JsonHubProtocolOptions _protocol = new();
+        private readonly Dictionary<string, (string Group, object Data)> _sent = [];
 
-        public BroadcastCapture()
+        public ISignalRBroadcastService Broadcast { get; }
+
+        /// <param name="configurePayloadSerializer">
+        /// Reconfigures the serializer the hubs send payloads with, as an app calling
+        /// <c>AddJsonProtocol</c> would.
+        /// </param>
+        public BroadcastCapture(Action<JsonSerializerOptions>? configurePayloadSerializer = null)
         {
-            Broadcast
-                .Setup(b => b.BroadcastStorageDeleteAsync(It.IsAny<string>(), It.IsAny<object>()))
-                .Callback<string, object>((group, data) => _delete = (group, data))
-                .Returns(Task.CompletedTask);
-            Broadcast
-                .Setup(b => b.BroadcastStorageCreateAsync(It.IsAny<string>(), It.IsAny<object>()))
-                .Callback<string, object>((group, data) => _create = (group, data))
-                .Returns(Task.CompletedTask);
+            configurePayloadSerializer?.Invoke(_protocol.PayloadSerializerOptions);
+
+            Broadcast = new SignalRBroadcastService(
+                StubHub<DataHub>(),
+                StubHub<AlarmHub>(),
+                StubHub<ConfigHub>(),
+                StubHub<AlertHub>(),
+                StubHub<HomeAssistantHub>(),
+                StubHub<OverviewHub>(),
+                MockTenantAccessor.Create().Object,
+                Options.Create(_protocol),
+                NullLogger<SignalRBroadcastService>.Instance
+            );
         }
 
-        public JsonElement Delete => Read(_delete, "delete");
+        public JsonElement Delete => Wire("delete");
 
-        public JsonElement Create => Read(_create, "create");
+        public JsonElement Create => Wire("create");
 
-        private static JsonElement Read((string Group, object Data)? captured, string kind)
+        private IHubContext<THub> StubHub<THub>()
+            where THub : Hub
         {
-            captured.Should().NotBeNull($"the producer must broadcast a {kind} event");
-            var payload = JsonSerializer.Deserialize<JsonElement>(
-                JsonSerializer.Serialize(captured!.Value.Data)
-            );
-            payload
-                .GetProperty("colName")
-                .GetString()
+            var clients = new Mock<IHubClients>();
+            clients
+                .Setup(c => c.Group(It.IsAny<string>()))
+                .Returns((string group) =>
+                {
+                    var proxy = new Mock<IClientProxy>();
+                    proxy
+                        .Setup(p =>
+                            p.SendCoreAsync(
+                                It.IsAny<string>(),
+                                It.IsAny<object?[]>(),
+                                It.IsAny<CancellationToken>()
+                            )
+                        )
+                        .Callback<string, object?[], CancellationToken>(
+                            (method, args, _) => _sent[method] = (group, args[0]!)
+                        )
+                        .Returns(Task.CompletedTask);
+                    return proxy.Object;
+                });
+
+            var hub = new Mock<IHubContext<THub>>();
+            hub.Setup(h => h.Clients).Returns(clients.Object);
+            return hub.Object;
+        }
+
+        /// <summary>
+        /// The event's bytes on the wire. The first argument of the hub invocation selects the
+        /// SignalR tenant group; the bridge picks the socket.io room off the payload's
+        /// <c>colName</c>. If the two disagree the event is delivered to a room no client of that
+        /// collection has joined.
+        /// </summary>
+        private JsonElement Wire(string method)
+        {
+            _sent.ContainsKey(method).Should().BeTrue($"the producer must broadcast a {method} event");
+            var (group, data) = _sent[method];
+
+            var frame = new JsonHubProtocol(Options.Create(_protocol))
+                .GetMessageBytes(new InvocationMessage(method, [data]))
+                .ToArray();
+            var payload = JsonSerializer
+                .Deserialize<JsonElement>(frame.AsSpan(0, frame.Length - 1)) // trailing 0x1e separator
+                .GetProperty("arguments")[0];
+
+            group
                 .Should()
                 .Be(
-                    captured.Value.Group,
+                    TenantAwareHub.FormatTenantGroup(
+                        MockTenantAccessor.DefaultTenantId.ToString(),
+                        payload.GetProperty("colName").GetString()!
+                    ),
                     "the SignalR group and the payload's colName select the same audience and must agree"
                 );
             return payload;
@@ -84,7 +142,7 @@ public class StorageDeleteBroadcastContractTests
     private static WriteSideEffectsService CreateSideEffects(BroadcastCapture capture) =>
         new(
             Mock.Of<ICacheService>(),
-            capture.Broadcast.Object,
+            capture.Broadcast,
             Mock.Of<IDecompositionPipeline>(),
             MockTenantAccessor.Create().Object,
             Enumerable.Empty<ICollectionEffectDescriptor>(),
@@ -92,7 +150,7 @@ public class StorageDeleteBroadcastContractTests
         );
 
     private static SignalRTreatmentEventSink CreateTreatmentSink(BroadcastCapture capture) =>
-        new(capture.Broadcast.Object, NullLogger<SignalRTreatmentEventSink>.Instance);
+        new(capture.Broadcast, NullLogger<SignalRTreatmentEventSink>.Instance);
 
     private static ActivityService CreateActivityService(
         BroadcastCapture capture,
@@ -103,7 +161,7 @@ public class StorageDeleteBroadcastContractTests
             stateSpans.Object,
             sleep.Object,
             Mock.Of<IDocumentProcessingService>(),
-            capture.Broadcast.Object,
+            capture.Broadcast,
             Mock.Of<IDataEventSink<Activity>>(),
             Mock.Of<IActivityDecomposer>(),
             Mock.Of<IHeartRateService>(),
@@ -256,10 +314,14 @@ public class StorageDeleteBroadcastContractTests
     /// </summary>
     private sealed class DisagreeingIds
     {
-        [System.Text.Json.Serialization.JsonPropertyName("identifier")]
+        /// <summary>A decoy: the first id-ish key on the wire is not the one clients match on.</summary>
+        [JsonPropertyName("pumpId")]
+        public string PumpId => "from-pump-id";
+
+        [JsonPropertyName("identifier")]
         public string Identifier => "from-identifier";
 
-        [System.Text.Json.Serialization.JsonPropertyName("_id")]
+        [JsonPropertyName("_id")]
         public string Id => "from-underscore-id";
     }
 
@@ -271,6 +333,110 @@ public class StorageDeleteBroadcastContractTests
         await CreateSideEffects(capture).OnDeletedAsync("entries", new DisagreeingIds());
 
         Identifier(capture.Delete).Should().Be("from-identifier");
+    }
+
+    /// <summary>
+    /// A document that spells its id the ordinary C# way, as a projection or DTO added later would.
+    /// Its wire spelling is whatever the hub's naming policy makes of it, which is the only spelling
+    /// the derivation may look for.
+    /// </summary>
+    private sealed class UnattributedIdentifier
+    {
+        public string Identifier => RecordGuid;
+    }
+
+    [Fact]
+    public async Task DeleteIdentifier_ReadsTheDocumentAsTheHubSpellsIt()
+    {
+        var capture = new BroadcastCapture();
+
+        await CreateSideEffects(capture).OnDeletedAsync("entries", new UnattributedIdentifier());
+
+        capture.Delete.GetProperty("doc").GetProperty("identifier").GetString().Should().Be(RecordGuid);
+        Identifier(capture.Delete).Should().Be(RecordGuid);
+    }
+
+    [Fact]
+    public async Task DeleteIdentifier_FollowsAReconfiguredPayloadSerializer()
+    {
+        var capture = new BroadcastCapture(o => o.PropertyNamingPolicy = null);
+
+        await CreateSideEffects(capture).OnDeletedAsync("entries", new UnattributedIdentifier());
+
+        var doc = capture.Delete.GetProperty("doc");
+        doc.TryGetProperty("identifier", out _)
+            .Should()
+            .BeFalse("this serializer spells the property verbatim");
+        doc.GetProperty("Identifier").GetString().Should().Be(RecordGuid);
+        capture
+            .Delete.GetProperty("identifier")
+            .ValueKind.Should()
+            .Be(
+                JsonValueKind.Null,
+                "the document put no contract id on the wire, and an id no client can match is worth no more than none"
+            );
+    }
+
+    /// <summary>A document carrying only the legacy id, and no record behind it to fall back on.</summary>
+    private sealed class LegacyIdOnly
+    {
+        [JsonPropertyName("_id")]
+        public string Id => RecordGuid;
+    }
+
+    [Fact]
+    public async Task DeleteIdentifier_FallsBackToTheLegacyId()
+    {
+        var capture = new BroadcastCapture();
+
+        await CreateSideEffects(capture).OnDeletedAsync("entries", new LegacyIdOnly());
+
+        Identifier(capture.Delete).Should().Be(RecordGuid);
+    }
+
+    /// <summary>A document whose id is a number, as a legacy import or an external store may spell it.</summary>
+    private sealed class NumericId
+    {
+        [JsonPropertyName("_id")]
+        public long Id => 12345;
+    }
+
+    [Fact]
+    public async Task DeleteIdentifier_CarriesANumericIdAsTheStringClientsMatchOn()
+    {
+        var capture = new BroadcastCapture();
+
+        await CreateSideEffects(capture).OnDeletedAsync("entries", new NumericId());
+
+        capture.Delete.GetProperty("doc").GetProperty("_id").GetInt64().Should().Be(12345);
+        Identifier(capture.Delete).Should().Be("12345");
+    }
+
+    /// <summary>A record whose document spells neither contract key, leaving only its own id.</summary>
+    private sealed class OrdinaryIdDocument : IProcessableDocument
+    {
+        public string? Id { get; set; }
+        public string? CreatedAt { get; set; }
+        public long Mills { get; set; }
+        public int? UtcOffset { get; set; }
+
+        public Dictionary<string, string?> GetSanitizableFields() => [];
+
+        public void SetSanitizedField(string fieldName, string? sanitizedValue) { }
+    }
+
+    [Fact]
+    public async Task DeleteIdentifier_FallsBackToTheRecordId_WhenTheDocumentSpellsNeitherKey()
+    {
+        var capture = new BroadcastCapture();
+
+        await CreateSideEffects(capture)
+            .OnDeletedAsync("entries", new OrdinaryIdDocument { Id = RecordGuid });
+
+        var doc = capture.Delete.GetProperty("doc");
+        doc.TryGetProperty("_id", out _).Should().BeFalse();
+        doc.TryGetProperty("identifier", out _).Should().BeFalse();
+        Identifier(capture.Delete).Should().Be(RecordGuid);
     }
 
     /// <summary>
@@ -316,7 +482,7 @@ public class StorageDeleteBroadcastContractTests
         var deleted = await new HeartRateService(
             context,
             Mock.Of<IDocumentProcessingService>(),
-            capture.Broadcast.Object,
+            capture.Broadcast,
             NullLogger<HeartRateService>.Instance
         ).DeleteHeartRateAsync(RecordGuid);
 


### PR DESCRIPTION
Closes #1023.

## What was wrong

`StorageDeleteEvent.WireIdentifier` serialized the removed document with **default** `JsonSerializerOptions` and read `identifier`/`_id` back out of the result, but the event leaves through SignalR's `JsonHubProtocol`, whose payload serializer is camelCase. `Entry`, `Treatment` and `DeviceStatus` only survived that because they attribute their id; a document spelling its id the ordinary C# way produced a top-level `identifier: null` two bytes from a correct one inside `doc` — #1020 reproduced by the mechanism meant to prevent it.

`ServiceRegistrationExtensions.cs:711` still calls `AddSignalR(...)` with no `AddJsonProtocol` and there is no MessagePack protocol registered, so the payload serializer is the framework default. That is now read rather than assumed.

## The restructuring, and why

Two shapes were on the table. I took the second: **producers build a payload without the identifier and `SignalRBroadcastService` fills it in.**

- `StorageDeleteEvent` is now a `sealed record` (and `StorageBulkDeleteEvent` alongside it) rather than a static factory returning an anonymous object. The three wire keys carry explicit `[JsonPropertyName]` — they are a contract AAPS and the reference server both spell literally, not a naming convention to be delegated to whatever policy is configured.
- `SignalRBroadcastService` takes `IOptions<JsonHubProtocolOptions>` and calls `delete.OnWire(options.Value.PayloadSerializerOptions)` before `SendCoreAsync`. It already owns the wire and is already a DI service.

Making `StorageDeleteEvent` an injectable service instead would have meant a constructor parameter on `WriteSideEffectsService`, `SignalRTreatmentEventSink`, `ActivityService` and `SimpleEntityService<,>` — and the last of those is an abstract base with three subclasses, so the churn would have spread across their tests for no behavioural gain. The cost of the shape I chose is one runtime type check in `BroadcastStorageDeleteAsync`; `SignalRV4RecordBroadcaster`'s own payload passes through untouched.

**Double serialization is gone.** `OnWire` puts the `JsonElement` it produced back into the payload as `doc`, so the hub writes it verbatim instead of reflecting over a ~120-property `Treatment` a second time. Id-only producers pass `doc: null` and are not serialized at all.

Behaviour otherwise held constant: same three keys in the same order, the identifier still prefers v3 `identifier` over legacy `_id` and still falls back to the record's own id.

## The other findings

- **Non-string id (#1023 point 4):** a numeric `_id` is now carried as its string form (`"12345"`) rather than silently degrading to null. A single-record delete that still resolves to no identifier is logged at Warning — the delete itself is not failed, since dropping the event would lose the `doc` body the web client uses.
- **Client-controlled devicestatus identifier (point 3):** fixed at the source. `DeviceStatus` has no member to absorb an inbound `identifier`, so it lands in `[JsonExtensionData]`, is persisted into `DeviceStatusExtras.Extras`, and was splatted back by `SplatExtras`. It is now **dropped**, not mapped onto the record's id: the projected record's identity is the id it was stored under, and every reader — v1 responses, the delete event — takes it from there. Mapping a client's value onto `_id` would hand a client control of an id it does not own; dropping it costs nothing, because nothing reads it.
- **Class summary (point 5):** corrected to "five of the six producers", naming `SignalRV4RecordBroadcaster` and why it is excluded.
- **`ForBulk`'s AAPS claim (point 5):** the "clients reconcile on their next catch-up load" assertion is gone. What replaces it was checked against AAPS `master`: `StoreDataForDbImpl.updateDeletedGlucoseValuesInDb` calls `persistenceLayer.getBgReadingByNSId(id)` → `AppRepository.findBgReadingByNSId` → `GlucoseValueDao.findByNSId`, whose query is `SELECT * FROM glucoseValues WHERE nightscoutId = :nsId AND referenceId IS NULL`. With `nsId = ""` that matches no record we delivered, and the `?.let` makes it a no-op. Whether a later catch-up load reconciles the deletion is **not** verified and is no longer claimed.

## The tests

`StorageDeleteBroadcastContractTests` previously read the captured payload with `JsonSerializer.Serialize(captured.Value.Data)` — default options on both sides, so every assertion compared default-options JSON against default-options JSON. It now runs the producers against a **real `SignalRBroadcastService`** with stubbed hub contexts, and reads each event back from the bytes `JsonHubProtocol` writes with the same `JsonHubProtocolOptions` instance the service was given. Five tests were added, and `DisagreeingIds` gained a leading `pumpId` decoy.

## Mutation results

All against `--filter FullyQualifiedName~StorageDeleteBroadcastContractTests` (19 tests). The first five are the five listed in the issue, each of which survived a full run before this change.

| Mutation | Before (#1023) | After |
|---|---|---|
| `Read(…,"_id")` → `Read(…,"id")` | Passed: 14 | **Failed: 2** — `FallsBackToTheLegacyId`, `CarriesANumericIdAsTheStringClientsMatchOn` |
| serialize with a hardcoded camelCase policy | Passed: 14 | **Failed: 1** — `FollowsAReconfiguredPayloadSerializer` |
| drop the record-id fallback | Passed: 14 | **Failed: 1** — `FallsBackToTheRecordId_WhenTheDocumentSpellsNeitherKey` |
| first string property whose name contains "id" | Passed: 14 | **Failed: 3** — `PrefersTheV3IdentifierOverTheLegacyId`, `FollowsAReconfiguredPayloadSerializer`, `CarriesANumericIdAsTheStringClientsMatchOn` |
| delete the `?? Read(…,"_id")` branch | Passed: 14 | **Failed: 2** — `FallsBackToTheLegacyId`, `CarriesANumericIdAsTheStringClientsMatchOn` |
| serialize with **default** options (the original bug) | — | **Failed: 1** — `ReadsTheDocumentAsTheHubSpellsIt` |
| drop the `JsonValueKind.Number` arm | — | **Failed: 1** — `CarriesANumericIdAsTheStringClientsMatchOn` |
| remove `case "identifier": break;` from `SplatExtras` | — | **Failed: 1** — `ProjectAsync_WithClientIdentifierInExtras_DoesNotReEmitIt` |

One caveat worth recording: the first attempt at the last mutation was invalid. Restoring the file with a preserved older mtime left MSBuild's incremental build serving the mutated assembly, so the test "failed" for both the mutant and the fix. Every mutation above was re-run with fresh timestamps, and the unmutated file was confirmed green on its own before and after.

## Suites

- `Nocturne.API.Tests` — `Passed! - Failed: 0, Passed: 6121, Skipped: 5, Total: 6126`
- `Nocturne.Core.Models.Tests` — `Passed! - Failed: 0, Passed: 829, Skipped: 0, Total: 829`

Both with `-p:GenerateNSwagClient=false`. No integration or E2E suite was run.

## Not verified

- No client was exercised end to end; the assertions are on the bytes the hub protocol produces, not on an AAPS or browser client consuming them.
- The `identifier`-vs-`_id` divergence between the entries socket event and the v3 REST projection is unchanged and still pinned by `DeleteIdentifier_DivergesFromTheV3RestProjection_ForEntries`.
- Whether a devicestatus previously stored with a client `identifier` in its extras needs a data fix is not addressed here; the projection simply stops re-emitting it.


---

## Review round

A hostile review found no blocker. It independently confirmed the parts that mattered, and I've fixed what it did find.

**Confirmed sound, with evidence I did not have:** `OnWire`'s two-pass serialization is byte-identical to the hub's one-pass output under every option reachable through `AddJsonProtocol` except one (below) — including `WriteIndented`, a relaxed encoder, `NumberHandling.WriteAsString` and `DefaultIgnoreCondition`, and with `decimal 1.500`, `1e21` and `9007199254740993` all surviving the `JsonElement` round-trip. The element is cloned off the pooled buffer, so it is still valid across an `await`, a forced GC and 200 intervening serializations. `IOptions<JsonHubProtocolOptions>.Value.PayloadSerializerOptions` is the same object reference `JsonHubProtocol` holds — not a snapshot or a clone — and exactly one protocol is registered. The record's emitted bytes are identical to the anonymous objects they replaced, with no `EqualityContract` leak. The AAPS chain in `StorageBulkDeleteEvent`'s remark was verified link by link, including the `referenceId IS NULL` clause and the `?.let` no-op.

**Fixed in `5e16ac58c`:**

- `StorageBulkDeleteEvent`'s `[JsonPropertyName]` attributes were unpinned — stripping both left all tests green, because no bulk case ran under a reconfigured serializer. Now covered.
- `ReferenceHandler.Preserve` is the one serializer this design cannot follow: the pre-serialized document brings its own `$id` namespace, so the envelope emits `$id` twice and a sibling `$ref` would dangle. Unreachable today, but the design is framed as following whatever `AddJsonProtocol` configures, so the exception is now documented next to the claim.
- New `CS1574`: the cref for the generic broadcaster needed `{TModel}`.
- The extras rationale was restated in the test covering it; trimmed to one site.

**Equivalent mutant, stated rather than papered over.** Dropping `Doc = doc` — the verbatim-write half — survives the suite, including a test written specifically to catch it. It is behaviourally identical: both paths serialize with the same options, so the bytes match either way. It is unpinnable, not uncovered; its only real effect is avoiding a second reflection pass, plus the `Preserve` interaction above.

**Two corrections to this PR body's earlier claims:**

- Dropping the inbound devicestatus `identifier` does change the **V1 HTTP response**, which previously echoed a stored client `identifier` via `[JsonExtensionData]`. "Nothing reads it" was true of our code, not of the HTTP surface. NS v1 has no `identifier` concept and no known consumer reads it, but the delta was undeclared.
- The suite count is not deterministically green from a clean build. `ChatIdentityPendingLinkCleanupServiceTests.ExecuteAsync_sweeps_once_before_waiting_for_the_next_tick` is a pre-existing `BackgroundService.ExecuteAsync` thread-pool race unrelated to this change; it passes in isolation and fails intermittently in a full run.

Suites after the review fixes: `Nocturne.API.Tests` 6123 passed, 0 failed, 5 skipped (6128); `Nocturne.Core.Models.Tests` 829 passed.
