### PR TITLE
fix: show basal injections on the dashboard chart, and stop inventing a 1 U/hr band

### DIFF
--- a/src/API/Nocturne.API/Services/ChartData/BasalSeriesBuilder.cs
+++ b/src/API/Nocturne.API/Services/ChartData/BasalSeriesBuilder.cs
@@ -12,7 +12,9 @@ namespace Nocturne.API.Services.ChartData;
 /// TempBasal records are the v4 source of truth for pump-confirmed basal delivery.
 /// Gaps in TempBasal coverage are filled at 5-minute resolution from the active
 /// basal rate schedule; when no TempBasal records exist the entire series is
-/// profile-derived.
+/// profile-derived. With no therapy settings at all there is no schedule to
+/// infer from, so the series is left empty rather than invented — a fabricated
+/// flat rate renders as real delivery on the chart.
 /// </summary>
 internal sealed class BasalSeriesBuilder(
     ITherapySettingsResolver therapySettingsResolver,
@@ -57,9 +59,7 @@ internal sealed class BasalSeriesBuilder(
             var origin = MapTempBasalOrigin(tb.Origin);
 
             var scheduledRate = tb.ScheduledRate
-                ?? (hasData
-                    ? timeline.SnapshotAt(tbStart).BasalRateAt(tbStart)
-                    : defaultBasalRate);
+                ?? (hasData ? timeline.SnapshotAt(tbStart).BasalRateAt(tbStart) : (double?)null);
 
             series.Add(
                 new BasalPoint
@@ -79,7 +79,7 @@ internal sealed class BasalSeriesBuilder(
         if (currentTime < endTime)
             series.AddRange(BuildFromProfile(currentTime, endTime, defaultBasalRate, timeline, hasData));
 
-        if (series.Count == 0)
+        if (series.Count == 0 && hasData)
         {
             series.Add(
                 new BasalPoint
@@ -106,14 +106,18 @@ internal sealed class BasalSeriesBuilder(
     )
     {
         var series = new List<BasalPoint>();
+
+        // No therapy settings means no basal schedule. Emitting defaultBasalRate
+        // here would draw a flat band the wearer never received.
+        if (!hasData)
+            return series;
+
         const long intervalMs = 5 * 60 * 1000;
         double? prevRate = null;
 
         for (long t = startTime; t <= endTime; t += intervalMs)
         {
-            var rate = hasData
-                ? timeline.SnapshotAt(t).BasalRateAt(t)
-                : defaultBasalRate;
+            var rate = timeline.SnapshotAt(t).BasalRateAt(t);
 
             if (prevRate == null || Math.Abs(rate - prevRate.Value) > 0.001)
             {

--- a/src/Core/Nocturne.Core.Models/ChartDataDtos.cs
+++ b/src/Core/Nocturne.Core.Models/ChartDataDtos.cs
@@ -148,7 +148,13 @@ public class BasalPoint
 {
     public long Timestamp { get; set; }
     public double Rate { get; set; }
-    public double ScheduledRate { get; set; }
+
+    /// <summary>
+    /// The rate the basal schedule called for at this instant, or <c>null</c> when
+    /// there is no therapy profile to read one from. Consumers fall back to
+    /// <see cref="Rate"/> rather than substituting a placeholder.
+    /// </summary>
+    public double? ScheduledRate { get; set; }
     public BasalDeliveryOrigin Origin { get; set; }
     public ChartColor FillColor { get; set; }
     public ChartColor StrokeColor { get; set; }

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ChartTooltip.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ChartTooltip.svelte
@@ -5,6 +5,7 @@
   import { BasalDeliveryOrigin, ChartSpanKind } from "$lib/api";
   import { bg, bgLabel } from "$lib/utils/formatting";
   import { getGlucoseChartContext } from "./chart-context.svelte";
+  import { isBasalAdjusted } from "./engine/basal-presentation";
   import type { GlucosePoint } from "./engine/chart-data-engine.svelte";
 
   interface Props {
@@ -133,10 +134,11 @@
       {/if}
       {#if showBasal && (activeBasal || activeBasalDelivery || activeTempBasal)}
         {#if activeBasal}
-          {@const isAdjusted =
-            (activeBasal.origin === BasalDeliveryOrigin.Algorithm ||
-              activeBasal.origin === BasalDeliveryOrigin.Manual) &&
-            activeBasal.rate !== activeBasal.scheduledRate}
+          {@const isAdjusted = isBasalAdjusted(
+            activeBasal.origin,
+            activeBasal.rate,
+            activeBasal.scheduledRate
+          )}
           {@const basalLabel =
             activeBasal.origin === BasalDeliveryOrigin.Suspended
               ? "Suspended"
@@ -159,7 +161,7 @@
                 : ""
             )}
           />
-          {#if isAdjusted && activeBasal.scheduledRate !== undefined}
+          {#if isAdjusted && activeBasal.scheduledRate != null}
             <Tooltip.Item
               label="Scheduled"
               value={activeBasal.scheduledRate}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/basal-presentation.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/basal-presentation.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { BasalDeliveryOrigin } from "$lib/api";
+import { isBasalAdjusted } from "./basal-presentation";
+
+describe("isBasalAdjusted", () => {
+  it("reports a rate that departs from a known schedule", () => {
+    expect(
+      isBasalAdjusted(BasalDeliveryOrigin.Algorithm, 0.65, 0.9)
+    ).toBe(true);
+  });
+
+  it("does not report a rate that matches its schedule", () => {
+    expect(isBasalAdjusted(BasalDeliveryOrigin.Manual, 0.9, 0.9)).toBe(false);
+  });
+
+  // With no therapy profile the server sends a null scheduledRate. Comparing a
+  // number against null is always unequal, which would paint every algorithm
+  // basal as a deviation and render a blank "Scheduled" row beside it.
+  it("does not treat an unknown schedule as a deviation", () => {
+    expect(isBasalAdjusted(BasalDeliveryOrigin.Algorithm, 0.65, null)).toBe(
+      false
+    );
+    expect(
+      isBasalAdjusted(BasalDeliveryOrigin.Manual, 0.65, undefined)
+    ).toBe(false);
+  });
+
+  it("only applies to algorithm and manual origins", () => {
+    for (const origin of [
+      BasalDeliveryOrigin.Scheduled,
+      BasalDeliveryOrigin.Suspended,
+      BasalDeliveryOrigin.Inferred,
+    ]) {
+      expect(isBasalAdjusted(origin, 0.65, 0.9), origin).toBe(false);
+    }
+  });
+});

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/basal-presentation.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/basal-presentation.ts
@@ -1,0 +1,22 @@
+import { BasalDeliveryOrigin } from "$lib/api";
+
+/**
+ * Whether a basal point departs from the schedule, which the chart paints in the
+ * temp-basal colour and labels "Auto Basal" / "Temp Basal".
+ *
+ * A null `scheduledRate` means the server had no therapy profile to resolve one
+ * from. That is an absence of knowledge, not a deviation, so it must not read as
+ * one — the tooltip would otherwise assert a departure from a schedule nobody
+ * knows, alongside a blank "Scheduled" row.
+ */
+export function isBasalAdjusted(
+  origin: BasalDeliveryOrigin | undefined,
+  rate: number | undefined,
+  scheduledRate: number | null | undefined
+): boolean {
+  const canBeAdjusted =
+    origin === BasalDeliveryOrigin.Algorithm ||
+    origin === BasalDeliveryOrigin.Manual;
+
+  return canBeAdjusted && scheduledRate != null && rate !== scheduledRate;
+}

--- a/src/Web/packages/app/src/lib/utils/chart-data-merge.test.ts
+++ b/src/Web/packages/app/src/lib/utils/chart-data-merge.test.ts
@@ -28,7 +28,7 @@ function chartData(overrides: Partial<TransformedChartData> = {}): TransformedCh
     tempBasalSpans: [],
     basalDeliverySpans: [],
     defaultBasalRate: 1,
-    thresholds: {} as TransformedChartData["thresholds"],
+    thresholds: { glucoseYMax: 300 } as TransformedChartData["thresholds"],
     maxIob: 0,
     maxCob: 0,
     maxBasalRate: 0,
@@ -88,6 +88,29 @@ describe("mergeChartData wearable series", () => {
 
     expect(merged.heartRateSeries).toHaveLength(1);
     expect(merged.stepSeries).toHaveLength(1);
+  });
+});
+
+describe("mergeChartData glucose axis", () => {
+  // The server sizes glucoseYMax to the max SGV in the range it was asked for,
+  // so the streamed half can need a taller axis than the blocking half. The
+  // chart's yDomain clips above it, which would drop the excursion entirely.
+  it("takes the taller glucose axis from either half", () => {
+    const merged = mergeChartData(
+      chartData({ thresholds: { glucoseYMax: 300 } as never }),
+      chartData({ thresholds: { glucoseYMax: 370 } as never })
+    );
+
+    expect(merged.thresholds.glucoseYMax).toBe(370);
+  });
+
+  it("keeps the initial half's other thresholds", () => {
+    const merged = mergeChartData(
+      chartData({ thresholds: { glucoseYMax: 300, low: 70 } as never }),
+      chartData({ thresholds: { glucoseYMax: 280, low: 80 } as never })
+    );
+
+    expect(merged.thresholds.low).toBe(70);
   });
 });
 

--- a/src/Web/packages/app/src/lib/utils/chart-data-merge.test.ts
+++ b/src/Web/packages/app/src/lib/utils/chart-data-merge.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { mergeChartData } from "./chart-data-merge";
+import type { TransformedChartData } from "./chart-data-transform";
+
+// The dashboard loads the most recent 6 hours blocking and streams hours 6→48
+// in a second payload, then merges the two. Anything the merge forgets is
+// silently truncated to the 6-hour window, so these tests assert on the
+// collections rather than on the merge helpers.
+function chartData(overrides: Partial<TransformedChartData> = {}): TransformedChartData {
+  return {
+    iobSeries: [],
+    cobSeries: [],
+    basalSeries: [],
+    glucoseData: [],
+    heartRateSeries: [],
+    stepSeries: [],
+    bolusMarkers: [],
+    carbMarkers: [],
+    deviceEventMarkers: [],
+    bgCheckMarkers: [],
+    systemEventMarkers: [],
+    trackerMarkers: [],
+    basalInjectionMarkers: [],
+    pumpModeSpans: [],
+    profileSpans: [],
+    overrideSpans: [],
+    activitySpans: [],
+    tempBasalSpans: [],
+    basalDeliverySpans: [],
+    defaultBasalRate: 1,
+    thresholds: {} as TransformedChartData["thresholds"],
+    maxIob: 0,
+    maxCob: 0,
+    maxBasalRate: 0,
+    ...overrides,
+  } as TransformedChartData;
+}
+
+function injection(id: string, time: string, units: number) {
+  return { id, time: new Date(time), units, insulinName: "Lantus" };
+}
+
+describe("mergeChartData basal injections", () => {
+  it("keeps an injection that only exists in the streamed historical half", () => {
+    // A once-daily long-acting dose at 00:16 falls outside the blocking
+    // 6-hour window for most of the day, so it only ever arrives streamed.
+    const initial = chartData({ basalInjectionMarkers: [] });
+    const historical = chartData({
+      basalInjectionMarkers: [injection("a", "2026-08-29T00:16:00Z", 22)],
+    });
+
+    const merged = mergeChartData(initial, historical);
+
+    expect(merged.basalInjectionMarkers).toHaveLength(1);
+    expect(merged.basalInjectionMarkers[0].id).toBe("a");
+  });
+
+  it("does not duplicate an injection present in both halves", () => {
+    const shared = injection("a", "2026-08-29T00:16:00Z", 22);
+    const merged = mergeChartData(
+      chartData({ basalInjectionMarkers: [shared] }),
+      chartData({ basalInjectionMarkers: [{ ...shared }] })
+    );
+
+    // Rendered in an {#each ... (marker.id)} block, so a duplicate id is a crash.
+    expect(merged.basalInjectionMarkers).toHaveLength(1);
+  });
+
+  it("keeps injections from both halves", () => {
+    const merged = mergeChartData(
+      chartData({ basalInjectionMarkers: [injection("late", "2026-08-29T21:00:00Z", 4)] }),
+      chartData({ basalInjectionMarkers: [injection("early", "2026-08-29T00:16:00Z", 22)] })
+    );
+
+    expect(merged.basalInjectionMarkers.map((m) => m.id)).toEqual(["early", "late"]);
+  });
+});
+
+describe("mergeChartData wearable series", () => {
+  it("keeps heart-rate and step samples from the historical half", () => {
+    const merged = mergeChartData(
+      chartData(),
+      chartData({
+        heartRateSeries: [{ time: new Date("2026-08-29T01:00:00Z"), bpm: 58 }],
+        stepSeries: [{ time: new Date("2026-08-29T01:00:00Z"), steps: 120 }],
+      })
+    );
+
+    expect(merged.heartRateSeries).toHaveLength(1);
+    expect(merged.stepSeries).toHaveLength(1);
+  });
+});
+
+describe("mergeChartData", () => {
+  it("returns the initial payload untouched when nothing streamed", () => {
+    const initial = chartData({
+      basalInjectionMarkers: [injection("a", "2026-08-29T21:00:00Z", 4)],
+    });
+
+    expect(mergeChartData(initial, null)).toBe(initial);
+  });
+});

--- a/src/Web/packages/app/src/lib/utils/chart-data-merge.ts
+++ b/src/Web/packages/app/src/lib/utils/chart-data-merge.ts
@@ -86,10 +86,18 @@ export function mergeChartData(
 			historical.basalDeliverySpans
 		),
 
-		// Resolved against the display window, which the historical half only extends
-		// backwards — the initial payload's values stand.
+		// Thresholds are profile-derived and identical across both halves, except
+		// glucoseYMax, which the server sizes to the max SGV it was asked for — the
+		// streamed half can carry a higher excursion, and the chart's yDomain clips
+		// anything above it.
 		defaultBasalRate: initial.defaultBasalRate,
-		thresholds: initial.thresholds,
+		thresholds: {
+			...initial.thresholds,
+			glucoseYMax: Math.max(
+				initial.thresholds.glucoseYMax,
+				historical.thresholds.glucoseYMax
+			),
+		},
 
 		// Take the max values from either dataset
 		maxIob: Math.max(initial.maxIob ?? 0, historical.maxIob ?? 0),

--- a/src/Web/packages/app/src/lib/utils/chart-data-merge.ts
+++ b/src/Web/packages/app/src/lib/utils/chart-data-merge.ts
@@ -51,23 +51,31 @@ export function mergeChartData(
 		return [...uniqueHistorical, ...initialArr];
 	};
 
+	// Every field is listed explicitly rather than spreading `initial`. A spread
+	// satisfies the return type on its own, so a collection left out of the merge
+	// keeps only the initial window's rows instead of failing to compile.
 	return {
-		...initial,
-		// Merge time-series data
+		// Time series
 		iobSeries: mergeByTime(initial.iobSeries, historical.iobSeries),
 		cobSeries: mergeByTime(initial.cobSeries, historical.cobSeries),
 		basalSeries: mergeByTime(initial.basalSeries, historical.basalSeries, 'timestamp'),
 		glucoseData: mergeByTime(initial.glucoseData, historical.glucoseData),
+		heartRateSeries: mergeByTime(initial.heartRateSeries, historical.heartRateSeries),
+		stepSeries: mergeByTime(initial.stepSeries, historical.stepSeries),
 
 		// Merge markers (keyed by time)
 		bolusMarkers: mergeByTime(initial.bolusMarkers, historical.bolusMarkers),
 		carbMarkers: mergeByTime(initial.carbMarkers, historical.carbMarkers),
 		deviceEventMarkers: mergeByTime(initial.deviceEventMarkers, historical.deviceEventMarkers),
-		systemEventMarkers: mergeSpansById(initial.systemEventMarkers, historical.systemEventMarkers),
-		trackerMarkers: mergeSpansById(initial.trackerMarkers, historical.trackerMarkers),
 		bgCheckMarkers: mergeByTime(initial.bgCheckMarkers, historical.bgCheckMarkers),
 
-		// Merge spans (keyed by id in {#each} blocks — must dedup by id)
+		// Merge markers and spans keyed by id in {#each} blocks — must dedup by id
+		systemEventMarkers: mergeSpansById(initial.systemEventMarkers, historical.systemEventMarkers),
+		trackerMarkers: mergeSpansById(initial.trackerMarkers, historical.trackerMarkers),
+		basalInjectionMarkers: mergeSpansById(
+			initial.basalInjectionMarkers,
+			historical.basalInjectionMarkers
+		),
 		pumpModeSpans: mergeSpansById(initial.pumpModeSpans, historical.pumpModeSpans),
 		profileSpans: mergeSpansById(initial.profileSpans, historical.profileSpans),
 		overrideSpans: mergeSpansById(initial.overrideSpans, historical.overrideSpans),
@@ -77,6 +85,11 @@ export function mergeChartData(
 			initial.basalDeliverySpans,
 			historical.basalDeliverySpans
 		),
+
+		// Resolved against the display window, which the historical half only extends
+		// backwards — the initial payload's values stand.
+		defaultBasalRate: initial.defaultBasalRate,
+		thresholds: initial.thresholds,
 
 		// Take the max values from either dataset
 		maxIob: Math.max(initial.maxIob ?? 0, historical.maxIob ?? 0),

--- a/tests/Unit/Nocturne.API.Tests/Services/ChartData/BasalSeriesBuilderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ChartData/BasalSeriesBuilderTests.cs
@@ -14,6 +14,27 @@ public class BasalSeriesBuilderTests
     // Common test timestamp: 2023-11-15T00:00:00Z in millis
     private const long TestMills = 1700000000000L;
 
+    /// <summary>
+    /// The timeline a tenant with no therapy profile still yields: one segment whose
+    /// snapshot carries no basal schedule. Its <c>BasalRateAt</c> answers the model's
+    /// own 1.0 placeholder, so a test asserting emptiness proves the hasData guard
+    /// rather than an empty timeline.
+    /// </summary>
+    private static TherapyTimeline ProfilelessTimeline(long startTime, long endTime) =>
+        new([
+            new TherapySegment(startTime, endTime + 1,
+                new TherapySnapshot(
+                    dia: 3.0,
+                    peakMinutes: TherapySnapshot.DefaultPeakMinutes,
+                    carbsPerHour: TherapySnapshot.DefaultCarbsPerHour,
+                    timezone: null,
+                    ccpPercentage: null,
+                    ccpTimeshiftMs: 0,
+                    sensitivityEntries: null,
+                    carbRatioEntries: null,
+                    basalEntries: null))
+        ]);
+
     [Fact]
     public void BuildFromProfile_WithHasData_UsesTimelineNotResolver()
     {
@@ -91,5 +112,93 @@ public class BasalSeriesBuilderTests
         // Output is driven by the supplied timeline's 1.7 U/hr schedule entry, not the default.
         result.Should().NotBeEmpty();
         result.Should().AllSatisfy(p => p.Rate.Should().BeApproximately(1.7, 0.001));
+    }
+
+    /// <summary>
+    /// Injection (MDI) therapy produces no TempBasal records and often no therapy
+    /// profile either. The builder used to fall back to a flat 1 U/hr band, which
+    /// the chart draws identically to pump-confirmed delivery — inventing basal the
+    /// wearer never received. With no therapy settings there must be no series.
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_WithoutTherapySettings_ReturnsNoPointsRatherThanAFlatDefault()
+    {
+        var startTime = TestMills;
+        var endTime = TestMills + 6 * 60 * 60 * 1000;
+        const double defaultBasalRate = 1.0;
+
+        var therapySettings = new Mock<ITherapySettingsResolver>();
+        therapySettings.Setup(s => s.HasDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var builder = new BasalSeriesBuilder(
+            therapySettings.Object,
+            NullLogger<BasalSeriesBuilder>.Instance);
+
+        var result = await builder.BuildAsync(
+            tempBasals: [],
+            startTime,
+            endTime,
+            defaultBasalRate,
+            ProfilelessTimeline(startTime, endTime),
+            CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Real TempBasal records are pump-confirmed delivery and must still be drawn
+    /// when the therapy profile is missing — only the inferred fill is suppressed.
+    /// </summary>
+    [Fact]
+    public async Task BuildAsync_WithoutTherapySettings_StillReturnsRecordedTempBasals()
+    {
+        var startTime = TestMills;
+        var endTime = TestMills + 60 * 60 * 1000;
+
+        // StartMills/EndMills are computed from the timestamps, so drive those.
+        var tempBasal = new TempBasal
+        {
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime + 10 * 60 * 1000).UtcDateTime,
+            EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(startTime + 40 * 60 * 1000).UtcDateTime,
+            Rate = 0.65,
+            Origin = TempBasalOrigin.Algorithm,
+        };
+
+        var therapySettings = new Mock<ITherapySettingsResolver>();
+        therapySettings.Setup(s => s.HasDataAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var builder = new BasalSeriesBuilder(
+            therapySettings.Object,
+            NullLogger<BasalSeriesBuilder>.Instance);
+
+        var result = await builder.BuildAsync(
+            tempBasals: [tempBasal],
+            startTime,
+            endTime,
+            defaultBasalRate: 1.0,
+            ProfilelessTimeline(startTime, endTime),
+            CancellationToken.None);
+
+        result.Should().ContainSingle();
+        result[0].Rate.Should().BeApproximately(0.65, 0.001);
+        // No profile means no scheduled rate to compare against, not a placeholder one.
+        result[0].ScheduledRate.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The gap-filling path is what produced the flat band: with a profile present it
+    /// still fills from the schedule, so the suppression must be keyed on hasData only.
+    /// </summary>
+    [Fact]
+    public void BuildFromProfile_WithoutHasData_EmitsNothing()
+    {
+        var startTime = TestMills;
+        var endTime = TestMills + 30 * 60 * 1000;
+
+        var result = BasalSeriesBuilder.BuildFromProfile(
+            startTime, endTime, defaultBasalRate: 1.0,
+            ProfilelessTimeline(startTime, endTime), hasData: false);
+
+        result.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
Reported from the dashboard: a basal injection at 00:16 showed on `/reports/day-in-review` but never on the dashboard, which instead drew a flat 1 U/hr basal band. Two independent causes.

## Basal injections never reached the dashboard

The dashboard loads the most recent 6 hours blocking and streams hours 6–48, then merges the two payloads. `mergeChartData` listed the collections to merge one at a time and spread `...initial` underneath — the spread satisfied the return type on its own, so a collection that was never listed silently kept only the 6-hour window's rows.

`basalInjectionMarkers`, `heartRateSeries` and `stepSeries` were all missing. A once-daily long-acting injection sits outside the blocking window for most of the day, so it never reached the chart. `/reports/day-in-review` fetches its whole range in one call, never hits the merge, and showed the same injection correctly.

The spread is gone and every field is listed, so a collection left out is now a compile error rather than silent truncation. `basalInjectionMarkers` dedups by id — it renders in an `{#each ... (marker.id)}` block where a duplicate id is a crash.

## The 1 U/hr band was fabricated

`BasalSeriesBuilder` fills gaps in TempBasal coverage from the active basal schedule, and with no TempBasal records at all the whole series is profile-derived. Injection (MDI) therapy produces no TempBasal records and frequently no therapy profile either, so both fallbacks collapsed onto `ProfileLoadStage`'s hardcoded `defaultBasalRate` of 1.0. The chart draws that identically to pump-confirmed delivery, so it reads as insulin the wearer never received.

With no therapy settings there is no schedule to infer from, so the series is now left empty. Recorded TempBasals are real delivery and are still drawn; only the inferred fill is suppressed. `BasalPoint.ScheduledRate` becomes nullable for the same reason — with no profile there is no scheduled rate to compare against.

`maxBasalRate` floors at `defaultBasalRate * 2.5`, so an empty series does not collapse the lane's scale, and the lane itself stays because basal injection markers anchor to it.

## Follow-on fixes from review

- With `ScheduledRate` nullable, the tooltip's `rate !== scheduledRate` was true for every algorithm basal on a profile-less tenant, since a number never equals null. It painted them as deviations and rendered a blank "Scheduled" row. The predicate moved into `isBasalAdjusted` so the rule is unit-testable.
- `glucoseYMax` is now merged across both payloads. The server sizes it to the max SGV in the range it was asked for and the chart's `yDomain` clips above it, so a 350 mg/dL excursion arriving in the streamed half was drawn outside the visible area and disappeared.

## Testing

New: 7 merge tests, 4 `isBasalAdjusted` tests, 3 `BasalSeriesBuilder` tests. Each was mutation-proven — reverting the fix fails them. Full `ChartData` suite green at 167; frontend `pnpm check` unchanged at its 53-error baseline.

## Known adjacent issue, not addressed here

`ChartDataService.cs:171` hardcodes `IsOverride = false` for every bolus marker, so the manual-override marker is unreachable from real dashboard data. Pre-existing; fixing it means deciding where that flag should come from.
