### PR TITLE
Give the V4 restore quadrant and the mapper id derivation one implementation each

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SoftDeleteRestoreExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SoftDeleteRestoreExtensions.cs
@@ -1,0 +1,88 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// The soft-delete restore quadrant — restore one, restore many, page the trash, count it — over the
+/// narrowest constraint it actually needs. Reads and writes only
+/// <see cref="ITenantScoped.TenantId"/>, <see cref="ISoftDeletable.DeletedAt"/> and the key, so the
+/// span-shaped and timestamp-less types that <see cref="IV4TimeSeriesEntity"/> keeps off
+/// <see cref="Repositories.V4.V4RepositoryBase{TModel,TEntity}"/> share the base's implementation
+/// rather than retyping it.
+/// </summary>
+/// <remarks>
+/// Parameterless <c>IgnoreQueryFilters()</c> drops <see cref="NocturneDbContext.TenantFilterKey"/>
+/// along with the soft-delete filter, so the tenant predicate is re-applied by hand — without it a
+/// restore would reach across tenants. The key is read through <see cref="EF.Property{TProperty}"/>
+/// because <c>PatientDeviceEntity</c> and <c>PatientInsulinEntity</c> declare it on no interface.
+/// </remarks>
+public static class SoftDeleteRestoreExtensions
+{
+    private const string IdProperty = "Id";
+
+    /// <summary>
+    /// Clears <see cref="ISoftDeletable.DeletedAt"/> on this tenant's soft-deleted row with the given
+    /// key and returns the tracked entity.
+    /// </summary>
+    /// <param name="ctx">Tenant-pinned context.</param>
+    /// <param name="id">Key of the soft-deleted row.</param>
+    /// <param name="recordType">Domain type name, for the not-found message.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="KeyNotFoundException">No soft-deleted row with that key in this tenant.</exception>
+    public static async Task<TEntity> RestoreDeletedAsync<TEntity>(
+        this NocturneDbContext ctx, Guid id, string recordType, CancellationToken ct = default)
+        where TEntity : class, ITenantScoped, ISoftDeletable
+    {
+        var entity = await ctx.DeletedRows<TEntity>()
+            .Where(e => EF.Property<Guid>(e, IdProperty) == id)
+            .FirstOrDefaultAsync(ct)
+            ?? throw new KeyNotFoundException($"Soft-deleted {recordType} {id} not found");
+
+        entity.DeletedAt = null;
+        await ctx.SaveChangesAsync(ct);
+        return entity;
+    }
+
+    /// <summary>
+    /// Clears <see cref="ISoftDeletable.DeletedAt"/> on every soft-deleted row of this tenant whose key
+    /// is in <paramref name="ids"/>, and returns those rows. Keys that are unknown or already live are
+    /// silently skipped.
+    /// </summary>
+    public static async Task<List<TEntity>> RestoreDeletedAsync<TEntity>(
+        this NocturneDbContext ctx, IEnumerable<Guid> ids, CancellationToken ct = default)
+        where TEntity : class, ITenantScoped, ISoftDeletable
+    {
+        var idSet = ids.ToHashSet();
+        var entities = await ctx.DeletedRows<TEntity>()
+            .Where(e => idSet.Contains(EF.Property<Guid>(e, IdProperty)))
+            .ToListAsync(ct);
+
+        foreach (var entity in entities)
+            entity.DeletedAt = null;
+
+        await ctx.SaveChangesAsync(ct);
+        return entities;
+    }
+
+    /// <summary>Pages this tenant's soft-deleted rows, newest deletion first.</summary>
+    public static Task<List<TEntity>> GetDeletedAsync<TEntity>(
+        this NocturneDbContext ctx, int limit, int offset, CancellationToken ct = default)
+        where TEntity : class, ITenantScoped, ISoftDeletable
+        => ctx.DeletedRows<TEntity>()
+            .OrderByDescending(e => e.DeletedAt)
+            .Skip(offset).Take(limit)
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+    /// <summary>Counts this tenant's soft-deleted rows.</summary>
+    public static Task<int> CountDeletedAsync<TEntity>(
+        this NocturneDbContext ctx, CancellationToken ct = default)
+        where TEntity : class, ITenantScoped, ISoftDeletable
+        => ctx.DeletedRows<TEntity>().CountAsync(ct);
+
+    private static IQueryable<TEntity> DeletedRows<TEntity>(this NocturneDbContext ctx)
+        where TEntity : class, ITenantScoped, ISoftDeletable
+        => ctx.Set<TEntity>().IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null);
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SoftDeleteRestoreExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SoftDeleteRestoreExtensions.cs
@@ -4,12 +4,8 @@ using Nocturne.Infrastructure.Data.Entities;
 namespace Nocturne.Infrastructure.Data.Extensions;
 
 /// <summary>
-/// The soft-delete restore quadrant — restore one, restore many, page the trash, count it — over the
-/// narrowest constraint it actually needs. Reads and writes only
-/// <see cref="ITenantScoped.TenantId"/>, <see cref="ISoftDeletable.DeletedAt"/> and the key, so the
-/// span-shaped and timestamp-less types that <see cref="IV4TimeSeriesEntity"/> keeps off
-/// <see cref="Repositories.V4.V4RepositoryBase{TModel,TEntity}"/> share the base's implementation
-/// rather than retyping it.
+/// Restore and trash-listing over <see cref="ISoftDeletable.DeletedAt"/>, for every tenant-scoped
+/// soft-deletable row.
 /// </summary>
 /// <remarks>
 /// Parameterless <c>IgnoreQueryFilters()</c> drops <see cref="NocturneDbContext.TenantFilterKey"/>
@@ -23,12 +19,9 @@ public static class SoftDeleteRestoreExtensions
 
     /// <summary>
     /// Clears <see cref="ISoftDeletable.DeletedAt"/> on this tenant's soft-deleted row with the given
-    /// key and returns the tracked entity.
+    /// key and returns the tracked entity. <paramref name="recordType"/> names the domain type in the
+    /// not-found message.
     /// </summary>
-    /// <param name="ctx">Tenant-pinned context.</param>
-    /// <param name="id">Key of the soft-deleted row.</param>
-    /// <param name="recordType">Domain type name, for the not-found message.</param>
-    /// <param name="ct">Cancellation token.</param>
     /// <exception cref="KeyNotFoundException">No soft-deleted row with that key in this tenant.</exception>
     public static async Task<TEntity> RestoreDeletedAsync<TEntity>(
         this NocturneDbContext ctx, Guid id, string recordType, CancellationToken ct = default)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/BodyWeightMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/BodyWeightMapper.cs
@@ -16,9 +16,7 @@ public static class BodyWeightMapper
     {
         return new BodyWeightEntity
         {
-            Id = string.IsNullOrEmpty(bodyWeight.Id)
-                ? Guid.CreateVersion7()
-                : MapperHelpers.ParseIdToGuid(bodyWeight.Id),
+            Id = MapperHelpers.ParseIdToGuid(bodyWeight.Id),
             OriginalId = MongoIdUtils.IsValidMongoId(bodyWeight.Id) ? bodyWeight.Id : null,
             Mills = bodyWeight.Mills,
             WeightKg = bodyWeight.WeightKg,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/FoodMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/FoodMapper.cs
@@ -17,7 +17,7 @@ public static class FoodMapper
     {
         return new FoodEntity
         {
-            Id = string.IsNullOrEmpty(food.Id) ? Guid.CreateVersion7() : ParseIdToGuid(food.Id),
+            Id = MapperHelpers.ParseIdToGuid(food.Id),
             OriginalId = MongoIdUtils.IsValidMongoId(food.Id) ? food.Id : null,
             Type = food.Type,
             Category = food.Category,
@@ -89,21 +89,5 @@ public static class FoodMapper
         entity.HideAfterUse = food.HideAfterUse;
         entity.Hidden = food.Hidden;
         entity.Position = food.Position;
-    }
-
-    /// <summary>
-    /// Convert string ID to GUID for consistent mapping
-    /// </summary>
-    private static Guid ParseIdToGuid(string id)
-    {
-        if (Guid.TryParse(id, out var guid))
-        {
-            return guid;
-        }
-
-        // For string IDs, create a deterministic GUID
-        // This ensures consistent mapping between string ID and GUID
-        var bytes = System.Text.Encoding.UTF8.GetBytes(id.PadRight(16, '0')[..16]);
-        return new Guid(bytes);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/HeartRateMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/HeartRateMapper.cs
@@ -16,9 +16,7 @@ public static class HeartRateMapper
     {
         return new HeartRateEntity
         {
-            Id = string.IsNullOrEmpty(heartRate.Id)
-                ? Guid.CreateVersion7()
-                : MapperHelpers.ParseIdToGuid(heartRate.Id),
+            Id = MapperHelpers.ParseIdToGuid(heartRate.Id),
             OriginalId = MongoIdUtils.IsValidMongoId(heartRate.Id) ? heartRate.Id : null,
             Timestamp = heartRate.Timestamp,
             Bpm = heartRate.Bpm,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/MapperHelpers.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/MapperHelpers.cs
@@ -11,7 +11,7 @@ internal static class MapperHelpers
     /// Parse string ID to GUID. Returns a new GUID for null/empty input,
     /// or a deterministic SHA1-derived GUID for non-GUID strings.
     /// </summary>
-    public static Guid ParseIdToGuid(string id)
+    public static Guid ParseIdToGuid(string? id)
     {
         if (string.IsNullOrEmpty(id))
             return Guid.CreateVersion7();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/SettingsMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/SettingsMapper.cs
@@ -17,9 +17,7 @@ public static class SettingsMapper
     {
         return new SettingsEntity
         {
-            Id = string.IsNullOrEmpty(settings.Id)
-                ? Guid.CreateVersion7()
-                : ParseIdToGuid(settings.Id),
+            Id = MapperHelpers.ParseIdToGuid(settings.Id),
             OriginalId = MongoIdUtils.IsValidMongoId(settings.Id) ? settings.Id : null,
             Key = settings.Key,
             Value = settings.Value != null ? JsonSerializer.Serialize(settings.Value) : null,
@@ -95,21 +93,5 @@ public static class SettingsMapper
         entity.Version = settings.Version;
         entity.IsActive = settings.IsActive;
         entity.Notes = settings.Notes;
-    }
-
-    /// <summary>
-    /// Convert string ID to GUID for consistent mapping
-    /// </summary>
-    private static Guid ParseIdToGuid(string id)
-    {
-        if (Guid.TryParse(id, out var guid))
-        {
-            return guid;
-        }
-
-        // For string IDs, create a deterministic GUID
-        // This ensures consistent mapping between string ID and GUID
-        var bytes = System.Text.Encoding.UTF8.GetBytes(id.PadRight(16, '0')[..16]);
-        return new Guid(bytes);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/SleepSessionMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/SleepSessionMapper.cs
@@ -14,9 +14,7 @@ public static class SleepSessionMapper
     /// </summary>
     public static SleepSessionEntity ToEntity(SleepSession session, Guid tenantId)
     {
-        var entityId = string.IsNullOrEmpty(session.Id)
-            ? Guid.CreateVersion7()
-            : MapperHelpers.ParseIdToGuid(session.Id);
+        var entityId = MapperHelpers.ParseIdToGuid(session.Id);
 
         var entity = new SleepSessionEntity
         {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StateSpanMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StateSpanMapper.cs
@@ -16,9 +16,7 @@ public static class StateSpanMapper
     {
         return new StateSpanEntity
         {
-            Id = string.IsNullOrEmpty(stateSpan.Id)
-                ? Guid.CreateVersion7()
-                : MapperHelpers.ParseIdToGuid(stateSpan.Id),
+            Id = MapperHelpers.ParseIdToGuid(stateSpan.Id),
             Category = stateSpan.Category.ToString(),
             State = stateSpan.State ?? string.Empty,
             StartTimestamp = stateSpan.StartTimestamp,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StepCountMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/StepCountMapper.cs
@@ -16,9 +16,7 @@ public static class StepCountMapper
     {
         return new StepCountEntity
         {
-            Id = string.IsNullOrEmpty(stepCount.Id)
-                ? Guid.CreateVersion7()
-                : MapperHelpers.ParseIdToGuid(stepCount.Id),
+            Id = MapperHelpers.ParseIdToGuid(stepCount.Id),
             OriginalId = MongoIdUtils.IsValidMongoId(stepCount.Id) ? stepCount.Id : null,
             Timestamp = stepCount.Timestamp,
             Metric = stepCount.Metric,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/SystemEventMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/SystemEventMapper.cs
@@ -16,9 +16,7 @@ public static class SystemEventMapper
     {
         return new SystemEventEntity
         {
-            Id = string.IsNullOrEmpty(systemEvent.Id)
-                ? Guid.CreateVersion7()
-                : MapperHelpers.ParseIdToGuid(systemEvent.Id),
+            Id = MapperHelpers.ParseIdToGuid(systemEvent.Id),
             EventType = systemEvent.EventType.ToString(),
             Category = systemEvent.Category.ToString(),
             Code = systemEvent.Code,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/FoodRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/FoodRepository.cs
@@ -182,8 +182,7 @@ public class FoodRepository : IFoodRepository
 
         foreach (var entity in entities)
         {
-            // Resolve the row the same way reads do: a legacy Mongo _id addresses its row through
-            // OriginalId, which the id-derived key does not reproduce.
+            // A legacy Mongo _id addresses its row through OriginalId, not the derived key.
             var entityId = entity.Id;
             var originalId = entity.OriginalId;
             var existingEntity = await _context.Foods.FirstOrDefaultAsync(

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/FoodRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/FoodRepository.cs
@@ -182,9 +182,12 @@ public class FoodRepository : IFoodRepository
 
         foreach (var entity in entities)
         {
-            // Check if a food with this ID already exists
+            // Resolve the row the same way reads do: a legacy Mongo _id addresses its row through
+            // OriginalId, which the id-derived key does not reproduce.
+            var entityId = entity.Id;
+            var originalId = entity.OriginalId;
             var existingEntity = await _context.Foods.FirstOrDefaultAsync(
-                f => f.Id == entity.Id,
+                f => f.Id == entityId || (originalId != null && f.OriginalId == originalId),
                 cancellationToken
             );
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/FoodRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/FoodRepository.cs
@@ -177,11 +177,11 @@ public class FoodRepository : IFoodRepository
         CancellationToken cancellationToken = default
     )
     {
-        var entities = foods.Select(FoodMapper.ToEntity).ToList();
         var resultEntities = new List<FoodEntity>();
 
-        foreach (var entity in entities)
+        foreach (var food in foods)
         {
+            var entity = FoodMapper.ToEntity(food);
             // A legacy Mongo _id addresses its row through OriginalId, not the derived key.
             var entityId = entity.Id;
             var originalId = entity.OriginalId;
@@ -192,14 +192,13 @@ public class FoodRepository : IFoodRepository
 
             if (existingEntity != null)
             {
-                var tenantId = existingEntity.TenantId;
-                _context.Entry(existingEntity).CurrentValues.SetValues(entity);
-                existingEntity.TenantId = tenantId;
+                // Through the mapper rather than CurrentValues.SetValues: a row matched on its
+                // OriginalId has its own primary key, and copying the derived one onto it throws.
+                FoodMapper.UpdateEntity(existingEntity, food);
                 resultEntities.Add(existingEntity);
             }
             else
             {
-                // Add new entity
                 _context.Foods.Add(entity);
                 resultEntities.Add(entity);
             }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/SettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/SettingsRepository.cs
@@ -134,29 +134,35 @@ public class SettingsRepository : ISettingsRepository
         CancellationToken cancellationToken = default
     )
     {
-        var entities = settings.Select(SettingsMapper.ToEntity).ToList();
         var resultEntities = new List<SettingsEntity>();
 
-        foreach (var entity in entities)
+        foreach (var setting in settings)
         {
-            // A legacy Mongo _id addresses its row through OriginalId, not the derived key.
+            var entity = SettingsMapper.ToEntity(setting);
             var entityId = entity.Id;
             var originalId = entity.OriginalId;
-            var existingEntity = await _context.Settings.FirstOrDefaultAsync(
-                s => s.Id == entityId || (originalId != null && s.OriginalId == originalId),
-                cancellationToken
-            );
+            var key = entity.Key;
+
+            // A setting's identity is its key — that is what ix_settings_tenant_id_key enforces —
+            // so the key claims its row before either id does. Failing that, a legacy Mongo _id
+            // addresses its row through OriginalId, not the derived key.
+            var existingEntity = (string.IsNullOrEmpty(key)
+                ? null
+                : await _context.Settings.FirstOrDefaultAsync(s => s.Key == key, cancellationToken))
+                ?? await _context.Settings.FirstOrDefaultAsync(
+                    s => s.Id == entityId || (originalId != null && s.OriginalId == originalId),
+                    cancellationToken
+                );
 
             if (existingEntity != null)
             {
-                var tenantId = existingEntity.TenantId;
-                _context.Entry(existingEntity).CurrentValues.SetValues(entity);
-                existingEntity.TenantId = tenantId;
+                // Through the mapper rather than CurrentValues.SetValues: the stored row keeps its
+                // own primary key, which the derived one need not match.
+                SettingsMapper.UpdateEntity(existingEntity, setting);
                 resultEntities.Add(existingEntity);
             }
             else
             {
-                // Add new entity
                 _context.Settings.Add(entity);
                 resultEntities.Add(entity);
             }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/SettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/SettingsRepository.cs
@@ -139,8 +139,7 @@ public class SettingsRepository : ISettingsRepository
 
         foreach (var entity in entities)
         {
-            // Resolve the row the same way reads do: a legacy Mongo _id addresses its row through
-            // OriginalId, which the id-derived key does not reproduce.
+            // A legacy Mongo _id addresses its row through OriginalId, not the derived key.
             var entityId = entity.Id;
             var originalId = entity.OriginalId;
             var existingEntity = await _context.Settings.FirstOrDefaultAsync(

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/SettingsRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/SettingsRepository.cs
@@ -139,9 +139,12 @@ public class SettingsRepository : ISettingsRepository
 
         foreach (var entity in entities)
         {
-            // Check if a setting with this ID already exists
+            // Resolve the row the same way reads do: a legacy Mongo _id addresses its row through
+            // OriginalId, which the id-derived key does not reproduce.
+            var entityId = entity.Id;
+            var originalId = entity.OriginalId;
             var existingEntity = await _context.Settings.FirstOrDefaultAsync(
-                s => s.Id == entity.Id,
+                s => s.Id == entityId || (originalId != null && s.OriginalId == originalId),
                 cancellationToken
             );
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -59,7 +59,6 @@ public class BasalInjectionRepository : V4RepositoryBase<BasalInjection, BasalIn
                 BasalInjectionMapper.UpdateEntity(existing, model);
                 await ctx.SaveChangesAsync(ct);
                 var upserted = BasalInjectionMapper.ToDomainModel(existing);
-                // A single explicit upsert always broadcasts (no material-change gate on the single path).
                 await RaiseBroadcastAsync([], [upserted], [], origin, ct);
                 return upserted;
             }
@@ -101,8 +100,6 @@ public class BasalInjectionRepository : V4RepositoryBase<BasalInjection, BasalIn
         var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
         var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
 
-        // Over-fetches by a Cartesian amount; the partial unique index
-        // on (tenant_id, data_source, sync_identifier) keeps this cheap.
         var existingRows = await ctx.BasalInjections.IgnoreQueryFilters()
             .Where(e => e.TenantId == ctx.TenantId)
             .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
@@ -122,7 +119,6 @@ public class BasalInjectionRepository : V4RepositoryBase<BasalInjection, BasalIn
                 // Update in place — mirror the single-record CreateAsync path via the mapper.
                 BasalInjectionMapper.UpdateEntity(existing, BasalInjectionMapper.ToDomainModel(entity));
                 updatedEntities.Add(existing);
-                // Capture material changes now, before SaveChanges clears the modified flags.
                 if (HasMaterialChange(ctx, existing))
                     materiallyChanged.Add(existing);
             }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
@@ -7,396 +6,147 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
+using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
 /// Repository for managing <see cref="BasalInjection"/> records (discrete long-acting basal
-/// insulin injections, MDI). Soft-deletes via <c>DeletedAt</c>; the global query filter
-/// configured in <see cref="NocturneDbContext"/> excludes soft-deleted rows from reads.
+/// insulin injections, MDI). A SyncId-upsert type, so it inherits the shared CRUD/soft-delete
+/// surface from <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the sync-key
+/// behaviour as overrides. Never cross-connector dedup-linked, so it takes no
+/// <c>PostCommitDedupAsync</c> override.
 /// </summary>
-public class BasalInjectionRepository : IBasalInjectionRepository
+public class BasalInjectionRepository : V4RepositoryBase<BasalInjection, BasalInjectionEntity>, IBasalInjectionRepository
 {
-    private readonly NocturneDbContext _context;
-    private readonly IAuditContext _auditContext;
-    private readonly ILogger<BasalInjectionRepository> _logger;
-    private readonly IV4RecordBroadcaster<BasalInjection>? _broadcaster;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="BasalInjectionRepository"/> class.
     /// </summary>
-    /// <param name="context">The database context.</param>
+    /// <param name="contextFactory">The tenant database context factory.</param>
     /// <param name="auditContext">The audit context for tracking mutations.</param>
-    /// <param name="logger">The logger instance.</param>
     /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
     public BasalInjectionRepository(
-        NocturneDbContext context,
+        ITenantDbContextFactory contextFactory,
         IAuditContext auditContext,
-        ILogger<BasalInjectionRepository> logger,
         IV4RecordBroadcaster<BasalInjection>? broadcaster = null)
+        : base(contextFactory, auditContext, broadcaster)
     {
-        _context = context;
-        _auditContext = auditContext;
-        _logger = logger;
-        _broadcaster = broadcaster;
-    }
-
-    /// <summary>
-    /// Fires the native V4 broadcast for a just-committed write — but only for <see cref="WriteOrigin.Live"/>
-    /// writes (backfill imports stay silent). Mirrors the gate in <c>V4RepositoryBase.RaiseBroadcastAsync</c>.
-    /// </summary>
-    private Task RaiseBroadcastAsync(
-        IReadOnlyList<BasalInjection> created,
-        IReadOnlyList<BasalInjection> updated,
-        IReadOnlyList<Guid> deletedIds,
-        WriteOrigin origin,
-        CancellationToken ct)
-        => V4RecordBroadcast.RaiseAsync(_broadcaster, created, updated, deletedIds, origin, ct);
-
-    /// <summary>
-    /// Gets basal injection records based on filter criteria.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="device">Optional device filter.</param>
-    /// <param name="source">Optional data source filter.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <param name="offset">The number of records to skip.</param>
-    /// <param name="descending">Whether to sort by timestamp in descending order.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>A collection of basal injection records.</returns>
-    public async Task<IEnumerable<BasalInjection>> GetAsync(
-        DateTime? from,
-        DateTime? to,
-        string? device,
-        string? source,
-        int limit = 100,
-        int offset = 0,
-        bool descending = true,
-        CancellationToken ct = default
-    )
-    {
-        var query = _context.BasalInjections.AsNoTracking().AsQueryable();
-        if (from is { } fromValue)
-            query = query.Where(e => e.Timestamp >= fromValue);
-        if (to is { } toValue)
-            query = query.Where(e => e.Timestamp <= toValue);
-        if (device != null)
-            query = query.Where(e => e.Device == device);
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-
-        query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
-        var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);
-        return entities.Select(BasalInjectionMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Gets a basal injection record by its unique identifier.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The basal injection record, or null if not found.</returns>
-    public async Task<BasalInjection?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        // Use FirstOrDefaultAsync instead of FindAsync so the soft-delete global query
-        // filter (WHERE DeletedAt IS NULL) is always applied. FindAsync checks the change
-        // tracker first and can return a cached soft-deleted entity.
-        var entity = await _context.BasalInjections
-            .FirstOrDefaultAsync(e => e.Id == id, ct);
-        return entity is null ? null : BasalInjectionMapper.ToDomainModel(entity);
     }
 
     /// <inheritdoc />
-    public async Task<BasalInjection?> GetByGuidRangeAsync(Guid low, Guid high, CancellationToken ct = default)
-    {
-        var entity = await _context.BasalInjections
-            .Where(e => e.Id >= low && e.Id <= high)
-            .OrderBy(e => e.Id)
-            .FirstOrDefaultAsync(ct);
-        return entity is null ? null : BasalInjectionMapper.ToDomainModel(entity);
-    }
+    protected override BasalInjectionEntity ToEntity(BasalInjection model) => BasalInjectionMapper.ToEntity(model);
+
+    /// <inheritdoc />
+    protected override BasalInjection ToDomain(BasalInjectionEntity entity) => BasalInjectionMapper.ToDomainModel(entity);
+
+    /// <inheritdoc />
+    protected override void ApplyUpdate(BasalInjectionEntity target, BasalInjection source) => BasalInjectionMapper.UpdateEntity(target, source);
 
     /// <summary>
     /// Creates a new basal injection record. When <c>DataSource</c> and <c>SyncIdentifier</c>
     /// match an existing row for this tenant, the record is updated in place (upsert) rather
     /// than inserted — making the operation idempotent for connector replays.
-    /// Tenant scoping is implicit via the DbContext's RLS-equivalent query filter.
     /// </summary>
     /// <remarks>
     /// The controller layer has its own idempotency check that returns the existing record
     /// unchanged (HTTP semantics). This repository-level upsert exists for non-HTTP callers
     /// (connectors, background services) that need "latest wins" semantics on replay.
     /// </remarks>
-    /// <param name="model">The basal injection to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created or updated basal injection record.</returns>
-    public async Task<BasalInjection> CreateAsync(BasalInjection model, WriteOrigin origin, CancellationToken ct = default)
+    public override async Task<BasalInjection> CreateAsync(BasalInjection model, WriteOrigin origin, CancellationToken ct = default)
     {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
         if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
         {
-            var existing = await _context.BasalInjections
+            var existing = await ctx.BasalInjections
                 .FirstOrDefaultAsync(
                     e => e.DataSource == model.DataSource && e.SyncIdentifier == model.SyncIdentifier,
                     ct);
             if (existing != null)
             {
                 BasalInjectionMapper.UpdateEntity(existing, model);
-                await _context.SaveChangesAsync(ct);
+                await ctx.SaveChangesAsync(ct);
                 var upserted = BasalInjectionMapper.ToDomainModel(existing);
-                // An in-place upsert broadcasts as an update.
+                // A single explicit upsert always broadcasts (no material-change gate on the single path).
                 await RaiseBroadcastAsync([], [upserted], [], origin, ct);
                 return upserted;
             }
         }
 
         var entity = BasalInjectionMapper.ToEntity(model);
-        _context.BasalInjections.Add(entity);
-        await _context.SaveChangesAsync(ct);
+        ctx.BasalInjections.Add(entity);
+        await ctx.SaveChangesAsync(ct);
         var created = BasalInjectionMapper.ToDomainModel(entity);
         await RaiseBroadcastAsync([created], [], [], origin, ct);
         return created;
     }
 
     /// <summary>
-    /// Updates an existing basal injection record.
+    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
+    /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
+    /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
     /// </summary>
-    /// <param name="id">The unique identifier of the record to update.</param>
-    /// <param name="model">The updated record data.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The updated basal injection record.</returns>
-    public async Task<BasalInjection> UpdateAsync(Guid id, BasalInjection model, WriteOrigin origin, CancellationToken ct = default)
+    protected override async Task<UpsertSplit> SplitUpsertsAsync(
+        NocturneDbContext ctx, List<BasalInjectionEntity> entities, CancellationToken ct)
     {
-        var entity =
-            await _context.BasalInjections.FirstOrDefaultAsync(e => e.Id == id, ct)
-            ?? throw new KeyNotFoundException($"BasalInjection {id} not found");
-        BasalInjectionMapper.UpdateEntity(entity, model);
-        await _context.SaveChangesAsync(ct);
-        var updated = BasalInjectionMapper.ToDomainModel(entity);
-        await RaiseBroadcastAsync([], [updated], [], origin, ct);
-        return updated;
-    }
+        // Records without both keys keep a unique grouping key so they're not collapsed.
+        entities = entities
+            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                : $"id|{e.Id}")
+            .Select(g => g.Last())
+            .ToList();
 
-    /// <summary>
-    /// Soft-deletes a basal injection record by setting <c>DeletedAt</c>. The row remains
-    /// in the database but is excluded from reads by the global query filter.
-    /// The <c>MutationAuditInterceptor</c> writes a "delete" audit entry automatically when
-    /// it observes the null → non-null transition on <c>DeletedAt</c>.
-    /// </summary>
-    /// <param name="id">The unique identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    public async Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
-    {
-        var entity =
-            await _context.BasalInjections.FirstOrDefaultAsync(e => e.Id == id, ct)
-            ?? throw new KeyNotFoundException($"BasalInjection {id} not found");
-        entity.DeletedAt = DateTime.UtcNow;
-        await _context.SaveChangesAsync(ct);
-        await RaiseBroadcastAsync([], [], [id], origin, ct);
-    }
+        var syncKeyed = entities
+            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+            .ToList();
 
-    /// <inheritdoc />
-    public async Task<BasalInjection> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
-    {
-        var entity = await _context.BasalInjections.IgnoreQueryFilters()
-            .Where(e => e.TenantId == _context.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted BasalInjection {id} not found");
-        entity.DeletedAt = null;
-        await _context.SaveChangesAsync(ct);
-        // A restored record reappears in the dataset: broadcast it as a create so clients re-add it.
-        var restored = BasalInjectionMapper.ToDomainModel(entity);
-        await RaiseBroadcastAsync([restored], [], [], origin, ct);
-        return restored;
-    }
+        var updatedEntities = new List<BasalInjectionEntity>();
+        var materiallyChanged = new List<BasalInjectionEntity>();
+        if (syncKeyed.Count == 0)
+            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
 
-    /// <inheritdoc />
-    public async Task<IEnumerable<BasalInjection>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
-    {
-        var idSet = ids.ToHashSet();
-        var entities = await _context.BasalInjections.IgnoreQueryFilters()
-            .Where(e => e.TenantId == _context.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
+        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+        // Over-fetches by a Cartesian amount; the partial unique index
+        // on (tenant_id, data_source, sync_identifier) keeps this cheap.
+        var existingRows = await ctx.BasalInjections.IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId)
+            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
             .ToListAsync(ct);
+
+        var existingByKey = existingRows
+            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var toInsert = new List<BasalInjectionEntity>();
         foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await _context.SaveChangesAsync(ct);
-        var restored = entities.Select(BasalInjectionMapper.ToDomainModel).ToList();
-        await RaiseBroadcastAsync(restored, [], [], origin, ct);
-        return restored;
-    }
-
-    /// <inheritdoc />
-    public async Task<IEnumerable<BasalInjection>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
-    {
-        var entities = await _context.BasalInjections.IgnoreQueryFilters()
-            .Where(e => e.TenantId == _context.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(BasalInjectionMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public async Task<int> CountDeletedAsync(CancellationToken ct = default)
-    {
-        return await _context.BasalInjections.IgnoreQueryFilters()
-            .Where(e => e.TenantId == _context.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Returns the timestamp of the most recently stored basal injection, optionally scoped to a data source.
-    /// Used by connectors to resume per-source sync without re-fetching already-stored data.
-    /// </summary>
-    public async Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default)
-    {
-        var query = _context.BasalInjections.AsNoTracking().AsQueryable();
-        if (source != null)
-            query = query.Where(e => e.DataSource == source);
-        return await query.MaxAsync(e => (DateTime?)e.Timestamp, ct);
-    }
-
-    /// <summary>
-    /// Counts basal injection records within a timestamp range.
-    /// </summary>
-    /// <param name="from">Optional start timestamp filter.</param>
-    /// <param name="to">Optional end timestamp filter.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The count of matching records.</returns>
-    public async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)
-    {
-        var query = _context.BasalInjections.AsNoTracking().AsQueryable();
-        if (from is { } fromValue)
-            query = query.Where(e => e.Timestamp >= fromValue);
-        if (to is { } toValue)
-            query = query.Where(e => e.Timestamp <= toValue);
-        return await query.CountAsync(ct);
-    }
-
-    /// <summary>
-    /// Bulk-create basal injection records. Atomic (the whole insert runs in one transaction via the
-    /// connection's execution strategy) and audit-aware: rows whose latest delete was user-initiated
-    /// stay blocked from resync re-creation. Deduplicates by (DataSource, SyncIdentifier) upsert and by
-    /// LegacyId. Mirrors the established <see cref="BolusRepository"/> bulk path, minus
-    /// DeduplicationService participation (BasalInjection is LegacyId-only / SyncId-keyed, never
-    /// cross-connector dedup-linked).
-    /// </summary>
-    public async Task<IEnumerable<BasalInjection>> BulkCreateAsync(IEnumerable<BasalInjection> records, WriteOrigin origin, CancellationToken ct = default)
-    {
-        var strategy = _context.Database.CreateExecutionStrategy();
-        return await strategy.ExecuteAsync(async () =>
         {
-            await using var tx = await _context.Database.BeginTransactionAsync(ct);
-            var entities = records.Select(BasalInjectionMapper.ToEntity).ToList();
-            if (entities.Count == 0)
+            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                && !string.IsNullOrEmpty(entity.SyncIdentifier);
+            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
             {
-                await tx.CommitAsync(ct);
-                return [];
+                // Update in place — mirror the single-record CreateAsync path via the mapper.
+                BasalInjectionMapper.UpdateEntity(existing, BasalInjectionMapper.ToDomainModel(entity));
+                updatedEntities.Add(existing);
+                // Capture material changes now, before SaveChanges clears the modified flags.
+                if (HasMaterialChange(ctx, existing))
+                    materiallyChanged.Add(existing);
             }
-
-            // Intra-batch SyncIdentifier dedup: keep last occurrence per (DataSource, SyncIdentifier).
-            // Records without both keys keep a unique grouping key so they're not collapsed.
-            entities = entities
-                .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                    ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                    : $"id|{e.Id}")
-                .Select(g => g.Last())
-                .ToList();
-
-            // DB-level SyncIdentifier upsert: rows matched by (DataSource, SyncIdentifier) are updated
-            // in place rather than inserted — so a connector replay updates the existing row instead of
-            // hitting the partial unique index. Everything else falls through to the LegacyId/insert
-            // path below. Mirrors BolusRepository.
-            var updatedEntities = new List<BasalInjectionEntity>();
-            var syncKeyed = entities
-                .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-                .ToList();
-
-            if (syncKeyed.Count > 0)
+            else
             {
-                var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-                var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-                var existingRows = await _context.BasalInjections.IgnoreQueryFilters()
-                    .Where(e => e.TenantId == _context.TenantId)
-                    .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-                    .ToListAsync(ct);
-
-                var existingByKey = existingRows
-                    .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-                    .ToDictionary(g => g.Key, g => g.First());
-
-                var toInsert = new List<BasalInjectionEntity>();
-                foreach (var entity in entities)
-                {
-                    var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                        && !string.IsNullOrEmpty(entity.SyncIdentifier);
-                    if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-                    {
-                        // Update in place — mirror the single-record CreateAsync path via the mapper.
-                        var domain = BasalInjectionMapper.ToDomainModel(entity);
-                        BasalInjectionMapper.UpdateEntity(existing, domain);
-                        updatedEntities.Add(existing);
-                    }
-                    else
-                    {
-                        toInsert.Add(entity);
-                    }
-                }
-
-                if (updatedEntities.Count > 0)
-                {
-                    // Persist updates before the insert-chunking loop clears the tracker.
-                    await _context.SaveChangesAsync(ct);
-                }
-
-                entities = toInsert;
+                toInsert.Add(entity);
             }
+        }
 
-            // Batch-level dedup: keep first occurrence per LegacyId
-            entities = entities
-                .GroupBy(e => e.LegacyId ?? e.Id.ToString())
-                .Select(g => g.First())
-                .ToList();
+        if (updatedEntities.Count > 0)
+        {
+            // Persist updates before the insert-chunking loop clears the tracker.
+            await ctx.SaveChangesAsync(ct);
+        }
 
-            // DB-level dedup: filter out records whose LegacyId is blocking (active row, or a
-            // soft-deleted row whose latest delete was user-initiated). System-sweep deletes stay
-            // re-creatable. Replaces the inline existence check, which ignored the user-delete flag.
-            var legacyIds = entities
-                .Where(e => !string.IsNullOrEmpty(e.LegacyId))
-                .Select(e => e.LegacyId!)
-                .ToHashSet();
-
-            if (legacyIds.Count > 0)
-            {
-                var blockedLegacyIds = await _context.GetBlockingLegacyIdsAsync<BasalInjectionEntity>(legacyIds, ct);
-
-                entities = entities
-                    .Where(e => string.IsNullOrEmpty(e.LegacyId) || !blockedLegacyIds.Contains(e.LegacyId))
-                    .ToList();
-            }
-
-            if (entities.Count > 0)
-            {
-                const int batchSize = 500;
-                foreach (var batch in entities.Chunk(batchSize))
-                {
-                    _context.BasalInjections.AddRange(batch);
-                    await _context.SaveChangesAsync(ct);
-                    _context.ChangeTracker.Clear();
-                }
-            }
-
-            await tx.CommitAsync(ct);
-            // Inserts broadcast as create; in-place upserts broadcast as update (unconditionally —
-            // no material-change diffing on this off-base path).
-            var insertedModels = entities.Select(BasalInjectionMapper.ToDomainModel).ToList();
-            var updatedModels = updatedEntities.Select(BasalInjectionMapper.ToDomainModel).ToList();
-            await RaiseBroadcastAsync(insertedModels, updatedModels, [], origin, ct);
-            return updatedModels.Concat(insertedModels);
-        });
+        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 
     /// <summary>
@@ -404,40 +154,23 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     /// pair. The global query filter scopes the lookup to the current tenant and skips rows already
     /// soft-deleted, so a repeat call for the same key returns 0.
     /// </summary>
-    /// <param name="dataSource">The external data source name.</param>
-    /// <param name="syncIdentifier">The external sync identifier.</param>
-    /// <param name="origin">Write origin; only <see cref="WriteOrigin.Live"/> broadcasts.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of records soft-deleted.</returns>
     public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
     {
-        var entities = await _context.BasalInjections
-            .Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier)
-            .ToListAsync(ct);
-
-        if (entities.Count == 0)
-            return 0;
-
-        var now = DateTime.UtcNow;
-        foreach (var entity in entities)
-            entity.DeletedAt = now;
-
-        await _context.SaveChangesAsync(ct);
-        await RaiseBroadcastAsync([], [], entities.Select(e => e.Id).ToList(), origin, ct);
-        return entities.Count;
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        return await AuditedSoftDeleteAndBroadcastAsync(
+            ctx,
+            ctx.BasalInjections.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
+            $"sync_identifier={dataSource}/{syncIdentifier}", origin, ct);
     }
 
     /// <summary>
     /// Finds a single basal injection by data source and sync identifier. The global query
     /// filter automatically scopes the lookup to the current tenant and excludes soft-deleted rows.
     /// </summary>
-    /// <param name="dataSource">The external data source name.</param>
-    /// <param name="syncIdentifier">The external sync identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
     public async Task<BasalInjection?> FindBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
     {
-        var entity = await _context.BasalInjections
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = await ctx.BasalInjections
             .FirstOrDefaultAsync(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier, ct);
         return entity is null ? null : BasalInjectionMapper.ToDomainModel(entity);
     }
@@ -445,11 +178,15 @@ public class BasalInjectionRepository : IBasalInjectionRepository
     /// <inheritdoc />
     public async Task<IReadOnlyList<BasalInjection>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default)
     {
-        var entities = await _context.GetUnattributedAsync<BasalInjectionEntity>(from, to, limit, ct);
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entities = await ctx.GetUnattributedAsync<BasalInjectionEntity>(from, to, limit, ct);
         return entities.Select(BasalInjectionMapper.ToDomainModel).ToList();
     }
 
     /// <inheritdoc />
-    public Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default)
-        => _context.SetPatientDeviceIdsAsync<BasalInjectionEntity>(patientDeviceIdByRecordId, ct);
+    public async Task<int> SetPatientDeviceIdsAsync(IReadOnlyDictionary<Guid, Guid> patientDeviceIdByRecordId, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        return await ctx.SetPatientDeviceIdsAsync<BasalInjectionEntity>(patientDeviceIdByRecordId, ct);
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -12,20 +12,12 @@ using Nocturne.Core.Contracts.V4;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing <see cref="BasalInjection"/> records (discrete long-acting basal
-/// insulin injections, MDI). A SyncId-upsert type, so it inherits the shared CRUD/soft-delete
-/// surface from <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the sync-key
-/// behaviour as overrides. Never cross-connector dedup-linked, so it takes no
-/// <c>PostCommitDedupAsync</c> override.
+/// Repository for <see cref="BasalInjection"/> records (discrete long-acting basal insulin
+/// injections, MDI). SyncId-upsert keyed; never cross-connector dedup-linked.
 /// </summary>
 public class BasalInjectionRepository : V4RepositoryBase<BasalInjection, BasalInjectionEntity>, IBasalInjectionRepository
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BasalInjectionRepository"/> class.
-    /// </summary>
-    /// <param name="contextFactory">The tenant database context factory.</param>
-    /// <param name="auditContext">The audit context for tracking mutations.</param>
-    /// <param name="broadcaster">Optional native V4 broadcaster; null disables broadcasting.</param>
+    /// <inheritdoc />
     public BasalInjectionRepository(
         ITenantDbContextFactory contextFactory,
         IAuditContext auditContext,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientDeviceRepository.cs
@@ -2,6 +2,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
@@ -204,48 +206,27 @@ public class PatientDeviceRepository : IPatientDeviceRepository
     public async Task<PatientDevice> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.PatientDevices.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted PatientDevice {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return PatientDeviceMapper.ToDomainModel(entity);
+        return PatientDeviceMapper.ToDomainModel(await ctx.RestoreDeletedAsync<PatientDeviceEntity>(id, nameof(PatientDevice), ct));
     }
 
     /// <inheritdoc />
     public async Task<IEnumerable<PatientDevice>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.PatientDevices.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(PatientDeviceMapper.ToDomainModel);
+        return (await ctx.RestoreDeletedAsync<PatientDeviceEntity>(ids, ct)).Select(PatientDeviceMapper.ToDomainModel);
     }
 
     /// <inheritdoc />
     public async Task<IEnumerable<PatientDevice>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.PatientDevices.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(PatientDeviceMapper.ToDomainModel);
+        return (await ctx.GetDeletedAsync<PatientDeviceEntity>(limit, offset, ct)).Select(PatientDeviceMapper.ToDomainModel);
     }
 
     /// <inheritdoc />
     public async Task<int> CountDeletedAsync(CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.PatientDevices.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
+        return await ctx.CountDeletedAsync<PatientDeviceEntity>(ct);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientInsulinRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PatientInsulinRepository.cs
@@ -2,6 +2,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
 using Nocturne.Core.Contracts.V4;
@@ -128,49 +130,28 @@ public class PatientInsulinRepository : IPatientInsulinRepository
     public async Task<PatientInsulin> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.PatientInsulins.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted PatientInsulin {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return PatientInsulinMapper.ToDomainModel(entity);
+        return PatientInsulinMapper.ToDomainModel(await ctx.RestoreDeletedAsync<PatientInsulinEntity>(id, nameof(PatientInsulin), ct));
     }
 
     /// <inheritdoc />
     public async Task<IEnumerable<PatientInsulin>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.PatientInsulins.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        return entities.Select(PatientInsulinMapper.ToDomainModel);
+        return (await ctx.RestoreDeletedAsync<PatientInsulinEntity>(ids, ct)).Select(PatientInsulinMapper.ToDomainModel);
     }
 
     /// <inheritdoc />
     public async Task<IEnumerable<PatientInsulin>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.PatientInsulins.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(PatientInsulinMapper.ToDomainModel);
+        return (await ctx.GetDeletedAsync<PatientInsulinEntity>(limit, offset, ct)).Select(PatientInsulinMapper.ToDomainModel);
     }
 
     /// <inheritdoc />
     public async Task<int> CountDeletedAsync(CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.PatientInsulins.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
+        return await ctx.CountDeletedAsync<PatientInsulinEntity>(ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -250,12 +250,7 @@ public class TempBasalRepository : ITempBasalRepository
     public async Task<TempBasal> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entity = await ctx.TempBasals.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted TempBasal {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
+        var entity = await ctx.RestoreDeletedAsync<TempBasalEntity>(id, nameof(TempBasal), ct);
         // A restored record reappears in the dataset: broadcast it as a create so clients re-add it.
         var restored = TempBasalMapper.ToDomainModel(entity);
         await RaiseBroadcastAsync([restored], [], [], origin, ct);
@@ -266,14 +261,8 @@ public class TempBasalRepository : ITempBasalRepository
     public async Task<IEnumerable<TempBasal>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.TempBasals.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        var restored = entities.Select(TempBasalMapper.ToDomainModel).ToList();
+        var restored = (await ctx.RestoreDeletedAsync<TempBasalEntity>(ids, ct))
+            .Select(TempBasalMapper.ToDomainModel).ToList();
         await RaiseBroadcastAsync(restored, [], [], origin, ct);
         return restored;
     }
@@ -282,22 +271,15 @@ public class TempBasalRepository : ITempBasalRepository
     public async Task<IEnumerable<TempBasal>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        var entities = await ctx.TempBasals.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(TempBasalMapper.ToDomainModel);
+        return (await ctx.GetDeletedAsync<TempBasalEntity>(limit, offset, ct))
+            .Select(TempBasalMapper.ToDomainModel);
     }
 
     /// <inheritdoc />
     public async Task<int> CountDeletedAsync(CancellationToken ct = default)
     {
         await using var ctx = await _contextFactory.CreateAsync(ct);
-        return await ctx.TempBasals.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
+        return await ctx.CountDeletedAsync<TempBasalEntity>(ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -329,15 +329,8 @@ public abstract class V4RepositoryBase<TModel, TEntity>
 
     /// <summary>
     /// Soft-deletes <paramref name="rows"/> through the audited helper and broadcasts the removals.
-    /// Exposed so subclasses' type-specific audited deletes (e.g. DeleteBySyncIdentifierAsync) get the
-    /// same audit rows, dedup discriminator and delete events as
-    /// <see cref="DeleteByLegacyIdAsync"/> rather than hand-rolling the pair.
+    /// <paramref name="scope"/> is the key the delete was issued against, recorded on the audit row.
     /// </summary>
-    /// <param name="ctx">The tenant-scoped context <paramref name="rows"/> was built on.</param>
-    /// <param name="rows">The rows to soft-delete.</param>
-    /// <param name="scope">The key the delete was issued against, recorded on the audit row.</param>
-    /// <param name="origin">Write origin; only <see cref="WriteOrigin.Live"/> broadcasts.</param>
-    /// <param name="ct">Cancellation token.</param>
     /// <returns>The number of rows soft-deleted.</returns>
     protected async Task<int> AuditedSoftDeleteAndBroadcastAsync(
         NocturneDbContext ctx, IQueryable<TEntity> rows, string scope, WriteOrigin origin, CancellationToken ct)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -266,12 +266,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     public async Task<TModel> RestoreAsync(Guid id, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        var entity = await ctx.Set<TEntity>().IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.Id == id && e.DeletedAt != null)
-            .FirstOrDefaultAsync(ct)
-            ?? throw new KeyNotFoundException($"Soft-deleted {typeof(TModel).Name} {id} not found");
-        entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
+        var entity = await ctx.RestoreDeletedAsync<TEntity>(id, typeof(TModel).Name, ct);
         // A restored record reappears in the dataset: broadcast it as a create so clients re-add it.
         var restored = ToDomain(entity);
         await RaiseBroadcastAsync([restored], [], [], origin, ct);
@@ -282,14 +277,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     public async Task<IEnumerable<TModel>> BulkRestoreAsync(IEnumerable<Guid> ids, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        var idSet = ids.ToHashSet();
-        var entities = await ctx.Set<TEntity>().IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && idSet.Contains(e.Id) && e.DeletedAt != null)
-            .ToListAsync(ct);
-        foreach (var entity in entities)
-            entity.DeletedAt = null;
-        await ctx.SaveChangesAsync(ct);
-        var restored = entities.Select(ToDomain).ToList();
+        var restored = (await ctx.RestoreDeletedAsync<TEntity>(ids, ct)).Select(ToDomain).ToList();
         await RaiseBroadcastAsync(restored, [], [], origin, ct);
         return restored;
     }
@@ -298,22 +286,14 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     public async Task<IEnumerable<TModel>> GetDeletedAsync(int limit, int offset, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        var entities = await ctx.Set<TEntity>().IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .OrderByDescending(e => e.DeletedAt)
-            .Skip(offset).Take(limit)
-            .AsNoTracking()
-            .ToListAsync(ct);
-        return entities.Select(ToDomain);
+        return (await ctx.GetDeletedAsync<TEntity>(limit, offset, ct)).Select(ToDomain);
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CountDeletedAsync" />
     public async Task<int> CountDeletedAsync(CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.Set<TEntity>().IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt != null)
-            .CountAsync(ct);
+        return await ctx.CountDeletedAsync<TEntity>(ct);
     }
 
     /// <summary>
@@ -343,8 +323,26 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     public virtual async Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
-        var result = await ctx.AuditedSoftDeleteWithEntitiesAsync(
-            ctx.Set<TEntity>().Where(e => e.LegacyId == legacyId), AuditContext, $"legacy_id={legacyId}", ct);
+        return await AuditedSoftDeleteAndBroadcastAsync(
+            ctx, ctx.Set<TEntity>().Where(e => e.LegacyId == legacyId), $"legacy_id={legacyId}", origin, ct);
+    }
+
+    /// <summary>
+    /// Soft-deletes <paramref name="rows"/> through the audited helper and broadcasts the removals.
+    /// Exposed so subclasses' type-specific audited deletes (e.g. DeleteBySyncIdentifierAsync) get the
+    /// same audit rows, dedup discriminator and delete events as
+    /// <see cref="DeleteByLegacyIdAsync"/> rather than hand-rolling the pair.
+    /// </summary>
+    /// <param name="ctx">The tenant-scoped context <paramref name="rows"/> was built on.</param>
+    /// <param name="rows">The rows to soft-delete.</param>
+    /// <param name="scope">The key the delete was issued against, recorded on the audit row.</param>
+    /// <param name="origin">Write origin; only <see cref="WriteOrigin.Live"/> broadcasts.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The number of rows soft-deleted.</returns>
+    protected async Task<int> AuditedSoftDeleteAndBroadcastAsync(
+        NocturneDbContext ctx, IQueryable<TEntity> rows, string scope, WriteOrigin origin, CancellationToken ct)
+    {
+        var result = await ctx.AuditedSoftDeleteWithEntitiesAsync(rows, AuditContext, scope, ct);
 
         if (result.Collapsed)
             await RaiseBulkDeleteBroadcastAsync(result.Count, origin, ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -328,8 +328,8 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <summary>
-    /// Soft-deletes <paramref name="rows"/> through the audited helper and broadcasts the removals.
-    /// <paramref name="scope"/> is the key the delete was issued against, recorded on the audit row.
+    /// Audited soft-delete of <paramref name="rows"/>, with <paramref name="scope"/> naming the key
+    /// the delete was issued against on the audit row.
     /// </summary>
     /// <returns>The number of rows soft-deleted.</returns>
     protected async Task<int> AuditedSoftDeleteAndBroadcastAsync(

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/MapperIdDerivationTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/MapperIdDerivationTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data.Mappers;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Mappers;
+
+/// <summary>
+/// Pins every mapper's string-id-to-key derivation to the one in <see cref="MapperHelpers"/>: the
+/// same legacy id must address the same row whichever collection it arrives on.
+/// </summary>
+[Trait("Category", "Unit")]
+public class MapperIdDerivationTests
+{
+    private const string LegacyObjectId = "5f8d0d55b54764421b7156c3";
+
+    [Fact]
+    public void FoodMapper_DerivesTheSharedKey_ForANonGuidId()
+        => FoodMapper.ToEntity(new Food { Id = LegacyObjectId, Name = "Apple" }).Id
+            .Should().Be(MapperHelpers.ParseIdToGuid(LegacyObjectId));
+
+    [Fact]
+    public void SettingsMapper_DerivesTheSharedKey_ForANonGuidId()
+        => SettingsMapper.ToEntity(new Settings { Id = LegacyObjectId, Key = "units" }).Id
+            .Should().Be(MapperHelpers.ParseIdToGuid(LegacyObjectId));
+
+    [Fact]
+    public void FoodAndSettingsMappers_AgreeOnTheSameNonGuidId()
+        => FoodMapper.ToEntity(new Food { Id = LegacyObjectId }).Id
+            .Should().Be(SettingsMapper.ToEntity(new Settings { Id = LegacyObjectId }).Id);
+
+    /// <summary>
+    /// Ids that differ only past their sixteenth character collided under the truncating
+    /// derivation, so a create addressed one key's row and overwrote another's.
+    /// </summary>
+    [Fact]
+    public void SettingsMapper_SeparatesIdsSharingTheirFirstSixteenCharacters()
+        => SettingsMapper.ToEntity(new Settings { Id = "settings-displayUnits", Key = "displayUnits" }).Id
+            .Should().NotBe(
+                SettingsMapper.ToEntity(new Settings { Id = "settings-displayRange", Key = "displayRange" }).Id);
+
+    [Fact]
+    public void Mappers_KeepAGuidIdVerbatim()
+    {
+        var id = Guid.CreateVersion7();
+
+        FoodMapper.ToEntity(new Food { Id = id.ToString() }).Id.Should().Be(id);
+        SettingsMapper.ToEntity(new Settings { Id = id.ToString() }).Id.Should().Be(id);
+    }
+
+    [Fact]
+    public void Mappers_MintAKey_WhenNoIdIsSupplied()
+    {
+        FoodMapper.ToEntity(new Food { Id = null }).Id.Should().NotBe(Guid.Empty);
+        SettingsMapper.ToEntity(new Settings { Id = "" }).Id.Should().NotBe(Guid.Empty);
+    }
+
+    /// <summary>Only a 24-hex id is recorded as the addressable legacy id.</summary>
+    [Fact]
+    public void Mappers_RecordOnlyAMongoShapedIdAsTheOriginalId()
+    {
+        FoodMapper.ToEntity(new Food { Id = LegacyObjectId }).OriginalId.Should().Be(LegacyObjectId);
+        FoodMapper.ToEntity(new Food { Id = "food-1A2B" }).OriginalId.Should().BeNull();
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/MapperUpdateCoverageTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/MapperUpdateCoverageTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Mappers;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Mappers;
+
+/// <summary>
+/// The create paths upsert through <c>UpdateEntity</c>, so a field it forgets is a field a re-post
+/// silently fails to change. Each mapper's update is held to its own <c>ToEntity</c>.
+/// </summary>
+[Trait("Category", "Unit")]
+public class MapperUpdateCoverageTests
+{
+    [Fact]
+    public void FoodMapper_UpdateEntity_SetsEveryFieldToEntityDoes_ExceptTheIdentityLinkAndBookkeepingColumnsAStoredRowKeeps()
+    {
+        var food = new Food
+        {
+            Id = "5f8d0d55b54764421b7156c3",
+            Type = "quickpick",
+            Category = "Breakfast",
+            Subcategory = "Cereal",
+            Name = "Muesli",
+            Portion = 45.5,
+            Carbs = 31.25,
+            Fat = 7.5,
+            Protein = 4.25,
+            Energy = 880,
+            Gi = 1,
+            Unit = "g",
+            Foods = [new QuickPickFood { Name = "Oats", Portion = 30, Carbs = 20 }],
+            HideAfterUse = true,
+            Hidden = true,
+            Position = 7,
+        };
+
+        var updated = new FoodEntity();
+        FoodMapper.UpdateEntity(updated, food);
+
+        updated.Should().BeEquivalentTo(FoodMapper.ToEntity(food), opts => opts
+            .Excluding(e => e.Id)
+            .Excluding(e => e.TenantId)
+            .Excluding(e => e.OriginalId)
+            .Excluding(e => e.ExternalSource)
+            .Excluding(e => e.ExternalId)
+            .Excluding(e => e.SysCreatedAt)
+            .Excluding(e => e.SysUpdatedAt)
+            .Excluding(e => e.AdditionalPropertiesJson));
+    }
+
+    [Fact]
+    public void SettingsMapper_UpdateEntity_SetsEveryFieldToEntityDoes_ExceptTheIdentityAndBookkeepingColumnsAStoredRowKeeps()
+    {
+        var settings = new Settings
+        {
+            Id = "5f8d0d55b54764421b7156c3",
+            Key = "displayUnits",
+            Value = "mg/dl",
+            CreatedAt = "2026-06-10T08:00:00.000Z",
+            Mills = 1_780_000_000_000,
+            UtcOffset = 600,
+            SrvCreated = new DateTimeOffset(2026, 6, 10, 8, 0, 0, TimeSpan.Zero),
+            SrvModified = new DateTimeOffset(2026, 6, 11, 8, 0, 0, TimeSpan.Zero),
+            App = "nocturne",
+            Device = "phone",
+            EnteredBy = "tester",
+            Version = 3,
+            IsActive = false,
+            Notes = "a note",
+        };
+
+        var updated = new SettingsEntity();
+        SettingsMapper.UpdateEntity(updated, settings);
+
+        updated.Should().BeEquivalentTo(SettingsMapper.ToEntity(settings), opts => opts
+            .Excluding(e => e.Id)
+            .Excluding(e => e.TenantId)
+            .Excluding(e => e.OriginalId)
+            .Excluding(e => e.SysCreatedAt)
+            .Excluding(e => e.SysUpdatedAt)
+            .Excluding(e => e.AdditionalPropertiesJson));
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CreateProbeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CreateProbeTests.cs
@@ -186,6 +186,21 @@ public class CreateProbeTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateSettings_FallsBackToTheLegacyId_WhenNoRowHoldsTheKey()
+    {
+        var storedId = SeedSetting(Guid.CreateVersion7(), LegacyObjectId, "displayUnits", "\"mmol\"");
+
+        await _settings.CreateSettingsAsync(
+            [new Settings { Id = LegacyObjectId, Key = "glucoseUnits", Value = "mg/dl" }]);
+
+        var rows = await ReadSettingsAsync();
+        rows.Should().ContainSingle("the legacy id names an existing row even when its key is being renamed");
+        rows[0].Id.Should().Be(storedId);
+        rows[0].Key.Should().Be("glucoseUnits");
+        rows[0].Value.Should().Be("\"mg/dl\"");
+    }
+
+    [Fact]
     public async Task CreateSettings_InsertsANewKey()
     {
         SeedSetting(Guid.CreateVersion7(), null, "displayUnits", "\"mmol\"");

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CreateProbeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/CreateProbeTests.cs
@@ -1,0 +1,197 @@
+using System.Data.Common;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Repositories;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories;
+
+/// <summary>
+/// The create paths for foods and settings are upserts: they resolve the row the incoming id names
+/// before inserting. Both populations that carry a legacy Nightscout <c>_id</c> — rows written by
+/// the migration job, and rows written by the mapper before its key derivation changed — hold that
+/// id in <c>OriginalId</c> and a primary key that does not follow from it.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class CreateProbeTests : IDisposable
+{
+    private const string LegacyObjectId = "5f8d0d55b54764421b7156c3";
+
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _options;
+    private readonly NocturneDbContext _context;
+    private readonly FoodRepository _foods;
+    private readonly SettingsRepository _settings;
+
+    public CreateProbeTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seed = new NocturneDbContext(_options) { TenantId = TestTenantId })
+        {
+            seed.Database.EnsureCreated();
+            seed.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seed.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(_options) { TenantId = TestTenantId };
+        _foods = new FoodRepository(_context);
+        _settings = new SettingsRepository(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>The key the mapper derived before it moved to the shared SHA1 derivation.</summary>
+    private static Guid PaddedKey(string id) =>
+        new(Encoding.UTF8.GetBytes(id.PadRight(16, '0')[..16]));
+
+    private Guid SeedFood(Guid id, string? originalId, string name)
+    {
+        _context.Foods.Add(new FoodEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            OriginalId = originalId,
+            Name = name,
+            Carbs = 10,
+        });
+        _context.SaveChanges();
+        _context.ChangeTracker.Clear();
+        return id;
+    }
+
+    private Guid SeedSetting(Guid id, string? originalId, string key, string value)
+    {
+        _context.Settings.Add(new SettingsEntity
+        {
+            Id = id,
+            TenantId = TestTenantId,
+            OriginalId = originalId,
+            Key = key,
+            Value = value,
+        });
+        _context.SaveChanges();
+        _context.ChangeTracker.Clear();
+        return id;
+    }
+
+    private async Task<List<FoodEntity>> ReadFoodsAsync()
+    {
+        await using var verify = new NocturneDbContext(_options) { TenantId = TestTenantId };
+        return await verify.Foods.AsNoTracking().ToListAsync();
+    }
+
+    private async Task<List<SettingsEntity>> ReadSettingsAsync()
+    {
+        await using var verify = new NocturneDbContext(_options) { TenantId = TestTenantId };
+        return await verify.Settings.AsNoTracking().ToListAsync();
+    }
+
+    [Fact]
+    public async Task CreateFood_UpdatesAMigratedRowInPlace_WhenTheLegacyIdComesBack()
+    {
+        // What MigrationJobService writes: a minted key, the Mongo _id kept as OriginalId.
+        var storedId = SeedFood(Guid.CreateVersion7(), LegacyObjectId, "Apple");
+
+        await _foods.CreateFoodAsync([new Food { Id = LegacyObjectId, Name = "Apple (edited)", Carbs = 12 }]);
+
+        var rows = await ReadFoodsAsync();
+        rows.Should().ContainSingle();
+        rows[0].Id.Should().Be(storedId, "the stored row keeps its own primary key");
+        rows[0].OriginalId.Should().Be(LegacyObjectId);
+        rows[0].Name.Should().Be("Apple (edited)");
+        rows[0].Carbs.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task CreateFood_UpdatesARowStoredUnderTheOldDerivation_WhenTheLegacyIdComesBack()
+    {
+        var storedId = SeedFood(PaddedKey(LegacyObjectId), LegacyObjectId, "Apple");
+
+        await _foods.CreateFoodAsync([new Food { Id = LegacyObjectId, Name = "Apple (edited)" }]);
+
+        var rows = await ReadFoodsAsync();
+        rows.Should().ContainSingle();
+        rows[0].Id.Should().Be(storedId);
+        rows[0].Name.Should().Be("Apple (edited)");
+    }
+
+    [Fact]
+    public async Task CreateFood_KeepsTheLegacyIdAddressable_WhenTheRowIsMatchedByItsKey()
+    {
+        var storedId = SeedFood(Guid.CreateVersion7(), LegacyObjectId, "Apple");
+
+        await _foods.CreateFoodAsync([new Food { Id = storedId.ToString(), Name = "Apple (edited)" }]);
+
+        var rows = await ReadFoodsAsync();
+        rows.Should().ContainSingle();
+        rows[0].OriginalId.Should().Be(LegacyObjectId, "an update must not drop the legacy handle reads resolve on");
+    }
+
+    [Fact]
+    public async Task CreateFood_InsertsWhenNothingMatches()
+    {
+        SeedFood(Guid.CreateVersion7(), LegacyObjectId, "Apple");
+
+        await _foods.CreateFoodAsync([new Food { Id = "5f8d0d55b54764421b7156ff", Name = "Banana" }]);
+
+        (await ReadFoodsAsync()).Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task CreateSettings_UpdatesTheRowHoldingTheKey_WhenTheIdIsUnrecognised()
+    {
+        // The unique index is (tenant_id, key), so an unmatched id must not become a second row.
+        var storedId = SeedSetting(Guid.CreateVersion7(), null, "displayUnits", "\"mmol\"");
+
+        await _settings.CreateSettingsAsync(
+            [new Settings { Id = "settings-displayUnits", Key = "displayUnits", Value = "mg/dl" }]);
+
+        var rows = await ReadSettingsAsync();
+        rows.Should().ContainSingle();
+        rows[0].Id.Should().Be(storedId);
+        rows[0].Value.Should().Be("\"mg/dl\"");
+    }
+
+    [Fact]
+    public async Task CreateSettings_UpdatesAMigratedRowInPlace_WhenTheLegacyIdComesBack()
+    {
+        var storedId = SeedSetting(PaddedKey(LegacyObjectId), LegacyObjectId, "displayUnits", "\"mmol\"");
+
+        await _settings.CreateSettingsAsync(
+            [new Settings { Id = LegacyObjectId, Key = "displayUnits", Value = "mg/dl" }]);
+
+        var rows = await ReadSettingsAsync();
+        rows.Should().ContainSingle();
+        rows[0].Id.Should().Be(storedId);
+        rows[0].OriginalId.Should().Be(LegacyObjectId);
+    }
+
+    [Fact]
+    public async Task CreateSettings_InsertsANewKey()
+    {
+        SeedSetting(Guid.CreateVersion7(), null, "displayUnits", "\"mmol\"");
+
+        await _settings.CreateSettingsAsync([new Settings { Id = "", Key = "theme", Value = "dark" }]);
+
+        (await ReadSettingsAsync()).Select(s => s.Key).Should().BeEquivalentTo(["displayUnits", "theme"]);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/BasalInjectionRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/BasalInjectionRepositoryTests.cs
@@ -2,12 +2,12 @@ using System.Data.Common;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 using Nocturne.Core.Contracts.V4;
 
@@ -46,9 +46,8 @@ public class BasalInjectionRepositoryTests : IDisposable
         _context.TenantId = TestTenantId;
 
         _repo = new BasalInjectionRepository(
-            _context,
-            new Mock<IAuditContext>().Object,
-            NullLogger<BasalInjectionRepository>.Instance);
+            new TestTenantDbContextFactory(_context),
+            new Mock<IAuditContext>().Object);
     }
 
     public void Dispose()
@@ -167,6 +166,24 @@ public class BasalInjectionRepositoryTests : IDisposable
             .FirstOrDefaultAsync(e => e.Id == created.Id);
         raw.Should().NotBeNull();
         raw!.DeletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteBySyncIdentifierAsync_records_the_delete_and_stamps_the_dedup_flag()
+    {
+        var created = await _repo.CreateAsync(MakeInjection("aaps", "sync-7"), WriteOrigin.Live);
+
+        await _repo.DeleteBySyncIdentifierAsync("aaps", "sync-7", WriteOrigin.Live);
+
+        await using var verify = new NocturneDbContext(_contextOptions) { TenantId = TestTenantId };
+        var raw = await verify.BasalInjections.IgnoreQueryFilters().SingleAsync(e => e.Id == created.Id);
+        verify.Entry(raw).Property("DeletedByUser").CurrentValue.Should().Be(true);
+
+        var audit = await verify.Set<MutationAuditLogEntity>()
+            .Where(a => a.EntityId == created.Id && a.Action == "delete")
+            .ToListAsync();
+        audit.Should().ContainSingle();
+        audit[0].EntityType.Should().Be("BasalInjection");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/BasalInjectionRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/BasalInjectionRepositoryTests.cs
@@ -106,12 +106,6 @@ public class BasalInjectionRepositoryTests : IDisposable
         found.Should().BeNull();
     }
 
-    // The end-to-end "soft-delete writes a MutationAuditLogEntity 'delete' entry"
-    // assertion is intentionally NOT made here. The audit interceptor lives outside
-    // the repository and is wired only by the production composition root, so a
-    // unit-test fixture cannot exercise it without duplicating that wiring. The
-    // assertion belongs at integration-test level where the full interceptor stack
-    // is live (Phase 3 / Task 3.3 BasalInjectionIntegrationTests).
     [Fact]
     public async Task DeleteAsync_sets_DeletedAt()
     {

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceAttributionBackstampTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DeviceAttributionBackstampTests.cs
@@ -61,7 +61,7 @@ public class DeviceAttributionBackstampTests : IDisposable
 
         _boluses = new BolusRepository(factory, dedup, audit, NullLogger<BolusRepository>.Instance);
         _tempBasals = new TempBasalRepository(factory, dedup, audit, NullLogger<TempBasalRepository>.Instance);
-        _basalInjections = new BasalInjectionRepository(_context, audit, NullLogger<BasalInjectionRepository>.Instance);
+        _basalInjections = new BasalInjectionRepository(factory, audit);
         _meterGlucose = new MeterGlucoseRepository(factory, audit, NullLogger<MeterGlucoseRepository>.Instance);
         _deviceEvents = new DeviceEventRepository(factory, dedup, audit, NullLogger<DeviceEventRepository>.Instance);
     }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SoftDeleteRestoreQuadrantTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SoftDeleteRestoreQuadrantTests.cs
@@ -1,0 +1,244 @@
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Covers the shared restore quadrant on the two repository shapes that stay off
+/// <c>V4RepositoryBase</c>: TempBasal (span-shaped, keys on StartTimestamp) and PatientDevice
+/// (no timestamp column at all). Both reach it through <c>SoftDeleteRestoreExtensions</c>, so this
+/// pins the tenant scoping and the already-live edge that the extension is responsible for.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class SoftDeleteRestoreQuadrantTests : IDisposable
+{
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-0000000000aa");
+    private static readonly Guid TenantB = Guid.Parse("00000000-0000-0000-0000-0000000000bb");
+    private static readonly DateTime Base = new(2026, 6, 10, 8, 0, 0, DateTimeKind.Utc);
+
+    private readonly DbConnection _connection;
+    private readonly NocturneDbContext _contextA;
+    private readonly NocturneDbContext _contextB;
+    private readonly TempBasalRepository _tempBasalsA;
+    private readonly TempBasalRepository _tempBasalsB;
+    private readonly PatientDeviceRepository _devicesA;
+    private readonly PatientDeviceRepository _devicesB;
+
+    public SoftDeleteRestoreQuadrantTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seed = new NocturneDbContext(options) { TenantId = TenantA })
+        {
+            seed.Database.EnsureCreated();
+            seed.Tenants.Add(new TenantEntity { Id = TenantA, Slug = "tenant-a" });
+            seed.Tenants.Add(new TenantEntity { Id = TenantB, Slug = "tenant-b" });
+            seed.SaveChanges();
+        }
+
+        _contextA = new NocturneDbContext(options) { TenantId = TenantA };
+        _contextB = new NocturneDbContext(options) { TenantId = TenantB };
+
+        var dedup = new Mock<IDeduplicationService>().Object;
+        var audit = new Mock<IAuditContext>().Object;
+
+        _tempBasalsA = new TempBasalRepository(
+            new TestTenantDbContextFactory(_contextA), dedup, audit, NullLogger<TempBasalRepository>.Instance);
+        _tempBasalsB = new TempBasalRepository(
+            new TestTenantDbContextFactory(_contextB), dedup, audit, NullLogger<TempBasalRepository>.Instance);
+        _devicesA = new PatientDeviceRepository(
+            new TestTenantDbContextFactory(_contextA), NullLogger<PatientDeviceRepository>.Instance);
+        _devicesB = new PatientDeviceRepository(
+            new TestTenantDbContextFactory(_contextB), NullLogger<PatientDeviceRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _contextA.Dispose();
+        _contextB.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static TempBasal NewTempBasal(DateTime start) => new()
+    {
+        StartTimestamp = start,
+        UtcOffset = 0,
+        Rate = 1.0,
+        Origin = TempBasalOrigin.Manual,
+    };
+
+    private static PatientDevice NewDevice(string model) => new()
+    {
+        DeviceCategory = DeviceCategory.InsulinPump,
+        Manufacturer = "Tandem",
+        Model = model,
+        IsCurrent = true,
+    };
+
+    /// <summary>Stamps <c>DeletedAt</c> directly so ordering assertions get distinct, known values.</summary>
+    private static void SoftDelete<TEntity>(NocturneDbContext ctx, Guid id, DateTime deletedAt)
+        where TEntity : class, ISoftDeletable
+    {
+        var entity = ctx.Set<TEntity>().IgnoreQueryFilters()
+            .Single(e => EF.Property<Guid>(e, "Id") == id);
+        entity.DeletedAt = deletedAt;
+        ctx.SaveChanges();
+        ctx.ChangeTracker.Clear();
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ClearsDeletedAt_AndTheRecordIsReadableAgain()
+    {
+        var created = await _tempBasalsA.CreateAsync(NewTempBasal(Base), WriteOrigin.Live);
+        SoftDelete<TempBasalEntity>(_contextA, created.Id, Base.AddHours(1));
+
+        var restored = await _tempBasalsA.RestoreAsync(created.Id, WriteOrigin.Live);
+
+        restored.Id.Should().Be(created.Id);
+        _contextA.TempBasals.IgnoreQueryFilters()
+            .Single(e => e.Id == created.Id).DeletedAt.Should().BeNull();
+        (await _tempBasalsA.GetByIdAsync(created.Id)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Throws_WhenTheRecordIsNotDeleted()
+    {
+        var created = await _tempBasalsA.CreateAsync(NewTempBasal(Base), WriteOrigin.Live);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _tempBasalsA.RestoreAsync(created.Id, WriteOrigin.Live));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Throws_AndLeavesTheRowDeleted_WhenItBelongsToAnotherTenant()
+    {
+        var created = await _tempBasalsB.CreateAsync(NewTempBasal(Base), WriteOrigin.Live);
+        SoftDelete<TempBasalEntity>(_contextB, created.Id, Base.AddHours(1));
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _tempBasalsA.RestoreAsync(created.Id, WriteOrigin.Live));
+
+        _contextB.TempBasals.IgnoreQueryFilters()
+            .Single(e => e.Id == created.Id).DeletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task BulkRestoreAsync_RestoresOnlyTheSoftDeletedIds()
+    {
+        var deleted = await _tempBasalsA.CreateAsync(NewTempBasal(Base), WriteOrigin.Live);
+        var live = await _tempBasalsA.CreateAsync(NewTempBasal(Base.AddMinutes(30)), WriteOrigin.Live);
+        SoftDelete<TempBasalEntity>(_contextA, deleted.Id, Base.AddHours(1));
+
+        var restored = (await _tempBasalsA.BulkRestoreAsync(
+            [deleted.Id, live.Id, Guid.CreateVersion7()], WriteOrigin.Live)).ToList();
+
+        restored.Select(r => r.Id).Should().Equal(deleted.Id);
+        _contextA.TempBasals.IgnoreQueryFilters()
+            .Count(e => e.DeletedAt == null).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task BulkRestoreAsync_LeavesAnotherTenantsSoftDeletedRowsAlone()
+    {
+        var mine = await _tempBasalsA.CreateAsync(NewTempBasal(Base), WriteOrigin.Live);
+        var theirs = await _tempBasalsB.CreateAsync(NewTempBasal(Base), WriteOrigin.Live);
+        SoftDelete<TempBasalEntity>(_contextA, mine.Id, Base.AddHours(1));
+        SoftDelete<TempBasalEntity>(_contextB, theirs.Id, Base.AddHours(1));
+
+        var restored = (await _tempBasalsA.BulkRestoreAsync([mine.Id, theirs.Id], WriteOrigin.Live)).ToList();
+
+        restored.Select(r => r.Id).Should().Equal(mine.Id);
+        _contextB.TempBasals.IgnoreQueryFilters()
+            .Single(e => e.Id == theirs.Id).DeletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetDeletedAsync_OrdersByNewestDeletionFirst_AndPages()
+    {
+        var oldest = await _devicesA.CreateAsync(NewDevice("oldest"), WriteOrigin.Live);
+        var middle = await _devicesA.CreateAsync(NewDevice("middle"), WriteOrigin.Live);
+        var newest = await _devicesA.CreateAsync(NewDevice("newest"), WriteOrigin.Live);
+        SoftDelete<PatientDeviceEntity>(_contextA, oldest.Id, Base);
+        SoftDelete<PatientDeviceEntity>(_contextA, middle.Id, Base.AddHours(1));
+        SoftDelete<PatientDeviceEntity>(_contextA, newest.Id, Base.AddHours(2));
+
+        var page = (await _devicesA.GetDeletedAsync(limit: 2, offset: 0)).ToList();
+        var next = (await _devicesA.GetDeletedAsync(limit: 2, offset: 2)).ToList();
+
+        page.Select(d => d.Id).Should().Equal(newest.Id, middle.Id);
+        next.Select(d => d.Id).Should().Equal(oldest.Id);
+    }
+
+    [Fact]
+    public async Task GetDeletedAsync_ExcludesLiveRowsAndOtherTenants()
+    {
+        var mine = await _devicesA.CreateAsync(NewDevice("mine"), WriteOrigin.Live);
+        await _devicesA.CreateAsync(NewDevice("still-live"), WriteOrigin.Live);
+        var theirs = await _devicesB.CreateAsync(NewDevice("theirs"), WriteOrigin.Live);
+        SoftDelete<PatientDeviceEntity>(_contextA, mine.Id, Base);
+        SoftDelete<PatientDeviceEntity>(_contextB, theirs.Id, Base);
+
+        var deleted = (await _devicesA.GetDeletedAsync(limit: 50, offset: 0)).ToList();
+
+        deleted.Select(d => d.Id).Should().Equal(mine.Id);
+    }
+
+    [Fact]
+    public async Task CountDeletedAsync_CountsOnlyThisTenantsDeletedRows()
+    {
+        var mine = await _devicesA.CreateAsync(NewDevice("mine"), WriteOrigin.Live);
+        await _devicesA.CreateAsync(NewDevice("still-live"), WriteOrigin.Live);
+        var theirs = await _devicesB.CreateAsync(NewDevice("theirs"), WriteOrigin.Live);
+        SoftDelete<PatientDeviceEntity>(_contextA, mine.Id, Base);
+        SoftDelete<PatientDeviceEntity>(_contextB, theirs.Id, Base);
+
+        (await _devicesA.CountDeletedAsync()).Should().Be(1);
+        (await _devicesB.CountDeletedAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ClearsDeletedAt_OnAnEntityWithNoTimestampColumn()
+    {
+        var created = await _devicesA.CreateAsync(NewDevice("t:slim X2"), WriteOrigin.Live);
+        SoftDelete<PatientDeviceEntity>(_contextA, created.Id, Base);
+
+        var restored = await _devicesA.RestoreAsync(created.Id, WriteOrigin.Live);
+
+        restored.Id.Should().Be(created.Id);
+        (await _devicesA.CountDeletedAsync()).Should().Be(0);
+        (await _devicesA.GetAllAsync()).Select(d => d.Id).Should().Equal(created.Id);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_Throws_ForAnotherTenantsDeviceWithNoTimestampColumn()
+    {
+        var theirs = await _devicesB.CreateAsync(NewDevice("theirs"), WriteOrigin.Live);
+        SoftDelete<PatientDeviceEntity>(_contextB, theirs.Id, Base);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _devicesA.RestoreAsync(theirs.Id, WriteOrigin.Live));
+
+        (await _devicesB.CountDeletedAsync()).Should().Be(1);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SoftDeleteRestoreQuadrantTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SoftDeleteRestoreQuadrantTests.cs
@@ -17,10 +17,10 @@ using Xunit;
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
 /// <summary>
-/// Covers the shared restore quadrant on the two repository shapes that stay off
-/// <c>V4RepositoryBase</c>: TempBasal (span-shaped, keys on StartTimestamp) and PatientDevice
-/// (no timestamp column at all). Both reach it through <c>SoftDeleteRestoreExtensions</c>, so this
-/// pins the tenant scoping and the already-live edge that the extension is responsible for.
+/// Covers the shared restore quadrant on the shapes that stay off <c>V4RepositoryBase</c> —
+/// TempBasal (span-shaped, keys on StartTimestamp) and PatientDevice (no timestamp column at all) —
+/// plus BasalInjection, which reaches the same extension through the base. Pins the tenant scoping
+/// and the already-live edge the extension is responsible for.
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("Category", "Repository")]
@@ -37,6 +37,8 @@ public class SoftDeleteRestoreQuadrantTests : IDisposable
     private readonly TempBasalRepository _tempBasalsB;
     private readonly PatientDeviceRepository _devicesA;
     private readonly PatientDeviceRepository _devicesB;
+    private readonly BasalInjectionRepository _basalInjectionsA;
+    private readonly BasalInjectionRepository _basalInjectionsB;
 
     public SoftDeleteRestoreQuadrantTests()
     {
@@ -70,6 +72,8 @@ public class SoftDeleteRestoreQuadrantTests : IDisposable
             new TestTenantDbContextFactory(_contextA), NullLogger<PatientDeviceRepository>.Instance);
         _devicesB = new PatientDeviceRepository(
             new TestTenantDbContextFactory(_contextB), NullLogger<PatientDeviceRepository>.Instance);
+        _basalInjectionsA = new BasalInjectionRepository(new TestTenantDbContextFactory(_contextA), audit);
+        _basalInjectionsB = new BasalInjectionRepository(new TestTenantDbContextFactory(_contextB), audit);
     }
 
     public void Dispose()
@@ -86,6 +90,14 @@ public class SoftDeleteRestoreQuadrantTests : IDisposable
         UtcOffset = 0,
         Rate = 1.0,
         Origin = TempBasalOrigin.Manual,
+    };
+
+    private static BasalInjection NewBasalInjection(string syncIdentifier) => new()
+    {
+        Timestamp = Base,
+        DataSource = "aaps",
+        SyncIdentifier = syncIdentifier,
+        Units = 10.0,
     };
 
     private static PatientDevice NewDevice(string model) => new()
@@ -144,16 +156,21 @@ public class SoftDeleteRestoreQuadrantTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkRestoreAsync_RestoresOnlyTheSoftDeletedIds()
+    public async Task BulkRestoreAsync_RestoresOnlyTheSoftDeletedIdsItWasGiven()
     {
-        var deleted = await _tempBasalsA.CreateAsync(NewTempBasal(Base), WriteOrigin.Live);
+        var asked = await _tempBasalsA.CreateAsync(NewTempBasal(Base), WriteOrigin.Live);
         var live = await _tempBasalsA.CreateAsync(NewTempBasal(Base.AddMinutes(30)), WriteOrigin.Live);
-        SoftDelete<TempBasalEntity>(_contextA, deleted.Id, Base.AddHours(1));
+        var otherDeleted = await _tempBasalsA.CreateAsync(NewTempBasal(Base.AddMinutes(60)), WriteOrigin.Live);
+        SoftDelete<TempBasalEntity>(_contextA, asked.Id, Base.AddHours(1));
+        SoftDelete<TempBasalEntity>(_contextA, otherDeleted.Id, Base.AddHours(1));
 
         var restored = (await _tempBasalsA.BulkRestoreAsync(
-            [deleted.Id, live.Id, Guid.CreateVersion7()], WriteOrigin.Live)).ToList();
+            [asked.Id, live.Id, Guid.CreateVersion7()], WriteOrigin.Live)).ToList();
 
-        restored.Select(r => r.Id).Should().Equal(deleted.Id);
+        restored.Select(r => r.Id).Should().Equal(asked.Id);
+        _contextA.TempBasals.IgnoreQueryFilters()
+            .Single(e => e.Id == otherDeleted.Id).DeletedAt.Should()
+            .NotBeNull("a soft-deleted row the caller did not name must stay deleted");
         _contextA.TempBasals.IgnoreQueryFilters()
             .Count(e => e.DeletedAt == null).Should().Be(2);
     }
@@ -228,6 +245,27 @@ public class SoftDeleteRestoreQuadrantTests : IDisposable
         restored.Id.Should().Be(created.Id);
         (await _devicesA.CountDeletedAsync()).Should().Be(0);
         (await _devicesA.GetAllAsync()).Select(d => d.Id).Should().Equal(created.Id);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_AndGetDeletedAsync_WorkThroughV4RepositoryBase()
+    {
+        var deleted = await _basalInjectionsA.CreateAsync(NewBasalInjection("sync-1"), WriteOrigin.Live);
+        await _basalInjectionsA.CreateAsync(NewBasalInjection("sync-2"), WriteOrigin.Live);
+        var theirs = await _basalInjectionsB.CreateAsync(NewBasalInjection("sync-3"), WriteOrigin.Live);
+        SoftDelete<BasalInjectionEntity>(_contextA, deleted.Id, Base);
+        SoftDelete<BasalInjectionEntity>(_contextB, theirs.Id, Base);
+
+        (await _basalInjectionsA.GetDeletedAsync(limit: 50, offset: 0)).Select(b => b.Id)
+            .Should().Equal(deleted.Id);
+        (await _basalInjectionsA.CountDeletedAsync()).Should().Be(1);
+
+        (await _basalInjectionsA.RestoreAsync(deleted.Id, WriteOrigin.Live)).Id.Should().Be(deleted.Id);
+
+        (await _basalInjectionsA.CountDeletedAsync()).Should().Be(0);
+        (await _basalInjectionsB.CountDeletedAsync()).Should().Be(1);
+        await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _basalInjectionsA.RestoreAsync(theirs.Id, WriteOrigin.Live));
     }
 
     [Fact]


### PR DESCRIPTION
## What

Four repositories retyped `RestoreAsync` / `BulkRestoreAsync` / `GetDeletedAsync` / `CountDeletedAsync` line-for-line instead of inheriting them, and two mappers carried a private, divergent copy of `ParseIdToGuid`.

- The restore quadrant moves to `SoftDeleteRestoreExtensions`, constrained to `ITenantScoped, ISoftDeletable` — the narrowest thing it actually reads — so the span-shaped (`TempBasal`) and timestamp-less (`PatientDevice`, `PatientInsulin`) types that `IV4TimeSeriesEntity` deliberately keeps off `V4RepositoryBase` share it. `V4RepositoryBase` delegates to the same extension, so there is one implementation, not two.
- The audited-delete-and-broadcast pair `DeleteByLegacyIdAsync` performed inline becomes a protected base helper.
- `BasalInjectionRepository` joins `V4RepositoryBase` (455 → 190 lines), keeping only its SyncId-upsert `CreateAsync` and the split that feeds the base's bulk write.
- `FoodMapper` and `SettingsMapper` lose their private `ParseIdToGuid`; the seven call sites that re-checked null before `MapperHelpers.ParseIdToGuid` (which already handles it) drop the check.

Net: 17 production files, −296 lines. No migration.

## Why the mapper change is a fix, not a refactor

The private copies padded or truncated the id to sixteen bytes; `MapperHelpers` hashes it. The same legacy id therefore mapped to two different keys depending on which collection it arrived on. Worse, truncation made ids that differ only past their sixteenth character collide — `settings-displayUnits` and `settings-displayRange` both derived from `settings-display`, so creating one silently overwrote the other's row, `Key` included.

## Behavioural deltas

1. **Food / Settings keys change for non-GUID ids.** Nothing is stranded: every read, update and delete resolves `OriginalId` before parsing the id as a GUID — none re-derives the key. The create-time "already exists" probe *did* depend on the derivation, so it now resolves the way reads do. Two consequences:
   - **Settings**: the probe consults the key first, which is what `ix_settings_tenant_id_key` (`NocturneDbContext.cs:699-703`) says a setting's identity is, falling back to the id and then `OriginalId`. A re-posted setting whose id is not recognised now updates its key's row instead of failing the unique index — on `main` that was a permanent 500 for that key, since it was also unreachable by id.
   - **Food**: closed for the Mongo-shaped id, which is the only shape `MongoIdUtils.IsValidMongoId` accepts and the only one Nightscout clients send. **Residual:** a client re-posting a stable non-GUID, non-24-hex `_id` created before this change gets a duplicate food, because that shape stores no `OriginalId`. It was already unaddressable by its original string id on `main` (`FoodRepository.cs:55`: `Guid.TryParse("food-1A2B")` fails), and V3-generated ids are ticks-salted so they never repeat.

2. **A matched food or setting is updated through its mapper, not `CurrentValues.SetValues`.** `SetValues` copied the derived key onto the stored row's primary key, which EF rejects for any row whose key does not follow from its legacy id — everything `MigrationJobService.TransformFoodAsync` (`:1553-1556`) wrote, and everything the mapper wrote before this change. Widening the probe without this would have turned a silent duplicate insert into a failing Nightscout connector food sync every cycle. Three further things `SetValues` destroyed on every re-post, now preserved:
   - `OriginalId` — nulled whenever the incoming id was not Mongo-shaped, dropping the handle every read resolves on.
   - `ExternalSource` / `ExternalId` — nulled on every re-post of a connector-linked food, breaking its `ix_foods_tenant_external` link (`NocturneDbContext.cs:630-633`).
   - `SysCreatedAt` (reported to clients as a food's `created_at`) and `AdditionalPropertiesJson`.

   `SaveChanges` still stamps `SysUpdatedAt` on real modifications (`NocturneDbContext.cs:2473-2476`), so nothing is lost.

3. **BasalInjection now reads through the tenant context factory** rather than a directly injected `DbContext`, so its reads carry the share-RLS session settings.

4. **A BasalInjection update whose values did not change no longer broadcasts**, matching every other V4 type; the same material-change gate now applies to a bulk upsert's in-place rows.

5. **`BasalInjectionRepository.DeleteBySyncIdentifierAsync` routes through the audited soft-delete helper**, so it is bounded at `BroadcastMaterializationCap` instead of materialising the whole match set, and shares the base's audit-and-broadcast path. It already wrote `delete` audit rows and stamped `deleted_by_user` via `MutationAuditInterceptor` (`Interceptors/MutationAuditInterceptor.cs:78-84`) — this changes the mechanism and the bound, not whether the delete is recorded.

6. **`BasalInjectionRepository.GetByIdAsync` now uses the base's `FindAsync`.** Its `FirstOrDefaultAsync` existed because a shared scoped `DbContext` could serve a change-tracker-cached soft-deleted entity; a per-call pooled context has an empty tracker, so the rationale does not survive the move.

7. `PatientDevice` and `PatientInsulin` restore/bulk-restore still broadcast nothing, exactly as before — the extension returns entities and leaves the event to the caller.

## Tests

The restore quadrant had **no repository-level coverage**, and `FoodRepository` / `SettingsRepository` had **none at all**. Added:

- `SoftDeleteRestoreQuadrantTests` — 11 tests over `TempBasal` (span-shaped), `PatientDevice` (no timestamp column) and `BasalInjection` (through `V4RepositoryBase`), two tenants on one SQLite connection: restore, already-live, cross-tenant, bulk restore leaving both live rows and un-named soft-deleted rows alone, deleted-list ordering and paging, per-tenant counts.
- `CreateProbeTests` — 8 tests over both legacy row shapes (migration-written and old-derivation), the insert path, `OriginalId` preservation, the settings key probe and its legacy-id fallback.
- `MapperIdDerivationTests` — 7 tests on the key derivation.
- `MapperUpdateCoverageTests` — 2 tests holding each mapper's `UpdateEntity` to its own `ToEntity`, so a field it forgets cannot pass.
- An audit assertion on `DeleteBySyncIdentifierAsync`.

`Nocturne.Infrastructure.Data.Tests` 707/707; `Nocturne.API.Tests` 6190/6190 (5 skipped).

Non-vacuous, verified by mutation — each applied, run, reverted:

| Mutation | Result |
| --- | --- |
| Re-introduce the padded `ParseIdToGuid` in both mappers | 3 mapper tests fail |
| Drop the tenant predicate from the restore extension | 5 quadrant tests fail |
| Drop the `DeletedAt != null` predicate | 5 quadrant tests fail |
| Drop the id predicate from bulk restore | 1 quadrant test fails |
| Pass a null audit context in the base's audited delete | 1 BasalInjection test fails |
| Food probe matches on id alone | 2 create-probe tests fail |
| Settings probe skips the key | 1 create-probe test fails |
| Settings fallback skips `OriginalId` | 1 create-probe test fails |
| Restore `CurrentValues.SetValues` | 3 create-probe tests fail, all `InvalidOperationException: 'FoodEntity.Id' is part of a key` |
| `UpdateEntity` drops two fields per mapper | 2 mapper-coverage tests fail |

Closes #1037
