### PR TITLE
refactor(api): consolidate glucose statistics into one module

### DIFF
--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
@@ -499,7 +499,8 @@ public class DataOverviewService : IDataOverviewService
         // SensorGlucose (CGM)
         await AccumulateMonthlyReadingsAsync(
             context.SensorGlucose
-                .Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Mgdl > 0)
+                .Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
+                .Where(e => e.Mgdl > 0 && !double.IsNaN(e.Mgdl))
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
                 .Where(e => !npSensorGlucoseIds.Contains(e.Id))
                 .Select(e => new { e.Timestamp, e.Mgdl }),
@@ -509,7 +510,8 @@ public class DataOverviewService : IDataOverviewService
         // MeterGlucose (finger sticks)
         await AccumulateMonthlyReadingsAsync(
             context.MeterGlucose
-                .Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Mgdl > 0)
+                .Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
+                .Where(e => e.Mgdl > 0 && !double.IsNaN(e.Mgdl))
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
                 .Select(e => new { e.Timestamp, e.Mgdl }),
             r => r.Timestamp, r => r.Mgdl, allGlucoseByMonth, tz,
@@ -694,9 +696,12 @@ public class DataOverviewService : IDataOverviewService
 
     /// <summary>
     /// Builds one month's GRI timeline period, or null when the month has fewer than
-    /// <paramref name="minimumReadings"/> glucose readings.
+    /// <paramref name="minimumReadings"/> glucose readings. Values that are not readings are
+    /// dropped before anything is counted, so they reach neither a zone nor the denominator — see
+    /// <see cref="GlucoseStatistics.IsReading"/>. Internal for the test assembly; not part of the
+    /// service's contract.
     /// </summary>
-    private GriTimelinePeriod? BuildGriPeriod(
+    internal GriTimelinePeriod? BuildGriPeriod(
         int month,
         int year,
         int minimumReadings,
@@ -706,10 +711,11 @@ public class DataOverviewService : IDataOverviewService
         Dictionary<int, double> tempBasalByMonth,
         Dictionary<int, double> carbsByMonth)
     {
-        if (
-            !allGlucoseByMonth.TryGetValue(month, out var glucoseReadings)
-            || glucoseReadings.Count < minimumReadings
-        )
+        if (!allGlucoseByMonth.TryGetValue(month, out var monthValues))
+            return null;
+
+        var glucoseReadings = monthValues.Where(GlucoseStatistics.IsReading).ToList();
+        if (glucoseReadings.Count < minimumReadings)
             return null;
 
         var totalCount = glucoseReadings.Count;
@@ -910,9 +916,8 @@ public class DataOverviewService : IDataOverviewService
                 .Select(lr => lr.RecordId);
 
             var sensorReadings = await context
-                .SensorGlucose.Where(e =>
-                    e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Mgdl > 0
-                )
+                .SensorGlucose.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
+                .Where(e => e.Mgdl > 0 && !double.IsNaN(e.Mgdl))
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
                 .Where(e => !npSensorGlucoseIds.Contains(e.Id))
                 .Select(e => new { e.Timestamp, e.Mgdl })
@@ -929,9 +934,8 @@ public class DataOverviewService : IDataOverviewService
         try
         {
             var meterReadings = await context
-                .MeterGlucose.Where(e =>
-                    e.Timestamp >= startUtc && e.Timestamp < endUtc && e.Mgdl > 0
-                )
+                .MeterGlucose.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
+                .Where(e => e.Mgdl > 0 && !double.IsNaN(e.Mgdl))
                 .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
                 .Select(e => new { e.Timestamp, e.Mgdl })
                 .ToListAsync(cancellationToken);
@@ -955,6 +959,7 @@ public class DataOverviewService : IDataOverviewService
 
         // Group by date and compute daily averages + time in range
         var grouped = allReadings
+            .Where(r => GlucoseStatistics.IsReading(r.Mgdl))
             .GroupBy(r => TimestampToDateString(r.Timestamp, tz))
             .Select(g =>
             {

--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
@@ -252,10 +252,7 @@ public class DataOverviewService : IDataOverviewService
         await using var context = await _factory.CreateAsync(cancellationToken);
 
         var tz = await GetUserTimeZoneAsync(cancellationToken);
-        var localYearStart = new DateTime(year, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
-        var localNextYearStart = new DateTime(year + 1, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
-        var startUtc = TimeZoneInfo.ConvertTimeToUtc(localYearStart, tz);
-        var endUtc = TimeZoneInfo.ConvertTimeToUtc(localNextYearStart, tz);
+        var (startUtc, endUtc) = LocalYearBoundsUtc(year, tz);
         var startMills = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
         var endMills = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
 
@@ -479,11 +476,7 @@ public class DataOverviewService : IDataOverviewService
         // Minimum readings required for a valid GRI calculation (72 = ~6 hours of 5-min CGM data)
         const int minimumReadings = 72;
 
-        // Compute year-level UTC boundaries once
-        var localYearStart = new DateTime(year, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
-        var localNextYearStart = new DateTime(year + 1, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
-        var startUtc = TimeZoneInfo.ConvertTimeToUtc(localYearStart, tz);
-        var endUtc = TimeZoneInfo.ConvertTimeToUtc(localNextYearStart, tz);
+        var (startUtc, endUtc) = LocalYearBoundsUtc(year, tz);
 
         // Hoist LinkedRecord subqueries — IQueryable construction is free
         var npSensorGlucoseIds = context
@@ -587,6 +580,21 @@ public class DataOverviewService : IDataOverviewService
     }
 
     /// <summary>
+    /// The half-open UTC interval covering <paramref name="year"/> in <paramref name="tz"/>, so a
+    /// year runs from local midnight to local midnight rather than from midnight UTC.
+    /// </summary>
+    private static (DateTime StartUtc, DateTime EndUtc) LocalYearBoundsUtc(int year, TimeZoneInfo tz)
+    {
+        var localYearStart = new DateTime(year, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+        var localNextYearStart = new DateTime(year + 1, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+        return (
+            TimeZoneInfo.ConvertTimeToUtc(localYearStart, tz),
+            TimeZoneInfo.ConvertTimeToUtc(localNextYearStart, tz)
+        );
+    }
+
+    /// <summary>
     /// Local month (1-12) for a UTC timestamp, in the user's time zone.
     /// </summary>
     private static int TimestampToMonth(DateTime utcTimestamp, TimeZoneInfo tz)
@@ -664,6 +672,27 @@ public class DataOverviewService : IDataOverviewService
     }
 
     /// <summary>
+    /// The zones the GRI is scored over. These are the consensus bounds rather than the tenant's
+    /// thresholds — <see cref="GetGriTimelineAsync"/> takes no <c>GlycemicThresholds</c>, so no
+    /// caller can move them.
+    /// </summary>
+    private enum GriZone
+    {
+        VeryLow,
+        Low,
+        Target,
+        High,
+        VeryHigh,
+    }
+
+    private static readonly GlucoseZoneScale GriZones = new(
+        GlucoseZoneBound.Under(GlucoseConstants.VeryLowMgdl),
+        GlucoseZoneBound.Under(GlucoseConstants.TargetBottomMgdl),
+        GlucoseZoneBound.UpTo(GlucoseConstants.TargetTopMgdl),
+        GlucoseZoneBound.UpTo(GlucoseConstants.VeryHighMgdl)
+    );
+
+    /// <summary>
     /// Builds one month's GRI timeline period, or null when the month has fewer than
     /// <paramref name="minimumReadings"/> glucose readings.
     /// </summary>
@@ -683,22 +712,17 @@ public class DataOverviewService : IDataOverviewService
         )
             return null;
 
-        // Bucket readings into TIR zones
         var totalCount = glucoseReadings.Count;
-        var veryLowCount = glucoseReadings.Count(v => v < 54);
-        var lowCount = glucoseReadings.Count(v => v >= 54 && v < GlucoseConstants.TargetBottomMgdl);
-        var targetCount = glucoseReadings.Count(
-            v => v >= GlucoseConstants.TargetBottomMgdl && v <= GlucoseConstants.TargetTopMgdl);
-        var highCount = glucoseReadings.Count(v => v > GlucoseConstants.TargetTopMgdl && v <= 250);
-        var veryHighCount = glucoseReadings.Count(v => v > 250);
+        var counts = GriZones.Count(glucoseReadings);
+        double Percent(GriZone zone) => (double)counts[(int)zone] / totalCount * 100.0;
 
         var percentages = new TimeInRangePercentages
         {
-            VeryLow = (double)veryLowCount / totalCount * 100.0,
-            Low = (double)lowCount / totalCount * 100.0,
-            Target = (double)targetCount / totalCount * 100.0,
-            High = (double)highCount / totalCount * 100.0,
-            VeryHigh = (double)veryHighCount / totalCount * 100.0,
+            VeryLow = Percent(GriZone.VeryLow),
+            Low = Percent(GriZone.Low),
+            Target = Percent(GriZone.Target),
+            High = Percent(GriZone.High),
+            VeryHigh = Percent(GriZone.VeryHigh),
         };
 
         var timeInRange = new TimeInRangeMetrics { Percentages = percentages };

--- a/src/API/Nocturne.API/Services/Analytics/GlucoseStatistics.cs
+++ b/src/API/Nocturne.API/Services/Analytics/GlucoseStatistics.cs
@@ -57,6 +57,16 @@ public static class GlucoseStatistics
             : sortedValues[sortedValues.Count / 2];
 
     /// <summary>
+    /// Whether <paramref name="mgdl"/> is a glucose reading at all. A <c>&gt; 0</c> test does not
+    /// settle it: PostgreSQL orders NaN above every number, so a NaN stored in a
+    /// <c>double precision</c> column passes that test when it runs in SQL. Admitted into a
+    /// series, a NaN fails every bound of a <see cref="GlucoseZoneScale"/> and so is classified
+    /// into the remainder zone — severe hyperglycaemia, on a scale that ends there — and makes any
+    /// mean taken over the series NaN.
+    /// </summary>
+    public static bool IsReading(double mgdl) => mgdl > 0 && !double.IsNaN(mgdl);
+
+    /// <summary>
     /// Estimated A1C as a percentage from mean glucose in mg/dL, by the ADAG regression
     /// <c>(mean + 46.7) / 28.7</c>. A mean of zero means there were no readings, and reports zero
     /// rather than the 1.6% the regression would give.

--- a/src/API/Nocturne.API/Services/Analytics/GlucoseStatistics.cs
+++ b/src/API/Nocturne.API/Services/Analytics/GlucoseStatistics.cs
@@ -1,0 +1,129 @@
+namespace Nocturne.API.Services.Analytics;
+
+/// <summary>
+/// Which population a variance is taken over: a <see cref="Sample"/> divides by <c>n - 1</c>, a
+/// <see cref="Population"/> by <c>n</c>. Which one a given glycemic metric is defined against is a
+/// clinical question, so every caller states its own rather than inheriting a default.
+/// </summary>
+public enum VarianceMode
+{
+    /// <summary>Bessel-corrected: <c>n - 1</c>, and zero for fewer than two readings.</summary>
+    Sample,
+
+    /// <summary>Uncorrected: <c>n</c>, and <see cref="double.NaN"/> for no readings.</summary>
+    Population,
+}
+
+/// <summary>
+/// The arithmetic that glucose statistics are assembled from — variance, median and estimated A1C —
+/// in one place, so a divisor or a formula exists once rather than once per metric.
+/// </summary>
+public static class GlucoseStatistics
+{
+    /// <summary>
+    /// Variance of <paramref name="values"/> about <paramref name="mean"/>. The mean is supplied
+    /// rather than derived because callers differ on whether they centre on the raw average or on
+    /// the rounded one <c>StatisticsService.CalculateMean</c> returns.
+    /// </summary>
+    public static double Variance(IReadOnlyCollection<double> values, double mean, VarianceMode mode)
+    {
+        if (mode == VarianceMode.Sample && values.Count < 2)
+            return 0;
+
+        var sumOfSquares = values.Sum(value => Math.Pow(value - mean, 2));
+        return sumOfSquares / (mode == VarianceMode.Sample ? values.Count - 1 : values.Count);
+    }
+
+    /// <inheritdoc cref="Variance(IReadOnlyCollection{double}, double, VarianceMode)"/>
+    public static double StandardDeviation(
+        IReadOnlyCollection<double> values,
+        double mean,
+        VarianceMode mode
+    ) => Math.Sqrt(Variance(values, mean, mode));
+
+    /// <summary>
+    /// Standard deviation about the raw arithmetic mean of <paramref name="values"/>.
+    /// </summary>
+    public static double StandardDeviation(IReadOnlyCollection<double> values, VarianceMode mode) =>
+        StandardDeviation(values, values.Average(), mode);
+
+    /// <summary>
+    /// Median of an already-sorted, non-empty series: the middle reading, or the midpoint of the
+    /// two middle readings when the count is even.
+    /// </summary>
+    public static double Median(IReadOnlyList<double> sortedValues) =>
+        sortedValues.Count % 2 == 0
+            ? (sortedValues[sortedValues.Count / 2 - 1] + sortedValues[sortedValues.Count / 2]) / 2.0
+            : sortedValues[sortedValues.Count / 2];
+
+    /// <summary>
+    /// Estimated A1C as a percentage from mean glucose in mg/dL, by the ADAG regression
+    /// <c>(mean + 46.7) / 28.7</c>. A mean of zero means there were no readings, and reports zero
+    /// rather than the 1.6% the regression would give.
+    /// </summary>
+    public static double EstimatedA1C(double meanGlucose) =>
+        meanGlucose == 0 ? 0 : (meanGlucose + 46.7) / 28.7;
+}
+
+/// <summary>
+/// One bound of a <see cref="GlucoseZoneScale"/>: the reading admitted into that zone is the one
+/// on the named side of <paramref name="Threshold"/>, with the edge itself belonging to the zone
+/// only when <paramref name="Inclusive"/>.
+/// </summary>
+public readonly record struct GlucoseZoneBound(double Threshold, bool Above, bool Inclusive)
+{
+    /// <summary>Readings strictly below <paramref name="threshold"/>.</summary>
+    public static GlucoseZoneBound Under(double threshold) => new(threshold, Above: false, Inclusive: false);
+
+    /// <summary>Readings up to and including <paramref name="threshold"/>.</summary>
+    public static GlucoseZoneBound UpTo(double threshold) => new(threshold, Above: false, Inclusive: true);
+
+    /// <summary>Readings strictly above <paramref name="threshold"/>.</summary>
+    public static GlucoseZoneBound Over(double threshold) => new(threshold, Above: true, Inclusive: false);
+
+    internal bool Admits(double value) =>
+        Above
+            ? (Inclusive ? value >= Threshold : value > Threshold)
+            : (Inclusive ? value <= Threshold : value < Threshold);
+}
+
+/// <summary>
+/// An ordered set of glucose zones, given as the bounds that separate them. A reading falls into
+/// the first zone whose bound admits it, and into a final remainder zone if none does — so the
+/// scale is the if-chain the zone sets were written as, with the edges as data.
+/// <para>
+/// Order is significant, and is the caller's: a scale that tests <c>&gt; veryHigh</c> before
+/// <c>&gt; targetTop</c> classifies differently from one that does not when a tenant configures
+/// the two out of order, so each caller lists its bounds in the order it has always tested them.
+/// Zones are identified by position, which the caller names with an enum whose members follow the
+/// same order, the remainder last.
+/// </para>
+/// </summary>
+public sealed class GlucoseZoneScale(params GlucoseZoneBound[] bounds)
+{
+    /// <summary>Number of zones, counting the remainder.</summary>
+    public int ZoneCount => bounds.Length + 1;
+
+    /// <summary>Zero-based index of the zone <paramref name="value"/> falls into.</summary>
+    public int Classify(double value)
+    {
+        for (var index = 0; index < bounds.Length; index++)
+        {
+            if (bounds[index].Admits(value))
+                return index;
+        }
+
+        return bounds.Length;
+    }
+
+    /// <summary>Readings per zone, indexed as <see cref="Classify"/> returns.</summary>
+    public int[] Count(IEnumerable<double> values)
+    {
+        var counts = new int[ZoneCount];
+
+        foreach (var value in values)
+            counts[Classify(value)]++;
+
+        return counts;
+    }
+}

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -690,25 +690,11 @@ public class StatisticsService : IStatisticsService
         var count = values.Count;
         var mean = CalculateMean(values);
 
-        // Calculate median correctly for even/odd number of values
-        double median;
-        if (count % 2 == 0)
-        {
-            // Even number of values - average of two middle values
-            median = (sorted[count / 2 - 1] + sorted[count / 2]) / 2.0;
-        }
-        else
-        {
-            // Odd number of values - middle value
-            median = sorted[count / 2];
-        }
-
+        var median = GlucoseStatistics.Median(sorted);
         var min = sorted[0];
         var max = sorted[count - 1];
-
-        // Standard deviation
-        var variance = count > 1 ? values.Sum(v => Math.Pow(v - mean, 2)) / (count - 1) : 0;
-        var standardDeviation = Math.Sqrt(variance);
+        var standardDeviation = GlucoseStatistics.StandardDeviation(
+            values, mean, VarianceMode.Sample);
 
         // Percentiles
         var percentiles = new GlucosePercentiles
@@ -808,11 +794,8 @@ public class StatisticsService : IStatisticsService
         }
 
         var mean = valuesList.Average();
-        var variance =
-            valuesList.Count > 1
-                ? valuesList.Sum(v => Math.Pow(v - mean, 2)) / (valuesList.Count - 1)
-                : 0;
-        var standardDeviation = Math.Sqrt(variance);
+        var standardDeviation = GlucoseStatistics.StandardDeviation(
+            valuesList, mean, VarianceMode.Sample);
         var coefficientOfVariation = (standardDeviation / mean) * 100;
 
         var mage = CalculateMAGE(valuesList);
@@ -910,13 +893,8 @@ public class StatisticsService : IStatisticsService
     /// </summary>
     /// <param name="averageGlucose">Average glucose in mg/dL</param>
     /// <returns>Estimated A1C percentage</returns>
-    public double CalculateEstimatedA1C(double averageGlucose)
-    {
-        if (averageGlucose == 0)
-            return 0;
-        var a1c = (averageGlucose + 46.7) / 28.7;
-        return a1c;
-    }
+    public double CalculateEstimatedA1C(double averageGlucose) =>
+        GlucoseStatistics.EstimatedA1C(averageGlucose);
 
     /// <summary>
     /// Calculate MAGE (Mean Amplitude of Glycemic Excursions)
@@ -930,8 +908,7 @@ public class StatisticsService : IStatisticsService
         if (valuesList.Count < 3)
             return 0;
 
-        var mean = valuesList.Average();
-        var sd = Math.Sqrt(valuesList.Sum(v => Math.Pow(v - mean, 2)) / valuesList.Count);
+        var sd = GlucoseStatistics.StandardDeviation(valuesList, VarianceMode.Population);
 
         var excursions = new List<double>();
         string? currentDirection = null;
@@ -1000,10 +977,8 @@ public class StatisticsService : IStatisticsService
     public double CalculateADRR(IEnumerable<double> values)
     {
         var logTransformed = values.Select(val => Math.Log(val)).ToList();
-        var mean = logTransformed.Average();
-        var variance = logTransformed.Sum(v => Math.Pow(v - mean, 2)) / logTransformed.Count();
 
-        return Math.Sqrt(variance) * 100;
+        return GlucoseStatistics.StandardDeviation(logTransformed, VarianceMode.Population) * 100;
     }
 
     /// <summary>
@@ -1041,7 +1016,7 @@ public class StatisticsService : IStatisticsService
     {
         const double targetMean = 112; // Target glucose level in mg/dL
         var meanComponent = 0.324 * Math.Pow(mean - targetMean, 2);
-        var variance = values.Sum(v => Math.Pow(v - mean, 2)) / values.Count();
+        var variance = GlucoseStatistics.Variance(values.ToList(), mean, VarianceMode.Population);
         var variabilityComponent = 0.0018 * variance;
 
         return meanComponent + variabilityComponent;
@@ -1193,6 +1168,71 @@ public class StatisticsService : IStatisticsService
     #region Time in Range
 
     /// <summary>
+    /// The mutually excluding zones <see cref="CalculateTimeInRange"/> counts against, listed in
+    /// the order it has always tested them: very-high before high, so a tenant who configures
+    /// <c>VeryHigh</c> below <c>TargetTop</c> keeps seeing the reading reported as very high.
+    /// <see cref="Target"/> is the remainder and is not reported from here — the target percentage
+    /// comes from the closed <c>TargetBottom</c>..<c>TargetTop</c> band, which overlaps
+    /// <see cref="Low"/> when the two are configured apart.
+    /// </summary>
+    private enum ExcludingZone
+    {
+        VeryLow,
+        Low,
+        VeryHigh,
+        High,
+        Target,
+    }
+
+    private static GlucoseZoneScale ExcludingZones(GlycemicThresholds thresholds) =>
+        new(
+            GlucoseZoneBound.Under(thresholds.VeryLow),
+            GlucoseZoneBound.Under(thresholds.Low),
+            GlucoseZoneBound.Over(thresholds.VeryHigh),
+            GlucoseZoneBound.Over(thresholds.TargetTop)
+        );
+
+    /// <summary>
+    /// The zones the per-range statistics partition on, which are not <see cref="ExcludingZone"/>:
+    /// <see cref="Low"/> is everything below <c>Low</c>, so it holds the very-low readings as well,
+    /// and <see cref="High"/> is everything above <c>TargetTop</c>.
+    /// </summary>
+    private enum RangeStatZone
+    {
+        Low,
+        High,
+        Target,
+    }
+
+    private static GlucoseZoneScale RangeStatZones(GlycemicThresholds thresholds) =>
+        new(
+            GlucoseZoneBound.Under(thresholds.Low),
+            GlucoseZoneBound.Over(thresholds.TargetTop)
+        );
+
+    /// <summary>
+    /// The hourly zone set, which splits the target band at 63 and 140 and hyperglycaemia at 200
+    /// rather than following the tenant's thresholds.
+    /// </summary>
+    private enum ExtendedZone
+    {
+        VeryLow,
+        Low,
+        Normal,
+        AboveTarget,
+        High,
+        VeryHigh,
+    }
+
+    private static readonly GlucoseZoneScale ExtendedZones = new(
+        GlucoseZoneBound.Under(GlucoseConstants.VeryLowMgdl),
+        GlucoseZoneBound.Under(63),
+        GlucoseZoneBound.Under(140),
+        GlucoseZoneBound.Under(GlucoseConstants.TargetTopMgdl),
+        GlucoseZoneBound.Under(200)
+    );
+
+    /// <summary>
     /// Calculate time in range metrics
     /// </summary>
     /// <param name="entries">Collection of glucose entries</param>
@@ -1232,18 +1272,23 @@ public class StatisticsService : IStatisticsService
             };
         }
 
-        // Single-pass counting across all ranges
-        int veryLowCount = 0, lowCount = 0, targetCount = 0, tightTargetCount = 0, highCount = 0, veryHighCount = 0;
+        // The target and tight-target bands overlap each other, and overlap the excluding zones
+        // whenever Low and TargetBottom are configured apart, so they are counted alongside the
+        // scale rather than read off it.
+        var zones = ExcludingZones(thresholds);
+        var zoneCounts = new int[zones.ZoneCount];
+        int targetCount = 0, tightTargetCount = 0;
         foreach (var v in glucoseValues)
         {
-            if (v < thresholds.VeryLow) veryLowCount++;
-            else if (v < thresholds.Low) lowCount++;
-            else if (v > thresholds.VeryHigh) veryHighCount++;
-            else if (v > thresholds.TargetTop) highCount++;
-            // Target and tight-target overlap, so count both independently
+            zoneCounts[zones.Classify(v)]++;
             if (v >= thresholds.TargetBottom && v <= thresholds.TargetTop) targetCount++;
             if (v >= thresholds.TightTargetBottom && v <= thresholds.TightTargetTop) tightTargetCount++;
         }
+
+        var veryLowCount = zoneCounts[(int)ExcludingZone.VeryLow];
+        var lowCount = zoneCounts[(int)ExcludingZone.Low];
+        var highCount = zoneCounts[(int)ExcludingZone.High];
+        var veryHighCount = zoneCounts[(int)ExcludingZone.VeryHigh];
 
         // Calculate percentages
         var percentages = new TimeInRangePercentages
@@ -1272,13 +1317,22 @@ public class StatisticsService : IStatisticsService
         var episodes = CalculateEpisodes(glucoseValues, thresholds);
 
         // Calculate per-range detailed statistics
+        var rangeZones = RangeStatZones(thresholds);
         var lowValues = new List<double>(veryLowCount + lowCount);
         var targetValues = new List<double>(targetCount);
         var highValues = new List<double>(highCount + veryHighCount);
         foreach (var v in glucoseValues)
         {
-            if (v < thresholds.Low) lowValues.Add(v);
-            else if (v > thresholds.TargetTop) highValues.Add(v);
+            switch ((RangeStatZone)rangeZones.Classify(v))
+            {
+                case RangeStatZone.Low:
+                    lowValues.Add(v);
+                    break;
+                case RangeStatZone.High:
+                    highValues.Add(v);
+                    break;
+            }
+
             if (v >= thresholds.TargetBottom && v <= thresholds.TargetTop) targetValues.Add(v);
         }
 
@@ -1358,15 +1412,8 @@ public class StatisticsService : IStatisticsService
         }
 
         var mean = values.Average();
-        var sortedValues = values.OrderBy(v => v).ToList();
-        var median =
-            sortedValues.Count % 2 == 0
-                ? (sortedValues[sortedValues.Count / 2 - 1] + sortedValues[sortedValues.Count / 2])
-                    / 2
-                : sortedValues[sortedValues.Count / 2];
-        var variance =
-            values.Count > 1 ? values.Sum(v => Math.Pow(v - mean, 2)) / (values.Count - 1) : 0;
-        var stdDev = Math.Sqrt(variance);
+        var median = GlucoseStatistics.Median(values.OrderBy(v => v).ToList());
+        var stdDev = GlucoseStatistics.StandardDeviation(values, mean, VarianceMode.Sample);
 
         return new PeriodMetrics
         {
@@ -1391,43 +1438,24 @@ public class StatisticsService : IStatisticsService
         if (!glucoseValues.Any())
             return episodes;
 
-        string? lastRange = null;
-        var episodeCounts = new Dictionary<string, int>();
+        var zones = ExcludingZones(thresholds);
+        var episodeCounts = new int[zones.ZoneCount];
+        var lastZone = -1;
 
         foreach (var value in glucoseValues)
         {
-            string currentRange;
-            if (value < thresholds.VeryLow)
-                currentRange = "VeryLow";
-            else if (value < thresholds.Low)
-                currentRange = "Low";
-            else if (value > thresholds.VeryHigh)
-                currentRange = "VeryHigh";
-            else if (value > thresholds.TargetTop)
-                currentRange = "High";
-            else
-                currentRange = "Target";
+            var zone = zones.Classify(value);
 
-            if (
-                currentRange != lastRange
-                && (
-                    currentRange == "VeryLow"
-                    || currentRange == "Low"
-                    || currentRange == "High"
-                    || currentRange == "VeryHigh"
-                )
-            )
-            {
-                episodeCounts[currentRange] = episodeCounts.GetValueOrDefault(currentRange, 0) + 1;
-            }
+            if (zone != lastZone && zone != (int)ExcludingZone.Target)
+                episodeCounts[zone]++;
 
-            lastRange = currentRange;
+            lastZone = zone;
         }
 
-        episodes.VeryLow = episodeCounts.GetValueOrDefault("VeryLow", 0);
-        episodes.Low = episodeCounts.GetValueOrDefault("Low", 0);
-        episodes.High = episodeCounts.GetValueOrDefault("High", 0);
-        episodes.VeryHigh = episodeCounts.GetValueOrDefault("VeryHigh", 0);
+        episodes.VeryLow = episodeCounts[(int)ExcludingZone.VeryLow];
+        episodes.Low = episodeCounts[(int)ExcludingZone.Low];
+        episodes.High = episodeCounts[(int)ExcludingZone.High];
+        episodes.VeryHigh = episodeCounts[(int)ExcludingZone.VeryHigh];
 
         return episodes;
     }
@@ -1499,11 +1527,8 @@ public class StatisticsService : IStatisticsService
     public string CalculateEstimatedHbA1C(IEnumerable<double> values)
     {
         var valuesList = values as IList<double> ?? values.ToList();
-        var mean = CalculateMean(valuesList);
-        if (mean == 0)
-            return "0.0";
-        var a1c = (mean + 46.7) / 28.7;
-        return a1c.ToString("F1");
+
+        return CalculateEstimatedA1C(CalculateMean(valuesList)).ToString("F1");
     }
 
     /// <summary>
@@ -1585,8 +1610,8 @@ public class StatisticsService : IStatisticsService
     }
 
     /// <summary>
-    /// Calculate extended 7-range time in range percentages
-    /// Ranges: &lt;54, 54-63, 63-140, 140-180, 180-200, 200-220, &gt;220
+    /// Calculate extended time in range percentages over the hourly zone set
+    /// Ranges: &lt;54, 54-63, 63-140, 140-180, 180-200, &gt;=200
     /// </summary>
     /// <param name="glucoseValues">Collection of glucose values in mg/dL</param>
     /// <returns>Extended time in range percentages</returns>
@@ -1598,23 +1623,18 @@ public class StatisticsService : IStatisticsService
         }
 
         var total = glucoseValues.Count;
+        var counts = ExtendedZones.Count(glucoseValues);
 
-        // Count readings in each of the 7 ranges
-        var veryLowCount = glucoseValues.Count(v => v < 54);
-        var lowCount = glucoseValues.Count(v => v >= 54 && v < 63);
-        var normalCount = glucoseValues.Count(v => v >= 63 && v < 140);
-        var aboveTargetCount = glucoseValues.Count(v => v >= 140 && v < 180);
-        var highCount = glucoseValues.Count(v => v >= 180 && v < 200);
-        var veryHighCount = glucoseValues.Count(v => v >= 200);
+        double Percent(ExtendedZone zone) => Math.Round((double)counts[(int)zone] / total * 100, 1);
 
         return new ExtendedTimeInRangePercentages
         {
-            VeryLow = Math.Round((double)veryLowCount / total * 100, 1),
-            Low = Math.Round((double)lowCount / total * 100, 1),
-            Normal = Math.Round((double)normalCount / total * 100, 1),
-            AboveTarget = Math.Round((double)aboveTargetCount / total * 100, 1),
-            High = Math.Round((double)highCount / total * 100, 1),
-            VeryHigh = Math.Round((double)veryHighCount / total * 100, 1),
+            VeryLow = Percent(ExtendedZone.VeryLow),
+            Low = Percent(ExtendedZone.Low),
+            Normal = Percent(ExtendedZone.Normal),
+            AboveTarget = Percent(ExtendedZone.AboveTarget),
+            High = Percent(ExtendedZone.High),
+            VeryHigh = Percent(ExtendedZone.VeryHigh),
         };
     }
 
@@ -2945,8 +2965,7 @@ public class StatisticsService : IStatisticsService
 
             var sorted = values.OrderBy(v => v).ToList();
             var mean = values.Average();
-            var variance = values.Sum(v => Math.Pow(v - mean, 2)) / values.Count;
-            var stdDev = Math.Sqrt(variance);
+            var stdDev = GlucoseStatistics.StandardDeviation(values, mean, VarianceMode.Population);
 
             dataPoints.Add(
                 new SiteChangeImpactDataPoint

--- a/src/API/Nocturne.API/Services/Sleep/SleepReportService.cs
+++ b/src/API/Nocturne.API/Services/Sleep/SleepReportService.cs
@@ -22,10 +22,10 @@ namespace Nocturne.API.Services.Sleep;
 /// </remarks>
 public class SleepReportService : ISleepReportService
 {
-    private const double DefaultVeryLow  = 54;
+    private const double DefaultVeryLow  = GlucoseConstants.VeryLowMgdl;
     private const double DefaultLow      = GlucoseConstants.TargetBottomMgdl;
     private const double DefaultHigh     = GlucoseConstants.TargetTopMgdl;
-    private const double DefaultVeryHigh = 250;
+    private const double DefaultVeryHigh = GlucoseConstants.VeryHighMgdl;
 
     private readonly ISleepSessionRepository _sessions;
     private readonly ISensorGlucoseRepository _glucose;

--- a/src/Core/Nocturne.Core.Constants/GlucoseConstants.cs
+++ b/src/Core/Nocturne.Core.Constants/GlucoseConstants.cs
@@ -25,6 +25,17 @@ public static class GlucoseConstants
     public const double TargetTopMgdl = 180;
 
     /// <summary>
+    /// Clinically significant hypoglycaemia in mg/dL: the level-2 boundary the consensus reports
+    /// time below, distinct from the level-1 boundary at <see cref="TargetBottomMgdl"/>.
+    /// </summary>
+    public const double VeryLowMgdl = 54;
+
+    /// <summary>
+    /// Clinically significant hyperglycaemia in mg/dL. See <see cref="VeryLowMgdl"/>.
+    /// </summary>
+    public const double VeryHighMgdl = 250;
+
+    /// <summary>
     /// Tile fill per glucose status as <c>RRGGBB</c>, for the native surfaces that paint a reading
     /// directly — the desktop tray tile and the taskbar sparkline — instead of resolving the web
     /// theme's status tokens.

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -174,9 +174,9 @@ public class GlycemicVariability
 public class GlycemicThresholds
 {
     /// <summary>
-    /// Threshold for very low glucose (default: 54 mg/dL)
+    /// Threshold for very low glucose (defaults to <see cref="GlucoseConstants.VeryLowMgdl"/>)
     /// </summary>
-    public double VeryLow { get; set; } = 54;
+    public double VeryLow { get; set; } = GlucoseConstants.VeryLowMgdl;
 
     /// <summary>
     /// Threshold for low glucose (defaults to <see cref="GlucoseConstants.TargetBottomMgdl"/>)
@@ -210,9 +210,9 @@ public class GlycemicThresholds
     public double High { get; set; } = GlucoseConstants.TargetTopMgdl;
 
     /// <summary>
-    /// Threshold for very high glucose (default: 250 mg/dL)
+    /// Threshold for very high glucose (defaults to <see cref="GlucoseConstants.VeryHighMgdl"/>)
     /// </summary>
-    public double VeryHigh { get; set; } = 250;
+    public double VeryHigh { get; set; } = GlucoseConstants.VeryHighMgdl;
 }
 
 /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewZoneCharacterisationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewZoneCharacterisationTests.cs
@@ -136,6 +136,31 @@ public class DataOverviewZoneCharacterisationTests : IDisposable
     }
 
     /// <summary>
+    /// A NaN reaches the series from Postgres rather than from the entity model, which the
+    /// in-memory provider cannot reproduce, so the month's readings are handed to
+    /// <see cref="DataOverviewService.BuildGriPeriod"/> directly.
+    /// </summary>
+    [Fact]
+    public void BuildGriPeriod_ExcludesANonReadingFromEveryZoneAndFromTheDenominator()
+    {
+        var readings = Enumerable.Repeat(120d, 72).Append(double.NaN).ToList();
+
+        var period = _service.BuildGriPeriod(
+            3, 2026, 72,
+            new Dictionary<int, List<double>> { [3] = readings },
+            [], [], [], []
+        );
+
+        period.Should().NotBeNull();
+        period!.ReadingCount.Should().Be(72);
+        period.AverageGlucoseMgdl.Should().Be(120);
+
+        var percentages = _griInputs.Should().ContainSingle().Subject.Percentages;
+        percentages.Target.Should().Be(100);
+        percentages.VeryHigh.Should().Be(0);
+    }
+
+    /// <summary>
     /// Seventy-two readings on 2026-01-01 Brisbane time, one probe an hour before the local year
     /// starts and one an hour after it ends.
     /// </summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewZoneCharacterisationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewZoneCharacterisationTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Analytics;
+using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Contracts.Profiles.Resolvers;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Tests.Shared.Infrastructure;
+
+namespace Nocturne.API.Tests.Services.Analytics;
+
+/// <summary>
+/// Pins the glucose zone bucketing behind the GRI timeline, whose percentages reach the response
+/// only through <see cref="IStatisticsService.CalculateGRI"/> and are therefore asserted on the
+/// argument, and the local-midnight year bounds that decide which readings a year contains at all.
+/// </summary>
+public class DataOverviewZoneCharacterisationTests : IDisposable
+{
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    /// <summary>
+    /// One reading on each side of, and one exactly on, every GRI zone bound: 54, 70, 180 and 250.
+    /// </summary>
+    private static readonly double[] ZoneEdges =
+    [
+        53, 54, 69, 70, 139, 140, 141, 179, 180, 181, 250, 251,
+    ];
+
+    private readonly NocturneDbContext _dbContext;
+    private readonly DataOverviewService _service;
+    private readonly Mock<ITherapySettingsResolver> _therapySettings = new();
+    private readonly List<TimeInRangeMetrics> _griInputs = [];
+
+    public DataOverviewZoneCharacterisationTests()
+    {
+        var dbName = $"data_overview_zones_{Guid.NewGuid()}";
+        _dbContext = TestDbContextFactory.CreateInMemoryContext(dbName);
+        _dbContext.TenantId = TenantId;
+
+        var factory = new Mock<ITenantDbContextFactory>();
+        factory
+            .Setup(f => f.CreateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var context = TestDbContextFactory.CreateInMemoryContext(dbName);
+                context.TenantId = TenantId;
+                return context;
+            });
+
+        _therapySettings
+            .Setup(p => p.GetTimezoneAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var statistics = new Mock<IStatisticsService>();
+        statistics
+            .Setup(s => s.CalculateGRI(It.IsAny<TimeInRangeMetrics>()))
+            .Callback<TimeInRangeMetrics>(_griInputs.Add)
+            .Returns(new GlycemicRiskIndex());
+
+        _service = new DataOverviewService(
+            factory.Object,
+            _therapySettings.Object,
+            statistics.Object,
+            NullLogger<DataOverviewService>.Instance
+        );
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    [Fact]
+    public async Task GetGriTimelineAsync_PinsEveryZoneBoundAndItsInclusivity()
+    {
+        // Six passes over the edge series clears the seventy-two-reading floor for a valid month.
+        var start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var readings = Enumerable
+            .Range(0, 6)
+            .SelectMany(pass => ZoneEdges.Select((value, index) => (Value: value, Slot: pass * 12 + index)));
+
+        foreach (var reading in readings)
+        {
+            _dbContext.SensorGlucose.Add(new SensorGlucoseEntity
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = start.AddMinutes(reading.Slot * 5),
+                Mgdl = reading.Value,
+                DataSource = "dexcom",
+            });
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetGriTimelineAsync(2026);
+
+        result.Periods.Should().ContainSingle().Which.ReadingCount.Should().Be(72);
+
+        // 53 | 54, 69 | 70, 139, 140, 141, 179, 180 | 181, 250 | 251, six times over.
+        var percentages = _griInputs.Should().ContainSingle().Subject.Percentages;
+        percentages.VeryLow.Should().BeApproximately(8.333333333333332, 1e-12);
+        percentages.Low.Should().BeApproximately(16.666666666666664, 1e-12);
+        percentages.Target.Should().Be(50);
+        percentages.High.Should().BeApproximately(16.666666666666664, 1e-12);
+        percentages.VeryHigh.Should().BeApproximately(8.333333333333332, 1e-12);
+    }
+
+    [Fact]
+    public async Task GetGriTimelineAsync_PinsTheYearBoundsAsLocalMidnight()
+    {
+        await SeedYearBoundaryProbesAsync();
+        _therapySettings
+            .Setup(p => p.GetTimezoneAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Australia/Brisbane");
+
+        var result = await _service.GetGriTimelineAsync(2026);
+
+        // Brisbane is UTC+10 year round, so 2026 runs from 2025-12-31T14:00Z to 2026-12-31T14:00Z.
+        // The 13:00Z probe is still 2025 locally; the 15:00Z one is January 2026.
+        result.Periods.Should().ContainSingle().Which.ReadingCount.Should().Be(72);
+        _griInputs.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetDailySummaryAsync_PinsTheYearBoundsAsLocalMidnight()
+    {
+        await SeedYearBoundaryProbesAsync();
+        _therapySettings
+            .Setup(p => p.GetTimezoneAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Australia/Brisbane");
+
+        var result = await _service.GetDailySummaryAsync(2026);
+
+        result.Days.Should().ContainSingle().Which.Date.Should().Be("2026-01-01");
+        result.Days[0].Counts["Glucose"].Should().Be(72);
+    }
+
+    /// <summary>
+    /// Seventy-two readings on 2026-01-01 Brisbane time, one probe an hour before the local year
+    /// starts and one an hour after it ends.
+    /// </summary>
+    private async Task SeedYearBoundaryProbesAsync()
+    {
+        var localYearStart = new DateTime(2025, 12, 31, 14, 0, 0, DateTimeKind.Utc);
+
+        for (var index = 0; index < 72; index++)
+        {
+            _dbContext.SensorGlucose.Add(new SensorGlucoseEntity
+            {
+                Id = Guid.NewGuid(),
+                Timestamp = localYearStart.AddMinutes(index * 5),
+                Mgdl = 120,
+                DataSource = "dexcom",
+            });
+        }
+
+        _dbContext.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = localYearStart.AddHours(-1),
+            Mgdl = 120,
+            DataSource = "dexcom",
+        });
+        _dbContext.SensorGlucose.Add(new SensorGlucoseEntity
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = new DateTime(2026, 12, 31, 15, 0, 0, DateTimeKind.Utc),
+            Mgdl = 120,
+            DataSource = "dexcom",
+        });
+
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/GlucoseStatisticsCharacterisationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/GlucoseStatisticsCharacterisationTests.cs
@@ -325,6 +325,28 @@ public class GlucoseStatisticsCharacterisationTests
         result.Percentages.VeryHigh.Should().Be(20);
     }
 
+    /// <summary>
+    /// Custom thresholds where <c>VeryHigh</c> sits below <c>TargetTop</c>. The chain reaches
+    /// <c>&gt; VeryHigh</c> before <c>&gt; TargetTop</c>, so both 120 — which no other bound
+    /// admits — and 200 — which <c>&gt; TargetTop</c> would take first, were the two tested the
+    /// other way round — are very high, in the percentages, the durations and the episode count
+    /// alike.
+    /// </summary>
+    [Fact]
+    public void CalculateTimeInRange_PinsVeryHighAheadOfHighWhenTheThresholdsAreInverted()
+    {
+        var thresholds = new GlycemicThresholds { TargetTop = 180, High = 180, VeryHigh = 100 };
+
+        var result = _service.CalculateTimeInRange(EntriesEveryFiveMinutes([120, 200]), thresholds);
+
+        result.Percentages.VeryHigh.Should().Be(100);
+        result.Percentages.High.Should().Be(0);
+        result.Durations.VeryHigh.Should().Be(10);
+        result.Durations.High.Should().Be(0);
+        result.Episodes.VeryHigh.Should().Be(1);
+        result.Episodes.High.Should().Be(0);
+    }
+
     [Fact]
     public void CalculateTimeInRange_PinsAnEmptyResultForNoReadings()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/GlucoseStatisticsCharacterisationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/GlucoseStatisticsCharacterisationTests.cs
@@ -1,0 +1,390 @@
+using FluentAssertions;
+using Nocturne.API.Services.Analytics;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Tests.Services.Analytics;
+
+/// <summary>
+/// Pins the numeric output of every statistic that is computed from a shared variance, median,
+/// A1C or glucose-zone rule, at full double precision rather than at the one decimal place the
+/// responses round to. The expected values were derived from the published formulae independently
+/// of the implementation, so a divisor, a bound, or an inclusive edge that moves is reported here
+/// as a wrong number rather than as a rounding coincidence.
+/// </summary>
+public class GlucoseStatisticsCharacterisationTests
+{
+    private readonly StatisticsService _service = new();
+
+    /// <summary>
+    /// A day's worth of readings that rises through the target band into hyperglycaemia and falls
+    /// back through hypoglycaemia, so mean, both variance divisors, MAGE's turning points and the
+    /// log-transformed metrics all have something to bite on.
+    /// </summary>
+    private static readonly double[] DayCurve =
+    [
+        95, 102, 118, 143, 167, 189, 201, 187, 165, 142, 128, 115,
+        104, 98, 88, 76, 68, 61, 55, 52, 63, 84, 110, 134,
+    ];
+
+    /// <summary>
+    /// One reading on each side of, and one exactly on, every default zone bound: 54, 70, 140
+    /// (tight-target top), 180 and 250.
+    /// </summary>
+    private static readonly double[] ZoneEdges =
+    [
+        53, 54, 69, 70, 139, 140, 141, 179, 180, 181, 250, 251,
+    ];
+
+    /// <summary>
+    /// One reading on each side of, and one exactly on, every bound of the extended hourly zone
+    /// set: 54, 63, 140, 180 and 200.
+    /// </summary>
+    private static readonly double[] ExtendedZoneEdges =
+    [
+        53, 54, 62, 63, 139, 140, 179, 180, 199, 200, 201,
+    ];
+
+    #region Sample-divisor standard deviation
+
+    [Fact]
+    public void CalculateBasicStats_PinsSampleStandardDeviationAndMedian()
+    {
+        var result = _service.CalculateBasicStats(DayCurve);
+
+        result.Count.Should().Be(24);
+        result.Mean.Should().Be(114.4);
+        result.Median.Should().Be(107.0);
+        result.Min.Should().Be(52);
+        result.Max.Should().Be(201);
+
+        // sqrt(sum((v - 114.4)^2) / 23) = 44.19110671892568, rounded to one decimal.
+        // CalculateMean rounds before the deviations are taken, so the centre is 114.4, not 114.375.
+        result.StandardDeviation.Should().Be(44.2);
+    }
+
+    [Theory]
+    [InlineData(new double[] { }, 0d, 0d)]
+    [InlineData(new[] { 123d }, 123d, 123d)]
+    [InlineData(new[] { 100d, 100d, 100d, 100d }, 100d, 100d)]
+    public void CalculateBasicStats_PinsZeroStandardDeviationForDegenerateSeries(
+        double[] values,
+        double expectedMean,
+        double expectedMedian)
+    {
+        var result = _service.CalculateBasicStats(values);
+
+        result.Mean.Should().Be(expectedMean);
+        result.Median.Should().Be(expectedMedian);
+        result.StandardDeviation.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalculateBasicStats_PinsMedianOfAnOddLengthSeries()
+    {
+        _service.CalculateBasicStats([70d, 90d, 250d]).Median.Should().Be(90);
+    }
+
+    [Fact]
+    public void CalculateGlycemicVariability_PinsSampleStandardDeviationAndDerivedMetrics()
+    {
+        var result = _service.CalculateGlycemicVariability(DayCurve, EntriesEveryFiveMinutes(DayCurve));
+
+        // Unlike CalculateBasicStats this centres on the unrounded mean 114.375, giving
+        // sqrt(sum((v - 114.375)^2) / 23) = 44.19109933990741.
+        result.StandardDeviation.Should().Be(44.2);
+        result.CoefficientOfVariation.Should().Be(38.6);
+
+        // Population divisor: the two excursions exceeding sqrt(sum(dev^2) / 24) = 43.260656 are
+        // 106 and 149.
+        result.MeanAmplitudeGlycemicExcursions.Should().Be(127.5);
+        result.AverageDailyRiskRange.Should().Be(39.2);
+        result.EstimatedA1c.Should().BeApproximately(5.612369337979094, 1e-12);
+    }
+
+    [Fact]
+    public void CalculateGlycemicVariability_ThrowsBelowTwoReadings()
+    {
+        var act = () => _service.CalculateGlycemicVariability([100d], EntriesEveryFiveMinutes([100d]));
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
+    #region Population-divisor standard deviation
+
+    [Fact]
+    public void CalculateMage_PinsThePopulationStandardDeviationThreshold()
+    {
+        _service.CalculateMAGE(DayCurve).Should().BeApproximately(127.5, 1e-12);
+    }
+
+    [Fact]
+    public void CalculateMage_PinsZeroWhenNoExcursionExceedsTheStandardDeviation()
+    {
+        _service.CalculateMAGE([100d, 100d, 100d, 100d]).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(new[] { 100d, 120d })]
+    [InlineData(new double[] { })]
+    public void CalculateMage_PinsZeroBelowThreeReadings(double[] values)
+    {
+        _service.CalculateMAGE(values).Should().Be(0);
+    }
+
+    [Fact]
+    public void CalculateAdrr_PinsThePopulationStandardDeviationOfLogGlucose()
+    {
+        _service.CalculateADRR(DayCurve).Should().BeApproximately(39.17853755994654, 1e-12);
+    }
+
+    [Fact]
+    public void CalculateAdrr_PinsZeroForIdenticalReadings()
+    {
+        _service.CalculateADRR([100d, 100d, 100d]).Should().BeApproximately(0, 1e-12);
+    }
+
+    [Fact]
+    public void CalculateJIndex_PinsThePopulationVarianceComponent()
+    {
+        var mean = DayCurve.Average();
+
+        // 0.324 * (114.375 - 112)^2 + 0.0018 * (sum(dev^2) / 24)
+        _service.CalculateJIndex(DayCurve, mean).Should().BeApproximately(5.1962343749999995, 1e-12);
+    }
+
+    [Fact]
+    public void CalculateSiteChangeImpact_PinsThePopulationStandardDeviationPerBucket()
+    {
+        var siteChange = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var deviceEvents = new[]
+        {
+            new DeviceEvent { Timestamp = siteChange, EventType = DeviceEventType.SiteChange },
+            new DeviceEvent { Timestamp = siteChange.AddDays(10), EventType = DeviceEventType.SiteChange },
+        };
+
+        // Only these three land inside a site-change window; the rest exist solely to clear the
+        // hundred-reading sufficiency floor.
+        var inBucket = new[] { 100d, 130d, 190d };
+        var entries = inBucket
+            .Select((value, index) => new SensorGlucose
+            {
+                Mgdl = value,
+                Timestamp = siteChange.AddMinutes(index + 1),
+            })
+            .Concat(Enumerable.Range(0, 100).Select(index => new SensorGlucose
+            {
+                Mgdl = 120,
+                Timestamp = siteChange.AddDays(-90).AddMinutes(index * 5),
+            }))
+            .ToList();
+
+        var result = _service.CalculateSiteChangeImpact(entries, deviceEvents);
+
+        var bucket = result.DataPoints.Should().ContainSingle().Subject;
+        bucket.MinutesFromChange.Should().Be(0);
+        bucket.Count.Should().Be(3);
+        bucket.AverageGlucose.Should().Be(140);
+
+        // sqrt(sum((v - 140)^2) / 3) = 37.416573867739416, rounded to one decimal.
+        bucket.StdDev.Should().Be(37.4);
+    }
+
+    #endregion
+
+    #region Estimated A1C
+
+    [Theory]
+    [InlineData(0d, 0d)]
+    [InlineData(100d, 5.111498257839721)]
+    [InlineData(114.375d, 5.612369337979094)]
+    [InlineData(154d, 6.99303135888502)]
+    public void CalculateEstimatedA1C_PinsTheFormula(double meanGlucose, double expected)
+    {
+        _service.CalculateEstimatedA1C(meanGlucose).Should().BeApproximately(expected, 1e-12);
+    }
+
+    /// <summary>
+    /// The string form takes the mean from <c>CalculateMean</c>, which rounds to one decimal first,
+    /// so 114.375 is centred at 114.4 and the two entry points do not share an input.
+    /// </summary>
+    [Theory]
+    [InlineData(new double[] { }, "0.0")]
+    [InlineData(new[] { 100d }, "5.1")]
+    [InlineData(new[] { 154d }, "7.0")]
+    public void CalculateEstimatedHbA1C_PinsTheFormattedFormula(double[] values, string expected)
+    {
+        _service.CalculateEstimatedHbA1C(values).Should().Be(expected);
+    }
+
+    [Fact]
+    public void CalculateEstimatedHbA1C_PinsTheRoundedMeanItCentresOn()
+    {
+        // CalculateMean gives 114.4, so the result is (114.4 + 46.7) / 28.7 = 5.6132..., not the
+        // 5.6124... that the unrounded 114.375 would give. Both format as "5.6"; the pin is that
+        // the string comes from the same formula as the double.
+        _service.CalculateEstimatedHbA1C(DayCurve).Should().Be("5.6");
+        _service.CalculateEstimatedA1C(114.4).Should().BeApproximately(5.613240418118468, 1e-12);
+    }
+
+    #endregion
+
+    #region Five-zone bucketing
+
+    [Fact]
+    public void CalculateTimeInRange_PinsEveryDefaultZoneBoundAndItsInclusivity()
+    {
+        var result = _service.CalculateTimeInRange(EntriesEveryFiveMinutes(ZoneEdges));
+
+        // 53 | 54, 69 | 70, 139, 140, 141, 179, 180 | 181, 250 | 251
+        result.Percentages.VeryLow.Should().BeApproximately(8.333333333333332, 1e-12);
+        result.Percentages.Low.Should().BeApproximately(16.666666666666664, 1e-12);
+        result.Percentages.Target.Should().Be(50);
+        result.Percentages.High.Should().BeApproximately(16.666666666666664, 1e-12);
+        result.Percentages.VeryHigh.Should().BeApproximately(8.333333333333332, 1e-12);
+
+        // The tight band is [70, 140] and overlaps the target band rather than partitioning it.
+        result.Percentages.TightTarget.Should().Be(25);
+
+        result.Durations.VeryLow.Should().Be(5);
+        result.Durations.Low.Should().Be(10);
+        result.Durations.Target.Should().Be(30);
+        result.Durations.TightTarget.Should().Be(15);
+        result.Durations.High.Should().Be(10);
+        result.Durations.VeryHigh.Should().Be(5);
+
+        result.Episodes.VeryLow.Should().Be(1);
+        result.Episodes.Low.Should().Be(1);
+        result.Episodes.High.Should().Be(1);
+        result.Episodes.VeryHigh.Should().Be(1);
+    }
+
+    /// <summary>
+    /// The per-range statistics partition on different bounds from the percentages above: the low
+    /// bucket is everything under <c>Low</c>, so it swallows the very-low readings, and the high
+    /// bucket is everything over <c>TargetTop</c>, so it swallows the very-high ones.
+    /// </summary>
+    [Fact]
+    public void CalculateTimeInRange_PinsPerRangeStatisticsOnTheSampleDivisor()
+    {
+        var result = _service.CalculateTimeInRange(EntriesEveryFiveMinutes(ZoneEdges));
+
+        result.RangeStats.Low.PeriodName.Should().Be("Low");
+        result.RangeStats.Low.ReadingCount.Should().Be(3);
+        result.RangeStats.Low.Mean.Should().Be(58.7);
+        result.RangeStats.Low.Median.Should().Be(54);
+        result.RangeStats.Low.StandardDeviation.Should().Be(9.0);
+        result.RangeStats.Low.TimeInRange.Should().Be(25);
+        result.RangeStats.Low.Min.Should().Be(53);
+        result.RangeStats.Low.Max.Should().Be(69);
+
+        result.RangeStats.Target.PeriodName.Should().Be("In Range");
+        result.RangeStats.Target.ReadingCount.Should().Be(6);
+        result.RangeStats.Target.Mean.Should().Be(141.5);
+        result.RangeStats.Target.Median.Should().Be(140.5);
+        result.RangeStats.Target.StandardDeviation.Should().Be(40.0);
+        result.RangeStats.Target.TimeInRange.Should().Be(50);
+
+        result.RangeStats.High.PeriodName.Should().Be("High");
+        result.RangeStats.High.ReadingCount.Should().Be(3);
+        result.RangeStats.High.Mean.Should().Be(227.3);
+        result.RangeStats.High.Median.Should().Be(250);
+        result.RangeStats.High.StandardDeviation.Should().Be(40.1);
+        result.RangeStats.High.TimeInRange.Should().Be(25);
+    }
+
+    /// <summary>
+    /// Custom thresholds where <c>Low</c> sits above <c>TargetBottom</c>: the exclusive chain and
+    /// the target band are counted independently, so readings between the two are counted twice
+    /// and the percentages sum past 100.
+    /// </summary>
+    [Fact]
+    public void CalculateTimeInRange_PinsTheOverlapBetweenTheLowChainAndTheTargetBand()
+    {
+        var thresholds = new GlycemicThresholds
+        {
+            VeryLow = 50,
+            Low = 90,
+            TargetBottom = 70,
+            TargetTop = 160,
+            TightTargetBottom = 70,
+            TightTargetTop = 140,
+            High = 160,
+            VeryHigh = 240,
+        };
+
+        var result = _service.CalculateTimeInRange(
+            EntriesEveryFiveMinutes([49, 75, 120, 200, 300]), thresholds);
+
+        result.Percentages.VeryLow.Should().Be(20);
+        result.Percentages.Low.Should().Be(20);
+        result.Percentages.Target.Should().Be(40);
+        result.Percentages.High.Should().Be(20);
+        result.Percentages.VeryHigh.Should().Be(20);
+    }
+
+    [Fact]
+    public void CalculateTimeInRange_PinsAnEmptyResultForNoReadings()
+    {
+        var result = _service.CalculateTimeInRange([]);
+
+        result.Percentages.Target.Should().Be(0);
+        result.Durations.Target.Should().Be(0);
+        result.Episodes.High.Should().Be(0);
+        result.RangeStats.Target.ReadingCount.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Extended six-zone bucketing
+
+    [Fact]
+    public void CalculateAveragedStats_PinsEveryExtendedZoneBoundAndItsInclusivity()
+    {
+        var midnight = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entries = ExtendedZoneEdges
+            .Select((value, index) => new SensorGlucose
+            {
+                Mgdl = value,
+                Timestamp = midnight.AddMinutes(index * 5),
+            })
+            .ToList();
+
+        var hour = _service.CalculateAveragedStats(entries).Single(stats => stats.Hour == 0);
+
+        // 53 | 54, 62 | 63, 139 | 140, 179 | 180, 199 | 200, 201
+        hour.Count.Should().Be(11);
+        hour.TimeInRange.VeryLow.Should().Be(9.1);
+        hour.TimeInRange.Low.Should().Be(18.2);
+        hour.TimeInRange.Normal.Should().Be(18.2);
+        hour.TimeInRange.AboveTarget.Should().Be(18.2);
+        hour.TimeInRange.High.Should().Be(18.2);
+        hour.TimeInRange.VeryHigh.Should().Be(18.2);
+    }
+
+    [Fact]
+    public void CalculateAveragedStats_PinsZeroedExtendedZonesForAnEmptyHour()
+    {
+        var hour = _service.CalculateAveragedStats([]).Single(stats => stats.Hour == 7);
+
+        hour.Count.Should().Be(0);
+        hour.TimeInRange.VeryLow.Should().Be(0);
+        hour.TimeInRange.VeryHigh.Should().Be(0);
+    }
+
+    #endregion
+
+    private static List<SensorGlucose> EntriesEveryFiveMinutes(IEnumerable<double> values)
+    {
+        var start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        return values
+            .Select((value, index) => new SensorGlucose
+            {
+                Mgdl = value,
+                Timestamp = start.AddMinutes(index * 5),
+            })
+            .ToList();
+    }
+}


### PR DESCRIPTION
## No numeric output changes, with one declared exception

This is a behaviour-preserving refactor for every well-formed reading. Every API response returns the same numbers it returned before, to the last bit, except for the one case in **Behavioural deltas** below — corrupt data that neither the old nor the new code handled correctly.

The 32 characterisation tests in the first commit were written and committed against the **unmodified** production code and pass there; the same tests, unchanged, still pass after the refactor. `git show bc00207b5 --stat` is the diff that proves the before state.

## Behavioural deltas

One, deliberate, reachable only by corrupt data.

**A stored NaN is no longer counted as a glucose reading on the data-overview path.**

`SensorGlucoseEntity.Mgdl` is a `double`, so the column is `double precision` and can hold a NaN. PostgreSQL orders NaN **above** every number, so a stored NaN passes the `mgdl > 0` filter that the four data-overview glucose queries apply *in SQL*. The C# intuition that `NaN > 0` is false does not hold there, and the EF InMemory provider — which does use C# semantics — structurally cannot reproduce it.

- **Before this PR**, the five independent `Count(v => …)` zone predicates all evaluated false for a NaN, so it fell into **no** zone while still counting toward `totalCount`: the GRI percentages summed to under 100.
- **On the refactor as first pushed**, `GlucoseZoneScale.Classify` fell through every bound and returned the **remainder** zone, which on the GRI scale is VeryHigh — inflating the hyperglycaemia component of the index.

Neither is correct, so this is not a restoration of the old numbers. A NaN is not a glucose reading. It is now excluded outright, so it reaches neither a zone **nor the denominator**: `ReadingCount` and every percentage are taken over one fewer reading than before, and the month's `AverageGlucoseMgdl` is a number rather than NaN. The daily summary had the same exposure through the same filter, and its per-day average and time-in-range are excluded consistently.

**Mechanism.** The four queries exclude it in SQL, and the two in-memory aggregations drop it from the series through `GlucoseStatistics.IsReading`, which is the one site the rule and its rationale live at.

`!double.IsNaN(e.Mgdl)` **does** translate — verified with `ToQueryString()` against an Npgsql-configured `NocturneDbContext`, which emits:

```sql
WHERE ... AND s.mgdl > 0.0 AND s.mgdl <> 'NaN'
```

`NaN <> 'NaN'` is false in PostgreSQL, so the row is dropped at the database. The in-memory rule is kept **as well as**, not instead of: it is the only form the InMemory-provider tests and any non-Postgres provider ever see, so without it the suite would exercise different behaviour from production — and it is what the regression test pins, because an InMemory test cannot get a NaN past the query filter at all.

**Regression test.** `BuildGriPeriod_ExcludesANonReadingFromEveryZoneAndFromTheDenominator` hands a month of 72 readings of 120 plus one NaN straight to the aggregation. Without the fix it reports `ReadingCount` 73, `AverageGlucoseMgdl` NaN and a non-zero VeryHigh percentage; with it, 72, 120 and 0. `BuildGriPeriod` is `internal` for this (the API assembly already grants `InternalsVisibleTo("Nocturne.API.Tests")`) rather than the test pretending an InMemory query proves the SQL-side filter.

**Not affected.** `StatisticsService.CalculateTimeInRange` and its neighbours filter `Mgdl > 0` **in C#**, where `NaN > 0` is already false, so no NaN reaches those zone scales.

## What was duplicated

- **Standard deviation, seven times**, with two divisors that had already drifted apart.
- **Glucose zone bucketing, five times**, across two services and three different zone sets.
- **The A1C regression twice**, the **median twice**, and **local-midnight-to-UTC year bounds twice**.

## The module

`src/API/Nocturne.API/Services/Analytics/GlucoseStatistics.cs` — both consumers live in `Services/Analytics/`, so it sits with them rather than in `src/Core/`. It has no dependency on anything above the analytics services and could move later if a third consumer appears outside the API; there is none today. `src/Widgets/Nocturne.Widget.Contracts/Helpers/GlucoseFormatHelper.cs` is a separate deployable and is explicitly **not** unified here.

Two pieces:

- `GlucoseStatistics.Variance` / `.StandardDeviation` / `.Median` / `.EstimatedA1C`. `VarianceMode` is a required argument with **no default** — whether a metric is defined against the sample or the population divisor is a clinical question, and the copies already disagreed, so a call site has to state which it means.
- `GlucoseZoneScale`, which takes zone bounds as data: each bound names its threshold, which side of it the zone lies on, and whether the edge itself belongs to it. That is enough to express the five-zone consensus set and the six-zone hourly set without either borrowing the other's edges.

Bound **order is the caller's**, and is preserved verbatim. `CalculateTimeInRange` tests `> VeryHigh` *before* `> TargetTop`, which classifies differently from an ascending scale when a tenant configures `VeryHigh` below `TargetTop` through the `thresholds` field on the request body. The scale is a first-match chain, not a sorted lookup, so that stays true.

That claim is now pinned rather than only asserted in a doc comment. `CalculateTimeInRange_PinsVeryHighAheadOfHighWhenTheThresholdsAreInverted` configures `VeryHigh = 100` against `TargetTop = 180` and asserts that both 120 and 200 are very high — in the percentages, the durations and the episode count. **200 is the reading that discriminates**: 120 is admitted by no other bound, so every ordering classifies it very high, whereas exchanging the two bounds makes 200 high. The suite previously pinned bound order only under sane thresholds, so a refactor to independent, non-first-match predicates could have passed it while changing what a misconfigured tenant sees.

## Divisor per call site — preserved exactly

| Call site | Metric | Divisor | Now |
|---|---|---|---|
| `StatisticsService:710` | `CalculateBasicStats` | `n - 1` (sample) | `VarianceMode.Sample` |
| `StatisticsService:813` | `CalculateGlycemicVariability` | `n - 1` (sample) | `VarianceMode.Sample` |
| `StatisticsService:1368` | `CalculateRangeMetrics` | `n - 1` (sample) | `VarianceMode.Sample` |
| `StatisticsService:934` | `CalculateMAGE` | `n` (population) | `VarianceMode.Population` |
| `StatisticsService:1004` | `CalculateADRR` (log-transformed) | `n` (population) | `VarianceMode.Population` |
| `StatisticsService:1044` | `CalculateJIndex` | `n` (population) | `VarianceMode.Population` |
| `StatisticsService:2948` | site-change buckets | `n` (population) | `VarianceMode.Population` |

Whether population is *correct* for MAGE and ADRR is a clinical question and is being filed separately. Nothing here moves.

Two guard behaviours also carried over, because they differ between the modes and were relied on:

- **Sample** returns `0` for `n < 2`. All three sample sites guarded with `count > 1 ? … : 0`.
- **Population** does not guard, so `n = 0` yields `NaN`. `CalculateADRR` has always been able to reach that, and still can.

`CalculateBasicStats` centres its variance on the **rounded** mean from `CalculateMean` (114.4, not 114.375 for the pinned series) while `CalculateGlycemicVariability` centres on the raw average. Both are pinned; `Variance` takes the mean as an argument rather than deriving it precisely so neither site changes.

## Zone sets — kept apart

Four scales, none folded into another:

| Scale | Bounds | Callers |
|---|---|---|
| `ExcludingZone` | `< VeryLow`, `< Low`, `> VeryHigh`, `> TargetTop`, remainder | TIR percentages/durations, TIR episodes |
| `RangeStatZone` | `< Low`, `> TargetTop`, remainder | TIR per-range statistics |
| `ExtendedZone` | `< 54`, `< 63`, `< 140`, `< 180`, `< 200`, remainder | hourly averaged stats |
| `GriZone` | `< 54`, `< 70`, `<= 180`, `<= 250`, remainder | GRI timeline |

`ExcludingZone` and `RangeStatZone` look similar and are not: the per-range low bucket is *everything below `Low`*, so it holds the very-low readings, which is why they are separate scales rather than one reused. The target and tight-target bands are still counted alongside the scale rather than read off it, because they overlap each other and — when `Low` and `TargetBottom` are configured apart — overlap the excluding zones too; a test pins percentages summing past 100 in that case.

The `CalculateExtendedTimeInRange` doc comment claimed seven ranges with bounds at 200-220 and >220. The code has never had those. The comment now describes the six ranges it counts; no code changed.

## The `250` verification — passed

**Verified, and it is safe to route.**

1. `GlycemicThresholds.VeryHigh` did default to `250` (`StatisticsModels.cs:215`, `public double VeryHigh { get; set; } = 250;`).
2. `DataOverviewService.BuildGriPeriod` is reached in production only from `GetGriTimelineAsync` (it is `internal` solely so the NaN regression test can hand it a series), which **accepts no `GlycemicThresholds`** and constructs none. There is no per-tenant, per-request or configuration path that can move it. `GlycemicThresholds` is only ever supplied by `StatisticsController`'s request body (a different endpoint) and by `SleepReportService`, neither of which reaches this code.

So routing it through a shared constant is a rename, not a behaviour change. `GlucoseConstants` gains `VeryLowMgdl = 54` and `VeryHighMgdl = 250` alongside the `TargetBottomMgdl`/`TargetTopMgdl` already there, and four sites that wrote the bare literals now point at them: the `GlycemicThresholds` defaults, `DataOverviewService`'s GRI zones, `SleepReportService`'s `DefaultVeryLow`/`DefaultVeryHigh`, and the 54/180 edges of the hourly zone set. `GlucoseConstants.MgdlPerMmol` is untouched; `GlucoseMirrorTests` guards only the factor, the target range and the palette, and is unaffected.

## `CalculateEstimatedHbA1C` — rounding checked

Now `CalculateEstimatedA1C(CalculateMean(values)).ToString("F1")`. The old code special-cased `mean == 0` to return `"0.0"`; `CalculateEstimatedA1C(0)` returns `0`, and `0d.ToString("F1")` is `"0.0"`, so the branch was redundant. Both entry points still take their own input — the string form centres on the **rounded** mean, the double form on whatever it is given — which is pinned in `CalculateEstimatedHbA1C_PinsTheRoundedMeanItCentresOn`.

## Mutation check

Two mutations, applied to the new module, each confirmed to redden and then reverted:

1. **Sample divisor → population** (`n - 1` → `n` in `GlucoseStatistics.Variance`): **3 failures** — `CalculateBasicStats_PinsSampleStandardDeviationAndMedian`, `CalculateGlycemicVariability_PinsSampleStandardDeviationAndDerivedMetrics`, `CalculateTimeInRange_PinsPerRangeStatisticsOnTheSampleDivisor`.
2. **Inclusive upper bound → exclusive** (`GlucoseZoneBound.UpTo`): **1 failure** — `GetGriTimelineAsync_PinsEveryZoneBoundAndItsInclusivity`, which is the test that puts a reading exactly on 180 and exactly on 250.

3. **Zone order exchanged** (`Over(thresholds.VeryHigh)` and `Over(thresholds.TargetTop)` swapped in `ExcludingZones`, with the `ExcludingZone` members swapped to match so the index mapping stays consistent): the new out-of-order-thresholds test fails, `Percentages.VeryHigh` 100 → 50, alongside four pre-existing zone pins. With a single reading of 120 that test stayed **green** under this mutation, which is why it carries 200 as well.

The NaN fix was likewise written test-first: the regression test fails on the pre-fix tree with `ReadingCount` 73 rather than 72.

All reverted and the assemblies rebuilt; the suite is green again on the pushed tree.

## Build and test

- `dotnet build src/API/Nocturne.API/Nocturne.API.csproj -p:GenerateNSwagClient=false` — succeeded, 0 errors.
- `dotnet test tests/Unit/Nocturne.API.Tests -p:GenerateNSwagClient=false --filter "Category!=Integration&Category!=Performance&Category!=E2E"` — **6154 passed, 0 failed, 5 skipped** (6152 before the two follow-up tests).
- Whole-solution unit run across all 22 unit assemblies — **8453 passed, 0 failed, 19 skipped**, including `Nocturne.Core.Constants.Tests` (29) and `Nocturne.Core.Models.Tests` (829), which cover the two files changed outside the API.
- `dotnet build nocturne.sln -p:GenerateNSwagClient=false` — succeeded, 0 errors.

Production diff: **+315 / -132** over 6 files, of which +129 is the new module — so about 260 lines of duplicated arithmetic and bucketing replaced by 129 lines of module plus its call sites. Tests add +564.

