### PR TITLE
docs: shoot the alerts screenshot on a tenant that has alerts

### DIFF
--- a/src/Web/packages/portal/src/content/docs/alerts/email.svx
+++ b/src/Web/packages/portal/src/content/docs/alerts/email.svx
@@ -75,8 +75,8 @@ Then restart Nocturne for the changes to take effect.
 
 ## 5. Set up an alert rule
 
-Alert rules live under **Alerts > Rules** in the sidebar. A new instance starts
-with none, so this is where you add your first:
+Alert rules live under **Alerts > Rules** in the sidebar. Each rule decides what
+Nocturne watches for; the email address goes on a channel inside one:
 
 <Screenshot id="alerts-configuration" />
 

--- a/src/Web/packages/screenshots/README.md
+++ b/src/Web/packages/screenshots/README.md
@@ -62,13 +62,21 @@ in-flight remote queries for an unbroken moment; otherwise the entry fails with 
 outstanding, e.g.
 
 ```
-alerts-configuration: /alerts did not settle within 120000ms (34 skeleton placeholders; 8 remote queries in flight)
+some-entry: /somewhere did not settle within 120000ms (34 skeleton placeholders; 8 remote queries in flight)
 ```
+
+Two very different things produce that, and the message reads the same either way.
 
 Remote queries stuck in flight while the API itself answers them in milliseconds is the dev server,
 not the app: a `vite dev` that has been up for hours, through several dependency re-optimisations,
 starts accepting remote-function requests and never answering them. Stopping and starting
 `nocturne-web` clears it.
+
+The other is the app, and the tell is `renderer did not answer N probes` alongside the skeletons:
+the page's main thread is pegged, so the queries only *look* outstanding — nothing is left to
+notice them landing. Restarting clears nothing, and a route that behaves on an empty tenant and
+hangs on a seeded one is pointing at a render loop rather than at the capture. Check whether the
+renderer answers at all before reaching for the dev server.
 
 ## Arranging state, and who is looking
 

--- a/src/Web/packages/screenshots/src/manifest.ts
+++ b/src/Web/packages/screenshots/src/manifest.ts
@@ -201,9 +201,7 @@ export const definitions: ScreenshotDefinition[] = [
 	{
 		id: 'alerts-configuration',
 		route: '/alerts',
-		// 'patient' once /alerts can render seeded data without pegging the renderer.
-		scenario: 'first-run',
-		alt: 'The Alerts page of a newly created site. It has no alert rules yet, and offers a New rule button to add the first one.',
+		alt: 'The Alerts page. Three tiles across the top count how many rules are switched on, how many alerts are sounding right now, and how many fired this week. Below them sits the list of rules — an urgent low, a low, a high, and one for the sensor going quiet — each showing the reading it watches for, a switch to turn it off, and a button to send a test alert. A New rule button sits in the top corner.',
 	},
 	{
 		id: 'report-agp',


### PR DESCRIPTION
Follow-up to #1031, which fixed the reason this entry could not be photographed on a seeded tenant.

`alerts-configuration` overrode the default scenario to `first-run` because `/alerts` pegged the renderer on a tenant with data. It no longer does, so the override goes and the entry takes the default: four rules, the counts across the top, and the row controls a reader is being told to use — rather than an empty state whose only content is the button that leaves it.

Captured locally at the pipeline's own settings (1440×900 @2x, en-AU, Australia/Sydney, pinned clock) to write the alt text against the real page rather than a guess: no skeletons, no spinners, `RULES ENABLED 4/4`, `ACTIVE NOW 0`, `FIRED THIS WEEK 40`, and the Urgent Low / Low / High / Signal Loss rows.

The prose above the embed asserted the page would be empty. It now says what a rule is *for*, which is what the numbered steps under the image go on to do, and is true of either page.

## The troubleshooting note was the part that was actually wrong

`README.md` used this entry's own failure as its worked example and attributed it to the known dev-server wedge — telling the next person to restart `nocturne-web` for a message a pegged renderer produces identically, where restarting achieves nothing. It now gives both causes and the tell that separates them: `renderer did not answer N probes` alongside the skeletons means the main thread is pegged and the queries only *look* outstanding.

## What this does not do

The committed image and the alt text in `manifest.json` are capture artifacts and stay as they are. The `Documentation screenshots` workflow re-shoots from the manifest and opens its own PR; until it is dispatched the docs keep the current image with its current alt, which remain consistent with each other. The reworded prose is true of both.

`validate`, `check-refs`, `check-embeds` and `tsc --noEmit` all pass in `@nocturne/screenshots`.

https://claude.ai/code/session_012xVgV9wznzr6oj6kCZhfmh
