### PR TITLE
fix(web): stop /alerts pegging the renderer on a tenant with data

### DIFF
--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
@@ -400,7 +400,7 @@
               <BasalTrack />
             {/if}
             <ThresholdRules />
-            <GlucoseTrack />
+            <GlucoseTrack showPoints={false} />
             {#if backgroundChart.chartConfig?.showPredictions ?? false}
               <PredictionTrack />
             {/if}
@@ -463,7 +463,7 @@
                         <BasalTrack />
                       {/if}
                       <ThresholdRules />
-                      <GlucoseTrack />
+                      <GlucoseTrack showPoints={false} />
                       {#if element.chartConfig?.showPredictions ?? false}
                         <PredictionTrack />
                       {/if}

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
@@ -391,6 +391,7 @@
       {@const bgChartEngine = createChartDataEngine({
         focusHours: backgroundChart.hours || 3,
         enablePredictions: backgroundChart.chartConfig?.showPredictions ?? false,
+        dataWindow: "display",
       })}
       <div class="absolute inset-0 z-0">
         <GlucoseChartShell engine={bgChartEngine} heightClass="h-full">
@@ -450,6 +451,7 @@
                 {@const inlineEngine = createChartDataEngine({
                   focusHours: element.hours || 3,
                   enablePredictions: element.chartConfig?.showPredictions ?? false,
+                  dataWindow: "display",
                 })}
                 <div
                   class="overflow-hidden rounded"

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine-harness.test.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine-harness.test.svelte
@@ -26,8 +26,11 @@
     pingTimeout: 0,
     pingInterval: 0,
   });
+  // Read once, deliberately: each test mounts the harness with the props it wants
+  // and never changes them, so there is nothing for a closure to track.
   // svelte-ignore state_referenced_locally
   store.entries = entries;
 
+  // svelte-ignore state_referenced_locally
   onengine(createChartDataEngine(options));
 </script>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine-harness.test.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine-harness.test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  // Test-only harness: the engine reads the realtime store out of context and
+  // registers effects, both of which need a real component lifecycle. Hands the
+  // engine back to the test.
+  import { createRealtimeStore } from "$lib/stores/realtime-store.svelte";
+  import type { Entry } from "$lib/websocket/types";
+  import { createChartDataEngine } from "./chart-data-engine.svelte";
+  import type {
+    ChartDataEngine,
+    ChartDataEngineOptions,
+  } from "./chart-data-engine.svelte";
+
+  interface Props {
+    entries: Entry[];
+    options: ChartDataEngineOptions;
+    onengine: (engine: ChartDataEngine) => void;
+  }
+
+  let { entries, options, onengine }: Props = $props();
+
+  const store = createRealtimeStore({
+    url: "",
+    reconnectAttempts: 0,
+    reconnectDelay: 0,
+    maxReconnectDelay: 0,
+    pingTimeout: 0,
+    pingInterval: 0,
+  });
+  // svelte-ignore state_referenced_locally
+  store.entries = entries;
+
+  onengine(createChartDataEngine(options));
+</script>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.test.ts
@@ -45,7 +45,7 @@ const entries = [
   reading(30 * 60, 140),
 ];
 
-async function engineFor(options: ChartDataEngineOptions) {
+async function glucoseOf(options: ChartDataEngineOptions) {
   let engine!: ChartDataEngine;
   render(Harness, {
     props: {
@@ -57,11 +57,6 @@ async function engineFor(options: ChartDataEngineOptions) {
 
   // The engine fetches its server half in an effect; nothing merges until it lands.
   await vi.waitFor(() => expect(engine.serverChartData).not.toBeNull());
-  return engine;
-}
-
-async function glucoseOf(options: ChartDataEngineOptions) {
-  const engine = await engineFor(options);
   return engine.glucoseData.map((p) => p.sgv).sort((a, b) => a - b);
 }
 
@@ -87,44 +82,32 @@ describe("chart data engine — realtime merge window", () => {
     expect(sgvs).toEqual([110, 120, 130, 140]);
   });
 
-  it("keeps the full buffer for a consumer that preloaded one", async () => {
-    const sgvs = await glucoseOf({
-      focusHours: 3,
-      enablePredictions: false,
-      initialChartData: served,
-    });
+  it("includes a reading sitting exactly on either bound", async () => {
+    // The bounds are the caller's own instants here, so both comparisons can be
+    // pinned without depending on where the minute happens to have ticked.
+    const from = Date.now() - 5 * HOUR;
+    const to = Date.now() - 1 * HOUR;
 
-    expect(sgvs).toEqual([110, 120, 130, 140]);
-  });
-
-  it("keeps an explicitly requested range", async () => {
-    const sgvs = await glucoseOf({
-      focusHours: 3,
-      enablePredictions: false,
-      dateRange: {
-        from: new Date(Date.now() - 40 * HOUR),
-        to: new Date(Date.now() + HOUR),
+    let engine!: ChartDataEngine;
+    render(Harness, {
+      props: {
+        entries: [
+          { _id: "before", type: "sgv", mills: from - 1, sgv: 60 },
+          { _id: "on-from", type: "sgv", mills: from, sgv: 70 },
+          { _id: "on-to", type: "sgv", mills: to, sgv: 80 },
+          { _id: "after", type: "sgv", mills: to + 1, sgv: 90 },
+        ],
+        options: {
+          enablePredictions: false,
+          dateRange: { from: new Date(from), to: new Date(to) },
+        },
+        onengine: (e: ChartDataEngine) => (engine = e),
       },
     });
+    await vi.waitFor(() => expect(engine.serverChartData).not.toBeNull());
 
-    expect(sgvs).toEqual([110, 120, 130, 140]);
-  });
-});
-
-describe("chart data engine — reference stability", () => {
-  // Svelte re-executes a derived it has flagged dirty on every read while more
-  // than one batch is alive, so a merge that allocated per read republished a new
-  // array each time and re-dirtied every chart scale reading it — the loop in
-  // #995. Repeated reads with unchanged inputs must hand back one instance.
-  it("hands out the same series until its inputs change", async () => {
-    const engine = await engineFor({
-      focusHours: 3,
-      enablePredictions: false,
-      dataWindow: "display",
-    });
-
-    const first = engine.glucoseData;
-    expect(engine.glucoseData).toBe(first);
-    expect(engine.glucoseData).toBe(first);
+    expect(engine.glucoseData.map((p) => p.sgv).sort((a, b) => a - b)).toEqual([
+      70, 80,
+    ]);
   });
 });

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.test.ts
@@ -45,7 +45,7 @@ const entries = [
   reading(30 * 60, 140),
 ];
 
-async function glucoseOf(options: ChartDataEngineOptions) {
+async function engineFor(options: ChartDataEngineOptions) {
   let engine!: ChartDataEngine;
   render(Harness, {
     props: {
@@ -57,21 +57,37 @@ async function glucoseOf(options: ChartDataEngineOptions) {
 
   // The engine fetches its server half in an effect; nothing merges until it lands.
   await vi.waitFor(() => expect(engine.serverChartData).not.toBeNull());
+  return engine;
+}
+
+async function glucoseOf(options: ChartDataEngineOptions) {
+  const engine = await engineFor(options);
   return engine.glucoseData.map((p) => p.sgv).sort((a, b) => a - b);
 }
 
 describe("chart data engine — realtime merge window", () => {
-  it("gives a self-fetching consumer only the window it displays", async () => {
-    // The sidebar widget and the clock face: no range, no preloaded data, so the
-    // engine fetched three hours and must not merge readings from outside it.
-    const sgvs = await glucoseOf({ focusHours: 3, enablePredictions: false });
+  it("reaches no further than a display-window consumer draws", async () => {
+    // The sidebar sparkline and the clock faces render `displayDateRange` and
+    // nothing wider, so readings outside it are points they would never draw.
+    const sgvs = await glucoseOf({
+      focusHours: 3,
+      enablePredictions: false,
+      dataWindow: "display",
+    });
 
     expect(sgvs).toEqual([110, 120]);
   });
 
+  it("keeps the full buffer by default", async () => {
+    // Anything that renders `fullXDomain` — GlucoseChartCard's mini overview —
+    // draws 48 hours whether or not it was handed them up front, so a consumer
+    // that says nothing must keep the wide merge.
+    const sgvs = await glucoseOf({ focusHours: 3, enablePredictions: false });
+
+    expect(sgvs).toEqual([110, 120, 130, 140]);
+  });
+
   it("keeps the full buffer for a consumer that preloaded one", async () => {
-    // The dashboard hands the engine 48 hours via SSR, and its MiniOverview draws
-    // all of it, so the merge has to span the same 48 hours.
     const sgvs = await glucoseOf({
       focusHours: 3,
       enablePredictions: false,
@@ -92,5 +108,23 @@ describe("chart data engine — realtime merge window", () => {
     });
 
     expect(sgvs).toEqual([110, 120, 130, 140]);
+  });
+});
+
+describe("chart data engine — reference stability", () => {
+  // Svelte re-executes a derived it has flagged dirty on every read while more
+  // than one batch is alive, so a merge that allocated per read republished a new
+  // array each time and re-dirtied every chart scale reading it — the loop in
+  // #995. Repeated reads with unchanged inputs must hand back one instance.
+  it("hands out the same series until its inputs change", async () => {
+    const engine = await engineFor({
+      focusHours: 3,
+      enablePredictions: false,
+      dataWindow: "display",
+    });
+
+    const first = engine.glucoseData;
+    expect(engine.glucoseData).toBe(first);
+    expect(engine.glucoseData).toBe(first);
   });
 });

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.test.ts
@@ -1,0 +1,96 @@
+import { render } from "vitest-browser-svelte";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("$api/chart-data.remote", () => ({
+  getChartData: vi.fn(async () => served),
+}));
+vi.mock("$api/predictions.remote", () => ({
+  getPredictions: vi.fn(async () => null),
+  getPredictionStatus: vi.fn(async () => ({ available: false })),
+}));
+
+import { transformChartData } from "$lib/utils/chart-data-transform";
+import type { Entry } from "$lib/websocket/types";
+import Harness from "./chart-data-engine-harness.test.svelte";
+import type {
+  ChartDataEngine,
+  ChartDataEngineOptions,
+} from "./chart-data-engine.svelte";
+
+// The server half of the merge is deliberately empty, so every point the engine
+// produces came from the realtime store and the window under test is the only
+// thing deciding which ones survive.
+const served = transformChartData({});
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+
+function reading(minutesAgo: number, sgv: number): Entry {
+  return {
+    _id: `e-${minutesAgo}`,
+    type: "sgv",
+    mills: Date.now() - minutesAgo * MINUTE,
+    sgv,
+  };
+}
+
+/**
+ * The realtime store holds the last 1000 readings — several days' worth — so
+ * what bounds the merge decides how much of that a chart is handed.
+ */
+const entries = [
+  reading(10, 110),
+  reading(120, 120),
+  reading(6 * 60, 130),
+  reading(30 * 60, 140),
+];
+
+async function glucoseOf(options: ChartDataEngineOptions) {
+  let engine!: ChartDataEngine;
+  render(Harness, {
+    props: {
+      entries,
+      options,
+      onengine: (e: ChartDataEngine) => (engine = e),
+    },
+  });
+
+  // The engine fetches its server half in an effect; nothing merges until it lands.
+  await vi.waitFor(() => expect(engine.serverChartData).not.toBeNull());
+  return engine.glucoseData.map((p) => p.sgv).sort((a, b) => a - b);
+}
+
+describe("chart data engine — realtime merge window", () => {
+  it("gives a self-fetching consumer only the window it displays", async () => {
+    // The sidebar widget and the clock face: no range, no preloaded data, so the
+    // engine fetched three hours and must not merge readings from outside it.
+    const sgvs = await glucoseOf({ focusHours: 3, enablePredictions: false });
+
+    expect(sgvs).toEqual([110, 120]);
+  });
+
+  it("keeps the full buffer for a consumer that preloaded one", async () => {
+    // The dashboard hands the engine 48 hours via SSR, and its MiniOverview draws
+    // all of it, so the merge has to span the same 48 hours.
+    const sgvs = await glucoseOf({
+      focusHours: 3,
+      enablePredictions: false,
+      initialChartData: served,
+    });
+
+    expect(sgvs).toEqual([110, 120, 130, 140]);
+  });
+
+  it("keeps an explicitly requested range", async () => {
+    const sgvs = await glucoseOf({
+      focusHours: 3,
+      enablePredictions: false,
+      dateRange: {
+        from: new Date(Date.now() - 40 * HOUR),
+        to: new Date(Date.now() + HOUR),
+      },
+    });
+
+    expect(sgvs).toEqual([110, 120, 130, 140]);
+  });
+});

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
@@ -25,6 +25,7 @@ import {
 import { mergeChartData } from "$lib/utils/chart-data-merge";
 import type { TransformedChartData } from "$lib/utils/chart-data-transform";
 import { getGlucoseColor } from "$lib/utils/chart-colors";
+import { stableBy } from "$lib/utils/stable-by";
 import { resolveGlucoseThresholds } from "$lib/constants/glucose-thresholds";
 import { bisector } from "d3";
 
@@ -372,21 +373,40 @@ export function createChartDataEngine(
         : fullDataRange.to,
   });
 
+  // ---- Data range ----
+  // The window this engine's data actually covers. The wider `fullDataRange`
+  // (48h) belongs to consumers that asked for a range or preloaded one — the
+  // MiniOverview on the dashboard, which gets its data via SSR. A consumer that
+  // fetches for itself (sidebar widget, clock face) only ever has the visible
+  // window, and merging realtime readings over the wider one hands its chart
+  // points it will never draw: the sidebar's 3-hour sparkline was being given 48
+  // hours of readings, sixteen times what it renders.
+  const dataRange = $derived(
+    options.dateRange || options.initialChartData
+      ? fullDataRange
+      : displayDateRange
+  );
+
   // ---- Stable fetch range ----
-  // Fetch only the visible window when no dateRange or preloaded data is
-  // configured. The wider `fullDataRange` (48h) is used by the MiniOverview
-  // on the dashboard, which preloads data via SSR — so consumers that hit
-  // this fetch path (sidebar widget, clock face) don't need the full buffer.
+  // Keyed on the rounded bounds so a re-evaluation returns the same window: this
+  // one drives the fetch effect below, and a fresh object from it re-runs that
+  // effect — a chart-data request per read. See the note on `stableBy`.
+  const fetchWindowOf = stableBy((startTime: number, endTime: number) => ({
+    startTime,
+    endTime,
+  }));
+
   const stableFetchRange = $derived.by(() => {
     if (!isBrowser) return null;
-    const range = options.dateRange ? fullDataRange : displayDateRange;
+    const range = dataRange;
     const fromTime = range.from.getTime();
     const toTime = range.to.getTime();
     if (isNaN(fromTime) || isNaN(toTime)) return null;
     const intervalMs = 5 * 60 * 1000;
-    const startRounded = Math.floor(fromTime / intervalMs) * intervalMs;
-    const endRounded = Math.ceil(toTime / intervalMs) * intervalMs;
-    return { startTime: startRounded, endTime: endRounded };
+    return fetchWindowOf(
+      Math.floor(fromTime / intervalMs) * intervalMs,
+      Math.ceil(toTime / intervalMs) * intervalMs
+    );
   });
 
   // ---- Effects: data fetching ----
@@ -538,41 +558,63 @@ export function createChartDataEngine(
   // A keyed {#each} downstream requires a unique key per point, so the same
   // mills value must never appear twice — even if base or realtimeStore
   // emit duplicates.
-  const glucoseData = $derived.by(() => {
-    const base = serverChartData?.glucoseData ?? [];
-    if (!serverChartData) return base as GlucosePoint[];
+  //
+  // Keyed on its four inputs rather than merged on each evaluation. A derived
+  // that Svelte has flagged dirty stays dirty for as long as more than one batch
+  // is alive — which is the whole time a page-level `<svelte:boundary>` is
+  // awaiting — so it is re-executed on *every read*, not once per change. This
+  // is the most-read and most expensive derived in the app, and a fresh array
+  // from it re-dirties the chart's entire scale and extent chain, which then
+  // reads it again. See the note on `stableBy`.
+  const mergeGlucose = stableBy(
+    (
+      chartData: TransformedChartData | null,
+      entries: typeof realtimeStore.entries,
+      fromMs: number,
+      toMs: number
+    ): GlucosePoint[] => {
+      const base = chartData?.glucoseData ?? [];
+      if (!chartData) return base as GlucosePoint[];
 
-    const thresholds = resolveGlucoseThresholds(serverChartData.thresholds);
-    const fromMs = fullDataRange.from.getTime();
-    const toMs = fullDataRange.to.getTime();
+      const thresholds = resolveGlucoseThresholds(chartData.thresholds);
 
-    const byMills = new Map<number, GlucosePoint>();
-    for (const p of base) byMills.set(p.time.getTime(), p);
+      const byMills = new Map<number, GlucosePoint>();
+      for (const p of base) byMills.set(p.time.getTime(), p);
 
-    for (const e of realtimeStore.entries) {
-      if (
-        e.type !== "sgv" ||
-        e.mills == null ||
-        e.sgv == null ||
-        e.mills < fromMs ||
-        e.mills > toMs ||
-        byMills.has(e.mills)
-      ) {
-        continue;
+      for (const e of entries) {
+        if (
+          e.type !== "sgv" ||
+          e.mills == null ||
+          e.sgv == null ||
+          e.mills < fromMs ||
+          e.mills > toMs ||
+          byMills.has(e.mills)
+        ) {
+          continue;
+        }
+        byMills.set(e.mills, {
+          time: new Date(e.mills),
+          sgv: e.sgv,
+          direction: e.direction,
+          dataSource: e.data_source,
+          color: getGlucoseColor(e.sgv, thresholds),
+        });
       }
-      byMills.set(e.mills, {
-        time: new Date(e.mills),
-        sgv: e.sgv,
-        direction: e.direction,
-        dataSource: e.data_source,
-        color: getGlucoseColor(e.sgv, thresholds),
-      });
-    }
 
-    return [...byMills.values()].sort(
-      (a, b) => a.time.getTime() - b.time.getTime()
-    ) as GlucosePoint[];
-  });
+      return [...byMills.values()].sort(
+        (a, b) => a.time.getTime() - b.time.getTime()
+      ) as GlucosePoint[];
+    }
+  );
+
+  const glucoseData = $derived(
+    mergeGlucose(
+      serverChartData,
+      realtimeStore.entries,
+      dataRange.from.getTime(),
+      dataRange.to.getTime()
+    )
+  );
 
   // ---- Series derivations ----
   const bolusMarkers = $derived(

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
@@ -184,15 +184,15 @@ export interface ChartDataEngineOptions {
   enablePredictions?: boolean;
   demoMode?: boolean;
   /**
-   * How wide a window the consumer draws, which is how far the realtime merge
-   * may reach. `"buffer"` is the 48-hour `fullDataRange` that `fullXDomain`
-   * spans — what anything rendering the mini overview needs, whether or not it
-   * was handed that data up front. `"display"` is the visible window alone, for
-   * a consumer that renders nothing wider: the sidebar sparkline, the clock
-   * faces.
+   * How wide a window the consumer draws, and so how far the realtime merge may
+   * reach. `"buffer"` is `fullDataRange` — `dateRange` when one was named, the
+   * 48-hour buffer otherwise — which is what `fullXDomain` spans and therefore
+   * what anything rendering the mini overview needs, however it was fed.
+   * `"display"` is the visible window alone, for a consumer that renders nothing
+   * wider: the sidebar sparkline, the clock faces.
    *
-   * Defaults to `"buffer"`, because over-reaching only costs points a chart
-   * declines to draw, where under-reaching silently drops points it is drawing.
+   * Defaults to `"buffer"`: over-reaching costs points a chart declines to draw,
+   * where under-reaching silently drops points it is drawing.
    */
   dataWindow?: "buffer" | "display";
   /** Fired once when `serverChartData` first becomes non-null. */
@@ -386,12 +386,10 @@ export function createChartDataEngine(
   });
 
   // ---- Data range ----
-  // How far the realtime merge may reach — the window the consumer draws, per
-  // `dataWindow`. The realtime store holds the last 1000 readings, so merging
-  // over `fullDataRange` for a consumer that only draws the visible window hands
-  // its chart points it will never render: the sidebar's 3-hour sparkline was
-  // being given 48 hours of readings, sixteen times what it draws, on every
-  // route, because the widget lives in the sidebar.
+  // How far the realtime merge may reach: the window the consumer draws, per
+  // `dataWindow`. The realtime store holds the last 1000 readings — several days
+  // of them — so merging over `fullDataRange` for a consumer that draws only the
+  // visible window hands its chart points it will never render.
   const dataRange = $derived(
     options.dataWindow === "display" ? displayDateRange : fullDataRange
   );
@@ -401,16 +399,6 @@ export function createChartDataEngine(
   // `fullDataRange` (48h) is used by the MiniOverview on the dashboard, which
   // preloads data via SSR — so consumers that hit this fetch path (sidebar
   // widget, clock face) don't need the full buffer.
-  //
-  // Keyed on the rounded bounds so a re-evaluation returns the same window: a
-  // fresh object here re-runs the fetch effect below, which under `nowMinute`
-  // alone was a chart-data request a minute, defeating the 5-minute rounding.
-  // See the note on `stableBy`.
-  const fetchWindowOf = stableBy((startTime: number, endTime: number) => ({
-    startTime,
-    endTime,
-  }));
-
   const stableFetchRange = $derived.by(() => {
     if (!isBrowser) return null;
     const range = options.dateRange ? fullDataRange : displayDateRange;
@@ -418,10 +406,9 @@ export function createChartDataEngine(
     const toTime = range.to.getTime();
     if (isNaN(fromTime) || isNaN(toTime)) return null;
     const intervalMs = 5 * 60 * 1000;
-    return fetchWindowOf(
-      Math.floor(fromTime / intervalMs) * intervalMs,
-      Math.ceil(toTime / intervalMs) * intervalMs
-    );
+    const startRounded = Math.floor(fromTime / intervalMs) * intervalMs;
+    const endRounded = Math.ceil(toTime / intervalMs) * intervalMs;
+    return { startTime: startRounded, endTime: endRounded };
   });
 
   // ---- Effects: data fetching ----
@@ -575,12 +562,11 @@ export function createChartDataEngine(
   // emit duplicates.
   //
   // Keyed on its four inputs rather than merged on each evaluation. A derived
-  // that Svelte has flagged dirty stays dirty for as long as more than one batch
-  // is alive — which is the whole time a page-level `<svelte:boundary>` is
-  // awaiting — so it is re-executed on *every read*, not once per change. This
-  // is the most-read and most expensive derived in the app, and a fresh array
-  // from it re-dirties the chart's entire scale and extent chain, which then
-  // reads it again. See the note on `stableBy`.
+  // Svelte has flagged dirty stays dirty for as long as more than one batch is
+  // alive — the whole time a page-level `<svelte:boundary>` is awaiting — so it
+  // is re-executed on every read, not once per change. This is the most-read
+  // series in the app, and a fresh array from it re-dirties the chart's entire
+  // extent and scale chain, which reads it again. See the note on `stableBy`.
   const mergeGlucose = stableBy(
     (
       chartData: TransformedChartData | null,

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
@@ -539,7 +539,6 @@ export function createChartDataEngine(
   // mills value must never appear twice — even if base or realtimeStore
   // emit duplicates.
   const glucoseData = $derived.by(() => {
-    $inspect.trace("glucoseData");
     const base = serverChartData?.glucoseData ?? [];
     if (!serverChartData) return base as GlucosePoint[];
 

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
@@ -183,6 +183,18 @@ export interface ChartDataEngineOptions {
   externalPredictionData?: PredictionData | null;
   enablePredictions?: boolean;
   demoMode?: boolean;
+  /**
+   * How wide a window the consumer draws, which is how far the realtime merge
+   * may reach. `"buffer"` is the 48-hour `fullDataRange` that `fullXDomain`
+   * spans — what anything rendering the mini overview needs, whether or not it
+   * was handed that data up front. `"display"` is the visible window alone, for
+   * a consumer that renders nothing wider: the sidebar sparkline, the clock
+   * faces.
+   *
+   * Defaults to `"buffer"`, because over-reaching only costs points a chart
+   * declines to draw, where under-reaching silently drops points it is drawing.
+   */
+  dataWindow?: "buffer" | "display";
   /** Fired once when `serverChartData` first becomes non-null. */
   onDataReady?: () => void;
 }
@@ -374,23 +386,26 @@ export function createChartDataEngine(
   });
 
   // ---- Data range ----
-  // The window this engine's data actually covers. The wider `fullDataRange`
-  // (48h) belongs to consumers that asked for a range or preloaded one — the
-  // MiniOverview on the dashboard, which gets its data via SSR. A consumer that
-  // fetches for itself (sidebar widget, clock face) only ever has the visible
-  // window, and merging realtime readings over the wider one hands its chart
-  // points it will never draw: the sidebar's 3-hour sparkline was being given 48
-  // hours of readings, sixteen times what it renders.
+  // How far the realtime merge may reach — the window the consumer draws, per
+  // `dataWindow`. The realtime store holds the last 1000 readings, so merging
+  // over `fullDataRange` for a consumer that only draws the visible window hands
+  // its chart points it will never render: the sidebar's 3-hour sparkline was
+  // being given 48 hours of readings, sixteen times what it draws, on every
+  // route, because the widget lives in the sidebar.
   const dataRange = $derived(
-    options.dateRange || options.initialChartData
-      ? fullDataRange
-      : displayDateRange
+    options.dataWindow === "display" ? displayDateRange : fullDataRange
   );
 
   // ---- Stable fetch range ----
-  // Keyed on the rounded bounds so a re-evaluation returns the same window: this
-  // one drives the fetch effect below, and a fresh object from it re-runs that
-  // effect — a chart-data request per read. See the note on `stableBy`.
+  // Fetch only the visible window when no dateRange is configured. The wider
+  // `fullDataRange` (48h) is used by the MiniOverview on the dashboard, which
+  // preloads data via SSR — so consumers that hit this fetch path (sidebar
+  // widget, clock face) don't need the full buffer.
+  //
+  // Keyed on the rounded bounds so a re-evaluation returns the same window: a
+  // fresh object here re-runs the fetch effect below, which under `nowMinute`
+  // alone was a chart-data request a minute, defeating the 5-minute rounding.
+  // See the note on `stableBy`.
   const fetchWindowOf = stableBy((startTime: number, endTime: number) => ({
     startTime,
     endTime,
@@ -398,7 +413,7 @@ export function createChartDataEngine(
 
   const stableFetchRange = $derived.by(() => {
     if (!isBrowser) return null;
-    const range = dataRange;
+    const range = options.dateRange ? fullDataRange : displayDateRange;
     const fromTime = range.from.getTime();
     const toTime = range.to.getTime();
     if (isNaN(fromTime) || isNaN(toTime)) return null;

--- a/src/Web/packages/app/src/lib/components/layout/SidebarGlucoseWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/SidebarGlucoseWidget.svelte
@@ -23,6 +23,7 @@
   const sidebarEngine = createChartDataEngine({
     enablePredictions: false,
     focusHours: 3,
+    dataWindow: "display",
   });
 
   // Glucose-only layout — no space reserved for basal/IOB/swim lanes

--- a/src/Web/packages/app/src/lib/components/layout/SidebarGlucoseWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/SidebarGlucoseWidget.svelte
@@ -130,7 +130,10 @@
         >
           {#snippet tracks(_ctx)}
             <ThresholdRules />
-            <GlucoseTrack showAxis={false} />
+            <!-- The density heuristic would show a dot per reading now that the
+                 series is the displayed window rather than the 48-hour buffer.
+                 A 120px sparkline reads as a line. -->
+            <GlucoseTrack showAxis={false} showPoints={false} />
           {/snippet}
         </GlucoseChartShell>
       </a>

--- a/src/Web/packages/app/src/lib/utils/stable-by.test.ts
+++ b/src/Web/packages/app/src/lib/utils/stable-by.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { stableBy } from "./stable-by";
+
+describe("stableBy", () => {
+  it("rebuilds only when a key changes", () => {
+    const build = vi.fn((a: number, b: string) => ({ a, b }));
+    const memo = stableBy(build);
+
+    const first = memo(1, "x");
+    expect(memo(1, "x")).toBe(first);
+    expect(build).toHaveBeenCalledTimes(1);
+
+    const second = memo(2, "x");
+    expect(second).not.toBe(first);
+    expect(build).toHaveBeenCalledTimes(2);
+
+    // A key it has moved away from is not remembered — one entry, not a cache.
+    expect(memo(1, "x")).not.toBe(first);
+    expect(build).toHaveBeenCalledTimes(3);
+  });
+
+  it("treats NaN bounds as unchanged", () => {
+    // An unparseable dateRange yields NaN bounds; `===` would thrash on them and
+    // rebuild forever, which is the failure this memo exists to avoid.
+    const memo = stableBy((from: number, to: number) => ({ from, to }));
+
+    const first = memo(NaN, NaN);
+    expect(memo(NaN, NaN)).toBe(first);
+  });
+
+  it("distinguishes undefined from a missing argument", () => {
+    const build = vi.fn((...key: unknown[]) => key.length);
+    const memo = stableBy(build);
+
+    expect(memo(undefined)).toBe(1);
+    expect(memo()).toBe(0);
+    expect(build).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not serve a stale value after the build throws", () => {
+    let fail = true;
+    const memo = stableBy((n: number) => {
+      if (fail) throw new Error("nope");
+      return { n };
+    });
+
+    fail = false;
+    expect(memo(1)).toEqual({ n: 1 });
+
+    fail = true;
+    expect(() => memo(2)).toThrow("nope");
+
+    // Recording key 2 beside value 1 would hand that stale value to every later
+    // caller asking for 2.
+    fail = false;
+    expect(memo(2)).toEqual({ n: 2 });
+  });
+});

--- a/src/Web/packages/app/src/lib/utils/stable-by.test.ts
+++ b/src/Web/packages/app/src/lib/utils/stable-by.test.ts
@@ -19,6 +19,23 @@ describe("stableBy", () => {
     expect(build).toHaveBeenCalledTimes(3);
   });
 
+  it("cannot see a key mutated in place", () => {
+    // The contract, pinned so it is not mistaken for a bug later: parts are
+    // compared by identity, so an object key is only safe when whatever owns it
+    // replaces it wholesale. `mergeGlucose` relies on exactly that of the
+    // realtime store's `$state.raw` entries array.
+    const build = vi.fn((rows: number[]) => rows.length);
+    const memo = stableBy(build);
+    const rows = [1];
+
+    expect(memo(rows)).toBe(1);
+    rows.push(2);
+    expect(memo(rows)).toBe(1);
+    expect(build).toHaveBeenCalledTimes(1);
+
+    expect(memo([...rows])).toBe(2);
+  });
+
   it("treats NaN bounds as unchanged", () => {
     // An unparseable dateRange yields NaN bounds; `===` would thrash on them and
     // rebuild forever, which is the failure this memo exists to avoid.

--- a/src/Web/packages/app/src/lib/utils/stable-by.ts
+++ b/src/Web/packages/app/src/lib/utils/stable-by.ts
@@ -36,8 +36,10 @@ export function stableBy<K extends readonly unknown[], T>(
       if (unchanged) return previous;
     }
 
-    previousKey = key;
+    // Committed only once `build` has returned: recording the new key beside the
+    // old value would serve that stale value to every later call with this key.
     previous = build(...key);
+    previousKey = key;
     return previous;
   };
 }

--- a/src/Web/packages/app/src/lib/utils/stable-by.ts
+++ b/src/Web/packages/app/src/lib/utils/stable-by.ts
@@ -1,0 +1,43 @@
+/**
+ * Builds a value from primitives, returning the previous instance whenever
+ * those primitives are unchanged.
+ *
+ * Svelte re-evaluates a `$derived` whenever a dependency _may_ have changed,
+ * and a derived it has flagged dirty is re-executed on every read for as long
+ * as more than one batch is alive — which is the whole time a page-level
+ * `<svelte:boundary>` is awaiting. A derived that allocates therefore publishes
+ * a new identity on each of those reads and reports a change it did not have.
+ * Where the result feeds a chart, that rebuilds the whole series and every
+ * scale below it, and the effects that reconciles re-enter the flush that
+ * provoked them.
+ *
+ * Keying the allocation on primitives makes the comparison succeed, so a
+ * re-evaluation costs nothing and propagates nothing.
+ *
+ * Each call returns a memo with its own one-entry cache, so build one per thing
+ * being kept stable — never one shared across component or store instances.
+ */
+export function stableBy<K extends readonly unknown[], T>(
+  build: (...key: K) => T
+): (...key: K) => T {
+  let previousKey: readonly unknown[] | null = null;
+  let previous: T;
+
+  return (...key: K): T => {
+    if (previousKey !== null && previousKey.length === key.length) {
+      const seen = previousKey.values();
+      let unchanged = true;
+      for (const value of key) {
+        if (!Object.is(seen.next().value, value)) {
+          unchanged = false;
+          break;
+        }
+      }
+      if (unchanged) return previous;
+    }
+
+    previousKey = key;
+    previous = build(...key);
+    return previous;
+  };
+}

--- a/src/Web/packages/app/src/lib/utils/stable-by.ts
+++ b/src/Web/packages/app/src/lib/utils/stable-by.ts
@@ -1,6 +1,6 @@
 /**
- * Builds a value from primitives, returning the previous instance whenever
- * those primitives are unchanged.
+ * Builds a value from a key, returning the previous instance whenever the key
+ * is unchanged.
  *
  * Svelte re-evaluates a `$derived` whenever a dependency _may_ have changed,
  * and a derived it has flagged dirty is re-executed on every read for as long
@@ -9,10 +9,15 @@
  * a new identity on each of those reads and reports a change it did not have.
  * Where the result feeds a chart, that rebuilds the whole series and every
  * scale below it, and the effects that reconciles re-enter the flush that
- * provoked them.
- *
- * Keying the allocation on primitives makes the comparison succeed, so a
+ * provoked them. Keying the allocation makes the comparison succeed, so a
  * re-evaluation costs nothing and propagates nothing.
+ *
+ * **Key parts are compared by identity** (`Object.is`), which is what makes the
+ * comparison cheap enough to run on every read. A key part that is an object is
+ * therefore only safe if it is replaced wholesale on every change —
+ * `$state.raw` holding an array that is always reassigned, never pushed into.
+ * One mutated in place looks unchanged and this returns a stale value
+ * indefinitely.
  *
  * Each call returns a memo with its own one-entry cache, so build one per thing
  * being kept stable — never one shared across component or store instances.


### PR DESCRIPTION
Navigating to `/alerts` on a tenant with glucose data never finished rendering. The page held its loading skeletons while the renderer main thread stayed pegged, and five minutes was not enough for it to settle. `/alerts/history` did the same — it was not in the report. The dashboard, which draws far more, was fine, and so was `/alerts` on a tenant with no data.

Fixes #995.

## Two things combine, and neither is sufficient alone

**The sidebar sparkline is handed sixteen times the data it draws.** `createChartDataEngine` merged realtime readings into the server series over `fullDataRange`, the 48-hour fetch buffer — but `stableFetchRange` only *fetches* that buffer for a consumer that named a `dateRange`. `SidebarGlucoseWidget` (`focusHours: 3`, 120px tall, mounted in the sidebar on **every** route) therefore fetched three hours of server points and merged ~576 of the realtime store's 1000 readings on top, to draw ~36.

**Under async batching a dirty derived is re-executed on every read.** In `update_derived`, the status reset is skipped while `batch_values !== null`, which a page-level `<svelte:boundary>` awaiting its queries keeps true for the life of the page. Instrumenting `is_dirty` in flight: `glucoseData` was marked dirty **once** by `mark_reactions` and then re-executed **598 times** off that same stale flag. It allocates, so every read republished a new array, which re-dirtied layerchart's `data → flatData → extents → yDomain → yScale → Rule.lines`, whose `{#each}` block effect reads it again. `Debugger.pause` stacks bottom out at `run_micro_tasks → flush → traverse → update_effect` every time. `flush_count` resets per flush, so `effect_update_depth_exceeded` never fires — hence a pegged thread and no error. A CPU profile put 61.6% of self time in that one derived.

Bisection agreed: removing `GlucoseTrack` from the sidebar chart → clean; capping `realtimeStore.entries` at 5 readings → clean. Spring motion, the points layer and the threshold rules are all innocent. Svelte 5.56.10 does not fix it.

## The fix

`dataWindow?: "buffer" | "display"` is now part of the engine's contract and decides how far the realtime merge reaches. `"display"` for a consumer that renders the visible window and nothing wider — the sidebar sparkline and both `ClockFaceRenderer` engines, all of which draw through `GlucoseChartShell`. `"buffer"` is the default, so every other call site keeps exactly its previous behaviour, merge window and fetch window both.

The first attempt inferred this from `dateRange || initialChartData`, which is the wrong question. `GlucoseChartCard` renders a 48-hour `fullXDomain` mini overview and a brush **regardless of how it was fed**, so the two `/clock/config/[id]` call sites that pass neither would have lost it — the strip collapsing to a smear at the right edge of a 48-hour axis, and brushing to any older window coming back empty. The dashboard's SSR-failure path had the same shape from the other side. Defaulting wide means a consumer that forgets to declare draws all its data: over-reaching costs points a chart declines to draw, under-reaching silently drops points it is drawing.

`glucoseData` is keyed on its four inputs via a new `stableBy`, so a re-evaluation returns the previous instance and propagates nothing.

## Narrowing the series also changed what the chart draws

`GlucoseTrack` shows a dot per reading below 0.5 points per pixel. Narrowing the sidebar took that from 2.4 to 0.15, so the sparkline sprouted a dot per reading — on every route, and on the clock faces, which people design. Measured against a seeded tenant: 49 circles in the sidebar against main's 12. The three narrowed consumers now ask for a line.

## Measured

Peg = the renderer stops answering a trivial `page.evaluate` for over 7s and never recovers. Seeded tenant, `sampleDataDays: 7`, fresh page per trial.

| route | before | after |
|---|---|---|
| `/alerts` | **6/6** (t+8.8–9.4s) | 0/6 |
| `/alerts/history` | **4/4** (t+9.8–32.1s) | 0/4 |
| `/alerts/simulator`, `/notifications`, `/clock`, `/` | 0/4 | 0/4 |
| `/alerts`, no sample data | 0/4 | — |

`/alerts` settles in 9.3s. Both halves are load-bearing, measured separately: narrowed window with dots suppressed but no memo is 4/6 pegged, memo with the wide window is 4/6, together 0/6. Sidebar renders identically to main, and the dashboard still draws its full 576-point span.

Memoising `stableFetchRange` as well was tried and reverted. `nowMinute` ticks every 60s, so on main the fetch effect re-ran every minute with identical rounded bounds; keying it made that five minutes, which is what the rounding says it wants but also means markers, IOB and COB lag five times longer, and a transient chart-data failure — which nulls `serverChartData` — leaves an empty chart for five minutes. It bought nothing measurable.

## Testing

`chart-data-engine.svelte.test.ts` pins the narrowed window, the wide default, and both merge bounds. Mutation-proved, one failure each and the right one: forcing the window wide reddens the display case, forcing it narrow reddens the default, and either comparison flipping reddens the bounds case. A reference-stability case was written and removed — it passed with the memo deleted, because `$derived` caches its own clean value and reproducing the real condition needs a mounted boundary the harness cannot provide; better absent than looking like cover.

`stable-by.test.ts` covers NaN keys, arity, not serving a stale value after a throwing build, and the identity-comparison contract — a key mutated in place is not detected, which is why the memo is only sound over `$state.raw` reassigned wholesale.

Full browser suite: the same 4 pre-existing failures as `main` (`OidcProviderDialog`, `CalendarHeader` ×2, `CurrentBGDisplay`), no new ones. `pnpm check` unchanged at its baseline. **Note that CI runs neither suite** — `tests.yml` never invokes `@nocturne/app`'s `test:unit` or `test:browser`, so a green check here says nothing about this coverage.

## Not fixed

The upstream fragility. Any chart with enough points inside an awaiting boundary can still reach the same loop; this removes the one that was firing. `fullDataRange`, `displayDateRange`, `displayDateRangeWithPredictions`, `fullXDomain` and `medianGlucose` all allocate per evaluation, and `engine.thresholds` is a plain getter allocating on every read that `GlucoseTrack` reads. Memoising them measured no better so they are left alone, but they are the margin this does not have. Worth an upstream report against Svelte before more charts land behind async boundaries.

One knock-on worth knowing: `medianGlucose` on a clock face is now taken over the displayed window rather than 48 hours, which moves device-event marker Y slightly.

The first commit is unrelated — it removes an `$inspect.trace` that reached `main` via #1025 and console-logs on every recompute of the app's hottest derived in dev. Happy to split it out if you'd rather.

Once this lands, the documentation screenshot pipeline can flip `alerts-configuration` back to a seeded tenant.

https://claude.ai/code/session_012xVgV9wznzr6oj6kCZhfmh
