### PR TITLE
fix(web): Updated routing for Day-In-Review + Reactive Glucose Chart

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChart.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChart.svelte
@@ -81,15 +81,14 @@
   }: Props = $props();
 
   // ---- Engine ----
-  // svelte-ignore state_referenced_locally
   const engine = createChartDataEngine({
-    dateRange,
-    focusHours,
-    initialChartData,
-    streamedHistoricalData,
-    externalPredictionData,
-    enablePredictions,
-    demoMode,
+    get dateRange() { return dateRange; },
+    get focusHours() { return focusHours; },
+    get initialChartData() { return initialChartData; },
+    get streamedHistoricalData() { return streamedHistoricalData; },
+    get externalPredictionData() { return externalPredictionData; },
+    get enablePredictions() { return enablePredictions; },
+    get demoMode() { return demoMode; },
   });
 
   // ---- Point inspection ----

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartCard.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartCard.svelte
@@ -87,15 +87,14 @@
   const isMobile = new IsMobile();
 
   // ===== ENGINE =====
-  // svelte-ignore state_referenced_locally
   const engine = createChartDataEngine({
-    dateRange,
-    focusHours: defaultFocusHours,
-    initialChartData,
-    streamedHistoricalData,
-    externalPredictionData,
-    enablePredictions: showPredictions,
-    demoMode,
+    get dateRange() { return dateRange; },
+    get focusHours() { return defaultFocusHours; },
+    get initialChartData() { return initialChartData; },
+    get streamedHistoricalData() { return streamedHistoricalData; },
+    get externalPredictionData() { return externalPredictionData; },
+    get enablePredictions() { return showPredictions; },
+    get demoMode() { return demoMode; },
   });
 
   // ===== POINT INSPECTION =====

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
@@ -79,11 +79,16 @@
     target.setDate(target.getDate() + days);
     goto(`/reports/day-in-review?date=${toDayString(target)}`, {
       invalidateAll: true,
+      replaceState: true,
     });
   }
 
-  function goBackToMonthView() {
-    goto("/calendar");
+  function goBackToPreviousView() {
+    if (window.history.length > 1) {
+      window.history.back();
+    } else {
+      goto("/calendar");
+    }
   }
 
   // Format date for display
@@ -280,10 +285,10 @@
           variant="ghost"
           size="sm"
           class="self-start @2xl:self-auto"
-          onclick={goBackToMonthView}
+          onclick={goBackToPreviousView}
         >
           <ArrowLeft class="h-4 w-4 mr-2" />
-          Back to Month View
+          Back to Previous View
         </Button>
 
         <div class="flex items-center justify-center gap-2">

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
@@ -408,12 +408,7 @@
   }
 
   function navigateToDayInReview(dateStr: string) {
-    if (reportsParams) {
-      reportsParams.setCustomRange(dateStr, dateStr);
-    }
-    goto(
-      `/reports/day-in-review?from=${dateStr}&to=${dateStr}&isDefault=false`
-    );
+    goto(`/reports/day-in-review?date=${dateStr}`);
   }
 
   // =========================================================================


### PR DESCRIPTION
## fix: improve routing reliability for day-in-review
- update navigation from `reports/year-overview` to `reports/day-in-review` to use `date` param instead of `from` and `to` params when user selects a single heatmap cell.
- update back navigation  to use `window.history` API so the user can return to prior view since user can be routed to `day-in-review` from both `/calendar with a fallback to calendar view if there is no prior route (e.g.  direct route in new browser tab)

## refactor: update glucose chart engine to use reactive getters
- Use reactive getters so that glucose charts can update with new data when the parameters change. This is most noticeable from the `reports/day-in-review` when using the arrows at the top to change the day