### PR TITLE
refactor(api): collapse the health record triplication onto shared controller and service bases

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
@@ -21,7 +22,8 @@ namespace Nocturne.API.Controllers.V4.Health;
 [Tags("Health")]
 [Route("api/v4/body-weight")]
 [Authorize]
-public class BodyWeightController : ControllerBase, IWriteScopedController
+public class BodyWeightController(IBodyWeightService bodyWeightService)
+    : HealthRecordControllerBase<BodyWeight>, IWriteScopedController
 {
     /// <summary>
     /// The OAuth scope every write action on this controller requires. Body weight has no category
@@ -33,14 +35,22 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     /// </summary>
     public string WriteScope => Scope.TherapyReadWrite;
 
-    private readonly IBodyWeightService _bodyWeightService;
-    private readonly ILogger<BodyWeightController> _logger;
+    protected override string RecordTypeName => "Body weight";
 
-    public BodyWeightController(IBodyWeightService bodyWeightService, ILogger<BodyWeightController> logger)
-    {
-        _bodyWeightService = bodyWeightService;
-        _logger = logger;
-    }
+    protected override Task<IEnumerable<BodyWeight>> ReadPageAsync(int count, int skip, CancellationToken ct) =>
+        bodyWeightService.GetBodyWeightsAsync(count, skip, ct);
+
+    protected override Task<BodyWeight?> ReadAsync(string id, CancellationToken ct) =>
+        bodyWeightService.GetBodyWeightByIdAsync(id, ct);
+
+    protected override Task<IEnumerable<BodyWeight>> WriteManyAsync(IReadOnlyList<BodyWeight> models, CancellationToken ct) =>
+        bodyWeightService.CreateBodyWeightsAsync(models, ct);
+
+    protected override Task<BodyWeight?> WriteAsync(string id, BodyWeight model, CancellationToken ct) =>
+        bodyWeightService.UpdateBodyWeightAsync(id, model, ct);
+
+    protected override Task<bool> EraseAsync(string id, CancellationToken ct) =>
+        bodyWeightService.DeleteBodyWeightAsync(id, ct);
 
     /// <summary>
     /// Get body weight records with optional pagination
@@ -54,18 +64,11 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [ProducesResponseType(typeof(IEnumerable<BodyWeight>), 200)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<IEnumerable<BodyWeight>>> GetBodyWeights(
-        [FromQuery] int count = 10,
+    public Task<ActionResult<IEnumerable<BodyWeight>>> GetBodyWeights(
+        [FromQuery] int count = DefaultCount,
         [FromQuery] int skip = 0,
         CancellationToken cancellationToken = default
-    )
-    {
-        count = V4ReadLimits.ClampLimit(count);
-        skip = V4ReadLimits.ClampOffset(skip);
-
-        var records = await _bodyWeightService.GetBodyWeightsAsync(count, skip, cancellationToken);
-        return Ok(records);
-    }
+    ) => ListResponseAsync(count, skip, cancellationToken);
 
     /// <summary>
     /// Get a specific body weight record by ID
@@ -78,17 +81,10 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<BodyWeight>> GetBodyWeight(
+    public Task<ActionResult<BodyWeight>> GetBodyWeight(
         string id,
         CancellationToken cancellationToken = default
-    )
-    {
-        var record = await _bodyWeightService.GetBodyWeightByIdAsync(id, cancellationToken);
-        if (record == null)
-            return Problem(detail: $"Body weight record with ID {id} not found", statusCode: 404, title: "Not Found");
-
-        return Ok(record);
-    }
+    ) => GetResponseAsync(id, cancellationToken);
 
     /// <summary>
     /// Create a single body weight record
@@ -108,56 +104,39 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
         if (bodyWeight == null)
             return Problem(detail: "Body weight data is required", statusCode: 400, title: "Bad Request");
 
-        var result = await _bodyWeightService.CreateBodyWeightsAsync([bodyWeight], cancellationToken);
+        var result = await WriteManyAsync([bodyWeight], cancellationToken);
         return StatusCode(StatusCodes.Status201Created, result.First());
     }
 
     /// <summary>
     /// Create one or more body weight records (single object or array)
     /// </summary>
+    // Untyped so one route takes either a bare record or an array of them. Seven published SDKs
+    // are generated from this operation, so the request shape cannot be tightened in place.
     [HttpPost("batch")]
     [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(IEnumerable<BodyWeight>), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<IEnumerable<BodyWeight>>> CreateBodyWeights(
+    public Task<ActionResult<IEnumerable<BodyWeight>>> CreateBodyWeights(
         [FromBody] object bodyWeights,
         CancellationToken cancellationToken = default
     )
     {
-        if (bodyWeights == null)
-            return Problem(detail: "Body weight data is required", statusCode: 400, title: "Bad Request");
+        if (bodyWeights is null)
+            return Task.FromResult<ActionResult<IEnumerable<BodyWeight>>>(
+                Problem(detail: "Body weight data is required", statusCode: 400, title: "Bad Request"));
 
-        List<BodyWeight> bodyWeightList;
+        if (bodyWeights is not JsonElement json)
+            return Task.FromResult<ActionResult<IEnumerable<BodyWeight>>>(
+                Problem(detail: "Invalid data format", statusCode: 400, title: "Bad Request"));
 
-        if (bodyWeights is System.Text.Json.JsonElement jsonElement)
-        {
-            if (jsonElement.ValueKind == System.Text.Json.JsonValueKind.Array)
-            {
-                bodyWeightList =
-                    System.Text.Json.JsonSerializer.Deserialize<List<BodyWeight>>(
-                        jsonElement.GetRawText()
-                    ) ?? [];
-            }
-            else
-            {
-                var single = System.Text.Json.JsonSerializer.Deserialize<BodyWeight>(
-                    jsonElement.GetRawText()
-                );
-                bodyWeightList = single != null ? [single] : [];
-            }
-        }
-        else
-        {
-            return Problem(detail: "Invalid data format", statusCode: 400, title: "Bad Request");
-        }
+        List<BodyWeight> models = json.ValueKind == JsonValueKind.Array
+            ? JsonSerializer.Deserialize<List<BodyWeight>>(json.GetRawText()) ?? []
+            : JsonSerializer.Deserialize<BodyWeight>(json.GetRawText()) is { } single ? [single] : [];
 
-        if (bodyWeightList.Count == 0)
-            return Problem(detail: "At least one body weight record is required", statusCode: 400, title: "Bad Request");
-
-        var result = await _bodyWeightService.CreateBodyWeightsAsync(bodyWeightList, cancellationToken);
-        return Ok(result);
+        return CreateResponseAsync(models, cancellationToken);
     }
 
     /// <summary>
@@ -170,18 +149,11 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<BodyWeight>> UpdateBodyWeight(
+    public Task<ActionResult<BodyWeight>> UpdateBodyWeight(
         string id,
         [FromBody] BodyWeight bodyWeight,
         CancellationToken cancellationToken = default
-    )
-    {
-        var updated = await _bodyWeightService.UpdateBodyWeightAsync(id, bodyWeight, cancellationToken);
-        if (updated == null)
-            return Problem(detail: $"Body weight record with ID {id} not found", statusCode: 404, title: "Not Found");
-
-        return Ok(updated);
-    }
+    ) => UpdateResponseAsync(id, bodyWeight, cancellationToken);
 
     /// <summary>
     /// Delete a body weight record by ID
@@ -193,15 +165,8 @@ public class BodyWeightController : ControllerBase, IWriteScopedController
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult> DeleteBodyWeight(
+    public Task<ActionResult> DeleteBodyWeight(
         string id,
         CancellationToken cancellationToken = default
-    )
-    {
-        var deleted = await _bodyWeightService.DeleteBodyWeightAsync(id, cancellationToken);
-        if (!deleted)
-            return Problem(detail: $"Body weight record with ID {id} not found", statusCode: 404, title: "Not Found");
-
-        return Ok(new { message = "Body weight record deleted successfully" });
-    }
+    ) => DeleteResponseAsync(id, cancellationToken);
 }

--- a/src/API/Nocturne.API/Controllers/V4/Health/HealthRecordControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/HealthRecordControllerBase.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Controllers.V4.Base;
+
+namespace Nocturne.API.Controllers.V4.Health;
+
+/// <summary>
+/// The bodies shared by the health-record controllers, which answer alike for the same record
+/// shape and differ only in the record type, the service behind it, and the scope each action is
+/// gated on.
+/// </summary>
+/// <remarks>
+/// The actions themselves stay declared on the derived controllers: NSwag names every operation
+/// <c>{Controller}_{ActionMethod}</c>, and the TypeScript client method and SvelteKit remote
+/// function are named from that, so an action inherited from here would rename all three.
+/// </remarks>
+/// <typeparam name="TModel">The domain model the controller reads and writes.</typeparam>
+public abstract class HealthRecordControllerBase<TModel> : ControllerBase
+{
+    /// <summary>Records returned when a caller supplies no <c>count</c> and no date range.</summary>
+    protected const int DefaultCount = 10;
+
+    /// <summary>
+    /// The record type as it opens a sentence — "Heart rate" — which is how it reads in an error
+    /// detail. Mid-sentence uses are lower-cased from it.
+    /// </summary>
+    protected abstract string RecordTypeName { get; }
+
+    protected abstract Task<IEnumerable<TModel>> ReadPageAsync(int count, int skip, CancellationToken ct);
+
+    protected abstract Task<TModel?> ReadAsync(string id, CancellationToken ct);
+
+    protected abstract Task<IEnumerable<TModel>> WriteManyAsync(IReadOnlyList<TModel> models, CancellationToken ct);
+
+    protected abstract Task<TModel?> WriteAsync(string id, TModel model, CancellationToken ct);
+
+    protected abstract Task<bool> EraseAsync(string id, CancellationToken ct);
+
+    protected async Task<ActionResult<IEnumerable<TModel>>> ListResponseAsync(int count, int skip, CancellationToken ct) =>
+        Ok(await ReadPageAsync(V4ReadLimits.ClampLimit(count), V4ReadLimits.ClampOffset(skip), ct));
+
+    protected async Task<ActionResult<TModel>> GetResponseAsync(string id, CancellationToken ct) =>
+        await ReadAsync(id, ct) is { } record ? Ok(record) : RecordNotFound(id);
+
+    protected async Task<ActionResult<IEnumerable<TModel>>> CreateResponseAsync(
+        IReadOnlyList<TModel> models, CancellationToken ct) =>
+        models.Count == 0
+            ? Problem(
+                detail: $"At least one {char.ToLowerInvariant(RecordTypeName[0]) + RecordTypeName[1..]} record is required",
+                statusCode: 400,
+                title: "Bad Request")
+            : Ok(await WriteManyAsync(models, ct));
+
+    protected async Task<ActionResult<TModel>> UpdateResponseAsync(string id, TModel model, CancellationToken ct) =>
+        await WriteAsync(id, model, ct) is { } updated ? Ok(updated) : RecordNotFound(id);
+
+    protected async Task<ActionResult> DeleteResponseAsync(string id, CancellationToken ct) =>
+        await EraseAsync(id, ct)
+            ? Ok(new { message = $"{RecordTypeName} record deleted successfully" })
+            : RecordNotFound(id);
+
+    private ObjectResult RecordNotFound(string id) =>
+        Problem(
+            detail: $"{RecordTypeName} record with ID {id} not found",
+            statusCode: 404,
+            title: "Not Found");
+}

--- a/src/API/Nocturne.API/Controllers/V4/Health/HealthSeriesControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/HealthSeriesControllerBase.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.API.Controllers.V4.Base;
+
+namespace Nocturne.API.Controllers.V4.Health;
+
+/// <summary>
+/// <see cref="HealthRecordControllerBase{TModel}"/> for the wearable measurement series, which
+/// additionally read a date range and create from an upsert request rather than the model itself.
+/// </summary>
+/// <typeparam name="TModel">The domain model the controller reads and writes.</typeparam>
+/// <typeparam name="TUpsertRequest">The request body a create or update carries.</typeparam>
+public abstract class HealthSeriesControllerBase<TModel, TUpsertRequest> : HealthRecordControllerBase<TModel>
+{
+    protected abstract Task<IEnumerable<TModel>> ReadRangeAsync(
+        DateTime from, DateTime to, int count, int skip, CancellationToken ct);
+
+    protected abstract TModel ToModel(TUpsertRequest request);
+
+    /// <remarks>
+    /// A date range without a <paramref name="count"/> reads up to
+    /// <see cref="V4ReadLimits.MaxPageSize"/> records rather than the whole range, so a wide range
+    /// cannot load the table into memory.
+    /// </remarks>
+    protected async Task<ActionResult<IEnumerable<TModel>>> ListResponseAsync(
+        int? count, int skip, DateTime? from, DateTime? to, CancellationToken ct)
+    {
+        skip = V4ReadLimits.ClampOffset(skip);
+
+        return Ok(from.HasValue && to.HasValue
+            ? await ReadRangeAsync(from.Value, to.Value, V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize), skip, ct)
+            : await ReadPageAsync(V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, ct));
+    }
+
+    protected Task<ActionResult<IEnumerable<TModel>>> CreateResponseAsync(
+        TUpsertRequest[] requests, CancellationToken ct) =>
+        CreateResponseAsync([.. requests.Select(ToModel)], ct);
+}

--- a/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/HeartRateController.cs
@@ -22,19 +22,41 @@ namespace Nocturne.API.Controllers.V4.Health;
 [Tags("Health")]
 [Route("api/v4/[controller]")]
 [Produces("application/json")]
-public class HeartRateController : ControllerBase
+public class HeartRateController(IHeartRateService heartRateService)
+    : HealthSeriesControllerBase<HeartRate, UpsertHeartRateRequest>
 {
-    /// <summary>Records returned when a caller supplies no <c>count</c> and no date range.</summary>
-    private const int DefaultCount = 10;
+    protected override string RecordTypeName => "Heart rate";
 
-    private readonly IHeartRateService _heartRateService;
-    private readonly ILogger<HeartRateController> _logger;
+    protected override Task<IEnumerable<HeartRate>> ReadPageAsync(int count, int skip, CancellationToken ct) =>
+        heartRateService.GetHeartRatesAsync(count, skip, ct);
 
-    public HeartRateController(IHeartRateService heartRateService, ILogger<HeartRateController> logger)
+    protected override Task<IEnumerable<HeartRate>> ReadRangeAsync(
+        DateTime from, DateTime to, int count, int skip, CancellationToken ct) =>
+        heartRateService.GetHeartRatesByDateRangeAsync(from, to, count, skip, ct);
+
+    protected override Task<HeartRate?> ReadAsync(string id, CancellationToken ct) =>
+        heartRateService.GetHeartRateByIdAsync(id, ct);
+
+    protected override Task<IEnumerable<HeartRate>> WriteManyAsync(IReadOnlyList<HeartRate> models, CancellationToken ct) =>
+        heartRateService.CreateHeartRatesAsync(models, ct);
+
+    protected override Task<HeartRate?> WriteAsync(string id, HeartRate model, CancellationToken ct) =>
+        heartRateService.UpdateHeartRateAsync(id, model, ct);
+
+    protected override Task<bool> EraseAsync(string id, CancellationToken ct) =>
+        heartRateService.DeleteHeartRateAsync(id, ct);
+
+    protected override HeartRate ToModel(UpsertHeartRateRequest request) => new()
     {
-        _heartRateService = heartRateService;
-        _logger = logger;
-    }
+        Timestamp = request.Timestamp.UtcDateTime,
+        UtcOffset = request.UtcOffset,
+        Bpm = request.Bpm,
+        Accuracy = request.Accuracy,
+        Device = request.Device,
+        EnteredBy = request.App,
+        DataSource = request.DataSource,
+        SyncIdentifier = request.SyncIdentifier,
+    };
 
     /// <summary>
     /// Get heart rate records with optional pagination and date filtering
@@ -56,27 +78,13 @@ public class HeartRateController : ControllerBase
     [ProducesResponseType(typeof(IEnumerable<HeartRate>), 200)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<IEnumerable<HeartRate>>> GetHeartRates(
+    public Task<ActionResult<IEnumerable<HeartRate>>> GetHeartRates(
         [FromQuery] int? count = null,
         [FromQuery] int skip = 0,
         [FromQuery] DateTime? from = null,
         [FromQuery] DateTime? to = null,
         CancellationToken cancellationToken = default
-    )
-    {
-        skip = V4ReadLimits.ClampOffset(skip);
-
-        IEnumerable<HeartRate> records;
-        if (from.HasValue && to.HasValue)
-            records = await _heartRateService.GetHeartRatesByDateRangeAsync(
-                from.Value, to.Value,
-                V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize), skip, cancellationToken);
-        else
-            records = await _heartRateService.GetHeartRatesAsync(
-                V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, cancellationToken);
-
-        return Ok(records);
-    }
+    ) => ListResponseAsync(count, skip, from, to, cancellationToken);
 
     /// <summary>
     /// Get a specific heart rate record by ID
@@ -90,17 +98,10 @@ public class HeartRateController : ControllerBase
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<HeartRate>> GetHeartRate(
+    public Task<ActionResult<HeartRate>> GetHeartRate(
         string id,
         CancellationToken cancellationToken = default
-    )
-    {
-        var record = await _heartRateService.GetHeartRateByIdAsync(id, cancellationToken);
-        if (record == null)
-            return Problem(detail: $"Heart rate record with ID {id} not found", statusCode: 404, title: "Not Found");
-
-        return Ok(record);
-    }
+    ) => GetResponseAsync(id, cancellationToken);
 
     /// <summary>
     /// Create one or more heart rate records
@@ -111,29 +112,10 @@ public class HeartRateController : ControllerBase
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<IEnumerable<HeartRate>>> CreateHeartRates(
+    public Task<ActionResult<IEnumerable<HeartRate>>> CreateHeartRates(
         [FromBody] UpsertHeartRateRequest[] requests,
         CancellationToken cancellationToken = default
-    )
-    {
-        if (requests.Length == 0)
-            return Problem(detail: "At least one heart rate record is required", statusCode: 400, title: "Bad Request");
-
-        var heartRateList = requests.Select(request => new HeartRate
-        {
-            Timestamp = request.Timestamp.UtcDateTime,
-            UtcOffset = request.UtcOffset,
-            Bpm = request.Bpm,
-            Accuracy = request.Accuracy,
-            Device = request.Device,
-            EnteredBy = request.App,
-            DataSource = request.DataSource,
-            SyncIdentifier = request.SyncIdentifier,
-        }).ToList();
-
-        var result = await _heartRateService.CreateHeartRatesAsync(heartRateList, cancellationToken);
-        return Ok(result);
-    }
+    ) => CreateResponseAsync(requests, cancellationToken);
 
     /// <summary>
     /// Update an existing heart rate record
@@ -144,30 +126,11 @@ public class HeartRateController : ControllerBase
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<HeartRate>> UpdateHeartRate(
+    public Task<ActionResult<HeartRate>> UpdateHeartRate(
         string id,
         [FromBody] UpsertHeartRateRequest request,
         CancellationToken cancellationToken = default
-    )
-    {
-        var heartRate = new HeartRate
-        {
-            Timestamp = request.Timestamp.UtcDateTime,
-            UtcOffset = request.UtcOffset,
-            Bpm = request.Bpm,
-            Accuracy = request.Accuracy,
-            Device = request.Device,
-            EnteredBy = request.App,
-            DataSource = request.DataSource,
-            SyncIdentifier = request.SyncIdentifier,
-        };
-
-        var updated = await _heartRateService.UpdateHeartRateAsync(id, heartRate, cancellationToken);
-        if (updated == null)
-            return Problem(detail: $"Heart rate record with ID {id} not found", statusCode: 404, title: "Not Found");
-
-        return Ok(updated);
-    }
+    ) => UpdateResponseAsync(id, ToModel(request), cancellationToken);
 
     /// <summary>
     /// Delete a heart rate record by ID
@@ -178,15 +141,8 @@ public class HeartRateController : ControllerBase
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult> DeleteHeartRate(
+    public Task<ActionResult> DeleteHeartRate(
         string id,
         CancellationToken cancellationToken = default
-    )
-    {
-        var deleted = await _heartRateService.DeleteHeartRateAsync(id, cancellationToken);
-        if (!deleted)
-            return Problem(detail: $"Heart rate record with ID {id} not found", statusCode: 404, title: "Not Found");
-
-        return Ok(new { message = "Heart rate record deleted successfully" });
-    }
+    ) => DeleteResponseAsync(id, cancellationToken);
 }

--- a/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/StepCountController.cs
@@ -13,28 +13,50 @@ namespace Nocturne.API.Controllers.V4.Health;
 /// Controller for step count data from diabetes apps and wearables.
 /// </summary>
 /// <remarks>
-/// Step count readings are stored as time-series observations.
-/// All operations delegate to <see cref="IStepCountService"/>. Callers must hold the
-/// appropriate scope (<c>read:health</c> or <c>write:health</c>).
+/// Step count readings are stored as time-series observations. All operations delegate to
+/// <see cref="IStepCountService"/>. Callers must hold the <c>read:health</c>
+/// or <c>write:health</c> scope as appropriate.
 /// </remarks>
 /// <seealso cref="IStepCountService"/>
 [ApiController]
 [Tags("Health")]
 [Route("api/v4/[controller]")]
 [Produces("application/json")]
-public class StepCountController : ControllerBase
+public class StepCountController(IStepCountService stepCountService)
+    : HealthSeriesControllerBase<StepCount, UpsertStepCountRequest>
 {
-    /// <summary>Records returned when a caller supplies no <c>count</c> and no date range.</summary>
-    private const int DefaultCount = 10;
+    protected override string RecordTypeName => "Step count";
 
-    private readonly IStepCountService _stepCountService;
-    private readonly ILogger<StepCountController> _logger;
+    protected override Task<IEnumerable<StepCount>> ReadPageAsync(int count, int skip, CancellationToken ct) =>
+        stepCountService.GetStepCountsAsync(count, skip, ct);
 
-    public StepCountController(IStepCountService stepCountService, ILogger<StepCountController> logger)
+    protected override Task<IEnumerable<StepCount>> ReadRangeAsync(
+        DateTime from, DateTime to, int count, int skip, CancellationToken ct) =>
+        stepCountService.GetStepCountsByDateRangeAsync(from, to, count, skip, ct);
+
+    protected override Task<StepCount?> ReadAsync(string id, CancellationToken ct) =>
+        stepCountService.GetStepCountByIdAsync(id, ct);
+
+    protected override Task<IEnumerable<StepCount>> WriteManyAsync(IReadOnlyList<StepCount> models, CancellationToken ct) =>
+        stepCountService.CreateStepCountsAsync(models, ct);
+
+    protected override Task<StepCount?> WriteAsync(string id, StepCount model, CancellationToken ct) =>
+        stepCountService.UpdateStepCountAsync(id, model, ct);
+
+    protected override Task<bool> EraseAsync(string id, CancellationToken ct) =>
+        stepCountService.DeleteStepCountAsync(id, ct);
+
+    protected override StepCount ToModel(UpsertStepCountRequest request) => new()
     {
-        _stepCountService = stepCountService;
-        _logger = logger;
-    }
+        Timestamp = request.Timestamp.UtcDateTime,
+        UtcOffset = request.UtcOffset,
+        Metric = request.Metric,
+        Source = request.Source,
+        Device = request.Device,
+        EnteredBy = request.App,
+        DataSource = request.DataSource,
+        SyncIdentifier = request.SyncIdentifier,
+    };
 
     /// <summary>
     /// Get step count records with optional pagination and date filtering
@@ -56,27 +78,13 @@ public class StepCountController : ControllerBase
     [ProducesResponseType(typeof(IEnumerable<StepCount>), 200)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<IEnumerable<StepCount>>> GetStepCounts(
+    public Task<ActionResult<IEnumerable<StepCount>>> GetStepCounts(
         [FromQuery] int? count = null,
         [FromQuery] int skip = 0,
         [FromQuery] DateTime? from = null,
         [FromQuery] DateTime? to = null,
         CancellationToken cancellationToken = default
-    )
-    {
-        skip = V4ReadLimits.ClampOffset(skip);
-
-        IEnumerable<StepCount> records;
-        if (from.HasValue && to.HasValue)
-            records = await _stepCountService.GetStepCountsByDateRangeAsync(
-                from.Value, to.Value,
-                V4ReadLimits.ClampLimit(count ?? V4ReadLimits.MaxPageSize), skip, cancellationToken);
-        else
-            records = await _stepCountService.GetStepCountsAsync(
-                V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, cancellationToken);
-
-        return Ok(records);
-    }
+    ) => ListResponseAsync(count, skip, from, to, cancellationToken);
 
     /// <summary>
     /// Get a specific step count record by ID
@@ -90,17 +98,10 @@ public class StepCountController : ControllerBase
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<StepCount>> GetStepCount(
+    public Task<ActionResult<StepCount>> GetStepCount(
         string id,
         CancellationToken cancellationToken = default
-    )
-    {
-        var record = await _stepCountService.GetStepCountByIdAsync(id, cancellationToken);
-        if (record == null)
-            return Problem(detail: $"Step count record with ID {id} not found", statusCode: 404, title: "Not Found");
-
-        return Ok(record);
-    }
+    ) => GetResponseAsync(id, cancellationToken);
 
     /// <summary>
     /// Create one or more step count records
@@ -111,29 +112,10 @@ public class StepCountController : ControllerBase
     [ProducesResponseType(400)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<IEnumerable<StepCount>>> CreateStepCounts(
+    public Task<ActionResult<IEnumerable<StepCount>>> CreateStepCounts(
         [FromBody] UpsertStepCountRequest[] requests,
         CancellationToken cancellationToken = default
-    )
-    {
-        if (requests.Length == 0)
-            return Problem(detail: "At least one step count record is required", statusCode: 400, title: "Bad Request");
-
-        var stepCountList = requests.Select(request => new StepCount
-        {
-            Timestamp = request.Timestamp.UtcDateTime,
-            UtcOffset = request.UtcOffset,
-            Metric = request.Metric,
-            Source = request.Source,
-            Device = request.Device,
-            EnteredBy = request.App,
-            DataSource = request.DataSource,
-            SyncIdentifier = request.SyncIdentifier,
-        }).ToList();
-
-        var result = await _stepCountService.CreateStepCountsAsync(stepCountList, cancellationToken);
-        return Ok(result);
-    }
+    ) => CreateResponseAsync(requests, cancellationToken);
 
     /// <summary>
     /// Update an existing step count record
@@ -144,30 +126,11 @@ public class StepCountController : ControllerBase
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult<StepCount>> UpdateStepCount(
+    public Task<ActionResult<StepCount>> UpdateStepCount(
         string id,
         [FromBody] UpsertStepCountRequest request,
         CancellationToken cancellationToken = default
-    )
-    {
-        var stepCount = new StepCount
-        {
-            Timestamp = request.Timestamp.UtcDateTime,
-            UtcOffset = request.UtcOffset,
-            Metric = request.Metric,
-            Source = request.Source,
-            Device = request.Device,
-            EnteredBy = request.App,
-            DataSource = request.DataSource,
-            SyncIdentifier = request.SyncIdentifier,
-        };
-
-        var updated = await _stepCountService.UpdateStepCountAsync(id, stepCount, cancellationToken);
-        if (updated == null)
-            return Problem(detail: $"Step count record with ID {id} not found", statusCode: 404, title: "Not Found");
-
-        return Ok(updated);
-    }
+    ) => UpdateResponseAsync(id, ToModel(request), cancellationToken);
 
     /// <summary>
     /// Delete a step count record by ID
@@ -178,15 +141,8 @@ public class StepCountController : ControllerBase
     [ProducesResponseType(404)]
     [ProducesResponseType(500)]
     [ErrorEnvelope]
-    public async Task<ActionResult> DeleteStepCount(
+    public Task<ActionResult> DeleteStepCount(
         string id,
         CancellationToken cancellationToken = default
-    )
-    {
-        var deleted = await _stepCountService.DeleteStepCountAsync(id, cancellationToken);
-        if (!deleted)
-            return Problem(detail: $"Step count record with ID {id} not found", statusCode: 404, title: "Not Found");
-
-        return Ok(new { message = "Step count record deleted successfully" });
-    }
+    ) => DeleteResponseAsync(id, cancellationToken);
 }

--- a/src/API/Nocturne.API/Services/Health/BodyWeightService.cs
+++ b/src/API/Nocturne.API/Services/Health/BodyWeightService.cs
@@ -45,20 +45,12 @@ public class BodyWeightService
     protected override void UpdateEntity(BodyWeightEntity entity, BodyWeight model) =>
         BodyWeightMapper.UpdateEntity(entity, model);
 
+    /// <remarks>Body weight keys on epoch milliseconds rather than a <see cref="DateTime"/>
+    /// column, which is why it stays on <see cref="SimpleEntityService{TModel,TEntity}"/> rather
+    /// than <see cref="TimeSeriesEntityService{TModel,TEntity}"/>.</remarks>
     protected override IOrderedQueryable<BodyWeightEntity> OrderByTimestamp(
         IQueryable<BodyWeightEntity> query
     ) => query.OrderByDescending(b => b.Mills);
-
-    protected override Task<BodyWeightEntity?> FindByIdAsync(
-        string id,
-        CancellationToken cancellationToken
-    ) =>
-        Guid.TryParse(id, out var guid)
-            ? DbContext.BodyWeights.FirstOrDefaultAsync(b => b.Id == guid, cancellationToken)
-            : DbContext.BodyWeights.FirstOrDefaultAsync(
-                b => b.OriginalId == id,
-                cancellationToken
-            );
 
     public Task<IEnumerable<BodyWeight>> GetBodyWeightsAsync(
         int count = 10,

--- a/src/API/Nocturne.API/Services/Health/HeartRateService.cs
+++ b/src/API/Nocturne.API/Services/Health/HeartRateService.cs
@@ -1,37 +1,35 @@
 using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Services.Legacy;
+using Nocturne.API.Services.Realtime;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.Legacy;
-using Nocturne.API.Services.Legacy;
 using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Mappers;
-using Nocturne.API.Services.Realtime;
 
 namespace Nocturne.API.Services.Health;
 
 /// <summary>
 /// Domain service for heart rate record operations. Inherits standard CRUD, SignalR broadcasting,
-/// and document-processing behaviour from <see cref="SimpleEntityService{TModel,TEntity}"/>.
+/// and document-processing behaviour from <see cref="TimeSeriesEntityService{TModel,TEntity}"/>.
 /// </summary>
 /// <seealso cref="IHeartRateService"/>
-/// <seealso cref="SimpleEntityService{TModel,TEntity}"/>
-public class HeartRateService
-    : SimpleEntityService<HeartRate, HeartRateEntity>,
+/// <seealso cref="TimeSeriesEntityService{TModel,TEntity}"/>
+/// <param name="dbContext">EF Core context providing access to the heart rates table.</param>
+/// <param name="documentProcessingService">Service that applies field processing before save.</param>
+/// <param name="signalRBroadcastService">Service used to broadcast entity changes over SignalR.</param>
+/// <param name="logger">Logger instance for this service.</param>
+public class HeartRateService(
+    NocturneDbContext dbContext,
+    IDocumentProcessingService documentProcessingService,
+    ISignalRBroadcastService signalRBroadcastService,
+    ILogger<HeartRateService> logger
+)
+    : TimeSeriesEntityService<HeartRate, HeartRateEntity>(
+        dbContext, documentProcessingService, signalRBroadcastService, logger),
         IHeartRateService
 {
-    /// <param name="dbContext">EF Core context providing access to the heart rates table.</param>
-    /// <param name="documentProcessingService">Service that applies field processing before save.</param>
-    /// <param name="signalRBroadcastService">Service used to broadcast entity changes over SignalR.</param>
-    /// <param name="logger">Logger instance for this service.</param>
-    public HeartRateService(
-        NocturneDbContext dbContext,
-        IDocumentProcessingService documentProcessingService,
-        ISignalRBroadcastService signalRBroadcastService,
-        ILogger<HeartRateService> logger
-    )
-        : base(dbContext, documentProcessingService, signalRBroadcastService, logger) { }
-
     protected override DbSet<HeartRateEntity> EntitySet => DbContext.HeartRates;
     protected override string CollectionName => "heartrate";
     protected override string EntityTypeName => "heart rate";
@@ -45,56 +43,19 @@ public class HeartRateService
     protected override void UpdateEntity(HeartRateEntity entity, HeartRate model) =>
         HeartRateMapper.UpdateEntity(entity, model);
 
-    protected override IOrderedQueryable<HeartRateEntity> OrderByTimestamp(
-        IQueryable<HeartRateEntity> query
-    ) => query.OrderByDescending(h => h.Timestamp);
-
-    protected override Task<HeartRateEntity?> FindByIdAsync(
-        string id,
-        CancellationToken cancellationToken
-    ) =>
-        Guid.TryParse(id, out var guid)
-            ? DbContext.HeartRates.FirstOrDefaultAsync(h => h.Id == guid, cancellationToken)
-            : DbContext.HeartRates.FirstOrDefaultAsync(
-                h => h.OriginalId == id,
-                cancellationToken
-            );
-
     public Task<IEnumerable<HeartRate>> GetHeartRatesAsync(
         int count = 10,
         int skip = 0,
         CancellationToken cancellationToken = default
     ) => GetAllAsync(count, skip, cancellationToken);
 
-    public async Task<IEnumerable<HeartRate>> GetHeartRatesByDateRangeAsync(
+    public Task<IEnumerable<HeartRate>> GetHeartRatesByDateRangeAsync(
         DateTime from,
         DateTime to,
         int? count = null,
         int skip = 0,
         CancellationToken cancellationToken = default
-    )
-    {
-        var query = EntitySet
-            .Where(h => h.Timestamp >= from && h.Timestamp < to)
-            .OrderBy(h => h.Timestamp)
-            .Skip(skip);
-
-        if (count is { } take)
-            query = query.Take(take);
-
-        var entities = await query.ToListAsync(cancellationToken);
-
-        return entities.Select(ToDomainModel);
-    }
-
-    public Task<DateTime?> GetLatestTimestampAsync(
-        string source,
-        CancellationToken cancellationToken = default
-    ) =>
-        EntitySet
-            .AsNoTracking()
-            .Where(h => h.DataSource == source)
-            .MaxAsync(h => (DateTime?)h.Timestamp, cancellationToken);
+    ) => GetByDateRangeAsync(from, to, count, skip, cancellationToken);
 
     public Task<HeartRate?> GetHeartRateByIdAsync(
         string id,

--- a/src/API/Nocturne.API/Services/Health/StepCountService.cs
+++ b/src/API/Nocturne.API/Services/Health/StepCountService.cs
@@ -1,37 +1,35 @@
 using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Services.Legacy;
+using Nocturne.API.Services.Realtime;
 using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Contracts.Legacy;
-using Nocturne.API.Services.Legacy;
 using Nocturne.Core.Models;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Mappers;
-using Nocturne.API.Services.Realtime;
 
 namespace Nocturne.API.Services.Health;
 
 /// <summary>
 /// Domain service for step count record operations. Inherits standard CRUD, SignalR broadcasting,
-/// and document-processing behaviour from <see cref="SimpleEntityService{TModel,TEntity}"/>.
+/// and document-processing behaviour from <see cref="TimeSeriesEntityService{TModel,TEntity}"/>.
 /// </summary>
 /// <seealso cref="IStepCountService"/>
-/// <seealso cref="SimpleEntityService{TModel,TEntity}"/>
-public class StepCountService
-    : SimpleEntityService<StepCount, StepCountEntity>,
+/// <seealso cref="TimeSeriesEntityService{TModel,TEntity}"/>
+/// <param name="dbContext">EF Core context providing access to the step counts table.</param>
+/// <param name="documentProcessingService">Service that applies field processing before save.</param>
+/// <param name="signalRBroadcastService">Service used to broadcast entity changes over SignalR.</param>
+/// <param name="logger">Logger instance for this service.</param>
+public class StepCountService(
+    NocturneDbContext dbContext,
+    IDocumentProcessingService documentProcessingService,
+    ISignalRBroadcastService signalRBroadcastService,
+    ILogger<StepCountService> logger
+)
+    : TimeSeriesEntityService<StepCount, StepCountEntity>(
+        dbContext, documentProcessingService, signalRBroadcastService, logger),
         IStepCountService
 {
-    /// <param name="dbContext">EF Core context providing access to the step counts table.</param>
-    /// <param name="documentProcessingService">Service that applies field processing before save.</param>
-    /// <param name="signalRBroadcastService">Service used to broadcast entity changes over SignalR.</param>
-    /// <param name="logger">Logger instance for this service.</param>
-    public StepCountService(
-        NocturneDbContext dbContext,
-        IDocumentProcessingService documentProcessingService,
-        ISignalRBroadcastService signalRBroadcastService,
-        ILogger<StepCountService> logger
-    )
-        : base(dbContext, documentProcessingService, signalRBroadcastService, logger) { }
-
     protected override DbSet<StepCountEntity> EntitySet => DbContext.StepCounts;
     protected override string CollectionName => "stepcount";
     protected override string EntityTypeName => "step count";
@@ -45,56 +43,19 @@ public class StepCountService
     protected override void UpdateEntity(StepCountEntity entity, StepCount model) =>
         StepCountMapper.UpdateEntity(entity, model);
 
-    protected override IOrderedQueryable<StepCountEntity> OrderByTimestamp(
-        IQueryable<StepCountEntity> query
-    ) => query.OrderByDescending(s => s.Timestamp);
-
-    protected override Task<StepCountEntity?> FindByIdAsync(
-        string id,
-        CancellationToken cancellationToken
-    ) =>
-        Guid.TryParse(id, out var guid)
-            ? DbContext.StepCounts.FirstOrDefaultAsync(s => s.Id == guid, cancellationToken)
-            : DbContext.StepCounts.FirstOrDefaultAsync(
-                s => s.OriginalId == id,
-                cancellationToken
-            );
-
     public Task<IEnumerable<StepCount>> GetStepCountsAsync(
         int count = 10,
         int skip = 0,
         CancellationToken cancellationToken = default
     ) => GetAllAsync(count, skip, cancellationToken);
 
-    public async Task<IEnumerable<StepCount>> GetStepCountsByDateRangeAsync(
+    public Task<IEnumerable<StepCount>> GetStepCountsByDateRangeAsync(
         DateTime from,
         DateTime to,
         int? count = null,
         int skip = 0,
         CancellationToken cancellationToken = default
-    )
-    {
-        var query = EntitySet
-            .Where(s => s.Timestamp >= from && s.Timestamp < to)
-            .OrderBy(s => s.Timestamp)
-            .Skip(skip);
-
-        if (count is { } take)
-            query = query.Take(take);
-
-        var entities = await query.ToListAsync(cancellationToken);
-
-        return entities.Select(ToDomainModel);
-    }
-
-    public Task<DateTime?> GetLatestTimestampAsync(
-        string source,
-        CancellationToken cancellationToken = default
-    ) =>
-        EntitySet
-            .AsNoTracking()
-            .Where(s => s.DataSource == source)
-            .MaxAsync(s => (DateTime?)s.Timestamp, cancellationToken);
+    ) => GetByDateRangeAsync(from, to, count, skip, cancellationToken);
 
     public Task<StepCount?> GetStepCountByIdAsync(
         string id,

--- a/src/API/Nocturne.API/Services/Legacy/SimpleEntityService.cs
+++ b/src/API/Nocturne.API/Services/Legacy/SimpleEntityService.cs
@@ -12,8 +12,10 @@ namespace Nocturne.API.Services.Legacy;
 /// <summary>
 /// Abstract base for simple entity CRUD services that use <see cref="NocturneDbContext"/> directly
 /// with document processing and SignalR broadcasting via <see cref="ISignalRBroadcastService"/>.
-/// Eliminates boilerplate for services like <see cref="HeartRateService"/> and <see cref="StepCountService"/>
-/// that follow the same get/create/update/delete + broadcast pattern.
+/// Eliminates boilerplate for services like <see cref="BodyWeightService"/> that follow the same
+/// get/create/update/delete + broadcast pattern. Services whose entity carries an observation
+/// timestamp derive from <see cref="TimeSeriesEntityService{TDomain,TEntity}"/> instead, which
+/// adds the reads that timestamp makes possible.
 /// </summary>
 /// <typeparam name="TDomain">The domain model type (must implement <see cref="IProcessableDocument"/>).</typeparam>
 /// <typeparam name="TEntity">The EF Core entity type stored in the database.</typeparam>
@@ -21,7 +23,7 @@ namespace Nocturne.API.Services.Legacy;
 /// <seealso cref="IDocumentProcessingService"/>
 public abstract class SimpleEntityService<TDomain, TEntity>
     where TDomain : class, IProcessableDocument
-    where TEntity : class
+    where TEntity : class, IOriginalIdentified
 {
     protected readonly NocturneDbContext DbContext;
     protected readonly IDocumentProcessingService DocumentProcessingService;
@@ -82,14 +84,18 @@ public abstract class SimpleEntityService<TDomain, TEntity>
     /// <returns>An <see cref="IOrderedQueryable{TEntity}"/> sorted by timestamp descending.</returns>
     protected abstract IOrderedQueryable<TEntity> OrderByTimestamp(IQueryable<TEntity> query);
 
-    /// <summary>Finds a single entity by its string ID, returning <see langword="null"/> if not found.</summary>
-    /// <param name="id">The string ID to look up.</param>
+    /// <summary>
+    /// Resolves the id in a route to a row. A GUID addresses the primary key; anything else is
+    /// taken for the MongoDB ObjectId the row carried into the migration, so links minted against
+    /// the legacy database keep resolving.
+    /// </summary>
+    /// <param name="id">The route id to look up.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The matching entity, or <see langword="null"/>.</returns>
-    protected abstract Task<TEntity?> FindByIdAsync(
-        string id,
-        CancellationToken cancellationToken
-    );
+    private Task<TEntity?> FindByIdAsync(string id, CancellationToken cancellationToken) =>
+        Guid.TryParse(id, out var guid)
+            ? EntitySet.FirstOrDefaultAsync(e => e.Id == guid, cancellationToken)
+            : EntitySet.FirstOrDefaultAsync(e => e.OriginalId == id, cancellationToken);
 
     /// <summary>
     /// Retrieves a page of entities ordered by timestamp descending.

--- a/src/API/Nocturne.API/Services/Legacy/TimeSeriesEntityService.cs
+++ b/src/API/Nocturne.API/Services/Legacy/TimeSeriesEntityService.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.API.Services.Legacy;
+
+/// <summary>
+/// <see cref="SimpleEntityService{TDomain,TEntity}"/> for entities keyed on an observation
+/// timestamp, adding the reads that timestamp makes possible: newest-first ordering, a half-open
+/// <c>[from, to)</c> range page, and the per-source watermark a connector resumes from.
+/// </summary>
+/// <typeparam name="TDomain">The domain model type.</typeparam>
+/// <typeparam name="TEntity">The EF Core entity type stored in the database.</typeparam>
+public abstract class TimeSeriesEntityService<TDomain, TEntity>(
+    NocturneDbContext dbContext,
+    IDocumentProcessingService documentProcessingService,
+    ISignalRBroadcastService signalRBroadcastService,
+    ILogger logger
+) : SimpleEntityService<TDomain, TEntity>(dbContext, documentProcessingService, signalRBroadcastService, logger)
+    where TDomain : class, IProcessableDocument
+    where TEntity : class, IOriginalIdentified, IObservationTimestamped, ISyncDedupable
+{
+    protected sealed override IOrderedQueryable<TEntity> OrderByTimestamp(IQueryable<TEntity> query) =>
+        query.OrderByDescending(e => e.Timestamp);
+
+    /// <summary>
+    /// Retrieves records observed in <c>[from, to)</c>, oldest first. A <see langword="null"/>
+    /// <paramref name="count"/> returns every record in the range.
+    /// </summary>
+    protected async Task<IEnumerable<TDomain>> GetByDateRangeAsync(
+        DateTime from,
+        DateTime to,
+        int? count = null,
+        int skip = 0,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var query = EntitySet
+            .Where(e => e.Timestamp >= from && e.Timestamp < to)
+            .OrderBy(e => e.Timestamp)
+            .Skip(skip);
+
+        if (count is { } take)
+            query = query.Take(take);
+
+        var entities = await query.ToListAsync(cancellationToken);
+
+        return entities.Select(ToDomainModel);
+    }
+
+    /// <summary>
+    /// Returns the latest timestamp written by <paramref name="source"/> (a connector's resume
+    /// watermark), or <see langword="null"/> when that source has written none.
+    /// </summary>
+    public Task<DateTime?> GetLatestTimestampAsync(
+        string source,
+        CancellationToken cancellationToken = default
+    ) =>
+        EntitySet
+            .AsNoTracking()
+            .Where(e => e.DataSource == source)
+            .MaxAsync(e => (DateTime?)e.Timestamp, cancellationToken);
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/BodyWeightEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/BodyWeightEntity.cs
@@ -7,7 +7,8 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Body composition measurement recorded by a scale or manual entry.
 /// </summary>
 [Table("body_weights")]
-public class BodyWeightEntity : ITenantScoped, ISoftDeletable, ISyncDedupable, ISystemTimestamped
+public class BodyWeightEntity
+    : ITenantScoped, ISoftDeletable, ISyncDedupable, ISystemTimestamped, IOriginalIdentified
 {
     /// <summary>Owning tenant for RLS isolation.</summary>
     [Column("tenant_id")]

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/HeartRateEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/HeartRateEntity.cs
@@ -8,7 +8,8 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.HeartRate
 /// </summary>
 [Table("heart_rates")]
-public class HeartRateEntity : ITenantScoped, ISoftDeletable, ISyncDedupable, ISystemTimestamped
+public class HeartRateEntity
+    : ITenantScoped, ISoftDeletable, ISyncDedupable, ISystemTimestamped, IOriginalIdentified, IObservationTimestamped
 {
     /// <summary>
     /// Identifier of the tenant this heart rate record belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IObservationTimestamped.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IObservationTimestamped.cs
@@ -1,0 +1,13 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// An entity carrying the instant its measurement was observed, as UTC — the domain timestamp a
+/// record is ordered, range-queried and watermarked on, as opposed to <see cref="ISystemTimestamped"/>,
+/// which records when the row was written.
+/// </summary>
+/// <remarks><inheritdoc cref="IOriginalIdentified" path="/remarks"/></remarks>
+public interface IObservationTimestamped
+{
+    /// <summary>When the measurement was taken, in UTC.</summary>
+    DateTime Timestamp { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IOriginalIdentified.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IOriginalIdentified.cs
@@ -1,0 +1,22 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// A row addressable both by its own primary key and by the MongoDB ObjectId it carried into the
+/// migration, so an id minted against the legacy database still resolves. The V4 clinical entities
+/// spell the same idea as <see cref="IV4Entity.LegacyId"/>.
+/// </summary>
+/// <remarks>
+/// Implementers MUST map every member as an ordinary EF column (a plain auto-property with a
+/// <c>[Column]</c> mapping) — not an explicit-interface implementation, backing-field-only, or
+/// <c>[NotMapped]</c> — so generic <c>Set&lt;TEntity&gt;()</c> queries translate the
+/// interface-member access to SQL, the same way they already do for
+/// <see cref="ITenantScoped.TenantId"/> and <see cref="ISoftDeletable.DeletedAt"/>.
+/// </remarks>
+public interface IOriginalIdentified
+{
+    /// <summary>Primary key.</summary>
+    Guid Id { get; set; }
+
+    /// <summary>The MongoDB ObjectId this row carried before migration, when it had one.</summary>
+    string? OriginalId { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
@@ -4,17 +4,10 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// A V4 record entity that carries the canonical time-series columns the shared
 /// <see cref="Repositories.V4.V4RepositoryBase{TModel,TEntity}"/> filters, orders, and watermarks
 /// on. Extends <see cref="IV4Entity"/> (Id, LegacyId, TenantId, DeletedAt) and
-/// <see cref="ISourcedEntity"/> (data source, device) with the domain timestamp. Span-shaped types
+/// <see cref="ISourcedEntity"/> (data source, device) with the domain timestamp of
+/// <see cref="IObservationTimestamped"/>. Span-shaped types
 /// (e.g. TempBasal, which keys on StartTimestamp) deliberately do NOT implement this and stay off
 /// the shared base.
-///
-/// Implementers MUST map these members as ordinary EF columns (plain auto-properties with a
-/// <c>[Column]</c> mapping) — not explicit-interface implementations, backing-field-only, or
-/// <c>[NotMapped]</c> — so the base's generic <c>ctx.Set&lt;TEntity&gt;()</c> queries translate the
-/// interface-member access to SQL (the same way it already does for ITenantScoped.TenantId and
-/// ISoftDeletable.DeletedAt).
 /// </summary>
-public interface IV4TimeSeriesEntity : IV4Entity, ISourcedEntity
-{
-    DateTime Timestamp { get; set; }
-}
+/// <remarks><inheritdoc cref="IOriginalIdentified" path="/remarks"/></remarks>
+public interface IV4TimeSeriesEntity : IV4Entity, ISourcedEntity, IObservationTimestamped;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StepCountEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StepCountEntity.cs
@@ -8,7 +8,8 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.StepCount
 /// </summary>
 [Table("step_counts")]
-public class StepCountEntity : ITenantScoped, ISoftDeletable, ISyncDedupable, ISystemTimestamped
+public class StepCountEntity
+    : ITenantScoped, ISoftDeletable, ISyncDedupable, ISystemTimestamped, IOriginalIdentified, IObservationTimestamped
 {
     /// <summary>
     /// Identifier of the tenant this step count record belongs to

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/HealthRecordResponseContractTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/HealthRecordResponseContractTests.cs
@@ -1,0 +1,300 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Moq;
+using Nocturne.API.Controllers.V4.Health;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Health;
+
+/// <summary>
+/// The response shapes the heart rate, step count and body weight routes have always answered
+/// with, now that all three read them from shared controller bodies. These are the wire contract
+/// three generated artefacts are built from — the NSwag TypeScript client, the Zod schemas and the
+/// SvelteKit remote functions — so each is pinned here rather than left to the shared base.
+/// </summary>
+[Trait("Category", "Unit")]
+public class HealthRecordResponseContractTests
+{
+    private const string MongoId = "507f1f77bcf86cd799439011";
+
+    private readonly Mock<IHeartRateService> _heartRates = new();
+    private readonly Mock<IStepCountService> _stepCounts = new();
+    private readonly Mock<IBodyWeightService> _bodyWeights = new();
+
+    private HeartRateController HeartRate() =>
+        new(_heartRates.Object) { ProblemDetailsFactory = new PassThroughProblemDetailsFactory() };
+
+    private StepCountController StepCount() =>
+        new(_stepCounts.Object) { ProblemDetailsFactory = new PassThroughProblemDetailsFactory() };
+
+    private BodyWeightController BodyWeight() =>
+        new(_bodyWeights.Object) { ProblemDetailsFactory = new PassThroughProblemDetailsFactory() };
+
+    // ── A count nobody supplied ─────────────────────────────────────
+
+    [Fact]
+    public async Task Heart_rate_list_without_a_count_reads_ten()
+    {
+        await HeartRate().GetHeartRates();
+
+        _heartRates.Verify(s => s.GetHeartRatesAsync(10, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Step_count_list_without_a_count_reads_ten()
+    {
+        await StepCount().GetStepCounts();
+
+        _stepCounts.Verify(s => s.GetStepCountsAsync(10, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Body_weight_list_without_a_count_reads_ten()
+    {
+        await BodyWeight().GetBodyWeights();
+
+        _bodyWeights.Verify(s => s.GetBodyWeightsAsync(10, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Heart_rate_range_read_forwards_the_skip_it_was_given()
+    {
+        var from = new DateTime(2026, 6, 16, 0, 0, 0, DateTimeKind.Utc);
+
+        await HeartRate().GetHeartRates(count: 50, skip: 3, from: from, to: from.AddDays(1));
+
+        _heartRates.Verify(
+            s => s.GetHeartRatesByDateRangeAsync(from, from.AddDays(1), 50, 3, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "paging through a range is the only way to read past the ceiling");
+    }
+
+    // ── A route id that is not a GUID ───────────────────────────────
+
+    [Fact]
+    public async Task Get_by_id_hands_a_mongo_object_id_to_the_service_verbatim()
+    {
+        _heartRates
+            .Setup(s => s.GetHeartRateByIdAsync(MongoId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HeartRate { Id = MongoId, Bpm = 61 });
+
+        var result = await HeartRate().GetHeartRate(MongoId);
+
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<HeartRate>()
+            .Which.Id.Should().Be(MongoId, "a legacy id reaches the service unparsed");
+    }
+
+    [Fact]
+    public async Task Get_by_an_unknown_id_answers_404_naming_the_record_type_and_the_id()
+    {
+        var result = await HeartRate().GetHeartRate("nope");
+
+        Problem(result.Result, 404).Detail
+            .Should().Be("Heart rate record with ID nope not found");
+    }
+
+    // ── Delete answers 200 with a message, not 204 ──────────────────
+
+    [Fact]
+    public async Task Delete_answers_200_with_a_message_rather_than_204()
+    {
+        _heartRates
+            .Setup(s => s.DeleteHeartRateAsync(MongoId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await HeartRate().DeleteHeartRate(MongoId);
+
+        var ok = result.Should().BeOfType<OkObjectResult>(
+            "a 204 carries no body, and the generated client would stop reading one").Subject;
+        ok.StatusCode.Should().Be(200);
+        Message(ok).Should().Be("Heart rate record deleted successfully");
+    }
+
+    [Fact]
+    public async Task Body_weight_delete_answers_200_with_its_own_message()
+    {
+        _bodyWeights
+            .Setup(s => s.DeleteBodyWeightAsync(MongoId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await BodyWeight().DeleteBodyWeight(MongoId);
+
+        Message(result.Should().BeOfType<OkObjectResult>().Subject)
+            .Should().Be("Body weight record deleted successfully");
+    }
+
+    [Fact]
+    public async Task Delete_of_a_missing_record_answers_404()
+    {
+        var result = await StepCount().DeleteStepCount("gone");
+
+        Problem(result, 404).Detail.Should().Be("Step count record with ID gone not found");
+    }
+
+    // ── Create takes an array and answers a bare array ──────────────
+
+    [Fact]
+    public async Task Create_maps_every_request_in_the_batch_and_answers_a_bare_array()
+    {
+        var taken = new DateTimeOffset(2026, 6, 16, 12, 0, 0, TimeSpan.FromHours(10));
+        _heartRates
+            .Setup(s => s.CreateHeartRatesAsync(It.IsAny<IEnumerable<HeartRate>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<HeartRate> models, CancellationToken _) => models);
+
+        var result = await HeartRate().CreateHeartRates([
+            new UpsertHeartRateRequest { Timestamp = taken, UtcOffset = 600, Bpm = 61, Accuracy = 2, App = "prelude" },
+            new UpsertHeartRateRequest { Timestamp = taken, Bpm = 74 },
+        ]);
+
+        var created = result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeAssignableTo<IEnumerable<HeartRate>>().Subject.ToList();
+
+        created.Should().HaveCount(2, "the response is the array itself, not a paginated envelope");
+        created[0].Timestamp.Should().Be(taken.UtcDateTime);
+        created[0].Bpm.Should().Be(61);
+        created[0].Accuracy.Should().Be(2);
+        created[0].UtcOffset.Should().Be(600);
+        created[0].EnteredBy.Should().Be("prelude", "the request's App names who entered the record");
+    }
+
+    [Fact]
+    public async Task Create_with_an_empty_array_answers_400_and_never_reaches_the_service()
+    {
+        var result = await StepCount().CreateStepCounts([]);
+
+        Problem(result.Result, 400).Detail.Should().Be("At least one step count record is required");
+        _stepCounts.Verify(
+            s => s.CreateStepCountsAsync(It.IsAny<IEnumerable<StepCount>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── The batch route takes one record or many ────────────────────
+
+    [Fact]
+    public async Task Batch_create_with_an_array_body_reaches_the_service_with_every_record()
+    {
+        var written = CaptureBodyWeights();
+        var body = JsonSerializer.SerializeToElement(new[]
+        {
+            new BodyWeight { Mills = 1_781_000_000_000, WeightKg = 80.5m },
+            new BodyWeight { Mills = 1_781_000_060_000, WeightKg = 81.0m },
+        });
+
+        var result = await BodyWeight().CreateBodyWeights(body);
+
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeAssignableTo<IEnumerable<BodyWeight>>()
+            .Which.Should().HaveCount(2);
+        written().Select(w => w.WeightKg).Should().Equal([80.5m, 81.0m]);
+    }
+
+    [Fact]
+    public async Task Batch_create_with_a_bare_object_body_reaches_the_service_with_one_record()
+    {
+        var written = CaptureBodyWeights();
+        var body = JsonSerializer.SerializeToElement(
+            new BodyWeight { Mills = 1_781_000_000_000, WeightKg = 80.5m });
+
+        var result = await BodyWeight().CreateBodyWeights(body);
+
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeAssignableTo<IEnumerable<BodyWeight>>()
+            .Which.Should().ContainSingle("a single object is accepted as a batch of one");
+        written().Single().WeightKg.Should().Be(80.5m);
+    }
+
+    [Fact]
+    public async Task Batch_create_with_no_body_answers_400()
+    {
+        var result = await BodyWeight().CreateBodyWeights(null!);
+
+        Problem(result.Result, 400).Detail.Should().Be("Body weight data is required");
+    }
+
+    [Fact]
+    public async Task Batch_create_with_a_body_that_is_not_json_answers_400()
+    {
+        var result = await BodyWeight().CreateBodyWeights("not a json element");
+
+        Problem(result.Result, 400).Detail.Should().Be("Invalid data format");
+    }
+
+    // ── Update ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Update_maps_the_request_onto_the_model_it_hands_the_service()
+    {
+        StepCount? written = null;
+        _stepCounts
+            .Setup(s => s.UpdateStepCountAsync(MongoId, It.IsAny<StepCount>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, StepCount model, CancellationToken _) => written = model)
+            .ReturnsAsync((string _, StepCount model, CancellationToken _) => model);
+
+        await StepCount().UpdateStepCount(MongoId, new UpsertStepCountRequest
+        {
+            Timestamp = new DateTimeOffset(2026, 6, 16, 12, 0, 0, TimeSpan.Zero),
+            Metric = 1200,
+            Source = 1,
+            Device = "watch",
+        });
+
+        written.Should().NotBeNull();
+        written!.Metric.Should().Be(1200);
+        written.Source.Should().Be(1);
+        written.Device.Should().Be("watch");
+    }
+
+    [Fact]
+    public async Task Update_of_a_missing_record_answers_404()
+    {
+        var result = await StepCount().UpdateStepCount("gone", new UpsertStepCountRequest());
+
+        Problem(result.Result, 404).Detail.Should().Be("Step count record with ID gone not found");
+    }
+
+    /// <summary>Records what the batch route handed the service, and echoes it back as the response.</summary>
+    private Func<List<BodyWeight>> CaptureBodyWeights()
+    {
+        List<BodyWeight> written = [];
+        _bodyWeights
+            .Setup(s => s.CreateBodyWeightsAsync(It.IsAny<IEnumerable<BodyWeight>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<BodyWeight> models, CancellationToken _) =>
+            {
+                written = models.ToList();
+                return written;
+            });
+        return () => written;
+    }
+
+    private static ProblemDetails Problem(ActionResult? result, int statusCode)
+    {
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(statusCode);
+        return objectResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+    }
+
+    private static string? Message(OkObjectResult ok) =>
+        ok.Value?.GetType().GetProperty("message")?.GetValue(ok.Value) as string;
+
+    /// <summary>Stands in for the MVC-registered factory, which needs a request scope.</summary>
+    private sealed class PassThroughProblemDetailsFactory : ProblemDetailsFactory
+    {
+        public override ProblemDetails CreateProblemDetails(
+            HttpContext httpContext, int? statusCode = null, string? title = null,
+            string? type = null, string? detail = null, string? instance = null) =>
+            new() { Status = statusCode, Title = title, Type = type, Detail = detail, Instance = instance };
+
+        public override ValidationProblemDetails CreateValidationProblemDetails(
+            HttpContext httpContext, ModelStateDictionary modelStateDictionary, int? statusCode = null,
+            string? title = null, string? type = null, string? detail = null, string? instance = null) =>
+            new(modelStateDictionary) { Status = statusCode, Title = title, Type = type, Detail = detail, Instance = instance };
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/V4ReadLimitClampTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/V4ReadLimitClampTests.cs
@@ -275,7 +275,7 @@ public class V4ReadLimitClampTests
     public async Task BodyWeights_CountAtCeiling_ReachesServiceUnchanged()
     {
         var service = new Mock<IBodyWeightService>();
-        var controller = new BodyWeightController(service.Object, Mock.Of<ILogger<BodyWeightController>>());
+        var controller = new BodyWeightController(service.Object);
 
         var result = await controller.GetBodyWeights(count: Ceiling, skip: 0);
 
@@ -287,7 +287,7 @@ public class V4ReadLimitClampTests
     public async Task BodyWeights_CountAboveCeiling_IsClamped()
     {
         var service = new Mock<IBodyWeightService>();
-        var controller = new BodyWeightController(service.Object, Mock.Of<ILogger<BodyWeightController>>());
+        var controller = new BodyWeightController(service.Object);
 
         var result = await controller.GetBodyWeights(count: AboveCeiling, skip: -1);
 
@@ -301,7 +301,7 @@ public class V4ReadLimitClampTests
     public async Task HeartRates_CountAtCeiling_ReachesServiceUnchanged()
     {
         var service = new Mock<IHeartRateService>();
-        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+        var controller = new HeartRateController(service.Object);
 
         var result = await controller.GetHeartRates(count: Ceiling, skip: 0);
 
@@ -313,7 +313,7 @@ public class V4ReadLimitClampTests
     public async Task HeartRates_CountAboveCeiling_IsClamped()
     {
         var service = new Mock<IHeartRateService>();
-        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+        var controller = new HeartRateController(service.Object);
 
         var result = await controller.GetHeartRates(count: AboveCeiling, skip: -1);
 
@@ -325,7 +325,7 @@ public class V4ReadLimitClampTests
     public async Task HeartRates_DateRangeWithoutCount_ReadsNoMoreThanTheCeiling()
     {
         var service = new Mock<IHeartRateService>();
-        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+        var controller = new HeartRateController(service.Object);
 
         var result = await controller.GetHeartRates(from: RangeFrom, to: RangeTo);
 
@@ -337,7 +337,7 @@ public class V4ReadLimitClampTests
     public async Task HeartRates_DateRangeCountAtCeiling_ReachesServiceUnchanged()
     {
         var service = new Mock<IHeartRateService>();
-        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+        var controller = new HeartRateController(service.Object);
 
         var result = await controller.GetHeartRates(count: Ceiling, skip: 0, from: RangeFrom, to: RangeTo);
 
@@ -349,7 +349,7 @@ public class V4ReadLimitClampTests
     public async Task HeartRates_DateRangeCountAboveCeiling_IsClamped()
     {
         var service = new Mock<IHeartRateService>();
-        var controller = new HeartRateController(service.Object, Mock.Of<ILogger<HeartRateController>>());
+        var controller = new HeartRateController(service.Object);
 
         var result = await controller.GetHeartRates(count: AboveCeiling, skip: -1, from: RangeFrom, to: RangeTo);
 
@@ -367,7 +367,7 @@ public class V4ReadLimitClampTests
     public async Task StepCounts_CountAtCeiling_ReachesServiceUnchanged()
     {
         var service = new Mock<IStepCountService>();
-        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+        var controller = new StepCountController(service.Object);
 
         var result = await controller.GetStepCounts(count: Ceiling, skip: 0);
 
@@ -379,7 +379,7 @@ public class V4ReadLimitClampTests
     public async Task StepCounts_CountAboveCeiling_IsClamped()
     {
         var service = new Mock<IStepCountService>();
-        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+        var controller = new StepCountController(service.Object);
 
         var result = await controller.GetStepCounts(count: AboveCeiling, skip: -1);
 
@@ -391,7 +391,7 @@ public class V4ReadLimitClampTests
     public async Task StepCounts_DateRangeWithoutCount_ReadsNoMoreThanTheCeiling()
     {
         var service = new Mock<IStepCountService>();
-        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+        var controller = new StepCountController(service.Object);
 
         var result = await controller.GetStepCounts(from: RangeFrom, to: RangeTo);
 
@@ -403,7 +403,7 @@ public class V4ReadLimitClampTests
     public async Task StepCounts_DateRangeCountAtCeiling_ReachesServiceUnchanged()
     {
         var service = new Mock<IStepCountService>();
-        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+        var controller = new StepCountController(service.Object);
 
         var result = await controller.GetStepCounts(count: Ceiling, skip: 0, from: RangeFrom, to: RangeTo);
 
@@ -415,7 +415,7 @@ public class V4ReadLimitClampTests
     public async Task StepCounts_DateRangeCountAboveCeiling_IsClamped()
     {
         var service = new Mock<IStepCountService>();
-        var controller = new StepCountController(service.Object, Mock.Of<ILogger<StepCountController>>());
+        var controller = new StepCountController(service.Object);
 
         var result = await controller.GetStepCounts(count: AboveCeiling, skip: -1, from: RangeFrom, to: RangeTo);
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Health/HealthRecordIdResolutionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Health/HealthRecordIdResolutionTests.cs
@@ -1,0 +1,219 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Health;
+using Nocturne.API.Services.Realtime;
+using Nocturne.Core.Contracts.Legacy;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Health;
+
+/// <summary>
+/// Every health record is addressable by two ids: the primary key it was assigned, and the
+/// MongoDB ObjectId it carried in from the pre-migration database. The routes take the id as a
+/// bare string for exactly that reason, and the resolution now lives once on
+/// <c>SimpleEntityService</c> — so read, update and delete are each proven to reach a row through
+/// either one.
+/// </summary>
+[Trait("Category", "Unit")]
+public class HealthRecordIdResolutionTests
+{
+    private const string MongoId = "507f1f77bcf86cd799439011";
+    private static readonly DateTime Taken = new(2026, 6, 16, 12, 0, 0, DateTimeKind.Utc);
+
+    private static NocturneDbContext Context() =>
+        new(new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options)
+        {
+            TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+        };
+
+    private static IDocumentProcessingService PassThrough<T>()
+        where T : class, IProcessableDocument
+    {
+        var processing = new Mock<IDocumentProcessingService>();
+        processing
+            .Setup(p => p.ProcessDocuments(It.IsAny<IEnumerable<T>>()))
+            .Returns((IEnumerable<T> docs) => docs);
+        return processing.Object;
+    }
+
+    private static (HeartRateService service, NocturneDbContext context) HeartRates()
+    {
+        var context = Context();
+        return (
+            new HeartRateService(
+                context,
+                PassThrough<HeartRate>(),
+                Mock.Of<ISignalRBroadcastService>(),
+                NullLogger<HeartRateService>.Instance),
+            context);
+    }
+
+    private static (StepCountService service, NocturneDbContext context) StepCounts()
+    {
+        var context = Context();
+        return (
+            new StepCountService(
+                context,
+                PassThrough<StepCount>(),
+                Mock.Of<ISignalRBroadcastService>(),
+                NullLogger<StepCountService>.Instance),
+            context);
+    }
+
+    private static (BodyWeightService service, NocturneDbContext context) BodyWeights()
+    {
+        var context = Context();
+        return (
+            new BodyWeightService(
+                context,
+                PassThrough<BodyWeight>(),
+                Mock.Of<ISignalRBroadcastService>(),
+                NullLogger<BodyWeightService>.Instance),
+            context);
+    }
+
+    [Fact]
+    public async Task Heart_rate_resolves_by_the_mongo_object_id_it_was_migrated_with()
+    {
+        var (service, _) = HeartRates();
+        await service.CreateHeartRatesAsync([new HeartRate { Id = MongoId, Timestamp = Taken, Bpm = 61 }]);
+
+        var found = await service.GetHeartRateByIdAsync(MongoId);
+
+        found.Should().NotBeNull("a legacy id must keep resolving after the migration");
+        found!.Bpm.Should().Be(61);
+    }
+
+    [Fact]
+    public async Task Heart_rate_resolves_by_its_primary_key()
+    {
+        var (service, context) = HeartRates();
+        await service.CreateHeartRatesAsync([new HeartRate { Id = MongoId, Timestamp = Taken, Bpm = 61 }]);
+        var key = (await context.HeartRates.AsNoTracking().SingleAsync()).Id;
+
+        var found = await service.GetHeartRateByIdAsync(key.ToString());
+
+        found.Should().NotBeNull();
+        found!.Bpm.Should().Be(61);
+    }
+
+    [Fact]
+    public async Task Step_count_resolves_by_the_mongo_object_id_it_was_migrated_with()
+    {
+        var (service, _) = StepCounts();
+        await service.CreateStepCountsAsync([new StepCount { Id = MongoId, Timestamp = Taken, Metric = 1200 }]);
+
+        (await service.GetStepCountByIdAsync(MongoId))!.Metric.Should().Be(1200);
+    }
+
+    [Fact]
+    public async Task Body_weight_resolves_by_the_mongo_object_id_it_was_migrated_with()
+    {
+        var (service, _) = BodyWeights();
+        await service.CreateBodyWeightsAsync([new BodyWeight { Id = MongoId, Mills = 1_781_000_000_000, WeightKg = 80.5m }]);
+
+        (await service.GetBodyWeightByIdAsync(MongoId))!.WeightKg.Should().Be(80.5m);
+    }
+
+    [Fact]
+    public async Task Update_by_the_mongo_object_id_writes_the_migrated_row()
+    {
+        var (service, context) = HeartRates();
+        await service.CreateHeartRatesAsync([new HeartRate { Id = MongoId, Timestamp = Taken, Bpm = 61 }]);
+
+        var updated = await service.UpdateHeartRateAsync(MongoId, new HeartRate { Timestamp = Taken, Bpm = 74 });
+
+        updated.Should().NotBeNull();
+        var rows = await context.HeartRates.AsNoTracking().ToListAsync();
+        rows.Should().ContainSingle("an update must find the row, not insert a second one");
+        rows[0].Bpm.Should().Be(74);
+    }
+
+    [Fact]
+    public async Task Delete_by_the_mongo_object_id_removes_the_migrated_row()
+    {
+        var (service, _) = HeartRates();
+        await service.CreateHeartRatesAsync([new HeartRate { Id = MongoId, Timestamp = Taken, Bpm = 61 }]);
+
+        (await service.DeleteHeartRateAsync(MongoId)).Should().BeTrue();
+        (await service.GetHeartRateByIdAsync(MongoId)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task An_id_matching_no_row_resolves_to_null_whichever_shape_it_takes()
+    {
+        var (service, _) = HeartRates();
+        await service.CreateHeartRatesAsync([new HeartRate { Id = MongoId, Timestamp = Taken, Bpm = 61 }]);
+
+        (await service.GetHeartRateByIdAsync("507f1f77bcf86cd799439099")).Should().BeNull();
+        (await service.GetHeartRateByIdAsync(Guid.NewGuid().ToString())).Should().BeNull();
+        (await service.DeleteHeartRateAsync("not-an-id")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_date_range_read_is_half_open_and_ordered_oldest_first()
+    {
+        var (service, _) = HeartRates();
+        await service.CreateHeartRatesAsync([
+            new HeartRate { Timestamp = Taken.AddMinutes(-5), Bpm = 55 },
+            new HeartRate { Timestamp = Taken, Bpm = 61 },
+            new HeartRate { Timestamp = Taken.AddMinutes(5), Bpm = 74 },
+        ]);
+
+        var range = (await service.GetHeartRatesByDateRangeAsync(Taken.AddMinutes(-5), Taken.AddMinutes(5))).ToList();
+
+        range.Select(r => r.Bpm).Should().Equal(55, 61);
+    }
+
+    [Fact]
+    public async Task A_page_read_is_newest_first()
+    {
+        var (service, _) = HeartRates();
+        await service.CreateHeartRatesAsync([
+            new HeartRate { Timestamp = Taken, Bpm = 61 },
+            new HeartRate { Timestamp = Taken.AddMinutes(10), Bpm = 88 },
+            new HeartRate { Timestamp = Taken.AddMinutes(-10), Bpm = 55 },
+        ]);
+
+        var page = (await service.GetHeartRatesAsync(count: 3)).ToList();
+
+        page.Select(r => r.Bpm).Should().Equal([88, 61, 55],
+            "a default page is the most recent readings, not the oldest");
+    }
+
+    [Fact]
+    public async Task A_date_range_read_skips_the_oldest_records_it_is_told_to()
+    {
+        var (service, _) = HeartRates();
+        await service.CreateHeartRatesAsync([
+            new HeartRate { Timestamp = Taken.AddMinutes(-10), Bpm = 55 },
+            new HeartRate { Timestamp = Taken, Bpm = 61 },
+            new HeartRate { Timestamp = Taken.AddMinutes(10), Bpm = 88 },
+        ]);
+
+        var range = (await service.GetHeartRatesByDateRangeAsync(
+            Taken.AddMinutes(-10), Taken.AddMinutes(11), skip: 2)).ToList();
+
+        range.Select(r => r.Bpm).Should().Equal([88], "skip drops the oldest, the range being ascending");
+    }
+
+    [Fact]
+    public async Task The_watermark_is_the_latest_timestamp_that_source_wrote()
+    {
+        var (service, _) = HeartRates();
+        await service.CreateHeartRatesAsync([
+            new HeartRate { Timestamp = Taken, Bpm = 61, DataSource = "prelude" },
+            new HeartRate { Timestamp = Taken.AddMinutes(5), Bpm = 74, DataSource = "prelude" },
+            new HeartRate { Timestamp = Taken.AddHours(1), Bpm = 88, DataSource = "other" },
+        ]);
+
+        (await service.GetLatestTimestampAsync("prelude")).Should().Be(Taken.AddMinutes(5));
+        (await service.GetLatestTimestampAsync("never-synced")).Should().BeNull();
+    }
+}


### PR DESCRIPTION
The heart rate and step count surfaces were one implementation typed out twice — 192-line controllers and 119-line services differing only in names — and body weight was a third copy of the same skeleton. Roughly 330 of those 534 controller lines were copies.

This is a pure refactor: **the wire contract is unchanged, byte for byte.**

## Services

`SimpleEntityService` now resolves a route id itself — a GUID addresses the primary key, anything else the MongoDB ObjectId the row was migrated with — over a new `IOriginalIdentified`, replacing three identical overrides.

A new `TimeSeriesEntityService` adds the reads an observation timestamp makes possible: newest-first ordering, the half-open `[from, to)` page, and the per-source watermark a connector resumes from. It sits over a new `IObservationTimestamped`, which `IV4TimeSeriesEntity` now extends rather than redeclaring, so the concept is declared once.

Body weight keys on epoch milliseconds rather than a `DateTime` column, so it keeps its own ordering and stays on `SimpleEntityService`.

## Controllers

`HealthRecordControllerBase` holds the bodies all three share — the paged read, the by-id lookup, the batch create, the update, the delete, and the 404 and 400 details that go with them. `HealthSeriesControllerBase` adds the date-range read and the mapping from an upsert request. Each controller keeps its route, its scope gates, and its own request-to-model mapping.

The action *methods* stay declared on each controller deliberately. NSwag names an operation `{Controller}_{ActionMethod}` — `CalibrationController`, which inherits its actions from `V4CrudControllerBase`, is published as `Calibration_GetAll`/`Calibration_Create` for exactly that reason. Inheriting `GetHeartRates` from a base would republish it as `HeartRate_GetAll`, renaming the generated TypeScript client method and the SvelteKit remote function with it, and `[ActionName]` sits on the base method so it cannot be varied per derived controller. Two reflection sweeps (`ShareReadSurfaceReachabilityTests`, `V4WriteScopeGatingTests`) independently require the actions to be declared per controller with per-controller `[RequireScope]`. `V4ReadLimitCoverageTests` already follows clamps into inherited helpers, so the read-limit guard still holds.

`V4CrudControllerBase` itself was not an option: it requires `IV4Repository<T>` and `{id:guid}` routes, which would 404 every legacy id, and it answers with a paginated envelope and 204 on delete.

Also drops the `ILogger` none of the three controllers ever read.

## Evidence

The OpenAPI spec, NSwag TypeScript client, Zod schemas and SvelteKit remote functions were generated from `origin/main` and from this branch and diffed. The **only** difference across all four artefacts is the regeneration timestamp comment in `schemas.ts`:

```
diff -ru baseline/generated  head/generated
--- baseline/generated/schemas.ts
+++ head/generated/schemas.ts
@@ -1,6 +1,6 @@
 // Auto-generated from OpenAPI spec - DO NOT EDIT
 // Generated by: pnpm run generate-zod-schemas
-// Source: openapi.json (2026-08-31T22:14:16.910Z)
+// Source: openapi.json (2026-08-31T22:16:17.812Z)
```

`openapi.json`, `nocturne-api-client.ts` and every `*.generated.remote.ts` are identical. All 16 operations — five heart rate, five step count, six body weight — keep their ids, summaries, descriptions, parameter names and defaults, status codes, response schemas, tags, security blocks and `x-remote-*` extensions. Body weight's `POST /batch` keeps its untyped single-or-array body verbatim — seven published SDKs are generated from that operation — and now shares the create body with the rest rather than hand-rolling it.

No EF migration: the new interfaces add no CLR members, and `NocturneDbContext` conventions key on explicit type lists plus `ITenantScoped`/`ISoftDeletable`.

## Tests

Existing tests pass unchanged apart from dropping the deleted logger argument from 12 constructor calls in `V4ReadLimitClampTests`.

Two new files add 28 tests. `HealthRecordResponseContractTests` (17) covers the count of ten nobody asked for on all three routes, a Mongo ObjectId reaching the service unparsed, 200-with-a-message on delete (both wordings), the exact 404 details, a bare create array, an empty batch answering 400 without touching the service, the `skip` a range read forwards, the update field mapping, and the body weight batch route answering to an array body, a bare object body, an absent body and a body that is not JSON. `HealthRecordIdResolutionTests` (11) proves read, update and delete each reach a row through either id shape for all three record types, that the shared page read stays newest-first, and that the range read stays ascending, half-open and skip-respecting.

Ten mutation proofs, each killed by a named test:

| Mutation | Failing test |
| --- | --- |
| delete answers `NoContent()` | `Delete_answers_200_with_a_message_rather_than_204`, `Body_weight_delete_answers_200_with_its_own_message` |
| `e.OriginalId == id` never matches | the five `…_by_the_mongo_object_id…` tests |
| `DefaultCount` 10 → 25 | the three `…_list_without_a_count_reads_ten` |
| empty-batch guard inverted | `Create_with_an_empty_array_answers_400_and_never_reaches_the_service` |
| range `Timestamp < to` → `<= to` | `A_date_range_read_is_half_open_and_ordered_oldest_first` |
| range arm forwards `skip` as `0` | `Heart_rate_range_read_forwards_the_skip_it_was_given` |
| page read `OrderByDescending` → `OrderBy` | `A_page_read_is_newest_first` |
| service range read `Skip(skip)` → `Skip(0)` | `A_date_range_read_skips_the_oldest_records_it_is_told_to` |
| batch `ValueKind == Array` → `!=` | `Batch_create_with_an_array_body_reaches_the_service_with_every_record`, `Batch_create_with_a_bare_object_body_reaches_the_service_with_one_record` |
| batch `"Invalid data format"` reworded | `Batch_create_with_a_body_that_is_not_json_answers_400` |

`Nocturne.API.Tests` 6226 passed / 0 failed / 5 skipped. `Nocturne.Infrastructure.Data.Tests` 707 passed / 0 failed.

Closes #1046
