### PR TITLE
fix(web): close a meal's treatment markers into one diamond

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
@@ -124,12 +124,14 @@ describe("glucose-chart mark registration", () => {
 
 		// The meal name is the one label placed beside the diamond rather than
 		// above it, so it is also the only one inside the band the triangles
-		// occupy. dy is pinned with it: it sets the row as much as y does.
+		// occupy. It reaches left, back over markers already painted, so a
+		// later meal's triangle cannot overdraw it. dy is pinned with it: it
+		// sets the row as much as y does.
 		const meal = byText("Lunch");
-		expect(meal?.getAttribute("x")).toBe(String(MARKER_HALF_WIDTH + 3));
+		expect(meal?.getAttribute("x")).toBe(String(-(MARKER_HALF_WIDTH + 3)));
 		expect(meal?.getAttribute("y")).toBe("0");
 		expect(meal?.getAttribute("dy")).toBe("0.35em");
-		expect(meal?.getAttribute("text-anchor")).toBe("start");
+		expect(meal?.getAttribute("text-anchor")).toBe("end");
 
 		for (const label of [carbs, units]) {
 			expect(Number(label?.getAttribute("y"))).toBeLessThan(-MARKER_HEIGHT);

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
@@ -1,7 +1,12 @@
 import { render } from "vitest-browser-svelte";
 import { describe, it, expect, vi } from "vitest";
 import Harness from "./MarkRegistrationHarness.test.svelte";
-import { MARKER_HEIGHT } from "$lib/components/icons/marker-shapes";
+import {
+	BOLUS_LABEL_Y,
+	CARB_LABEL_Y,
+	MARKER_HALF_WIDTH,
+	MARKER_HEIGHT,
+} from "$lib/components/icons/marker-shapes";
 
 /**
  * Every layerchart component registers itself with the chart on mount, and
@@ -104,23 +109,33 @@ describe("glucose-chart mark registration", () => {
 				(t) => t.textContent?.trim() === value,
 			);
 
+		// Amounts stack above the diamond, the meal name beside its waist.
+		const carbs = byText("30g");
+		expect(carbs?.getAttribute("y")).toBe(String(CARB_LABEL_Y));
+		expect(carbs?.getAttribute("dy")).toBe("-0.355em");
+		expect(carbs?.getAttribute("text-anchor")).toBe("middle");
+		expect(carbs?.getAttribute("x")).toBeNull();
+
 		const units = byText("1.5U");
-		expect(units?.getAttribute("x")).toBe("-11");
-		expect(units?.getAttribute("text-anchor")).toBe("end");
+		expect(units?.getAttribute("y")).toBe(String(BOLUS_LABEL_Y));
+		expect(units?.getAttribute("dy")).toBe("-0.355em");
+		expect(units?.getAttribute("text-anchor")).toBe("middle");
+		expect(units?.getAttribute("x")).toBeNull();
 
 		const meal = byText("Lunch");
-		expect(meal?.getAttribute("x")).toBe("11");
+		expect(meal?.getAttribute("x")).toBe(String(MARKER_HALF_WIDTH + 3));
+		expect(meal?.getAttribute("y")).toBe("0");
 		expect(meal?.getAttribute("text-anchor")).toBe("start");
 
-		const carbs = byText("30g");
-		expect(carbs?.getAttribute("text-anchor")).toBe("middle");
-		expect(Number(carbs?.getAttribute("y"))).toBeLessThan(-MARKER_HEIGHT);
+		// Only the meal name may sit in the band the triangles occupy.
+		for (const label of [carbs, units]) {
+			expect(Number(label?.getAttribute("y"))).toBeLessThan(-MARKER_HEIGHT);
+		}
 
-		// None of them may sit below the baseline: the IOB/COB track is the last
-		// one, so the chart clips at its bottom edge and a label past the bolus
-		// tip is cut off on a short chart.
-		for (const label of [units, meal, carbs]) {
-			expect(Number(label?.getAttribute("y"))).toBeLessThanOrEqual(0);
+		// A label can outgrow its own glyph and reach over a neighbouring
+		// marker, so none of them may take a click that marker would have had.
+		for (const label of [carbs, units, meal]) {
+			expect(label?.getAttribute("pointer-events")).toBe("none");
 		}
 	});
 

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
@@ -1,6 +1,7 @@
 import { render } from "vitest-browser-svelte";
 import { describe, it, expect, vi } from "vitest";
 import Harness from "./MarkRegistrationHarness.test.svelte";
+import { MARKER_HEIGHT } from "$lib/components/icons/marker-shapes";
 
 /**
  * Every layerchart component registers itself with the chart on mount, and
@@ -75,24 +76,52 @@ describe("glucose-chart mark registration", () => {
 	it("keeps marker glyph geometry and classes", async () => {
 		const { container } = await renderAt(1);
 
-		// Bolus override triangle (i % 3 === 0), pointing down at the baseline.
+		// Bolus override triangle (i % 3 === 0), hanging below the baseline.
 		const triangle = container.querySelector<SVGPolygonElement>(
-			"polygon[points='-8,-12 8,-12 0,0']",
+			"polygon[points='-8,0 8,0 0,12']",
 		);
 		expect(triangle).not.toBeNull();
 		expect(triangle?.getAttribute("class")).toBe(
 			"opacity-90 fill-insulin-bolus hover:opacity-100 transition-opacity",
 		);
 
-		// Carb triangle, pointing up at the same baseline.
+		// Carb triangle, rising from the baseline off the same base edge.
 		expect(
-			container.querySelector("polygon[points='-8,8 8,8 0,0']"),
+			container.querySelector("polygon[points='-8,0 8,0 0,-8']"),
 		).not.toBeNull();
 
 		// Tracker pill.
 		const pill = container.querySelector<SVGRectElement>("rect[rx='8']");
 		expect(pill?.getAttribute("width")).toBe("48");
 		expect(pill?.getAttribute("class")).toBe("opacity-90");
+	});
+
+	it("hangs the treatment labels off the baseline", async () => {
+		const { container } = await renderAt(1);
+
+		const byText = (value: string) =>
+			Array.from(container.querySelectorAll<SVGTextElement>("text")).find(
+				(t) => t.textContent?.trim() === value,
+			);
+
+		const units = byText("1.5U");
+		expect(units?.getAttribute("x")).toBe("-11");
+		expect(units?.getAttribute("text-anchor")).toBe("end");
+
+		const meal = byText("Lunch");
+		expect(meal?.getAttribute("x")).toBe("11");
+		expect(meal?.getAttribute("text-anchor")).toBe("start");
+
+		const carbs = byText("30g");
+		expect(carbs?.getAttribute("text-anchor")).toBe("middle");
+		expect(Number(carbs?.getAttribute("y"))).toBeLessThan(-MARKER_HEIGHT);
+
+		// None of them may sit below the baseline: the IOB/COB track is the last
+		// one, so the chart clips at its bottom edge and a label past the bolus
+		// tip is cut off on a short chart.
+		for (const label of [units, meal, carbs]) {
+			expect(Number(label?.getAttribute("y"))).toBeLessThanOrEqual(0);
+		}
 	});
 
 	it("draws BasalTrack temp-basal spans and hatched steps without marks", async () => {

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/mark-registration.svelte.test.ts
@@ -122,12 +122,15 @@ describe("glucose-chart mark registration", () => {
 		expect(units?.getAttribute("text-anchor")).toBe("middle");
 		expect(units?.getAttribute("x")).toBeNull();
 
+		// The meal name is the one label placed beside the diamond rather than
+		// above it, so it is also the only one inside the band the triangles
+		// occupy. dy is pinned with it: it sets the row as much as y does.
 		const meal = byText("Lunch");
 		expect(meal?.getAttribute("x")).toBe(String(MARKER_HALF_WIDTH + 3));
 		expect(meal?.getAttribute("y")).toBe("0");
+		expect(meal?.getAttribute("dy")).toBe("0.35em");
 		expect(meal?.getAttribute("text-anchor")).toBe("start");
 
-		// Only the meal name may sit in the band the triangles occupy.
 		for (const label of [carbs, units]) {
 			expect(Number(label?.getAttribute("y"))).toBeLessThan(-MARKER_HEIGHT);
 		}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import {
-    trianglePoints,
-    MARKER_HALF_WIDTH,
+    bolusMarkerPoints,
     MARKER_HEIGHT,
     MARKER_HEIGHT_OVERRIDE,
   } from "$lib/components/icons/marker-shapes";
@@ -38,13 +37,8 @@
     bolusType === "AutomaticBolus" || bolusType === "Smb",
   );
 
-  const points = $derived(
-    trianglePoints(
-      "down",
-      MARKER_HALF_WIDTH,
-      isOverride ? MARKER_HEIGHT_OVERRIDE : MARKER_HEIGHT,
-    ),
-  );
+  const height = $derived(isOverride ? MARKER_HEIGHT_OVERRIDE : MARKER_HEIGHT);
+  const points = $derived(bolusMarkerPoints(height));
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -68,8 +62,8 @@
     />
   {/if}
   <text
-    y={-14}
-    dy="-0.355em"
+    y={height + 3}
+    dy="0.8em"
     text-anchor="middle"
     class="text-[8px] fill-insulin-bolus font-medium"
   >

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     bolusMarkerPoints,
+    MARKER_HALF_WIDTH,
     MARKER_HEIGHT,
     MARKER_HEIGHT_OVERRIDE,
   } from "$lib/components/icons/marker-shapes";
@@ -62,9 +63,11 @@
     />
   {/if}
   <text
-    y={height + 3}
-    dy="0.8em"
-    text-anchor="middle"
+    x={-(MARKER_HALF_WIDTH + 3)}
+    y={0}
+    dy="0.35em"
+    text-anchor="end"
+    pointer-events="none"
     class="text-[8px] fill-insulin-bolus font-medium"
   >
     {insulin.toFixed(1)}U

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/BolusMarker.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {
     bolusMarkerPoints,
-    MARKER_HALF_WIDTH,
+    BOLUS_LABEL_Y,
     MARKER_HEIGHT,
     MARKER_HEIGHT_OVERRIDE,
   } from "$lib/components/icons/marker-shapes";
@@ -63,10 +63,9 @@
     />
   {/if}
   <text
-    x={-(MARKER_HALF_WIDTH + 3)}
-    y={0}
-    dy="0.35em"
-    text-anchor="end"
+    y={BOLUS_LABEL_Y}
+    dy="-0.355em"
+    text-anchor="middle"
     pointer-events="none"
     class="text-[8px] fill-insulin-bolus font-medium"
   >

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
@@ -29,7 +29,6 @@
     y={-MARKER_HEIGHT - 2}
     dy="-0.355em"
     text-anchor="middle"
-    pointer-events="none"
     class="text-[8px] fill-carbs font-medium"
   >
     {carbs}g

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import {
-    carbMarkerPoints,
+    CARB_LABEL_Y,
+    CARB_MARKER_POINTS,
     MARKER_HALF_WIDTH,
-    MARKER_HEIGHT,
   } from "$lib/components/icons/marker-shapes";
 
   interface Props {
@@ -26,15 +26,16 @@
   class="cursor-pointer"
 >
   <text
-    y={-MARKER_HEIGHT - 2}
+    y={CARB_LABEL_Y}
     dy="-0.355em"
     text-anchor="middle"
+    pointer-events="none"
     class="text-[8px] fill-carbs font-medium"
   >
     {carbs}g
   </text>
   <polygon
-    points={carbMarkerPoints()}
+    points={CARB_MARKER_POINTS}
     fill="var(--carbs)"
     class="opacity-90 hover:opacity-100 transition-opacity"
   />

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
@@ -41,10 +41,10 @@
   />
   {#if label}
     <text
-      x={MARKER_HALF_WIDTH + 3}
+      x={-(MARKER_HALF_WIDTH + 3)}
       y={0}
       dy="0.35em"
-      text-anchor="start"
+      text-anchor="end"
       pointer-events="none"
       class="text-[7px] fill-carbs font-medium opacity-80"
     >

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {
-    trianglePoints,
+    carbMarkerPoints,
     MARKER_HALF_WIDTH,
     MARKER_HEIGHT,
   } from "$lib/components/icons/marker-shapes";
@@ -25,28 +25,29 @@
   onclick={() => onMarkerClick(treatmentId)}
   class="cursor-pointer"
 >
-  <!-- Food/meal label above the marker -->
-  {#if label}
-    <text
-      y={-18}
-      dy="-0.355em"
-      text-anchor="middle"
-      class="text-[7px] fill-carbs font-medium opacity-80"
-    >
-      {label}
-    </text>
-  {/if}
-  <polygon
-    points={trianglePoints("up", MARKER_HALF_WIDTH, MARKER_HEIGHT)}
-    fill="var(--carbs)"
-    class="opacity-90 hover:opacity-100 transition-opacity"
-  />
   <text
-    y={18}
+    y={-MARKER_HEIGHT - 2}
     dy="-0.355em"
     text-anchor="middle"
     class="text-[8px] fill-carbs font-medium"
   >
     {carbs}g
   </text>
+  <polygon
+    points={carbMarkerPoints()}
+    fill="var(--carbs)"
+    class="opacity-90 hover:opacity-100 transition-opacity"
+  />
+  <!-- Beside the diamond's waist, clear of the bolus label a meal also carries -->
+  {#if label}
+    <text
+      x={MARKER_HALF_WIDTH + 3}
+      y={0}
+      dy="0.35em"
+      text-anchor="start"
+      class="text-[7px] fill-carbs font-medium opacity-80"
+    >
+      {label}
+    </text>
+  {/if}
 </g>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/markers/CarbMarker.svelte
@@ -29,6 +29,7 @@
     y={-MARKER_HEIGHT - 2}
     dy="-0.355em"
     text-anchor="middle"
+    pointer-events="none"
     class="text-[8px] fill-carbs font-medium"
   >
     {carbs}g
@@ -38,13 +39,13 @@
     fill="var(--carbs)"
     class="opacity-90 hover:opacity-100 transition-opacity"
   />
-  <!-- Beside the diamond's waist, clear of the bolus label a meal also carries -->
   {#if label}
     <text
       x={MARKER_HALF_WIDTH + 3}
       y={0}
       dy="0.35em"
       text-anchor="start"
+      pointer-events="none"
       class="text-[7px] fill-carbs font-medium opacity-80"
     >
       {label}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/IobCobTrack.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/tracks/IobCobTrack.svelte
@@ -66,9 +66,9 @@
   {@const iobZero = iobCobLayout.zero}
   {@const iobTrackTop = iobCobLayout.top}
   {@const iobAxisScale = iobCobLayout.axisScale}
-  <!-- Treatment markers share one baseline so a bolus (pointing down from above)
-       and a carb entry (pointing up from below) at the same time meet apex to
-       apex. Magnitude is conveyed by the marker labels, not height. -->
+  <!-- Treatment markers share one baseline so a carb entry (rising above it) and
+       a bolus (hanging below it) at the same time compose into one diamond.
+       Magnitude is conveyed by the marker labels, not height. -->
   {@const markerBaselineY = (iobCobLayout.top + iobCobLayout.bottom) / 2}
 
   <!-- IOB axis on right -->

--- a/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   /**
-   * Bolus marker icon — a triangle pointing down at the baseline. Used for bolus
+   * Bolus marker icon — a triangle hanging below the baseline. Used for bolus
    * treatment markers in legends and stat cards; the chart draws the same shape
    * from <see>marker-shapes</see>. When isOverride is true it is taller, echoing
    * the chart's manual-override marker — scaled to the icon box rather than

--- a/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   /**
-   * Bolus marker icon — the lower half of the chart's meal diamond, drawn to
-   * fill its own icon box rather than sharing the chart's baseline. Used for
-   * bolus treatment markers in legends and stat cards; the chart draws the same
-   * shape from <see>marker-shapes</see>. When isOverride is true it is taller,
+   * Bolus marker icon — the lower half of the chart's meal diamond, sized to
+   * its own icon box rather than to the chart's baseline. Used for bolus
+   * treatment markers in legends and stat cards; the chart draws the same shape
+   * from <see>marker-shapes</see>. When isOverride is true it is taller,
    * echoing the chart's manual-override marker — scaled to the icon box rather
    * than sharing the chart's pixel height.
    */

--- a/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/BolusIcon.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   /**
-   * Bolus marker icon — a triangle hanging below the baseline. Used for bolus
-   * treatment markers in legends and stat cards; the chart draws the same shape
-   * from <see>marker-shapes</see>. When isOverride is true it is taller, echoing
-   * the chart's manual-override marker — scaled to the icon box rather than
-   * sharing the chart's pixel height.
+   * Bolus marker icon — the lower half of the chart's meal diamond, drawn to
+   * fill its own icon box rather than sharing the chart's baseline. Used for
+   * bolus treatment markers in legends and stat cards; the chart draws the same
+   * shape from <see>marker-shapes</see>. When isOverride is true it is taller,
+   * echoing the chart's manual-override marker — scaled to the icon box rather
+   * than sharing the chart's pixel height.
    */
   import type { IconProps } from "./types";
   import { trianglePoints } from "./marker-shapes";

--- a/src/Web/packages/app/src/lib/components/icons/CarbsIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/CarbsIcon.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   /**
-   * Carbs marker icon — the upper half of the chart's meal diamond, drawn to
-   * fill its own icon box rather than sharing the chart's baseline. Used for
-   * carb treatment markers in legends and stat cards; the chart draws the same
-   * shape from <see>marker-shapes</see>.
+   * Carbs marker icon — the upper half of the chart's meal diamond, sized to
+   * its own icon box rather than to the chart's baseline. Used for carb
+   * treatment markers in legends and stat cards; the chart draws the same shape
+   * from <see>marker-shapes</see>. Complements BolusIcon, the lower half.
    */
   import type { IconProps } from "./types";
   import { trianglePoints } from "./marker-shapes";

--- a/src/Web/packages/app/src/lib/components/icons/CarbsIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/CarbsIcon.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   /**
-   * Carbs marker icon — a triangle pointing up at the baseline. Used for carb
+   * Carbs marker icon — a triangle rising from the baseline. Used for carb
    * treatment markers in legends and stat cards; the chart draws the same shape
-   * from <see>marker-shapes</see>. Complements BolusIcon, which points down at
-   * the same baseline.
+   * from <see>marker-shapes</see>. Complements BolusIcon, which hangs below the
+   * same baseline.
    */
   import type { IconProps } from "./types";
   import { trianglePoints } from "./marker-shapes";

--- a/src/Web/packages/app/src/lib/components/icons/CarbsIcon.svelte
+++ b/src/Web/packages/app/src/lib/components/icons/CarbsIcon.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   /**
-   * Carbs marker icon — a triangle rising from the baseline. Used for carb
-   * treatment markers in legends and stat cards; the chart draws the same shape
-   * from <see>marker-shapes</see>. Complements BolusIcon, which hangs below the
-   * same baseline.
+   * Carbs marker icon — the upper half of the chart's meal diamond, drawn to
+   * fill its own icon box rather than sharing the chart's baseline. Used for
+   * carb treatment markers in legends and stat cards; the chart draws the same
+   * shape from <see>marker-shapes</see>.
    */
   import type { IconProps } from "./types";
   import { trianglePoints } from "./marker-shapes";

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { trianglePoints } from "./marker-shapes";
+import {
+  trianglePoints,
+  carbMarkerPoints,
+  bolusMarkerPoints,
+  MARKER_HEIGHT,
+  MARKER_HEIGHT_OVERRIDE,
+} from "./marker-shapes";
 
 /** Parse an SVG points string into [x, y] pairs. */
 function parse(points: string): [number, number][] {
@@ -40,12 +46,24 @@ describe("trianglePoints", () => {
     expect(apex).toEqual([0, 0]);
   });
 
-  it("makes a bolus and a carb marker meet apex to apex on one baseline", () => {
-    // The chart draws both at the same y; they must not overlap.
-    const bolus = parse(trianglePoints("down", 8, 8));
-    const carbs = parse(trianglePoints("up", 8, 8));
+  it("joins a bolus and a carb marker base to base into one diamond", () => {
+    // The chart draws both at the same y, so the pair must share the baseline
+    // edge and lie on opposite sides of it.
+    const carbs = parse(carbMarkerPoints());
+    const bolus = parse(bolusMarkerPoints());
 
-    expect(Math.max(...bolus.map(([, y]) => y))).toBe(0);
-    expect(Math.min(...carbs.map(([, y]) => y))).toBe(0);
+    expect(carbs.slice(0, 2)).toEqual(bolus.slice(0, 2));
+    expect(carbs.every(([, y]) => y <= 0)).toBe(true);
+    expect(bolus.every(([, y]) => y >= 0)).toBe(true);
+    expect(carbs.at(-1)).toEqual([0, -MARKER_HEIGHT]);
+    expect(bolus.at(-1)).toEqual([0, MARKER_HEIGHT]);
+  });
+
+  it("keeps a taller override bolus on the same shared base", () => {
+    const carbs = parse(carbMarkerPoints());
+    const override = parse(bolusMarkerPoints(MARKER_HEIGHT_OVERRIDE));
+
+    expect(override.slice(0, 2)).toEqual(carbs.slice(0, 2));
+    expect(override.at(-1)).toEqual([0, MARKER_HEIGHT_OVERRIDE]);
   });
 });

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from "vitest";
 import {
   trianglePoints,
-  carbMarkerPoints,
   bolusMarkerPoints,
+  BOLUS_LABEL_Y,
+  CARB_LABEL_Y,
+  CARB_MARKER_POINTS,
   MARKER_HEIGHT,
   MARKER_HEIGHT_OVERRIDE,
 } from "./marker-shapes";
+
+/** Cap height plus descender of an 8px label, the tallest the markers draw. */
+const LABEL_LINE_HEIGHT = 8;
 
 /** Parse an SVG points string into [x, y] pairs. */
 function parse(points: string): [number, number][] {
@@ -49,7 +54,7 @@ describe("trianglePoints", () => {
   it("joins a bolus and a carb marker base to base into one diamond", () => {
     // The chart draws both at the same y, so the pair must share the baseline
     // edge and lie on opposite sides of it.
-    const carbs = parse(carbMarkerPoints());
+    const carbs = parse(CARB_MARKER_POINTS);
     const bolus = parse(bolusMarkerPoints(MARKER_HEIGHT));
 
     expect(carbs.slice(0, 2)).toEqual(bolus.slice(0, 2));
@@ -60,12 +65,24 @@ describe("trianglePoints", () => {
   });
 
   it("keeps a taller override bolus on the same shared base", () => {
-    const carbs = parse(carbMarkerPoints());
+    const carbs = parse(CARB_MARKER_POINTS);
     const normal = parse(bolusMarkerPoints(MARKER_HEIGHT));
     const override = parse(bolusMarkerPoints(MARKER_HEIGHT_OVERRIDE));
 
     expect(override.slice(0, 2)).toEqual(carbs.slice(0, 2));
     // Taller, and only downward: the base cannot drift off the baseline.
     expect(override.at(-1)?.[1]).toBeGreaterThan(normal.at(-1)![1]);
+  });
+
+  it("stacks both label rows above the diamond without overlapping", () => {
+    // Below the baseline the chart clips, and on it a neighbouring meal's
+    // triangle overdraws; only above the carb tip is clear.
+    expect(CARB_LABEL_Y).toBeLessThan(-MARKER_HEIGHT);
+    expect(BOLUS_LABEL_Y).toBeLessThan(-MARKER_HEIGHT);
+
+    // The bolus row sits a full line clear of the carb row beneath it.
+    expect(CARB_LABEL_Y - BOLUS_LABEL_Y).toBeGreaterThanOrEqual(
+      LABEL_LINE_HEIGHT,
+    );
   });
 });

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
@@ -9,8 +9,18 @@ import {
   MARKER_HEIGHT_OVERRIDE,
 } from "./marker-shapes";
 
-/** Cap height plus descender of an 8px label, the tallest the markers draw. */
-const LABEL_LINE_HEIGHT = 8;
+/**
+ * Line box of an 8px label, the tallest the markers draw: measured at 8.8px
+ * rendered, rounded up. Two rows closer than this touch.
+ */
+const LABEL_LINE_HEIGHT = 9;
+
+/**
+ * How far above the baseline a label may sit. The rows clear the chart's own
+ * IOB/COB track and hang over the glucose track above it, which is intended and
+ * unclipped; this only pins them to the marker rather than the chart.
+ */
+const LABEL_MAX_RISE = 40;
 
 /** Parse an SVG points string into [x, y] pairs. */
 function parse(points: string): [number, number][] {
@@ -20,7 +30,7 @@ function parse(points: string): [number, number][] {
     .map((pair) => pair.split(",").map(Number) as [number, number]);
 }
 
-describe("trianglePoints", () => {
+describe("marker shapes", () => {
   it("anchors every direction on the apex", () => {
     for (const direction of ["down", "up", "right"] as const) {
       const pts = parse(trianglePoints(direction, 8, 10, 30, 40));
@@ -82,7 +92,11 @@ describe("trianglePoints", () => {
 
     // The bolus row sits a full line clear of the carb row beneath it.
     expect(CARB_LABEL_Y - BOLUS_LABEL_Y).toBeGreaterThanOrEqual(
-      LABEL_LINE_HEIGHT,
+      LABEL_LINE_HEIGHT
     );
+
+    for (const row of [CARB_LABEL_Y, BOLUS_LABEL_Y]) {
+      expect(row).toBeGreaterThan(-LABEL_MAX_RISE);
+    }
   });
 });

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.test.ts
@@ -50,7 +50,7 @@ describe("trianglePoints", () => {
     // The chart draws both at the same y, so the pair must share the baseline
     // edge and lie on opposite sides of it.
     const carbs = parse(carbMarkerPoints());
-    const bolus = parse(bolusMarkerPoints());
+    const bolus = parse(bolusMarkerPoints(MARKER_HEIGHT));
 
     expect(carbs.slice(0, 2)).toEqual(bolus.slice(0, 2));
     expect(carbs.every(([, y]) => y <= 0)).toBe(true);
@@ -61,9 +61,11 @@ describe("trianglePoints", () => {
 
   it("keeps a taller override bolus on the same shared base", () => {
     const carbs = parse(carbMarkerPoints());
+    const normal = parse(bolusMarkerPoints(MARKER_HEIGHT));
     const override = parse(bolusMarkerPoints(MARKER_HEIGHT_OVERRIDE));
 
     expect(override.slice(0, 2)).toEqual(carbs.slice(0, 2));
-    expect(override.at(-1)).toEqual([0, MARKER_HEIGHT_OVERRIDE]);
+    // Taller, and only downward: the base cannot drift off the baseline.
+    expect(override.at(-1)?.[1]).toBeGreaterThan(normal.at(-1)![1]);
   });
 });

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
@@ -2,9 +2,7 @@
  * Treatment marker geometry, shared by the chart markers and the legend/stat
  * icons so the two cannot drift apart.
  *
- * Every triangle is anchored on its apex, which is what the marker points at:
- * a bolus hangs above the baseline pointing down at it, carbs sit below
- * pointing up at it, so a simultaneous pair meets apex to apex.
+ * Every triangle is anchored on its apex, which is what the marker points at.
  */
 export type MarkerDirection = "down" | "up" | "right";
 
@@ -32,3 +30,17 @@ export const MARKER_HEIGHT = 8;
 
 /** A manually overridden bolus keeps the taller silhouette it had before. */
 export const MARKER_HEIGHT_OVERRIDE = 12;
+
+/**
+ * The chart's carb and bolus markers rest their *bases* on the one shared
+ * baseline — carbs rise above it, a bolus hangs below — so a meal's pair
+ * composes into a single diamond rather than an hourglass.
+ */
+export function carbMarkerPoints(height = MARKER_HEIGHT): string {
+  return trianglePoints("up", MARKER_HALF_WIDTH, height, 0, -height);
+}
+
+/** @see carbMarkerPoints */
+export function bolusMarkerPoints(height = MARKER_HEIGHT): string {
+  return trianglePoints("down", MARKER_HALF_WIDTH, height, 0, height);
+}

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
@@ -32,14 +32,15 @@ export const MARKER_HEIGHT = 8;
 export const MARKER_HEIGHT_OVERRIDE = 12;
 
 /**
- * The chart's carb and bolus markers rest their *bases* on the one shared
+ * The chart's carb and bolus markers rest their bases on the one shared
  * baseline — carbs rise above it, a bolus hangs below — so a meal's pair
- * composes into a single diamond rather than an hourglass.
+ * composes into a single diamond.
  *
- * That leaves the baseline as the only band clear of both triangles, so the
- * markers hang their labels off it sideways rather than stacking them above and
- * below: the track is only 18% of the chart, and a label pushed past a marker's
- * outer tip is clipped away on a short chart.
+ * The baseline is therefore the only band clear of both triangles, and it is
+ * where the markers anchor their labels: the IOB/COB track holds the baseline
+ * at its midpoint and is the chart's last track, so the chart clips at the
+ * track's bottom edge and a label placed past the bolus tip is cut off on a
+ * short chart. See computeTrackLayout for the track's share of the chart.
  */
 export function carbMarkerPoints(): string {
   return trianglePoints(
@@ -47,7 +48,7 @@ export function carbMarkerPoints(): string {
     MARKER_HALF_WIDTH,
     MARKER_HEIGHT,
     0,
-    -MARKER_HEIGHT,
+    -MARKER_HEIGHT
   );
 }
 

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
@@ -2,7 +2,9 @@
  * Treatment marker geometry, shared by the chart markers and the legend/stat
  * icons so the two cannot drift apart.
  *
- * Every triangle is anchored on its apex, which is what the marker points at.
+ * A triangle from trianglePoints is anchored on its apex, which is what a
+ * marker points at. The chart's own markers anchor on their base instead — see
+ * CARB_MARKER_POINTS.
  */
 export type MarkerDirection = "down" | "up" | "right";
 
@@ -35,24 +37,29 @@ export const MARKER_HEIGHT_OVERRIDE = 12;
  * The chart's carb and bolus markers rest their bases on the one shared
  * baseline — carbs rise above it, a bolus hangs below — so a meal's pair
  * composes into a single diamond.
- *
- * The baseline is therefore the only band clear of both triangles, and it is
- * where the markers anchor their labels: the IOB/COB track holds the baseline
- * at its midpoint and is the chart's last track, so the chart clips at the
- * track's bottom edge and a label placed past the bolus tip is cut off on a
- * short chart. See computeTrackLayout for the track's share of the chart.
  */
-export function carbMarkerPoints(): string {
-  return trianglePoints(
-    "up",
-    MARKER_HALF_WIDTH,
-    MARKER_HEIGHT,
-    0,
-    -MARKER_HEIGHT
-  );
-}
+export const CARB_MARKER_POINTS = trianglePoints(
+  "up",
+  MARKER_HALF_WIDTH,
+  MARKER_HEIGHT,
+  0,
+  -MARKER_HEIGHT
+);
 
-/** @see carbMarkerPoints */
+/** @see CARB_MARKER_POINTS */
 export function bolusMarkerPoints(height: number): string {
   return trianglePoints("down", MARKER_HALF_WIDTH, height, 0, height);
 }
+
+/**
+ * Both amount labels stack above the diamond, the carb amount nearest it.
+ *
+ * Below is unusable: the IOB/COB track is 18% of the chart (computeTrackLayout)
+ * and holds the baseline at its midpoint, and being the last track its bottom
+ * edge is where the chart clips — so a label under the bolus tip is cut off on
+ * a short chart. The baseline itself is unusable too: every marker's triangle
+ * meets it, and carb markers paint after bolus markers, so a label left there
+ * is overdrawn by a neighbouring meal's triangle. Above the diamond is clear.
+ */
+export const CARB_LABEL_Y = -MARKER_HEIGHT - 2;
+export const BOLUS_LABEL_Y = -MARKER_HEIGHT - 12;

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
@@ -3,8 +3,8 @@
  * icons so the two cannot drift apart.
  *
  * A triangle from trianglePoints is anchored on its apex, which is what a
- * marker points at. The chart's own markers anchor on their base instead — see
- * CARB_MARKER_POINTS.
+ * marker points at. The treatment pair is the exception and anchors on the base
+ * — see <see>CARB_MARKER_POINTS</see>.
  */
 export type MarkerDirection = "down" | "up" | "right";
 
@@ -52,14 +52,16 @@ export function bolusMarkerPoints(height: number): string {
 }
 
 /**
- * Both amount labels stack above the diamond, the carb amount nearest it.
+ * Rows for the two amount labels, the carb amount nearest the diamond. They
+ * rise clear of every treatment glyph, over the glucose track above — the
+ * IOB/COB track is a fifth of the chart (<see>computeTrackLayout</see>), too
+ * shallow to hold them.
  *
- * Below is unusable: the IOB/COB track is 18% of the chart (computeTrackLayout)
- * and holds the baseline at its midpoint, and being the last track its bottom
- * edge is where the chart clips — so a label under the bolus tip is cut off on
- * a short chart. The baseline itself is unusable too: every marker's triangle
- * meets it, and carb markers paint after bolus markers, so a label left there
- * is overdrawn by a neighbouring meal's triangle. Above the diamond is clear.
+ * They may not go below the baseline: that track is the chart's last, so its
+ * bottom edge is where the chart clips. Nor on it, where every triangle meets
+ * and a later-painted marker would overdraw them.
  */
 export const CARB_LABEL_Y = -MARKER_HEIGHT - 2;
+
+/** @see CARB_LABEL_Y */
 export const BOLUS_LABEL_Y = -MARKER_HEIGHT - 12;

--- a/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
+++ b/src/Web/packages/app/src/lib/components/icons/marker-shapes.ts
@@ -35,12 +35,23 @@ export const MARKER_HEIGHT_OVERRIDE = 12;
  * The chart's carb and bolus markers rest their *bases* on the one shared
  * baseline — carbs rise above it, a bolus hangs below — so a meal's pair
  * composes into a single diamond rather than an hourglass.
+ *
+ * That leaves the baseline as the only band clear of both triangles, so the
+ * markers hang their labels off it sideways rather than stacking them above and
+ * below: the track is only 18% of the chart, and a label pushed past a marker's
+ * outer tip is clipped away on a short chart.
  */
-export function carbMarkerPoints(height = MARKER_HEIGHT): string {
-  return trianglePoints("up", MARKER_HALF_WIDTH, height, 0, -height);
+export function carbMarkerPoints(): string {
+  return trianglePoints(
+    "up",
+    MARKER_HALF_WIDTH,
+    MARKER_HEIGHT,
+    0,
+    -MARKER_HEIGHT,
+  );
 }
 
 /** @see carbMarkerPoints */
-export function bolusMarkerPoints(height = MARKER_HEIGHT): string {
+export function bolusMarkerPoints(height: number): string {
   return trianglePoints("down", MARKER_HALF_WIDTH, height, 0, height);
 }


### PR DESCRIPTION
## Problem

`trianglePoints` anchors every triangle on its apex, so both chart markers put their *apex* on the IOB/COB track's shared baseline — carbs pointing up from below, a bolus pointing down from above. A meal's pair therefore met point-to-point as an hourglass, the inversion of the intended shape.

The same flip left two labels stacked in the same space above the baseline: the meal name at `y=-18` and the bolus units at `y=-14`. They overlapped on every bolused meal.

## Fix

- `marker-shapes.ts` grows `carbMarkerPoints()` / `bolusMarkerPoints(height)`, which anchor each triangle's **base** on the baseline — carbs rise above it, the bolus hangs below. Both call sites use these, so the composition rule lives in one place rather than as apex arithmetic copied into two components.
- Each amount label moves to its own triangle's outer side, so neither sits inside the other half. The bolus label offsets from the actual height, so an override's taller silhouette keeps the same gap.
- The meal name moves beside the diamond's waist (`text-anchor="start"`, vertically centred), clear of both amount labels.

Halves stay fixed-size, so magnitude is still carried by the labels, as the track comment says.

## Tests

`marker-shapes.test.ts` replaces the "meet apex to apex" assertion with one that the two share the base edge and occupy opposite sides of it, plus a case pinning the taller override to that same shared base.

`pnpm run check` reports no new errors (the 19 pre-existing ones are in the gitignored generated client and unrelated files).
