### PR TITLE
fix(web): keep $derived-held remote queries registered for the component's lifetime

### DIFF
--- a/src/Web/packages/app/src/lib/api/retain-query.svelte.ts
+++ b/src/Web/packages/app/src/lib/api/retain-query.svelte.ts
@@ -3,9 +3,12 @@
  * component lives.
  *
  * SvelteKit registers a query instance in its client-side query map from an `$effect.pre` created
- * wherever the query was constructed, and Svelte destroys a `$derived`'s effects the moment that
- * derived loses its last consumer. So a query held as `$derived(cond ? someQuery() : null)` leaves
- * the map as soon as the markup reading it stops doing so — an optimistic override that
+ * wherever the query was constructed, and that registration is released by the effect's teardown.
+ * Svelte runs the teardown of every effect a `$derived` owns the moment that derived loses its last
+ * consumer (`remove_reaction` disconnects it and calls `freeze_derived_effects`), and re-reading it
+ * does not unfreeze anything that would re-register: the entry is created in the query's
+ * constructor, not in the effect body. So a query held as `$derived(cond ? someQuery() : null)`
+ * leaves the map as soon as the markup reading it stops doing so — an optimistic override that
  * short-circuits the expression reading `.current`, or an `{#if}` block unmounting, is enough.
  * Reading the derived again does not bring it back: its own dependencies have not changed, so it
  * replays the cached, already-released instance. The next command's single-flight refresh then has

--- a/src/Web/packages/app/src/lib/api/retain-query.svelte.ts
+++ b/src/Web/packages/app/src/lib/api/retain-query.svelte.ts
@@ -1,0 +1,22 @@
+/**
+ * Keeps a remote query that was constructed inside a `$derived` usable for as long as the
+ * component lives.
+ *
+ * SvelteKit registers a query instance in its client-side query map from an `$effect.pre` created
+ * wherever the query was constructed, and Svelte destroys a `$derived`'s effects the moment that
+ * derived loses its last consumer. So a query held as `$derived(cond ? someQuery() : null)` leaves
+ * the map as soon as the markup reading it stops doing so — an optimistic override that
+ * short-circuits the expression reading `.current`, or an `{#if}` block unmounting, is enough.
+ * Reading the derived again does not bring it back: its own dependencies have not changed, so it
+ * replays the cached, already-released instance. The next command's single-flight refresh then has
+ * no instance to apply its payload to and is dropped silently — the command still resolves, so
+ * nothing surfaces an error and the stale value survives until a full page load.
+ *
+ * Reading the derived from a component-owned effect gives it a consumer that outlives every
+ * conditional reader, so the registration lasts as long as the component does.
+ */
+export function retainQuery(query: () => unknown): void {
+  $effect(() => {
+    query();
+  });
+}

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorSetup.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorSetup.svelte
@@ -49,6 +49,7 @@
   import ConnectorSelectionGrid from "$lib/components/connectors/ConnectorSelectionGrid.svelte";
   import ConnectorDangerZone from "$lib/components/connectors/ConnectorDangerZone.svelte";
   import SyncResultCard from "$lib/components/connectors/SyncResultCard.svelte";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   interface Props {
     /** Pre-select a specific connector (skips selection grid) */
@@ -105,6 +106,11 @@
   const effectiveConfigQuery = $derived(activeId ? getConnectorEffectiveConfig(activeId) : null);
   const dataSummaryQuery = $derived(activeId ? getConnectorDataSummary(activeId) : null);
   const capabilitiesQuery = $derived(activeId ? getConnectorCapabilities(activeId) : null);
+  retainQuery(() => schemaQuery);
+  retainQuery(() => configQuery);
+  retainQuery(() => effectiveConfigQuery);
+  retainQuery(() => dataSummaryQuery);
+  retainQuery(() => capabilitiesQuery);
   const statusQuery = getAllConnectorStatus();
 
   // --- Derived data from queries ---

--- a/src/Web/packages/app/src/lib/components/meal-matching/MealMatchReviewDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/meal-matching/MealMatchReviewDialog.svelte
@@ -10,6 +10,7 @@
     ConnectorFoodEntry,
     SuggestedMealMatch,
   } from "$lib/api/generated/nocturne-api-client";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   interface Props {
     open: boolean;
@@ -57,6 +58,7 @@
   const foodEntryQuery = $derived(
     open && foodEntryId ? getFoodEntry(foodEntryId) : null,
   );
+  retainQuery(() => foodEntryQuery);
   const foodEntry = $derived<ConnectorFoodEntry | null>(
     foodEntryQuery?.current ?? null,
   );

--- a/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
+++ b/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
@@ -29,6 +29,7 @@
     type GuestLinkInfo,
     GuestLinkStatus,
   } from "$api/generated/nocturne-api-client";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? []
@@ -46,6 +47,7 @@
   const guestLinksQuery = $derived(
     canCreateGuestLinks ? getGuestLinks({ includeDismissed: true }) : null
   );
+  retainQuery(() => guestLinksQuery);
   const allLinks = $derived(guestLinksQuery?.current ?? []);
   const guestLinks = $derived(
     showDismissed ? allLinks : allLinks.filter((l) => !l.dismissedAt)

--- a/src/Web/packages/app/src/lib/components/members/MembershipRequestsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/MembershipRequestsCard.svelte
@@ -8,6 +8,7 @@
     setMembershipRequestSettings,
     getPendingRequests,
   } from "$api/generated/membershipRequests.generated.remote";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],
@@ -19,6 +20,8 @@
 
   const settingsQuery = $derived(canManage ? getMembershipRequestSettings() : null);
   const pendingQuery = $derived(canManage ? getPendingRequests() : null);
+  retainQuery(() => settingsQuery);
+  retainQuery(() => pendingQuery);
 
   let pendingAllow = $state<boolean | null>(null);
   const allow = $derived(pendingAllow ?? settingsQuery?.current?.allowRequests ?? false);

--- a/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
@@ -26,6 +26,7 @@
     publicDataCategories,
     formatList,
   } from "./public-data-categories";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],
@@ -36,6 +37,7 @@
   );
 
   const shareQuery = $derived(canManageSharing ? getShareLink() : null);
+  retainQuery(() => shareQuery);
   const share = $derived(shareQuery?.current ?? null);
 
   // Optimistic overrides held only while a mutation is in flight; null = use server truth.

--- a/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte.test.ts
@@ -1,0 +1,89 @@
+import { render } from "vitest-browser-svelte";
+import { page as browser } from "vitest/browser";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { tick } from "svelte";
+import { page } from "$app/state";
+import { remoteQuery } from "$lib/test-stubs/remote-resource";
+
+// The framework registers a query instance from an `$effect.pre` created wherever the query was
+// constructed, and a command's single-flight refresh reaches only the instances still registered.
+// Modelling that here is what makes the card's `$derived`-held query observable: a query the
+// component has stopped consuming is released, and the refresh below then has nothing to write to.
+let registered = 0;
+
+const enabledShare = {
+  enabled: true,
+  url: null,
+  fullHistory: false,
+  scopes: ["glucose.read"],
+  lastAccessedAt: null,
+};
+const disabledShare = {
+  enabled: false,
+  url: null,
+  fullHistory: false,
+  scopes: [] as string[],
+  lastAccessedAt: null,
+};
+
+let share = $state.raw<typeof enabledShare>(enabledShare);
+
+function registerShareQuery() {
+  registered += 1;
+  $effect.pre(() => () => {
+    registered -= 1;
+  });
+  return remoteQuery(() => share);
+}
+
+let disableCall: Promise<unknown> | null = null;
+
+const disableShareLink = vi.fn(() => {
+  disableCall = (async () => {
+    // A round trip, so the optimistic override has flushed before the refresh comes back.
+    await tick();
+    if (registered > 0) share = disabledShare;
+    return disabledShare;
+  })();
+  return disableCall;
+});
+
+vi.mock("$api/generated/shareLinks.generated.remote", () => ({
+  getShareLink: () => registerShareQuery(),
+  disableShareLink: () => disableShareLink(),
+  rotateShareLink: vi.fn(),
+  setShareLinkFullHistory: vi.fn(),
+  setShareLinkScopes: vi.fn(),
+}));
+
+import PublicAccessCard from "./PublicAccessCard.svelte";
+
+describe("PublicAccessCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registered = 0;
+    disableCall = null;
+    share = enabledShare;
+    page.data = { effectivePermissions: ["*"] };
+  });
+
+  it("settles on the off state after turning public access off", async () => {
+    render(PublicAccessCard);
+
+    await expect
+      .element(browser.getByTestId("public-access-window"))
+      .toBeVisible();
+
+    await browser.getByTestId("public-access-toggle").click();
+
+    await vi.waitFor(() => expect(disableCall).not.toBeNull());
+    await disableCall;
+    await tick();
+    await tick();
+
+    expect(
+      document.querySelector('[data-testid="public-access-window"]')
+    ).toBeNull();
+    expect(document.body.textContent).toContain("Public access is off.");
+  });
+});

--- a/src/Web/packages/app/src/lib/components/settings/ApiReference.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ApiReference.svelte
@@ -7,6 +7,7 @@
     getTenantSettings,
     setPublicDocs,
   } from "$api/generated/tenantSettings.generated.remote";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],
@@ -17,6 +18,7 @@
   );
 
   const settingsQuery = $derived(canManageSettings ? getTenantSettings() : null);
+  retainQuery(() => settingsQuery);
 
   // Held only while a write is in flight; null = use server truth.
   let pending = $state<boolean | null>(null);

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/dnd/+page.svelte
@@ -22,6 +22,7 @@
   } from "$lib/components/ui/card";
   import { ArrowLeft, BellOff, Save, Loader2, ShieldAlert } from "lucide-svelte";
   import { EditorActionBar } from "$lib/components/layout";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],
@@ -34,6 +35,7 @@
   );
 
   const dndQuery = $derived(canSetDnd ? getDnd() : undefined);
+  retainQuery(() => dndQuery);
 
   let saving = $state(false);
   let error = $state<string | null>(null);

--- a/src/Web/packages/app/src/routes/(authenticated)/oauth/consent/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/oauth/consent/+page.svelte
@@ -18,6 +18,7 @@
   } from "lucide-svelte";
   import { consentForm, getClientInfo } from "../oauth.remote";
   import { getOAuthScopeDescription } from "$lib/constants/oauth-scopes";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   // Auth guard: redirect to login if not authenticated
   $effect(() => {
@@ -39,6 +40,7 @@
 
   // Fetch client info via remote function
   const clientInfoQuery = $derived(clientId ? getClientInfo({ clientId }) : null);
+  retainQuery(() => clientInfoQuery);
   const clientInfo = $derived(clientInfoQuery?.current ?? {
     clientId,
     displayName: null,

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
@@ -41,6 +41,7 @@
   import PublicAccessCard from "$lib/components/members/PublicAccessCard.svelte";
   import MembershipRequestsCard from "$lib/components/members/MembershipRequestsCard.svelte";
   import RolesSection from "$lib/components/members/RolesSection.svelte";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],
@@ -80,6 +81,9 @@
   const rolesQuery = getRoles();
   const pendingRequestsQuery = $derived(canManageMembers ? getPendingRequests() : null);
   const shareQuery = $derived(canManageSharing ? getShareLink() : null);
+  retainQuery(() => invitesQuery);
+  retainQuery(() => pendingRequestsQuery);
+  retainQuery(() => shareQuery);
 
   // Data
   const allMembers = $derived(membersQuery.current ?? []);

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/bot/authorize/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/bot/authorize/+page.svelte
@@ -5,6 +5,7 @@
 	import { Button } from "$lib/components/ui/button";
 	import { getBotAuthorizeContext, buildTenantRedirectUrl } from "../bot.remote";
 	import { getPending, claimLink } from "$lib/api/generated/chatIdentities.generated.remote";
+	import { retainQuery } from "$lib/api/retain-query.svelte";
 
 	// Read state token from URL
 	const stateToken = $derived(page.url.searchParams.get("state") ?? "");
@@ -17,6 +18,7 @@
 	const pendingQuery = $derived(
 		context?.mode === "tenant" && stateToken ? getPending(stateToken) : null,
 	);
+	retainQuery(() => pendingQuery);
 	const pending = $derived(pendingQuery?.current);
 	const pendingError = $derived(pendingQuery?.error);
 

--- a/src/Web/packages/app/src/routes/(unauthenticated)/join/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/join/+page.svelte
@@ -33,12 +33,14 @@
     parseCeremonyOptions,
   } from "$lib/components/auth/passkey-errors";
   import { FormError, describeSubmitError } from "$lib/forms";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   // ── URL params ────────────────────────────────────────────────────
   const token = $derived(page.url.searchParams.get("token") ?? "");
 
   // ── Remote data ───────────────────────────────────────────────────
   const inviteInfoQuery = $derived(token ? getInviteInfo(token) : undefined);
+  retainQuery(() => inviteInfoQuery);
   const oidcQuery = getOidcProviders();
 
   const inviteInfo = $derived(inviteInfoQuery?.current);

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/+page@.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/+page@.svelte
@@ -35,6 +35,7 @@
   import UploaderSetupView from "$lib/components/connectors/UploaderSetupView.svelte";
   import ImportProgress from "./steps/ImportProgress.svelte";
   import Finish from "./steps/Finish.svelte";
+  import { retainQuery } from "$lib/api/retain-query.svelte";
 
   // Auth check is handled server-side in +page.server.ts:
   // - setupRequired=true → show two-step setup (tenant identity → account creation)
@@ -114,6 +115,9 @@
   const uploaderSetupQuery = $derived(
     selectedUploader?.id ? getUploaderSetup(selectedUploader.id) : null
   );
+  retainQuery(() => servicesQuery);
+  retainQuery(() => dataSourcesQuery);
+  retainQuery(() => uploaderSetupQuery);
 
   const servicesData = $derived(servicesQuery?.current ?? null);
   const activeDataSources = $derived<DataSourceInfo[]>(


### PR DESCRIPTION
Fixes #1013.

## Root cause

Not the API, not the codegen, and not the `Invalidates` declaration — all three do the right thing. The refresh is produced correctly and then dropped on the client.

SvelteKit registers a query instance in its client-side `query_map` from an `$effect.pre` created **wherever the query was constructed** (`QueryProxy` constructor, `client/remote-functions/query.svelte.js`). Svelte destroys a `$derived`'s effects as soon as that derived loses its last consumer (`remove_reaction` → `destroy_derived_effects`). So a query held as

```js
const shareQuery = $derived(canManageSharing ? getShareLink() : null);
```

leaves the map the moment the markup reading it stops doing so. On this card two things stop reading it at once when the toggle is clicked:

- `enabled = pendingEnabled ?? share?.enabled ?? false` — while the optimistic override is set, `??` short-circuits and `share` is never read;
- `{#if enabled}` unmounts, and everything else that reads `share` (`scopes`, `fullHistory`, `share?.lastAccessedAt`) lives inside that block.

Reading the derived again afterwards does **not** re-register it: its own dependencies (`canManageSharing`) have not changed, so it replays the cached — already released — `QueryProxy`, whose `.current` reads a `query_map` entry that no longer exists. `share` is likewise clean, so it replays its last value. The card is frozen on stale data until a full page load.

The command's single-flight `refreshes` payload then lands in `apply_refreshes` with nothing to write to. Because that path is silent, the command still resolves successfully — no error surfaces, and the UI simply lies.

## Evidence

Against a local stack, watching `query_map` refcounts for `getShareLink` while clicking the toggle:

```
T0            {"held":[["",2]],"toggle":"unchecked"}   ← page + card both hold it
post-enable   {"held":[["",1]],"toggle":"checked"}     ← one holder released, never re-acquired
post-disable  {"held":[],       "toggle":"checked"}    ← entry destroyed; card stuck "on"
```

The `disableShareLink` POST response is correct throughout — it carries the post-disable value:

```
{"type":"result","result":"…",
 "refreshes":"[{\"uopdor/getShareLink/\":1},{\"type\":2,\"data\":3},\"result\",
               {\"enabled\":4,…},false,null,[]]"}
```

Instrumenting `apply_singleflight` confirms where it goes:

```
[INSTR] singleflight key=uopdor/getShareLink/ id=uopdor/getShareLink payload="" payloadsForId=NONE
[INSTR] entry=false resource=false
```

A standalone SvelteKit 2.59.1 app (one query, one command, nothing else) reproduces it from first principles: with the query held in a `$derived` behind an optimistic short-circuit, `query_map` empties on the first click and the value never updates again; giving the derived a component-owned consumer fixes it.

## The fix

`retainQuery` (`src/lib/api/retain-query.svelte.ts`) reads the derived from a component-owned effect, giving it a consumer that outlives every conditional reader, so the registration lasts as long as the component. It is applied at every site that holds a remote query in a `$derived` — this is a latent defect at all of them, not just the sharing card.

Verified end-to-end on a running stack by injecting the equivalent effect into the two compiled components:

```
T0            {"held":[["",2]],"toggle":"unchecked","window":false}
post-enable   {"held":[["",2]],"toggle":"checked",  "window":true}
post-disable  {"held":[["",2]],"toggle":"unchecked","window":false}   ← correct, no reload
```

## Test

`PublicAccessCard.svelte.test.ts` (browser) stands in for the remote module with a query that mirrors the framework's registration lifetime — it registers from an `$effect.pre` created where the component constructs it, and the mocked `disableShareLink` applies its refresh only while at least one instance is still registered, as a single-flight refresh does. The test clicks the toggle off, waits for the command to settle, and asserts the card is left on the off body.

Mutation proof: deleting the `retainQuery(() => shareQuery)` line makes it fail with the time-window control still on screen — the reported bug exactly.

## Upstream defect

This looks like a genuine SvelteKit bug, not just a misuse: `$derived(getThing(id))` is the documented way to hold a query whose argument is reactive, yet the instance's `query_map` registration is tied to whatever reactive scope constructed it. Any derived that temporarily loses its consumers silently de-registers a query that is still mounted and still being displayed, and the next command's refresh is discarded without an error. The dangerous part is the silence: `apply_singleflight` skips unknown keys, and the command resolves as if the refresh had been applied. Reproduction: SvelteKit 2.59.1 + Svelte 5.55.5, a query read only through an expression that `??`-short-circuits while a mutation is in flight.



https://claude.ai/code/session_01BbK5W7zQy2xLHUzRkmj7n6
