### PR TITLE
fix(web): respect the 12/24-hour preference on the glucose chart

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ChartTooltip.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ChartTooltip.svelte
@@ -270,7 +270,7 @@
   {#snippet children({ data })}
     <Tooltip.Item
       value={data?.time}
-      format="minute"
+      format={(v) => (v instanceof Date ? time(v) : String(v))}
       onclick={() => goto(`/reports/day-in-review?date=${data?.time}`)}
     />
   {/snippet}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ChartTooltip.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ChartTooltip.svelte
@@ -3,7 +3,7 @@
   import { cn } from "$lib/utils";
   import { goto } from "$app/navigation";
   import { BasalDeliveryOrigin, ChartSpanKind } from "$lib/api";
-  import { bg, bgLabel } from "$lib/utils/formatting";
+  import { bg, bgLabel, time } from "$lib/utils/formatting";
   import { getGlucoseChartContext } from "./chart-context.svelte";
   import type { GlucosePoint } from "./engine/chart-data-engine.svelte";
 
@@ -80,7 +80,7 @@
 
     <Tooltip.Header
       value={data?.time}
-      format="minute"
+      format={(v) => (v instanceof Date ? time(v) : String(v))}
       class="text-popover-foreground border-b border-border pb-1 mb-1 text-sm font-semibold"
     />
     <Tooltip.List>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte
@@ -8,6 +8,7 @@
   import { setGlucoseChartContext } from "./chart-context.svelte";
   import { computeTrackLayout } from "./engine/track-layout";
   import { hourLabel } from "$lib/utils/formatting";
+  import { hourTicks } from "./engine/axis-ticks";
 
   interface Props {
     engine: ChartDataEngine;
@@ -114,6 +115,7 @@
         {#if showTimeAxis}
           <Axis
             placement="bottom"
+            ticks={hourTicks}
             format={(v) => (v instanceof Date ? hourLabel(v) : String(v))}
             tickLabelProps={{ class: "text-xs fill-muted-foreground" }}
           />

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte
@@ -7,6 +7,7 @@
   import type { GlucoseChartContext, LegendState } from "./chart-context.svelte";
   import { setGlucoseChartContext } from "./chart-context.svelte";
   import { computeTrackLayout } from "./engine/track-layout";
+  import { hourLabel } from "$lib/utils/formatting";
 
   interface Props {
     engine: ChartDataEngine;
@@ -113,7 +114,7 @@
         {#if showTimeAxis}
           <Axis
             placement="bottom"
-            format="hour"
+            format={(v) => (v instanceof Date ? hourLabel(v) : String(v))}
             tickLabelProps={{ class: "text-xs fill-muted-foreground" }}
           />
         {/if}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ZoomIndicator.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ZoomIndicator.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import RotateCcw from "lucide-svelte/icons/rotate-ccw";
   import { Button } from "$lib/components/ui/button";
+  import { time } from "$lib/utils/formatting";
 
   interface Props {
     isZoomed: boolean;
@@ -19,13 +20,7 @@
       <span class="font-medium">Zoomed view</span>
       {#if brushXDomain}
         <span class="text-xs text-muted-foreground">
-          {brushXDomain[0].toLocaleTimeString([], {
-            hour: "numeric",
-            minute: "2-digit",
-          })} - {brushXDomain[1].toLocaleTimeString([], {
-            hour: "numeric",
-            minute: "2-digit",
-          })}
+          {time(brushXDomain[0])} - {time(brushXDomain[1])}
         </span>
       {/if}
     </div>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ZoomIndicator.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/ZoomIndicator.svelte.test.ts
@@ -1,9 +1,15 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import ZoomIndicator from "./ZoomIndicator.svelte";
+import { timeFormat } from "$lib/stores/appearance-store.svelte";
+import { time } from "$lib/utils/formatting";
 
 describe("ZoomIndicator", () => {
+	afterEach(() => {
+		timeFormat.current = "12";
+	});
+
 	it("renders nothing when not zoomed", async () => {
 		render(ZoomIndicator, {
 			isZoomed: false,
@@ -38,18 +44,31 @@ describe("ZoomIndicator", () => {
 			onResetZoom: vi.fn(),
 		});
 
-		const formatted_start = start.toLocaleTimeString([], {
-			hour: "numeric",
-			minute: "2-digit",
-		});
-		const formatted_end = end.toLocaleTimeString([], {
-			hour: "numeric",
-			minute: "2-digit",
+		await expect
+			.element(page.getByText(`${time(start)} - ${time(end)}`))
+			.toBeVisible();
+	});
+
+	// The chart used to format its own times, so the preference reached the
+	// settings page and the mini overview strip but not the chart itself. Both
+	// directions are asserted because whichever one matches the browser's own
+	// locale would pass without the preference being consulted at all.
+	it.each([
+		{ format: "24" as const, shown: "20:30", hidden: "8:30" },
+		{ format: "12" as const, shown: "8:30", hidden: "20:30" },
+	])("honours the $format-hour preference", async ({ format, shown, hidden }) => {
+		timeFormat.current = format;
+
+		render(ZoomIndicator, {
+			isZoomed: true,
+			brushXDomain: [new Date(2026, 3, 26, 8, 0), new Date(2026, 3, 26, 20, 30)],
+			onResetZoom: vi.fn(),
 		});
 
+		await expect.element(page.getByText(shown, { exact: false })).toBeVisible();
 		await expect
-			.element(page.getByText(`${formatted_start} - ${formatted_end}`))
-			.toBeVisible();
+			.element(page.getByText(hidden, { exact: true }))
+			.not.toBeInTheDocument();
 	});
 
 	it("calls onResetZoom when reset button is clicked", async () => {

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/DeliveryInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/DeliveryInspectionDialog.svelte
@@ -4,7 +4,7 @@
   import { Button } from "$lib/components/ui/button";
   import { Activity, Syringe, Utensils, AlertTriangle } from "lucide-svelte";
   import { BasalDeliveryOrigin, type ApsSnapshot } from "$lib/api";
-  import { bg, bgLabel } from "$lib/utils/formatting";
+  import { bg, bgLabel, time } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
   import type { PredictionData } from "$api/predictions.remote";
   import { getAll as getApsSnapshots } from "$lib/api/generated/apsSnapshots.generated.remote";
@@ -170,11 +170,7 @@
         </Badge>
       </Dialog.Title>
       <Dialog.Description>
-        {timestamp.toLocaleTimeString([], {
-          hour: "numeric",
-          minute: "2-digit",
-          second: "2-digit",
-        })}
+        {time(timestamp, { seconds: true })}
         &mdash;
         {timestamp.toLocaleDateString([], {
           month: "short",

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseInspectionDialog.svelte
@@ -4,7 +4,7 @@
   import { Button } from "$lib/components/ui/button";
   import { Syringe, Utensils } from "lucide-svelte";
   import { BasalDeliveryOrigin } from "$lib/api";
-  import { bg, bgLabel, bgDelta } from "$lib/utils/formatting";
+  import { bg, bgLabel, bgDelta, time } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
   import type { PredictionData } from "$api/predictions.remote";
   import { getAll as getApsSnapshots } from "$lib/api/generated/apsSnapshots.generated.remote";
@@ -151,11 +151,7 @@
         {/if}
       </Dialog.Title>
       <Dialog.Description>
-        {timestamp.toLocaleTimeString([], {
-          hour: "numeric",
-          minute: "2-digit",
-          second: "2-digit",
-        })}
+        {time(timestamp, { seconds: true })}
         &mdash;
         {timestamp.toLocaleDateString([], {
           month: "short",

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseResponseChart.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseResponseChart.svelte
@@ -11,7 +11,7 @@
   import { scaleTime, scaleLinear } from "d3-scale";
   import { curveMonotoneX } from "d3";
   import type { PredictionData } from "$api/predictions.remote";
-  import { bg } from "$lib/utils/formatting";
+  import { bg, time } from "$lib/utils/formatting";
 
   interface GlucoseDataPoint {
     time: Date;
@@ -209,10 +209,7 @@
           ticks={4}
           format={(v) =>
             v instanceof Date
-              ? v.toLocaleTimeString([], {
-                  hour: "numeric",
-                  minute: "2-digit",
-                })
+              ? time(v)
               : String(v)}
           tickLabelProps={{ class: "text-[9px] fill-muted-foreground" }}
         />

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentDisambiguationDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentDisambiguationDialog.svelte
@@ -4,6 +4,7 @@
   import { Badge } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
   import * as Dialog from "$lib/components/ui/dialog";
+  import { time } from "$lib/utils/formatting";
 
   interface Props {
     open: boolean;
@@ -60,10 +61,7 @@
             </div>
             <div class="text-xs text-muted-foreground">
               {entry.data.mills
-                ? new Date(entry.data.mills).toLocaleTimeString([], {
-                    hour: "numeric",
-                    minute: "2-digit",
-                  })
+                ? time(entry.data.mills)
                 : ""}
             </div>
           </div>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentInspectionDialog.svelte
@@ -3,7 +3,7 @@
   import { Badge } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
   import { Activity, Syringe, Pencil } from "lucide-svelte";
-  import { bg, bgLabel } from "$lib/utils/formatting";
+  import { bg, bgLabel, time } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
   import type { PredictionData } from "$api/predictions.remote";
   import type { BolusCalculation } from "$lib/api";
@@ -230,11 +230,7 @@
         {/if}
       </Dialog.Title>
       <Dialog.Description>
-        {timestamp.toLocaleTimeString([], {
-          hour: "numeric",
-          minute: "2-digit",
-          second: "2-digit",
-        })}
+        {time(timestamp, { seconds: true })}
         &mdash;
         {timestamp.toLocaleDateString([], {
           month: "short",
@@ -383,10 +379,7 @@
                 </div>
                 <div class="text-xs text-muted-foreground">
                   {record.data.mills
-                    ? new Date(record.data.mills).toLocaleTimeString([], {
-                        hour: "numeric",
-                        minute: "2-digit",
-                      })
+                    ? time(record.data.mills)
                     : ""}
                 </div>
               </div>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/axis-ticks.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/axis-ticks.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { scaleTime } from "d3-scale";
+import { hourTicks } from "./axis-ticks";
+import { hourLabel } from "$lib/utils/formatting";
+
+// The dashboard's blocking window; see the page loader's INITIAL_HOURS.
+function window(hours: number, width = 960) {
+  const end = new Date(2026, 7, 29, 21, 0);
+  const start = new Date(end.getTime() - hours * 60 * 60 * 1000);
+  return scaleTime().domain([start, end]).range([0, width]);
+}
+
+describe("hourTicks", () => {
+  it("keeps only ticks that land on an hour", () => {
+    for (const hours of [1, 3, 6, 24, 48]) {
+      const ticks = hourTicks(window(hours));
+      expect(ticks.length, `${hours}h`).toBeGreaterThan(0);
+      for (const t of ticks) {
+        expect([t.getMinutes(), t.getSeconds(), t.getMilliseconds()]).toEqual([
+          0, 0, 0,
+        ]);
+      }
+    }
+  });
+
+  // A custom `format` function makes layerchart skip filterTicksByFormat, so the
+  // scale's raw sub-hour ticks would each render the same hour label twice in a
+  // row. A window longer than a day repeats an hour on the next day, which is
+  // why this checks neighbours rather than uniqueness.
+  it("never labels two neighbouring ticks the same", () => {
+    for (const hours of [1, 3, 6, 24, 48]) {
+      const labels = hourTicks(window(hours)).map(hourLabel);
+      const repeated = labels.filter((l, i) => i > 0 && l === labels[i - 1]);
+      expect(repeated, `${hours}h`).toEqual([]);
+    }
+  });
+
+  it("scales the tick count with the axis width", () => {
+    const narrow = hourTicks(window(24, 320));
+    const wide = hourTicks(window(24, 1600));
+    expect(wide.length).toBeGreaterThan(narrow.length);
+  });
+
+  it("still yields ticks on a very narrow axis", () => {
+    expect(hourTicks(window(6, 40)).length).toBeGreaterThan(0);
+  });
+});

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/axis-ticks.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/axis-ticks.ts
@@ -1,0 +1,32 @@
+import { timeHour } from "d3-time";
+
+/**
+ * The part of a scale this needs. Written structurally rather than as
+ * layerchart's `AnyScale`, which the package does not export from its root, and
+ * loosely enough that `AnyScale` is assignable to it — a `ticks` prop is called
+ * with the scale, so a narrower parameter would not typecheck.
+ */
+type TickScale = {
+  range: () => unknown[];
+  ticks?: (count?: number) => unknown[];
+};
+
+/**
+ * Ticks for an hour-labelled time axis: the scale's own ticks, thinned to the
+ * ones that land on an hour.
+ *
+ * layerchart derives this itself from `format="hour"`, but only for its built-in
+ * format names — `filterTicksByFormat` hands a custom formatter's ticks back
+ * untouched, so an hour label would repeat on every sub-hour tick. `spacing`
+ * mirrors Axis's own default for a bottom placement.
+ *
+ * Assumes a local-time scale, matching the chart's `scaleTime()`; a `scaleUtc()`
+ * would need `utcHour`, whose UTC-midnight ticks local intervals never floor to.
+ */
+export function hourTicks(scale: TickScale, spacing = 80): Date[] {
+  if (typeof scale.ticks !== "function") return [];
+
+  const [start, end] = scale.range() as number[];
+  const count = Math.max(2, Math.round(Math.abs(end - start) / spacing));
+  return (scale.ticks(count) as Date[]).filter((d) => +timeHour.floor(d) === +d);
+}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/TrackerExpirationMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/TrackerExpirationMarker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { TrackerCategoryIcon } from "$lib/components/icons";
   import type { TrackerCategory } from "$lib/api";
+  import { time as formatTime } from "$lib/utils/formatting";
 
   interface Props {
     xPos: number;
@@ -54,9 +55,6 @@
     text-anchor="start"
     class="text-[7px] fill-muted-foreground font-medium"
   >
-    {time.toLocaleTimeString([], {
-      hour: "numeric",
-      minute: "2-digit",
-    })}
+    {formatTime(time)}
   </text>
 </g>

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -179,17 +179,38 @@ export function prefersHour12(override?: boolean): boolean {
 /**
  * Format a time using the global time format and language preferences
  * @param date - Date object or Unix milliseconds
- * @param compact - If true, use numeric minutes in 12h mode
+ * @param opts.compact - If true, use numeric minutes in 12h mode
+ * @param opts.seconds - If true, append 2-digit seconds
  * @returns Formatted time string (e.g. "2:30 pm" or "14:30")
  */
-export function time(date: Date | number, compact?: boolean): string {
+export function time(
+  date: Date | number,
+  opts: { compact?: boolean; seconds?: boolean } = {}
+): string {
   const d = typeof date === "number" ? new Date(date) : date;
   const options: Intl.DateTimeFormatOptions = {
     hour: "numeric",
-    minute: compact && prefersHour12() ? "numeric" : "2-digit",
+    minute: opts.compact && prefersHour12() ? "numeric" : "2-digit",
     hour12: prefersHour12(),
   };
+  if (opts.seconds) options.second = "2-digit";
   return d.toLocaleTimeString(formatLocale(), options);
+}
+
+/**
+ * Format an hour-granularity label using the global time format and language
+ * preferences. Chart time axes tick on the hour, where `time`'s minutes are
+ * noise; layerchart's own `format="hour"` emits no hour12 token and so falls
+ * back to the browser locale, ignoring the preference entirely.
+ * @param date - Date object or Unix milliseconds
+ * @returns Formatted hour string (e.g. "2 pm" or "14")
+ */
+export function hourLabel(date: Date | number): string {
+  const d = typeof date === "number" ? new Date(date) : date;
+  return d.toLocaleTimeString(formatLocale(), {
+    hour: "numeric",
+    hour12: prefersHour12(),
+  });
 }
 
 /**

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -203,7 +203,8 @@ export function time(
  * noise; layerchart's own `format="hour"` emits no hour12 token and so falls
  * back to the browser locale, ignoring the preference entirely.
  * @param date - Date object or Unix milliseconds
- * @returns Formatted hour string (e.g. "2 pm" or "14")
+ * @returns Formatted hour string (e.g. "2 pm", or "14" — 24-hour output is
+ * zero-padded and may carry a locale suffix, e.g. "09" or "09 Uhr")
  */
 export function hourLabel(date: Date | number): string {
   const d = typeof date === "number" ? new Date(date) : date;

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
@@ -23,7 +23,7 @@
   } from "lucide-svelte";
   import { getDayInReviewData } from "./data.remote";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
-  import { formatGlucoseValue, getUnitLabel } from "$lib/utils/formatting";
+  import { formatGlucoseValue, getUnitLabel, time } from "$lib/utils/formatting";
   import {
     getRowTypeStyle,
     mergeTreatmentRows,
@@ -503,12 +503,7 @@
                 onclick={() => handleTreatmentClick(row)}
               >
                 <Table.Cell class="font-medium">
-                  {row.mills
-                    ? new Date(row.mills).toLocaleTimeString(undefined, {
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })
-                    : "—"}
+                  {row.mills ? time(row.mills) : "—"}
                 </Table.Cell>
                 <Table.Cell>
                   <Badge


### PR DESCRIPTION
The glucose chart ignored the app's 12/24-hour time preference everywhere.

The time axis passed layerchart's `format="hour"`, whose token set carries no `hour12` token, so Intl fell back to the browser locale and `timeFormat` was never consulted. The tooltip header did the same via `format="minute"`, and the zoom indicator, the five inspection dialogs, the tracker marker and the day-in-review table each called `toLocaleTimeString` with hand-written options and no `hour12` at all.

The preference therefore reached the settings page and the mini overview strip — which already formats through `time()` — but not the chart sitting directly above it.

All of them now route through the shared helpers. Adds `hourLabel` for hour-granularity axis ticks, where `time`'s minutes are noise, and gives `time` a `seconds` option so the inspection dialogs stop hand-rolling their own options object. No caller ever passed the old `compact` boolean, so widening that parameter is safe.

## The axis fix needed a second half

Swapping `format="hour"` for a formatter function changes **which ticks are drawn**, not just how they read. `Axis.shared.svelte.js` runs `filterTicksByFormat`, and `utils/ticks.js` only filters for layerchart's own format names — a `CustomFormatter` falls through to `return tickVals`.

So the first commit alone left the scale's sub-hour ticks in place, each rendering an hour label: `3 PM | 3 PM | 4 PM | 4 PM` on the dashboard's 6-hour window, and one hour repeated a dozen times when zoomed in. `hourTicks` restores the two-step behaviour — the scale's own ticks at `Axis`'s default 80px spacing, then only the ones on an hour.

Also routes the axis-anchored time chip through `time()`; it still carried `format="minute"` and so disagreed with the tooltip header directly above it.

## Testing

New: 4 `hourTicks` tests covering 1/3/6/24/48-hour windows and axis widths from 40px to 1600px, asserting no two neighbouring ticks share a label. The `ZoomIndicator` test now exercises both clock directions, because whichever one matches the browser's own locale would pass without the preference being consulted at all — the 12-hour direction is the discriminating one in CI.

Both mutation-proven. `pnpm check` unchanged at its 53-error baseline.
