### PR TITLE
fix(connectors): make Tandem, MyLife and Glooko answer the sync request's window

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -457,9 +457,10 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     ///     The lower bound a whole request crawls from, for a source that cannot crawl from an open
     ///     one. An explicit range is answered as asked: it is the shape a manual re-import of one
     ///     window sends, and widening it back to a resume point below re-crawls everything in
-    ///     between. A range naming no lower bound is asking for everything the source still holds,
-    ///     which is <paramref name="historyFloor"/> — the reading the reset-cursor endpoint
-    ///     documents, and the only one under which it resets anything.
+    ///     between. A range naming no lower bound is asking for everything available, so it starts
+    ///     at <paramref name="historyFloor"/> — as far back as the connector reaches, which is the
+    ///     reading the reset-cursor endpoint documents and the only one under which it resets
+    ///     anything.
     /// </summary>
     protected static DateTime ResumeFrom(
         SyncRequest request, DateTime resumePoint, DateTime historyFloor) =>

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -456,7 +456,9 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     /// <summary>
     ///     The lower bound a whole request crawls from. An explicit range is answered as asked:
     ///     it is the shape a manual re-import of one window sends, and widening it back to a
-    ///     resume point below re-crawls everything in between.
+    ///     resume point below re-crawls everything in between. A range that names no lower bound
+    ///     stands on the resume point — a source that cannot crawl from an open bound has to start
+    ///     somewhere, and the resume point is where the last one left off.
     /// </summary>
     protected static DateTime ResumeFrom(SyncRequest request, DateTime resumePoint) =>
         request.To is null ? ResumeFrom(request.From, resumePoint) : request.From ?? resumePoint;

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -454,6 +454,14 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         ResumeFrom(requested, (DateTime?)resumePoint) ?? resumePoint;
 
     /// <summary>
+    ///     The lower bound a whole request crawls from. An explicit range is answered as asked:
+    ///     it is the shape a manual re-import of one window sends, and widening it back to a
+    ///     resume point below re-crawls everything in between.
+    /// </summary>
+    protected static DateTime ResumeFrom(SyncRequest request, DateTime resumePoint) =>
+        request.To is null ? ResumeFrom(request.From, resumePoint) : request.From ?? resumePoint;
+
+    /// <summary>
     ///     Applies the catch-up overlap to a latest-record timestamp: returns the timestamp
     ///     minus a small overlap (to absorb clock drift), or <c>null</c> when there is no
     ///     usable prior timestamp.

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -366,36 +366,24 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
     }
 
     /// <summary>
-    ///     Calculate the optimal "since" timestamp for fetching glucose entries
-    ///     Uses catch-up logic to fetch from the most recent entry, or falls back to default lookback
+    ///     The glucose family's resume point: the most recent stored entry (minus the catch-up
+    ///     overlap), or <see cref="InitialSyncFloor"/> when none is stored. Combine it with a
+    ///     caller's bound through <see cref="ResumeFrom(DateTime?, DateTime?)"/> rather than
+    ///     choosing between the two.
     /// </summary>
-    protected async Task<DateTime?> CalculateSinceTimestampAsync(
-        TConfig config,
-        DateTime? defaultSince = null
-    )
+    protected async Task<DateTime?> CalculateSinceTimestampAsync(TConfig config)
     {
-        if (defaultSince.HasValue)
-            return defaultSince.Value;
-
-        // Get the most recent entry timestamp from Nocturne API
         var latestEntryTimestamp = await FetchLatestEntryTimestampAsync(config);
 
         return CalculateSinceFromTimestamp(latestEntryTimestamp, "entries");
     }
 
     /// <summary>
-    ///     Calculate the optimal "since" timestamp for fetching treatments
-    ///     Uses catch-up logic to fetch from the most recent treatment, or falls back to default lookback
+    ///     The treatment family's resume point: the most recent stored treatment (minus the
+    ///     catch-up overlap), or <see cref="InitialSyncFloor"/> when none is stored.
     /// </summary>
-    protected async Task<DateTime?> CalculateTreatmentSinceTimestampAsync(
-        TConfig config,
-        DateTime? defaultSince = null
-    )
+    protected async Task<DateTime?> CalculateTreatmentSinceTimestampAsync(TConfig config)
     {
-        if (defaultSince.HasValue)
-            return defaultSince.Value;
-
-        // Get the most recent treatment timestamp from Nocturne API
         var latestTreatmentTimestamp = await FetchLatestTreatmentTimestampAsync(config);
 
         return CalculateSinceFromTimestamp(latestTreatmentTimestamp, "treatments");
@@ -456,6 +444,14 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
         return requested < resumePoint ? requested : resumePoint;
     }
+
+    /// <summary>
+    ///     The lower bound for a source that cannot crawl from an open one: as
+    ///     <see cref="ResumeFrom(DateTime?, DateTime?)"/>, over a resume point already resolved to
+    ///     a concrete timestamp.
+    /// </summary>
+    protected static DateTime ResumeFrom(DateTime? requested, DateTime resumePoint) =>
+        ResumeFrom(requested, (DateTime?)resumePoint) ?? resumePoint;
 
     /// <summary>
     ///     Applies the catch-up overlap to a latest-record timestamp: returns the timestamp

--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -454,14 +454,16 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         ResumeFrom(requested, (DateTime?)resumePoint) ?? resumePoint;
 
     /// <summary>
-    ///     The lower bound a whole request crawls from. An explicit range is answered as asked:
-    ///     it is the shape a manual re-import of one window sends, and widening it back to a
-    ///     resume point below re-crawls everything in between. A range that names no lower bound
-    ///     stands on the resume point — a source that cannot crawl from an open bound has to start
-    ///     somewhere, and the resume point is where the last one left off.
+    ///     The lower bound a whole request crawls from, for a source that cannot crawl from an open
+    ///     one. An explicit range is answered as asked: it is the shape a manual re-import of one
+    ///     window sends, and widening it back to a resume point below re-crawls everything in
+    ///     between. A range naming no lower bound is asking for everything the source still holds,
+    ///     which is <paramref name="historyFloor"/> — the reading the reset-cursor endpoint
+    ///     documents, and the only one under which it resets anything.
     /// </summary>
-    protected static DateTime ResumeFrom(SyncRequest request, DateTime resumePoint) =>
-        request.To is null ? ResumeFrom(request.From, resumePoint) : request.From ?? resumePoint;
+    protected static DateTime ResumeFrom(
+        SyncRequest request, DateTime resumePoint, DateTime historyFloor) =>
+        request.To is null ? ResumeFrom(request.From, resumePoint) : request.From ?? historyFloor;
 
     /// <summary>
     ///     Applies the catch-up overlap to a latest-record timestamp: returns the timestamp

--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoConnectorService.cs
@@ -289,7 +289,7 @@ public class GlookoConnectorService : BaseConnectorService<GlookoConnectorConfig
             var from = request.From.HasValue
                 ? context.TimeMapper.ToGlookoTime(request.From.Value).AddDays(-1)
                 : context.TimeMapper.ToGlookoTime(DateTime.UtcNow.AddMonths(-6)).AddDays(-1);
-            var to = context.TimeMapper.ToGlookoTime(DateTime.UtcNow).AddDays(1);
+            var to = context.TimeMapper.ToGlookoTime(request.To ?? DateTime.UtcNow).AddDays(1);
 
             var chunks = DateChunker.Chunk(from, to, GlookoConstants.SyncChunkSize).ToList();
 

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -125,10 +125,18 @@ public class MyLifeConnectorService(
             var needRecords = treatmentSubTypes.Any(t => activeTypes.Contains(t));
             var needStateSpans = activeTypes.Contains(SyncDataType.StateSpans);
 
-            // Calculate since timestamps. MyLife streams the source month by month, so it needs a
-            // concrete lower bound; fall back to the default initial window when no cursor exists.
-            var glucoseSince = await CalculateSinceTimestampAsync(config, request.From) ?? DefaultInitialSyncFloor();
-            var treatmentSince = await CalculateTreatmentSinceTimestampAsync(config, request.From) ?? DefaultInitialSyncFloor();
+            // MyLife streams the source month by month, so every bound below has to be concrete:
+            // a resume point left open by this connector's floor becomes the default initial window.
+            var openEnded = request.To is null;
+            var glucoseSince = Bound(await CalculateSinceTimestampAsync(config));
+            var treatmentSince = Bound(await CalculateTreatmentSinceTimestampAsync(config));
+
+            DateTime Bound(DateTime? resumePoint)
+            {
+                var resume = resumePoint ?? DefaultInitialSyncFloor();
+                return openEnded ? ResumeFrom(request.From, resume) : request.From ?? resume;
+            }
+
             var overallSince = glucoseSince < treatmentSince ? glucoseSince : treatmentSince;
             var until = request.To ?? DateTime.UtcNow;
 

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -125,11 +125,13 @@ public class MyLifeConnectorService(
             var needRecords = treatmentSubTypes.Any(t => activeTypes.Contains(t));
             var needStateSpans = activeTypes.Contains(SyncDataType.StateSpans);
 
-            // MyLife streams the source month by month, so every bound below has to be concrete.
+            // MyLife streams the source month by month, so every bound below has to be concrete;
+            // the initial-sync floor is both the fallback and as far back as this source goes.
+            var floor = InitialSyncFloor ?? DefaultInitialSyncFloor();
             var glucoseSince = ResumeFrom(
-                request, await CalculateSinceTimestampAsync(config) ?? DefaultInitialSyncFloor());
+                request, await CalculateSinceTimestampAsync(config) ?? floor, floor);
             var treatmentSince = ResumeFrom(
-                request, await CalculateTreatmentSinceTimestampAsync(config) ?? DefaultInitialSyncFloor());
+                request, await CalculateTreatmentSinceTimestampAsync(config) ?? floor, floor);
 
             var overallSince = glucoseSince < treatmentSince ? glucoseSince : treatmentSince;
             var until = request.To ?? DateTime.UtcNow;

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -125,8 +125,9 @@ public class MyLifeConnectorService(
             var needRecords = treatmentSubTypes.Any(t => activeTypes.Contains(t));
             var needStateSpans = activeTypes.Contains(SyncDataType.StateSpans);
 
-            // MyLife streams the source month by month, so every bound below has to be concrete;
-            // the initial-sync floor is both the fallback and as far back as this source goes.
+            // MyLife streams the source month by month, so every bound below has to be concrete.
+            // The initial-sync floor is the fallback, and as far back as this connector reaches for
+            // a range naming no lower bound; whether the source itself holds more is unverified.
             var floor = InitialSyncFloor ?? DefaultInitialSyncFloor();
             var glucoseSince = ResumeFrom(
                 request, await CalculateSinceTimestampAsync(config) ?? floor, floor);

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -125,17 +125,11 @@ public class MyLifeConnectorService(
             var needRecords = treatmentSubTypes.Any(t => activeTypes.Contains(t));
             var needStateSpans = activeTypes.Contains(SyncDataType.StateSpans);
 
-            // MyLife streams the source month by month, so every bound below has to be concrete:
-            // a resume point left open by this connector's floor becomes the default initial window.
-            var openEnded = request.To is null;
-            var glucoseSince = Bound(await CalculateSinceTimestampAsync(config));
-            var treatmentSince = Bound(await CalculateTreatmentSinceTimestampAsync(config));
-
-            DateTime Bound(DateTime? resumePoint)
-            {
-                var resume = resumePoint ?? DefaultInitialSyncFloor();
-                return openEnded ? ResumeFrom(request.From, resume) : request.From ?? resume;
-            }
+            // MyLife streams the source month by month, so every bound below has to be concrete.
+            var glucoseSince = ResumeFrom(
+                request, await CalculateSinceTimestampAsync(config) ?? DefaultInitialSyncFloor());
+            var treatmentSince = ResumeFrom(
+                request, await CalculateTreatmentSinceTimestampAsync(config) ?? DefaultInitialSyncFloor());
 
             var overallSince = glucoseSince < treatmentSince ? glucoseSince : treatmentSince;
             var until = request.To ?? DateTime.UtcNow;

--- a/src/Connectors/Nocturne.Connectors.Tandem/Mappers/TandemBasalMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Mappers/TandemBasalMapper.cs
@@ -4,6 +4,17 @@ using Nocturne.Core.Models.V4;
 
 namespace Nocturne.Connectors.Tandem.Mappers;
 
+/// <summary>The spans a payload yields, and the one it holds no end for.</summary>
+/// <param name="Spans">The spans, each closed by the delivery event that follows it.</param>
+/// <param name="UnclosedFrom">
+///     The start of the span the payload cannot close — the last event's, when nothing above it was
+///     fetched — or <c>null</c> when every span has an end. That span is absent from
+///     <paramref name="Spans"/>, because the records upsert on a stable id and any end invented for
+///     it (the fetch's upper bound, or the pump's newest event) overwrites the real one already
+///     stored, either shortening the span or stretching it over days it did not run.
+/// </param>
+public readonly record struct TandemBasalSpans(List<TempBasal> Spans, DateTime? UnclosedFrom);
+
 /// <summary>
 /// Maps Tandem basal-delivery events (emitted roughly every five minutes) to <see cref="TempBasal"/>
 /// spans. Each span runs from one delivery event to the next, with the final span ending at the
@@ -16,12 +27,11 @@ public sealed class TandemBasalMapper(ILogger logger, TandemTimeResolver time)
     private readonly TandemTimeResolver _time = time ?? throw new ArgumentNullException(nameof(time));
 
     /// <param name="fetchedThroughUtc">
-    ///     The point the payload is complete through, which closes the final span. A window that
-    ///     stops short of the pump's newest event never fetched that span's successor, so its end
-    ///     is unknown: pass <c>null</c> and the span is left unpublished rather than given an end
-    ///     that would upsert over the one already stored.
+    ///     The point the payload is complete through, which closes the final span, or <c>null</c>
+    ///     when the fetch stopped short of the pump's newest event and that span's successor was
+    ///     never fetched — see <see cref="TandemBasalSpans.UnclosedFrom"/>.
     /// </param>
-    public List<TempBasal> Map(
+    public TandemBasalSpans Map(
         IEnumerable<TandemPumpEvent> events, DateTime? fetchedThroughUtc, bool ignoreZeroUnitBasal)
     {
         var ordered = events
@@ -31,17 +41,22 @@ public sealed class TandemBasalMapper(ILogger logger, TandemTimeResolver time)
 
         var now = DateTime.UtcNow;
         var records = new List<TempBasal>();
+        DateTime? unclosedFrom = null;
 
         for (var i = 0; i < ordered.Count; i++)
         {
             var (ev, start) = ordered[i];
-            var end = i < ordered.Count - 1 ? ordered[i + 1].Start : fetchedThroughUtc;
-            if (end is null)
-                continue;
 
             var rate = TandemMapHelpers.MilliunitsToUnits(ev.Num("Commanded Rate") ?? 0);
             if (ignoreZeroUnitBasal && rate < 0.01)
                 continue;
+
+            var end = i < ordered.Count - 1 ? ordered[i + 1].Start : fetchedThroughUtc;
+            if (end is null)
+            {
+                unclosedFrom = start;
+                continue;
+            }
 
             records.Add(new TempBasal
             {
@@ -61,7 +76,7 @@ public sealed class TandemBasalMapper(ILogger logger, TandemTimeResolver time)
         }
 
         _logger.LogDebug("Mapped {Count} Tandem temp basals", records.Count);
-        return records;
+        return new TandemBasalSpans(records, unclosedFrom);
     }
 
     private static TempBasalOrigin MapOrigin(string? source) => source switch

--- a/src/Connectors/Nocturne.Connectors.Tandem/Mappers/TandemBasalMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Mappers/TandemBasalMapper.cs
@@ -7,15 +7,22 @@ namespace Nocturne.Connectors.Tandem.Mappers;
 /// <summary>
 /// Maps Tandem basal-delivery events (emitted roughly every five minutes) to <see cref="TempBasal"/>
 /// spans. Each span runs from one delivery event to the next, with the final span ending at the
-/// window end. Mirrors <c>tconnectsync</c>'s <c>process_basal.py</c>, including the
-/// <c>IGNORE_ZERO_UNIT_BASAL</c> behaviour.
+/// point the fetch is complete through. Mirrors <c>tconnectsync</c>'s <c>process_basal.py</c>,
+/// including the <c>IGNORE_ZERO_UNIT_BASAL</c> behaviour.
 /// </summary>
 public sealed class TandemBasalMapper(ILogger logger, TandemTimeResolver time)
 {
     private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly TandemTimeResolver _time = time ?? throw new ArgumentNullException(nameof(time));
 
-    public List<TempBasal> Map(IEnumerable<TandemPumpEvent> events, DateTime windowEndUtc, bool ignoreZeroUnitBasal)
+    /// <param name="fetchedThroughUtc">
+    ///     The point the payload is complete through, which closes the final span. A window that
+    ///     stops short of the pump's newest event never fetched that span's successor, so its end
+    ///     is unknown: pass <c>null</c> and the span is left unpublished rather than given an end
+    ///     that would upsert over the one already stored.
+    /// </param>
+    public List<TempBasal> Map(
+        IEnumerable<TandemPumpEvent> events, DateTime? fetchedThroughUtc, bool ignoreZeroUnitBasal)
     {
         var ordered = events
             .Select(ev => (Event: ev, Start: _time.ToUtc(ev.RawTimestampSeconds)))
@@ -28,7 +35,9 @@ public sealed class TandemBasalMapper(ILogger logger, TandemTimeResolver time)
         for (var i = 0; i < ordered.Count; i++)
         {
             var (ev, start) = ordered[i];
-            var end = i < ordered.Count - 1 ? ordered[i + 1].Start : windowEndUtc;
+            var end = i < ordered.Count - 1 ? ordered[i + 1].Start : fetchedThroughUtc;
+            if (end is null)
+                continue;
 
             var rate = TandemMapHelpers.MilliunitsToUnits(ev.Num("Commanded Rate") ?? 0);
             if (ignoreZeroUnitBasal && rate < 0.01)

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -164,8 +164,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         var window = request.To is null
             ? (PublishWindow?)null
             : new PublishWindow(start.Date, end.Date.AddDays(1).AddTicks(-1));
-        var first = ParseWallClockUtc(device.AvailableDataRange?.Start, time);
-        var fetchFrom = window is null ? start : Later(start.Date.AddDays(-1), first);
+        var fetchFrom = window is null ? start : Later(start.Date.AddDays(-1), FirstEvent(device, time));
         var fetchTo = window is null ? end : Earlier(end.AddDays(1), ceiling);
 
         // LID_DAILY_BASAL (device status) is not in the backend's default event filter, so the full
@@ -227,6 +226,10 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     {
         internal bool Holds(DateTime at) => at >= From && at <= Through;
     }
+
+    /// <summary>The oldest event the pump still holds, or <c>null</c> when it does not say.</summary>
+    private static DateTime? FirstEvent(TandemBffPump device, TandemTimeResolver time) =>
+        ParseWallClockUtc(device.AvailableDataRange?.Start, time);
 
     private static DateTime Later(DateTime value, DateTime? floor) =>
         floor is { } bound && bound > value ? bound : value;
@@ -347,7 +350,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
         // The pump's own range is how far back this source goes, and the floor a range naming no
         // lower bound resolves to — named, rather than left to the clamp below to arrive at.
-        var first = ParseWallClockUtc(device.AvailableDataRange?.Start, time);
+        var first = FirstEvent(device, time);
         var start = ResumeFrom(request, resume, first ?? DefaultInitialSyncFloor());
 
         return Later(start, first);
@@ -360,7 +363,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     /// </summary>
     private static string? ClampNotice(
         SyncRequest request, TandemBffPump device, TandemTimeResolver time) =>
-        ParseWallClockUtc(device.AvailableDataRange?.Start, time) is { } first && request.From < first
+        FirstEvent(device, time) is { } first && request.From < first
             ? $"The pump holds no data before {first.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} UTC; "
               + "the sync started there."
             : null;

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -98,7 +98,8 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
             await SyncProfilesAsync(device, activeTypes, result, config, cancellationToken);
 
-            await SyncEventsAsync(region, pumperId, device, activeTypes, time, result, config, cancellationToken);
+            await SyncEventsAsync(
+                request, region, pumperId, device, activeTypes, time, result, config, cancellationToken);
         }
         catch (OperationCanceledException)
         {
@@ -130,12 +131,16 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     }
 
     private async Task SyncEventsAsync(
-        TandemConstants.RegionUrls region, string pumperId, TandemBffPump device,
+        SyncRequest request, TandemConstants.RegionUrls region, string pumperId, TandemBffPump device,
         HashSet<SyncDataType> activeTypes, TandemTimeResolver time, SyncResult result,
         TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
+        // The pump's newest event is a hard ceiling: there is nothing above it to ask for.
         var end = ParseWallClockUtc(device.MaxDateOfEvents, time) ?? DateTime.UtcNow;
-        var start = await ResolveStartAsync(config, device, time);
+        if (request.To is { } until && until < end)
+            end = until;
+
+        var start = await ResolveStartAsync(request, config, device, time, result);
         if (start >= end)
         {
             _logger.LogInformation(
@@ -262,20 +267,33 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     }
 
     /// <summary>
-    /// Resolves the start of the sync window: the earliest catch-up point across glucose and
-    /// treatments (so no active data type is missed), never earlier than the pump's first event.
+    /// Resolves the start of the sync window from the caller's bound and the pump's own resume
+    /// point — the earliest catch-up point across glucose and treatments, so no active data type is
+    /// missed — never earlier than the pump's first event. The pump serves nothing below that
+    /// first event, so a caller's bound below it is clamped and the run says so.
     /// </summary>
     private async Task<DateTime> ResolveStartAsync(
-        TandemConnectorConfiguration config, TandemBffPump device, TandemTimeResolver time)
+        SyncRequest request, TandemConnectorConfiguration config, TandemBffPump device,
+        TandemTimeResolver time, SyncResult result)
     {
         var glucoseSince = await CalculateSinceTimestampAsync(config);
         var treatmentSince = await CalculateTreatmentSinceTimestampAsync(config);
 
         var candidates = new[] { glucoseSince, treatmentSince }.Where(d => d.HasValue).Select(d => d!.Value).ToList();
-        var start = candidates.Count > 0 ? candidates.Min() : DefaultInitialSyncFloor();
+        var resume = candidates.Count > 0 ? candidates.Min() : DefaultInitialSyncFloor();
+
+        var start = request.To is null
+            ? ResumeFrom(request.From, resume)
+            : request.From ?? resume;
 
         if (ParseWallClockUtc(device.AvailableDataRange?.Start, time) is { } min && min > start)
+        {
+            if (request.From < min)
+                result.Message =
+                    $"The pump holds no data before {min:yyyy-MM-dd HH:mm} UTC; the requested window starts there.";
+
             start = min;
+        }
 
         return start;
     }

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -111,6 +111,10 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             _logger.LogError(ex, "[{Source}] Error during Tandem sync", ConnectorSource);
             result.Success = false;
             result.Errors.Add($"Sync error: {ex.Message}");
+
+            // Message is the failure summary the tenant's card reads, so a window notice recorded
+            // before the throw must not stand in for the failure.
+            result.Message = string.Empty;
         }
 
         result.EndTime = DateTimeOffset.UtcNow;
@@ -135,10 +139,11 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         HashSet<SyncDataType> activeTypes, TandemTimeResolver time, SyncResult result,
         TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        // The pump's newest event is a hard ceiling: there is nothing above it to ask for.
-        var end = ParseWallClockUtc(device.MaxDateOfEvents, time) ?? DateTime.UtcNow;
-        if (request.To is { } until && until < end)
-            end = until;
+        // The pump's newest event is a hard ceiling: there is nothing above it to ask for, and it
+        // is where a still-open span closes however narrowly the fetch below is bounded — a span
+        // ended at the caller's bound instead would upsert a shortened end over the real one.
+        var ceiling = ParseWallClockUtc(device.MaxDateOfEvents, time) ?? DateTime.UtcNow;
+        var end = request.To is { } until && until < ceiling ? until : ceiling;
 
         var start = await ResolveStartAsync(request, config, device, time, result);
         if (start >= end)
@@ -192,7 +197,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             .ToDictionary(g => g.Key, g => g.ToList());
 
         await PublishEventsAsync(
-            groups, activeTypes, end, cgm, bolus, basal, deviceEvents, systemEvents,
+            groups, activeTypes, ceiling, cgm, bolus, basal, deviceEvents, systemEvents,
             userMode, deviceStatus, result, config, cancellationToken);
     }
 
@@ -288,7 +293,8 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         {
             if (request.From < min)
                 result.Message =
-                    $"The pump holds no data before {min:yyyy-MM-dd HH:mm} UTC; the requested window starts there.";
+                    $"The pump holds no data before {min.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} UTC; "
+                    + "the requested window starts there.";
 
             start = min;
         }

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -220,7 +220,10 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     /// <summary>
     /// The span of a bounded run's own window. The fetch reaches a day either side of it, and those
     /// days' records belong to the neighbouring windows: only a record assembled or closed across
-    /// the edge is this run's to publish, and it lands inside.
+    /// the edge is this run's to publish, and it lands inside. It bounds the record types whose
+    /// correctness depends on an event across the edge — spans and the bolus family. A record
+    /// complete in one event is published as fetched, so a padded day's own can reach the tenant:
+    /// it upserts on a stable id to the same values whichever window carries it.
     /// </summary>
     private readonly record struct PublishWindow(DateTime From, DateTime Through)
     {

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -100,6 +100,11 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
             await SyncEventsAsync(
                 request, region, pumperId, device, activeTypes, time, result, config, cancellationToken);
+
+            // Assigned here, after everything that can fail: on a run that did, Message is the
+            // failure summary the tenant's card reads and must not be a window notice instead.
+            if (result.Success && ClampNotice(request, device, time) is { } notice)
+                result.Message = notice;
         }
         catch (OperationCanceledException)
         {
@@ -111,10 +116,6 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             _logger.LogError(ex, "[{Source}] Error during Tandem sync", ConnectorSource);
             result.Success = false;
             result.Errors.Add($"Sync error: {ex.Message}");
-
-            // Message is the failure summary the tenant's card reads, so a window notice recorded
-            // before the throw must not stand in for the failure.
-            result.Message = string.Empty;
         }
 
         result.EndTime = DateTimeOffset.UtcNow;
@@ -139,13 +140,11 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         HashSet<SyncDataType> activeTypes, TandemTimeResolver time, SyncResult result,
         TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        // The pump's newest event is a hard ceiling: there is nothing above it to ask for, and it
-        // is where a still-open span closes however narrowly the fetch below is bounded — a span
-        // ended at the caller's bound instead would upsert a shortened end over the real one.
+        // The pump's newest event is a hard ceiling: there is nothing above it to ask for.
         var ceiling = ParseWallClockUtc(device.MaxDateOfEvents, time) ?? DateTime.UtcNow;
         var end = request.To is { } until && until < ceiling ? until : ceiling;
 
-        var start = await ResolveStartAsync(request, config, device, time, result);
+        var start = await ResolveStartAsync(request, config, device, time);
         if (start >= end)
         {
             _logger.LogInformation(
@@ -196,14 +195,18 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             .GroupBy(x => x.Class!.Value, x => x.Event)
             .ToDictionary(g => g.Key, g => g.ToList());
 
+        // What the payload is complete through: the ceiling only when the fetch reached it. A
+        // window bounded below it never fetched the events that would close the last span.
+        var fetchedThrough = end < ceiling ? null : (DateTime?)ceiling;
+
         await PublishEventsAsync(
-            groups, activeTypes, ceiling, cgm, bolus, basal, deviceEvents, systemEvents,
+            groups, activeTypes, fetchedThrough, cgm, bolus, basal, deviceEvents, systemEvents,
             userMode, deviceStatus, result, config, cancellationToken);
     }
 
     private async Task PublishEventsAsync(
         IReadOnlyDictionary<TandemEventClass, List<TandemPumpEvent>> groups,
-        HashSet<SyncDataType> activeTypes, DateTime windowEnd,
+        HashSet<SyncDataType> activeTypes, DateTime? fetchedThrough,
         TandemCgmMapper cgm, TandemBolusMapper bolus, TandemBasalMapper basal,
         TandemDeviceEventMapper deviceEvents, TandemSystemEventMapper systemEvents,
         TandemUserModeMapper userMode, TandemDeviceStatusMapper deviceStatus,
@@ -226,7 +229,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
         if (groups.TryGetValue(TandemEventClass.Basal, out var basalEvents))
             await PublishRecordTypeAsync(result, SyncDataType.TempBasals, activeTypes,
-                basal.Map(basalEvents, windowEnd, config.IgnoreZeroUnitBasal), PublishTempBasalDataAsync,
+                basal.Map(basalEvents, fetchedThrough, config.IgnoreZeroUnitBasal), PublishTempBasalDataAsync,
                 config, cancellationToken);
 
         var devEvents = Concat(groups, TandemEventClass.Cartridge, TandemEventClass.CgmStartJoinStop,
@@ -274,12 +277,12 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
     /// <summary>
     /// Resolves the start of the sync window from the caller's bound and the pump's own resume
     /// point — the earliest catch-up point across glucose and treatments, so no active data type is
-    /// missed — never earlier than the pump's first event. The pump serves nothing below that
-    /// first event, so a caller's bound below it is clamped and the run says so.
+    /// missed — never earlier than the pump's first event, which is where <see cref="ClampNotice"/>
+    /// reports a bound below.
     /// </summary>
     private async Task<DateTime> ResolveStartAsync(
         SyncRequest request, TandemConnectorConfiguration config, TandemBffPump device,
-        TandemTimeResolver time, SyncResult result)
+        TandemTimeResolver time)
     {
         var glucoseSince = await CalculateSinceTimestampAsync(config);
         var treatmentSince = await CalculateTreatmentSinceTimestampAsync(config);
@@ -290,17 +293,22 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         var start = ResumeFrom(request, resume);
 
         if (ParseWallClockUtc(device.AvailableDataRange?.Start, time) is { } min && min > start)
-        {
-            if (request.From < min)
-                result.Message =
-                    $"The pump holds no data before {min.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} UTC; "
-                    + "the requested window starts there.";
-
             start = min;
-        }
 
         return start;
     }
+
+    /// <summary>
+    /// What the run says when it covered less than it was asked for: the pump serves nothing before
+    /// its available range begins, and a success over a window that was silently narrowed reads the
+    /// same as one that covered it.
+    /// </summary>
+    private static string? ClampNotice(
+        SyncRequest request, TandemBffPump device, TandemTimeResolver time) =>
+        ParseWallClockUtc(device.AvailableDataRange?.Start, time) is { } first && request.From < first
+            ? $"The pump holds no data before {first.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} UTC; "
+              + "the requested window starts there."
+            : null;
 
     /// <summary>
     /// Selects the pump to follow: the one matching the configured serial number, or — when none is

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -98,13 +98,14 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
             await SyncProfilesAsync(device, activeTypes, result, config, cancellationToken);
 
-            await SyncEventsAsync(
+            var unclosed = await SyncEventsAsync(
                 request, region, pumperId, device, activeTypes, time, result, config, cancellationToken);
 
             // Assigned here, after everything that can fail: on a run that did, Message is the
-            // failure summary the tenant's card reads and must not be a window notice instead.
-            if (result.Success && ClampNotice(request, device, time) is { } notice)
-                result.Message = notice;
+            // failure summary the tenant's card reads and must not be a coverage notice instead.
+            if (result.Success)
+                result.Message = string.Join(" ", new[] { ClampNotice(request, device, time), unclosed }
+                    .Where(notice => notice is not null));
         }
         catch (OperationCanceledException)
         {
@@ -135,7 +136,8 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             PublishProfileDataAsync, config, cancellationToken);
     }
 
-    private async Task SyncEventsAsync(
+    /// <returns>What the run has to say about a span it could not close, or <c>null</c>.</returns>
+    private async Task<string?> SyncEventsAsync(
         SyncRequest request, TandemConstants.RegionUrls region, string pumperId, TandemBffPump device,
         HashSet<SyncDataType> activeTypes, TandemTimeResolver time, SyncResult result,
         TandemConnectorConfiguration config, CancellationToken cancellationToken)
@@ -150,8 +152,21 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             _logger.LogInformation(
                 "[{Source}] Nothing to sync for device {Device} (start {Start} >= end {End})",
                 ConnectorSource, device.AssignmentId, start, end);
-            return;
+            return null;
         }
+
+        // A record at either edge of a bounded window is assembled from, or closed by, events on
+        // the far side of it: a bolus's request messages, a basal span's successor, an exercise
+        // stop. The fetch reaches a day past each edge so those events are in hand — the pump-logs
+        // endpoint is day-granular, so this is one more chunk-day, not a different request shape —
+        // and only the window itself is published. An open-ended run already spans the pump's
+        // whole range and neither pads nor filters.
+        var window = request.To is null
+            ? (PublishWindow?)null
+            : new PublishWindow(start.Date, end.Date.AddDays(1).AddTicks(-1));
+        var first = ParseWallClockUtc(device.AvailableDataRange?.Start, time);
+        var fetchFrom = window is null ? start : Later(start.Date.AddDays(-1), first);
+        var fetchTo = window is null ? end : Earlier(end.AddDays(1), ceiling);
 
         // LID_DAILY_BASAL (device status) is not in the backend's default event filter, so the full
         // history log must be requested when device status is enabled — matching tconnectsync.
@@ -174,7 +189,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         // identity, and the separately-returned clockChanges are not consumed (matching upstream).
         var allEvents = new List<TandemPumpEvent>();
         var seen = new HashSet<(long, uint)>();
-        foreach (var (windowStart, windowEnd) in Chunk(start, end))
+        foreach (var (windowStart, windowEnd) in Chunk(fetchFrom, fetchTo))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -187,7 +202,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         }
 
         if (allEvents.Count == 0)
-            return;
+            return null;
 
         var groups = allEvents
             .Select(e => (Event: e, Class: TandemEventClasses.ForEvent(e)))
@@ -195,23 +210,45 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
             .GroupBy(x => x.Class!.Value, x => x.Event)
             .ToDictionary(g => g.Key, g => g.ToList());
 
-        // What the payload is complete through: the ceiling only when the fetch reached it. A
-        // window bounded below it never fetched the events that would close the last span.
-        var fetchedThrough = end < ceiling ? null : (DateTime?)ceiling;
+        // What the payload is complete through: the ceiling only when the fetch reached it.
+        var fetchedThrough = fetchTo < ceiling ? null : (DateTime?)ceiling;
 
-        await PublishEventsAsync(
-            groups, activeTypes, fetchedThrough, cgm, bolus, basal, deviceEvents, systemEvents,
-            userMode, deviceStatus, result, config, cancellationToken);
+        return await PublishEventsAsync(
+            groups, activeTypes, fetchedThrough, window, cgm, bolus, basal, deviceEvents,
+            systemEvents, userMode, deviceStatus, result, config, cancellationToken);
     }
 
-    private async Task PublishEventsAsync(
+    /// <summary>
+    /// The span of a bounded run's own window. The fetch reaches a day either side of it, and those
+    /// days' records belong to the neighbouring windows: only a record assembled or closed across
+    /// the edge is this run's to publish, and it lands inside.
+    /// </summary>
+    private readonly record struct PublishWindow(DateTime From, DateTime Through)
+    {
+        internal bool Holds(DateTime at) => at >= From && at <= Through;
+    }
+
+    private static DateTime Later(DateTime value, DateTime? floor) =>
+        floor is { } bound && bound > value ? bound : value;
+
+    private static DateTime Earlier(DateTime value, DateTime ceiling) =>
+        value < ceiling ? value : ceiling;
+
+    /// <returns>What the run has to say about a span it could not close, or <c>null</c>.</returns>
+    private async Task<string?> PublishEventsAsync(
         IReadOnlyDictionary<TandemEventClass, List<TandemPumpEvent>> groups,
-        HashSet<SyncDataType> activeTypes, DateTime? fetchedThrough,
+        HashSet<SyncDataType> activeTypes, DateTime? fetchedThrough, PublishWindow? window,
         TandemCgmMapper cgm, TandemBolusMapper bolus, TandemBasalMapper basal,
         TandemDeviceEventMapper deviceEvents, TandemSystemEventMapper systemEvents,
         TandemUserModeMapper userMode, TandemDeviceStatusMapper deviceStatus,
         SyncResult result, TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
+        // The records a padded day can only complete, rather than carry whole: a bolus reassembled
+        // from messages either side of the edge, a span closed by an event beyond it. The padded
+        // day's own are the neighbouring window's to publish.
+        List<T> Inside<T>(List<T> records, Func<T, DateTime> at) =>
+            window is { } bounds ? records.Where(record => bounds.Holds(at(record))).ToList() : records;
+
         if (groups.TryGetValue(TandemEventClass.CgmReading, out var cgmEvents))
             await PublishRecordTypeAsync(result, SyncDataType.Glucose, activeTypes,
                 cgm.Map(cgmEvents), PublishSensorGlucoseDataAsync, config, cancellationToken);
@@ -220,17 +257,32 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         {
             var decomposed = bolus.Map(bolusEvents);
             await PublishRecordTypeAsync(result, SyncDataType.Boluses, activeTypes,
-                decomposed.Boluses, PublishBolusDataAsync, config, cancellationToken);
+                Inside(decomposed.Boluses, record => record.Timestamp),
+                PublishBolusDataAsync, config, cancellationToken);
             await PublishRecordTypeAsync(result, SyncDataType.CarbIntake, activeTypes,
-                decomposed.CarbIntakes, PublishCarbIntakeDataAsync, config, cancellationToken);
+                Inside(decomposed.CarbIntakes, record => record.Timestamp),
+                PublishCarbIntakeDataAsync, config, cancellationToken);
             await PublishRecordTypeAsync(result, SyncDataType.BolusCalculations, activeTypes,
-                decomposed.BolusCalculations, PublishBolusCalculationDataAsync, config, cancellationToken);
+                Inside(decomposed.BolusCalculations, record => record.Timestamp),
+                PublishBolusCalculationDataAsync, config, cancellationToken);
         }
 
+        string? unclosed = null;
         if (groups.TryGetValue(TandemEventClass.Basal, out var basalEvents))
+        {
+            var spans = basal.Map(basalEvents, fetchedThrough, config.IgnoreZeroUnitBasal);
+
+            // The padded day held no further delivery event, so this span ran longer than the day
+            // the fetch reached past the window and is the tenant's to chase, not silently absent.
+            if (spans.UnclosedFrom is { } unclosedFrom && window is { } bounds && bounds.Holds(unclosedFrom))
+                unclosed =
+                    $"The basal span starting {unclosedFrom.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} "
+                    + "UTC is not published: the delivery event that ends it is more than a day above the window.";
+
             await PublishRecordTypeAsync(result, SyncDataType.TempBasals, activeTypes,
-                basal.Map(basalEvents, fetchedThrough, config.IgnoreZeroUnitBasal), PublishTempBasalDataAsync,
+                Inside(spans.Spans, record => record.StartTimestamp), PublishTempBasalDataAsync,
                 config, cancellationToken);
+        }
 
         var devEvents = Concat(groups, TandemEventClass.Cartridge, TandemEventClass.CgmStartJoinStop,
             TandemEventClass.BasalSuspension, TandemEventClass.BasalResume);
@@ -243,11 +295,14 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
 
         if (groups.TryGetValue(TandemEventClass.UserMode, out var userModeEvents))
             await PublishRecordTypeAsync(result, SyncDataType.StateSpans, activeTypes,
-                userMode.Map(userModeEvents), PublishStateSpanDataAsync, config, cancellationToken);
+                Inside(userMode.Map(userModeEvents), record => record.StartTimestamp),
+                PublishStateSpanDataAsync, config, cancellationToken);
 
         if (groups.TryGetValue(TandemEventClass.DeviceStatus, out var dailyBasal))
             await PublishRecordTypeAsync(result, SyncDataType.DeviceStatus, activeTypes,
                 deviceStatus.Map(dailyBasal), PublishDeviceStatusAsync, config, cancellationToken);
+
+        return unclosed;
     }
 
     private async Task<TandemPumpLogsResponse?> FetchWindowAsync(
@@ -290,24 +345,24 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         var candidates = new[] { glucoseSince, treatmentSince }.Where(d => d.HasValue).Select(d => d!.Value).ToList();
         var resume = candidates.Count > 0 ? candidates.Min() : DefaultInitialSyncFloor();
 
-        var start = ResumeFrom(request, resume);
+        // The pump's own range is how far back this source goes, and the floor a range naming no
+        // lower bound resolves to — named, rather than left to the clamp below to arrive at.
+        var first = ParseWallClockUtc(device.AvailableDataRange?.Start, time);
+        var start = ResumeFrom(request, resume, first ?? DefaultInitialSyncFloor());
 
-        if (ParseWallClockUtc(device.AvailableDataRange?.Start, time) is { } min && min > start)
-            start = min;
-
-        return start;
+        return Later(start, first);
     }
 
     /// <summary>
     /// What the run says when it covered less than it was asked for: the pump serves nothing before
-    /// its available range begins, and a success over a window that was silently narrowed reads the
+    /// its available range begins, and a success over a range that was silently narrowed reads the
     /// same as one that covered it.
     /// </summary>
     private static string? ClampNotice(
         SyncRequest request, TandemBffPump device, TandemTimeResolver time) =>
         ParseWallClockUtc(device.AvailableDataRange?.Start, time) is { } first && request.From < first
             ? $"The pump holds no data before {first.ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture)} UTC; "
-              + "the requested window starts there."
+              + "the sync started there."
             : null;
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemConnectorService.cs
@@ -282,9 +282,7 @@ public class TandemConnectorService : BaseConnectorService<TandemConnectorConfig
         var candidates = new[] { glucoseSince, treatmentSince }.Where(d => d.HasValue).Select(d => d!.Value).ToList();
         var resume = candidates.Count > 0 ? candidates.Min() : DefaultInitialSyncFloor();
 
-        var start = request.To is null
-            ? ResumeFrom(request.From, resume)
-            : request.From ?? resume;
+        var start = ResumeFrom(request, resume);
 
         if (ParseWallClockUtc(device.AvailableDataRange?.Start, time) is { } min && min > start)
         {

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceSyncWindowTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceSyncWindowTests.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+using FluentAssertions;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Glooko.Configurations;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+/// The chunk loop is bounded at both ends by the request. A run that reads only the lower bound
+/// answers a re-import of one month by crawling every chunk from that month to today.
+/// </summary>
+public class GlookoConnectorServiceSyncWindowTests
+{
+    private static readonly DateTime AskedFrom = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime AskedTo = new(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SyncDataAsync_WhenGivenAnUpperBound_StopsTheChunkLoopThere(bool useV3Api)
+    {
+        var handler = new GlookoEndpointHandler();
+        var service = GlookoSyncHarness.Service(handler);
+
+        var result = await service.SyncDataAsync(
+            new SyncRequest
+            {
+                From = AskedFrom,
+                To = AskedTo,
+                DataTypes =
+                [
+                    SyncDataType.StateSpans, SyncDataType.TempBasals,
+                    SyncDataType.DeviceEvents, SyncDataType.Profiles,
+                ],
+            },
+            GlookoSyncHarness.Config(useV3Api),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+
+        // A month, padded a day each side, is three of the connector's fortnightly chunks.
+        handler.WindowCount.Should().Be(3);
+        Parse(handler.Windows[^1].End).Should().BeBefore(AskedTo.AddDays(2),
+            "the caller bounded the range at both ends");
+    }
+
+    private static DateTime Parse(string timestamp) =>
+        DateTime.Parse(timestamp, CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
@@ -193,7 +193,7 @@ internal sealed class GlookoEndpointHandler(
     bool withHistoryMeals = false) : HttpMessageHandler
 {
     private readonly Func<int, int> _recordsPerWindow = recordsPerWindow ?? (_ => 1);
-    private readonly List<string> _windows = [];
+    private readonly List<(string Start, string End)> _windows = [];
     private readonly List<string> _requested = [];
     private readonly Lock _gate = new();
     private bool _forbiddenIssued;
@@ -204,6 +204,12 @@ internal sealed class GlookoEndpointHandler(
     public int WindowCount
     {
         get { lock (_gate) return _windows.Count; }
+    }
+
+    /// <summary>The date windows asked for, in the order the sync first asked for them.</summary>
+    public IReadOnlyList<(string Start, string End)> Windows
+    {
+        get { lock (_gate) return [.. _windows]; }
     }
 
     /// <summary>How many times an endpoint was asked, over every date window and sync pass.</summary>
@@ -289,7 +295,8 @@ internal sealed class GlookoEndpointHandler(
 
     private Window ResolveWindow(string query)
     {
-        var startDate = QueryValue(query, "startDate");
+        var startDate = QueryValue(query, "startDate") ?? string.Empty;
+        var endDate = QueryValue(query, "endDate") ?? string.Empty;
         var start = DateTime.TryParse(startDate, null, System.Globalization.DateTimeStyles.AdjustToUniversal
             | System.Globalization.DateTimeStyles.AssumeUniversal, out var parsed)
             ? parsed
@@ -298,10 +305,10 @@ internal sealed class GlookoEndpointHandler(
         int ordinal;
         lock (_gate)
         {
-            ordinal = _windows.IndexOf(startDate ?? string.Empty);
+            ordinal = _windows.FindIndex(window => window.Start == startDate);
             if (ordinal < 0)
             {
-                _windows.Add(startDate ?? string.Empty);
+                _windows.Add((startDate, endDate));
                 ordinal = _windows.Count - 1;
             }
         }

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceSyncWindowTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceSyncWindowTests.cs
@@ -1,0 +1,210 @@
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.MyLife.Configurations;
+using Nocturne.Connectors.MyLife.Mappers.Constants;
+using Nocturne.Connectors.MyLife.Models;
+using Nocturne.Connectors.MyLife.Services;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Connectors.MyLife.Tests.Services;
+
+/// <summary>
+/// What a <see cref="SyncRequest"/>'s window means to the MyLife connector. MyLife streams the
+/// source a calendar month at a time and filters each month by a per-family bound, so both the
+/// fetched window and the family bounds have to answer the request.
+/// </summary>
+public class MyLifeConnectorServiceSyncWindowTests
+{
+    private static readonly DateTime GlucoseWatermark = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime TreatmentWatermark = new(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>Overlap the shared catch-up calculation subtracts to absorb clock drift.</summary>
+    private static readonly TimeSpan CatchUpOverlap = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// A background cycle carries the glucose watermark as its <c>from</c>. Treatments that fell
+    /// behind — one cycle's publish failed while glucose succeeded — sit below that bound, and
+    /// answering the run from it strands them there: every later cycle carries an even newer
+    /// glucose watermark, so the gap is never crawled again.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTreatmentsFellBehindGlucose_ResumesFromTheTreatmentWatermark()
+    {
+        var strandedBolus = new DateTime(2026, 3, 15, 9, 0, 0, DateTimeKind.Utc);
+        var fixture = new Fixture(BolusAt(strandedBolus));
+
+        var result = await fixture.RunAsync(new SyncRequest
+        {
+            From = GlucoseWatermark,
+            To = null,
+            DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses],
+        });
+
+        result.Success.Should().BeTrue();
+        fixture.Sync.Since.Should().Be(TreatmentWatermark - CatchUpOverlap,
+            "the month stream has to reach back to the family that fell behind");
+        fixture.Boluses.Should().ContainSingle().Which.Timestamp.Should().Be(strandedBolus,
+            "a treatment below the glucose bound is exactly the record the run owes the tenant");
+    }
+
+    /// <summary>
+    /// A caller's lower bound is never narrowed by a family's resume point: an explicit <c>from</c>
+    /// with no <c>to</c> is the shape an admin repairing a months-old gap sends, and answering it
+    /// from the watermark fetches nothing and reports the run as a success with a zero count.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenGivenALowerBoundBelowTheResumePoint_HonoursTheCallersBound()
+    {
+        var askedFrom = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var repairedBolus = new DateTime(2026, 1, 20, 9, 0, 0, DateTimeKind.Utc);
+        var fixture = new Fixture(BolusAt(repairedBolus));
+
+        var result = await fixture.RunAsync(new SyncRequest
+        {
+            From = askedFrom,
+            To = null,
+            DataTypes = [SyncDataType.Boluses],
+        });
+
+        result.Success.Should().BeTrue();
+        fixture.Sync.Since.Should().Be(askedFrom, "the caller asked for this lower bound");
+        fixture.Boluses.Should().ContainSingle().Which.Timestamp.Should().Be(repairedBolus);
+    }
+
+    /// <summary>
+    /// An explicit range is answered as asked, resume points and all: it is the shape a manual
+    /// re-import of one window sends, and a bound widened back to a watermark below it re-streams
+    /// every month in between.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenGivenAnExplicitRange_AsksForItAsGiven()
+    {
+        var askedFrom = new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc);
+        var askedTo = new DateTime(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+        var fixture = new Fixture();
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = askedFrom,
+            To = askedTo,
+            DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses],
+        });
+
+        fixture.Sync.Since.Should().Be(askedFrom);
+        fixture.Sync.Until.Should().Be(askedTo, "the caller bounded the range at both ends");
+    }
+
+    /// <summary>
+    /// A caller supplying no lower bound is not asking for everything: the tenant's own sync button
+    /// sends that shape, and each family still stands on its own resume point.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenTheCallerSuppliesNoLowerBound_ResumesFromTheEarliestWatermark()
+    {
+        var fixture = new Fixture();
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = null,
+            To = null,
+            DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses],
+        });
+
+        fixture.Sync.Since.Should().Be(TreatmentWatermark - CatchUpOverlap);
+    }
+
+    private static MyLifeEvent BolusAt(DateTime at) => new()
+    {
+        EventTypeId = MyLifeEventType.BolusNormal,
+        EventDateTime = new DateTimeOffset(at).ToUnixTimeMilliseconds() * 10_000,
+        InformationFromDevice = "{\"AmountOfBolus\":2.5}",
+        Value = "2.5",
+        PatientId = "patient-1",
+        DeviceId = "device-1",
+    };
+
+    /// <summary>
+    /// A MyLife sync whose month stream is stubbed: it records the window it was asked for and
+    /// serves the events under test whatever that window is, so the bounds the connector applies
+    /// to each family are what the assertions read.
+    /// </summary>
+    private sealed class Fixture
+    {
+        private readonly MyLifeConnectorService _service;
+
+        public RecordingSyncService Sync { get; private set; } = null!;
+
+        public List<Bolus> Boluses { get; } = [];
+
+        public Fixture(params MyLifeEvent[] events)
+        {
+            var treatments = new Mock<ITreatmentPublisher>();
+            treatments
+                .Setup(p => p.GetLatestTreatmentTimestampAsync(
+                    It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(TreatmentWatermark);
+            treatments
+                .Setup(p => p.PublishBolusesAsync(
+                    It.IsAny<IEnumerable<Bolus>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<IEnumerable<Bolus>, string, WriteOrigin, CancellationToken>(
+                    (records, _, _, _) => Boluses.AddRange(records))
+                .ReturnsAsync(true);
+
+            var glucose = new Mock<IGlucosePublisher>();
+            glucose
+                .Setup(p => p.GetLatestEntryTimestampAsync(
+                    It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(GlucoseWatermark);
+
+            var publisher = new Mock<IConnectorPublisher>();
+            publisher.Setup(p => p.IsAvailable).Returns(true);
+            publisher.Setup(p => p.Glucose).Returns(glucose.Object);
+            publisher.Setup(p => p.Treatments).Returns(treatments.Object);
+            publisher.Setup(p => p.Device).Returns(Mock.Of<IDevicePublisher>());
+            publisher.Setup(p => p.Metadata).Returns(Mock.Of<IMetadataPublisher>());
+
+            var http = new HttpClient(new SoapStubHandler(loginSucceeds: true));
+            (_service, _, _) = MyLifeSyncHarness.BuildService(
+                http,
+                Guid.NewGuid(),
+                soapClient => Sync = new RecordingSyncService(soapClient, events),
+                publisher.Object);
+        }
+
+        public Task<SyncResult> RunAsync(SyncRequest request) =>
+            _service.SyncDataAsync(
+                request,
+                new MyLifeConnectorConfiguration
+                {
+                    Username = "user@example.com",
+                    Password = "secret",
+                    PatientId = "patient-1",
+                },
+                CancellationToken.None);
+    }
+
+    private sealed class RecordingSyncService(
+        MyLifeSoapClient soapClient, IReadOnlyList<MyLifeEvent> events)
+        : MyLifeSyncService(soapClient, NullLogger<MyLifeSyncService>.Instance)
+    {
+        public DateTime Since { get; private set; }
+        public DateTime Until { get; private set; }
+
+        public override async IAsyncEnumerable<MyLifeMonthBatch> FetchEventsPerMonthAsync(
+            string serviceUrl, string authToken, string patientId, DateTime since, DateTime until,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            Since = since;
+            Until = until;
+            await Task.CompletedTask;
+            yield return new MyLifeMonthBatch("2026-01", [.. events]);
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceSyncWindowTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceSyncWindowTests.cs
@@ -119,6 +119,29 @@ public class MyLifeConnectorServiceSyncWindowTests
         fixture.Sync.Since.Should().Be(TreatmentWatermark - CatchUpOverlap);
     }
 
+    /// <summary>
+    /// A range naming no lower bound is the reset-cursor shape, and it asks for everything the
+    /// source still holds — which for MyLife is its initial-sync floor. Answering it from the
+    /// resume point resets nothing: the resume point is what it is asking to reset.
+    /// </summary>
+    [Fact]
+    public async Task SyncDataAsync_WhenAnExplicitRangeNamesNoLowerBound_CrawlsFromTheHistoryFloor()
+    {
+        // Both watermarks sit well inside the floor, so resuming from either is a different answer.
+        var fixture = new Fixture(
+            glucoseWatermark: DateTime.UtcNow.AddDays(-3),
+            treatmentWatermark: DateTime.UtcNow.AddDays(-5));
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = null,
+            To = DateTime.UtcNow,
+            DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses],
+        });
+
+        fixture.Sync.Since.Should().BeCloseTo(DateTime.UtcNow.AddMonths(-6), TimeSpan.FromMinutes(1));
+    }
+
     private static MyLifeEvent BolusAt(DateTime at) => new()
     {
         EventTypeId = MyLifeEventType.BolusNormal,
@@ -143,12 +166,17 @@ public class MyLifeConnectorServiceSyncWindowTests
         public List<Bolus> Boluses { get; } = [];
 
         public Fixture(params MyLifeEvent[] events)
+            : this(GlucoseWatermark, TreatmentWatermark, events)
+        {
+        }
+
+        public Fixture(DateTime glucoseWatermark, DateTime treatmentWatermark, params MyLifeEvent[] events)
         {
             var treatments = new Mock<ITreatmentPublisher>();
             treatments
                 .Setup(p => p.GetLatestTreatmentTimestampAsync(
                     It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TreatmentWatermark);
+                .ReturnsAsync(treatmentWatermark);
             treatments
                 .Setup(p => p.PublishBolusesAsync(
                     It.IsAny<IEnumerable<Bolus>>(), It.IsAny<string>(), It.IsAny<WriteOrigin>(),
@@ -161,7 +189,7 @@ public class MyLifeConnectorServiceSyncWindowTests
             glucose
                 .Setup(p => p.GetLatestEntryTimestampAsync(
                     It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(GlucoseWatermark);
+                .ReturnsAsync(glucoseWatermark);
 
             var publisher = new Mock<IConnectorPublisher>();
             publisher.Setup(p => p.IsAvailable).Returns(true);

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeConnectorServiceTests.cs
@@ -1,15 +1,10 @@
 using System.Net;
-using System.Text;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using Nocturne.Connectors.Core.Models;
-using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.MyLife.Configurations;
-using Nocturne.Connectors.MyLife.Mappers;
 using Nocturne.Connectors.MyLife.Models;
 using Nocturne.Connectors.MyLife.Services;
-using Nocturne.Core.Contracts.Multitenancy;
 using Xunit;
 
 namespace Nocturne.Connectors.MyLife.Tests.Services;
@@ -23,14 +18,12 @@ namespace Nocturne.Connectors.MyLife.Tests.Services;
 /// </summary>
 public class MyLifeConnectorServiceTests
 {
-    private const string ServiceUrl = "https://svc.example";
-
     [Fact]
     public async Task SyncDataAsync_EstablishesSession_WithValidCredentials()
     {
         var tenantId = Guid.NewGuid();
         using var http = new HttpClient(new SoapStubHandler(loginSucceeds: true));
-        var (service, sessionCache, _) = BuildService(http, tenantId);
+        var (service, sessionCache, _) = MyLifeSyncHarness.BuildService(http, tenantId);
 
         var config = new MyLifeConnectorConfiguration
         {
@@ -46,7 +39,7 @@ public class MyLifeConnectorServiceTests
         var session = sessionCache.Get(tenantId);
         session.Should().NotBeNull("the connector must populate the session cache via the token provider");
         session!.AuthToken.Should().Be("tok-123");
-        session.ServiceUrl.Should().Be(ServiceUrl);
+        session.ServiceUrl.Should().Be(MyLifeSyncHarness.ServiceUrl);
         session.PatientId.Should().Be("patient-1");
     }
 
@@ -55,7 +48,7 @@ public class MyLifeConnectorServiceTests
     {
         var tenantId = Guid.NewGuid();
         using var http = new HttpClient(new SoapStubHandler(loginSucceeds: false));
-        var (service, sessionCache, _) = BuildService(http, tenantId);
+        var (service, sessionCache, _) = MyLifeSyncHarness.BuildService(http, tenantId);
 
         var config = new MyLifeConnectorConfiguration
         {
@@ -85,7 +78,7 @@ public class MyLifeConnectorServiceTests
     {
         var tenantId = Guid.NewGuid();
         using var http = new HttpClient(new SoapStubHandler(loginSucceeds: true, syncStatus: syncStatus));
-        var (service, _, tokenProvider) = BuildService(http, tenantId);
+        var (service, _, tokenProvider) = MyLifeSyncHarness.BuildService(http, tenantId);
 
         var config = new MyLifeConnectorConfiguration
         {
@@ -122,7 +115,7 @@ public class MyLifeConnectorServiceTests
                 UploadDateTime = 1767261600000L * 10_000
             }
         };
-        var (service, _, _) = BuildService(http, tenantId,
+        var (service, _, _) = MyLifeSyncHarness.BuildService(http, tenantId,
             soapClient => new StubPumpSettingsSyncService(soapClient, readouts));
 
         var config = new MyLifeConnectorConfiguration
@@ -139,43 +132,6 @@ public class MyLifeConnectorServiceTests
         result.Errors.Should().Contain("StateSpans publish failed");
     }
 
-    private static (MyLifeConnectorService Service, IMyLifeSessionCache SessionCache,
-        MyLifeAuthTokenProvider TokenProvider) BuildService(
-        HttpClient http, Guid tenantId, Func<MyLifeSoapClient, MyLifeSyncService>? syncServiceFactory = null)
-    {
-        var resolver = new ConnectorServerResolver<MyLifeConnectorConfiguration>(null, null, null);
-
-        var tenantAccessor = new Mock<ITenantAccessor>();
-        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
-        tenantAccessor.Setup(t => t.TenantId).Returns(tenantId);
-
-        var soapClient = new MyLifeSoapClient(http, NullLogger<MyLifeSoapClient>.Instance);
-        var sessionCache = new MyLifeSessionCache();
-        var tokenProvider = new MyLifeAuthTokenProvider(
-            http,
-            new ConnectorTokenCache(),
-            resolver,
-            tenantAccessor.Object,
-            soapClient,
-            sessionCache,
-            NullLogger<MyLifeAuthTokenProvider>.Instance);
-        var syncService = syncServiceFactory?.Invoke(soapClient)
-            ?? new MyLifeSyncService(soapClient, NullLogger<MyLifeSyncService>.Instance);
-
-        var service = new MyLifeConnectorService(
-            http,
-            resolver,
-            NullLogger<MyLifeConnectorService>.Instance,
-            tokenProvider,
-            new MyLifeEventProcessor(),
-            sessionCache,
-            tenantAccessor.Object,
-            syncService,
-            publisher: null);
-
-        return (service, sessionCache, tokenProvider);
-    }
-
     /// <summary>
     /// Returns fixed pump-settings readouts, bypassing the encrypted-archive fetch.
     /// </summary>
@@ -186,52 +142,5 @@ public class MyLifeConnectorServiceTests
         public override Task<IReadOnlyList<MyLifePumpSettingsReadout>> FetchPumpSettingsAsync(
             string serviceUrl, string authToken, string patientId, CancellationToken cancellationToken)
             => Task.FromResult(readouts);
-    }
-
-    /// <summary>
-    /// Stubs the MyLife SOAP endpoints, routing by SOAPAction. Returns a valid location, login, and
-    /// single-patient list; events and pump-settings return no result element so the sync completes
-    /// with no data (and never reaches the archive-decryption path).
-    /// </summary>
-    private sealed class SoapStubHandler(
-        bool loginSucceeds, HttpStatusCode syncStatus = HttpStatusCode.OK) : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            var action = request.Headers.TryGetValues("SOAPAction", out var values)
-                ? values.FirstOrDefault() ?? string.Empty
-                : string.Empty;
-
-            var (status, body) = Respond(action);
-            return Task.FromResult(new HttpResponseMessage(status)
-            {
-                Content = new StringContent(body, Encoding.UTF8, "text/xml")
-            });
-        }
-
-        private (HttpStatusCode Status, string Body) Respond(string action)
-        {
-            if (action.Contains("GetUser20"))
-                return (HttpStatusCode.OK, Envelope("GetUser20Result",
-                    $"{{\"Country20\":{{\"ServiceUrl\":\"{ServiceUrl}\",\"RestServiceUrl\":\"https://rest.example\"}}}}"));
-
-            if (action.Contains("SyncPatientList"))
-                return (HttpStatusCode.OK, Envelope("SyncPatientListResult",
-                    "[{\"OnlinePatientId\":\"patient-1\",\"EmailNewPatient\":\"user@example.com\"}]"));
-
-            if (action.Contains("Login"))
-                return loginSucceeds
-                    ? (HttpStatusCode.OK, Envelope("LoginResult", "{\"UserId\":\"user-1\",\"AuthToken\":\"tok-123\"}"))
-                    : (HttpStatusCode.Unauthorized, string.Empty);
-
-            // SyncEvents / SyncPumpSettings: no result element → treated as "no data".
-            return (syncStatus,
-                "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body/></s:Envelope>");
-        }
-
-        private static string Envelope(string element, string innerJson) =>
-            "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body>"
-            + $"<{element}>{innerJson}</{element}></s:Body></s:Envelope>";
     }
 }

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeSyncHarness.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.MyLife.Configurations;
+using Nocturne.Connectors.MyLife.Mappers;
+using Nocturne.Connectors.MyLife.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+
+namespace Nocturne.Connectors.MyLife.Tests.Services;
+
+/// <summary>
+/// A MyLife connector wired to stubbed SOAP endpoints, so a test drives the real sync flow from an
+/// established session onwards.
+/// </summary>
+internal static class MyLifeSyncHarness
+{
+    public const string ServiceUrl = "https://svc.example";
+
+    public static (MyLifeConnectorService Service, IMyLifeSessionCache SessionCache,
+        MyLifeAuthTokenProvider TokenProvider) BuildService(
+        HttpClient http,
+        Guid tenantId,
+        Func<MyLifeSoapClient, MyLifeSyncService>? syncServiceFactory = null,
+        IConnectorPublisher? publisher = null)
+    {
+        var resolver = new ConnectorServerResolver<MyLifeConnectorConfiguration>(null, null, null);
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+        tenantAccessor.Setup(t => t.TenantId).Returns(tenantId);
+
+        var soapClient = new MyLifeSoapClient(http, NullLogger<MyLifeSoapClient>.Instance);
+        var sessionCache = new MyLifeSessionCache();
+        var tokenProvider = new MyLifeAuthTokenProvider(
+            http,
+            new ConnectorTokenCache(),
+            resolver,
+            tenantAccessor.Object,
+            soapClient,
+            sessionCache,
+            NullLogger<MyLifeAuthTokenProvider>.Instance);
+        var syncService = syncServiceFactory?.Invoke(soapClient)
+            ?? new MyLifeSyncService(soapClient, NullLogger<MyLifeSyncService>.Instance);
+
+        var service = new MyLifeConnectorService(
+            http,
+            resolver,
+            NullLogger<MyLifeConnectorService>.Instance,
+            tokenProvider,
+            new MyLifeEventProcessor(),
+            sessionCache,
+            tenantAccessor.Object,
+            syncService,
+            publisher);
+
+        return (service, sessionCache, tokenProvider);
+    }
+}
+
+/// <summary>
+/// Stubs the MyLife SOAP endpoints, routing by SOAPAction. Returns a valid location, login, and
+/// single-patient list; events and pump-settings return no result element so the sync completes
+/// with no data (and never reaches the archive-decryption path).
+/// </summary>
+internal sealed class SoapStubHandler(
+    bool loginSucceeds, HttpStatusCode syncStatus = HttpStatusCode.OK) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var action = request.Headers.TryGetValues("SOAPAction", out var values)
+            ? values.FirstOrDefault() ?? string.Empty
+            : string.Empty;
+
+        var (status, body) = Respond(action);
+        return Task.FromResult(new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "text/xml")
+        });
+    }
+
+    private (HttpStatusCode Status, string Body) Respond(string action)
+    {
+        if (action.Contains("GetUser20"))
+            return (HttpStatusCode.OK, Envelope("GetUser20Result",
+                $"{{\"Country20\":{{\"ServiceUrl\":\"{MyLifeSyncHarness.ServiceUrl}\",\"RestServiceUrl\":\"https://rest.example\"}}}}"));
+
+        if (action.Contains("SyncPatientList"))
+            return (HttpStatusCode.OK, Envelope("SyncPatientListResult",
+                "[{\"OnlinePatientId\":\"patient-1\",\"EmailNewPatient\":\"user@example.com\"}]"));
+
+        if (action.Contains("Login"))
+            return loginSucceeds
+                ? (HttpStatusCode.OK, Envelope("LoginResult", "{\"UserId\":\"user-1\",\"AuthToken\":\"tok-123\"}"))
+                : (HttpStatusCode.Unauthorized, string.Empty);
+
+        // SyncEvents / SyncPumpSettings: no result element → treated as "no data".
+        return (syncStatus,
+            "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body/></s:Envelope>");
+    }
+
+    private static string Envelope(string element, string innerJson) =>
+        "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body>"
+        + $"<{element}>{innerJson}</{element}></s:Body></s:Envelope>";
+}

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Mappers/TandemMapperTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Mappers/TandemMapperTests.cs
@@ -102,7 +102,7 @@ public class TandemMapperTests
         var windowEnd = Time.ToUtc(Raw + 600);
 
         var basals = new TandemBasalMapper(NullLogger.Instance, Time)
-            .Map(events, windowEnd, ignoreZeroUnitBasal: false);
+            .Map(events, windowEnd, ignoreZeroUnitBasal: false).Spans;
 
         basals.Should().HaveCount(2);
         basals[0].Rate.Should().Be(1.0);

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Mappers/TandemProcessorPortTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Mappers/TandemProcessorPortTests.cs
@@ -54,7 +54,7 @@ public static class TandemProcessorPortTests
         public void Consecutive_run_spans_each_delivery_to_the_next()
         {
             // Window ends 5 minutes after the last event, like upstream's RUN_TIME_END.
-            var records = _mapper.Map(Run, Utc(2026, 5, 14, 4, 16, 0), ignoreZeroUnitBasal: false);
+            var records = _mapper.Map(Run, Utc(2026, 5, 14, 4, 16, 0), ignoreZeroUnitBasal: false).Spans;
 
             records.Should().HaveCount(3);
             records[0].StartTimestamp.Should().Be(Utc(2026, 5, 14, 4, 1, 0));
@@ -83,7 +83,7 @@ public static class TandemProcessorPortTests
                 _ => SrcTempAndAlgo,
             };
 
-            var records = _mapper.Map([ev], Utc(2026, 5, 17, 0, 0, 0), ignoreZeroUnitBasal: false);
+            var records = _mapper.Map([ev], Utc(2026, 5, 17, 0, 0, 0), ignoreZeroUnitBasal: false).Spans;
 
             var basal = records.Should().ContainSingle().Subject;
             basal.Rate.Should().Be(rate);
@@ -94,7 +94,7 @@ public static class TandemProcessorPortTests
         public void Zero_rate_events_are_skipped_when_ignore_zero_unit_basal()
         {
             var records = _mapper.Map(
-                [SrcSuspended, SrcProfile], Utc(2026, 5, 17, 0, 0, 0), ignoreZeroUnitBasal: true);
+                [SrcSuspended, SrcProfile], Utc(2026, 5, 17, 0, 0, 0), ignoreZeroUnitBasal: true).Spans;
 
             records.Should().ContainSingle().Which.PumpRecordId.Should().Be("447435");
         }
@@ -106,7 +106,7 @@ public static class TandemProcessorPortTests
             var start = Utc(2026, 5, 16, 0, 48, 27); // SrcProfile at 20:48:27-04:00
             var windowEnd = start.AddHours(25);
 
-            var records = _mapper.Map([SrcProfile], windowEnd, ignoreZeroUnitBasal: false);
+            var records = _mapper.Map([SrcProfile], windowEnd, ignoreZeroUnitBasal: false).Spans;
 
             records.Should().ContainSingle().Which.EndTimestamp.Should().Be(windowEnd);
         }

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
@@ -68,6 +68,33 @@ public class TandemE2eSyncTests
 
     private const string EmptyPumpLogsJson = """{"events": [], "clockChanges": []}""";
 
+    // A basal delivery and an exercise stop on the day AFTER a window ending 2026-05-15: the events
+    // that close a span opened inside it, which only the padded day reaches.
+    private const string NextDayEvents = """
+                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 229, "sequenceGroup": 0, "sequenceNumber": 450100, "pumpDateTime": "2026-05-15T10:00:00", "eventProperties": {"currentUserMode": 2, "previousUserMode": 0, "requestedAction": 3, "spareA3": 0, "sleepStartedByGui": 0, "activeSleepSchedule": [0], "spareB6": 0, "exerciseStoppedByTimer": 0, "exerciseChoice": 0, "exerciseTime": 0, "eatingSoonStoppedByTimer": 0}, "estimatedDateTime": "2026-05-15T10:00:00Z"},
+                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 279, "sequenceGroup": 0, "sequenceNumber": 450200, "pumpDateTime": "2026-05-16T09:00:00", "eventProperties": {"commandedRateSource": 1, "reservedA2": 3, "spareA3": 0, "commandedRate": 800, "profileBasalRate": 800, "algorithmRate": 800, "tempRate": 65535}, "estimatedDateTime": "2026-05-16T09:00:00Z"},
+                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 20, "sequenceGroup": 0, "sequenceNumber": 450250, "pumpDateTime": "2026-05-16T09:15:00", "eventProperties": {"completionStatus": 3, "bolusId": 1600, "iob": 1.0, "insulinDelivered": 1.0, "insulinRequested": 1.0}, "estimatedDateTime": "2026-05-16T09:15:00Z"},
+                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 229, "sequenceGroup": 0, "sequenceNumber": 450300, "pumpDateTime": "2026-05-16T09:30:00", "eventProperties": {"currentUserMode": 0, "previousUserMode": 2, "requestedAction": 4, "spareA3": 0, "sleepStartedByGui": 0, "activeSleepSchedule": [0], "spareB6": 0, "exerciseStoppedByTimer": 0, "exerciseChoice": 0, "exerciseTime": 0, "eatingSoonStoppedByTimer": 0}, "estimatedDateTime": "2026-05-16T09:30:00Z"},
+        """;
+
+    /// <summary>The fixture's events plus <see cref="NextDayEvents"/>.</summary>
+    private static string WithNextDayEvents() =>
+        PumpLogsJson.Replace("\"events\": [", "\"events\": [\n" + NextDayEvents);
+
+    // One bolus whose request messages land on 2026-05-13 and whose completion lands on 2026-05-14:
+    // reassembling it needs both days, and only the completion carries the delivered amount.
+    private const string StraddlingBolusJson = """
+        {
+        "events": [
+                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 64, "sequenceGroup": 0, "sequenceNumber": 442680, "pumpDateTime": "2026-05-13T23:58:00", "eventProperties": {"bolusId": 1583, "bolusType": 3, "correctionBolusIncluded": 1, "carbAmount": 20, "bg": 116, "iob": 0, "carbRatio": 0}, "estimatedDateTime": "2026-05-13T23:58:00Z"},
+                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 65, "sequenceGroup": 0, "sequenceNumber": 442681, "pumpDateTime": "2026-05-13T23:58:00", "eventProperties": {"bolusId": 1583, "options": 4, "standardPercent": 100, "duration": 0, "spareB6": 0, "isf": 0, "targetBg": 0, "userOverride": 0, "declinedCorrection": 0, "selectedIob": 1}, "estimatedDateTime": "2026-05-13T23:58:00Z"},
+                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 66, "sequenceGroup": 0, "sequenceNumber": 442682, "pumpDateTime": "2026-05-13T23:58:00", "eventProperties": {"bolusId": 1583, "spareA2": 0, "foodBolusSize": 3.33, "correctionBolusSize": 0.2, "totalBolusSize": 3.53}, "estimatedDateTime": "2026-05-13T23:58:00Z"},
+                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 20, "sequenceGroup": 0, "sequenceNumber": 442700, "pumpDateTime": "2026-05-14T00:02:00", "eventProperties": {"completionStatus": 3, "bolusId": 1583, "iob": 3.53, "insulinDelivered": 3.53, "insulinRequested": 3.53}, "estimatedDateTime": "2026-05-14T00:02:00Z"}
+            ],
+        "clockChanges": []
+        }
+        """;
+
     [Fact]
     public async Task Full_sync_publishes_expected_records()
     {
@@ -264,11 +291,12 @@ public class TandemE2eSyncTests
     }
 
     /// <summary>
-    /// A bounded re-import asks the pump for exactly the window it was given. The pump-logs
-    /// endpoint is day-granular, so each bound is the date it falls on.
+    /// A bounded re-import asks the pump for a day either side of the window it was given, so the
+    /// events that complete a record at each edge are in hand; the day-granular endpoint means that
+    /// is one more chunk-day at each end, capped at the pump's newest event.
     /// </summary>
     [Fact]
-    public async Task Explicit_request_window_bounds_the_pump_log_request()
+    public async Task Explicit_request_window_fetches_a_day_either_side()
     {
         var fixture = new Fixture();
 
@@ -281,27 +309,147 @@ public class TandemE2eSyncTests
 
         var pumpLogs = fixture.Requests.Should()
             .ContainSingle(r => r.Path.Contains("/pump-logs/")).Subject;
-        pumpLogs.Path.Should().Contain("startDate=2026-05-16T00%3A00%3A00Z")
-            .And.Contain("endDate=2026-05-17T23%3A59%3A59Z");
+        pumpLogs.Path.Should().Contain("startDate=2026-05-15T00%3A00%3A00Z")
+            .And.Contain("endDate=2026-05-18T23%3A59%3A59Z");
 
-        // The fixture's CGM readings are two days below the window, and the pump serves only what
-        // is inside it — so the bound is what decides this, not the payload.
+        // The fixture's CGM readings are below even the padded window, and the pump serves only
+        // what is inside the window asked for — so the bound is what decides this, not the payload.
         fixture.Publisher.SensorGlucoses.Should().BeEmpty();
     }
 
     /// <summary>
-    /// A basal span ends where the next delivery event begins, so the last one in a bounded window
-    /// has no end: the event that would close it is above the bound and was never fetched. It goes
-    /// unpublished. Ending it at the caller's bound would upsert a shortened end over the real one,
-    /// and ending it at the pump's newest event would invent a span days long — both over a row
-    /// that a full sync already stored correctly, and both visible in IOB.
+    /// The event that closes the window's last span sits in the day fetched past it, so the span is
+    /// published with its true end — while the padded day's own span, which nothing closes, is not
+    /// published at all: it belongs to the next window along.
+    /// </summary>
+    [Fact]
+    public async Task Span_closed_in_the_padded_day_is_published_with_its_true_end()
+    {
+        // The pump's range opens before the window, so nothing here is clamped and the run has
+        // nothing to report.
+        var fixture = new Fixture(
+            pumperJson: PumperJson.Replace("2026-05-14T00:01:00", "2026-05-12T00:00:00"),
+            pumpLogsJson: WithNextDayEvents());
+
+        var result = await fixture.RunAsync(new SyncRequest
+        {
+            From = Utc(2026, 5, 14, 0, 0, 0),
+            To = Utc(2026, 5, 15, 0, 0, 0),
+            DataTypes = [SyncDataType.TempBasals],
+        });
+
+        fixture.Publisher.TempBasals.Should().HaveCount(2);
+        fixture.Publisher.TempBasals[^1].StartTimestamp.Should().Be(Utc(2026, 5, 14, 4, 6, 0));
+        fixture.Publisher.TempBasals[^1].EndTimestamp.Should().Be(Utc(2026, 5, 16, 13, 0, 0));
+        result.Message.Should().BeEmpty("every span inside the window was closed");
+    }
+
+    /// <summary>
+    /// An exercise span is paired from its start and stop events, and a stop in the day fetched past
+    /// the window closes it. Left unpaired it publishes open, under the id an unpaired span carries
+    /// — a second row beside the closed one a full sync stored, rather than an upsert over it.
+    /// </summary>
+    [Fact]
+    public async Task Exercise_span_stopped_in_the_padded_day_is_published_closed()
+    {
+        var fixture = new Fixture(pumpLogsJson: WithNextDayEvents());
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = Utc(2026, 5, 14, 0, 0, 0),
+            To = Utc(2026, 5, 15, 0, 0, 0),
+            DataTypes = [SyncDataType.StateSpans],
+        });
+
+        var span = fixture.Publisher.StateSpans.Should().ContainSingle().Subject;
+        span.StartTimestamp.Should().Be(Utc(2026, 5, 15, 14, 0, 0));
+        span.EndTimestamp.Should().Be(Utc(2026, 5, 16, 13, 30, 0));
+        span.OriginalId.Should().Be("tandem_usermode_450100_450300");
+    }
+
+    /// <summary>
+    /// The days fetched either side of the window are there to complete its edge records, not to
+    /// widen what it returns: a record of the padded day's own belongs to the window that covers
+    /// it, and a caller that asked for one window is not handed three.
+    /// </summary>
+    [Fact]
+    public async Task Records_of_the_padded_day_are_left_to_the_window_that_covers_them()
+    {
+        var fixture = new Fixture(
+            pumperJson: PumperJson.Replace("2026-05-14T00:01:00", "2026-05-12T00:00:00"),
+            pumpLogsJson: WithNextDayEvents());
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = Utc(2026, 5, 14, 0, 0, 0),
+            To = Utc(2026, 5, 15, 0, 0, 0),
+            DataTypes = [SyncDataType.Boluses],
+        });
+
+        fixture.Publisher.Boluses.Should().ContainSingle()
+            .Which.SyncIdentifier.Should().Be("tandem_bolus_1583",
+                "the padded day's own bolus is the next window's to publish");
+    }
+
+    /// <summary>
+    /// A bolus is reassembled from messages that can straddle the window's lower edge: the request
+    /// messages carry the carbs and the calculation, the completion carries the delivery. Fetched
+    /// alone, the completion still publishes — as a bare bolus, under the same stable id, over the
+    /// complete record a full sync stored.
+    /// </summary>
+    [Fact]
+    public async Task Bolus_straddling_the_lower_edge_is_published_complete()
+    {
+        var fixture = new Fixture(
+            pumperJson: PumperJson.Replace("2026-05-14T00:01:00", "2026-05-12T00:00:00"),
+            pumpLogsJson: StraddlingBolusJson);
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = Utc(2026, 5, 14, 0, 0, 0),
+            To = Utc(2026, 5, 15, 0, 0, 0),
+            DataTypes = [SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.BolusCalculations],
+        });
+
+        var bolus = fixture.Publisher.Boluses.Should().ContainSingle().Subject;
+        bolus.Timestamp.Should().Be(Utc(2026, 5, 14, 4, 2, 0));
+        fixture.Publisher.CarbIntakes.Should().ContainSingle().Which.Carbs.Should().Be(20);
+        fixture.Publisher.BolusCalculations.Should().ContainSingle()
+            .Which.InsulinRecommendationForCarbs.Should().Be(3.33);
+    }
+
+    /// <summary>
+    /// A range naming no lower bound is the reset-cursor shape, and it asks for everything the pump
+    /// still holds — the resume point is what it is resetting, so answering from it resets nothing.
+    /// </summary>
+    [Fact]
+    public async Task Explicit_range_without_a_lower_bound_crawls_from_the_pumps_available_range()
+    {
+        var fixture = new Fixture(
+            pumperJson: PumperJson.Replace("2026-05-14T00:01:00", "2026-04-01T00:00:00"));
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = null,
+            To = Utc(2026, 5, 16, 0, 0, 0),
+            DataTypes = [SyncDataType.Glucose],
+        });
+
+        fixture.Requests.First(r => r.Path.Contains("/pump-logs/")).Path
+            .Should().Contain("startDate=2026-04-01T00%3A00%3A00Z");
+    }
+
+    /// <summary>
+    /// A span the day fetched past the window still does not close — one running longer than that
+    /// day — is not published, and the run says so. See
+    /// <see cref="Nocturne.Connectors.Tandem.Mappers.TandemBasalSpans.UnclosedFrom"/>.
     /// </summary>
     [Fact]
     public async Task Explicit_upper_bound_publishes_only_spans_whose_end_was_fetched()
     {
         var fixture = new Fixture();
 
-        await fixture.RunAsync(new SyncRequest
+        var result = await fixture.RunAsync(new SyncRequest
         {
             From = Utc(2026, 5, 14, 0, 0, 0),
             To = Utc(2026, 5, 15, 0, 0, 0),
@@ -312,6 +460,9 @@ public class TandemE2eSyncTests
         var basal = fixture.Publisher.TempBasals.Should().ContainSingle().Subject;
         basal.StartTimestamp.Should().Be(Utc(2026, 5, 14, 4, 1, 0));
         basal.EndTimestamp.Should().Be(Utc(2026, 5, 14, 4, 6, 0));
+
+        result.Message.Should().Contain("2026-05-14 04:06",
+            "a span the run could not publish is the tenant's to chase, not silently absent");
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
@@ -283,6 +283,27 @@ public class TandemE2eSyncTests
     }
 
     /// <summary>
+    /// A span still open at the end of the window closes at the pump's newest event, not at the
+    /// caller's upper bound: the records upsert on a stable id, so a bounded re-import that ended
+    /// them early would write a shortened end over the real one.
+    /// </summary>
+    [Fact]
+    public async Task Explicit_request_window_does_not_shorten_the_last_basal_span()
+    {
+        var fixture = new Fixture();
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = Utc(2026, 5, 15, 0, 0, 0),
+            To = Utc(2026, 5, 17, 0, 0, 0),
+            DataTypes = [SyncDataType.TempBasals],
+        });
+
+        fixture.Publisher.TempBasals.Should().NotBeEmpty();
+        fixture.Publisher.TempBasals[^1].EndTimestamp.Should().Be(Utc(2026, 5, 18, 14, 19, 55));
+    }
+
+    /// <summary>
     /// The pump serves nothing before its available range begins, so a repair request reaching
     /// further back than that is clamped to it — and the run says so, rather than reporting a
     /// success that quietly covered a different window than the one asked for.

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using System.Net;
 using System.Text;
+using System.Text.Json.Nodes;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -249,7 +251,8 @@ public class TandemE2eSyncTests
         var fixture = new Fixture(
             pumperJson: PumperJson.Replace("2026-05-14T00:01:00", "2026-04-01T00:00:00"),
             latestEntry: Utc(2026, 4, 10, 0, 0, 0),
-            latestTreatment: Utc(2026, 4, 10, 0, 0, 0));
+            latestTreatment: Utc(2026, 4, 10, 0, 0, 0),
+            servesEveryWindow: true);
 
         var result = await fixture.RunAsync();
 
@@ -280,27 +283,35 @@ public class TandemE2eSyncTests
             .ContainSingle(r => r.Path.Contains("/pump-logs/")).Subject;
         pumpLogs.Path.Should().Contain("startDate=2026-05-16T00%3A00%3A00Z")
             .And.Contain("endDate=2026-05-17T23%3A59%3A59Z");
+
+        // The fixture's CGM readings are two days below the window, and the pump serves only what
+        // is inside it — so the bound is what decides this, not the payload.
+        fixture.Publisher.SensorGlucoses.Should().BeEmpty();
     }
 
     /// <summary>
-    /// A span still open at the end of the window closes at the pump's newest event, not at the
-    /// caller's upper bound: the records upsert on a stable id, so a bounded re-import that ended
-    /// them early would write a shortened end over the real one.
+    /// A basal span ends where the next delivery event begins, so the last one in a bounded window
+    /// has no end: the event that would close it is above the bound and was never fetched. It goes
+    /// unpublished. Ending it at the caller's bound would upsert a shortened end over the real one,
+    /// and ending it at the pump's newest event would invent a span days long — both over a row
+    /// that a full sync already stored correctly, and both visible in IOB.
     /// </summary>
     [Fact]
-    public async Task Explicit_request_window_does_not_shorten_the_last_basal_span()
+    public async Task Explicit_upper_bound_publishes_only_spans_whose_end_was_fetched()
     {
         var fixture = new Fixture();
 
         await fixture.RunAsync(new SyncRequest
         {
-            From = Utc(2026, 5, 15, 0, 0, 0),
-            To = Utc(2026, 5, 17, 0, 0, 0),
+            From = Utc(2026, 5, 14, 0, 0, 0),
+            To = Utc(2026, 5, 15, 0, 0, 0),
             DataTypes = [SyncDataType.TempBasals],
         });
 
-        fixture.Publisher.TempBasals.Should().NotBeEmpty();
-        fixture.Publisher.TempBasals[^1].EndTimestamp.Should().Be(Utc(2026, 5, 18, 14, 19, 55));
+        // The window holds two delivery events; only the first is closed by one the fetch reached.
+        var basal = fixture.Publisher.TempBasals.Should().ContainSingle().Subject;
+        basal.StartTimestamp.Should().Be(Utc(2026, 5, 14, 4, 1, 0));
+        basal.EndTimestamp.Should().Be(Utc(2026, 5, 14, 4, 6, 0));
     }
 
     /// <summary>
@@ -354,14 +365,22 @@ public class TandemE2eSyncTests
 
     private sealed record CapturedRequest(string Path, string? Authorization, string? Origin, string? Referer);
 
-    private sealed class CapturingHandler(Dictionary<string, string> responses, List<CapturedRequest> requests)
+    /// <param name="servesEveryWindow">
+    ///     Whether the pump-logs payload is served whole however narrow the requested window is.
+    ///     The real endpoint returns only the events inside it, so a test that asserts on what a
+    ///     window published needs the default; the paging test wants the same events served twice.
+    /// </param>
+    private sealed class CapturingHandler(
+        Dictionary<string, string> responses, List<CapturedRequest> requests,
+        bool servesEveryWindow = false)
         : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            var pathAndQuery = request.RequestUri?.PathAndQuery ?? string.Empty;
             requests.Add(new CapturedRequest(
-                request.RequestUri?.PathAndQuery ?? string.Empty,
+                pathAndQuery,
                 request.Headers.Authorization?.ToString(),
                 request.Headers.TryGetValues("Origin", out var origin) ? origin.First() : null,
                 request.Headers.TryGetValues("Referer", out var referer) ? referer.First() : null));
@@ -369,11 +388,61 @@ public class TandemE2eSyncTests
             var path = request.RequestUri?.AbsolutePath ?? string.Empty;
             foreach (var (key, json) in responses)
                 if (path.Contains(key, StringComparison.OrdinalIgnoreCase))
+                {
+                    var body = key.Contains("pump-logs", StringComparison.Ordinal) && !servesEveryWindow
+                        ? WithinWindow(json, pathAndQuery)
+                        : json;
+
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+                        Content = new StringContent(body, Encoding.UTF8, "application/json"),
                     });
+                }
+
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        /// <summary>
+        /// The payload's events that fall inside the query's window, compared on the pump's own
+        /// naive clock — the basis both the events' pumpDateTime and the query's dates are written on.
+        /// </summary>
+        private static string WithinWindow(string json, string pathAndQuery)
+        {
+            var from = QueryDate(pathAndQuery, "startDate");
+            var to = QueryDate(pathAndQuery, "endDate");
+            if (from is null || to is null)
+                return json;
+
+            var payload = JsonNode.Parse(json)!;
+            var kept = new JsonArray();
+            foreach (var node in payload["events"]!.AsArray().ToList())
+            {
+                var at = DateTime.Parse(
+                    node!["pumpDateTime"]!.GetValue<string>(), CultureInfo.InvariantCulture,
+                    DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+                if (at >= from && at <= to)
+                    kept.Add(node.DeepClone());
+            }
+
+            payload["events"] = kept;
+            return payload.ToJsonString();
+        }
+
+        private static DateTime? QueryDate(string pathAndQuery, string key)
+        {
+            var value = pathAndQuery
+                .Split('?', 2).Last()
+                .Split('&', StringSplitOptions.RemoveEmptyEntries)
+                .Select(pair => pair.Split('=', 2))
+                .Where(pair => pair.Length == 2 && pair[0] == key)
+                .Select(pair => Uri.UnescapeDataString(pair[1]))
+                .FirstOrDefault();
+
+            return DateTime.TryParse(
+                value, CultureInfo.InvariantCulture,
+                DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var parsed)
+                ? parsed
+                : null;
         }
     }
 
@@ -501,7 +570,8 @@ public class TandemE2eSyncTests
             string pumperJson = PumperJson,
             string pumpLogsJson = PumpLogsJson,
             DateTime? latestEntry = null,
-            DateTime? latestTreatment = null)
+            DateTime? latestTreatment = null,
+            bool servesEveryWindow = false)
         {
             // Default watermarks put the catch-up start just before the pump's available range so
             // the sync window is deterministic (no dependence on "now" via the initial-sync floor).
@@ -522,7 +592,7 @@ public class TandemE2eSyncTests
             {
                 ["/api/reports/bff/pumper/"] = pumperJson,
                 ["/api/reports/bff/pump-logs/"] = pumpLogsJson,
-            }, Requests);
+            }, Requests, servesEveryWindow);
 
             _service = new TandemConnectorService(
                 new HttpClient(handler),

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
@@ -260,6 +260,74 @@ public class TandemE2eSyncTests
         fixture.Publisher.TempBasals.Should().HaveCount(2);
     }
 
+    /// <summary>
+    /// A bounded re-import asks the pump for exactly the window it was given. The pump-logs
+    /// endpoint is day-granular, so each bound is the date it falls on.
+    /// </summary>
+    [Fact]
+    public async Task Explicit_request_window_bounds_the_pump_log_request()
+    {
+        var fixture = new Fixture();
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = Utc(2026, 5, 16, 0, 0, 0),
+            To = Utc(2026, 5, 17, 0, 0, 0),
+            DataTypes = [SyncDataType.Glucose],
+        });
+
+        var pumpLogs = fixture.Requests.Should()
+            .ContainSingle(r => r.Path.Contains("/pump-logs/")).Subject;
+        pumpLogs.Path.Should().Contain("startDate=2026-05-16T00%3A00%3A00Z")
+            .And.Contain("endDate=2026-05-17T23%3A59%3A59Z");
+    }
+
+    /// <summary>
+    /// The pump serves nothing before its available range begins, so a repair request reaching
+    /// further back than that is clamped to it — and the run says so, rather than reporting a
+    /// success that quietly covered a different window than the one asked for.
+    /// </summary>
+    [Fact]
+    public async Task Request_below_the_pumps_available_range_is_clamped_and_reported()
+    {
+        var fixture = new Fixture();
+
+        var result = await fixture.RunAsync(new SyncRequest
+        {
+            From = Utc(2026, 1, 1, 0, 0, 0),
+            DataTypes = [SyncDataType.Glucose],
+        });
+
+        var pumpLogs = fixture.Requests.Should()
+            .ContainSingle(r => r.Path.Contains("/pump-logs/")).Subject;
+        pumpLogs.Path.Should().Contain("startDate=2026-05-14T00%3A00%3A00Z");
+        result.Message.Should().Contain("2026-05-14 04:01",
+            "a window the pump cannot serve is a clamp the tenant has to be told about");
+    }
+
+    /// <summary>
+    /// On a background cycle the caller's bound is the glucose watermark, and it must not narrow
+    /// the window past a data type that fell behind: the pump is crawled once for every type, so
+    /// the earliest resume point across them is what the run owes.
+    /// </summary>
+    [Fact]
+    public async Task Background_bound_does_not_narrow_a_type_that_fell_behind()
+    {
+        var fixture = new Fixture(
+            latestEntry: Utc(2026, 5, 17, 0, 5, 0),
+            latestTreatment: Utc(2026, 5, 16, 0, 0, 0));
+
+        await fixture.RunAsync(new SyncRequest
+        {
+            From = Utc(2026, 5, 17, 0, 0, 0),
+            DataTypes = [SyncDataType.Glucose, SyncDataType.Boluses],
+        });
+
+        var pumpLogs = fixture.Requests.Should()
+            .ContainSingle(r => r.Path.Contains("/pump-logs/")).Subject;
+        pumpLogs.Path.Should().Contain("startDate=2026-05-15T00%3A00%3A00Z");
+    }
+
     private static DateTime Utc(int y, int mo, int d, int h, int mi, int s) =>
         new(y, mo, d, h, mi, s, DateTimeKind.Utc);
 

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
@@ -68,13 +68,21 @@ public class TandemE2eSyncTests
 
     private const string EmptyPumpLogsJson = """{"events": [], "clockChanges": []}""";
 
-    // A basal delivery and an exercise stop on the day AFTER a window ending 2026-05-15: the events
-    // that close a span opened inside it, which only the padded day reaches.
+    // An exercise start inside a window ending 2026-05-15, and — on the day after it — every
+    // shape of record the padded day can carry: the delivery and stop events that close the
+    // window's own span and exercise, and a closed basal pair, a whole bolus and a complete
+    // exercise pair belonging to the day itself.
     private const string NextDayEvents = """
-                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 229, "sequenceGroup": 0, "sequenceNumber": 450100, "pumpDateTime": "2026-05-15T10:00:00", "eventProperties": {"currentUserMode": 2, "previousUserMode": 0, "requestedAction": 3, "spareA3": 0, "sleepStartedByGui": 0, "activeSleepSchedule": [0], "spareB6": 0, "exerciseStoppedByTimer": 0, "exerciseChoice": 0, "exerciseTime": 0, "eatingSoonStoppedByTimer": 0}, "estimatedDateTime": "2026-05-15T10:00:00Z"},
-                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 279, "sequenceGroup": 0, "sequenceNumber": 450200, "pumpDateTime": "2026-05-16T09:00:00", "eventProperties": {"commandedRateSource": 1, "reservedA2": 3, "spareA3": 0, "commandedRate": 800, "profileBasalRate": 800, "algorithmRate": 800, "tempRate": 65535}, "estimatedDateTime": "2026-05-16T09:00:00Z"},
-                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 20, "sequenceGroup": 0, "sequenceNumber": 450250, "pumpDateTime": "2026-05-16T09:15:00", "eventProperties": {"completionStatus": 3, "bolusId": 1600, "iob": 1.0, "insulinDelivered": 1.0, "insulinRequested": 1.0}, "estimatedDateTime": "2026-05-16T09:15:00Z"},
-                {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 229, "sequenceGroup": 0, "sequenceNumber": 450300, "pumpDateTime": "2026-05-16T09:30:00", "eventProperties": {"currentUserMode": 0, "previousUserMode": 2, "requestedAction": 4, "spareA3": 0, "sleepStartedByGui": 0, "activeSleepSchedule": [0], "spareB6": 0, "exerciseStoppedByTimer": 0, "exerciseChoice": 0, "exerciseTime": 0, "eatingSoonStoppedByTimer": 0}, "estimatedDateTime": "2026-05-16T09:30:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 229, "sequenceGroup": 0, "sequenceNumber": 450100, "pumpDateTime": "2026-05-15T10:00:00", "eventProperties": {"currentUserMode": 2, "previousUserMode": 0, "requestedAction": 3, "spareA3": 0, "sleepStartedByGui": 0, "activeSleepSchedule": [0], "spareB6": 0, "exerciseStoppedByTimer": 0, "exerciseChoice": 0, "exerciseTime": 0, "eatingSoonStoppedByTimer": 0}, "estimatedDateTime": "2026-05-15T10:00:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 279, "sequenceGroup": 0, "sequenceNumber": 450200, "pumpDateTime": "2026-05-16T09:00:00", "eventProperties": {"commandedRateSource": 1, "reservedA2": 3, "spareA3": 0, "commandedRate": 800, "profileBasalRate": 800, "algorithmRate": 800, "tempRate": 65535}, "estimatedDateTime": "2026-05-16T09:00:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 279, "sequenceGroup": 0, "sequenceNumber": 450210, "pumpDateTime": "2026-05-16T10:00:00", "eventProperties": {"commandedRateSource": 1, "reservedA2": 3, "spareA3": 0, "commandedRate": 900, "profileBasalRate": 900, "algorithmRate": 900, "tempRate": 65535}, "estimatedDateTime": "2026-05-16T10:00:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 64, "sequenceGroup": 0, "sequenceNumber": 450240, "pumpDateTime": "2026-05-16T09:15:00", "eventProperties": {"bolusId": 1600, "bolusType": 3, "correctionBolusIncluded": 0, "carbAmount": 45, "bg": 130, "iob": 0, "carbRatio": 0}, "estimatedDateTime": "2026-05-16T09:15:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 65, "sequenceGroup": 0, "sequenceNumber": 450241, "pumpDateTime": "2026-05-16T09:15:00", "eventProperties": {"bolusId": 1600, "options": 4, "standardPercent": 100, "duration": 0, "spareB6": 0, "isf": 0, "targetBg": 0, "userOverride": 0, "declinedCorrection": 0, "selectedIob": 1}, "estimatedDateTime": "2026-05-16T09:15:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 66, "sequenceGroup": 0, "sequenceNumber": 450242, "pumpDateTime": "2026-05-16T09:15:00", "eventProperties": {"bolusId": 1600, "spareA2": 0, "foodBolusSize": 5.0, "correctionBolusSize": 0.0, "totalBolusSize": 5.0}, "estimatedDateTime": "2026-05-16T09:15:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 20, "sequenceGroup": 0, "sequenceNumber": 450250, "pumpDateTime": "2026-05-16T09:15:00", "eventProperties": {"completionStatus": 3, "bolusId": 1600, "iob": 5.0, "insulinDelivered": 5.0, "insulinRequested": 5.0}, "estimatedDateTime": "2026-05-16T09:15:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 229, "sequenceGroup": 0, "sequenceNumber": 450300, "pumpDateTime": "2026-05-16T09:30:00", "eventProperties": {"currentUserMode": 0, "previousUserMode": 2, "requestedAction": 4, "spareA3": 0, "sleepStartedByGui": 0, "activeSleepSchedule": [0], "spareB6": 0, "exerciseStoppedByTimer": 0, "exerciseChoice": 0, "exerciseTime": 0, "eatingSoonStoppedByTimer": 0}, "estimatedDateTime": "2026-05-16T09:30:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 229, "sequenceGroup": 0, "sequenceNumber": 450400, "pumpDateTime": "2026-05-16T11:00:00", "eventProperties": {"currentUserMode": 2, "previousUserMode": 0, "requestedAction": 3, "spareA3": 0, "sleepStartedByGui": 0, "activeSleepSchedule": [0], "spareB6": 0, "exerciseStoppedByTimer": 0, "exerciseChoice": 0, "exerciseTime": 0, "eatingSoonStoppedByTimer": 0}, "estimatedDateTime": "2026-05-16T11:00:00Z"},
+        {"deviceAssignmentId": "e2e-device-assignment-id", "eventCode": 229, "sequenceGroup": 0, "sequenceNumber": 450410, "pumpDateTime": "2026-05-16T11:30:00", "eventProperties": {"currentUserMode": 0, "previousUserMode": 2, "requestedAction": 4, "spareA3": 0, "sleepStartedByGui": 0, "activeSleepSchedule": [0], "spareB6": 0, "exerciseStoppedByTimer": 0, "exerciseChoice": 0, "exerciseTime": 0, "eatingSoonStoppedByTimer": 0}, "estimatedDateTime": "2026-05-16T11:30:00Z"},
         """;
 
     /// <summary>The fixture's events plus <see cref="NextDayEvents"/>.</summary>
@@ -370,7 +378,9 @@ public class TandemE2eSyncTests
     /// <summary>
     /// The days fetched either side of the window are there to complete its edge records, not to
     /// widen what it returns: a record of the padded day's own belongs to the window that covers
-    /// it, and a caller that asked for one window is not handed three.
+    /// it, and a caller that asked for one window is not handed three. Every record type whose
+    /// correctness depends on an event across the edge is bounded, so each is pinned here — the
+    /// padded day carries one of each, complete and publishable but for the bound.
     /// </summary>
     [Fact]
     public async Task Records_of_the_padded_day_are_left_to_the_window_that_covers_them()
@@ -383,12 +393,26 @@ public class TandemE2eSyncTests
         {
             From = Utc(2026, 5, 14, 0, 0, 0),
             To = Utc(2026, 5, 15, 0, 0, 0),
-            DataTypes = [SyncDataType.Boluses],
+            DataTypes =
+            [
+                SyncDataType.Boluses, SyncDataType.CarbIntake, SyncDataType.BolusCalculations,
+                SyncDataType.TempBasals, SyncDataType.StateSpans,
+            ],
         });
 
-        fixture.Publisher.Boluses.Should().ContainSingle()
-            .Which.SyncIdentifier.Should().Be("tandem_bolus_1583",
-                "the padded day's own bolus is the next window's to publish");
+        var publisher = fixture.Publisher;
+        publisher.Boluses.Should().ContainSingle()
+            .Which.SyncIdentifier.Should().Be("tandem_bolus_1583");
+        publisher.CarbIntakes.Should().ContainSingle().Which.Carbs.Should().Be(20);
+        publisher.BolusCalculations.Should().ContainSingle().Which.CarbInput.Should().Be(20);
+
+        // The window's two deliveries, the second closed by the padded day's first; that one's own
+        // span, closed by the delivery an hour after it, belongs to the next window.
+        publisher.TempBasals.Should().HaveCount(2);
+        publisher.TempBasals.Should().OnlyContain(record => record.StartTimestamp < Utc(2026, 5, 16, 0, 0, 0));
+
+        publisher.StateSpans.Should().ContainSingle()
+            .Which.StartTimestamp.Should().Be(Utc(2026, 5, 15, 14, 0, 0));
     }
 
     /// <summary>


### PR DESCRIPTION
An admin repairing a gap posts an explicit window and the connector quietly crawls something else. #954/#972 fixed that for Nightscout; the same story was live in three more connectors, each by a different mechanism.

## The contract

A `SyncRequest`'s `from` is a lower bound that neither the caller nor a data family's own resume point may narrow — they widen each other — while a request carrying an explicit `to` is answered exactly as asked, catch-up bypassed, and one naming no `from` at all resolves to the source's history floor rather than to a resume point.

`ResumeFrom` on `BaseConnectorService` is the vocabulary. It now carries all three clauses, so MyLife and Tandem state them once rather than twice each.

This PR implements the contract for the explicit-window path in all three connectors. Glooko's *scheduled* lower bound still consults no per-family watermark — the #954 stranding class in its catch-up path, along with the unvalidated inverted window (`to` before `from`) that reports success over zero work — and both are tracked in #1054 rather than changed here, because either would move the scheduled path for every tenant.

## Per connector

| Connector | Before | After |
|---|---|---|
| **MyLife** | `request.From` was passed as `defaultSince` and returned verbatim, so the family watermark was never consulted. A treatments publish failing one cycle while glucose succeeded left those treatments below every later cycle's bound — permanently. | Each family widens the caller's bound with its own resume point. An explicit range is answered as asked; one with no lower bound crawls from the initial-sync floor. |
| **Tandem** | `request.From`/`request.To` were never read at all: the window came from the watermarks and the pump's available range. A repair request crawled the ordinary catch-up window and reported success having fetched nothing. | Both bounds threaded, a day fetched either side so edge records are complete, and the window's own records published. A bound below the pump's `availableDataRange.start` is still clamped — the pump serves nothing there — but the run says so. |
| **Glooko** | `to` was built from `DateTime.UtcNow` unconditionally, so a bounded re-import chunked from the requested start to today. | `request.To` bounds the chunk loop. |

The `defaultSince` pass-through is gone from `CalculateSinceTimestampAsync`/`CalculateTreatmentSinceTimestampAsync`: MyLife was its only caller, and the branch that returned it verbatim is the whole bug class. The other four call sites pass no argument and are unchanged, as are the nine connectors that call neither.

## Records at the window's edges

A record at the edge of a bounded window is assembled from, or closed by, events on the far side of it, and the run had none of them:

- the **last basal span** had no closing event, so it went unpublished — a permanent hole, because the next scheduled run resumes above the repaired range and never looks again;
- a **bolus** whose request messages fell below the edge published bare — no carbs, no calculation, type reset to normal — under the same stable `tandem_bolus_{id}`, over the complete record a full sync had stored;
- an **exercise span** whose stop fell above the edge published open, under the id an unpaired span carries: a second row beside the closed one.

The fetch now reaches one day past each edge, capped at the pump's own range below and its newest event above. The pump-logs endpoint is day-granular and already overshoots to `23:59:59`, so this is one more chunk-day, not a different request shape.

What the window then bounds is the record types whose correctness depends on an event across the edge — temp basals, state spans, and the bolus/carb/calculation family: a padded day's own records of those types belong to the window that covers them. **Point records are published as fetched**: a CGM reading, device event, system event or device status is complete in the single event that carries it and upserts on a stable id to the same values whichever window carries it, so a bounded run's `ItemsSynced` can include up to a day either side of the window for those types.

A span that even the padded day does not close ran longer than a day; it is still unpublished, but the run now names it in `SyncResult.Message` beside the clamp notice.

## Declared behaviour deltas

**Scheduled path.** MyLife's treatment bound now resumes from the treatment watermark instead of the glucose watermark — the fix — and MyLife makes two watermark reads it previously skipped when `from` was set, so a publisher that cannot answer one fails the cycle (the semantics #972 gave NocturneRemote). Tandem and Glooko are byte-identical: an open-ended run pads nothing, filters nothing, and `fetchedThrough` is the pump ceiling exactly as before, while Glooko's `request.To ?? DateTime.UtcNow` is literally main's expression.

**Cursor reset.** `{from: null, to: now}` — the shape `POST connectors/{id}/reset-cursor` sends — now crawls from the pump's available range (Tandem) or the initial-sync floor (MyLife) instead of the watermark. This is a change against main for both, and it is what `ServicesController.ResetConnectorCursor` and `ConnectorCursorResetService` have always documented: "a null From means no lower bound — re-pull everything available". Under the old reading the endpoint reset nothing for these two. One residual gap remains for MyLife: its floor is the connector's own six-month initial-sync window, so a reset re-pulls that much rather than literally all history, and whether mylife Cloud serves more than six months is unverified.

**Manual sync.** The connectors settings card's **Manual Sync** button fans out `{from: now-30d, to: now}` to every enabled connector, so Tandem now re-crawls 30 days per press, as Nightscout and NocturneRemote already did. (The connector details dialog's own sync sends the range the user picks, and is unaffected beyond honouring it.) `request.To` on those paths is the browser's clock, where the connector previously used the server's.

**Unchanged edges**, declared rather than fixed: a bolus straddling the *scheduled* run's own lower edge is still split (main's behaviour — the background window starts at the watermark's midnight), and Tandem's window is rounded outward to whole days by the vendor's endpoint.

## Tests

Sixteen new cases across the three connectors. Every bound, pad, publish filter and notice is mutation-proved — the old behaviour is reintroduced and a named test fails. The five filtered publish sites were proved one at a time, after a hostile review found that a four-site mutation left the suite green: the padded-day payload could not leak four of the five types, so it now carries a closed basal pair, a bolus with carbs and a calculation, and a complete exercise pair of its own.

| Mutation | Test that fails |
|---|---|
| MyLife bound → `request.From ?? resume` (main's exact semantics) | `SyncDataAsync_WhenTreatmentsFellBehindGlucose_ResumesFromTheTreatmentWatermark` |
| explicit-range branch dropped | `…WhenGivenAnExplicitRange_AsksForItAsGiven`, `Explicit_request_window_fetches_a_day_either_side` |
| caller's bound narrows the resume point | MyLife stranding, `Background_bound_does_not_narrow_a_type_that_fell_behind` |
| Glooko `to` → `UtcNow` | `SyncDataAsync_WhenGivenAnUpperBound_StopsTheChunkLoopThere` (V2 and V3) |
| null-`from` → resume point | `Explicit_range_without_a_lower_bound_crawls_from_the_pumps_available_range`, `…CrawlsFromTheHistoryFloor` |
| upper pad removed | `Span_closed_in_the_padded_day_is_published_with_its_true_end`, `Exercise_span_stopped_in_the_padded_day_is_published_closed` |
| lower pad removed | `Bolus_straddling_the_lower_edge_is_published_complete` |
| publish bound removed, per site — boluses / carbs / calculations | `Records_of_the_padded_day_are_left_to_the_window_that_covers_them` |
| publish bound removed, per site — temp basals | `Span_closed_in_the_padded_day…` (3 spans, not 2), `Records_of_the_padded_day…` |
| publish bound removed, per site — state spans | `Exercise_span_stopped_in_the_padded_day…`, `Records_of_the_padded_day…` |
| unclosed-span notice removed | `Explicit_upper_bound_publishes_only_spans_whose_end_was_fetched` |
| span end invented (either the caller's bound or the pump ceiling) | same, with the phantom span visible in the failure |
| test fake's window filter disabled | `Explicit_request_window_fetches_a_day_either_side` |

Main's catch-up behaviour is pinned by tests that pass unchanged before and after: MyLife's `…ResumesFromTheEarliestWatermark`, Tandem's `Requests_carry_bearer_token_and_source_origin` (the exact unbounded window), `Full_sync_publishes_expected_records` (the last basal still ends at `maxDateOfEvents`), `Caught_up_sync_fetches_no_events` and `Windows_over_28_days_are_paged_and_deduplicated`.

The pump-logs fake served its whole payload for every window, which is what let the edge cases through a green suite; it now serves only the events inside the window asked for, and the paging test — which needs the same events served twice — says so explicitly.

Full runs: Connectors.Core 155, Nightscout 69, NocturneRemote 25, MyLife 39, Tandem 68, Glooko 126, and `Nocturne.API.Tests` 6198 passed / 5 skipped. The other six connector test projects and the three untested connector projects build and pass unchanged.

Closes #973
