### PR TITLE
refactor(api): move inline 500 shaping to an IExceptionHandler seam

### DIFF
--- a/src/API/Nocturne.API/Attributes/ErrorEnvelopeAttribute.cs
+++ b/src/API/Nocturne.API/Attributes/ErrorEnvelopeAttribute.cs
@@ -1,0 +1,13 @@
+namespace Nocturne.API.Attributes;
+
+/// <summary>
+/// Marks an action whose unhandled exceptions are shaped by
+/// <see cref="Middleware.ApiErrorEnvelopeHandler"/> into the error envelope its API version uses.
+/// </summary>
+/// <remarks>
+/// Opt-in per action: an action without it keeps the framework's default
+/// <c>ProblemDetails</c> response.
+/// </remarks>
+/// <seealso cref="Middleware.ApiErrorEnvelopeHandler"/>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class ErrorEnvelopeAttribute : Attribute;

--- a/src/API/Nocturne.API/Configuration/NightscoutApiPath.cs
+++ b/src/API/Nocturne.API/Configuration/NightscoutApiPath.cs
@@ -1,0 +1,35 @@
+namespace Nocturne.API.Configuration;
+
+/// <summary>
+/// Resolves the Nightscout-compatible API version a request path belongs to.
+/// </summary>
+/// <seealso cref="NightscoutJsonFilter"/>
+public static class NightscoutApiPath
+{
+    /// <summary>
+    /// Returns 1, 2 or 3 for a <c>/api/v{n}/…</c> path, or <c>null</c> for anything else
+    /// (v4 and above, and non-API paths).
+    /// </summary>
+    public static int? Version(PathString path)
+    {
+        var value = path.Value;
+
+        if (value is null || value.Length < 8)
+        {
+            return null;
+        }
+
+        if (!value.StartsWith("/api/v", StringComparison.OrdinalIgnoreCase) || value[7] != '/')
+        {
+            return null;
+        }
+
+        return value[6] switch
+        {
+            '1' => 1,
+            '2' => 2,
+            '3' => 3,
+            _ => null,
+        };
+    }
+}

--- a/src/API/Nocturne.API/Configuration/NightscoutJsonFilter.cs
+++ b/src/API/Nocturne.API/Configuration/NightscoutJsonFilter.cs
@@ -16,11 +16,8 @@ public class NightscoutJsonFilter : IAsyncResultFilter
 
     public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
     {
-        // Check if this is a Nightscout endpoint (v1, v2, v3)
-        var path = context.HttpContext.Request.Path.Value?.ToLowerInvariant() ?? "";
-        var isNightscoutEndpoint = path.StartsWith("/api/v1/") ||
-                                   path.StartsWith("/api/v2/") ||
-                                   path.StartsWith("/api/v3/");
+        var isNightscoutEndpoint =
+            NightscoutApiPath.Version(context.HttpContext.Request.Path) is not null;
 
         if (isNightscoutEndpoint && context.Result is ObjectResult objectResult)
         {

--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -170,6 +170,7 @@ public class EntriesController : ControllerBase
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(typeof(Entry[]), 304)] // Not Modified response
     [RequireScope(Scope.GlucoseRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Entry[]>> GetEntry(
         string spec,
         CancellationToken cancellationToken = default
@@ -181,112 +182,94 @@ public class EntriesController : ControllerBase
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        // Accept legacy MongoDB ObjectIds and system-assigned UUID v7 ids.
+        bool isId = System.Text.RegularExpressions.Regex.IsMatch(
+                spec,
+                "^([a-f\\d]{24}|[a-f\\d]{32})$",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase
+            );
+
+        if (isId)
         {
-            // Accept legacy MongoDB ObjectIds and system-assigned UUID v7 ids.
-            bool isId = System.Text.RegularExpressions.Regex.IsMatch(
-                    spec,
-                    "^([a-f\\d]{24}|[a-f\\d]{32})$",
-                    System.Text.RegularExpressions.RegexOptions.IgnoreCase
-                );
-
-            if (isId)
+            // Fetch specific entry by ID
+            var entry = await _entryService.GetEntryByIdAsync(spec, cancellationToken);
+            if (entry == null)
             {
-                // Fetch specific entry by ID
-                var entry = await _entryService.GetEntryByIdAsync(spec, cancellationToken);
-                if (entry == null)
-                {
-                    _logger.LogDebug("Entry with ID {Id} not found", spec);
-                    // Set Last-Modified to current time when entry not found
-                    var notFoundLastModified = DateTimeOffset.UtcNow;
-                    Response.Headers["Last-Modified"] = notFoundLastModified.ToString("R");
-                    return Ok(Array.Empty<Entry>());
-                }
+                _logger.LogDebug("Entry with ID {Id} not found", spec);
+                // Set Last-Modified to current time when entry not found
+                var notFoundLastModified = DateTimeOffset.UtcNow;
+                Response.Headers["Last-Modified"] = notFoundLastModified.ToString("R");
+                return Ok(Array.Empty<Entry>());
+            }
 
-                _logger.LogDebug("Found entry with ID: {Id}", spec);
-                // Set Last-Modified header
-                var lastModified = DateTimeOffset.FromUnixTimeMilliseconds(entry.Mills);
-                Response.Headers["Last-Modified"] = lastModified.ToString("R");
+            _logger.LogDebug("Found entry with ID: {Id}", spec);
+            // Set Last-Modified header
+            var lastModified = DateTimeOffset.FromUnixTimeMilliseconds(entry.Mills);
+            Response.Headers["Last-Modified"] = lastModified.ToString("R");
 
-                return Ok(new[] { entry }.ToV1Responses());
+            return Ok(new[] { entry }.ToV1Responses());
+        }
+        else
+        {
+            // Treat spec as entry type (e.g., "sgv", "mbg", "cal")
+            _logger.LogDebug("Fetching entries of type: {Type}", spec);
+            var entries = await _entryService.GetEntriesAsync(
+                type: spec,
+                count: 10,
+                skip: 0,
+                cancellationToken
+            );
+            var entriesArray = entries.ToArray();
+
+            // Set Last-Modified header for caching
+            DateTimeOffset lastModified;
+            if (entriesArray.Length > 0)
+            {
+                // Set Last-Modified header based on most recent entry
+                lastModified = DateTimeOffset.FromUnixTimeMilliseconds(entriesArray[0].Mills);
             }
             else
             {
-                // Treat spec as entry type (e.g., "sgv", "mbg", "cal")
-                _logger.LogDebug("Fetching entries of type: {Type}", spec);
-                var entries = await _entryService.GetEntriesAsync(
-                    type: spec,
-                    count: 10,
-                    skip: 0,
-                    cancellationToken
-                );
-                var entriesArray = entries.ToArray();
+                // Set Last-Modified to current time when no entries exist
+                lastModified = DateTimeOffset.UtcNow;
+            }
+            Response.Headers["Last-Modified"] = lastModified.ToString("R");
 
-                // Set Last-Modified header for caching
-                DateTimeOffset lastModified;
-                if (entriesArray.Length > 0)
-                {
-                    // Set Last-Modified header based on most recent entry
-                    lastModified = DateTimeOffset.FromUnixTimeMilliseconds(entriesArray[0].Mills);
-                }
-                else
-                {
-                    // Set Last-Modified to current time when no entries exist
-                    lastModified = DateTimeOffset.UtcNow;
-                }
-                Response.Headers["Last-Modified"] = lastModified.ToString("R");
-
-                // Check If-Modified-Since header
-                if (Request.Headers.IfModifiedSince.Count > 0)
-                {
-                    if (
-                        DateTimeOffset.TryParse(
-                            Request.Headers.IfModifiedSince.First(),
-                            out var ifModifiedSince
-                        )
+            // Check If-Modified-Since header
+            if (Request.Headers.IfModifiedSince.Count > 0)
+            {
+                if (
+                    DateTimeOffset.TryParse(
+                        Request.Headers.IfModifiedSince.First(),
+                        out var ifModifiedSince
                     )
+                )
+                {
+                    if (lastModified <= ifModifiedSince)
                     {
-                        if (lastModified <= ifModifiedSince)
-                        {
-                            _logger.LogDebug(
-                                "Entries not modified since {IfModifiedSince}, returning 304",
-                                ifModifiedSince
-                            );
-                            return StatusCode(
-                                304,
-                                new
-                                {
-                                    status = 304,
-                                    message = "Not modified",
-                                    type = "internal",
-                                }
-                            );
-                        }
+                        _logger.LogDebug(
+                            "Entries not modified since {IfModifiedSince}, returning 304",
+                            ifModifiedSince
+                        );
+                        return StatusCode(
+                            304,
+                            new
+                            {
+                                status = 304,
+                                message = "Not modified",
+                                type = "internal",
+                            }
+                        );
                     }
                 }
-
-                _logger.LogDebug(
-                    "Found {Count} entries of type: {Type}",
-                    entriesArray.Length,
-                    spec
-                );
-                return Ok(entriesArray.ToV1Responses());
             }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving entry with spec: {Spec}", spec);
 
-            return StatusCode(
-                500,
-                new
-                {
-                    status = 500,
-                    message = "Internal server error",
-                    type = "internal",
-                    error = ex.Message,
-                }
+            _logger.LogDebug(
+                "Found {Count} entries of type: {Type}",
+                entriesArray.Length,
+                spec
             );
+            return Ok(entriesArray.ToV1Responses());
         }
     }
 
@@ -313,6 +296,7 @@ public class EntriesController : ControllerBase
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(typeof(Entry[]), 304)] // Not Modified response
     [RequireScope(Scope.GlucoseRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetEntries(
         [FromQuery] string? find = null,
         [FromQuery] int? count = null,
@@ -359,174 +343,156 @@ public class EntriesController : ControllerBase
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        // In Nightscout v1, the ?type= parameter does NOT filter by entry type
+        // It may be related to output format. To filter by type, use find[type]=xxx
+        // Only apply type filtering when it comes from find query, not from ?type= parameter
+        string? entryType = null;
+
+        // Check if find query contains type filter
+        if (
+            !string.IsNullOrEmpty(findQuery)
+            && (findQuery.Contains("find[type]") || findQuery.Contains("find%5Btype%5D"))
+        )
         {
-            // In Nightscout v1, the ?type= parameter does NOT filter by entry type
-            // It may be related to output format. To filter by type, use find[type]=xxx
-            // Only apply type filtering when it comes from find query, not from ?type= parameter
-            string? entryType = null;
+            // Type filtering will be handled by the find query parser
+            entryType = null;
+        }
 
-            // Check if find query contains type filter
+        // Handle count parameter for Nightscout compatibility:
+        // - null/not specified: default to 10 (Nightscout default)
+        // - 0 or negative: return empty array (Nightscout behavior)
+        // - positive: return that many entries
+        if (count.HasValue && count.Value <= 0)
+        {
+            // Nightscout returns empty array for count=0 or negative values
+            return Ok(Array.Empty<Entry>());
+        }
+        // Nightscout defaults to 10 when count is not specified; the upper bound is ours.
+        var limitedCount = LegacyReadLimits.ClampCount(count ?? 10);
+
+        // Use advanced filtering if any advanced parameters are provided
+        // reverseResults stays false (newest-first): legacy Nightscout ignores the cache-busting
+        // "rr" query parameter, so a nonzero "rr" value must never flip the sort order.
+        var entries = await _entryService.GetEntriesWithAdvancedFilterAsync(
+            type: entryType,
+            count: limitedCount,
+            skip: 0,
+            findQuery: findQuery,
+            dateString: dateString,
+            reverseResults: false,
+            cancellationToken: cancellationToken
+        );
+        var entriesArray = entries.ToArray();
+
+        // Set Last-Modified header for caching
+        DateTimeOffset lastModified;
+        if (entriesArray.Length > 0)
+        {
+            // Set Last-Modified header based on most recent entry
+            lastModified = DateTimeOffset.FromUnixTimeMilliseconds(entriesArray[0].Mills);
+        }
+        else
+        {
+            // Set Last-Modified to current time when no entries exist
+            lastModified = DateTimeOffset.UtcNow;
+        }
+        Response.Headers["Last-Modified"] = lastModified.ToString("R");
+
+        // Check If-Modified-Since header
+        if (Request.Headers.IfModifiedSince.Count > 0)
+        {
             if (
-                !string.IsNullOrEmpty(findQuery)
-                && (findQuery.Contains("find[type]") || findQuery.Contains("find%5Btype%5D"))
-            )
-            {
-                // Type filtering will be handled by the find query parser
-                entryType = null;
-            }
-
-            // Handle count parameter for Nightscout compatibility:
-            // - null/not specified: default to 10 (Nightscout default)
-            // - 0 or negative: return empty array (Nightscout behavior)
-            // - positive: return that many entries
-            if (count.HasValue && count.Value <= 0)
-            {
-                // Nightscout returns empty array for count=0 or negative values
-                return Ok(Array.Empty<Entry>());
-            }
-            // Nightscout defaults to 10 when count is not specified; the upper bound is ours.
-            var limitedCount = LegacyReadLimits.ClampCount(count ?? 10);
-
-            // Use advanced filtering if any advanced parameters are provided
-            // reverseResults stays false (newest-first): legacy Nightscout ignores the cache-busting
-            // "rr" query parameter, so a nonzero "rr" value must never flip the sort order.
-            var entries = await _entryService.GetEntriesWithAdvancedFilterAsync(
-                type: entryType,
-                count: limitedCount,
-                skip: 0,
-                findQuery: findQuery,
-                dateString: dateString,
-                reverseResults: false,
-                cancellationToken: cancellationToken
-            );
-            var entriesArray = entries.ToArray();
-
-            // Set Last-Modified header for caching
-            DateTimeOffset lastModified;
-            if (entriesArray.Length > 0)
-            {
-                // Set Last-Modified header based on most recent entry
-                lastModified = DateTimeOffset.FromUnixTimeMilliseconds(entriesArray[0].Mills);
-            }
-            else
-            {
-                // Set Last-Modified to current time when no entries exist
-                lastModified = DateTimeOffset.UtcNow;
-            }
-            Response.Headers["Last-Modified"] = lastModified.ToString("R");
-
-            // Check If-Modified-Since header
-            if (Request.Headers.IfModifiedSince.Count > 0)
-            {
-                if (
-                    DateTimeOffset.TryParse(
-                        Request.Headers.IfModifiedSince.First(),
-                        out var ifModifiedSince
-                    )
+                DateTimeOffset.TryParse(
+                    Request.Headers.IfModifiedSince.First(),
+                    out var ifModifiedSince
                 )
-                {
-                    if (lastModified <= ifModifiedSince)
-                    {
-                        _logger.LogDebug(
-                            "Entries not modified since {IfModifiedSince}, returning 304",
-                            ifModifiedSince
-                        );
-                        return StatusCode(
-                            304,
-                            new
-                            {
-                                status = 304,
-                                message = "Not modified",
-                                type = "internal",
-                            }
-                        );
-                    }
-                }
-            }
-            _logger.LogDebug(
-                "Found {Count} entries of type: {Type}",
-                entriesArray.Length,
-                entryType
-            );
-
-            // Determine format from format parameter or Accept header (content negotiation)
-            var effectiveFormat = format;
-            if (
-                string.IsNullOrEmpty(effectiveFormat)
-                || effectiveFormat.Equals("json", StringComparison.OrdinalIgnoreCase)
             )
             {
-                // Check Accept header for content negotiation (Nightscout compatibility)
-                var acceptHeader = Request.Headers.Accept.ToString().ToLowerInvariant();
-                if (acceptHeader.Contains("text/tab-separated-values"))
+                if (lastModified <= ifModifiedSince)
                 {
-                    effectiveFormat = "tsv";
-                }
-                else if (acceptHeader.Contains("text/csv"))
-                {
-                    effectiveFormat = "csv";
-                }
-                else if (
-                    acceptHeader.Contains("text/plain")
-                    && !acceptHeader.Contains("application/json")
-                )
-                {
-                    // text/plain returns TSV for Nightscout compatibility
-                    effectiveFormat = "tsv";
-                }
-            }
-
-            // Handle different output formats
-            if (
-                !string.IsNullOrEmpty(effectiveFormat)
-                && !effectiveFormat.Equals("json", StringComparison.OrdinalIgnoreCase)
-            )
-            {
-                try
-                {
-                    var formattedData = DataFormatService.FormatEntries(
-                        entriesArray,
-                        effectiveFormat
+                    _logger.LogDebug(
+                        "Entries not modified since {IfModifiedSince}, returning 304",
+                        ifModifiedSince
                     );
-                    var contentType = DataFormatService.GetContentType(effectiveFormat);
-                    return Content(formattedData, contentType);
-                }
-                catch (ArgumentException ex)
-                {
-                    _logger.LogWarning(
-                        ex,
-                        "Unsupported format requested: {Format}",
-                        effectiveFormat
-                    );
-                    return BadRequest(
+                    return StatusCode(
+                        304,
                         new
                         {
-                            status = 400,
-                            message = $"Unsupported format: {effectiveFormat}. Supported formats: json, csv, tsv, txt",
-                            type = "client",
+                            status = 304,
+                            message = "Not modified",
+                            type = "internal",
                         }
                     );
                 }
             }
-
-            return Ok(entriesArray.ToV1Responses());
         }
-        catch (Exception ex)
+        _logger.LogDebug(
+            "Found {Count} entries of type: {Type}",
+            entriesArray.Length,
+            entryType
+        );
+
+        // Determine format from format parameter or Accept header (content negotiation)
+        var effectiveFormat = format;
+        if (
+            string.IsNullOrEmpty(effectiveFormat)
+            || effectiveFormat.Equals("json", StringComparison.OrdinalIgnoreCase)
+        )
         {
-            _logger.LogError(ex, "Error retrieving entries");
-
-            return StatusCode(
-                500,
-                new
-                {
-                    status = 500,
-                    message = "Internal server error",
-                    type = "internal",
-                    error = ex.Message,
-                }
-            );
+            // Check Accept header for content negotiation (Nightscout compatibility)
+            var acceptHeader = Request.Headers.Accept.ToString().ToLowerInvariant();
+            if (acceptHeader.Contains("text/tab-separated-values"))
+            {
+                effectiveFormat = "tsv";
+            }
+            else if (acceptHeader.Contains("text/csv"))
+            {
+                effectiveFormat = "csv";
+            }
+            else if (
+                acceptHeader.Contains("text/plain")
+                && !acceptHeader.Contains("application/json")
+            )
+            {
+                // text/plain returns TSV for Nightscout compatibility
+                effectiveFormat = "tsv";
+            }
         }
+
+        // Handle different output formats
+        if (
+            !string.IsNullOrEmpty(effectiveFormat)
+            && !effectiveFormat.Equals("json", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            try
+            {
+                var formattedData = DataFormatService.FormatEntries(
+                    entriesArray,
+                    effectiveFormat
+                );
+                var contentType = DataFormatService.GetContentType(effectiveFormat);
+                return Content(formattedData, contentType);
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Unsupported format requested: {Format}",
+                    effectiveFormat
+                );
+                return BadRequest(
+                    new
+                    {
+                        status = 400,
+                        message = $"Unsupported format: {effectiveFormat}. Supported formats: json, csv, tsv, txt",
+                        type = "client",
+                    }
+                );
+            }
+        }
+
+        return Ok(entriesArray.ToV1Responses());
     }
 
     /// <summary>
@@ -543,6 +509,7 @@ public class EntriesController : ControllerBase
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(typeof(object), 400)]
     [ProducesResponseType(typeof(object), 500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Entry[]>> CreateEntries(
         [FromBody] object entryData,
         CancellationToken cancellationToken = default
@@ -668,20 +635,6 @@ public class EntriesController : ControllerBase
                     status = 400,
                     message = "Invalid JSON format",
                     type = "client",
-                    error = ex.Message,
-                }
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating entries");
-            return StatusCode(
-                500,
-                new
-                {
-                    status = 500,
-                    message = "Internal server error",
-                    type = "internal",
                     error = ex.Message,
                 }
             );
@@ -832,6 +785,7 @@ public class EntriesController : ControllerBase
     [ProducesResponseType(typeof(object), 400)]
     [ProducesResponseType(typeof(object), 404)]
     [ProducesResponseType(typeof(object), 500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Entry>> UpdateEntry(
         string id,
         [FromBody] Entry entryData,
@@ -844,68 +798,51 @@ public class EntriesController : ControllerBase
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
-        {
-            // Validate ID format: legacy MongoDB ObjectIds (24 hex) and system-assigned
-            // UUID v7 ids from POST /api/v1/entries (32 hex, see NormalizeEntry) are both valid.
-            if (
-                string.IsNullOrEmpty(id)
-                || !System.Text.RegularExpressions.Regex.IsMatch(
-                    id,
-                    "^([a-f\\d]{24}|[a-f\\d]{32})$",
-                    System.Text.RegularExpressions.RegexOptions.IgnoreCase
-                )
-            )
-            {
-                return BadRequest(
-                    new
-                    {
-                        status = 400,
-                        message = "Invalid entry ID format",
-                        type = "client",
-                    }
-                );
-            }
-
-            // Ensure the ID in the data matches the URL parameter
-            entryData.Id = id;
-
-            var updatedEntry = await _entryService.UpdateEntryAsync(
+        // Validate ID format: legacy MongoDB ObjectIds (24 hex) and system-assigned
+        // UUID v7 ids from POST /api/v1/entries (32 hex, see NormalizeEntry) are both valid.
+        if (
+            string.IsNullOrEmpty(id)
+            || !System.Text.RegularExpressions.Regex.IsMatch(
                 id,
-                entryData,
-                cancellationToken
-            );
-
-            if (updatedEntry == null)
-            {
-                _logger.LogDebug("Entry with ID {Id} not found for update", id);
-                return NotFound(
-                    new
-                    {
-                        status = 404,
-                        message = "Entry not found",
-                        type = "client",
-                    }
-                );
-            }
-
-            _logger.LogDebug("Successfully updated entry with ID: {Id}", id);
-            return Ok(updatedEntry.ToV1Response());
-        }
-        catch (Exception ex)
+                "^([a-f\\d]{24}|[a-f\\d]{32})$",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase
+            )
+        )
         {
-            _logger.LogError(ex, "Error updating entry with ID: {Id}", id);
-            return StatusCode(
-                500,
+            return BadRequest(
                 new
                 {
-                    status = 500,
-                    message = "Internal server error",
-                    type = "internal",
-                    error = ex.Message,
+                    status = 400,
+                    message = "Invalid entry ID format",
+                    type = "client",
                 }
             );
         }
+
+        // Ensure the ID in the data matches the URL parameter
+        entryData.Id = id;
+
+        var updatedEntry = await _entryService.UpdateEntryAsync(
+            id,
+            entryData,
+            cancellationToken
+        );
+
+        if (updatedEntry == null)
+        {
+            _logger.LogDebug("Entry with ID {Id} not found for update", id);
+            return NotFound(
+                new
+                {
+                    status = 404,
+                    message = "Entry not found",
+                    type = "client",
+                }
+            );
+        }
+
+        _logger.LogDebug("Successfully updated entry with ID: {Id}", id);
+        return Ok(updatedEntry.ToV1Response());
     }
 
     /// <summary>
@@ -922,6 +859,7 @@ public class EntriesController : ControllerBase
     [ProducesResponseType(typeof(object), 400)]
     [ProducesResponseType(typeof(object), 404)]
     [ProducesResponseType(typeof(object), 500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteEntry(
         string id,
         CancellationToken cancellationToken = default
@@ -933,69 +871,52 @@ public class EntriesController : ControllerBase
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
-        {
-            // Validate ID format: legacy MongoDB ObjectIds (24 hex) and system-assigned
-            // UUID v7 ids from POST /api/v1/entries (32 hex, see NormalizeEntry) are both valid.
-            if (
-                string.IsNullOrEmpty(id)
-                || !System.Text.RegularExpressions.Regex.IsMatch(
-                    id,
-                    "^([a-f\\d]{24}|[a-f\\d]{32})$",
-                    System.Text.RegularExpressions.RegexOptions.IgnoreCase
-                )
+        // Validate ID format: legacy MongoDB ObjectIds (24 hex) and system-assigned
+        // UUID v7 ids from POST /api/v1/entries (32 hex, see NormalizeEntry) are both valid.
+        if (
+            string.IsNullOrEmpty(id)
+            || !System.Text.RegularExpressions.Regex.IsMatch(
+                id,
+                "^([a-f\\d]{24}|[a-f\\d]{32})$",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase
             )
-            {
-                return BadRequest(
-                    new
-                    {
-                        status = 400,
-                        message = "Invalid entry ID format",
-                        type = "client",
-                    }
-                );
-            }
-
-            var deleted = await _entryService.DeleteEntryAsync(id, cancellationToken);
-
-            if (!deleted)
-            {
-                _logger.LogDebug("Entry with ID {Id} not found for deletion", id);
-                return NotFound(
-                    new
-                    {
-                        status = 404,
-                        message = "Entry not found",
-                        type = "client",
-                    }
-                );
-            }
-
-            _logger.LogDebug("Successfully deleted entry with ID: {Id}", id);
-            return Ok(
-                new
-                {
-                    status = 200,
-                    message = "Entry deleted successfully",
-                    type = "success",
-                    id = id,
-                }
-            );
-        }
-        catch (Exception ex)
+        )
         {
-            _logger.LogError(ex, "Error deleting entry with ID: {Id}", id);
-            return StatusCode(
-                500,
+            return BadRequest(
                 new
                 {
-                    status = 500,
-                    message = "Internal server error",
-                    type = "internal",
-                    error = ex.Message,
+                    status = 400,
+                    message = "Invalid entry ID format",
+                    type = "client",
                 }
             );
         }
+
+        var deleted = await _entryService.DeleteEntryAsync(id, cancellationToken);
+
+        if (!deleted)
+        {
+            _logger.LogDebug("Entry with ID {Id} not found for deletion", id);
+            return NotFound(
+                new
+                {
+                    status = 404,
+                    message = "Entry not found",
+                    type = "client",
+                }
+            );
+        }
+
+        _logger.LogDebug("Successfully deleted entry with ID: {Id}", id);
+        return Ok(
+            new
+            {
+                status = 200,
+                message = "Entry deleted successfully",
+                type = "success",
+                id = id,
+            }
+        );
     }
 
     /// <summary>
@@ -1011,6 +932,7 @@ public class EntriesController : ControllerBase
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(typeof(object), 400)]
     [ProducesResponseType(typeof(object), 500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> BulkDeleteEntries(
         [FromQuery] string? find = null,
         CancellationToken cancellationToken = default
@@ -1021,61 +943,44 @@ public class EntriesController : ControllerBase
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        string? findQuery = find;
+
+        // If no simple find parameter provided, check for complex query parameters
+        if (string.IsNullOrEmpty(findQuery))
         {
-            string? findQuery = find;
+            var queryString = HttpContext?.Request?.QueryString.ToString() ?? "";
 
-            // If no simple find parameter provided, check for complex query parameters
-            if (string.IsNullOrEmpty(findQuery))
+            if (!string.IsNullOrEmpty(queryString) && queryString != "?")
             {
-                var queryString = HttpContext?.Request?.QueryString.ToString() ?? "";
-
-                if (!string.IsNullOrEmpty(queryString) && queryString != "?")
-                {
-                    // Remove the leading '?' from query string and use it as the find query
-                    findQuery = queryString.TrimStart('?');
-                }
+                // Remove the leading '?' from query string and use it as the find query
+                findQuery = queryString.TrimStart('?');
             }
+        }
 
-            if (string.IsNullOrEmpty(findQuery))
-            {
-                return BadRequest(
-                    new
-                    {
-                        status = 400,
-                        message = "Find query parameter is required for bulk delete",
-                        type = "client",
-                    }
-                );
-            }
-
-            var deletedCount = await _entryService.DeleteEntriesAsync(findQuery, cancellationToken);
-
-            _logger.LogDebug("Successfully deleted {Count} entries with query", deletedCount);
-            return Ok(
+        if (string.IsNullOrEmpty(findQuery))
+        {
+            return BadRequest(
                 new
                 {
-                    status = 200,
-                    message = $"Deleted {deletedCount} entries",
-                    type = "success",
-                    deletedCount = deletedCount,
+                    status = 400,
+                    message = "Find query parameter is required for bulk delete",
+                    type = "client",
                 }
             );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error in bulk delete entries");
-            return StatusCode(
-                500,
-                new
-                {
-                    status = 500,
-                    message = "Internal server error",
-                    type = "internal",
-                    error = ex.Message,
-                }
-            );
-        }
+
+        var deletedCount = await _entryService.DeleteEntriesAsync(findQuery, cancellationToken);
+
+        _logger.LogDebug("Successfully deleted {Count} entries with query", deletedCount);
+        return Ok(
+            new
+            {
+                status = 200,
+                message = $"Deleted {deletedCount} entries",
+                type = "success",
+                deletedCount = deletedCount,
+            }
+        );
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V1/EntriesController.cs
@@ -76,6 +76,7 @@ public class EntriesController : ControllerBase
     [ProducesResponseType(typeof(Entry[]), 200)]
     [ProducesResponseType(typeof(Entry[]), 304)] // Not Modified response
     [RequireScope(Scope.GlucoseRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Entry[]>> GetCurrentEntry(
         CancellationToken cancellationToken = default
     )
@@ -85,78 +86,59 @@ public class EntriesController : ControllerBase
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
-        {
-            var currentEntry = await _entryService.GetCurrentEntryAsync(cancellationToken);
+        var currentEntry = await _entryService.GetCurrentEntryAsync(cancellationToken);
 
-            // Set Last-Modified header for caching
-            DateTimeOffset lastModified;
-            if (currentEntry == null)
-            {
-                _logger.LogDebug("No current entry found, returning empty array");
-                // Set Last-Modified to current time when no entries exist
-                lastModified = DateTimeOffset.UtcNow;
-                Response.Headers["Last-Modified"] = lastModified.ToString("R");
-                return Ok(Array.Empty<Entry>());
-            }
-            lastModified = DateTimeOffset.FromUnixTimeMilliseconds(currentEntry.Mills);
+        // Set Last-Modified header for caching
+        DateTimeOffset lastModified;
+        if (currentEntry == null)
+        {
+            _logger.LogDebug("No current entry found, returning empty array");
+            // Set Last-Modified to current time when no entries exist
+            lastModified = DateTimeOffset.UtcNow;
             Response.Headers["Last-Modified"] = lastModified.ToString("R");
+            return Ok(Array.Empty<Entry>());
+        }
+        lastModified = DateTimeOffset.FromUnixTimeMilliseconds(currentEntry.Mills);
+        Response.Headers["Last-Modified"] = lastModified.ToString("R");
 
-            // Check If-Modified-Since header
-            if (Request.Headers.IfModifiedSince.Count > 0)
-            {
-                if (
-                    DateTimeOffset.TryParse(
-                        Request.Headers.IfModifiedSince.First(),
-                        out var ifModifiedSince
-                    )
+        // Check If-Modified-Since header
+        if (Request.Headers.IfModifiedSince.Count > 0)
+        {
+            if (
+                DateTimeOffset.TryParse(
+                    Request.Headers.IfModifiedSince.First(),
+                    out var ifModifiedSince
                 )
+            )
+            {
+                if (lastModified <= ifModifiedSince)
                 {
-                    if (lastModified <= ifModifiedSince)
-                    {
-                        _logger.LogDebug(
-                            "Current entry not modified since {IfModifiedSince}, returning 304",
-                            ifModifiedSince
-                        );
-                        return StatusCode(
-                            304,
-                            new
-                            {
-                                status = 304,
-                                message = "Not modified",
-                                type = "internal",
-                            }
-                        );
-                    }
+                    _logger.LogDebug(
+                        "Current entry not modified since {IfModifiedSince}, returning 304",
+                        ifModifiedSince
+                    );
+                    return StatusCode(
+                        304,
+                        new
+                        {
+                            status = 304,
+                            message = "Not modified",
+                            type = "internal",
+                        }
+                    );
                 }
             }
-
-            _logger.LogDebug(
-                "Returning current entry with ID: {EntryId}, Mills: {Mills}, SGV: {Sgv}",
-                currentEntry.Id,
-                currentEntry.Mills,
-                currentEntry.Sgv ?? currentEntry.Mgdl
-            );
-
-            // Return as array to match legacy API format with V1 response structure
-            return Ok(new[] { currentEntry }.ToV1Responses());
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving current entry");
 
-            // Return error response in legacy format
-            return StatusCode(
-                500,
-                new
-                {
-                    status = 500,
-                    message = "Internal server error",
-                    type = "internal",
-                    error = ex.Message,
-                }
-            );
-        }
+        _logger.LogDebug(
+            "Returning current entry with ID: {EntryId}, Mills: {Mills}, SGV: {Sgv}",
+            currentEntry.Id,
+            currentEntry.Mills,
+            currentEntry.Sgv ?? currentEntry.Mgdl
+        );
+
+        // Return as array to match legacy API format with V1 response structure
+        return Ok(new[] { currentEntry }.ToV1Responses());
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V2/AuthorizationController.cs
+++ b/src/API/Nocturne.API/Controllers/V2/AuthorizationController.cs
@@ -57,36 +57,29 @@ public class AuthorizationController : ControllerBase
     [NightscoutEndpoint("/api/v2/authorization/request/:accessToken")]
     [ProducesResponseType(typeof(AuthorizationResponse), 200)]
     [ProducesResponseType(401)]
+    [ErrorEnvelope]
     public async Task<ActionResult<AuthorizationResponse>> GenerateJwtFromAccessToken(
         string accessToken
     )
     {
         _logger.LogDebug("JWT generation requested for access token");
 
-        try
+        if (string.IsNullOrEmpty(accessToken))
         {
-            if (string.IsNullOrEmpty(accessToken))
-            {
-                _logger.LogWarning("Empty access token provided");
-                return Unauthorized();
-            }
-
-            var result = await _authorizationService.GenerateJwtFromAccessTokenAsync(accessToken);
-
-            if (result == null)
-            {
-                _logger.LogWarning("JWT generation failed - invalid access token");
-                return Unauthorized();
-            }
-
-            _logger.LogDebug("Successfully generated JWT for subject {Subject}", result.Sub);
-            return Ok(result);
+            _logger.LogWarning("Empty access token provided");
+            return Unauthorized();
         }
-        catch (Exception ex)
+
+        var result = await _authorizationService.GenerateJwtFromAccessTokenAsync(accessToken);
+
+        if (result == null)
         {
-            _logger.LogError(ex, "Error generating JWT from access token");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+            _logger.LogWarning("JWT generation failed - invalid access token");
+            return Unauthorized();
         }
+
+        _logger.LogDebug("Successfully generated JWT for subject {Subject}", result.Sub);
+        return Ok(result);
     }
 
     /// <summary>
@@ -97,22 +90,15 @@ public class AuthorizationController : ControllerBase
     [NightscoutEndpoint("/api/v2/authorization/permissions")]
     [RemoteQuery]
     [ProducesResponseType(typeof(PermissionsResponse), 200)]
+    [ErrorEnvelope]
     public async Task<ActionResult<PermissionsResponse>> GetAllPermissions()
     {
         _logger.LogDebug("All permissions requested");
 
-        try
-        {
-            var result = await _authorizationService.GetAllPermissionsAsync();
+        var result = await _authorizationService.GetAllPermissionsAsync();
 
-            _logger.LogDebug("Successfully returned {Count} permissions", result.Permissions.Count);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting all permissions");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        _logger.LogDebug("Successfully returned {Count} permissions", result.Permissions.Count);
+        return Ok(result);
     }
 
     /// <summary>
@@ -123,25 +109,18 @@ public class AuthorizationController : ControllerBase
     [NightscoutEndpoint("/api/v2/authorization/permissions/trie")]
     [RemoteQuery]
     [ProducesResponseType(typeof(PermissionTrieResponse), 200)]
+    [ErrorEnvelope]
     public async Task<ActionResult<PermissionTrieResponse>> GetPermissionTrie()
     {
         _logger.LogDebug("Permission trie structure requested");
 
-        try
-        {
-            var result = await _authorizationService.GetPermissionTrieAsync();
+        var result = await _authorizationService.GetPermissionTrieAsync();
 
-            _logger.LogDebug(
-                "Successfully returned permission trie with {Count} permissions",
-                result.Count
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting permission trie");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        _logger.LogDebug(
+            "Successfully returned permission trie with {Count} permissions",
+            result.Count
+        );
+        return Ok(result);
     }
 
     // Subject management endpoints
@@ -156,22 +135,15 @@ public class AuthorizationController : ControllerBase
     [ProducesResponseType(typeof(List<Subject>), 200)]
     [ProducesResponseType(401)]
     [ProducesResponseType(403)]
+    [ErrorEnvelope]
     public async Task<ActionResult<List<Subject>>> GetAllSubjects()
     {
         _logger.LogDebug("Get all subjects requested");
 
-        try
-        {
-            var subjects = await _authorizationService.GetAllSubjectsAsync();
+        var subjects = await _authorizationService.GetAllSubjectsAsync();
 
-            _logger.LogDebug("Successfully returned {Count} subjects", subjects.Count);
-            return Ok(subjects);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting all subjects");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        _logger.LogDebug("Successfully returned {Count} subjects", subjects.Count);
+        return Ok(subjects);
     }
 
     /// <summary>
@@ -192,34 +164,27 @@ public class AuthorizationController : ControllerBase
     [ProducesResponseType(400)]
     [ProducesResponseType(401)]
     [ProducesResponseType(403)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Subject>> CreateSubject([FromBody] Subject subject)
     {
         _logger.LogDebug("Create subject requested: {Name}", subject.Name);
 
-        try
+        if (!ModelState.IsValid)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest(ModelState);
-            }
-
-            // Clear ID to ensure new object
-            subject.Id = null;
-
-            var createdSubject = await _authorizationService.CreateSubjectAsync(subject);
-
-            _logger.LogDebug(
-                "Successfully created subject: {Name} with ID: {Id}",
-                createdSubject.Name,
-                createdSubject.Id
-            );
-            return CreatedAtAction(nameof(GetAllSubjects), createdSubject);
+            return BadRequest(ModelState);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating subject: {Name}", subject.Name);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+
+        // Clear ID to ensure new object
+        subject.Id = null;
+
+        var createdSubject = await _authorizationService.CreateSubjectAsync(subject);
+
+        _logger.LogDebug(
+            "Successfully created subject: {Name} with ID: {Id}",
+            createdSubject.Name,
+            createdSubject.Id
+        );
+        return CreatedAtAction(nameof(GetAllSubjects), createdSubject);
     }
 
     /// <summary>
@@ -236,38 +201,31 @@ public class AuthorizationController : ControllerBase
     [ProducesResponseType(401)]
     [ProducesResponseType(403)]
     [ProducesResponseType(404)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Subject>> UpdateSubject([FromBody] Subject subject)
     {
         _logger.LogDebug("Update subject requested: {Id}", subject.Id);
 
-        try
+        if (!ModelState.IsValid)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest(ModelState);
-            }
-
-            if (string.IsNullOrEmpty(subject.Id))
-            {
-                return Problem(detail: "Subject ID is required for update", statusCode: 400, title: "Bad Request");
-            }
-
-            var updatedSubject = await _authorizationService.UpdateSubjectAsync(subject);
-
-            if (updatedSubject == null)
-            {
-                _logger.LogDebug("Subject not found for update: {Id}", subject.Id);
-                return NotFound();
-            }
-
-            _logger.LogDebug("Successfully updated subject: {Id}", updatedSubject.Id);
-            return Ok(updatedSubject);
+            return BadRequest(ModelState);
         }
-        catch (Exception ex)
+
+        if (string.IsNullOrEmpty(subject.Id))
         {
-            _logger.LogError(ex, "Error updating subject: {Id}", subject.Id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+            return Problem(detail: "Subject ID is required for update", statusCode: 400, title: "Bad Request");
         }
+
+        var updatedSubject = await _authorizationService.UpdateSubjectAsync(subject);
+
+        if (updatedSubject == null)
+        {
+            _logger.LogDebug("Subject not found for update: {Id}", subject.Id);
+            return NotFound();
+        }
+
+        _logger.LogDebug("Successfully updated subject: {Id}", updatedSubject.Id);
+        return Ok(updatedSubject);
     }
 
     /// <summary>
@@ -283,28 +241,21 @@ public class AuthorizationController : ControllerBase
     [ProducesResponseType(401)]
     [ProducesResponseType(403)]
     [ProducesResponseType(404)]
+    [ErrorEnvelope]
     public async Task<IActionResult> DeleteSubject(string id)
     {
         _logger.LogDebug("Delete subject requested: {Id}", id);
 
-        try
-        {
-            var deleted = await _authorizationService.DeleteSubjectAsync(id);
+        var deleted = await _authorizationService.DeleteSubjectAsync(id);
 
-            if (!deleted)
-            {
-                _logger.LogDebug("Subject not found for deletion: {Id}", id);
-                return NotFound();
-            }
-
-            _logger.LogDebug("Successfully deleted subject: {Id}", id);
-            return NoContent();
-        }
-        catch (Exception ex)
+        if (!deleted)
         {
-            _logger.LogError(ex, "Error deleting subject: {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+            _logger.LogDebug("Subject not found for deletion: {Id}", id);
+            return NotFound();
         }
+
+        _logger.LogDebug("Successfully deleted subject: {Id}", id);
+        return NoContent();
     }
 
     // Role management endpoints
@@ -319,22 +270,15 @@ public class AuthorizationController : ControllerBase
     [ProducesResponseType(typeof(List<Role>), 200)]
     [ProducesResponseType(401)]
     [ProducesResponseType(403)]
+    [ErrorEnvelope]
     public async Task<ActionResult<List<Role>>> GetAllRoles()
     {
         _logger.LogDebug("Get all roles requested");
 
-        try
-        {
-            var roles = await _authorizationService.GetAllRolesAsync();
+        var roles = await _authorizationService.GetAllRolesAsync();
 
-            _logger.LogDebug("Successfully returned {Count} roles", roles.Count);
-            return Ok(roles);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting all roles");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        _logger.LogDebug("Successfully returned {Count} roles", roles.Count);
+        return Ok(roles);
     }
 
     /// <summary>
@@ -350,34 +294,27 @@ public class AuthorizationController : ControllerBase
     [ProducesResponseType(400)]
     [ProducesResponseType(401)]
     [ProducesResponseType(403)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Role>> CreateRole([FromBody] Role role)
     {
         _logger.LogDebug("Create role requested: {Name}", role.Name);
 
-        try
+        if (!ModelState.IsValid)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest(ModelState);
-            }
-
-            // Clear ID to ensure new object
-            role.Id = null;
-
-            var createdRole = await _authorizationService.CreateRoleAsync(role);
-
-            _logger.LogDebug(
-                "Successfully created role: {Name} with ID: {Id}",
-                createdRole.Name,
-                createdRole.Id
-            );
-            return CreatedAtAction(nameof(GetAllRoles), createdRole);
+            return BadRequest(ModelState);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating role: {Name}", role.Name);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+
+        // Clear ID to ensure new object
+        role.Id = null;
+
+        var createdRole = await _authorizationService.CreateRoleAsync(role);
+
+        _logger.LogDebug(
+            "Successfully created role: {Name} with ID: {Id}",
+            createdRole.Name,
+            createdRole.Id
+        );
+        return CreatedAtAction(nameof(GetAllRoles), createdRole);
     }
 
     /// <summary>
@@ -394,38 +331,31 @@ public class AuthorizationController : ControllerBase
     [ProducesResponseType(401)]
     [ProducesResponseType(403)]
     [ProducesResponseType(404)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Role>> UpdateRole([FromBody] Role role)
     {
         _logger.LogDebug("Update role requested: {Id}", role.Id);
 
-        try
+        if (!ModelState.IsValid)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest(ModelState);
-            }
-
-            if (string.IsNullOrEmpty(role.Id))
-            {
-                return Problem(detail: "Role ID is required for update", statusCode: 400, title: "Bad Request");
-            }
-
-            var updatedRole = await _authorizationService.UpdateRoleAsync(role);
-
-            if (updatedRole == null)
-            {
-                _logger.LogDebug("Role not found for update: {Id}", role.Id);
-                return NotFound();
-            }
-
-            _logger.LogDebug("Successfully updated role: {Id}", updatedRole.Id);
-            return Ok(updatedRole);
+            return BadRequest(ModelState);
         }
-        catch (Exception ex)
+
+        if (string.IsNullOrEmpty(role.Id))
         {
-            _logger.LogError(ex, "Error updating role: {Id}", role.Id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+            return Problem(detail: "Role ID is required for update", statusCode: 400, title: "Bad Request");
         }
+
+        var updatedRole = await _authorizationService.UpdateRoleAsync(role);
+
+        if (updatedRole == null)
+        {
+            _logger.LogDebug("Role not found for update: {Id}", role.Id);
+            return NotFound();
+        }
+
+        _logger.LogDebug("Successfully updated role: {Id}", updatedRole.Id);
+        return Ok(updatedRole);
     }
 
     /// <summary>
@@ -441,27 +371,20 @@ public class AuthorizationController : ControllerBase
     [ProducesResponseType(401)]
     [ProducesResponseType(403)]
     [ProducesResponseType(404)]
+    [ErrorEnvelope]
     public async Task<IActionResult> DeleteRole(string id)
     {
         _logger.LogDebug("Delete role requested: {Id}", id);
 
-        try
-        {
-            var deleted = await _authorizationService.DeleteRoleAsync(id);
+        var deleted = await _authorizationService.DeleteRoleAsync(id);
 
-            if (!deleted)
-            {
-                _logger.LogDebug("Role not found for deletion: {Id}", id);
-                return NotFound();
-            }
-
-            _logger.LogDebug("Successfully deleted role: {Id}", id);
-            return NoContent();
-        }
-        catch (Exception ex)
+        if (!deleted)
         {
-            _logger.LogError(ex, "Error deleting role: {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+            _logger.LogDebug("Role not found for deletion: {Id}", id);
+            return NotFound();
         }
+
+        _logger.LogDebug("Successfully deleted role: {Id}", id);
+        return NoContent();
     }
 }

--- a/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/DeviceStatusController.cs
@@ -65,6 +65,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.DevicesRead)]
+    [ErrorEnvelope]
     public async Task<IActionResult> GetDeviceStatus(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -138,11 +139,6 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             _logger.LogWarning(ex, "Invalid V3 devicestatus request parameters");
             return CreateV3ErrorResponse(400, "Invalid request parameters", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 devicestatus");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -157,6 +153,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.DevicesRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetDeviceStatusById(
         string id,
         CancellationToken cancellationToken = default
@@ -168,22 +165,14 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
-        {
-            var result = await _projection.GetByIdAsync(id, cancellationToken);
+        var result = await _projection.GetByIdAsync(id, cancellationToken);
 
-            if (result == null)
-            {
-                return CreateV3ErrorResponse(404, "Device status not found");
-            }
-
-            return CreateV3SuccessResponse(MapToV3Dto(result));
-        }
-        catch (Exception ex)
+        if (result == null)
         {
-            _logger.LogError(ex, "Error retrieving device status with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
+            return CreateV3ErrorResponse(404, "Device status not found");
         }
+
+        return CreateV3SuccessResponse(MapToV3Dto(result));
     }
 
     /// <summary>
@@ -199,6 +188,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
     [ProducesResponseType(typeof(DeviceStatus[]), 201)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> CreateDeviceStatus(
         [FromBody] JsonElement deviceStatusData,
         CancellationToken cancellationToken = default
@@ -318,11 +308,6 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             _logger.LogWarning(ex, "Invalid V3 devicestatus create request");
             return CreateV3ErrorResponse(400, "Invalid request data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating V3 devicestatus");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -340,6 +325,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
     [ProducesResponseType(typeof(Dictionary<string, object>), 200)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
+    [ErrorEnvelope]
     public async Task<IActionResult> UpdateDeviceStatus(
         string id,
         [FromBody] JsonElement request,
@@ -385,46 +371,38 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
         deviceStatus.Id = id;
         ProcessDeviceStatusForCreation(deviceStatus);
 
-        try
+        // Verify the record exists in V4 before updating
+        var existing = await _projection.GetByIdAsync(id, cancellationToken);
+        if (existing == null)
         {
-            // Verify the record exists in V4 before updating
-            var existing = await _projection.GetByIdAsync(id, cancellationToken);
-            if (existing == null)
+            return CreateV3ErrorResponse(404, "Device status not found");
+        }
+
+        // Delete old V4 records by legacy ID, then decompose the updated DeviceStatus
+        await _decomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
+        // Direct v3 update has no connector data source; a live update broadcasts.
+        await _decomposer.DecomposeAsync(deviceStatus, source: null, WriteOrigin.Live, cancellationToken);
+
+        // Project the V4 snapshots back to DeviceStatus shape for the response
+        var updated = await _projection.GetByIdAsync(id, cancellationToken) ?? deviceStatus;
+
+        // Broadcast via WriteSideEffectsService (cache invalidation + SignalR)
+        await _sideEffects.OnUpdatedAsync(
+            CollectionName,
+            updated,
+            NoDecompose,
+            cancellationToken
+        );
+
+        await _events.OnUpdatedAsync(updated, cancellationToken);
+
+        return Ok(
+            new Dictionary<string, object>
             {
-                return CreateV3ErrorResponse(404, "Device status not found");
+                ["status"] = 200,
+                ["result"] = MapToV3Dto(updated),
             }
-
-            // Delete old V4 records by legacy ID, then decompose the updated DeviceStatus
-            await _decomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
-            // Direct v3 update has no connector data source; a live update broadcasts.
-            await _decomposer.DecomposeAsync(deviceStatus, source: null, WriteOrigin.Live, cancellationToken);
-
-            // Project the V4 snapshots back to DeviceStatus shape for the response
-            var updated = await _projection.GetByIdAsync(id, cancellationToken) ?? deviceStatus;
-
-            // Broadcast via WriteSideEffectsService (cache invalidation + SignalR)
-            await _sideEffects.OnUpdatedAsync(
-                CollectionName,
-                updated,
-                NoDecompose,
-                cancellationToken
-            );
-
-            await _events.OnUpdatedAsync(updated, cancellationToken);
-
-            return Ok(
-                new Dictionary<string, object>
-                {
-                    ["status"] = 200,
-                    ["result"] = MapToV3Dto(updated),
-                }
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating device status with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+        );
     }
 
     /// <summary>
@@ -440,6 +418,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
     [ProducesResponseType(204)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteDeviceStatus(
         string id,
         CancellationToken cancellationToken = default
@@ -451,41 +430,33 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        // Get the projected record before deleting (for broadcast)
+        var deviceStatusToDelete = await _projection.GetByIdAsync(id, cancellationToken);
+
+        // Delete V4 snapshot records by legacy ID
+        var deleted = await _decomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
+
+        if (deleted == 0 && deviceStatusToDelete == null)
         {
-            // Get the projected record before deleting (for broadcast)
-            var deviceStatusToDelete = await _projection.GetByIdAsync(id, cancellationToken);
-
-            // Delete V4 snapshot records by legacy ID
-            var deleted = await _decomposer.DeleteByLegacyIdAsync(id, WriteOrigin.Live, cancellationToken);
-
-            if (deleted == 0 && deviceStatusToDelete == null)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Device status not found",
-                    $"Device status with ID '{id}' was not found"
-                );
-            }
-
-            await _sideEffects.OnDeletedAsync(
-                CollectionName,
-                deviceStatusToDelete,
-                NoDecompose,
-                cancellationToken
+            return CreateV3ErrorResponse(
+                404,
+                "Device status not found",
+                $"Device status with ID '{id}' was not found"
             );
-
-            await _events.OnDeletedAsync(deviceStatusToDelete, cancellationToken);
-
-            _logger.LogDebug("Successfully deleted device status with ID {Id}", id);
-
-            return NoContent();
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error deleting device status with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        await _sideEffects.OnDeletedAsync(
+            CollectionName,
+            deviceStatusToDelete,
+            NoDecompose,
+            cancellationToken
+        );
+
+        await _events.OnDeletedAsync(deviceStatusToDelete, cancellationToken);
+
+        _logger.LogDebug("Successfully deleted device status with ID {Id}", id);
+
+        return NoContent();
     }
 
     /// <summary>
@@ -500,6 +471,7 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.DevicesRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetDeviceStatusHistory(
         long lastModified,
         [FromQuery] int limit = 1000,
@@ -512,29 +484,21 @@ public class DeviceStatusController : BaseV3Controller<DeviceStatus>
             limit
         );
 
-        try
+        limit = Math.Min(Math.Max(limit, 1), 1000);
+
+        var deviceStatuses = (await _projection.GetModifiedSinceAsync(
+            lastModified,
+            limit,
+            cancellationToken
+        )).ToList();
+
+        if (deviceStatuses.Count > 0)
         {
-            limit = Math.Min(Math.Max(limit, 1), 1000);
-
-            var deviceStatuses = (await _projection.GetModifiedSinceAsync(
-                lastModified,
-                limit,
-                cancellationToken
-            )).ToList();
-
-            if (deviceStatuses.Count > 0)
-            {
-                SetHistoryCursorHeaders(deviceStatuses.Max(d => d.Mills));
-            }
-
-            var mappedData = deviceStatuses.Select(MapToV3Dto);
-            return CreateV3SuccessResponse(mappedData);
+            SetHistoryCursorHeaders(deviceStatuses.Max(d => d.Mills));
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving devicestatus history");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        var mappedData = deviceStatuses.Select(MapToV3Dto);
+        return CreateV3SuccessResponse(mappedData);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/EntriesController.cs
@@ -66,6 +66,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.GlucoseRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetEntries(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -128,11 +129,6 @@ public class EntriesController : BaseV3Controller<Entry>
             _logger.LogWarning(ex, "Invalid V3 entries request parameters");
             return CreateV3ErrorResponse(400, "Invalid request parameters", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 entries");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -147,6 +143,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.GlucoseRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Entry>> GetEntry(
         string id,
         CancellationToken cancellationToken = default
@@ -154,30 +151,22 @@ public class EntriesController : BaseV3Controller<Entry>
     {
         _logger.LogDebug("V3 entry by ID requested: {Id}", id);
 
-        try
+        var entry = await _entryService.GetEntryByIdAsync(id, cancellationToken);
+
+        if (entry == null)
         {
-            var entry = await _entryService.GetEntryByIdAsync(id, cancellationToken);
-
-            if (entry == null)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Entry not found",
-                    $"No entry found with ID: {id}"
-                );
-            }
-
-            // Set appropriate headers
-            Response.Headers["ETag"] = FormatCursorETag(entry.Mills);
-            Response.Headers["Cache-Control"] = "public, max-age=60";
-
-            return Ok(entry.ToV3Response());
+            return CreateV3ErrorResponse(
+                404,
+                "Entry not found",
+                $"No entry found with ID: {id}"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 entry {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        // Set appropriate headers
+        Response.Headers["ETag"] = FormatCursorETag(entry.Mills);
+        Response.Headers["Cache-Control"] = "public, max-age=60";
+
+        return Ok(entry.ToV3Response());
     }
 
     /// <summary>
@@ -203,6 +192,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [ProducesResponseType(typeof(Entry), 201)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Entry>> CreateEntry(
         [FromBody] Entry entry,
         CancellationToken cancellationToken = default
@@ -280,11 +270,6 @@ public class EntriesController : BaseV3Controller<Entry>
             _logger.LogWarning(ex, "Invalid V3 entry data");
             return CreateV3ErrorResponse(400, "Invalid entry data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating V3 entry");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -300,6 +285,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [ProducesResponseType(typeof(Entry[]), 201)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Entry[]>> CreateEntries(
         [FromBody] Entry[] entries,
         CancellationToken cancellationToken = default
@@ -356,11 +342,6 @@ public class EntriesController : BaseV3Controller<Entry>
             _logger.LogWarning(ex, "Invalid V3 bulk entry data");
             return CreateV3ErrorResponse(400, "Invalid entries data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating V3 bulk entries");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -378,6 +359,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Entry>> UpdateEntry(
         string id,
         [FromBody] Entry entry,
@@ -428,11 +410,6 @@ public class EntriesController : BaseV3Controller<Entry>
             _logger.LogWarning(ex, "Invalid V3 entry update data for {Id}", id);
             return CreateV3ErrorResponse(400, "Invalid entry data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating V3 entry {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -448,6 +425,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [ProducesResponseType(204)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteEntry(
         string id,
         CancellationToken cancellationToken = default
@@ -455,28 +433,20 @@ public class EntriesController : BaseV3Controller<Entry>
     {
         _logger.LogDebug("V3 entry deletion requested for {Id}", id);
 
-        try
+        var deleted = await _entryService.DeleteEntryAsync(id, cancellationToken);
+
+        if (!deleted)
         {
-            var deleted = await _entryService.DeleteEntryAsync(id, cancellationToken);
-
-            if (!deleted)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Entry not found",
-                    $"No entry found with ID: {id}"
-                );
-            }
-
-            _logger.LogDebug("Successfully deleted V3 entry {Id}", id);
-
-            return NoContent();
+            return CreateV3ErrorResponse(
+                404,
+                "Entry not found",
+                $"No entry found with ID: {id}"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error deleting V3 entry {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        _logger.LogDebug("Successfully deleted V3 entry {Id}", id);
+
+        return NoContent();
     }
 
     /// <summary>
@@ -493,6 +463,7 @@ public class EntriesController : BaseV3Controller<Entry>
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.GlucoseRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetEntryHistory(
         long lastModified,
         [FromQuery] int limit = 1000,
@@ -505,40 +476,32 @@ public class EntriesController : BaseV3Controller<Entry>
             limit
         );
 
-        try
+        limit = Math.Min(Math.Max(limit, 1), 1000);
+
+        // Build a find query for entries strictly newer than the cursor. Strictly-greater
+        // (not $gte) so the cursor record AAPS already holds is not re-returned, which
+        // would otherwise loop the incremental sync.
+        var findQuery = $"{{\"date\":{{\"$gt\":{lastModified}}}}}";
+        // Page oldest-first (reverseResults: true -> ascending) so a backlog larger than one
+        // page advances the cursor forward record by record. Newest-first would set the
+        // cursor to the newest of the first page and skip every older unsynced entry.
+        var entries = (await _entryService.GetEntriesWithAdvancedFilterAsync(
+            type: null,
+            count: limit,
+            skip: 0,
+            findQuery: findQuery,
+            dateString: null,
+            reverseResults: true,
+            cancellationToken: cancellationToken
+        )).ToList();
+
+        if (entries.Count > 0)
         {
-            limit = Math.Min(Math.Max(limit, 1), 1000);
-
-            // Build a find query for entries strictly newer than the cursor. Strictly-greater
-            // (not $gte) so the cursor record AAPS already holds is not re-returned, which
-            // would otherwise loop the incremental sync.
-            var findQuery = $"{{\"date\":{{\"$gt\":{lastModified}}}}}";
-            // Page oldest-first (reverseResults: true -> ascending) so a backlog larger than one
-            // page advances the cursor forward record by record. Newest-first would set the
-            // cursor to the newest of the first page and skip every older unsynced entry.
-            var entries = (await _entryService.GetEntriesWithAdvancedFilterAsync(
-                type: null,
-                count: limit,
-                skip: 0,
-                findQuery: findQuery,
-                dateString: null,
-                reverseResults: true,
-                cancellationToken: cancellationToken
-            )).ToList();
-
-            if (entries.Count > 0)
-            {
-                SetHistoryCursorHeaders(entries.Max(e => e.Mills));
-            }
-
-            var v3Entries = entries.ToV3Responses().ToList();
-            return CreateV3SuccessResponse(v3Entries);
+            SetHistoryCursorHeaders(entries.Max(e => e.Mills));
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving entry history");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        var v3Entries = entries.ToV3Responses().ToList();
+        return CreateV3SuccessResponse(v3Entries);
     }
 
     #region Helper Methods

--- a/src/API/Nocturne.API/Controllers/V3/FoodController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/FoodController.cs
@@ -46,6 +46,7 @@ public class FoodController : BaseV3Controller<Food>
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.FoodRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetFood(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -116,11 +117,6 @@ public class FoodController : BaseV3Controller<Food>
             _logger.LogWarning(ex, "Invalid V3 food request parameters");
             return CreateV3ErrorResponse(400, "Invalid request parameters", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 food");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -142,6 +138,7 @@ public class FoodController : BaseV3Controller<Food>
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.FoodRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetFoodHistory(
         long lastModified,
         [FromQuery] int limit = 1000,
@@ -154,37 +151,29 @@ public class FoodController : BaseV3Controller<Food>
             limit
         );
 
-        try
-        {
-            limit = Math.Min(Math.Max(limit, 1), 1000);
+        limit = Math.Min(Math.Max(limit, 1), 1000);
 
-            var foodRecords = await _foods.GetFoodWithAdvancedFilterAsync(
-                count: int.MaxValue,
-                skip: 0,
-                findQuery: null,
-                type: null,
-                reverseResults: false,
-                cancellationToken: cancellationToken
-            );
+        var foodRecords = await _foods.GetFoodWithAdvancedFilterAsync(
+            count: int.MaxValue,
+            skip: 0,
+            findQuery: null,
+            type: null,
+            reverseResults: false,
+            cancellationToken: cancellationToken
+        );
 
-            var newerFoods = foodRecords
-                .Select(f => (Food: f, Mills: ParseCreatedAtMills(f.CreatedAt)))
-                .Where(x => x.Mills.HasValue && x.Mills.Value > lastModified)
-                .OrderBy(x => x.Mills)
-                .Take(limit)
-                .ToList();
+        var newerFoods = foodRecords
+            .Select(f => (Food: f, Mills: ParseCreatedAtMills(f.CreatedAt)))
+            .Where(x => x.Mills.HasValue && x.Mills.Value > lastModified)
+            .OrderBy(x => x.Mills)
+            .Take(limit)
+            .ToList();
 
-            SetHistoryCursorHeaders(
-                newerFoods.Count > 0 ? newerFoods.Max(x => x.Mills!.Value) : lastModified
-            );
+        SetHistoryCursorHeaders(
+            newerFoods.Count > 0 ? newerFoods.Max(x => x.Mills!.Value) : lastModified
+        );
 
-            return CreateV3SuccessResponse(newerFoods.Select(x => x.Food).ToList());
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 food history");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+        return CreateV3SuccessResponse(newerFoods.Select(x => x.Food).ToList());
     }
 
     /// <summary>
@@ -299,6 +288,7 @@ public class FoodController : BaseV3Controller<Food>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.FoodRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetFoodById(
         string id,
         CancellationToken cancellationToken = default
@@ -310,31 +300,23 @@ public class FoodController : BaseV3Controller<Food>
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        var food = await _foods.GetFoodByIdAsync(id, cancellationToken);
+
+        if (food == null)
         {
-            var food = await _foods.GetFoodByIdAsync(id, cancellationToken);
-
-            if (food == null)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Food not found",
-                    $"Food with ID '{id}' was not found"
-                );
-            }
-
-            var parameters = ParseV3QueryParameters(); // Apply field selection if specified
-            var result = ApplyFieldSelection(new[] { food }, parameters.Fields).FirstOrDefault();
-
-            _logger.LogDebug("Successfully returned food with ID {Id}", id);
-
-            return Ok(result);
+            return CreateV3ErrorResponse(
+                404,
+                "Food not found",
+                $"Food with ID '{id}' was not found"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving food with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        var parameters = ParseV3QueryParameters(); // Apply field selection if specified
+        var result = ApplyFieldSelection(new[] { food }, parameters.Fields).FirstOrDefault();
+
+        _logger.LogDebug("Successfully returned food with ID {Id}", id);
+
+        return Ok(result);
     }
 
     /// <summary>
@@ -351,6 +333,7 @@ public class FoodController : BaseV3Controller<Food>
     [ProducesResponseType(typeof(Food[]), 201)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> CreateFood(
         [FromBody] JsonElement foodData,
         CancellationToken cancellationToken = default
@@ -422,11 +405,6 @@ public class FoodController : BaseV3Controller<Food>
             _logger.LogWarning(ex, "Invalid V3 food create request");
             return CreateV3ErrorResponse(400, "Invalid request data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating V3 food");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -445,6 +423,7 @@ public class FoodController : BaseV3Controller<Food>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> UpdateFood(
         string id,
         [FromBody] JsonElement foodData,
@@ -502,11 +481,6 @@ public class FoodController : BaseV3Controller<Food>
         {
             _logger.LogWarning(ex, "Invalid V3 food update request for ID {Id}", id);
             return CreateV3ErrorResponse(400, "Invalid request data", ex.Message);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating food with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
         }
     }
 
@@ -582,6 +556,7 @@ public class FoodController : BaseV3Controller<Food>
     [ProducesResponseType(204)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteFood(
         string id,
         CancellationToken cancellationToken = default
@@ -593,28 +568,20 @@ public class FoodController : BaseV3Controller<Food>
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        var deleted = await _foods.DeleteFoodAsync(id, cancellationToken);
+
+        if (!deleted)
         {
-            var deleted = await _foods.DeleteFoodAsync(id, cancellationToken);
-
-            if (!deleted)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Food not found",
-                    $"Food with ID '{id}' was not found"
-                );
-            }
-
-            _logger.LogDebug("Successfully deleted food with ID {Id}", id);
-
-            return NoContent();
+            return CreateV3ErrorResponse(
+                404,
+                "Food not found",
+                $"Food with ID '{id}' was not found"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error deleting food with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        _logger.LogDebug("Successfully deleted food with ID {Id}", id);
+
+        return NoContent();
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V3/ProfileController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/ProfileController.cs
@@ -50,6 +50,7 @@ public class ProfileController : BaseV3Controller<Profile>
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.TherapyRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetProfiles(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -95,11 +96,6 @@ public class ProfileController : BaseV3Controller<Profile>
             _logger.LogWarning(ex, "Invalid V3 profile request parameters");
             return CreateV3ErrorResponse(400, "Invalid request parameters", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 profiles");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -120,6 +116,7 @@ public class ProfileController : BaseV3Controller<Profile>
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.TherapyRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetProfileHistory(
         long lastModified,
         [FromQuery] int limit = 10,
@@ -132,38 +129,30 @@ public class ProfileController : BaseV3Controller<Profile>
             limit
         );
 
-        try
-        {
-            limit = Math.Min(Math.Max(limit, 1), 100);
+        limit = Math.Min(Math.Max(limit, 1), 100);
 
-            // The projection returns the newest `limit` profiles. A record newer than the
-            // cursor but older than this window is a superseded profile version; AAPS only
-            // activates the newest store in the page, so skipping it loses nothing.
-            var profiles = await _projectionService.GetProfilesAsync(
-                count: limit,
-                skip: 0,
-                ct: cancellationToken
-            );
+        // The projection returns the newest `limit` profiles. A record newer than the
+        // cursor but older than this window is a superseded profile version; AAPS only
+        // activates the newest store in the page, so skipping it loses nothing.
+        var profiles = await _projectionService.GetProfilesAsync(
+            count: limit,
+            skip: 0,
+            ct: cancellationToken
+        );
 
-            // Ascending order: AAPS activates the LAST element of the page.
-            var newerProfiles = profiles
-                .Where(p => p.Mills > lastModified)
-                .OrderBy(p => p.Mills)
-                .ToList();
+        // Ascending order: AAPS activates the LAST element of the page.
+        var newerProfiles = profiles
+            .Where(p => p.Mills > lastModified)
+            .OrderBy(p => p.Mills)
+            .ToList();
 
-            // Echo the request cursor on an empty page so conditional clients always see
-            // a parseable cursor ETag.
-            SetHistoryCursorHeaders(
-                newerProfiles.Count > 0 ? newerProfiles.Max(p => p.Mills) : lastModified
-            );
+        // Echo the request cursor on an empty page so conditional clients always see
+        // a parseable cursor ETag.
+        SetHistoryCursorHeaders(
+            newerProfiles.Count > 0 ? newerProfiles.Max(p => p.Mills) : lastModified
+        );
 
-            return CreateV3SuccessResponse(newerProfiles);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 profile history");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+        return CreateV3SuccessResponse(newerProfiles);
     }
 
     /// <summary>
@@ -178,6 +167,7 @@ public class ProfileController : BaseV3Controller<Profile>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.TherapyRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetProfileById(
         string id,
         CancellationToken cancellationToken = default
@@ -189,31 +179,23 @@ public class ProfileController : BaseV3Controller<Profile>
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        var profile = await _projectionService.GetProfileByIdAsync(id, cancellationToken);
+
+        if (profile == null)
         {
-            var profile = await _projectionService.GetProfileByIdAsync(id, cancellationToken);
-
-            if (profile == null)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Profile not found",
-                    $"Profile with ID '{id}' was not found"
-                );
-            }
-
-            var parameters = ParseV3QueryParameters(); // Apply field selection if specified
-            var result = ApplyFieldSelection(new[] { profile }, parameters.Fields).FirstOrDefault();
-
-            _logger.LogDebug("Successfully returned profile with ID {Id}", id);
-
-            return Ok(result);
+            return CreateV3ErrorResponse(
+                404,
+                "Profile not found",
+                $"Profile with ID '{id}' was not found"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving profile with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        var parameters = ParseV3QueryParameters(); // Apply field selection if specified
+        var result = ApplyFieldSelection(new[] { profile }, parameters.Fields).FirstOrDefault();
+
+        _logger.LogDebug("Successfully returned profile with ID {Id}", id);
+
+        return Ok(result);
     }
 
     /// <summary>
@@ -229,6 +211,7 @@ public class ProfileController : BaseV3Controller<Profile>
     [ProducesResponseType(typeof(Profile[]), 201)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> CreateProfile(
         [FromBody] JsonElement profileData,
         CancellationToken cancellationToken = default
@@ -272,11 +255,6 @@ public class ProfileController : BaseV3Controller<Profile>
             _logger.LogWarning(ex, "Invalid V3 profile create request");
             return CreateV3ErrorResponse(400, "Invalid request data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating V3 profiles");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -294,6 +272,7 @@ public class ProfileController : BaseV3Controller<Profile>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> UpdateProfile(
         string id,
         [FromBody] Profile profile,
@@ -343,11 +322,6 @@ public class ProfileController : BaseV3Controller<Profile>
             _logger.LogWarning(ex, "Invalid V3 profile update request for ID {Id}", id);
             return CreateV3ErrorResponse(400, "Invalid request data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating profile with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -363,6 +337,7 @@ public class ProfileController : BaseV3Controller<Profile>
     [ProducesResponseType(204)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteProfile(
         string id,
         CancellationToken cancellationToken = default
@@ -374,28 +349,20 @@ public class ProfileController : BaseV3Controller<Profile>
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        var deleted = await _writeService.DeleteProfileAsync(id, cancellationToken);
+
+        if (!deleted)
         {
-            var deleted = await _writeService.DeleteProfileAsync(id, cancellationToken);
-
-            if (!deleted)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Profile not found",
-                    $"Profile with ID '{id}' was not found"
-                );
-            }
-
-            _logger.LogDebug("Successfully deleted profile with ID {Id}", id);
-
-            return NoContent();
+            return CreateV3ErrorResponse(
+                404,
+                "Profile not found",
+                $"Profile with ID '{id}' was not found"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error deleting profile with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        _logger.LogDebug("Successfully deleted profile with ID {Id}", id);
+
+        return NoContent();
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V3/SettingsController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/SettingsController.cs
@@ -49,6 +49,7 @@ public class SettingsController : BaseV3Controller<Settings>
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.TherapyRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetSettings(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -107,11 +108,6 @@ public class SettingsController : BaseV3Controller<Settings>
             _logger.LogWarning(ex, "Invalid V3 settings request parameters");
             return CreateV3ErrorResponse(400, "Invalid request parameters", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 settings");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -128,6 +124,7 @@ public class SettingsController : BaseV3Controller<Settings>
     [ProducesResponseType(typeof(V3ErrorResponse), 403)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.TherapyRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetSettingsById(
         string id,
         CancellationToken cancellationToken = default
@@ -139,34 +136,26 @@ public class SettingsController : BaseV3Controller<Settings>
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        // CHECKME: Should validate admin permissions here
+
+        var settings = await _settings.GetSettingsByIdAsync(id, cancellationToken);
+
+        if (settings == null)
         {
-            // CHECKME: Should validate admin permissions here
-
-            var settings = await _settings.GetSettingsByIdAsync(id, cancellationToken);
-
-            if (settings == null)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Settings not found",
-                    $"Settings with ID '{id}' was not found"
-                );
-            }
-
-            var parameters = ParseV3QueryParameters(); // Apply field selection if specified
-            var result = ApplyFieldSelection(new[] { settings }, parameters.Fields)
-                .FirstOrDefault();
-
-            _logger.LogDebug("Successfully returned settings with ID {Id}", id);
-
-            return Ok(result);
+            return CreateV3ErrorResponse(
+                404,
+                "Settings not found",
+                $"Settings with ID '{id}' was not found"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving settings with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        var parameters = ParseV3QueryParameters(); // Apply field selection if specified
+        var result = ApplyFieldSelection(new[] { settings }, parameters.Fields)
+            .FirstOrDefault();
+
+        _logger.LogDebug("Successfully returned settings with ID {Id}", id);
+
+        return Ok(result);
     }
 
     /// <summary>
@@ -184,6 +173,7 @@ public class SettingsController : BaseV3Controller<Settings>
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(typeof(V3ErrorResponse), 403)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> CreateSettings(
         [FromBody] JsonElement settingsData,
         CancellationToken cancellationToken = default
@@ -233,11 +223,6 @@ public class SettingsController : BaseV3Controller<Settings>
             _logger.LogWarning(ex, "Invalid V3 settings create request");
             return CreateV3ErrorResponse(400, "Invalid request data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating V3 settings");
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -257,6 +242,7 @@ public class SettingsController : BaseV3Controller<Settings>
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(typeof(V3ErrorResponse), 403)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> UpdateSettings(
         string id,
         [FromBody] Settings settings,
@@ -308,11 +294,6 @@ public class SettingsController : BaseV3Controller<Settings>
             _logger.LogWarning(ex, "Invalid V3 settings update request for ID {Id}", id);
             return CreateV3ErrorResponse(400, "Invalid request data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating settings with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
     }
 
     /// <summary>
@@ -330,6 +311,7 @@ public class SettingsController : BaseV3Controller<Settings>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(typeof(V3ErrorResponse), 403)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteSettings(
         string id,
         CancellationToken cancellationToken = default
@@ -341,30 +323,22 @@ public class SettingsController : BaseV3Controller<Settings>
             HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "unknown"
         );
 
-        try
+        // CHECKME: Should validate admin permissions here
+
+        var deleted = await _settings.DeleteSettingsAsync(id, cancellationToken);
+
+        if (!deleted)
         {
-            // CHECKME: Should validate admin permissions here
-
-            var deleted = await _settings.DeleteSettingsAsync(id, cancellationToken);
-
-            if (!deleted)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Settings not found",
-                    $"Settings with ID '{id}' was not found"
-                );
-            }
-
-            _logger.LogDebug("Successfully deleted settings with ID {Id}", id);
-
-            return NoContent();
+            return CreateV3ErrorResponse(
+                404,
+                "Settings not found",
+                $"Settings with ID '{id}' was not found"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error deleting settings with ID {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", ex.Message);
-        }
+
+        _logger.LogDebug("Successfully deleted settings with ID {Id}", id);
+
+        return NoContent();
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
+++ b/src/API/Nocturne.API/Controllers/V3/TreatmentsController.cs
@@ -62,6 +62,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(304)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.TreatmentsRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetTreatments(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -119,11 +120,6 @@ public class TreatmentsController : BaseV3Controller<Treatment>
             _logger.LogWarning(ex, "Invalid V3 treatments request parameters");
             return CreateV3ErrorResponse(400, "Invalid request parameters", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 treatments");
-            return CreateV3ErrorResponse(500, "Internal server error", "An unexpected error occurred");
-        }
     }
 
     /// <summary>
@@ -138,6 +134,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.TreatmentsRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Treatment>> GetTreatment(
         string id,
         CancellationToken cancellationToken = default
@@ -145,30 +142,22 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     {
         _logger.LogDebug("V3 treatment by ID requested: {Id}", id);
 
-        try
+        var treatment = await _treatmentService.GetTreatmentByIdAsync(id, cancellationToken);
+
+        if (treatment == null)
         {
-            var treatment = await _treatmentService.GetTreatmentByIdAsync(id, cancellationToken);
-
-            if (treatment == null)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Treatment not found",
-                    $"No treatment found with ID: {id}"
-                );
-            }
-
-            // Set appropriate headers
-            Response.Headers["ETag"] = FormatCursorETag(treatment.SrvModified ?? treatment.Mills);
-            Response.Headers["Cache-Control"] = "public, max-age=60";
-
-            return Ok(treatment);
+            return CreateV3ErrorResponse(
+                404,
+                "Treatment not found",
+                $"No treatment found with ID: {id}"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving V3 treatment {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", "An unexpected error occurred");
-        }
+
+        // Set appropriate headers
+        Response.Headers["ETag"] = FormatCursorETag(treatment.SrvModified ?? treatment.Mills);
+        Response.Headers["Cache-Control"] = "public, max-age=60";
+
+        return Ok(treatment);
     }
 
     /// <summary>
@@ -194,6 +183,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(typeof(Treatment), 201)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Treatment>> CreateTreatment(
         [FromBody] Treatment treatment,
         CancellationToken cancellationToken = default
@@ -268,11 +258,6 @@ public class TreatmentsController : BaseV3Controller<Treatment>
             _logger.LogWarning(ex, "Invalid V3 treatment data");
             return CreateV3ErrorResponse(400, "Invalid treatment data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating V3 treatment");
-            return CreateV3ErrorResponse(500, "Internal server error", "An unexpected error occurred");
-        }
     }
 
     /// <summary>
@@ -288,6 +273,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(typeof(Treatment[]), 201)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Treatment[]>> CreateTreatments(
         [FromBody] Treatment[] treatments,
         CancellationToken cancellationToken = default
@@ -343,11 +329,6 @@ public class TreatmentsController : BaseV3Controller<Treatment>
             _logger.LogWarning(ex, "Invalid V3 bulk treatment data");
             return CreateV3ErrorResponse(400, "Invalid treatments data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating V3 bulk treatments");
-            return CreateV3ErrorResponse(500, "Internal server error", "An unexpected error occurred");
-        }
     }
 
     /// <summary>
@@ -365,6 +346,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(typeof(V3ErrorResponse), 400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<Treatment>> UpdateTreatment(
         string id,
         [FromBody] Treatment treatment,
@@ -415,11 +397,6 @@ public class TreatmentsController : BaseV3Controller<Treatment>
             _logger.LogWarning(ex, "Invalid V3 treatment update data for {Id}", id);
             return CreateV3ErrorResponse(400, "Invalid treatment data", ex.Message);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating V3 treatment {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", "An unexpected error occurred");
-        }
     }
 
     /// <summary>
@@ -435,6 +412,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(204)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteTreatment(
         string id,
         CancellationToken cancellationToken = default
@@ -442,28 +420,20 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     {
         _logger.LogDebug("V3 treatment deletion requested for {Id}", id);
 
-        try
+        var deleted = await _treatmentService.DeleteTreatmentAsync(id, cancellationToken);
+
+        if (!deleted)
         {
-            var deleted = await _treatmentService.DeleteTreatmentAsync(id, cancellationToken);
-
-            if (!deleted)
-            {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Treatment not found",
-                    $"No treatment found with ID: {id}"
-                );
-            }
-
-            _logger.LogDebug("Successfully deleted V3 treatment {Id}", id);
-
-            return NoContent();
+            return CreateV3ErrorResponse(
+                404,
+                "Treatment not found",
+                $"No treatment found with ID: {id}"
+            );
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error deleting V3 treatment {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", "An unexpected error occurred");
-        }
+
+        _logger.LogDebug("Successfully deleted V3 treatment {Id}", id);
+
+        return NoContent();
     }
 
     /// <summary>
@@ -480,6 +450,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(500)]
     [RequireScope(Scope.TreatmentsRead)]
+    [ErrorEnvelope]
     public async Task<ActionResult> GetTreatmentHistory(
         long lastModified,
         [FromQuery] int limit = 1000,
@@ -492,29 +463,21 @@ public class TreatmentsController : BaseV3Controller<Treatment>
             limit
         );
 
-        try
+        limit = Math.Min(Math.Max(limit, 1), 1000);
+
+        var treatments = await _treatmentService.GetTreatmentsModifiedSinceAsync(
+            lastModified,
+            limit,
+            cancellationToken
+        );
+
+        var treatmentsList = treatments.ToList();
+        if (treatmentsList.Count > 0)
         {
-            limit = Math.Min(Math.Max(limit, 1), 1000);
-
-            var treatments = await _treatmentService.GetTreatmentsModifiedSinceAsync(
-                lastModified,
-                limit,
-                cancellationToken
-            );
-
-            var treatmentsList = treatments.ToList();
-            if (treatmentsList.Count > 0)
-            {
-                SetHistoryCursorHeaders(treatmentsList.Max(t => t.SrvModified ?? t.Mills));
-            }
-
-            return CreateV3SuccessResponse(treatmentsList);
+            SetHistoryCursorHeaders(treatmentsList.Max(t => t.SrvModified ?? t.Mills));
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving treatment history");
-            return CreateV3ErrorResponse(500, "Internal server error", "An unexpected error occurred");
-        }
+
+        return CreateV3SuccessResponse(treatmentsList);
     }
 
     /// <summary>
@@ -539,6 +502,7 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     [ProducesResponseType(typeof(object), 200)]
     [ProducesResponseType(typeof(V3ErrorResponse), 404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> PatchTreatment(
         string id,
         [FromBody] JsonElement patchData,
@@ -547,39 +511,31 @@ public class TreatmentsController : BaseV3Controller<Treatment>
     {
         _logger.LogDebug("V3 treatment PATCH requested for {Id}", id);
 
-        try
-        {
-            var result = await _treatmentService.PatchTreatmentAsync(
-                id,
-                patchData,
-                cancellationToken
-            );
+        var result = await _treatmentService.PatchTreatmentAsync(
+            id,
+            patchData,
+            cancellationToken
+        );
 
-            if (result == null)
+        if (result == null)
+        {
+            return CreateV3ErrorResponse(
+                404,
+                "Treatment not found",
+                $"No treatment found with ID: {id}"
+            );
+        }
+
+        _logger.LogDebug("Successfully patched V3 treatment {Id}", id);
+
+        return Ok(
+            new
             {
-                return CreateV3ErrorResponse(
-                    404,
-                    "Treatment not found",
-                    $"No treatment found with ID: {id}"
-                );
+                status = 200,
+                result,
+                identifier = MongoObjectId.Coerce(result.Id),
             }
-
-            _logger.LogDebug("Successfully patched V3 treatment {Id}", id);
-
-            return Ok(
-                new
-                {
-                    status = 200,
-                    result,
-                    identifier = MongoObjectId.Coerce(result.Id),
-                }
-            );
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error patching V3 treatment {Id}", id);
-            return CreateV3ErrorResponse(500, "Internal server error", "An unexpected error occurred");
-        }
+        );
     }
 
     #region Helper Methods

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/ActogramController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/ActogramController.cs
@@ -57,6 +57,7 @@ public class ActogramController : ControllerBase
     [ProducesResponseType(typeof(ActogramReportData), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<ActogramReportData>> GetActogram(
         [FromQuery] long startTime,
         [FromQuery] long endTime,
@@ -66,15 +67,7 @@ public class ActogramController : ControllerBase
         if (endTime <= startTime)
             return Problem(detail: "endTime must be greater than startTime", statusCode: 400, title: "Bad Request");
 
-        try
-        {
-            var result = await _service.GetAsync(startTime, endTime, cancellationToken);
-            return Ok(ActogramReadScopeGuard.Redact(result, HttpContext.GetGrantedScopes()));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error building actogram report for window {Start}-{End}", startTime, endTime);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        var result = await _service.GetAsync(startTime, endTime, cancellationToken);
+        return Ok(ActogramReadScopeGuard.Redact(result, HttpContext.GetGrantedScopes()));
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/ChartDataController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/ChartDataController.cs
@@ -69,6 +69,7 @@ public class ChartDataController : ControllerBase
     [ProducesResponseType(typeof(DashboardChartData), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<DashboardChartData>> GetDashboardChartData(
         [FromQuery] long startTime,
         [FromQuery] long endTime,
@@ -76,28 +77,20 @@ public class ChartDataController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            if (endTime <= startTime)
-                return Problem(detail: "endTime must be greater than startTime", statusCode: 400, title: "Bad Request");
+        if (endTime <= startTime)
+            return Problem(detail: "endTime must be greater than startTime", statusCode: 400, title: "Bad Request");
 
-            if (intervalMinutes < 1 || intervalMinutes > 60)
-                return Problem(detail: "intervalMinutes must be between 1 and 60", statusCode: 400, title: "Bad Request");
+        if (intervalMinutes < 1 || intervalMinutes > 60)
+            return Problem(detail: "intervalMinutes must be between 1 and 60", statusCode: 400, title: "Bad Request");
 
-            var result = await _chartDataService.GetDashboardChartDataAsync(
-                startTime,
-                endTime,
-                intervalMinutes,
-                cancellationToken
-            );
+        var result = await _chartDataService.GetDashboardChartDataAsync(
+            startTime,
+            endTime,
+            intervalMinutes,
+            cancellationToken
+        );
 
-            return Ok(ChartDataReadScopeGuard.Redact(result, HttpContext.GetGrantedScopes()));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error calculating dashboard chart data");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(ChartDataReadScopeGuard.Redact(result, HttpContext.GetGrantedScopes()));
     }
 
     /// <summary>
@@ -117,25 +110,18 @@ public class ChartDataController : ControllerBase
     [ProducesResponseType(typeof(List<BasalPoint>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<List<BasalPoint>>> GetBasalSeries(
         [FromQuery] long startTime,
         [FromQuery] long endTime,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            if (endTime <= startTime)
-                return Problem(detail: "endTime must be greater than startTime", statusCode: 400, title: "Bad Request");
+        if (endTime <= startTime)
+            return Problem(detail: "endTime must be greater than startTime", statusCode: 400, title: "Bad Request");
 
-            var basalSeries = await _chartDataService.GetBasalSeriesAsync(startTime, endTime, cancellationToken);
+        var basalSeries = await _chartDataService.GetBasalSeriesAsync(startTime, endTime, cancellationToken);
 
-            return Ok(basalSeries);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error calculating basal series");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(basalSeries);
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/DataOverviewController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/DataOverviewController.cs
@@ -55,20 +55,13 @@ public class DataOverviewController : ControllerBase
     [ResponseCache(Duration = 300)]
     [ProducesResponseType(typeof(DataOverviewYearsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<DataOverviewYearsResponse>> GetAvailableYears(
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            var result = await _dataOverviewService.GetAvailableYearsAsync(cancellationToken);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting available years for data overview");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        var result = await _dataOverviewService.GetAvailableYearsAsync(cancellationToken);
+        return Ok(result);
     }
 
     /// <summary>
@@ -83,34 +76,27 @@ public class DataOverviewController : ControllerBase
     [ProducesResponseType(typeof(DailySummaryResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<DailySummaryResponse>> GetDailySummary(
         [FromQuery] int year,
         [FromQuery] string[]? dataSources = null,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            if (year < 1970 || year > 2100)
-                return Problem(detail: "Year must be between 1970 and 2100", statusCode: 400, title: "Bad Request");
+        if (year < 1970 || year > 2100)
+            return Problem(detail: "Year must be between 1970 and 2100", statusCode: 400, title: "Bad Request");
 
-            // Filter out empty strings
-            var cleanSources = dataSources?.Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
-            if (cleanSources is { Length: 0 })
-                cleanSources = null;
+        // Filter out empty strings
+        var cleanSources = dataSources?.Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
+        if (cleanSources is { Length: 0 })
+            cleanSources = null;
 
-            var result = await _dataOverviewService.GetDailySummaryAsync(
-                year,
-                cleanSources,
-                cancellationToken
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting daily summary for year {Year}", year);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        var result = await _dataOverviewService.GetDailySummaryAsync(
+            year,
+            cleanSources,
+            cancellationToken
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -125,33 +111,26 @@ public class DataOverviewController : ControllerBase
     [ProducesResponseType(typeof(GriTimelineResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<GriTimelineResponse>> GetGriTimeline(
         [FromQuery] int year,
         [FromQuery] string[]? dataSources = null,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            if (year < 1970 || year > 2100)
-                return Problem(detail: "Year must be between 1970 and 2100", statusCode: 400, title: "Bad Request");
+        if (year < 1970 || year > 2100)
+            return Problem(detail: "Year must be between 1970 and 2100", statusCode: 400, title: "Bad Request");
 
-            // Filter out empty strings
-            var cleanSources = dataSources?.Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
-            if (cleanSources is { Length: 0 })
-                cleanSources = null;
+        // Filter out empty strings
+        var cleanSources = dataSources?.Where(s => !string.IsNullOrWhiteSpace(s)).ToArray();
+        if (cleanSources is { Length: 0 })
+            cleanSources = null;
 
-            var result = await _dataOverviewService.GetGriTimelineAsync(
-                year,
-                cleanSources,
-                cancellationToken
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting GRI timeline for year {Year}", year);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        var result = await _dataOverviewService.GetGriTimelineAsync(
+            year,
+            cleanSources,
+            cancellationToken
+        );
+        return Ok(result);
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/RetrospectiveController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/RetrospectiveController.cs
@@ -87,123 +87,116 @@ public class RetrospectiveController : ControllerBase
     [ProducesResponseType(typeof(RetrospectiveDataResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<RetrospectiveDataResponse>> GetRetrospectiveData(
         [FromQuery] long time,
         CancellationToken cancellationToken = default
     )
     {
-        try
+        if (time <= 0)
         {
-            if (time <= 0)
-            {
-                return Problem(detail: "Time parameter must be a positive Unix timestamp in milliseconds", statusCode: 400, title: "Bad Request");
-            }
-            // Get glucose entries for context (entries around the target time)
-            // Use JSON format for the findQuery with mills field
-            var fromMills = time - (30 * 60 * 1000); // 30 minutes before
-            var toMills = time + (5 * 60 * 1000);    // 5 minutes after
-            var findQuery = $"{{\"mills\":{{\"$gte\":{fromMills},\"$lte\":{toMills}}}}}";
-            var entries = await _entryService.GetEntriesWithAdvancedFilterAsync(
-                type: "sgv",
-                count: 50,
-                skip: 0,
-                findQuery: findQuery,
-                dateString: null,
-                reverseResults: false,
-                cancellationToken: cancellationToken
-            );
-            var entryList = entries?.ToList() ?? new List<Entry>();
-            _logger.LogDebug("GetRetrospectiveData: Found {Count} entries for time {Time} (range: {From} to {To})",
-                entryList.Count, time, fromMills, toMills);
-            // Query v4 types for IOB/COB calculation (8 hours before for DIA)
-            var targetDateTime = DateTimeOffset.FromUnixTimeMilliseconds(time).UtcDateTime;
-            var fetchFrom = targetDateTime.AddHours(-8);
-            var boluses = (await _bolusRepository.GetAsync(
-                from: fetchFrom, to: targetDateTime, device: null, source: null,
-                limit: 2000, offset: 0, descending: false, ct: cancellationToken
-            )).ToList();
-            var tempBasals = (await _tempBasalRepository.GetAsync(
-                from: fetchFrom, to: targetDateTime, device: null, source: null,
-                limit: 2000, offset: 0, descending: false, ct: cancellationToken
-            )).ToList();
-            var carbIntakes = (await _carbIntakeRepository.GetAsync(
-                from: fetchFrom, to: targetDateTime, device: null, source: null,
-                limit: 2000, offset: 0, descending: false, ct: cancellationToken
-            )).ToList();
-            // Calculate IOB at the specified time
-            var iobResult = await _iobCalculator.CalculateTotalAsync(
-                boluses,
-                tempBasals,
-                time,
-                ct: cancellationToken
-            );
-            // Calculate COB at the specified time
-            var cobResult = await _cobCalculator.CalculateTotalAsync(
-                carbIntakes,
-                boluses,
-                tempBasals,
-                time,
-                ct: cancellationToken
-            );
-            // Get glucose at the specified time (interpolated)
-            var glucoseData = GetGlucoseAtTime(entryList, time);
-            // Get basal rate at the specified time
-            var basalData = await GetBasalRateAtTimeAsync(tempBasals, time);
-            // Get recent treatments as summary data (boluses and carb intakes within 30 minutes)
-            var recentTreatments = new List<TreatmentSummaryData>();
-            var recentCutoff = time - 30 * 60 * 1000;
-            foreach (var b in boluses.Where(b => b.Mills >= recentCutoff && b.Mills <= time).OrderByDescending(b => b.Mills).Take(10))
-            {
-                recentTreatments.Add(new TreatmentSummaryData
-                {
-                    Id = b.Id.ToString(),
-                    Mills = b.Mills,
-                    EventType = "Bolus",
-                    Insulin = b.Insulin,
-                });
-            }
-            foreach (var c in carbIntakes.Where(c => c.Mills >= recentCutoff && c.Mills <= time).OrderByDescending(c => c.Mills).Take(10))
-            {
-                recentTreatments.Add(new TreatmentSummaryData
-                {
-                    Id = c.Id.ToString(),
-                    Mills = c.Mills,
-                    EventType = "Carb Correction",
-                    Carbs = c.Carbs,
-                });
-            }
-            recentTreatments = recentTreatments.OrderByDescending(t => t.Mills).Take(10).ToList();
-            var response = new RetrospectiveDataResponse
-            {
-                Time = time,
-                TimeFormatted = DateTimeOffset.FromUnixTimeMilliseconds(time).ToString("HH:mm:ss"),
-                Glucose = glucoseData,
-                Iob = new IobData
-                {
-                    Total = iobResult.Iob,
-                    Bolus = iobResult.Iob - (iobResult.BasalIob ?? 0),
-                    Basal = iobResult.BasalIob ?? 0,
-                    Activity = iobResult.Activity,
-                    Source = iobResult.Source
-                },
-                Cob = new CobData
-                {
-                    Total = cobResult.Cob,
-                    IsDecaying = cobResult.IsDecaying ?? 0,
-                    CarbsHr = cobResult.CarbsHr,
-                    RawCarbImpact = cobResult.RawCarbImpact,
-                    Source = cobResult.Source
-                },
-                Basal = basalData,
-                RecentTreatments = recentTreatments
-            };
-            return Ok(RetrospectiveReadScopeGuard.Redact(response, HttpContext.GetGrantedScopes()));
+            return Problem(detail: "Time parameter must be a positive Unix timestamp in milliseconds", statusCode: 400, title: "Bad Request");
         }
-        catch (Exception ex)
+        // Get glucose entries for context (entries around the target time)
+        // Use JSON format for the findQuery with mills field
+        var fromMills = time - (30 * 60 * 1000); // 30 minutes before
+        var toMills = time + (5 * 60 * 1000);    // 5 minutes after
+        var findQuery = $"{{\"mills\":{{\"$gte\":{fromMills},\"$lte\":{toMills}}}}}";
+        var entries = await _entryService.GetEntriesWithAdvancedFilterAsync(
+            type: "sgv",
+            count: 50,
+            skip: 0,
+            findQuery: findQuery,
+            dateString: null,
+            reverseResults: false,
+            cancellationToken: cancellationToken
+        );
+        var entryList = entries?.ToList() ?? new List<Entry>();
+        _logger.LogDebug("GetRetrospectiveData: Found {Count} entries for time {Time} (range: {From} to {To})",
+            entryList.Count, time, fromMills, toMills);
+        // Query v4 types for IOB/COB calculation (8 hours before for DIA)
+        var targetDateTime = DateTimeOffset.FromUnixTimeMilliseconds(time).UtcDateTime;
+        var fetchFrom = targetDateTime.AddHours(-8);
+        var boluses = (await _bolusRepository.GetAsync(
+            from: fetchFrom, to: targetDateTime, device: null, source: null,
+            limit: 2000, offset: 0, descending: false, ct: cancellationToken
+        )).ToList();
+        var tempBasals = (await _tempBasalRepository.GetAsync(
+            from: fetchFrom, to: targetDateTime, device: null, source: null,
+            limit: 2000, offset: 0, descending: false, ct: cancellationToken
+        )).ToList();
+        var carbIntakes = (await _carbIntakeRepository.GetAsync(
+            from: fetchFrom, to: targetDateTime, device: null, source: null,
+            limit: 2000, offset: 0, descending: false, ct: cancellationToken
+        )).ToList();
+        // Calculate IOB at the specified time
+        var iobResult = await _iobCalculator.CalculateTotalAsync(
+            boluses,
+            tempBasals,
+            time,
+            ct: cancellationToken
+        );
+        // Calculate COB at the specified time
+        var cobResult = await _cobCalculator.CalculateTotalAsync(
+            carbIntakes,
+            boluses,
+            tempBasals,
+            time,
+            ct: cancellationToken
+        );
+        // Get glucose at the specified time (interpolated)
+        var glucoseData = GetGlucoseAtTime(entryList, time);
+        // Get basal rate at the specified time
+        var basalData = await GetBasalRateAtTimeAsync(tempBasals, time);
+        // Get recent treatments as summary data (boluses and carb intakes within 30 minutes)
+        var recentTreatments = new List<TreatmentSummaryData>();
+        var recentCutoff = time - 30 * 60 * 1000;
+        foreach (var b in boluses.Where(b => b.Mills >= recentCutoff && b.Mills <= time).OrderByDescending(b => b.Mills).Take(10))
         {
-            _logger.LogError(ex, "Error calculating retrospective data for time {Time}", time);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+            recentTreatments.Add(new TreatmentSummaryData
+            {
+                Id = b.Id.ToString(),
+                Mills = b.Mills,
+                EventType = "Bolus",
+                Insulin = b.Insulin,
+            });
         }
+        foreach (var c in carbIntakes.Where(c => c.Mills >= recentCutoff && c.Mills <= time).OrderByDescending(c => c.Mills).Take(10))
+        {
+            recentTreatments.Add(new TreatmentSummaryData
+            {
+                Id = c.Id.ToString(),
+                Mills = c.Mills,
+                EventType = "Carb Correction",
+                Carbs = c.Carbs,
+            });
+        }
+        recentTreatments = recentTreatments.OrderByDescending(t => t.Mills).Take(10).ToList();
+        var response = new RetrospectiveDataResponse
+        {
+            Time = time,
+            TimeFormatted = DateTimeOffset.FromUnixTimeMilliseconds(time).ToString("HH:mm:ss"),
+            Glucose = glucoseData,
+            Iob = new IobData
+            {
+                Total = iobResult.Iob,
+                Bolus = iobResult.Iob - (iobResult.BasalIob ?? 0),
+                Basal = iobResult.BasalIob ?? 0,
+                Activity = iobResult.Activity,
+                Source = iobResult.Source
+            },
+            Cob = new CobData
+            {
+                Total = cobResult.Cob,
+                IsDecaying = cobResult.IsDecaying ?? 0,
+                CarbsHr = cobResult.CarbsHr,
+                RawCarbImpact = cobResult.RawCarbImpact,
+                Source = cobResult.Source
+            },
+            Basal = basalData,
+            RecentTreatments = recentTreatments
+        };
+        return Ok(RetrospectiveReadScopeGuard.Redact(response, HttpContext.GetGrantedScopes()));
     }
     /// <summary>
     /// Get retrospective data for an entire day at specified interval
@@ -222,118 +215,111 @@ public class RetrospectiveController : ControllerBase
     [ProducesResponseType(typeof(RetrospectiveTimelineResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<RetrospectiveTimelineResponse>> GetRetrospectiveTimeline(
         [FromQuery] string date,
         [FromQuery] int intervalMinutes = 5,
         CancellationToken cancellationToken = default
     )
     {
-        try
+        if (string.IsNullOrEmpty(date) || !DateTimeOffset.TryParse(date, out var parsedDate))
         {
-            if (string.IsNullOrEmpty(date) || !DateTimeOffset.TryParse(date, out var parsedDate))
-            {
-                return Problem(detail: "Date parameter must be in YYYY-MM-DD format", statusCode: 400, title: "Bad Request");
-            }
-            if (intervalMinutes < 1 || intervalMinutes > 60)
-            {
-                return Problem(detail: "Interval must be between 1 and 60 minutes", statusCode: 400, title: "Bad Request");
-            }
-            // Calculate day boundaries
-            var dayStart = new DateTimeOffset(parsedDate.Year, parsedDate.Month, parsedDate.Day, 0, 0, 0, TimeSpan.Zero);
-            var dayEnd = dayStart.AddDays(1).AddMilliseconds(-1);
-            var startMills = dayStart.ToUnixTimeMilliseconds();
-            var endMills = dayEnd.ToUnixTimeMilliseconds();
-            // Fetch all data for the day (plus 8 hours before for IOB calculation context)
-            var fetchFrom = dayStart.UtcDateTime.AddHours(-8);
-            var fetchTo = dayEnd.UtcDateTime;
-            // Get entries for the day
-            var entries = await _entryService.GetEntriesAsync(
-                $"find[date][$gte]={startMills}&find[date][$lte]={endMills}",
-                count: 5000,
-                skip: 0,
-                cancellationToken
-            );
-            var entryList = entries?.ToList() ?? new List<Entry>();
-            // Query v4 types
-            var boluses = (await _bolusRepository.GetAsync(
-                from: fetchFrom, to: fetchTo, device: null, source: null,
-                limit: 5000, offset: 0, descending: false, ct: cancellationToken
-            )).ToList();
-            var tempBasals = (await _tempBasalRepository.GetAsync(
-                from: fetchFrom, to: fetchTo, device: null, source: null,
-                limit: 5000, offset: 0, descending: false, ct: cancellationToken
-            )).ToList();
-            var carbIntakes = (await _carbIntakeRepository.GetAsync(
-                from: fetchFrom, to: fetchTo, device: null, source: null,
-                limit: 5000, offset: 0, descending: false, ct: cancellationToken
-            )).ToList();
-            // Get device status
-            var deviceStatus = await _projectionService.GetAsync(
-                count: 500,
-                skip: 0,
-                find: null,
-                ct: cancellationToken
-            );
-            var deviceStatusList = deviceStatus?
-                .Where(d => d.Mills >= startMills && d.Mills <= endMills)
-                .ToList() ?? new List<DeviceStatus>();
-            // Calculate data points at each interval
-            var rateAt = await _basalRateResolver.BuildResolverAsync(startMills, endMills, cancellationToken);
-            var dataPoints = new List<RetrospectiveDataPoint>();
-            var totalIntervals = (24 * 60) / intervalMinutes;
-            for (int i = 0; i < totalIntervals; i++)
-            {
-                var pointTime = startMills + (i * intervalMinutes * 60 * 1000);
-                var timestamp = DateTimeOffset.FromUnixTimeMilliseconds(pointTime);
-                // Filter records relevant to this time point
-                var relevantBoluses = boluses.Where(b => b.Mills <= pointTime).ToList();
-                var relevantCarbIntakes = carbIntakes.Where(c => c.Mills <= pointTime).ToList();
-                var relevantTempBasals = tempBasals.Where(t => t.StartMills <= pointTime).ToList();
-                // Calculate IOB
-                var iobResult = _iobCalculator.FromBoluses(relevantBoluses, pointTime);
-                // Calculate COB
-                var cobResult = _cobCalculator.FromCarbIntakes(
-                    relevantCarbIntakes,
-                    relevantBoluses,
-                    relevantTempBasals,
-                    pointTime
-                );
-                // Get glucose at this time
-                var glucose = GetGlucoseAtTime(entryList, pointTime);
-                // Get basal rate
-                var basal = GetBasalRateAtTime(tempBasals, pointTime, rateAt);
-                dataPoints.Add(new RetrospectiveDataPoint
-                {
-                    Time = pointTime,
-                    Hour = timestamp.Hour,
-                    Minute = timestamp.Minute,
-                    TimeLabel = timestamp.ToString("HH:mm"),
-                    Glucose = glucose?.Value,
-                    GlucoseDirection = glucose?.Direction,
-                    Iob = Math.Round(iobResult.Iob, 3),
-                    BolusIob = Math.Round(iobResult.Iob - (iobResult.BasalIob ?? 0), 3),
-                    BasalIob = Math.Round(iobResult.BasalIob ?? 0, 3),
-                    Cob = Math.Round(cobResult.Cob, 1),
-                    BasalRate = basal.Rate,
-                    IsTemp = basal.IsTemp
-                });
-            }
-            var response = new RetrospectiveTimelineResponse
-            {
-                Date = date,
-                StartTime = startMills,
-                EndTime = endMills,
-                IntervalMinutes = intervalMinutes,
-                TotalPoints = dataPoints.Count,
-                Data = dataPoints
-            };
-            return Ok(RetrospectiveReadScopeGuard.Redact(response, HttpContext.GetGrantedScopes()));
+            return Problem(detail: "Date parameter must be in YYYY-MM-DD format", statusCode: 400, title: "Bad Request");
         }
-        catch (Exception ex)
+        if (intervalMinutes < 1 || intervalMinutes > 60)
         {
-            _logger.LogError(ex, "Error calculating retrospective timeline for date {Date}", date);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+            return Problem(detail: "Interval must be between 1 and 60 minutes", statusCode: 400, title: "Bad Request");
         }
+        // Calculate day boundaries
+        var dayStart = new DateTimeOffset(parsedDate.Year, parsedDate.Month, parsedDate.Day, 0, 0, 0, TimeSpan.Zero);
+        var dayEnd = dayStart.AddDays(1).AddMilliseconds(-1);
+        var startMills = dayStart.ToUnixTimeMilliseconds();
+        var endMills = dayEnd.ToUnixTimeMilliseconds();
+        // Fetch all data for the day (plus 8 hours before for IOB calculation context)
+        var fetchFrom = dayStart.UtcDateTime.AddHours(-8);
+        var fetchTo = dayEnd.UtcDateTime;
+        // Get entries for the day
+        var entries = await _entryService.GetEntriesAsync(
+            $"find[date][$gte]={startMills}&find[date][$lte]={endMills}",
+            count: 5000,
+            skip: 0,
+            cancellationToken
+        );
+        var entryList = entries?.ToList() ?? new List<Entry>();
+        // Query v4 types
+        var boluses = (await _bolusRepository.GetAsync(
+            from: fetchFrom, to: fetchTo, device: null, source: null,
+            limit: 5000, offset: 0, descending: false, ct: cancellationToken
+        )).ToList();
+        var tempBasals = (await _tempBasalRepository.GetAsync(
+            from: fetchFrom, to: fetchTo, device: null, source: null,
+            limit: 5000, offset: 0, descending: false, ct: cancellationToken
+        )).ToList();
+        var carbIntakes = (await _carbIntakeRepository.GetAsync(
+            from: fetchFrom, to: fetchTo, device: null, source: null,
+            limit: 5000, offset: 0, descending: false, ct: cancellationToken
+        )).ToList();
+        // Get device status
+        var deviceStatus = await _projectionService.GetAsync(
+            count: 500,
+            skip: 0,
+            find: null,
+            ct: cancellationToken
+        );
+        var deviceStatusList = deviceStatus?
+            .Where(d => d.Mills >= startMills && d.Mills <= endMills)
+            .ToList() ?? new List<DeviceStatus>();
+        // Calculate data points at each interval
+        var rateAt = await _basalRateResolver.BuildResolverAsync(startMills, endMills, cancellationToken);
+        var dataPoints = new List<RetrospectiveDataPoint>();
+        var totalIntervals = (24 * 60) / intervalMinutes;
+        for (int i = 0; i < totalIntervals; i++)
+        {
+            var pointTime = startMills + (i * intervalMinutes * 60 * 1000);
+            var timestamp = DateTimeOffset.FromUnixTimeMilliseconds(pointTime);
+            // Filter records relevant to this time point
+            var relevantBoluses = boluses.Where(b => b.Mills <= pointTime).ToList();
+            var relevantCarbIntakes = carbIntakes.Where(c => c.Mills <= pointTime).ToList();
+            var relevantTempBasals = tempBasals.Where(t => t.StartMills <= pointTime).ToList();
+            // Calculate IOB
+            var iobResult = _iobCalculator.FromBoluses(relevantBoluses, pointTime);
+            // Calculate COB
+            var cobResult = _cobCalculator.FromCarbIntakes(
+                relevantCarbIntakes,
+                relevantBoluses,
+                relevantTempBasals,
+                pointTime
+            );
+            // Get glucose at this time
+            var glucose = GetGlucoseAtTime(entryList, pointTime);
+            // Get basal rate
+            var basal = GetBasalRateAtTime(tempBasals, pointTime, rateAt);
+            dataPoints.Add(new RetrospectiveDataPoint
+            {
+                Time = pointTime,
+                Hour = timestamp.Hour,
+                Minute = timestamp.Minute,
+                TimeLabel = timestamp.ToString("HH:mm"),
+                Glucose = glucose?.Value,
+                GlucoseDirection = glucose?.Direction,
+                Iob = Math.Round(iobResult.Iob, 3),
+                BolusIob = Math.Round(iobResult.Iob - (iobResult.BasalIob ?? 0), 3),
+                BasalIob = Math.Round(iobResult.BasalIob ?? 0, 3),
+                Cob = Math.Round(cobResult.Cob, 1),
+                BasalRate = basal.Rate,
+                IsTemp = basal.IsTemp
+            });
+        }
+        var response = new RetrospectiveTimelineResponse
+        {
+            Date = date,
+            StartTime = startMills,
+            EndTime = endMills,
+            IntervalMinutes = intervalMinutes,
+            TotalPoints = dataPoints.Count,
+            Data = dataPoints
+        };
+        return Ok(RetrospectiveReadScopeGuard.Redact(response, HttpContext.GetGrantedScopes()));
     }
     /// <summary>
     /// Get basal rate timeline for a day
@@ -349,64 +335,57 @@ public class RetrospectiveController : ControllerBase
     [ProducesResponseType(typeof(BasalTimelineResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<BasalTimelineResponse>> GetBasalTimeline(
         [FromQuery] string date,
         [FromQuery] int intervalMinutes = 5,
         CancellationToken cancellationToken = default
     )
     {
-        try
+        if (string.IsNullOrEmpty(date) || !DateTimeOffset.TryParse(date, out var parsedDate))
         {
-            if (string.IsNullOrEmpty(date) || !DateTimeOffset.TryParse(date, out var parsedDate))
-            {
-                return Problem(detail: "Date parameter must be in YYYY-MM-DD format", statusCode: 400, title: "Bad Request");
-            }
-            // Calculate day boundaries
-            var dayStart = new DateTimeOffset(parsedDate.Year, parsedDate.Month, parsedDate.Day, 0, 0, 0, TimeSpan.Zero);
-            var dayEnd = dayStart.AddDays(1);
-            var startMills = dayStart.ToUnixTimeMilliseconds();
-            var endMills = dayEnd.ToUnixTimeMilliseconds();
-            // Query temp basals (include 1 hour before for active temp basals spanning midnight)
-            var fetchFrom = dayStart.UtcDateTime.AddHours(-1);
-            var fetchTo = dayEnd.UtcDateTime;
-            var tempBasals = (await _tempBasalRepository.GetAsync(
-                from: fetchFrom, to: fetchTo, device: null, source: null,
-                limit: 2000, offset: 0, descending: false, ct: cancellationToken
-            )).ToList();
-            // Generate basal timeline
-            var rateAt = await _basalRateResolver.BuildResolverAsync(startMills, endMills, cancellationToken);
-            var dataPoints = new List<BasalDataPoint>();
-            var totalIntervals = (24 * 60) / intervalMinutes;
-            for (int i = 0; i < totalIntervals; i++)
-            {
-                var pointTime = startMills + (i * intervalMinutes * 60 * 1000);
-                var timestamp = DateTimeOffset.FromUnixTimeMilliseconds(pointTime);
-                var basal = GetBasalRateAtTime(tempBasals, pointTime, rateAt);
-                dataPoints.Add(new BasalDataPoint
-                {
-                    Time = pointTime,
-                    Hour = timestamp.Hour,
-                    Minute = timestamp.Minute,
-                    TimeLabel = timestamp.ToString("HH:mm"),
-                    Rate = basal.Rate,
-                    IsTemp = basal.IsTemp
-                });
-            }
-            var response = new BasalTimelineResponse
-            {
-                Date = date,
-                StartTime = startMills,
-                EndTime = endMills,
-                IntervalMinutes = intervalMinutes,
-                Data = dataPoints
-            };
-            return Ok(response);
+            return Problem(detail: "Date parameter must be in YYYY-MM-DD format", statusCode: 400, title: "Bad Request");
         }
-        catch (Exception ex)
+        // Calculate day boundaries
+        var dayStart = new DateTimeOffset(parsedDate.Year, parsedDate.Month, parsedDate.Day, 0, 0, 0, TimeSpan.Zero);
+        var dayEnd = dayStart.AddDays(1);
+        var startMills = dayStart.ToUnixTimeMilliseconds();
+        var endMills = dayEnd.ToUnixTimeMilliseconds();
+        // Query temp basals (include 1 hour before for active temp basals spanning midnight)
+        var fetchFrom = dayStart.UtcDateTime.AddHours(-1);
+        var fetchTo = dayEnd.UtcDateTime;
+        var tempBasals = (await _tempBasalRepository.GetAsync(
+            from: fetchFrom, to: fetchTo, device: null, source: null,
+            limit: 2000, offset: 0, descending: false, ct: cancellationToken
+        )).ToList();
+        // Generate basal timeline
+        var rateAt = await _basalRateResolver.BuildResolverAsync(startMills, endMills, cancellationToken);
+        var dataPoints = new List<BasalDataPoint>();
+        var totalIntervals = (24 * 60) / intervalMinutes;
+        for (int i = 0; i < totalIntervals; i++)
         {
-            _logger.LogError(ex, "Error calculating basal timeline for date {Date}", date);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+            var pointTime = startMills + (i * intervalMinutes * 60 * 1000);
+            var timestamp = DateTimeOffset.FromUnixTimeMilliseconds(pointTime);
+            var basal = GetBasalRateAtTime(tempBasals, pointTime, rateAt);
+            dataPoints.Add(new BasalDataPoint
+            {
+                Time = pointTime,
+                Hour = timestamp.Hour,
+                Minute = timestamp.Minute,
+                TimeLabel = timestamp.ToString("HH:mm"),
+                Rate = basal.Rate,
+                IsTemp = basal.IsTemp
+            });
         }
+        var response = new BasalTimelineResponse
+        {
+            Date = date,
+            StartTime = startMills,
+            EndTime = endMills,
+            IntervalMinutes = intervalMinutes,
+            Data = dataPoints
+        };
+        return Ok(response);
     }
     #region Helper Methods
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/Devices/BatteryController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/BatteryController.cs
@@ -55,6 +55,7 @@ public class BatteryController : ControllerBase
     [RemoteQuery]
     [ProducesResponseType(typeof(CurrentBatteryStatus), 200)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<CurrentBatteryStatus>> GetCurrentBatteryStatus(
         [FromQuery] int recentMinutes = 30,
         CancellationToken cancellationToken = default
@@ -65,20 +66,12 @@ public class BatteryController : ControllerBase
             recentMinutes
         );
 
-        try
-        {
-            var status = await _batteryService.GetCurrentBatteryStatusAsync(
-                recentMinutes,
-                cancellationToken
-            );
+        var status = await _batteryService.GetCurrentBatteryStatusAsync(
+            recentMinutes,
+            cancellationToken
+        );
 
-            return Ok(status);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting current battery status");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(status);
     }
 
     /// <summary>
@@ -93,6 +86,7 @@ public class BatteryController : ControllerBase
     [RemoteQuery]
     [ProducesResponseType(typeof(IEnumerable<BatteryReading>), 200)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<BatteryReading>>> GetBatteryReadings(
         [FromQuery] string? device = null,
         [FromQuery] DateTime? from = null,
@@ -107,22 +101,14 @@ public class BatteryController : ControllerBase
             to
         );
 
-        try
-        {
-            var readings = await _batteryService.GetBatteryReadingsAsync(
-                device,
-                from.HasValue ? new DateTimeOffset(from.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
-                to.HasValue ? new DateTimeOffset(to.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
-                cancellationToken
-            );
+        var readings = await _batteryService.GetBatteryReadingsAsync(
+            device,
+            from.HasValue ? new DateTimeOffset(from.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
+            to.HasValue ? new DateTimeOffset(to.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
+            cancellationToken
+        );
 
-            return Ok(readings);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting battery readings");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(readings);
     }
 
     /// <summary>
@@ -137,6 +123,7 @@ public class BatteryController : ControllerBase
     [RemoteQuery]
     [ProducesResponseType(typeof(IEnumerable<BatteryStatistics>), 200)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<BatteryStatistics>>> GetBatteryStatistics(
         [FromQuery] string? device = null,
         [FromQuery] DateTime? from = null,
@@ -151,22 +138,14 @@ public class BatteryController : ControllerBase
             to
         );
 
-        try
-        {
-            var statistics = await _batteryService.GetBatteryStatisticsAsync(
-                device,
-                from.HasValue ? new DateTimeOffset(from.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
-                to.HasValue ? new DateTimeOffset(to.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
-                cancellationToken
-            );
+        var statistics = await _batteryService.GetBatteryStatisticsAsync(
+            device,
+            from.HasValue ? new DateTimeOffset(from.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
+            to.HasValue ? new DateTimeOffset(to.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
+            cancellationToken
+        );
 
-            return Ok(statistics);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting battery statistics");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(statistics);
     }
 
     /// <summary>
@@ -182,6 +161,7 @@ public class BatteryController : ControllerBase
     [RemoteQuery]
     [ProducesResponseType(typeof(IEnumerable<ChargeCycle>), 200)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<ChargeCycle>>> GetChargeCycles(
         [FromQuery] string? device = null,
         [FromQuery] DateTime? from = null,
@@ -200,23 +180,15 @@ public class BatteryController : ControllerBase
             limit
         );
 
-        try
-        {
-            var cycles = await _batteryService.GetChargeCyclesAsync(
-                device,
-                from.HasValue ? new DateTimeOffset(from.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
-                to.HasValue ? new DateTimeOffset(to.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
-                limit,
-                cancellationToken
-            );
+        var cycles = await _batteryService.GetChargeCyclesAsync(
+            device,
+            from.HasValue ? new DateTimeOffset(from.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
+            to.HasValue ? new DateTimeOffset(to.Value, TimeSpan.Zero).ToUnixTimeMilliseconds() : null,
+            limit,
+            cancellationToken
+        );
 
-            return Ok(cycles);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting charge cycles");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(cycles);
     }
 
     /// <summary>
@@ -228,21 +200,14 @@ public class BatteryController : ControllerBase
     [RemoteQuery]
     [ProducesResponseType(typeof(IEnumerable<string>), 200)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<string>>> GetKnownDevices(
         CancellationToken cancellationToken = default
     )
     {
         _logger.LogDebug("Known devices requested");
 
-        try
-        {
-            var devices = await _batteryService.GetKnownDevicesAsync(cancellationToken);
-            return Ok(devices);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting known devices");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        var devices = await _batteryService.GetKnownDevicesAsync(cancellationToken);
+        return Ok(devices);
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
@@ -53,6 +53,7 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [RemoteQuery]
     [ProducesResponseType(typeof(IEnumerable<BodyWeight>), 200)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<BodyWeight>>> GetBodyWeights(
         [FromQuery] int count = 10,
         [FromQuery] int skip = 0,
@@ -62,16 +63,8 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
         count = V4ReadLimits.ClampLimit(count);
         skip = V4ReadLimits.ClampOffset(skip);
 
-        try
-        {
-            var records = await _bodyWeightService.GetBodyWeightsAsync(count, skip, cancellationToken);
-            return Ok(records);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving body weight records");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        var records = await _bodyWeightService.GetBodyWeightsAsync(count, skip, cancellationToken);
+        return Ok(records);
     }
 
     /// <summary>
@@ -84,24 +77,17 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [ProducesResponseType(typeof(BodyWeight), 200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<BodyWeight>> GetBodyWeight(
         string id,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            var record = await _bodyWeightService.GetBodyWeightByIdAsync(id, cancellationToken);
-            if (record == null)
-                return Problem(detail: $"Body weight record with ID {id} not found", statusCode: 404, title: "Not Found");
+        var record = await _bodyWeightService.GetBodyWeightByIdAsync(id, cancellationToken);
+        if (record == null)
+            return Problem(detail: $"Body weight record with ID {id} not found", statusCode: 404, title: "Not Found");
 
-            return Ok(record);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving body weight record with ID {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(record);
     }
 
     /// <summary>
@@ -113,24 +99,17 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [ProducesResponseType(typeof(BodyWeight), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<BodyWeight>> Create(
         [FromBody] BodyWeight bodyWeight,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            if (bodyWeight == null)
-                return Problem(detail: "Body weight data is required", statusCode: 400, title: "Bad Request");
+        if (bodyWeight == null)
+            return Problem(detail: "Body weight data is required", statusCode: 400, title: "Bad Request");
 
-            var result = await _bodyWeightService.CreateBodyWeightsAsync([bodyWeight], cancellationToken);
-            return StatusCode(StatusCodes.Status201Created, result.First());
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error creating body weight record");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        var result = await _bodyWeightService.CreateBodyWeightsAsync([bodyWeight], cancellationToken);
+        return StatusCode(StatusCodes.Status201Created, result.First());
     }
 
     /// <summary>
@@ -141,51 +120,44 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [ProducesResponseType(typeof(IEnumerable<BodyWeight>), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<BodyWeight>>> CreateBodyWeights(
         [FromBody] object bodyWeights,
         CancellationToken cancellationToken = default
     )
     {
-        try
+        if (bodyWeights == null)
+            return Problem(detail: "Body weight data is required", statusCode: 400, title: "Bad Request");
+
+        List<BodyWeight> bodyWeightList;
+
+        if (bodyWeights is System.Text.Json.JsonElement jsonElement)
         {
-            if (bodyWeights == null)
-                return Problem(detail: "Body weight data is required", statusCode: 400, title: "Bad Request");
-
-            List<BodyWeight> bodyWeightList;
-
-            if (bodyWeights is System.Text.Json.JsonElement jsonElement)
+            if (jsonElement.ValueKind == System.Text.Json.JsonValueKind.Array)
             {
-                if (jsonElement.ValueKind == System.Text.Json.JsonValueKind.Array)
-                {
-                    bodyWeightList =
-                        System.Text.Json.JsonSerializer.Deserialize<List<BodyWeight>>(
-                            jsonElement.GetRawText()
-                        ) ?? [];
-                }
-                else
-                {
-                    var single = System.Text.Json.JsonSerializer.Deserialize<BodyWeight>(
+                bodyWeightList =
+                    System.Text.Json.JsonSerializer.Deserialize<List<BodyWeight>>(
                         jsonElement.GetRawText()
-                    );
-                    bodyWeightList = single != null ? [single] : [];
-                }
+                    ) ?? [];
             }
             else
             {
-                return Problem(detail: "Invalid data format", statusCode: 400, title: "Bad Request");
+                var single = System.Text.Json.JsonSerializer.Deserialize<BodyWeight>(
+                    jsonElement.GetRawText()
+                );
+                bodyWeightList = single != null ? [single] : [];
             }
-
-            if (bodyWeightList.Count == 0)
-                return Problem(detail: "At least one body weight record is required", statusCode: 400, title: "Bad Request");
-
-            var result = await _bodyWeightService.CreateBodyWeightsAsync(bodyWeightList, cancellationToken);
-            return Ok(result);
         }
-        catch (Exception ex)
+        else
         {
-            _logger.LogError(ex, "Error creating body weight records");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
+            return Problem(detail: "Invalid data format", statusCode: 400, title: "Bad Request");
         }
+
+        if (bodyWeightList.Count == 0)
+            return Problem(detail: "At least one body weight record is required", statusCode: 400, title: "Bad Request");
+
+        var result = await _bodyWeightService.CreateBodyWeightsAsync(bodyWeightList, cancellationToken);
+        return Ok(result);
     }
 
     /// <summary>
@@ -197,25 +169,18 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [ProducesResponseType(typeof(BodyWeight), 200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<BodyWeight>> UpdateBodyWeight(
         string id,
         [FromBody] BodyWeight bodyWeight,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            var updated = await _bodyWeightService.UpdateBodyWeightAsync(id, bodyWeight, cancellationToken);
-            if (updated == null)
-                return Problem(detail: $"Body weight record with ID {id} not found", statusCode: 404, title: "Not Found");
+        var updated = await _bodyWeightService.UpdateBodyWeightAsync(id, bodyWeight, cancellationToken);
+        if (updated == null)
+            return Problem(detail: $"Body weight record with ID {id} not found", statusCode: 404, title: "Not Found");
 
-            return Ok(updated);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating body weight record with ID {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(updated);
     }
 
     /// <summary>
@@ -227,23 +192,16 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [ProducesResponseType(200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteBodyWeight(
         string id,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            var deleted = await _bodyWeightService.DeleteBodyWeightAsync(id, cancellationToken);
-            if (!deleted)
-                return Problem(detail: $"Body weight record with ID {id} not found", statusCode: 404, title: "Not Found");
+        var deleted = await _bodyWeightService.DeleteBodyWeightAsync(id, cancellationToken);
+        if (!deleted)
+            return Problem(detail: $"Body weight record with ID {id} not found", statusCode: 404, title: "Not Found");
 
-            return Ok(new { message = "Body weight record deleted successfully" });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error deleting body weight record with ID {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(new { message = "Body weight record deleted successfully" });
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
@@ -55,6 +55,7 @@ public class HeartRateController : ControllerBase
     [RequireScope(Scope.HeartRateRead)]
     [ProducesResponseType(typeof(IEnumerable<HeartRate>), 200)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<HeartRate>>> GetHeartRates(
         [FromQuery] int? count = null,
         [FromQuery] int skip = 0,
@@ -65,24 +66,16 @@ public class HeartRateController : ControllerBase
     {
         skip = V4ReadLimits.ClampOffset(skip);
 
-        try
-        {
-            IEnumerable<HeartRate> records;
-            if (from.HasValue && to.HasValue)
-                records = await _heartRateService.GetHeartRatesByDateRangeAsync(
-                    from.Value, to.Value,
-                    V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize), skip, cancellationToken);
-            else
-                records = await _heartRateService.GetHeartRatesAsync(
-                    V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, cancellationToken);
+        IEnumerable<HeartRate> records;
+        if (from.HasValue && to.HasValue)
+            records = await _heartRateService.GetHeartRatesByDateRangeAsync(
+                from.Value, to.Value,
+                V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize), skip, cancellationToken);
+        else
+            records = await _heartRateService.GetHeartRatesAsync(
+                V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, cancellationToken);
 
-            return Ok(records);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving heart rate records");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(records);
     }
 
     /// <summary>
@@ -96,24 +89,17 @@ public class HeartRateController : ControllerBase
     [ProducesResponseType(typeof(HeartRate), 200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<HeartRate>> GetHeartRate(
         string id,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            var record = await _heartRateService.GetHeartRateByIdAsync(id, cancellationToken);
-            if (record == null)
-                return Problem(detail: $"Heart rate record with ID {id} not found", statusCode: 404, title: "Not Found");
+        var record = await _heartRateService.GetHeartRateByIdAsync(id, cancellationToken);
+        if (record == null)
+            return Problem(detail: $"Heart rate record with ID {id} not found", statusCode: 404, title: "Not Found");
 
-            return Ok(record);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving heart rate record with ID {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(record);
     }
 
     /// <summary>
@@ -124,36 +110,29 @@ public class HeartRateController : ControllerBase
     [ProducesResponseType(typeof(IEnumerable<HeartRate>), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<HeartRate>>> CreateHeartRates(
         [FromBody] UpsertHeartRateRequest[] requests,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            if (requests.Length == 0)
-                return Problem(detail: "At least one heart rate record is required", statusCode: 400, title: "Bad Request");
+        if (requests.Length == 0)
+            return Problem(detail: "At least one heart rate record is required", statusCode: 400, title: "Bad Request");
 
-            var heartRateList = requests.Select(request => new HeartRate
-            {
-                Timestamp = request.Timestamp.UtcDateTime,
-                UtcOffset = request.UtcOffset,
-                Bpm = request.Bpm,
-                Accuracy = request.Accuracy,
-                Device = request.Device,
-                EnteredBy = request.App,
-                DataSource = request.DataSource,
-                SyncIdentifier = request.SyncIdentifier,
-            }).ToList();
-
-            var result = await _heartRateService.CreateHeartRatesAsync(heartRateList, cancellationToken);
-            return Ok(result);
-        }
-        catch (Exception ex)
+        var heartRateList = requests.Select(request => new HeartRate
         {
-            _logger.LogError(ex, "Error creating heart rate records");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+            Timestamp = request.Timestamp.UtcDateTime,
+            UtcOffset = request.UtcOffset,
+            Bpm = request.Bpm,
+            Accuracy = request.Accuracy,
+            Device = request.Device,
+            EnteredBy = request.App,
+            DataSource = request.DataSource,
+            SyncIdentifier = request.SyncIdentifier,
+        }).ToList();
+
+        var result = await _heartRateService.CreateHeartRatesAsync(heartRateList, cancellationToken);
+        return Ok(result);
     }
 
     /// <summary>
@@ -164,37 +143,30 @@ public class HeartRateController : ControllerBase
     [ProducesResponseType(typeof(HeartRate), 200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<HeartRate>> UpdateHeartRate(
         string id,
         [FromBody] UpsertHeartRateRequest request,
         CancellationToken cancellationToken = default
     )
     {
-        try
+        var heartRate = new HeartRate
         {
-            var heartRate = new HeartRate
-            {
-                Timestamp = request.Timestamp.UtcDateTime,
-                UtcOffset = request.UtcOffset,
-                Bpm = request.Bpm,
-                Accuracy = request.Accuracy,
-                Device = request.Device,
-                EnteredBy = request.App,
-                DataSource = request.DataSource,
-                SyncIdentifier = request.SyncIdentifier,
-            };
+            Timestamp = request.Timestamp.UtcDateTime,
+            UtcOffset = request.UtcOffset,
+            Bpm = request.Bpm,
+            Accuracy = request.Accuracy,
+            Device = request.Device,
+            EnteredBy = request.App,
+            DataSource = request.DataSource,
+            SyncIdentifier = request.SyncIdentifier,
+        };
 
-            var updated = await _heartRateService.UpdateHeartRateAsync(id, heartRate, cancellationToken);
-            if (updated == null)
-                return Problem(detail: $"Heart rate record with ID {id} not found", statusCode: 404, title: "Not Found");
+        var updated = await _heartRateService.UpdateHeartRateAsync(id, heartRate, cancellationToken);
+        if (updated == null)
+            return Problem(detail: $"Heart rate record with ID {id} not found", statusCode: 404, title: "Not Found");
 
-            return Ok(updated);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating heart rate record with ID {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(updated);
     }
 
     /// <summary>
@@ -205,23 +177,16 @@ public class HeartRateController : ControllerBase
     [ProducesResponseType(200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteHeartRate(
         string id,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            var deleted = await _heartRateService.DeleteHeartRateAsync(id, cancellationToken);
-            if (!deleted)
-                return Problem(detail: $"Heart rate record with ID {id} not found", statusCode: 404, title: "Not Found");
+        var deleted = await _heartRateService.DeleteHeartRateAsync(id, cancellationToken);
+        if (!deleted)
+            return Problem(detail: $"Heart rate record with ID {id} not found", statusCode: 404, title: "Not Found");
 
-            return Ok(new { message = "Heart rate record deleted successfully" });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error deleting heart rate record with ID {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(new { message = "Heart rate record deleted successfully" });
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
@@ -55,6 +55,7 @@ public class StepCountController : ControllerBase
     [RequireScope(Scope.StepCountRead)]
     [ProducesResponseType(typeof(IEnumerable<StepCount>), 200)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<StepCount>>> GetStepCounts(
         [FromQuery] int? count = null,
         [FromQuery] int skip = 0,
@@ -65,24 +66,16 @@ public class StepCountController : ControllerBase
     {
         skip = V4ReadLimits.ClampOffset(skip);
 
-        try
-        {
-            IEnumerable<StepCount> records;
-            if (from.HasValue && to.HasValue)
-                records = await _stepCountService.GetStepCountsByDateRangeAsync(
-                    from.Value, to.Value,
-                    V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize), skip, cancellationToken);
-            else
-                records = await _stepCountService.GetStepCountsAsync(
-                    V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, cancellationToken);
+        IEnumerable<StepCount> records;
+        if (from.HasValue && to.HasValue)
+            records = await _stepCountService.GetStepCountsByDateRangeAsync(
+                from.Value, to.Value,
+                V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize), skip, cancellationToken);
+        else
+            records = await _stepCountService.GetStepCountsAsync(
+                V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, cancellationToken);
 
-            return Ok(records);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving step count records");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(records);
     }
 
     /// <summary>
@@ -96,24 +89,17 @@ public class StepCountController : ControllerBase
     [ProducesResponseType(typeof(StepCount), 200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<StepCount>> GetStepCount(
         string id,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            var record = await _stepCountService.GetStepCountByIdAsync(id, cancellationToken);
-            if (record == null)
-                return Problem(detail: $"Step count record with ID {id} not found", statusCode: 404, title: "Not Found");
+        var record = await _stepCountService.GetStepCountByIdAsync(id, cancellationToken);
+        if (record == null)
+            return Problem(detail: $"Step count record with ID {id} not found", statusCode: 404, title: "Not Found");
 
-            return Ok(record);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving step count record with ID {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(record);
     }
 
     /// <summary>
@@ -124,36 +110,29 @@ public class StepCountController : ControllerBase
     [ProducesResponseType(typeof(IEnumerable<StepCount>), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<IEnumerable<StepCount>>> CreateStepCounts(
         [FromBody] UpsertStepCountRequest[] requests,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            if (requests.Length == 0)
-                return Problem(detail: "At least one step count record is required", statusCode: 400, title: "Bad Request");
+        if (requests.Length == 0)
+            return Problem(detail: "At least one step count record is required", statusCode: 400, title: "Bad Request");
 
-            var stepCountList = requests.Select(request => new StepCount
-            {
-                Timestamp = request.Timestamp.UtcDateTime,
-                UtcOffset = request.UtcOffset,
-                Metric = request.Metric,
-                Source = request.Source,
-                Device = request.Device,
-                EnteredBy = request.App,
-                DataSource = request.DataSource,
-                SyncIdentifier = request.SyncIdentifier,
-            }).ToList();
-
-            var result = await _stepCountService.CreateStepCountsAsync(stepCountList, cancellationToken);
-            return Ok(result);
-        }
-        catch (Exception ex)
+        var stepCountList = requests.Select(request => new StepCount
         {
-            _logger.LogError(ex, "Error creating step count records");
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+            Timestamp = request.Timestamp.UtcDateTime,
+            UtcOffset = request.UtcOffset,
+            Metric = request.Metric,
+            Source = request.Source,
+            Device = request.Device,
+            EnteredBy = request.App,
+            DataSource = request.DataSource,
+            SyncIdentifier = request.SyncIdentifier,
+        }).ToList();
+
+        var result = await _stepCountService.CreateStepCountsAsync(stepCountList, cancellationToken);
+        return Ok(result);
     }
 
     /// <summary>
@@ -164,37 +143,30 @@ public class StepCountController : ControllerBase
     [ProducesResponseType(typeof(StepCount), 200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult<StepCount>> UpdateStepCount(
         string id,
         [FromBody] UpsertStepCountRequest request,
         CancellationToken cancellationToken = default
     )
     {
-        try
+        var stepCount = new StepCount
         {
-            var stepCount = new StepCount
-            {
-                Timestamp = request.Timestamp.UtcDateTime,
-                UtcOffset = request.UtcOffset,
-                Metric = request.Metric,
-                Source = request.Source,
-                Device = request.Device,
-                EnteredBy = request.App,
-                DataSource = request.DataSource,
-                SyncIdentifier = request.SyncIdentifier,
-            };
+            Timestamp = request.Timestamp.UtcDateTime,
+            UtcOffset = request.UtcOffset,
+            Metric = request.Metric,
+            Source = request.Source,
+            Device = request.Device,
+            EnteredBy = request.App,
+            DataSource = request.DataSource,
+            SyncIdentifier = request.SyncIdentifier,
+        };
 
-            var updated = await _stepCountService.UpdateStepCountAsync(id, stepCount, cancellationToken);
-            if (updated == null)
-                return Problem(detail: $"Step count record with ID {id} not found", statusCode: 404, title: "Not Found");
+        var updated = await _stepCountService.UpdateStepCountAsync(id, stepCount, cancellationToken);
+        if (updated == null)
+            return Problem(detail: $"Step count record with ID {id} not found", statusCode: 404, title: "Not Found");
 
-            return Ok(updated);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error updating step count record with ID {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(updated);
     }
 
     /// <summary>
@@ -205,23 +177,16 @@ public class StepCountController : ControllerBase
     [ProducesResponseType(200)]
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
+    [ErrorEnvelope]
     public async Task<ActionResult> DeleteStepCount(
         string id,
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            var deleted = await _stepCountService.DeleteStepCountAsync(id, cancellationToken);
-            if (!deleted)
-                return Problem(detail: $"Step count record with ID {id} not found", statusCode: 404, title: "Not Found");
+        var deleted = await _stepCountService.DeleteStepCountAsync(id, cancellationToken);
+        if (!deleted)
+            return Problem(detail: $"Step count record with ID {id} not found", statusCode: 404, title: "Not Found");
 
-            return Ok(new { message = "Step count record deleted successfully" });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error deleting step count record with ID {Id}", id);
-            return Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error");
-        }
+        return Ok(new { message = "Step count record deleted successfully" });
     }
 }

--- a/src/API/Nocturne.API/Controllers/V4/TenantAdmin/NightscoutTransitionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/TenantAdmin/NightscoutTransitionController.cs
@@ -65,33 +65,22 @@ public class NightscoutTransitionController : ControllerBase
     [RemoteQuery]
     [ProducesResponseType(typeof(NightscoutTransitionStatus), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ErrorEnvelope]
     public async Task<ActionResult<NightscoutTransitionStatus>> GetTransitionStatus(
         CancellationToken cancellationToken = default
     )
     {
-        try
-        {
-            var compatibility = await BuildCompatibilityInfoAsync(cancellationToken);
+        var compatibility = await BuildCompatibilityInfoAsync(cancellationToken);
 
-            var status = new NightscoutTransitionStatus
-            {
-                Migration = await BuildMigrationStatusAsync(cancellationToken),
-                WriteBack = BuildWriteBackHealth(),
-                Compatibility = compatibility,
-                Recommendation = await BuildRecommendationAsync(compatibility, cancellationToken)
-            };
-
-            return Ok(status);
-        }
-        catch (Exception ex)
+        var status = new NightscoutTransitionStatus
         {
-            _logger.LogError(ex, "Error building Nightscout transition status");
-            return Problem(
-                detail: "Internal server error",
-                statusCode: 500,
-                title: "Internal Server Error"
-            );
-        }
+            Migration = await BuildMigrationStatusAsync(cancellationToken),
+            WriteBack = BuildWriteBackHealth(),
+            Compatibility = compatibility,
+            Recommendation = await BuildRecommendationAsync(compatibility, cancellationToken)
+        };
+
+        return Ok(status);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Filters/ReadAccessAuditFilter.cs
+++ b/src/API/Nocturne.API/Filters/ReadAccessAuditFilter.cs
@@ -13,10 +13,10 @@ using Nocturne.Infrastructure.Data.Entities;
 namespace Nocturne.API.Filters;
 
 /// <summary>
-/// Result filter that logs V4 PHI read access to the audit log.
-/// Runs after the action produces a result; failures are swallowed to never block requests.
+/// Logs V4 PHI read access to the audit log, whether the action produced a result or threw.
+/// Failures are swallowed to never block requests.
 /// </summary>
-public class ReadAccessAuditFilter : IAsyncResultFilter
+public class ReadAccessAuditFilter : IAsyncResultFilter, IAsyncExceptionFilter
 {
     private static readonly HashSet<string> WhitelistedParams = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -44,9 +44,25 @@ public class ReadAccessAuditFilter : IAsyncResultFilter
     {
         await next();
 
+        await AuditAsync(context.HttpContext, context.Result, context.HttpContext.Response.StatusCode);
+    }
+
+    /// <summary>
+    /// Audits a read whose action threw. MVC skips the result pipeline in that case, so this is the
+    /// only stage that still sees the request.
+    /// </summary>
+    /// <remarks>
+    /// The status is named rather than read off the response: the exception has not reached
+    /// <see cref="Middleware.ApiErrorEnvelopeHandler"/> yet, so the response still carries its
+    /// pre-action status. The exception is deliberately left unhandled so it reaches that handler.
+    /// </remarks>
+    public Task OnExceptionAsync(ExceptionContext context) =>
+        AuditAsync(context.HttpContext, result: null, StatusCodes.Status500InternalServerError);
+
+    private async Task AuditAsync(HttpContext httpContext, IActionResult? result, int statusCode)
+    {
         try
         {
-            var httpContext = context.HttpContext;
             var path = httpContext.Request.Path.Value;
             var method = httpContext.Request.Method;
 
@@ -60,7 +76,6 @@ public class ReadAccessAuditFilter : IAsyncResultFilter
                 return;
 
             // Skip auth failures — no meaningful read occurred
-            var statusCode = httpContext.Response.StatusCode;
             if (statusCode is 401 or 403)
                 return;
 
@@ -74,7 +89,7 @@ public class ReadAccessAuditFilter : IAsyncResultFilter
                 return;
 
             // Extract result metadata (best-effort)
-            var (recordCount, entityType) = ExtractResultMetadata(context.Result);
+            var (recordCount, entityType) = ExtractResultMetadata(result);
 
             // Sanitize query parameters
             var queryParams = SanitizeQueryParameters(httpContext.Request.Query);
@@ -113,7 +128,7 @@ public class ReadAccessAuditFilter : IAsyncResultFilter
     /// <summary>
     /// Extracts record count and entity type from the action result (best-effort).
     /// </summary>
-    internal static (int? RecordCount, string? EntityType) ExtractResultMetadata(IActionResult result)
+    internal static (int? RecordCount, string? EntityType) ExtractResultMetadata(IActionResult? result)
     {
         if (result is not ObjectResult { Value: not null } objectResult)
             return (null, null);

--- a/src/API/Nocturne.API/Middleware/ApiErrorEnvelopeHandler.cs
+++ b/src/API/Nocturne.API/Middleware/ApiErrorEnvelopeHandler.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Attributes;
+using Nocturne.API.Configuration;
+
+namespace Nocturne.API.Middleware;
+
+/// <summary>
+/// Answers an unhandled exception from an <see cref="ErrorEnvelopeAttribute"/> action with the
+/// error envelope its API version already uses.
+/// </summary>
+/// <remarks>
+/// The envelope is a wire contract, not a presentation choice — Nightscout clients parse it — so
+/// each version keeps the shape it shipped with: V1 <c>{status, message, type, error}</c>, V3
+/// <c>{status, message}</c>, and V2/V4 an RFC 9457 <c>ProblemDetails</c>. The V1 <c>error</c>
+/// member carries <see cref="Exception.Message"/>, which uploaders surface to the user.
+///
+/// V1-V3 bodies are written with <see cref="NightscoutJsonOptions"/> because
+/// <see cref="NightscoutJsonFilter"/> serialises every other result on those routes that way, and
+/// a result filter cannot run once the pipeline has unwound to the exception handler.
+/// </remarks>
+/// <seealso cref="ErrorEnvelopeAttribute"/>
+internal sealed class ApiErrorEnvelopeHandler : IExceptionHandler
+{
+    private const string Detail = "Internal server error";
+    private const string Title = "Internal Server Error";
+    private const string ContentType = "application/json; charset=utf-8";
+
+    private static readonly JsonSerializerOptions NightscoutOptions = NightscoutJsonOptions.Create();
+
+    private readonly ILogger<ApiErrorEnvelopeHandler> _logger;
+    private readonly ProblemDetailsFactory _problemDetailsFactory;
+    private readonly JsonSerializerOptions _mvcOptions;
+
+    public ApiErrorEnvelopeHandler(
+        ILogger<ApiErrorEnvelopeHandler> logger,
+        ProblemDetailsFactory problemDetailsFactory,
+        IOptions<JsonOptions> mvcJsonOptions
+    )
+    {
+        _logger = logger;
+        _problemDetailsFactory = problemDetailsFactory;
+        _mvcOptions = mvcJsonOptions.Value.JsonSerializerOptions;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken
+    )
+    {
+        // ExceptionHandlerMiddleware clears the endpoint before running handlers; the feature
+        // carries it forward.
+        var endpoint =
+            httpContext.Features.Get<IExceptionHandlerFeature>()?.Endpoint
+            ?? httpContext.GetEndpoint();
+
+        if (endpoint?.Metadata.GetMetadata<ErrorEnvelopeAttribute>() is null)
+        {
+            return false;
+        }
+
+        _logger.LogError(
+            exception,
+            "Unhandled exception serving {Method} {Path}",
+            httpContext.Request.Method,
+            httpContext.Request.Path
+        );
+
+        var (body, options) = NightscoutApiPath.Version(httpContext.Request.Path) switch
+        {
+            1 => (
+                (object)new
+                {
+                    status = StatusCodes.Status500InternalServerError,
+                    message = Detail,
+                    type = "internal",
+                    error = exception.Message,
+                },
+                NightscoutOptions
+            ),
+            3 => (
+                new { status = StatusCodes.Status500InternalServerError, message = Detail },
+                NightscoutOptions
+            ),
+            2 => (CreateProblem(httpContext), NightscoutOptions),
+            _ => (CreateProblem(httpContext), _mvcOptions),
+        };
+
+        httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        await httpContext.Response.WriteAsJsonAsync(
+            body,
+            options,
+            contentType: ContentType,
+            cancellationToken
+        );
+
+        return true;
+    }
+
+    private ProblemDetails CreateProblem(HttpContext httpContext) =>
+        _problemDetailsFactory.CreateProblemDetails(
+            httpContext,
+            statusCode: StatusCodes.Status500InternalServerError,
+            title: Title,
+            detail: Detail
+        );
+}

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -163,6 +163,7 @@ builder.Services.AddControllers(options =>
 builder.Services.AddFluentValidationAutoValidation();
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 builder.Services.AddProblemDetails();
+builder.Services.AddExceptionHandler<ApiErrorEnvelopeHandler>();
 builder.Services.AddEndpointsApiExplorer();
 
 // ── OpenAPI document generation ──────────────────────────────────────

--- a/tests/Unit/Nocturne.API.Tests/Configuration/NightscoutApiPathTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Configuration/NightscoutApiPathTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Http;
+using Nocturne.API.Configuration;
+
+namespace Nocturne.API.Tests.Configuration;
+
+/// <summary>
+/// Pins which paths count as Nightscout-compatible, which decides both the error envelope shape
+/// and — through <see cref="NightscoutJsonFilter"/> — the serializer every v1-v3 response uses.
+/// </summary>
+[Trait("Category", "Unit")]
+public class NightscoutApiPathTests
+{
+    [Theory]
+    [InlineData("/api/v1/x", 1)]
+    [InlineData("/api/v2/x", 2)]
+    [InlineData("/api/v3/x", 3)]
+    [InlineData("/api/v3/", 3)]
+    [InlineData("/API/V1/x", 1)]
+    [InlineData("/api/v4/x", null)]
+    [InlineData("/api/v10/", null)]
+    [InlineData("/api/v1", null)]
+    [InlineData("//api/v1/", null)]
+    [InlineData("/api/v1x/y", null)]
+    [InlineData("/scalar/v1/x", null)]
+    [InlineData("/", null)]
+    [InlineData("", null)]
+    public void Version_ClassifiesThePath(string path, int? expected) =>
+        NightscoutApiPath.Version(new PathString(path)).Should().Be(expected);
+
+    [Fact]
+    public void Version_PathWithNoValue_IsNotNightscout() =>
+        NightscoutApiPath.Version(default).Should().BeNull();
+
+    /// <summary>
+    /// The comparison is ordinal, so a version segment padded with an ignorable character is not
+    /// Nightscout. Endpoint routing compares segments ordinally too, so such a request never
+    /// reaches MVC — but a culture-sensitive comparison here would have matched it.
+    /// </summary>
+    [Fact]
+    public void Version_SoftHyphenInTheVersionSegment_IsNotNightscout() =>
+        NightscoutApiPath.Version(new PathString("/api/v­1/x")).Should().BeNull();
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/AuthorizationManagementControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/AuthorizationManagementControllerTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V2;
 using Nocturne.Core.Contracts.Identity;
 using Xunit;
@@ -60,19 +61,16 @@ public class AuthorizationManagementControllerTests
     }
 
     [Fact]
-    public async Task GetAllSubjects_WhenServiceThrows_ReturnsInternalServerError()
+    public async Task GetAllSubjects_WhenServiceThrows_LeavesTheResponseToTheErrorEnvelopeSeam()
     {
         // Arrange
         _mockAuthorizationService
             .Setup(s => s.GetAllSubjectsAsync())
             .ThrowsAsync(new Exception("Database error"));
 
-        // Act
-        var result = await _controller.GetAllSubjects();
-
-        // Assert
-        var statusResult = Assert.IsType<ObjectResult>(result.Result);
-        Assert.Equal(500, statusResult.StatusCode);
+        // Act & Assert
+        await Assert.ThrowsAsync<Exception>(() => _controller.GetAllSubjects());
+        AssertOptsIntoTheErrorEnvelope(nameof(AuthorizationController.GetAllSubjects));
     }
 
     [Fact]
@@ -242,20 +240,30 @@ public class AuthorizationManagementControllerTests
     }
 
     [Fact]
-    public async Task GetAllRoles_WhenServiceThrows_ReturnsInternalServerError()
+    public async Task GetAllRoles_WhenServiceThrows_LeavesTheResponseToTheErrorEnvelopeSeam()
     {
         // Arrange
         _mockAuthorizationService
             .Setup(s => s.GetAllRolesAsync())
             .ThrowsAsync(new Exception("Database error"));
 
-        // Act
-        var result = await _controller.GetAllRoles();
-
-        // Assert
-        var statusResult = Assert.IsType<ObjectResult>(result.Result);
-        Assert.Equal(500, statusResult.StatusCode);
+        // Act & Assert
+        await Assert.ThrowsAsync<Exception>(() => _controller.GetAllRoles());
+        AssertOptsIntoTheErrorEnvelope(nameof(AuthorizationController.GetAllRoles));
     }
+
+    /// <summary>
+    /// Propagating is only equivalent to the old inline 500 while the action opts into
+    /// <see cref="ErrorEnvelopeAttribute"/>; the body itself is pinned by
+    /// <c>ApiErrorEnvelopeTests</c>.
+    /// </summary>
+    private static void AssertOptsIntoTheErrorEnvelope(string actionName) =>
+        Assert.NotNull(
+            typeof(AuthorizationController)
+                .GetMethod(actionName)!
+                .GetCustomAttributes(typeof(ErrorEnvelopeAttribute), inherit: false)
+                .SingleOrDefault()
+        );
 
     [Fact]
     public async Task CreateRole_WithValidRole_ReturnsCreatedRole()

--- a/tests/Unit/Nocturne.API.Tests/Controllers/AuthorizationManagementControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/AuthorizationManagementControllerTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Nocturne.API.Attributes;
 using Nocturne.API.Controllers.V2;
 using Nocturne.Core.Contracts.Identity;
 using Xunit;
@@ -58,19 +57,6 @@ public class AuthorizationManagementControllerTests
         var returnedSubjects = Assert.IsType<List<Subject>>(okResult.Value);
         Assert.Equal(2, returnedSubjects.Count);
         Assert.Equal("Test Subject 1", returnedSubjects[0].Name);
-    }
-
-    [Fact]
-    public async Task GetAllSubjects_WhenServiceThrows_LeavesTheResponseToTheErrorEnvelopeSeam()
-    {
-        // Arrange
-        _mockAuthorizationService
-            .Setup(s => s.GetAllSubjectsAsync())
-            .ThrowsAsync(new Exception("Database error"));
-
-        // Act & Assert
-        await Assert.ThrowsAsync<Exception>(() => _controller.GetAllSubjects());
-        AssertOptsIntoTheErrorEnvelope(nameof(AuthorizationController.GetAllSubjects));
     }
 
     [Fact]
@@ -238,32 +224,6 @@ public class AuthorizationManagementControllerTests
         Assert.Equal(2, returnedRoles.Count);
         Assert.Equal("admin", returnedRoles[0].Name);
     }
-
-    [Fact]
-    public async Task GetAllRoles_WhenServiceThrows_LeavesTheResponseToTheErrorEnvelopeSeam()
-    {
-        // Arrange
-        _mockAuthorizationService
-            .Setup(s => s.GetAllRolesAsync())
-            .ThrowsAsync(new Exception("Database error"));
-
-        // Act & Assert
-        await Assert.ThrowsAsync<Exception>(() => _controller.GetAllRoles());
-        AssertOptsIntoTheErrorEnvelope(nameof(AuthorizationController.GetAllRoles));
-    }
-
-    /// <summary>
-    /// Propagating is only equivalent to the old inline 500 while the action opts into
-    /// <see cref="ErrorEnvelopeAttribute"/>; the body itself is pinned by
-    /// <c>ApiErrorEnvelopeTests</c>.
-    /// </summary>
-    private static void AssertOptsIntoTheErrorEnvelope(string actionName) =>
-        Assert.NotNull(
-            typeof(AuthorizationController)
-                .GetMethod(actionName)!
-                .GetCustomAttributes(typeof(ErrorEnvelopeAttribute), inherit: false)
-                .SingleOrDefault()
-        );
 
     [Fact]
     public async Task CreateRole_WithValidRole_ReturnsCreatedRole()

--- a/tests/Unit/Nocturne.API.Tests/Filters/ReadAccessAuditOnFailureTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Filters/ReadAccessAuditOnFailureTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.API.Tests.Filters;
+
+/// <summary>
+/// Pins that a V4 PHI read is audited whether it succeeds or the action throws.
+/// </summary>
+/// <remarks>
+/// The trail is compliance-relevant, so a failed read has to leave a row too — and a throwing
+/// action is precisely the case MVC answers by skipping the result pipeline, which is where the
+/// audit row is written from on every other path.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class ReadAccessAuditOnFailureTests
+    : IClassFixture<ReadAccessAuditOnFailureTests.AuditingThrowingFactory>
+{
+    private const string ThrowingEndpoint = "GET /api/v4/body-weight";
+    private const string NotFoundEndpoint = "GET /api/v4/body-weight/missing";
+
+    private readonly HttpClient _client;
+    private readonly IDbContextFactory<NocturneDbContext> _contextFactory;
+
+    public ReadAccessAuditOnFailureTests(AuditingThrowingFactory factory)
+    {
+        _contextFactory = factory.Services.GetRequiredService<
+            IDbContextFactory<NocturneDbContext>
+        >();
+        _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add(
+            "api-secret",
+            Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(AuthenticationTestFactory.ApiSecret)))
+                .ToLowerInvariant()
+        );
+    }
+
+    [Fact]
+    public async Task ThrowingRead_IsAuditedWithStatus500()
+    {
+        var response = await _client.GetAsync("/api/v4/body-weight");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        var entry = await WaitForEntryAsync(ThrowingEndpoint);
+        entry.Should().NotBeNull("a failed PHI read still has to leave an audit trail");
+        entry!.StatusCode.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task NonThrowingRead_IsStillAuditedWithItsOwnStatus()
+    {
+        var response = await _client.GetAsync("/api/v4/body-weight/missing");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var entry = await WaitForEntryAsync(NotFoundEndpoint);
+        entry.Should().NotBeNull();
+        entry!.StatusCode.Should().Be(404);
+    }
+
+    /// <summary>
+    /// The audit write is fire-and-forget, so it can land after the response.
+    /// </summary>
+    private async Task<ReadAccessLogEntity?> WaitForEntryAsync(string endpoint)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            await using var db = await _contextFactory.CreateDbContextAsync();
+            db.TenantId = TestDatabaseSeeder.TenantId;
+            var entry = await db
+                .ReadAccessLog.AsNoTracking()
+                .FirstOrDefaultAsync(e => e.Endpoint == endpoint);
+            if (entry is not null)
+                return entry;
+
+            await Task.Delay(50);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Makes the collection read throw, so one route on the controller fails while the sibling
+    /// by-id route still answers normally.
+    /// </summary>
+    public sealed class AuditingThrowingFactory : AuthenticationTestFactory
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+
+            builder.ConfigureServices(services =>
+            {
+                var auditConfig = new Mock<ITenantAuditConfigCache>();
+                auditConfig
+                    .Setup(c => c.GetConfigAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new TenantAuditConfig(ReadAuditEnabled: true, null, null));
+                services.AddSingleton(auditConfig.Object);
+
+                var bodyWeight = new Mock<IBodyWeightService>();
+                bodyWeight
+                    .Setup(s =>
+                        s.GetBodyWeightsAsync(
+                            It.IsAny<int>(),
+                            It.IsAny<int>(),
+                            It.IsAny<CancellationToken>()
+                        )
+                    )
+                    .ThrowsAsync(new InvalidOperationException("boom from the service layer"));
+                services.AddSingleton(bodyWeight.Object);
+            });
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Middleware/ApiErrorEnvelopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/ApiErrorEnvelopeTests.cs
@@ -87,13 +87,17 @@ public class ApiErrorEnvelopeTests : IClassFixture<ApiErrorEnvelopeTests.Throwin
     }
 
     /// <summary>
-    /// V2 routes carry the V4 <c>ProblemDetails</c> body but are serialised by
-    /// <c>NightscoutJsonFilter</c>, which drops default-valued members.
+    /// V2 routes carry the V4 <c>ProblemDetails</c> body, serialised by
+    /// <c>ApiErrorEnvelopeHandler</c> under the Nightscout options its remarks explain — no result
+    /// filter can run once the pipeline has unwound to the exception handler.
     /// </summary>
-    [Fact]
-    public async Task V2_ThrowingAction_AnswersProblemDetailsWithoutTheExceptionMessage()
+    [Theory]
+    [InlineData("/api/v2/authorization/request/some-access-token")]
+    [InlineData("/api/v2/authorization/subjects")]
+    [InlineData("/api/v2/authorization/roles")]
+    public async Task V2_ThrowingAction_AnswersProblemDetailsWithoutTheExceptionMessage(string route)
     {
-        var response = await _client.GetAsync("/api/v2/authorization/request/some-access-token");
+        var response = await _client.GetAsync(route);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
@@ -147,6 +151,12 @@ public class ApiErrorEnvelopeTests : IClassFixture<ApiErrorEnvelopeTests.Throwin
                 var authorization = new Mock<IAuthorizationService>();
                 authorization
                     .Setup(s => s.GenerateJwtFromAccessTokenAsync(It.IsAny<string>()))
+                    .ThrowsAsync(new InvalidOperationException(BoomMessage));
+                authorization
+                    .Setup(s => s.GetAllSubjectsAsync())
+                    .ThrowsAsync(new InvalidOperationException(BoomMessage));
+                authorization
+                    .Setup(s => s.GetAllRolesAsync())
                     .ThrowsAsync(new InvalidOperationException(BoomMessage));
                 services.AddSingleton(authorization.Object);
             });

--- a/tests/Unit/Nocturne.API.Tests/Middleware/ApiErrorEnvelopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/ApiErrorEnvelopeTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Core.Contracts.Alerts;
+using Nocturne.Core.Contracts.Glucose;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.Identity;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.Legacy;
+using Xunit;
+
+namespace Nocturne.API.Tests.Middleware;
+
+/// <summary>
+/// Pins the error envelope each API version answers with when an action throws.
+/// </summary>
+/// <remarks>
+/// The three shapes are wire contracts, not implementation detail: V1 and V3 are what Nightscout
+/// clients (AAPS, xDrip, Loop) parse, and the V1 body carries <c>ex.Message</c> that uploaders
+/// surface to users. Nothing pinned them before, so they were free to drift apart.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class ApiErrorEnvelopeTests : IClassFixture<ApiErrorEnvelopeTests.ThrowingServiceFactory>
+{
+    private const string BoomMessage = "boom from the service layer";
+    private const string TwentyFourHexId = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+    private readonly HttpClient _client;
+
+    public ApiErrorEnvelopeTests(ThrowingServiceFactory factory)
+    {
+        _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add(
+            "api-secret",
+            Sha1Hex(AuthenticationTestFactory.ApiSecret)
+        );
+    }
+
+    [Fact]
+    public async Task V1_ThrowingAction_AnswersTheNightscoutV1Envelope()
+    {
+        var response = await _client.GetAsync($"/api/v1/entries/{TwentyFourHexId}");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(
+            $$"""{"status":500,"message":"Internal server error","type":"internal","error":"{{BoomMessage}}"}""",
+            await response.Content.ReadAsStringAsync()
+        );
+    }
+
+    [Fact]
+    public async Task V3_ThrowingAction_AnswersTheNightscoutV3Envelope()
+    {
+        var response = await _client.GetAsync($"/api/v3/entries/{TwentyFourHexId}");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(
+            """{"status":500,"message":"Internal server error"}""",
+            await response.Content.ReadAsStringAsync()
+        );
+    }
+
+    [Fact]
+    public async Task V4_ThrowingAction_AnswersProblemDetails()
+    {
+        var response = await _client.GetAsync("/api/v4/body-weight");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = body.RootElement;
+        Assert.Equal("Internal Server Error", root.GetProperty("title").GetString());
+        Assert.Equal("Internal server error", root.GetProperty("detail").GetString());
+        Assert.Equal(500, root.GetProperty("status").GetInt32());
+        Assert.Equal(
+            "https://tools.ietf.org/html/rfc9110#section-15.6.1",
+            root.GetProperty("type").GetString()
+        );
+        Assert.False(root.TryGetProperty("message", out _));
+    }
+
+    /// <summary>
+    /// V2 routes carry the V4 <c>ProblemDetails</c> body but are serialised by
+    /// <c>NightscoutJsonFilter</c>, which drops default-valued members.
+    /// </summary>
+    [Fact]
+    public async Task V2_ThrowingAction_AnswersProblemDetailsWithoutTheExceptionMessage()
+    {
+        var response = await _client.GetAsync("/api/v2/authorization/request/some-access-token");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        var raw = await response.Content.ReadAsStringAsync();
+        using var body = JsonDocument.Parse(raw);
+        var root = body.RootElement;
+        Assert.Equal("Internal Server Error", root.GetProperty("title").GetString());
+        Assert.Equal("Internal server error", root.GetProperty("detail").GetString());
+        Assert.Equal(500, root.GetProperty("status").GetInt32());
+        Assert.DoesNotContain(BoomMessage, raw);
+    }
+
+    private static string Sha1Hex(string value) =>
+        Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+
+    /// <summary>
+    /// Replaces the services behind one action per envelope family with a stub that throws, so the
+    /// request reaches the error path with a message the assertions can match exactly.
+    /// </summary>
+    public sealed class ThrowingServiceFactory : AuthenticationTestFactory
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+
+            builder.ConfigureServices(services =>
+            {
+                var entries = new Mock<IEntryService>();
+                entries
+                    .Setup(s =>
+                        s.GetEntryByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())
+                    )
+                    .ThrowsAsync(new InvalidOperationException(BoomMessage));
+                services.AddSingleton(entries.Object);
+                services.AddSingleton(new Mock<IDocumentProcessingService>().Object);
+                services.AddSingleton(new Mock<IProcessingStatusService>().Object);
+                services.AddSingleton(new Mock<ICanonicalAlertEvaluator>().Object);
+
+                var bodyWeight = new Mock<IBodyWeightService>();
+                bodyWeight
+                    .Setup(s =>
+                        s.GetBodyWeightsAsync(
+                            It.IsAny<int>(),
+                            It.IsAny<int>(),
+                            It.IsAny<CancellationToken>()
+                        )
+                    )
+                    .ThrowsAsync(new InvalidOperationException(BoomMessage));
+                services.AddSingleton(bodyWeight.Object);
+
+                var authorization = new Mock<IAuthorizationService>();
+                authorization
+                    .Setup(s => s.GenerateJwtFromAccessTokenAsync(It.IsAny<string>()))
+                    .ThrowsAsync(new InvalidOperationException(BoomMessage));
+                services.AddSingleton(authorization.Object);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## What moved

`Program.cs` already called `AddProblemDetails()` and `UseExceptionHandler()`, but 262 `catch (Exception ex)` blocks across 60 controller files re-implemented error shaping inline. `ApiErrorEnvelopeHandler` (an `IExceptionHandler`, registered next to `AddProblemDetails()`) now builds each API version's envelope once and logs once, at `LogError` — the severity every removed block used.

**87 catch blocks removed** (262 to 175 in `src/API/Nocturne.API/Controllers`). `src/` is -463 lines net; most of the remaining churn is the de-indentation of 68 action bodies that lost their `try`.

### The seam is opt-in, not path-based

The handler fires only for actions marked `[ErrorEnvelope]`. That is deliberate and is the load-bearing design decision: a handler keyed purely on `/api/v{n}/` would also have started rewriting every action that has **no** catch today, silently replacing the framework's default `ProblemDetails` with a Nightscout envelope. That is an observable change on an unknown number of routes, so the attribute records exactly which actions delegated their shaping. Path/version then selects *which* envelope, per the existing `NightscoutJsonFilter` rule (now shared via `NightscoutApiPath.Version`).

## Per-family decisions

| Family | Sites | Decision |
|---|---|---|
| `Problem(detail: "Internal server error", statusCode: 500, title: "Internal Server Error")` | 42 | **Moved.** Rebuilt through the same `ProblemDetailsFactory` the controller used, so the body matches down to `traceId`. |
| `CreateV3ErrorResponse(500, "Internal server error", ...)` | 38 | **Moved.** The helper discards its third argument, so the `ex.Message` (30 sites) and `"An unexpected error occurred"` (8 sites) variants were already the same `{status, message}` body. 19 of the sites shared their `try` with a `catch (ArgumentException)` mapping to 400; those keep the `try` and lose only the catch-all clause. |
| `StatusCode(500, new { status, message, type = "internal", error = ex.Message })` | 7 of 11 | **Moved** for the 7 in `V1/EntriesController`. See below for the 4 kept. |
| `BadRequest(new { error = ex.Message })` | 29 | **Kept.** See "400 vs 500". |
| `StatusCode(500, new { error = "Internal server error" })` | 9 | **Kept.** A fourth wire shape that contradicts its own routes' version convention — it appears on v1, v2 *and* v4 paths. Encoding it in the seam would make it a reusable, first-class envelope. Aligning those nine onto their version's envelope is a behavioural change and belongs in its own PR. |
| ~130 others | | **Kept**, see below. |

### 400 vs 500 — the `StatisticsController` call

29 sites (`V4/Analytics/StatisticsController.cs`) answer *any* exception with **400** and `ex.Message`, with no logging at all. **I kept them.**

The seam could support this with an explicit opt-in, and preserving the 400 is the only correct option — converting it to 500 is an observable change and is out of scope here. But adding a `BadRequest`-on-unhandled-exception envelope to shared infrastructure advertises it as a legitimate choice and invites new controllers to adopt it. Keeping the catches confines the wrongness to one file and leaves one obvious place to fix it. Worth a follow-up: those endpoints should classify their own bad input and let everything else be a 500.

### Catches deliberately left alone

Only catches that did nothing but log and return a generic error were removed. Kept:

- **Cleanup / recovery** — `V1/EntriesController.cs` marks processing failed on the async-ingest path; `V4/Connectors/CareLinkConnectController`; `V4/Platform/CompatibilityController` (records per-probe timing and error text into the result).
- **Specific exception to specific status** — every `catch (ArgumentException)` mapping to 400, `catch (JsonException)`, the `PasskeyController` / `SetupController` 400s (which also write an auth-audit row).
- **Compatibility fallbacks that return 200** — `V1/AlexaController`, `V1/PebbleController`, `V1/StatusController`, `V1/VersionsController`, `V3/StatusController`, `V3/VersionController`, `V3/LastModifiedController`, `V4/Platform/StatusController`. These deliberately answer a success envelope on failure so clients (AAPS especially) do not wedge.
- **Endpoint-specific 500 messages** — e.g. `V1/ActivityController`'s `"An error occurred while retrieving activities"`. These add contextual data the seam cannot reconstruct.
- **Non-action helpers** — `V1/TimeQueryController`'s three private `...Internal` methods carry the V1 envelope. An attribute on a private method contributes no endpoint metadata, and hoisting it to the 9 public actions that delegate to them would widen the covered region past what the catch covered (each caller runs `RefuseUnsupportedStorage` / `LegacyStorageReadScopes.RefuseRead` first). Left as-is.
- **Rethrow / return-null / return-default** — `V4/Analytics/SummaryController` (`throw;`), the `BaseV3Controller` count helpers.
- **`V4/TenantAdmin/ProcessingController`** — carries the V1 envelope on a `/api/v4/` path, plus a `correlationId` member. Path-based selection cannot produce it.

## `ex.Message` disclosure — follow-up, not fixed here

The V1 envelope's `error` member is `ex.Message`, so an unhandled server exception's message reaches Nightscout clients verbatim. That is pre-existing information disclosure and it is **preserved exactly** — redacting it is a behavioural change to a wire field uploaders surface to users, and it needs its own PR and its own decision about what V1 clients should see instead. Same for the 29 `BadRequest(new { error = ex.Message })` sites.

## Behavioural deltas

None of these change a wire body, but all of them are real and none were declared before.

- **Log message and its structured parameters.** Each removed catch logged its own message with its own parameters (`{Id}`, `{Spec}`, `{Year}`, ...). All 87 now log one `"Unhandled exception serving {Method} {Path}"`. The per-route identifiers are gone from the log record; the path and the stack trace remain.
- **Log category.** Logging moves from the 17 controller types to `Nocturne.API.Middleware.ApiErrorEnvelopeHandler`. Any per-category log-level filter aimed at one of those controllers no longer applies to its unhandled exceptions.
- **Double logging and framework diagnostics.** `ExceptionHandlerMiddleware` logs the exception as well, so these 87 paths now produce two records. They also now increment ASP.NET Core's unhandled-exception diagnostics and metrics - previously the action swallowed the exception and the framework never saw it.
- **Headers set before the throw are dropped.** `Response.Clear()` on the exception path wipes them. Concretely, `BaseV3Controller.SetHistoryCursorHeaders` sets `Last-Modified` and `ETag` before the read on the V3 `history/{lastModified}` routes; those headers no longer survive onto a 500.
- **Read-access audit rows on failed V4 GETs - regressed, then fixed.** `ReadAccessAuditFilter` is an `IAsyncResultFilter`, and MVC skips result filters when an action throws, so removing the catches silently dropped the audit row for every failed V4 read (`ActogramController`, `ChartDataController`, `DataOverviewController`, `RetrospectiveController`, `BatteryController`, the `BodyWeight`/`HeartRate`/`StepCount` GETs, `NightscoutTransitionController.GetTransitionStatus`). The filter now also implements `IAsyncExceptionFilter`, sharing one write path with the result stage and leaving the exception unhandled so it still reaches the seam. The status is **named** as 500 rather than read off `Response.StatusCode`, which at that point has not yet been set by the exception handler. Two knock-on differences on that path: `EntityType`/`RecordCount` are now null instead of `"ProblemDetails"`/`1` (the old values described the error body, not a read), and a V4 GET that never had a catch at all is now audited on failure too, where before this PR it was not.

## Tests

`tests/Unit/Nocturne.API.Tests/Middleware/ApiErrorEnvelopeTests.cs` — one test per envelope family, driving a real request through `WebApplicationFactory` with the service behind the action stubbed to throw:

- **V1** `/api/v1/entries/{id}` — exact body `{"status":500,"message":"Internal server error","type":"internal","error":"..."}`
- **V3** `/api/v3/entries/{id}` — exact body `{"status":500,"message":"Internal server error"}`
- **V4** `/api/v4/body-weight` — `ProblemDetails` fields
- **V2** `/api/v2/authorization/request/{token}`, `/subjects`, `/roles` — `ProblemDetails` serialised by the handler under `NightscoutJsonOptions` (a result filter cannot run once the pipeline has unwound to the exception handler), and asserts `ex.Message` does **not** leak on v2

These were written and run green **against `main` before any catch was removed**, which is what makes them a before/after equivalence proof rather than a description of the new code. Commit order reflects that: tests first, then the seam, then the removals.

`tests/Unit/Nocturne.API.Tests/Filters/ReadAccessAuditOnFailureTests.cs` — a throwing V4 GET must leave a `ReadAccessLogEntity` with `StatusCode = 500`, alongside a 404 read on the sibling route as a positive control. **Written first and run against this branch before the fix**: the 404 control passed and the throwing case failed with no row at all, which is the regression declared above.

`tests/Unit/Nocturne.API.Tests/Configuration/NightscoutApiPathTests.cs` — a table over `NightscoutApiPath.Version`, which the `NightscoutJsonFilter` refactor put in the path of every v1-v3 response and not just errors. It pins the ordinal comparison as a decision: the `StartsWith(string)` it replaced used `CurrentCulture`, so ICU ignored zero-width and soft-hyphen characters and `/api/v­1/x` matched. The new check is stricter and the case is unreachable — endpoint routing compares path segments ordinally, so such a request 404s before reaching MVC — so no real route loses Nightscout serialization.

**Mutation check performed.** The handler's version switch was temporarily scrambled (v1 to the V3 body, v3 to `ProblemDetails`, default to the V1 body). All 4 tests failed. Reverted; all 4 pass again.

## Build and test

- `dotnet build src/API/Nocturne.API/Nocturne.API.csproj -p:GenerateNSwagClient=false` — 0 errors, no new warnings.
- `dotnet test tests/Unit/Nocturne.API.Tests --filter "Category!=Integration&Category!=Performance&Category!=E2E"` — **6141 passed, 0 failed, 5 skipped** (6129 before this PR).

Two pre-existing tests were removed: `AuthorizationManagementControllerTests.{GetAllSubjects,GetAllRoles}_WhenServiceThrows_*` invoked the controller method directly and asserted the inline catch's `ObjectResult`. Asserting only that the action propagates is weaker than what they replaced — it no longer separates a 500 from a 200, a 400, or a broken fixture — so both actions are covered by `ApiErrorEnvelopeTests` over HTTP instead, which asserts the status and the `ProblemDetails` body a client receives.

## Follow-ups

1. Redact `ex.Message` from the V1 envelope (behavioural).
2. `StatisticsController`'s 29 unhandled-exception 400s.
3. The 9 `{ error: "Internal server error" }` sites, onto their version's envelope.
4. `[ErrorEnvelope]` could move to the class where every action in a controller is provably covered; applied per-action here so the change is mechanically exact.


