### PR TITLE
fix(connectors): bind ApiSecret in NocturneRemote configuration

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
@@ -90,7 +90,7 @@ public class NocturneRemoteConnectorBackgroundService : ConnectorBackgroundServi
                 var connection = new HubConnectionBuilder()
                     .WithUrl(hubUrl, options =>
                     {
-                        options.Headers.Add("Authorization", $"Bearer {config.Token}");
+                        options.Headers.Add("Authorization", $"Bearer {config.AccessToken}");
                     })
                     .WithAutomaticReconnect(new InfiniteRetryPolicy())
                     .Build();

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationBinder.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorConfigurationBinder.cs
@@ -1,12 +1,14 @@
 using System.Reflection;
 using System.Text.Json;
 using System.Linq;
+using Nocturne.Connectors.Core.Extensions;
 
 namespace Nocturne.Connectors.Core.Services;
 
 /// <summary>
 ///     Applies JSON and secret values to connector configuration objects via reflection.
-///     Extracted from ConnectorSyncExecutor for reuse by ConnectorConfigurationLoader.
+///     Uses <see cref="ConnectorPropertyAttribute.GetKeyName"/> when present so that
+///     binding matches the attribute key used by schema generation and configuration storage.
 /// </summary>
 public static class ConnectorConfigurationBinder
 {
@@ -19,7 +21,7 @@ public static class ConnectorConfigurationBinder
 
         foreach (var property in properties.Where(p => p.CanWrite))
         {
-            var camelName = char.ToLowerInvariant(property.Name[0]) + property.Name[1..];
+            var camelName = GetBoundKeyName(property);
             if (!root.TryGetProperty(camelName, out var element))
                 continue;
 
@@ -59,9 +61,17 @@ public static class ConnectorConfigurationBinder
 
         foreach (var property in properties.Where(p => p.CanWrite && p.PropertyType == typeof(string)))
         {
-            var camelName = char.ToLowerInvariant(property.Name[0]) + property.Name[1..];
+            var camelName = GetBoundKeyName(property);
             if (secrets.TryGetValue(camelName, out var value))
                 property.SetValue(config, value);
         }
     }
+
+    private static string GetBoundKeyName(PropertyInfo property)
+    {
+        var keyName = property.GetCustomAttribute<ConnectorPropertyAttribute>()?.GetKeyName()
+            ?? property.Name;
+        return char.ToLowerInvariant(keyName[0]) + keyName[1..];
+    }
 }
+

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Configurations/NocturneRemoteConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Configurations/NocturneRemoteConnectorConfiguration.cs
@@ -46,20 +46,10 @@ public class NocturneRemoteConnectorConfiguration : BaseConnectorConfiguration
     public string Url { get; set; } = string.Empty;
 
     /// <summary>
-    ///     Direct grant bearer token for the remote instance. Property name matches
-    ///     <see cref="ConnectorPropertyKey.ApiSecret"/> for reflection binder compatibility.
+    ///     Direct grant bearer token for the remote instance.
     /// </summary>
-    [ConnectorProperty(ConnectorPropertyKey.ApiSecret, Required = true, Secret = true)]
-    public string ApiSecret { get; set; } = string.Empty;
-
-    /// <summary>
-    ///     Compatibility alias for service and test callers referencing Token.
-    /// </summary>
-    public string Token
-    {
-        get => ApiSecret;
-        set => ApiSecret = value;
-    }
+    [ConnectorProperty(ConnectorPropertyKey.AccessToken, Required = true, Secret = true)]
+    public string AccessToken { get; set; } = string.Empty;
 
     /// <summary>
     ///     Page size for paginated V4 API requests.

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Configurations/NocturneRemoteConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Configurations/NocturneRemoteConnectorConfiguration.cs
@@ -46,10 +46,20 @@ public class NocturneRemoteConnectorConfiguration : BaseConnectorConfiguration
     public string Url { get; set; } = string.Empty;
 
     /// <summary>
-    ///     Direct grant bearer token for the remote instance.
+    ///     Direct grant bearer token for the remote instance. Property name matches
+    ///     <see cref="ConnectorPropertyKey.ApiSecret"/> for reflection binder compatibility.
     /// </summary>
     [ConnectorProperty(ConnectorPropertyKey.ApiSecret, Required = true, Secret = true)]
-    public string Token { get; set; } = string.Empty;
+    public string ApiSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     Compatibility alias for service and test callers referencing Token.
+    /// </summary>
+    public string Token
+    {
+        get => ApiSecret;
+        set => ApiSecret = value;
+    }
 
     /// <summary>
     ///     Page size for paginated V4 API requests.

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -450,8 +450,8 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
         var body = await response.Content.ReadAsStringAsync(ct);
 
-        if (!string.IsNullOrEmpty(config.Token))
-            body = body.Replace(config.Token, "[redacted]", StringComparison.Ordinal);
+        if (!string.IsNullOrEmpty(config.AccessToken))
+            body = body.Replace(config.AccessToken, "[redacted]", StringComparison.Ordinal);
 
         return body.Length <= maxQuotedBody ? body : body[..maxQuotedBody] + "...";
     }
@@ -612,8 +612,8 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
         _resolvedBaseUrl = url.TrimEnd('/');
 
-        _authHeaders = !string.IsNullOrEmpty(config.Token)
-            ? new Dictionary<string, string> { ["Authorization"] = $"Bearer {config.Token}" }
+        _authHeaders = !string.IsNullOrEmpty(config.AccessToken)
+            ? new Dictionary<string, string> { ["Authorization"] = $"Bearer {config.AccessToken}" }
             : null;
     }
 

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationBinderTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorConfigurationBinderTests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Services;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Services;
+
+public class ConnectorConfigurationBinderTests
+{
+    private class DifferingNameConfig : BaseConnectorConfiguration
+    {
+        [ConnectorProperty(ConnectorPropertyKey.AccessToken, Required = true, Secret = true)]
+        public string TokenPropertyWithDifferentName { get; set; } = string.Empty;
+
+        [ConnectorProperty(ConnectorPropertyKey.Url, Required = true)]
+        public string CustomUrlProperty { get; set; } = string.Empty;
+
+        public string UnattributedProperty { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void ApplySecretsToConfig_BindsViaAttributeKeyName()
+    {
+        const string secretValue = "noc_secret_12345";
+        var secrets = new Dictionary<string, string>
+        {
+            ["accessToken"] = secretValue,
+        };
+
+        var config = new DifferingNameConfig();
+        ConnectorConfigurationBinder.ApplySecretsToConfig(secrets, config);
+
+        config.TokenPropertyWithDifferentName.Should().Be(
+            secretValue,
+            "binder should resolve key name from [ConnectorProperty(ConnectorPropertyKey.AccessToken)] attribute");
+    }
+
+    [Fact]
+    public void ApplyJsonToConfig_BindsViaAttributeKeyName()
+    {
+        const string url = "https://example.com";
+        const string plainValue = "direct-property-value";
+        using var doc = JsonDocument.Parse(
+            $$"""
+            {
+                "url": "{{url}}",
+                "unattributedProperty": "{{plainValue}}"
+            }
+            """);
+
+        var config = new DifferingNameConfig();
+        ConnectorConfigurationBinder.ApplyJsonToConfig(doc, config);
+
+        config.CustomUrlProperty.Should().Be(
+            url,
+            "binder should resolve key name from [ConnectorProperty(ConnectorPropertyKey.Url)] attribute");
+        config.UnattributedProperty.Should().Be(
+            plainValue,
+            "binder should fall back to property name when no [ConnectorProperty] is present");
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Configurations/NocturneRemoteConnectorConfigurationBindingTests.cs
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Configurations/NocturneRemoteConnectorConfigurationBindingTests.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.NocturneRemote.Configurations;
+using Xunit;
+
+namespace Nocturne.Connectors.NocturneRemote.Tests.Configurations;
+
+public class NocturneRemoteConnectorConfigurationBindingTests
+{
+    [Fact]
+    public void ApplySecretsToConfig_BindsApiSecret_FromPersistedSecretKey()
+    {
+        const string secretToken = "nocturne_secret_token_12345";
+        var secrets = new Dictionary<string, string>
+        {
+            ["apiSecret"] = secretToken,
+        };
+
+        var config = new NocturneRemoteConnectorConfiguration();
+        ConnectorConfigurationBinder.ApplySecretsToConfig(secrets, config);
+
+        config.ApiSecret.Should().Be(secretToken);
+        config.Token.Should().Be(secretToken);
+    }
+
+    [Fact]
+    public void ApplyJsonToConfig_BindsUrlAndSettings_FromPersistedConfigKey()
+    {
+        const string remoteUrl = "https://nocturne.example.com";
+        using var doc = JsonDocument.Parse(
+            $$"""
+            {
+                "enabled": true,
+                "url": "{{remoteUrl}}",
+                "maxCount": 250
+            }
+            """);
+
+        var config = new NocturneRemoteConnectorConfiguration();
+        ConnectorConfigurationBinder.ApplyJsonToConfig(doc, config);
+
+        config.Url.Should().Be(remoteUrl);
+        config.MaxCount.Should().Be(250);
+        config.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConnectorProperties_HaveNameMatchingConfigKey()
+    {
+        // The binder keys off the camel-cased property NAME while values are persisted under the
+        // camel-cased ConnectorProperty KEY. If they diverge for any property, that value silently
+        // never binds. Guard the whole config so a future rename can't reintroduce the bug.
+        var mismatches = new List<string>();
+
+        foreach (var property in typeof(NocturneRemoteConnectorConfiguration)
+                     .GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var attr = property.GetCustomAttribute<ConnectorPropertyAttribute>();
+            if (attr is null)
+                continue;
+
+            var nameKey = Camel(property.Name);
+            var configKey = Camel(attr.GetKeyName());
+            if (nameKey != configKey)
+                mismatches.Add($"{property.Name} binds '{nameKey}' but persists '{configKey}'");
+        }
+
+        mismatches.Should().BeEmpty();
+    }
+
+    private static string Camel(string s) => char.ToLowerInvariant(s[0]) + s[1..];
+}

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Configurations/NocturneRemoteConnectorConfigurationBindingTests.cs
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Configurations/NocturneRemoteConnectorConfigurationBindingTests.cs
@@ -11,19 +11,18 @@ namespace Nocturne.Connectors.NocturneRemote.Tests.Configurations;
 public class NocturneRemoteConnectorConfigurationBindingTests
 {
     [Fact]
-    public void ApplySecretsToConfig_BindsApiSecret_FromPersistedSecretKey()
+    public void ApplySecretsToConfig_BindsAccessToken_FromPersistedSecretKey()
     {
-        const string secretToken = "nocturne_secret_token_12345";
+        const string secretToken = "noc_secret_token_12345";
         var secrets = new Dictionary<string, string>
         {
-            ["apiSecret"] = secretToken,
+            ["accessToken"] = secretToken,
         };
 
         var config = new NocturneRemoteConnectorConfiguration();
         ConnectorConfigurationBinder.ApplySecretsToConfig(secrets, config);
 
-        config.ApiSecret.Should().Be(secretToken);
-        config.Token.Should().Be(secretToken);
+        config.AccessToken.Should().Be(secretToken);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
+++ b/tests/Unit/Nocturne.Connectors.NocturneRemote.Tests/Services/NocturneRemoteConnectorServiceCrawlTests.cs
@@ -460,7 +460,7 @@ public class NocturneRemoteConnectorServiceCrawlTests
 
         var manual = NewConfig();
         manual.MaxCount = ManualRunPageSize;
-        manual.Token = ManualRunToken;
+        manual.AccessToken = ManualRunToken;
 
         await fixture.Service.SyncDataAsync(
             new SyncRequest { DataTypes = [SyncDataType.Glucose] },
@@ -628,7 +628,7 @@ public class NocturneRemoteConnectorServiceCrawlTests
                 new HttpResponseMessage(HttpStatusCode.BadGateway)
                 {
                     Content = new StringContent(
-                        $"upstream refused; sent authorization: Bearer {config.Token}"),
+                        $"upstream refused; sent authorization: Bearer {config.AccessToken}"),
                 });
         var fixture = new ServiceFixture(handler, config: config);
 
@@ -639,7 +639,7 @@ public class NocturneRemoteConnectorServiceCrawlTests
 
         result.Success.Should().BeFalse();
         result.Errors.Should().ContainSingle()
-            .Which.Should().NotContain(config.Token).And.Contain("HTTP 502 BadGateway");
+            .Which.Should().NotContain(config.AccessToken).And.Contain("HTTP 502 BadGateway");
     }
 
     /// <summary>
@@ -657,7 +657,7 @@ public class NocturneRemoteConnectorServiceCrawlTests
         int maxRetryAttempts = 1) => new()
     {
         Url = RemoteFakeHandler.BaseUrl,
-        Token = "direct-grant-token",
+        AccessToken = "direct-grant-token",
         MaxCount = RemoteFakeHandler.PageSize,
         // One attempt unless a test is about the budget, so each scripted response answers exactly
         // one request and a crawl script reads in the order the crawl makes them.


### PR DESCRIPTION
The NocturneRemote connector configuration decorated Token with ConnectorPropertyKey.ApiSecret. The schema generator produced the camel-cased property name "apiSecret" for the UI, while the reflection binder looked for a property named "Token" ("token"). This property name mismatch prevented entered API secrets from binding, causing sync to fail with "Not syncing: ApiSecret is required but not configured."

Rename the configuration property to ApiSecret to match the attribute key name, and retain Token as a compatibility alias. Add configuration binding unit tests to guard against future property name and attribute key drift.