### PR TITLE
fix(web): draw treatment markers as Trio-style triangles

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
@@ -75,18 +75,18 @@ describe("glucose-chart mark registration", () => {
 	it("keeps marker glyph geometry and classes", async () => {
 		const { container } = await renderAt(1);
 
-		// Bolus override triangle (i % 3 === 0).
+		// Bolus override triangle (i % 3 === 0), pointing down at the baseline.
 		const triangle = container.querySelector<SVGPolygonElement>(
-			"polygon[points='0,12 -8,0 8,0']",
+			"polygon[points='-8,-12 8,-12 0,0']",
 		);
 		expect(triangle).not.toBeNull();
 		expect(triangle?.getAttribute("class")).toBe(
 			"opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity",
 		);
 
-		// Carb bowl.
+		// Carb triangle, pointing up at the same baseline.
 		expect(
-			container.querySelector("path[d='M -8,0 A 8,8 0 0,0 8,0 Z']"),
+			container.querySelector("polygon[points='-8,8 8,8 0,0']"),
 		).not.toBeNull();
 
 		// Tracker pill.

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BasalInjectionMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BasalInjectionMarker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Syringe } from "lucide-svelte";
+  import { trianglePoints } from "$lib/components/icons/marker-shapes";
 
   interface Props {
     xPos: number;
@@ -41,12 +41,11 @@
     stroke-width="1"
     opacity={0.9}
   />
-  <!-- Syringe icon via foreignObject -->
-  <foreignObject x="-22" y="-7" width="14" height="14">
-    <div class="flex items-center justify-center w-full h-full">
-      <Syringe size={10} class="text-indigo-600 dark:text-indigo-400" />
-    </div>
-  </foreignObject>
+  <!-- Triangle pointing along the time axis, sized to sit inside the pill -->
+  <polygon
+    points={trianglePoints("right", 5, 9, -10, 0)}
+    class="fill-indigo-600 dark:fill-indigo-400"
+  />
   <!-- Units label -->
   <text
     x={2}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
@@ -30,6 +30,10 @@
   // Algorithm-delivered doses (SMBs / auto-boluses) render outlined so they read
   // distinctly from a user-initiated (filled) bolus. Category comes from the
   // backend; the frontend only picks the shape.
+  //
+  // Fill and height are independent: a dose that is both automatic and a manual
+  // override draws outlined *and* tall, where the two used to be exclusive
+  // branches and the override silhouette won.
   const isAutomatic = $derived(
     bolusType === "AutomaticBolus" || bolusType === "Smb",
   );

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
@@ -1,4 +1,11 @@
 <script lang="ts">
+  import {
+    trianglePoints,
+    MARKER_HALF_WIDTH,
+    MARKER_HEIGHT,
+    MARKER_HEIGHT_OVERRIDE,
+  } from "$lib/components/icons/marker-shapes";
+
   interface Props {
     xPos: number;
     yPos: number;
@@ -20,11 +27,19 @@
     onMarkerClick,
   }: Props = $props();
 
-  // Algorithm-delivered doses (SMBs / auto-boluses) render as an outlined dome so
-  // they read distinctly from a user-initiated (filled) bolus. Category comes from
-  // the backend; the frontend only picks the shape.
+  // Algorithm-delivered doses (SMBs / auto-boluses) render outlined so they read
+  // distinctly from a user-initiated (filled) bolus. Category comes from the
+  // backend; the frontend only picks the shape.
   const isAutomatic = $derived(
     bolusType === "AutomaticBolus" || bolusType === "Smb",
+  );
+
+  const points = $derived(
+    trianglePoints(
+      "down",
+      MARKER_HALF_WIDTH,
+      isOverride ? MARKER_HEIGHT_OVERRIDE : MARKER_HEIGHT,
+    ),
   );
 </script>
 
@@ -35,24 +50,16 @@
   onclick={() => onMarkerClick(treatmentId)}
   class="cursor-pointer"
 >
-  {#if isOverride}
-    <!-- Triangle for manual override -->
+  {#if isAutomatic}
     <polygon
-      points="0,12 -8,0 8,0"
-      class="opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity"
-    />
-  {:else if isAutomatic}
-    <!-- Outlined dome for algorithm-delivered doses (SMB / auto-bolus) -->
-    <path
-      d="M -8,0 A 8,8 0 0,1 8,0 Z"
+      {points}
       fill="none"
       class="stroke-insulin-bolus opacity-90 hover:opacity-100 transition-opacity"
       stroke-width="1.5"
     />
   {:else}
-    <!-- Hemisphere (dome shape - curves above baseline) -->
-    <path
-      d="M -8,0 A 8,8 0 0,1 8,0 Z"
+    <polygon
+      {points}
       class="opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity"
     />
   {/if}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
@@ -1,4 +1,10 @@
 <script lang="ts">
+  import {
+    trianglePoints,
+    MARKER_HALF_WIDTH,
+    MARKER_HEIGHT,
+  } from "$lib/components/icons/marker-shapes";
+
   interface Props {
     xPos: number;
     yPos: number;
@@ -30,9 +36,8 @@
       {label}
     </text>
   {/if}
-  <!-- Hemisphere (bowl shape - curves below baseline) -->
-  <path
-    d="M -8,0 A 8,8 0 0,0 8,0 Z"
+  <polygon
+    points={trianglePoints("up", MARKER_HALF_WIDTH, MARKER_HEIGHT)}
     fill="var(--carbs)"
     class="opacity-90 hover:opacity-100 transition-opacity"
   />

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/IobCobTrack.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/IobCobTrack.svelte
@@ -66,9 +66,9 @@
   {@const iobZero = iobCobLayout.zero}
   {@const iobTrackTop = iobCobLayout.top}
   {@const iobAxisScale = iobCobLayout.axisScale}
-  <!-- Treatment markers share one baseline so a bolus (dome above) and a carb
-       entry (bowl below) at the same time meet at their flat edge and form a
-       single circle. Magnitude is conveyed by the marker labels, not height. -->
+  <!-- Treatment markers share one baseline so a bolus (pointing down from above)
+       and a carb entry (pointing up from below) at the same time meet apex to
+       apex. Magnitude is conveyed by the marker labels, not height. -->
   {@const markerBaselineY = (iobCobLayout.top + iobCobLayout.bottom) / 2}
 
   <!-- IOB axis on right -->

--- a/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
@@ -2,8 +2,9 @@
   /**
    * Bolus marker icon — a triangle pointing down at the baseline. Used for bolus
    * treatment markers in legends and stat cards; the chart draws the same shape
-   * from <see>marker-shapes</see>. When isOverride is true it is taller, matching
-   * the chart's manual-override marker.
+   * from <see>marker-shapes</see>. When isOverride is true it is taller, echoing
+   * the chart's manual-override marker — scaled to the icon box rather than
+   * sharing the chart's pixel height.
    */
   import type { IconProps } from "./types";
   import { trianglePoints } from "./marker-shapes";

--- a/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
   /**
-   * Bolus hemisphere icon - dome shape curving above baseline. Used for bolus
-   * treatment markers on charts and in legends. When isOverride is true,
-   * displays a triangle instead to indicate manual override.
+   * Bolus marker icon — a triangle pointing down at the baseline. Used for bolus
+   * treatment markers in legends and stat cards; the chart draws the same shape
+   * from <see>marker-shapes</see>. When isOverride is true it is taller, matching
+   * the chart's manual-override marker.
    */
   import type { IconProps } from "./types";
+  import { trianglePoints } from "./marker-shapes";
 
   interface BolusIconProps extends IconProps {
-    /**
-     * Whether this bolus was a manual override (shows triangle instead of
-     * hemisphere)
-     */
+    /** Whether this bolus was a manual override (taller triangle) */
     isOverride?: boolean;
   }
 
@@ -25,6 +24,7 @@
   // Scale factor based on default 12px reference size
   const scale = $derived(size / 12);
   const radius = $derived(6 * scale);
+  const height = $derived(isOverride ? size / 2 + 2 : size / 2);
 </script>
 
 <svg
@@ -34,19 +34,8 @@
   class={className}
   {...rest}
 >
-  {#if isOverride}
-    <!-- Triangle for manual override -->
-    <polygon
-      points="{size / 2},{size / 2} {size / 2 - radius},{0} {size / 2 +
-        radius},{0}"
-      fill={color}
-    />
-  {:else}
-    <!-- Hemisphere (dome shape - curves above baseline) -->
-    <path
-      d="M {size / 2 - radius},{size / 2} A {radius},{radius} 0 0,1 {size / 2 +
-        radius},{size / 2} Z"
-      fill={color}
-    />
-  {/if}
+  <polygon
+    points={trianglePoints("down", radius, height, size / 2, size / 2 + 2)}
+    fill={color}
+  />
 </svg>

--- a/src/Web/packages/app/src/lib/components/icons/CarbsIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/CarbsIcon.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   /**
-   * Carbs hemisphere icon - bowl shape curving below baseline. Used for carb
-   * treatment markers on charts and in legends. Complements BolusIcon to form a
-   * complete circle when both are present.
+   * Carbs marker icon — a triangle pointing up at the baseline. Used for carb
+   * treatment markers in legends and stat cards; the chart draws the same shape
+   * from <see>marker-shapes</see>. Complements BolusIcon, which points down at
+   * the same baseline.
    */
   import type { IconProps } from "./types";
+  import { trianglePoints } from "./marker-shapes";
 
   let {
     size = 16,
@@ -25,10 +27,8 @@
   class={className}
   {...rest}
 >
-  <!-- Hemisphere (bowl shape - curves below baseline) -->
-  <path
-    d="M {size / 2 - radius},{0} A {radius},{radius} 0 0,0 {size / 2 +
-      radius},{0} Z"
+  <polygon
+    points={trianglePoints("up", radius, size / 2, size / 2, 0)}
     fill={color}
   />
 </svg>

--- a/src/Web/packages/app/src/lib/components/icons/index.ts
+++ b/src/Web/packages/app/src/lib/components/icons/index.ts
@@ -2,7 +2,8 @@
  * Semantic icon components for diabetes-related events and states
  *
  * Device event and therapy icons use AAPS (AndroidAPS) SVG paths.
- * Chart marker icons (BolusIcon, CarbsIcon) use custom hemisphere shapes.
+ * Chart marker icons (BolusIcon, CarbsIcon) use the shared triangle geometry
+ * in marker-shapes.ts, so they match what the chart draws.
  *
  * NOTE: For SVG chart contexts (inside <svg>), use the raw SVG paths defined
  * in GlucoseChartCard.svelte since Lucide components render their own <svg>.

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { trianglePoints } from "./marker-shapes";
+
+/** Parse an SVG points string into [x, y] pairs. */
+function parse(points: string): [number, number][] {
+  return points
+    .trim()
+    .split(/\s+/)
+    .map((pair) => pair.split(",").map(Number) as [number, number]);
+}
+
+describe("trianglePoints", () => {
+  it("anchors every direction on the apex", () => {
+    for (const direction of ["down", "up", "right"] as const) {
+      const pts = parse(trianglePoints(direction, 8, 10, 30, 40));
+      expect(pts, direction).toHaveLength(3);
+      expect(pts.at(-1), direction).toEqual([30, 40]);
+    }
+  });
+
+  it("hangs a down triangle above its apex", () => {
+    // SVG y grows downward, so the base sits at a smaller y than the apex.
+    const [a, b, apex] = parse(trianglePoints("down", 8, 10));
+    expect(a).toEqual([-8, -10]);
+    expect(b).toEqual([8, -10]);
+    expect(apex).toEqual([0, 0]);
+  });
+
+  it("hangs an up triangle below its apex", () => {
+    const [a, b, apex] = parse(trianglePoints("up", 8, 10));
+    expect(a).toEqual([-8, 10]);
+    expect(b).toEqual([8, 10]);
+    expect(apex).toEqual([0, 0]);
+  });
+
+  it("puts a right triangle's base to the left of its apex", () => {
+    const [a, b, apex] = parse(trianglePoints("right", 5, 9));
+    expect(a).toEqual([-9, -5]);
+    expect(b).toEqual([-9, 5]);
+    expect(apex).toEqual([0, 0]);
+  });
+
+  it("makes a bolus and a carb marker meet apex to apex on one baseline", () => {
+    // The chart draws both at the same y; they must not overlap.
+    const bolus = parse(trianglePoints("down", 8, 8));
+    const carbs = parse(trianglePoints("up", 8, 8));
+
+    expect(Math.max(...bolus.map(([, y]) => y))).toBe(0);
+    expect(Math.min(...carbs.map(([, y]) => y))).toBe(0);
+  });
+});

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
@@ -1,0 +1,34 @@
+/**
+ * Treatment marker geometry, shared by the chart markers and the legend/stat
+ * icons so the two cannot drift apart.
+ *
+ * Every triangle is anchored on its apex, which is what the marker points at:
+ * a bolus hangs above the baseline pointing down at it, carbs sit below
+ * pointing up at it, so a simultaneous pair meets apex to apex.
+ */
+export type MarkerDirection = "down" | "up" | "right";
+
+export function trianglePoints(
+  direction: MarkerDirection,
+  halfWidth: number,
+  height: number,
+  apexX = 0,
+  apexY = 0
+): string {
+  const apex = `${apexX},${apexY}`;
+  switch (direction) {
+    case "down":
+      return `${apexX - halfWidth},${apexY - height} ${apexX + halfWidth},${apexY - height} ${apex}`;
+    case "up":
+      return `${apexX - halfWidth},${apexY + height} ${apexX + halfWidth},${apexY + height} ${apex}`;
+    case "right":
+      return `${apexX - height},${apexY - halfWidth} ${apexX - height},${apexY + halfWidth} ${apex}`;
+  }
+}
+
+/** Half-width and height of a chart treatment marker, in chart pixels. */
+export const MARKER_HALF_WIDTH = 8;
+export const MARKER_HEIGHT = 8;
+
+/** A manually overridden bolus keeps the taller silhouette it had before. */
+export const MARKER_HEIGHT_OVERRIDE = 12;


### PR DESCRIPTION
Bolus and carbs rendered as hemispheres facing away from each other — a dome above the baseline for insulin and a bowl below it for carbs — so the pair read back to front against the convention Trio and Loop use.

Both become triangles anchored on their apex: a blue one hanging above the baseline pointing down for a bolus, an orange one below pointing up for carbs, so a simultaneous pair still meets on one baseline without overlapping. Basal injections swap their syringe glyph for a triangle pointing along the time axis.

Colours are untouched — `--insulin-bolus` is already blue and `--carbs` already orange in every theme.

## Why a shared module

The chart markers and the legend/stat-card icons each drew their own copy of the shape and could drift, so the geometry moves into `marker-shapes.ts` and both consume it.

## Two behaviour notes

- A manually overridden bolus keeps the taller silhouette that previously distinguished it, since the shape it used to be distinguished by is now what every bolus looks like.
- Fill and height are now independent: a dose that is both automatic and a manual override draws outlined *and* tall, where the two used to be exclusive branches and the override silhouette won.

This also fixes a pre-existing overlap — the old override polygon `points="0,12 -8,0 8,0"` hung *below* the baseline and collided with the carb bowl whenever a bolus and carb landed at the same time.

## Testing

New: 5 geometry tests covering the apex-anchored invariant, all three directions, and the non-overlap property. The existing `mark-registration` glyph assertions are updated to the new shapes, keeping their intent (markers stay native SVG rather than layerchart marks).

Geometry was verified to sit inside each icon's viewBox at the sizes actually used (16 and 20), and inside the basal marker's background pill. `pnpm check` unchanged at its 53-error baseline.

## Not addressed here

`src/Web/packages/glucose-chart/` still draws the old dome/bowl shapes. Nothing imports it, so the app and that package now disagree.
