### PR TITLE
Deduplicate the scaffolding around BaseConnectorService, and fix a narrowed sync request being ignored

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -441,7 +441,7 @@ public class DataSourceService : IDataSourceService
         var connectors = ConnectorMetadataService.GetAll()
             .Select(connector => new AvailableConnector
             {
-                Id = connector.ConnectorName.ToLowerInvariant(),
+                Id = connector.ConnectorId,
                 Name = connector.DisplayName,
                 Category = connector.Category.ToString().ToLowerInvariant(),
                 Description = connector.Description,

--- a/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/DataSourceService.cs
@@ -346,7 +346,7 @@ public class DataSourceService : IDataSourceService
             var connectorMeta = ConnectorMetadataService.GetByDataSourceId(connectorKey);
             if (connectorMeta != null)
             {
-                info.ConnectorId = connectorMeta.ConnectorName.ToLowerInvariant();
+                info.ConnectorId = connectorMeta.ConnectorId;
                 var connConfig = connectorConfigs.FirstOrDefault(c =>
                     c.ConnectorName.Equals(connectorMeta.ConnectorName, StringComparison.OrdinalIgnoreCase));
                 if (connConfig?.LastSuccessfulSync != null)
@@ -407,7 +407,7 @@ public class DataSourceService : IDataSourceService
             var connectorMeta = ConnectorMetadataService.GetByDataSourceId(key);
             if (connectorMeta != null)
             {
-                info.ConnectorId = connectorMeta.ConnectorName.ToLowerInvariant();
+                info.ConnectorId = connectorMeta.ConnectorId;
                 var connConfig = connectorConfigs.FirstOrDefault(c =>
                     c.ConnectorName.Equals(connectorMeta.ConnectorName, StringComparison.OrdinalIgnoreCase));
                 if (connConfig?.LastSuccessfulSync != null)

--- a/src/Connectors/Nocturne.Connectors.CareLink/CareLinkConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/CareLinkConnectorInstaller.cs
@@ -22,7 +22,7 @@ public class CareLinkConnectorInstaller : IConnectorInstaller
         if (config == null) return;
 
         services.AddConnectorTokenProvider<CareLinkAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<CareLinkSyncExecutor>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<CareLinkConnectorService, CareLinkConnectorConfiguration>>();
     }
 
     private sealed class CareLinkConnectorOptions : ConnectorOptions
@@ -39,11 +39,4 @@ public class CareLinkConnectorInstaller : IConnectorInstaller
             GetServerRegion = config => ((CareLinkConnectorConfiguration)config).Server;
         }
     }
-}
-
-public class CareLinkSyncExecutor
-    : ConnectorSyncExecutor<CareLinkConnectorService, CareLinkConnectorConfiguration>
-{
-    public override string ConnectorId => "carelink";
-    protected override string ConnectorName => "CareLink";
 }

--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -122,13 +122,13 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
         // Seed the tenant timezone timeline from the pump's reported zone (idempotent; first sync only).
         await ConfigureCareLinkTimezoneAsync(data, cancellationToken);
 
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
+        var activeTypes = ResolveActiveTypes(request, config);
         var isStale = IsDataStale(data);
 
-        await PublishSensorGlucoseStepAsync(data, config, enabledTypes, isStale, result, cancellationToken);
-        await PublishDeviceStatusStepAsync(data, config, enabledTypes, result, cancellationToken);
-        await PublishAlarmStepAsync(data, config, enabledTypes, result, cancellationToken);
-        await PublishTreatmentsStepAsync(data, config, enabledTypes, result, cancellationToken);
+        await PublishSensorGlucoseStepAsync(data, config, activeTypes, isStale, result, cancellationToken);
+        await PublishDeviceStatusStepAsync(data, config, activeTypes, result, cancellationToken);
+        await PublishAlarmStepAsync(data, config, activeTypes, result, cancellationToken);
+        await PublishTreatmentsStepAsync(data, config, activeTypes, result, cancellationToken);
 
         // Persist refresh token if it changed during sync
         await PersistRefreshTokenIfChangedAsync(cancellationToken);
@@ -232,12 +232,12 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     private async Task PublishSensorGlucoseStepAsync(
         CareLinkData data,
         CareLinkConnectorConfiguration config,
-        HashSet<SyncDataType> enabledTypes,
+        HashSet<SyncDataType> activeTypes,
         bool isStale,
         SyncResult result,
         CancellationToken cancellationToken)
     {
-        if (!enabledTypes.Contains(SyncDataType.Glucose))
+        if (!activeTypes.Contains(SyncDataType.Glucose))
             return;
 
         if (isStale)
@@ -252,7 +252,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
 
         try
         {
-            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                 _sgMapper.Map(data), PublishSensorGlucoseDataAsync, config, cancellationToken);
         }
         catch (OperationCanceledException) { throw; }
@@ -276,12 +276,12 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     private async Task PublishDeviceStatusStepAsync(
         CareLinkData data,
         CareLinkConnectorConfiguration config,
-        HashSet<SyncDataType> enabledTypes,
+        HashSet<SyncDataType> activeTypes,
         SyncResult result,
         CancellationToken cancellationToken)
     {
         // Gated here as well as in the shared path, so a switched-off type is not mapped at all.
-        if (!enabledTypes.Contains(SyncDataType.DeviceStatus))
+        if (!activeTypes.Contains(SyncDataType.DeviceStatus))
             return;
 
         try
@@ -289,7 +289,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
             List<Nocturne.Core.Models.DeviceStatus> deviceStatuses =
                 CareLinkDeviceStatusMapper.Map(data) is { } deviceStatus ? [deviceStatus] : [];
 
-            await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, enabledTypes,
+            await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, activeTypes,
                 deviceStatuses, PublishDeviceStatusAsync, config, cancellationToken);
         }
         catch (OperationCanceledException) { throw; }
@@ -316,7 +316,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     private async Task PublishAlarmStepAsync(
         CareLinkData data,
         CareLinkConnectorConfiguration config,
-        HashSet<SyncDataType> enabledTypes,
+        HashSet<SyncDataType> activeTypes,
         SyncResult result,
         CancellationToken cancellationToken)
     {
@@ -332,7 +332,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
                     data.MedicalDeviceTime ?? "", data.CurrentServerTime);
                 var systemEvent = CareLinkSystemEventMapper.Map(data.LastAlarm, pumpOffsetMs, data.CurrentServerTime);
                 if (systemEvent != null
-                    && await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabledTypes,
+                    && await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
                         [systemEvent], PublishSystemEventDataAsync, config, cancellationToken,
                         context: "from the last alarm"))
                     _lastAlarmKey = alarmKey;
@@ -357,7 +357,7 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     private async Task PublishTreatmentsStepAsync(
         CareLinkData data,
         CareLinkConnectorConfiguration config,
-        HashSet<SyncDataType> enabledTypes,
+        HashSet<SyncDataType> activeTypes,
         SyncResult result,
         CancellationToken cancellationToken)
     {
@@ -366,19 +366,19 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
             var pumpOffsetMs = Utilities.CareLinkTimestampParser.CalculatePumpOffsetMs(
                 data.MedicalDeviceTime ?? "", data.CurrentServerTime);
 
-            await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabledTypes,
+            await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
                 CareLinkTreatmentMapper.MapBoluses(data, pumpOffsetMs), PublishBolusDataAsync,
                 config, cancellationToken);
 
-            await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabledTypes,
+            await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
                 CareLinkTreatmentMapper.MapCarbIntakes(data, pumpOffsetMs), PublishCarbIntakeDataAsync,
                 config, cancellationToken);
 
-            await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabledTypes,
+            await PublishRecordTypeAsync(result, SyncDataType.TempBasals, activeTypes,
                 CareLinkTreatmentMapper.MapTempBasals(data, pumpOffsetMs), PublishTempBasalDataAsync,
                 config, cancellationToken);
 
-            await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabledTypes,
+            await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
                 CareLinkSystemEventMapper.MapNotifications(data.NotificationHistory, pumpOffsetMs),
                 PublishSystemEventDataAsync, config, cancellationToken,
                 context: "from notification history");

--- a/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/Services/CareLinkConnectorService.cs
@@ -52,14 +52,6 @@ public class CareLinkConnectorService : BaseConnectorService<CareLinkConnectorCo
     protected override string ConnectorSource => DataSources.CareLinkConnector;
     public override string ServiceName => ServiceNames.CareLinkConnector;
 
-    /// <inheritdoc />
-    public override Task<bool> AuthenticateAsync()
-    {
-        // Legacy method; actual auth happens per-tenant in PerformSyncInternalAsync
-        TrackSuccessfulRequest();
-        return Task.FromResult(true);
-    }
-
     private async Task<bool> AuthenticateWithConfigAsync(CareLinkConnectorConfiguration config)
     {
         // Seed the token provider with persisted secrets so refresh is available immediately

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/AspireAttributes.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/AspireAttributes.cs
@@ -63,7 +63,14 @@ public class ConnectorRegistrationAttribute(
     ///     Connector name used in configuration paths (e.g., "LibreLinkUp")
     /// </summary>
     public string ConnectorName { get; } = connectorName;
-    
+
+    /// <summary>
+    ///     The key every sync trigger dispatches on — the API route segment, the stored
+    ///     <c>ConnectorConfiguration.ConnectorName</c> lowered, and the id the tenant UI sends back
+    ///     (e.g. "librelinkup"). Derived so the name and the key cannot drift apart.
+    /// </summary>
+    public string ConnectorId { get; } = connectorName.ToLowerInvariant();
+
     /// <summary>
     ///     Service name constant (e.g., "ServiceNames.LibreConnector")
     /// </summary>

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
@@ -223,9 +223,28 @@ public static class ConnectorServiceCollectionExtensions
         ///     Registers a sync executor as a scoped IConnectorSyncExecutor.
         /// </summary>
         /// <typeparam name="TSyncExecutor">Sync executor type</typeparam>
+        /// <exception cref="InvalidOperationException">
+        ///     Another executor type already answers the same
+        ///     <see cref="IConnectorSyncExecutor.ConnectorId"/>. A trigger resolves one executor per id
+        ///     by enumeration order, so the collision would silently run one vendor's sync under the
+        ///     other's trigger.
+        /// </exception>
         public IServiceCollection AddConnectorSyncExecutor<TSyncExecutor>()
-            where TSyncExecutor : class, IConnectorSyncExecutor
+            where TSyncExecutor : class, IConnectorSyncExecutor, new()
         {
+            var connectorId = new TSyncExecutor().ConnectorId;
+
+            var clash = services.FirstOrDefault(descriptor =>
+                descriptor.ServiceType == typeof(IConnectorSyncExecutor)
+                && descriptor.ImplementationType is { } registered
+                && registered != typeof(TSyncExecutor)
+                && ConnectorIdOf(registered) == connectorId);
+
+            if (clash is not null)
+                throw new InvalidOperationException(
+                    $"{typeof(TSyncExecutor).Name} and {clash.ImplementationType!.Name} both dispatch " +
+                    $"on '{connectorId}'.");
+
             services.AddScoped<IConnectorSyncExecutor, TSyncExecutor>();
             return services;
         }
@@ -341,4 +360,9 @@ public static class ConnectorServiceCollectionExtensions
             return services;
         }
     }
+
+    private static string? ConnectorIdOf(Type executorType) =>
+        executorType.GetConstructor(Type.EmptyTypes) is null
+            ? null
+            : ((IConnectorSyncExecutor)Activator.CreateInstance(executorType)!).ConnectorId;
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/HttpResponseExtensions.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/HttpResponseExtensions.cs
@@ -7,26 +7,23 @@ namespace Nocturne.Connectors.Core.Extensions;
 /// </summary>
 public static class HttpResponseExtensions
 {
+    /// <summary>
+    ///     The statuses worth sending the same request again for: the source is rate-limiting us or
+    ///     is transiently unwell, so the request itself is not at fault.
+    /// </summary>
+    public static bool IsRetryableStatusCode(HttpStatusCode? statusCode) =>
+        statusCode is HttpStatusCode.TooManyRequests
+            or HttpStatusCode.ServiceUnavailable
+            or HttpStatusCode.InternalServerError
+            or HttpStatusCode.BadGateway
+            or HttpStatusCode.GatewayTimeout
+            or HttpStatusCode.RequestTimeout;
+
     /// <param name="response">The HTTP response to check</param>
     extension(HttpResponseMessage response)
     {
-        /// <summary>
-        ///     Determines if the response indicates a retryable error (rate limiting, server errors, etc.)
-        /// </summary>
-        /// <returns>True if the request should be retried</returns>
-        public bool IsRetryableError()
-        {
-            return response.StatusCode switch
-            {
-                HttpStatusCode.TooManyRequests => true,
-                HttpStatusCode.ServiceUnavailable => true,
-                HttpStatusCode.InternalServerError => true,
-                HttpStatusCode.BadGateway => true,
-                HttpStatusCode.GatewayTimeout => true,
-                HttpStatusCode.RequestTimeout => true,
-                _ => false
-            };
-        }
+        /// <inheritdoc cref="IsRetryableStatusCode"/>
+        public bool IsRetryableError() => IsRetryableStatusCode(response.StatusCode);
 
         /// <summary>
         ///     Determines if the response indicates that re-authentication is required.

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -533,9 +533,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     /// <summary>
     ///     The data types one run of <see cref="PerformSyncInternalAsync"/> may touch: what the
     ///     caller asked for, narrowed to what the tenant has switched on. An empty
-    ///     <see cref="SyncRequest.DataTypes"/> asks for everything, which is how the background flow
-    ///     and an unfiltered cursor reset arrive; a narrowed one is an operator re-pulling a single
-    ///     type and must not drag the rest of the connector's history back with it.
+    ///     <see cref="SyncRequest.DataTypes"/> asks for everything, which is how an unfiltered cursor
+    ///     reset arrives; a narrowed one is an operator re-pulling a single type and must not drag
+    ///     the rest of the connector's history back with it.
     /// </summary>
     /// <remarks>
     ///     Answered rather than written back into <paramref name="request"/>: a tenant-wide cursor

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -79,7 +79,18 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         typeof(TConfig).GetCustomAttribute<ConnectorRegistrationAttribute>()?.SupportedDataTypes
         ?? [SyncDataType.Glucose];
 
-    public abstract Task<bool> AuthenticateAsync();
+    /// <summary>
+    ///     The pre-flight <see cref="RunBackgroundSyncAsync"/> runs before it fetches anything.
+    ///     It carries no configuration, so a connector whose credentials are per-tenant has nothing
+    ///     to authenticate against here and admits the run: it resolves and checks the tenant's
+    ///     credential inside <see cref="PerformSyncInternalAsync"/>, where the config is in hand.
+    ///     Only a connector holding a process-wide credential overrides this.
+    /// </summary>
+    public virtual Task<bool> AuthenticateAsync()
+    {
+        TrackSuccessfulRequest();
+        return Task.FromResult(true);
+    }
 
     /// <inheritdoc />
     public virtual async Task<SyncResult> SyncDataAsync(

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -1482,7 +1482,7 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
                     TrackFailedRequest("Unauthorized and re-authentication failed");
                     return RetryStep<T>.Complete(default);
                 }
-                catch (HttpRequestException ex) when (IsRetryableStatusCode(ex.StatusCode))
+                catch (HttpRequestException ex) when (HttpResponseExtensions.IsRetryableStatusCode(ex.StatusCode))
                 {
                     lastException = ex;
                     _logger.LogWarning(
@@ -1625,20 +1625,6 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
             content,
             cancellationToken
         );
-    }
-
-    /// <summary>
-    ///     Determines if an HTTP status code is retryable.
-    /// </summary>
-    private static bool IsRetryableStatusCode(HttpStatusCode? statusCode)
-    {
-        return statusCode
-            is HttpStatusCode.TooManyRequests
-                or HttpStatusCode.ServiceUnavailable
-                or HttpStatusCode.InternalServerError
-                or HttpStatusCode.BadGateway
-                or HttpStatusCode.GatewayTimeout
-                or HttpStatusCode.RequestTimeout;
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -508,16 +508,35 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     protected static DateTime DefaultInitialSyncFloor() => DateTime.UtcNow.AddMonths(-6);
 
     /// <summary>
-    ///     Core synchronization logic: fetches and publishes every data type the tenant has enabled,
-    ///     honouring <see cref="BaseConnectorConfiguration.GetEnabledDataTypes"/> over
-    ///     <see cref="SupportedDataTypes"/>. Shared between the manual and background sync flows.
-    ///     There is deliberately no default implementation: a connector that advertises data types it
-    ///     does not sync would fail silently, so the omission is a compile error instead.
+    ///     Core synchronization logic: fetches and publishes the data types
+    ///     <see cref="ResolveActiveTypes"/> resolves for the run. Shared between the manual and
+    ///     background sync flows. There is deliberately no default implementation: a connector that
+    ///     advertises data types it does not sync would fail silently, so the omission is a compile
+    ///     error instead.
     /// </summary>
     protected abstract Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TConfig config,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     The data types one run of <see cref="PerformSyncInternalAsync"/> may touch: what the
+    ///     caller asked for, narrowed to what the tenant has switched on. An empty
+    ///     <see cref="SyncRequest.DataTypes"/> asks for everything, which is how the background flow
+    ///     and an unfiltered cursor reset arrive; a narrowed one is an operator re-pulling a single
+    ///     type and must not drag the rest of the connector's history back with it.
+    /// </summary>
+    /// <remarks>
+    ///     Answered rather than written back into <paramref name="request"/>: a tenant-wide cursor
+    ///     reset builds one <see cref="SyncRequest"/> and hands the same instance to every connector
+    ///     it fans out to, so a connector recording its own answer there would narrow the next
+    ///     connector's run to its own supported types.
+    /// </remarks>
+    protected HashSet<SyncDataType> ResolveActiveTypes(SyncRequest request, TConfig config)
+    {
+        var enabled = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
+        return request.DataTypes.Count == 0 ? enabled : [.. request.DataTypes.Where(enabled.Contains)];
+    }
 
     protected virtual Task<IEnumerable<Profile>> FetchProfilesAsync()
     {

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorMetadataService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorMetadataService.cs
@@ -118,6 +118,7 @@ public static class ConnectorMetadataService
                         var info = new ConnectorDisplayInfo
                         {
                             ConnectorName = attr.ConnectorName,
+                            ConnectorId = attr.ConnectorId,
                             DisplayName = attr.DisplayName,
                             DataSourceId = attr.DataSourceId,
                             Icon = attr.Icon,
@@ -130,8 +131,7 @@ public static class ConnectorMetadataService
 
                         ConnectorsByDataSourceId[attr.DataSourceId] = info;
 
-                        var connectorId = attr.ConnectorName.ToLowerInvariant();
-                        RegistrationsByConnectorId[connectorId] = attr;
+                        RegistrationsByConnectorId[attr.ConnectorId] = attr;
                     }
                 }
                 catch (ReflectionTypeLoadException)
@@ -149,6 +149,9 @@ public static class ConnectorMetadataService
     public class ConnectorDisplayInfo
     {
         public string ConnectorName { get; init; } = string.Empty;
+
+        /// <inheritdoc cref="ConnectorRegistrationAttribute.ConnectorId"/>
+        public string ConnectorId { get; init; } = string.Empty;
         public string DisplayName { get; init; } = string.Empty;
         public string DataSourceId { get; init; } = string.Empty;
         public string Icon { get; init; } = string.Empty;

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorSyncExecutor.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorSyncExecutor.cs
@@ -1,21 +1,25 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 
 namespace Nocturne.Connectors.Core.Services;
 
 /// <summary>
-///     Base class for connector sync executors. Handles service resolution
-///     and per-tenant config loading via <see cref="IConnectorConfigurationLoader{TConfig}"/>,
-///     then delegates to the connector service.
+///     Runs one connector's sync: resolves the service, loads the tenant's config through
+///     <see cref="IConnectorConfigurationLoader{TConfig}"/>, and delegates.
 /// </summary>
-public abstract class ConnectorSyncExecutor<TService, TConfig> : IConnectorSyncExecutor
+public class ConnectorSyncExecutor<TService, TConfig> : IConnectorSyncExecutor
     where TService : class, IConnectorService<TConfig>
     where TConfig : BaseConnectorConfiguration
 {
-    public abstract string ConnectorId { get; }
-
-    protected abstract string ConnectorName { get; }
+    /// <inheritdoc />
+    public string ConnectorId { get; } =
+        typeof(TConfig).GetCustomAttribute<ConnectorRegistrationAttribute>()?.ConnectorId
+        ?? throw new InvalidOperationException(
+            $"{typeof(TConfig).Name} carries no {nameof(ConnectorRegistrationAttribute)}, so no " +
+            "sync trigger could ever dispatch to it.");
 
     public async Task<SyncResult> ExecuteSyncAsync(
         IServiceProvider scopeProvider,

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorSyncExecutor.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorSyncExecutor.cs
@@ -15,11 +15,16 @@ public class ConnectorSyncExecutor<TService, TConfig> : IConnectorSyncExecutor
     where TConfig : BaseConnectorConfiguration
 {
     /// <inheritdoc />
+    /// <remarks>
+    ///     Read without inheritance: a config declared by subclassing another connector's config
+    ///     (Gluroo extends Nightscout) would otherwise answer the parent's id, registering a second
+    ///     executor under it and leaving a trigger to pick whichever DI enumerated first.
+    /// </remarks>
     public string ConnectorId { get; } =
-        typeof(TConfig).GetCustomAttribute<ConnectorRegistrationAttribute>()?.ConnectorId
+        typeof(TConfig).GetCustomAttribute<ConnectorRegistrationAttribute>(inherit: false)?.ConnectorId
         ?? throw new InvalidOperationException(
-            $"{typeof(TConfig).Name} carries no {nameof(ConnectorRegistrationAttribute)}, so no " +
-            "sync trigger could ever dispatch to it.");
+            $"{typeof(TConfig).Name} declares no {nameof(ConnectorRegistrationAttribute)} of its own, " +
+            "so no sync trigger could ever dispatch to it.");
 
     public async Task<SyncResult> ExecuteSyncAsync(
         IServiceProvider scopeProvider,

--- a/src/Connectors/Nocturne.Connectors.Dexcom/DexcomConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/DexcomConnectorInstaller.cs
@@ -26,7 +26,7 @@ public class DexcomConnectorInstaller : IConnectorInstaller
             return;
 
         services.AddConnectorTokenProvider<DexcomAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<DexcomSyncExecutor>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<DexcomConnectorService, DexcomConnectorConfiguration>>();
     }
 
     private sealed class DexcomConnectorOptions : ConnectorOptions
@@ -44,12 +44,4 @@ public class DexcomConnectorInstaller : IConnectorInstaller
             GetServerRegion = config => ((DexcomConnectorConfiguration)config).Server;
         }
     }
-}
-
-public class DexcomSyncExecutor
-    : ConnectorSyncExecutor<DexcomConnectorService, DexcomConnectorConfiguration>
-{
-    public override string ConnectorId => "dexcom";
-
-    protected override string ConnectorName => "Dexcom";
 }

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
@@ -82,8 +82,8 @@ public class DexcomConnectorService : BaseConnectorService<DexcomConnectorConfig
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
-        if (!enabledTypes.Contains(SyncDataType.Glucose))
+        var activeTypes = ResolveActiveTypes(request, config);
+        if (!activeTypes.Contains(SyncDataType.Glucose))
         {
             result.EndTime = DateTimeOffset.UtcNow;
             return result;
@@ -93,7 +93,7 @@ public class DexcomConnectorService : BaseConnectorService<DexcomConnectorConfig
         {
             var sensorGlucose = await FetchSensorGlucoseAsync(config, request.From);
 
-            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                 sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken);
         }
         catch (Exception ex)

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Services/DexcomConnectorService.cs
@@ -47,13 +47,6 @@ public class DexcomConnectorService : BaseConnectorService<DexcomConnectorConfig
     protected override string ConnectorSource => DataSources.DexcomConnector;
     public override string ServiceName => "Dexcom Share";
 
-    public override async Task<bool> AuthenticateAsync()
-    {
-        // AuthenticateAsync is a legacy method; actual auth happens per-tenant in sync flow
-        TrackSuccessfulRequest();
-        return true;
-    }
-
     /// <summary>
     ///     Fetches SensorGlucose records from the Dexcom Share API.
     /// </summary>

--- a/src/Connectors/Nocturne.Connectors.Eversense/EversenseConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/EversenseConnectorInstaller.cs
@@ -23,7 +23,7 @@ public class EversenseConnectorInstaller : IConnectorInstaller
             return;
 
         services.AddConnectorTokenProvider<EversenseAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<EversenseSyncExecutor>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<EversenseConnectorService, EversenseConnectorConfiguration>>();
     }
 
     private sealed class EversenseConnectorOptions : ConnectorOptions
@@ -39,12 +39,4 @@ public class EversenseConnectorInstaller : IConnectorInstaller
             GetServerRegion = config => ((EversenseConnectorConfiguration)config).Server;
         }
     }
-}
-
-public class EversenseSyncExecutor
-    : ConnectorSyncExecutor<EversenseConnectorService, EversenseConnectorConfiguration>
-{
-    public override string ConnectorId => "eversense";
-
-    protected override string ConnectorName => "Eversense";
 }

--- a/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
@@ -42,13 +42,6 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
     protected override string ConnectorSource => DataSources.EversenseConnector;
     public override string ServiceName => "Eversense Now";
 
-    public override async Task<bool> AuthenticateAsync()
-    {
-        // AuthenticateAsync is a legacy method; actual auth happens per-tenant in sync flow
-        TrackSuccessfulRequest();
-        return true;
-    }
-
     /// <summary>
     ///     Selects the appropriate patient from the patient list.
     ///     If only one patient, auto-selects. If multiple, matches by username (case-insensitive).

--- a/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/Services/EversenseConnectorService.cs
@@ -81,8 +81,8 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
-        if (!enabledTypes.Contains(SyncDataType.Glucose))
+        var activeTypes = ResolveActiveTypes(request, config);
+        if (!activeTypes.Contains(SyncDataType.Glucose))
         {
             result.EndTime = DateTimeOffset.UtcNow;
             return result;
@@ -162,7 +162,7 @@ public class EversenseConnectorService : BaseConnectorService<EversenseConnector
                 sg.Mgdl,
                 sg.Timestamp);
 
-            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                 [sg], PublishSensorGlucoseDataAsync, config, cancellationToken);
         }
         catch (Exception ex)

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/FreeStyleConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/FreeStyleConnectorInstaller.cs
@@ -23,7 +23,7 @@ public class FreeStyleConnectorInstaller : IConnectorInstaller
             return;
 
         services.AddConnectorTokenProvider<LibreLinkAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<FreeStyleSyncExecutor>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<LibreConnectorService, LibreLinkUpConnectorConfiguration>>();
     }
 
     private sealed class LibreLinkUpConnectorOptions : ConnectorOptions
@@ -54,12 +54,4 @@ public class FreeStyleConnectorInstaller : IConnectorInstaller
             };
         }
     }
-}
-
-public class FreeStyleSyncExecutor
-    : ConnectorSyncExecutor<LibreConnectorService, LibreLinkUpConnectorConfiguration>
-{
-    public override string ConnectorId => "librelinkup";
-
-    protected override string ConnectorName => "LibreLinkUp";
 }

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
@@ -74,13 +74,6 @@ public class LibreConnectorService(
 
     public override bool IsHealthy => base.IsHealthy && !_tokenProvider.IsTokenExpired;
 
-    public override async Task<bool> AuthenticateAsync()
-    {
-        // Legacy method; actual auth happens per-tenant in sync flow
-        TrackSuccessfulRequest();
-        return true;
-    }
-
     private async Task<bool> AuthenticateWithConfigAsync(LibreLinkUpConnectorConfiguration config)
     {
         var token = await _tokenProvider.GetValidTokenAsync(config);

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
@@ -172,8 +172,8 @@ public class LibreConnectorService(
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
-        if (!enabledTypes.Contains(SyncDataType.Glucose))
+        var activeTypes = ResolveActiveTypes(request, config);
+        if (!activeTypes.Contains(SyncDataType.Glucose))
         {
             result.EndTime = DateTimeOffset.UtcNow;
             return result;
@@ -183,7 +183,7 @@ public class LibreConnectorService(
         {
             var sensorGlucose = await FetchSensorGlucoseAsync(config, request.From);
 
-            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                 sensorGlucose.ToList(), PublishSensorGlucoseDataAsync, config, cancellationToken);
         }
         catch (Exception ex)

--- a/src/Connectors/Nocturne.Connectors.Glooko/GlookoConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/GlookoConnectorInstaller.cs
@@ -23,7 +23,7 @@ public class GlookoConnectorInstaller : IConnectorInstaller
             return;
 
         services.AddConnectorTokenProvider<GlookoAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<GlookoSyncExecutor>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<GlookoConnectorService, GlookoConnectorConfiguration>>();
     }
 
     private sealed class GlookoConnectorOptions : ConnectorOptions
@@ -37,11 +37,4 @@ public class GlookoConnectorInstaller : IConnectorInstaller
             AddResilience = true;
         }
     }
-}
-
-public class GlookoSyncExecutor : ConnectorSyncExecutor<GlookoConnectorService, GlookoConnectorConfiguration>
-{
-    public override string ConnectorId => "glooko";
-
-    protected override string ConnectorName => "Glooko";
 }

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -63,13 +63,6 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
 
     // ── Authentication ──────────────────────────────────────────────────
 
-    public override async Task<bool> AuthenticateAsync()
-    {
-        // Legacy method; actual auth happens per-tenant in sync flow
-        TrackSuccessfulRequest();
-        return true;
-    }
-
     private async Task<bool> AuthenticateWithConfigAsync(GlookoSyncContext context)
     {
         var token = await _tokenProvider.GetValidTokenAsync(context.Config);

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -282,10 +282,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
                 return result;
             }
 
-            if (!request.DataTypes.Any())
-                request.DataTypes = SupportedDataTypes;
-            var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
-            var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
+            var activeTypes = ResolveActiveTypes(request, config);
 
             // Resolve the tenant's timezone timeline before mapping any records. The account's home
             // zone (from the V3 profile) seeds the timeline's origin on first sync; thereafter the

--- a/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
@@ -37,14 +37,6 @@ public class GlurooConnectorInstaller : IConnectorInstaller
             .ConfigureConnectorClient(
                 string.IsNullOrEmpty(glurooConfig.Url) ? null : glurooConfig.Url);
 
-        services.AddScoped<IConnectorSyncExecutor, GlurooSyncExecutor>();
+        services.AddScoped<IConnectorSyncExecutor, ConnectorSyncExecutor<GlurooConnectorService, GlurooConnectorConfiguration>>();
     }
-}
-
-public class GlurooSyncExecutor
-    : ConnectorSyncExecutor<GlurooConnectorService, GlurooConnectorConfiguration>
-{
-    public override string ConnectorId => "gluroo";
-
-    protected override string ConnectorName => "Gluroo";
 }

--- a/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
@@ -37,6 +37,6 @@ public class GlurooConnectorInstaller : IConnectorInstaller
             .ConfigureConnectorClient(
                 string.IsNullOrEmpty(glurooConfig.Url) ? null : glurooConfig.Url);
 
-        services.AddScoped<IConnectorSyncExecutor, ConnectorSyncExecutor<GlurooConnectorService, GlurooConnectorConfiguration>>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<GlurooConnectorService, GlurooConnectorConfiguration>>();
     }
 }

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/MyFitnessPalConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/MyFitnessPalConnectorInstaller.cs
@@ -23,7 +23,7 @@ public class MyFitnessPalConnectorInstaller : IConnectorInstaller
             return;
 
         services.AddConnectorTokenProvider<MyFitnessPalAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<MyFitnessPalSyncExecutor>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<MyFitnessPalConnectorService, MyFitnessPalConnectorConfiguration>>();
     }
 
     private sealed class MyFitnessPalConnectorOptions : ConnectorOptions
@@ -37,12 +37,4 @@ public class MyFitnessPalConnectorInstaller : IConnectorInstaller
             UserAgent = $"MyFitnessPal/{MyFitnessPalConstants.AppVersion} Android";
         }
     }
-}
-
-public class MyFitnessPalSyncExecutor
-    : ConnectorSyncExecutor<MyFitnessPalConnectorService, MyFitnessPalConnectorConfiguration>
-{
-    public override string ConnectorId => "myfitnesspal";
-
-    protected override string ConnectorName => "MyFitnessPal";
 }

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
@@ -54,14 +54,6 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
     protected override string ConnectorSource => DataSources.MyFitnessPalConnector;
     public override string ServiceName => "MyFitnessPal";
 
-    /// <inheritdoc />
-    public override Task<bool> AuthenticateAsync()
-    {
-        // Legacy method; actual auth happens per-tenant in PerformSyncInternalAsync
-        TrackSuccessfulRequest();
-        return Task.FromResult(true);
-    }
-
     /// <summary>
     /// Entry point for the scheduled sync.
     /// </summary>

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/Services/MyFitnessPalConnectorService.cs
@@ -93,8 +93,8 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
 
         // This override replaces the base's data-type dispatch, so the toggle it would have
         // honoured has to be checked here.
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
-        if (!enabledTypes.Contains(SyncDataType.Food))
+        var activeTypes = ResolveActiveTypes(request, config);
+        if (!activeTypes.Contains(SyncDataType.Food))
         {
             _logger.LogInformation(
                 "[{ConnectorSource}] Food sync is disabled; nothing to do", ConnectorSource);
@@ -130,7 +130,7 @@ public class MyFitnessPalConnectorService : BaseConnectorService<MyFitnessPalCon
 
         var foodEntryImports = _mapper.Map(read.Entries, config, from, to, mealNames);
 
-        await PublishRecordTypeAsync(result, SyncDataType.Food, enabledTypes, foodEntryImports,
+        await PublishRecordTypeAsync(result, SyncDataType.Food, activeTypes, foodEntryImports,
             PublishFoodEntriesAsync, config, cancellationToken,
             context: $"since {from:yyyy-MM-dd}");
 

--- a/src/Connectors/Nocturne.Connectors.MyLife/MyLifeConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/MyLifeConnectorInstaller.cs
@@ -47,14 +47,6 @@ public class MyLifeConnectorInstaller : IConnectorInstaller
         services.AddSingleton<MyLifeSyncService>();
         services.AddSingleton<MyLifeEventProcessor>();
 
-        services.AddScoped<IConnectorSyncExecutor, MyLifeSyncExecutor>();
+        services.AddScoped<IConnectorSyncExecutor, ConnectorSyncExecutor<MyLifeConnectorService, MyLifeConnectorConfiguration>>();
     }
-}
-
-public class MyLifeSyncExecutor
-    : ConnectorSyncExecutor<MyLifeConnectorService, MyLifeConnectorConfiguration>
-{
-    public override string ConnectorId => "mylife";
-
-    protected override string ConnectorName => "MyLife";
 }

--- a/src/Connectors/Nocturne.Connectors.MyLife/MyLifeConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/MyLifeConnectorInstaller.cs
@@ -47,6 +47,6 @@ public class MyLifeConnectorInstaller : IConnectorInstaller
         services.AddSingleton<MyLifeSyncService>();
         services.AddSingleton<MyLifeEventProcessor>();
 
-        services.AddScoped<IConnectorSyncExecutor, ConnectorSyncExecutor<MyLifeConnectorService, MyLifeConnectorConfiguration>>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<MyLifeConnectorService, MyLifeConnectorConfiguration>>();
     }
 }

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -39,13 +39,6 @@ public class MyLifeConnectorService(
     public override bool IsHealthy =>
         FailedRequestCount < MaxFailedRequestsBeforeUnhealthy && !tokenProvider.IsTokenExpired;
 
-    public override Task<bool> AuthenticateAsync()
-    {
-        // Auth happens per-tenant inside PerformSyncInternalAsync where config is available
-        TrackSuccessfulRequest();
-        return Task.FromResult(true);
-    }
-
     /// <summary>
     /// Fetches pump settings readouts from MyLife. Returns an empty list when no valid session
     /// is established.

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -92,11 +92,7 @@ public class MyLifeConnectorService(
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        if (!request.DataTypes.Any())
-            request.DataTypes = SupportedDataTypes;
-
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
-        var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
+        var activeTypes = ResolveActiveTypes(request, config);
 
         try
         {

--- a/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
@@ -52,7 +52,7 @@ public class NightscoutConnectorInstaller : IConnectorInstaller
             .ConfigureConnectorClient(
                 string.IsNullOrEmpty(nightscoutConfig.Url) ? null : nightscoutConfig.Url);
 
-        services.AddScoped<IConnectorSyncExecutor, NightscoutSyncExecutor>();
+        services.AddScoped<IConnectorSyncExecutor, ConnectorSyncExecutor<NightscoutConnectorService, NightscoutConnectorConfiguration>>();
 
         // Write-back sinks (circuit breaker is shared singleton, sinks are scoped)
         services.AddSingleton<NightscoutCircuitBreaker>();
@@ -71,12 +71,4 @@ public class NightscoutConnectorInstaller : IConnectorInstaller
         RegisterWriteBackClient<NightscoutFoodWriteBackSink>();
         RegisterWriteBackClient<NightscoutActivityWriteBackSink>();
     }
-}
-
-public class NightscoutSyncExecutor
-    : ConnectorSyncExecutor<NightscoutConnectorService, NightscoutConnectorConfiguration>
-{
-    public override string ConnectorId => "nightscout";
-
-    protected override string ConnectorName => "Nightscout";
 }

--- a/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
@@ -52,7 +52,7 @@ public class NightscoutConnectorInstaller : IConnectorInstaller
             .ConfigureConnectorClient(
                 string.IsNullOrEmpty(nightscoutConfig.Url) ? null : nightscoutConfig.Url);
 
-        services.AddScoped<IConnectorSyncExecutor, ConnectorSyncExecutor<NightscoutConnectorService, NightscoutConnectorConfiguration>>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<NightscoutConnectorService, NightscoutConnectorConfiguration>>();
 
         // Write-back sinks (circuit breaker is shared singleton, sinks are scoped)
         services.AddSingleton<NightscoutCircuitBreaker>();

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -151,11 +151,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        if (!request.DataTypes.Any())
-            request.DataTypes = SupportedDataTypes;
-
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
-        var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
+        var activeTypes = ResolveActiveTypes(request, config);
 
         // On an open-ended catch-up (no explicit upper bound) each data type below resolves its
         // bound through ResumeFrom, from request.From and its own resume point. Explicit ranged

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/NocturneRemoteConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/NocturneRemoteConnectorInstaller.cs
@@ -41,14 +41,6 @@ public class NocturneRemoteConnectorInstaller : IConnectorInstaller
         services.AddHttpClient<NocturneRemoteConnectorService>()
             .ConfigureConnectorClient(string.IsNullOrEmpty(config.Url) ? null : config.Url);
 
-        services.AddScoped<IConnectorSyncExecutor, NocturneRemoteSyncExecutor>();
+        services.AddScoped<IConnectorSyncExecutor, ConnectorSyncExecutor<NocturneRemoteConnectorService, NocturneRemoteConnectorConfiguration>>();
     }
-}
-
-public class NocturneRemoteSyncExecutor
-    : ConnectorSyncExecutor<NocturneRemoteConnectorService, NocturneRemoteConnectorConfiguration>
-{
-    public override string ConnectorId => "nocturneremote";
-
-    protected override string ConnectorName => "NocturneRemote";
 }

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/NocturneRemoteConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/NocturneRemoteConnectorInstaller.cs
@@ -41,6 +41,6 @@ public class NocturneRemoteConnectorInstaller : IConnectorInstaller
         services.AddHttpClient<NocturneRemoteConnectorService>()
             .ConfigureConnectorClient(string.IsNullOrEmpty(config.Url) ? null : config.Url);
 
-        services.AddScoped<IConnectorSyncExecutor, ConnectorSyncExecutor<NocturneRemoteConnectorService, NocturneRemoteConnectorConfiguration>>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<NocturneRemoteConnectorService, NocturneRemoteConnectorConfiguration>>();
     }
 }

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -36,13 +36,6 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
     public override string ServiceName => "Nocturne Remote";
 
     /// <summary>
-    ///     Legacy no-config overload, carrying no configuration to authenticate against. This
-    ///     connector resolves and checks the run's credential in
-    ///     <see cref="PerformSyncInternalAsync"/>, where both entry points supply their own.
-    /// </summary>
-    public override Task<bool> AuthenticateAsync() => Task.FromResult(true);
-
-    /// <summary>
     ///     Resolves the run's base URL and bearer header, then asks the remote whether it accepts the
     ///     credential. Answers with the result that ends the run, or null for a run that may proceed.
     /// </summary>

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -160,11 +160,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        if (!request.DataTypes.Any())
-            request.DataTypes = SupportedDataTypes;
-
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
-        var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
+        var activeTypes = ResolveActiveTypes(request, config);
 
         // Glucose keeps request.From: the framework derived it from the newest stored glucose
         // record, so it already is glucose's own cursor. Every other family widens it with its own

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -45,13 +45,6 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     public override string ServiceName => "Tandem Source";
 
 
-    public override Task<bool> AuthenticateAsync()
-    {
-        // Authentication runs per-tenant inside PerformSyncInternalAsync, where the config is available.
-        TrackSuccessfulRequest();
-        return Task.FromResult(true);
-    }
-
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TandemConnectorConfiguration config,

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -58,7 +58,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
-        var enabled = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
+        var activeTypes = ResolveActiveTypes(request, config);
         var region = TandemConstants.ForRegion(config.Region);
 
         try
@@ -103,9 +103,9 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
             var time = new TandemTimeResolver(config.TimezoneOffset);
 
-            await SyncProfilesAsync(device, enabled, result, config, cancellationToken);
+            await SyncProfilesAsync(device, activeTypes, result, config, cancellationToken);
 
-            await SyncEventsAsync(region, pumperId, device, enabled, time, result, config, cancellationToken);
+            await SyncEventsAsync(region, pumperId, device, activeTypes, time, result, config, cancellationToken);
         }
         catch (OperationCanceledException)
         {
@@ -124,7 +124,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     }
 
     private async Task SyncProfilesAsync(
-        TandemBffPump device, HashSet<SyncDataType> enabled, SyncResult result,
+        TandemBffPump device, HashSet<SyncDataType> activeTypes, SyncResult result,
         TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var profile = new TandemProfileMapper(_logger).Map(device.Settings?.Details);
@@ -132,13 +132,13 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             return;
 
         await PublishRecordTypeAsync<Nocturne.Core.Models.Profile>(
-            result, SyncDataType.Profiles, enabled, [profile],
+            result, SyncDataType.Profiles, activeTypes, [profile],
             PublishProfileDataAsync, config, cancellationToken);
     }
 
     private async Task SyncEventsAsync(
         TandemConstants.RegionUrls region, string pumperId, TandemBffPump device,
-        HashSet<SyncDataType> enabled, TandemTimeResolver time, SyncResult result,
+        HashSet<SyncDataType> activeTypes, TandemTimeResolver time, SyncResult result,
         TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var end = ParseWallClockUtc(device.MaxDateOfEvents, time) ?? DateTime.UtcNow;
@@ -153,7 +153,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
         // LID_DAILY_BASAL (device status) is not in the backend's default event filter, so the full
         // history log must be requested when device status is enabled — matching tconnectsync.
-        var fetchAll = config.FetchAllEventTypes || enabled.Contains(SyncDataType.DeviceStatus);
+        var fetchAll = config.FetchAllEventTypes || activeTypes.Contains(SyncDataType.DeviceStatus);
         var eventIdsFilter = fetchAll ? null : TandemConstants.DefaultEventIds;
 
         var cgm = new TandemCgmMapper(_logger, time);
@@ -194,53 +194,53 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             .ToDictionary(g => g.Key, g => g.ToList());
 
         await PublishEventsAsync(
-            groups, enabled, end, cgm, bolus, basal, deviceEvents, systemEvents,
+            groups, activeTypes, end, cgm, bolus, basal, deviceEvents, systemEvents,
             userMode, deviceStatus, result, config, cancellationToken);
     }
 
     private async Task PublishEventsAsync(
         IReadOnlyDictionary<TandemEventClass, List<TandemPumpEvent>> groups,
-        HashSet<SyncDataType> enabled, DateTime windowEnd,
+        HashSet<SyncDataType> activeTypes, DateTime windowEnd,
         TandemCgmMapper cgm, TandemBolusMapper bolus, TandemBasalMapper basal,
         TandemDeviceEventMapper deviceEvents, TandemSystemEventMapper systemEvents,
         TandemUserModeMapper userMode, TandemDeviceStatusMapper deviceStatus,
         SyncResult result, TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
         if (groups.TryGetValue(TandemEventClass.CgmReading, out var cgmEvents))
-            await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabled,
+            await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                 cgm.Map(cgmEvents), PublishSensorGlucoseDataAsync, config, cancellationToken);
 
         if (groups.TryGetValue(TandemEventClass.Bolus, out var bolusEvents))
         {
             var decomposed = bolus.Map(bolusEvents);
-            await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabled,
+            await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
                 decomposed.Boluses, PublishBolusDataAsync, config, cancellationToken);
-            await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabled,
+            await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
                 decomposed.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken);
-            await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, enabled,
+            await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, activeTypes,
                 decomposed.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken);
         }
 
         if (groups.TryGetValue(TandemEventClass.Basal, out var basalEvents))
-            await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabled,
+            await PublishRecordTypeAsync(result, SyncDataType.TempBasals, activeTypes,
                 basal.Map(basalEvents, windowEnd, config.IgnoreZeroUnitBasal), PublishTempBasalDataAsync,
                 config, cancellationToken);
 
         var devEvents = Concat(groups, TandemEventClass.Cartridge, TandemEventClass.CgmStartJoinStop,
             TandemEventClass.BasalSuspension, TandemEventClass.BasalResume);
-        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabled,
+        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
             deviceEvents.Map(devEvents), PublishDeviceEventDataAsync, config, cancellationToken);
 
         var sysEvents = Concat(groups, TandemEventClass.Alarm, TandemEventClass.CgmAlert);
-        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, enabled,
+        await PublishRecordTypeAsync(result, SyncDataType.DeviceEvents, activeTypes,
             systemEvents.Map(sysEvents), PublishSystemEventDataAsync, config, cancellationToken);
 
         if (groups.TryGetValue(TandemEventClass.UserMode, out var userModeEvents))
-            await PublishRecordTypeAsync(result, SyncDataType.StateSpans, enabled,
+            await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
                 userMode.Map(userModeEvents), PublishStateSpanDataAsync, config, cancellationToken);
 
         if (groups.TryGetValue(TandemEventClass.DeviceStatus, out var dailyBasal))
-            await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, enabled,
+            await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, activeTypes,
                 deviceStatus.Map(dailyBasal), PublishDeviceStatusAsync, config, cancellationToken);
     }
 
@@ -270,7 +270,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
     /// <summary>
     /// Resolves the start of the sync window: the earliest catch-up point across glucose and
-    /// treatments (so no enabled data type is missed), never earlier than the pump's first event.
+    /// treatments (so no active data type is missed), never earlier than the pump's first event.
     /// </summary>
     private async Task<DateTime> ResolveStartAsync(
         TandemConnectorConfiguration config, TandemBffPump device, TandemTimeResolver time)

--- a/src/Connectors/Nocturne.Connectors.Tandem/TandemConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/TandemConnectorInstaller.cs
@@ -23,7 +23,7 @@ public class TandemConnectorInstaller : IConnectorInstaller
             return;
 
         services.AddConnectorTokenProvider<TandemAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<TandemSyncExecutor>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TandemConnectorService, TandemConnectorConfiguration>>();
     }
 
     private sealed class TandemConnectorOptions : ConnectorOptions
@@ -38,12 +38,4 @@ public class TandemConnectorInstaller : IConnectorInstaller
             AddResilience = true;
         }
     }
-}
-
-public class TandemSyncExecutor
-    : ConnectorSyncExecutor<TandemConnectorService, TandemConnectorConfiguration>
-{
-    public override string ConnectorId => "tandem";
-
-    protected override string ConnectorName => "Tandem";
 }

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -46,13 +46,6 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
     protected override string ConnectorSource => DataSources.TidepoolConnector;
     public override string ServiceName => "Tidepool";
 
-    public override Task<bool> AuthenticateAsync()
-    {
-        // Auth happens per-tenant inside PerformSyncInternalAsync where config is available
-        TrackSuccessfulRequest();
-        return Task.FromResult(true);
-    }
-
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TidepoolConnectorConfiguration config,

--- a/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/Services/TidepoolConnectorService.cs
@@ -60,11 +60,7 @@ public class TidepoolConnectorService : BaseConnectorService<TidepoolConnectorCo
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
 
-        if (!request.DataTypes.Any())
-            request.DataTypes = SupportedDataTypes;
-
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes);
-        var activeTypes = request.DataTypes.Where(t => enabledTypes.Contains(t)).ToHashSet();
+        var activeTypes = ResolveActiveTypes(request, config);
 
         // Authenticate up front. The data fetches below treat a missing token as "no data" and
         // return null without raising an error, so without this gate an auth failure (e.g. bad

--- a/src/Connectors/Nocturne.Connectors.Tidepool/TidepoolConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/TidepoolConnectorInstaller.cs
@@ -23,7 +23,7 @@ public class TidepoolConnectorInstaller : IConnectorInstaller
             return;
 
         services.AddConnectorTokenProvider<TidepoolAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<TidepoolSyncExecutor>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TidepoolConnectorService, TidepoolConnectorConfiguration>>();
     }
 
     private sealed class TidepoolConnectorOptions : ConnectorOptions
@@ -40,12 +40,4 @@ public class TidepoolConnectorInstaller : IConnectorInstaller
             GetServerRegion = config => ((TidepoolConnectorConfiguration)config).Server;
         }
     }
-}
-
-public class TidepoolSyncExecutor
-    : ConnectorSyncExecutor<TidepoolConnectorService, TidepoolConnectorConfiguration>
-{
-    public override string ConnectorId => "tidepool";
-
-    protected override string ConnectorName => "Tidepool";
 }

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -49,13 +49,6 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     public override string ServiceName => "Twiist Insight";
 
 
-    public override Task<bool> AuthenticateAsync()
-    {
-        // Auth happens per-tenant inside PerformSyncInternalAsync where config is available
-        TrackSuccessfulRequest();
-        return Task.FromResult(true);
-    }
-
     protected override async Task<SyncResult> PerformSyncInternalAsync(
         SyncRequest request,
         TwiistConnectorConfiguration config,

--- a/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/Services/TwiistConnectorService.cs
@@ -62,7 +62,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
         CancellationToken cancellationToken)
     {
         var result = new SyncResult { StartTime = DateTimeOffset.UtcNow, Success = true };
-        var enabledTypes = config.GetEnabledDataTypes(SupportedDataTypes).ToHashSet();
+        var activeTypes = ResolveActiveTypes(request, config);
 
         try
         {
@@ -89,27 +89,27 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
             }
 
             // Glucose from binary blob
-            if (enabledTypes.Contains(SyncDataType.Glucose))
+            if (activeTypes.Contains(SyncDataType.Glucose))
             {
-                await SyncGlucoseAsync(package.Status, result, enabledTypes, config, cancellationToken);
+                await SyncGlucoseAsync(package.Status, result, activeTypes, config, cancellationToken);
             }
 
             // Boluses from insulin history
-            if (enabledTypes.Contains(SyncDataType.Boluses))
+            if (activeTypes.Contains(SyncDataType.Boluses))
             {
-                await SyncBolusesAsync(package.Status, result, enabledTypes, config, cancellationToken);
+                await SyncBolusesAsync(package.Status, result, activeTypes, config, cancellationToken);
             }
 
             // Carbs from meal history
-            if (enabledTypes.Contains(SyncDataType.CarbIntake))
+            if (activeTypes.Contains(SyncDataType.CarbIntake))
             {
-                await SyncCarbIntakeAsync(package.Status, result, enabledTypes, config, cancellationToken);
+                await SyncCarbIntakeAsync(package.Status, result, activeTypes, config, cancellationToken);
             }
 
             // Temp basals from the insulin-delivery blob (closed-loop enacted rates)
-            if (enabledTypes.Contains(SyncDataType.TempBasals))
+            if (activeTypes.Contains(SyncDataType.TempBasals))
             {
-                await SyncTempBasalsAsync(package.Status, result, enabledTypes, config, cancellationToken);
+                await SyncTempBasalsAsync(package.Status, result, activeTypes, config, cancellationToken);
             }
         }
         catch (OperationCanceledException)
@@ -129,7 +129,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
     }
 
     private async Task SyncGlucoseAsync(
-        TwiistStatus status, SyncResult result, HashSet<SyncDataType> enabledTypes,
+        TwiistStatus status, SyncResult result, HashSet<SyncDataType> activeTypes,
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var glucoseRecords = TwiistBlobDecoder.ParseGlucoseRecords(status.GlucoseHistory?.Data);
@@ -149,30 +149,30 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
             latest.Direction = TwiistGlucoseMapper.ParseTrend(status.Summary.LastGlucoseTrend);
         }
 
-        await PublishRecordTypeAsync(result, SyncDataType.Glucose, enabledTypes,
+        await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
             sensorGlucose, PublishSensorGlucoseDataAsync, config, cancellationToken);
     }
 
     private async Task SyncBolusesAsync(
-        TwiistStatus status, SyncResult result, HashSet<SyncDataType> enabledTypes,
+        TwiistStatus status, SyncResult result, HashSet<SyncDataType> activeTypes,
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        await PublishRecordTypeAsync(result, SyncDataType.Boluses, enabledTypes,
+        await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
             _insulinMapper.MapBoluses(status.InsulinHistory).ToList(), PublishBolusDataAsync,
             config, cancellationToken);
     }
 
     private async Task SyncCarbIntakeAsync(
-        TwiistStatus status, SyncResult result, HashSet<SyncDataType> enabledTypes,
+        TwiistStatus status, SyncResult result, HashSet<SyncDataType> activeTypes,
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, enabledTypes,
+        await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
             _mealMapper.MapMeals(status.MealHistory).ToList(), PublishCarbIntakeDataAsync,
             config, cancellationToken);
     }
 
     private async Task SyncTempBasalsAsync(
-        TwiistStatus status, SyncResult result, HashSet<SyncDataType> enabledTypes,
+        TwiistStatus status, SyncResult result, HashSet<SyncDataType> activeTypes,
         TwiistConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var scheduledRate = _tempBasalMapper.ParseScheduledRate(status.Details?.BasalRateUnitsPerHour);
@@ -180,7 +180,7 @@ public class TwiistConnectorService : BaseConnectorService<TwiistConnectorConfig
             .Concat(_tempBasalMapper.MapSuspensions(status.InsulinHistory))
             .ToList();
 
-        await PublishRecordTypeAsync(result, SyncDataType.TempBasals, enabledTypes,
+        await PublishRecordTypeAsync(result, SyncDataType.TempBasals, activeTypes,
             tempBasals, PublishTempBasalDataAsync, config, cancellationToken);
     }
 

--- a/src/Connectors/Nocturne.Connectors.Twiist/TwiistConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/TwiistConnectorInstaller.cs
@@ -23,7 +23,7 @@ public class TwiistConnectorInstaller : IConnectorInstaller
             return;
 
         services.AddConnectorTokenProvider<TwiistAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<TwiistSyncExecutor>();
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TwiistConnectorService, TwiistConnectorConfiguration>>();
     }
 
     private sealed class TwiistConnectorOptions : ConnectorOptions
@@ -34,12 +34,4 @@ public class TwiistConnectorInstaller : IConnectorInstaller
             ConnectorName = "Twiist";
         }
     }
-}
-
-public class TwiistSyncExecutor
-    : ConnectorSyncExecutor<TwiistConnectorService, TwiistConnectorConfiguration>
-{
-    public override string ConnectorId => "twiist";
-
-    protected override string ConnectorName => "Twiist";
 }

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorSyncExecutorRegistrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorSyncExecutorRegistrationTests.cs
@@ -1,0 +1,72 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Interfaces;
+using Xunit;
+
+namespace Nocturne.API.Tests.Connectors;
+
+/// <summary>
+/// Pins the dispatch id every shipped connector answers. <c>ConnectorSyncService</c> resolves an
+/// executor by matching a trigger's id against <see cref="IConnectorSyncExecutor.ConnectorId"/>, and
+/// that id is derived from the registration attribute rather than written down — so a rename of a
+/// connector's <c>ConnectorName</c> silently moves its API route segment and orphans the
+/// <c>connector_name</c> rows already stored under the old one.
+/// </summary>
+public partial class ConnectorSyncExecutorRegistrationTests
+{
+    /// <summary>
+    /// The id each connector dispatches on. <c>librelinkup</c> is the FreeStyle connector's
+    /// <c>ConnectorName</c> lowered; its <c>DataSourceId</c> ("libre") is a different key and is not
+    /// interchangeable with it.
+    /// </summary>
+    private static readonly string[] Expected =
+    [
+        "carelink", "dexcom", "eversense", "glooko", "gluroo", "librelinkup", "myfitnesspal",
+        "mylife", "nightscout", "nocturneremote", "tandem", "tidepool", "twiist",
+    ];
+
+    public static TheoryData<string> ExpectedConnectorIds() => [.. Expected];
+
+    [Theory]
+    [MemberData(nameof(ExpectedConnectorIds))]
+    public void EveryShippedConnector_RegistersAnExecutorUnderItsId(string connectorId)
+    {
+        RegisteredConnectorIds().Should().Contain(connectorId);
+    }
+
+    [Fact]
+    public void NoOtherExecutorIsRegistered()
+    {
+        // Also guards the theory: an empty registration set would leave every case above vacuous.
+        RegisteredConnectorIds().Should().BeEquivalentTo(Expected);
+    }
+
+    /// <summary>
+    /// The id is an API route segment and a stored key, so it has to survive both without escaping.
+    /// Nothing constrains the <c>ConnectorName</c> it is lowered from — a display-friendly rename to
+    /// "Nocturne Remote" would yield "nocturne remote" — so the constraint lives here.
+    /// </summary>
+    [Fact]
+    public void EveryConnectorId_IsUrlSafe()
+    {
+        RegisteredConnectorIds().Should().OnlyContain(id => UrlSafeId().IsMatch(id));
+    }
+
+    [GeneratedRegex("^[a-z0-9-]+$")]
+    private static partial Regex UrlSafeId();
+
+    private static List<string> RegisteredConnectorIds()
+    {
+        var services = new ServiceCollection();
+        services.AddConnectors(new ConfigurationBuilder().Build());
+
+        return [.. services
+            .Where(descriptor => descriptor.ServiceType == typeof(IConnectorSyncExecutor))
+            .Select(descriptor => (IConnectorSyncExecutor)Activator.CreateInstance(
+                descriptor.ImplementationType!)!)
+            .Select(executor => executor.ConnectorId)];
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.CareLink.Tests/Services/CareLinkConnectorServiceTests.cs
@@ -335,6 +335,47 @@ public class CareLinkConnectorServiceTests
             "a type the tenant switched off is never reported, stale payload or not");
     }
 
+    /// <summary>
+    /// A narrowed request re-pulls one type; every other type the tenant has switched on stays
+    /// untouched, however much of it the payload carries.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_NarrowedRequest_SyncsOnlyTheRequestedType()
+    {
+        var handler = new CareLinkFakeHandler
+        {
+            MonitorDataJson = """
+                {
+                  "currentServerTime": 1767261600000,
+                  "lastSG": { "sg": 120, "datetime": "2026-01-01T10:00:00", "kind": "SG" },
+                  "sgs": [
+                    { "sg": 120, "datetime": "2026-01-01T10:00:00", "kind": "SG" }
+                  ],
+                  "markers": [
+                    {
+                      "type": "INSULIN",
+                      "dateTime": "2026-01-01T10:00:00",
+                      "id": 1,
+                      "bolusType": "NORMAL",
+                      "programmedFastAmount": 2.5,
+                      "deliveredFastAmount": 2.5
+                    }
+                  ]
+                }
+                """
+        };
+        // The default config leaves every type switched on, so only the request can narrow the run.
+        var fixture = new ServiceFixture(handler, withPublisher: true);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.Glucose] }, fixture.Config, CancellationToken.None);
+
+        // ItemsSynced carries a key per type the run looked at, so every other type must be absent.
+        result.ItemsSynced.Keys.Should().Equal(SyncDataType.Glucose);
+        fixture.PublishedGlucose.Should().ContainSingle();
+        fixture.PublishedDeviceStatuses.Should().BeEmpty();
+    }
+
     /// <summary>Leaves only the glucose step able to publish.</summary>
     private static CareLinkConnectorConfiguration GlucoseOnlyConfiguration() => new()
     {

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorSyncExecutorTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorSyncExecutorTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Services;
+
+public class ConnectorSyncExecutorTests
+{
+    [Fact]
+    public void ConnectorId_IsTheRegisteredNameLowered()
+    {
+        Executor<AcmeConfiguration>().ConnectorId.Should().Be("acmepump");
+    }
+
+    [Fact]
+    public void ConnectorId_PrefersTheDerivedTypesOwnRegistration()
+    {
+        // A connector configured by subclassing another connector's config (Gluroo extends
+        // Nightscout) inherits its attribute too, and dispatching to the parent's id would run
+        // the wrong connector.
+        Executor<DerivedConfiguration>().ConnectorId.Should().Be("acmepumpplus");
+    }
+
+    [Fact]
+    public void ConnectorId_UnregisteredConfiguration_Throws()
+    {
+        var build = () => Executor<UnregisteredConfiguration>();
+
+        build.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ConnectorRegistrationAttribute*");
+    }
+
+    private static ConnectorSyncExecutor<StubService<TConfig>, TConfig> Executor<TConfig>()
+        where TConfig : BaseConnectorConfiguration => new();
+
+    [ConnectorRegistration("AcmePump", "acme-service", "ACME", "ConnectSource.Nightscout")]
+    private class AcmeConfiguration : BaseConnectorConfiguration;
+
+    [ConnectorRegistration("AcmePumpPlus", "acme-service", "ACME", "ConnectSource.Nightscout")]
+    private sealed class DerivedConfiguration : AcmeConfiguration;
+
+    private sealed class UnregisteredConfiguration : BaseConnectorConfiguration;
+
+    private sealed class StubService<TConfig> : IConnectorService<TConfig>
+        where TConfig : BaseConnectorConfiguration
+    {
+        public string ServiceName => nameof(StubService<TConfig>);
+        public List<SyncDataType> SupportedDataTypes => [];
+        public Task<bool> AuthenticateAsync() => Task.FromResult(true);
+        public void Dispose() { }
+
+        public Task<SyncResult> SyncDataAsync(
+            SyncRequest request, TConfig config, CancellationToken cancellationToken,
+            ISyncProgressReporter? progressReporter = null) =>
+            Task.FromResult(new SyncResult());
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorSyncExecutorTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorSyncExecutorTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
@@ -33,6 +34,29 @@ public class ConnectorSyncExecutorTests
             .WithMessage("*ConnectorRegistrationAttribute*");
     }
 
+    [Fact]
+    public void ConnectorId_DerivedConfigurationWithoutItsOwnRegistration_Throws()
+    {
+        // Answering the parent's id here would register a second executor under it, and a trigger
+        // resolves by enumeration order — one vendor's credentials fetching under another's trigger.
+        var build = () => Executor<DerivedWithoutRegistrationConfiguration>();
+
+        build.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ConnectorRegistrationAttribute*");
+    }
+
+    [Fact]
+    public void AddConnectorSyncExecutor_TwoExecutorsClaimingOneId_Throws()
+    {
+        var services = new ServiceCollection()
+            .AddConnectorSyncExecutor<ConnectorSyncExecutor<StubService<AcmeConfiguration>, AcmeConfiguration>>();
+
+        var register = () => services
+            .AddConnectorSyncExecutor<ConnectorSyncExecutor<OtherStubService, AcmeConfiguration>>();
+
+        register.Should().Throw<InvalidOperationException>().WithMessage("*acmepump*");
+    }
+
     private static ConnectorSyncExecutor<StubService<TConfig>, TConfig> Executor<TConfig>()
         where TConfig : BaseConnectorConfiguration => new();
 
@@ -44,7 +68,12 @@ public class ConnectorSyncExecutorTests
 
     private sealed class UnregisteredConfiguration : BaseConnectorConfiguration;
 
-    private sealed class StubService<TConfig> : IConnectorService<TConfig>
+    private sealed class DerivedWithoutRegistrationConfiguration : AcmeConfiguration;
+
+    /// <summary>A second service type over the same config, so two executors answer one id.</summary>
+    private sealed class OtherStubService : StubService<AcmeConfiguration>;
+
+    private class StubService<TConfig> : IConnectorService<TConfig>
         where TConfig : BaseConnectorConfiguration
     {
         public string ServiceName => nameof(StubService<TConfig>);

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServicePublishFailureTests.cs
@@ -170,7 +170,7 @@ public class GlookoConnectorServicePublishFailureTests
         var result = await service.SyncDataAsync(
             request, BuildConfig(useV3Api: true), CancellationToken.None);
 
-        request.DataTypes.Should().Contain(SyncDataType.Food,
+        result.ItemsSynced.Should().ContainKey(SyncDataType.Food,
             "the expansion must actually reach food, or the assertions below prove nothing");
         result.Success.Should().BeTrue();
         result.Errors.Should().BeEmpty();

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
@@ -194,6 +194,25 @@ public class TandemE2eSyncTests
         fixture.Publisher.SystemEvents.Should().BeEmpty();
     }
 
+    /// <summary>
+    /// A narrowed request re-pulls one type; every other type the tenant has switched on stays
+    /// untouched, however much of it the window carries.
+    /// </summary>
+    [Fact]
+    public async Task Narrowed_request_syncs_only_the_requested_type()
+    {
+        var fixture = new Fixture();
+
+        var result = await fixture.RunAsync(new SyncRequest { DataTypes = [SyncDataType.Glucose] });
+
+        // ItemsSynced carries a key per type the run looked at, so every other type must be absent.
+        result.ItemsSynced.Keys.Should().Equal(SyncDataType.Glucose);
+        fixture.Publisher.SensorGlucoses.Should().HaveCount(2);
+        fixture.Publisher.Boluses.Should().BeEmpty();
+        fixture.Publisher.TempBasals.Should().BeEmpty();
+        fixture.Publisher.DeviceEvents.Should().BeEmpty();
+    }
+
     [Fact]
     public async Task Empty_window_publishes_nothing()
     {
@@ -425,7 +444,7 @@ public class TandemE2eSyncTests
                 Publisher);
         }
 
-        public Task<SyncResult> RunAsync() =>
-            _service.SyncDataAsync(new SyncRequest(), _config, CancellationToken.None);
+        public Task<SyncResult> RunAsync(SyncRequest? request = null) =>
+            _service.SyncDataAsync(request ?? new SyncRequest(), _config, CancellationToken.None);
     }
 }

--- a/tests/Unit/Nocturne.Connectors.Twiist.Tests/Services/TwiistConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Twiist.Tests/Services/TwiistConnectorServiceTests.cs
@@ -93,6 +93,43 @@ public class TwiistConnectorServiceTests
     }
 
     [Fact]
+    public async Task SyncDataAsync_NarrowedRequest_SyncsOnlyTheRequestedType()
+    {
+        var fixture = new ServiceFixture(
+            responses: new()
+            {
+                ["/package"] = Json(new TwiistPackage { PwdId = PwdId, Status = new TwiistStatus() })
+            },
+            patientId: PwdId);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest { DataTypes = [SyncDataType.CarbIntake] }, fixture.Config, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        // ItemsSynced carries a key per type the run looked at, so the untouched three must be absent.
+        result.ItemsSynced.Keys.Should().Equal(SyncDataType.CarbIntake);
+    }
+
+    [Fact]
+    public async Task SyncDataAsync_UnfilteredRequest_SyncsEveryEnabledType()
+    {
+        var fixture = new ServiceFixture(
+            responses: new()
+            {
+                ["/package"] = Json(new TwiistPackage { PwdId = PwdId, Status = new TwiistStatus() })
+            },
+            patientId: PwdId);
+
+        var result = await fixture.Service.SyncDataAsync(
+            new SyncRequest(), fixture.Config, CancellationToken.None);
+
+        // Glucose is absent from an empty package either way: it bails before publishing when the
+        // blob decodes to nothing, so it cannot tell a narrowed run from an unfiltered one.
+        result.ItemsSynced.Keys.Should().Contain(
+            [SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.TempBasals]);
+    }
+
+    [Fact]
     public async Task SyncDataAsync_PackageNotFound_ReportsUnhealthy()
     {
         var overviews = new List<TwiistOverview> { new() { PwdId = PwdId, PwdNickname = "Pat" } };


### PR DESCRIPTION
Four items agreed with Rhys, in priority order. The first carries a live bug; the rest are DRY.

## 1. `ResolveActiveTypes` — the bug

Every `PerformSyncInternalAsync` opens by deciding which data types to sync, and two incompatible forms had grown up.

Seven connectors asked the config what was enabled and **discarded `request.DataTypes` entirely** — CareLink, Dexcom, Eversense, FreeStyle, MyFitnessPal, Tandem, Twiist. `ConnectorCursorResetService` builds a `SyncRequest` with a caller-supplied, possibly-narrower `DataTypes` so an operator can re-pull one data type; on **CareLink (7 supported types), Tandem (7) and Twiist (4)** that narrowing was silently dropped and every enabled type was re-fetched and republished. Dexcom, Eversense, FreeStyle and MyFitnessPal support exactly one type each, which is why this stayed hidden.

`ResolveActiveTypes` now owns both halves — empty means all, then intersect with what the tenant enabled — and all twelve call sites route through it.

### Mutate vs. return: returns, does not mutate

The five connectors that *did* read `request.DataTypes` expanded an empty list by writing `SupportedDataTypes` back into the request. Evidence for dropping that:

- **No production reader.** Grepping every `.DataTypes` reference in `src/` finds only three construction sites (`ServicesController:512`, `ConnectorCursorResetService:171`, `TimezoneTimelineController:113`) and the connector services themselves. Nothing reads the request after `PerformSyncInternalAsync` returns.
- **The write-back was itself a bug.** `ConnectorCursorResetService` builds **one** `SyncRequest` *outside* its per-connector loop (`:167-172`) and hands that same instance to every connector in the tenant, ordered by name. On an unfiltered tenant-wide reset the first connector to run set `request.DataTypes` to its own `SupportedDataTypes`, and every connector after it then intersected against that instead of against "all" — so e.g. Nightscout, running after Glooko, would silently skip any type Glooko does not support.
- **One test read it.** `GlookoConnectorServicePublishFailureTests.SyncDataAsync_WhenTheRequestNamesNoTypes_CountsFoodAsChecked` asserted `request.DataTypes` contained `Food` after the sync, as a guard that the expansion had actually reached food. That intent is unchanged and now reads the run's own report (`result.ItemsSynced`), which is the non-mutating observable for the same fact.

### Failing-on-`main` test

`TwiistConnectorServiceTests.SyncDataAsync_NarrowedRequest_SyncsOnlyTheRequestedType`. Against unmodified `src/`:

```
Expected result.ItemsSynced.Keys to be equal to {SyncDataType.CarbIntake},
but {SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.TempBasals}
contains 2 item(s) too many.
```

A request naming only `CarbIntake` pulled and published boluses and temp basals as well. A companion test covers the other half — an unfiltered request still reaches every enabled type.

## 2. `AuthenticateAsync()` dead stubs

`AuthenticateAsync()` was `abstract`, so all thirteen connectors implemented it and eleven had nothing to say: they authenticate per-tenant inside `PerformSyncInternalAsync`, so the no-config pre-flight the background flow runs can only admit the run. The base now carries that body as a `virtual` and the eleven overrides are gone. Only Nightscout, which is primed with a config, has real logic.

### Behaviour change: NocturneRemote

Ten of the stubs were `TrackSuccessfulRequest(); return true;`. NocturneRemote returned `true` **without** the tracking call, and adopting the shared body changes that either way. It now clears its accumulated failure count at the start of a background run, where before an unhealthy connector stayed unhealthy until a real request succeeded. `TrackSuccessfulRequest` only resets `_failedRequestCount` (which feeds `IsHealthy`); nothing else observes it. Aligning is the deliberate choice — the divergence looks like drift rather than a decision — but it is a change, not a no-op.

## 3. Per-vendor `ConnectorSyncExecutor` subclasses

Thirteen subclasses whose entire body was two property overrides: a lowercase dispatch id, and a `ConnectorName` the base never read. `ConnectorRegistrationAttribute` now exposes `ConnectorId`, `ConnectorSyncExecutor<TService, TConfig>` is concrete and reads it off `TConfig` the same way `BaseConnectorService` already reads `SupportedDataTypes`, and all thirteen subclasses are deleted.

### `ConnectorId` equality proof

`ConnectorId` is a dispatch key. Its consumers:

| Site | Use |
|---|---|
| `ConnectorSyncService:87` | `e.ConnectorId.Equals(connectorId, OrdinalIgnoreCase)` — the dispatch itself |
| `ConnectorSyncService:103` | `$"connector:{executor.ConnectorId}"` activity name |
| `ConnectorMetadataService:132` | key of `RegistrationsByConnectorId`; `GetRegistrationByConnectorId` lowers its argument |
| `DataSourceService:349,410` | the id handed to the tenant UI, which sends it back on the route |

The callers supplying that id are the route segment (`ServicesController`), the stored `ConnectorConfiguration.ConnectorName` (`ConnectorCursorResetService`) and the literal `"glooko"` (`TimezoneTimelineController`).

Machine-compared each deleted literal against `ConnectorName.ToLowerInvariant()` from the attribute, **13/13 identical**:

```
config type                            old ConnectorId   lower(attr.ConnectorName)
CareLinkConnectorConfiguration         carelink          carelink          OK
DexcomConnectorConfiguration           dexcom            dexcom            OK
EversenseConnectorConfiguration        eversense         eversense         OK
GlookoConnectorConfiguration           glooko            glooko            OK
GlurooConnectorConfiguration           gluroo            gluroo            OK
LibreLinkUpConnectorConfiguration      librelinkup       librelinkup       OK
MyFitnessPalConnectorConfiguration     myfitnesspal      myfitnesspal      OK
MyLifeConnectorConfiguration           mylife            mylife            OK
NightscoutConnectorConfiguration       nightscout        nightscout        OK
NocturneRemoteConnectorConfiguration   nocturneremote    nocturneremote    OK
TandemConnectorConfiguration           tandem            tandem            OK
TidepoolConnectorConfiguration         tidepool          tidepool          OK
TwiistConnectorConfiguration           twiist            twiist            OK
```

Every executor's `ConnectorName` override also matched its attribute's `ConnectorName` exactly, so nothing else moved either. This is not a new derivation — `ConnectorMetadataService` and `DataSourceService` already computed the id this way; the attribute now owns it and those two defer to it, so the four copies become one.

**Attribute-inheritance edge:** `GlurooConnectorConfiguration` extends `NightscoutConnectorConfiguration`, and `ConnectorRegistrationAttribute` is `Inherited` by default, so a naive lookup could resolve Gluroo to `nightscout` and dispatch to the wrong connector. `GetCustomAttribute` returns the most-derived instance, which the existing `RegisteredDataTypes` lookup already relies on (Gluroo advertises its own six data types today). `ConnectorSyncExecutorTests` now pins that explicitly, along with the derivation rule and the throw when a config carries no registration.

## 4a. Tandem's `Chunk` vs `DateChunker` — left alone, deliberately

The window arithmetic does **not** match, so swapping would change what Tandem fetches:

- `DateChunker.Chunk` is half-open: `chunkEnd = current + chunkSize`, next `current = chunkEnd`, so adjacent windows share a boundary instant.
- `TandemConnectorService.Chunk` is date-granular and **inclusive**: `windowEnd = cursor.AddDays(PumpLogsWindowDays - 1)`, next `cursor = windowEnd.AddDays(1)`.

Tandem's pump-logs endpoint expands bounds to `T00:00:00Z`–`T23:59:59Z`, so the inclusive form is what keeps windows from overlapping. For `2026-01-01 → 2026-03-01` at 28 days, Tandem yields `(01-01, 01-28), (01-29, 02-25), (02-26, 03-01)` while `DateChunker` yields `(01-01, 01-29), (01-29, 02-26), (02-26, 03-01)` — every boundary day re-fetched and re-published. `DateChunker` also has exactly one other caller (Glooko), so generalising it for a single second user would be speculative. The method already documents its inclusive semantics.

## 4b. Retryable status codes

`HttpResponseExtensions.IsRetryableError` and `BaseConnectorService`'s private `IsRetryableStatusCode` each hard-coded the same six statuses. The extension now owns the predicate over a nullable status — the shape the base needs, since it asks of an `HttpRequestException` — and `IsRetryableError` answers from it.

## Numbers

`src/`: **161 insertions, 334 deletions** across 31 files (net −173). Types removed: **13** `ConnectorSyncExecutor` subclasses. Members removed: **11** `AuthenticateAsync` overrides, **13** `ConnectorId` + **13** `ConnectorName` overrides, **2** duplicated retryable-status predicates, **12** hand-rolled active-type resolutions, **2** hand-rolled lowercase id derivations.

Build and unit tests, `main` baseline vs this branch (`Category!=Integration&Category!=Performance&Category!=E2E`, 22 assemblies):

| | assemblies | passed | failed | skipped |
|---|---|---|---|---|
| `main` @ 4e1eaaf88 | 22 | 8419 | 0 | 19 |
| this branch | 22 | 8424 | 0 | 19 |

`+5` is the two new Twiist tests and three new `ConnectorSyncExecutor` tests. Build is clean with no new warnings in any `src/Connectors` project. All four commits build individually.

Two notes on the baseline. The `ConnectorCursorReset` and `PasskeyController` tests flagged as known-flaky both **passed** on `main` here, so neither was masking anything. `tests/Performance/Nocturne.API.Performance.Tests` and the `tests/Integration` API/Infrastructure projects hang at discovery on this machine even with their categories filtered out; they are excluded from both columns, so the comparison is like-for-like.

## Out of scope

Vendor auth flows, event decoders and `GlookoV4TreatmentMapper` untouched; Nightscout's `FetchPagesAsync` not promoted to Core.
