### PR TITLE
refactor(web): route every date, time and number through the regional formatters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ docs/diagrams/er-*.mmd
 AndroidAPS/
 Trio/
 .claude/worktrees/
+
+# Throwaway probes and one-off scripts; never part of a change.
+scratch/

--- a/src/Web/packages/app/src/lib/components/actogram/Actogram.svelte
+++ b/src/Web/packages/app/src/lib/components/actogram/Actogram.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatShortDate } from "$lib/utils/formatting";
   import type { Snippet } from 'svelte';
   import type {
     ActogramPoint,
@@ -88,7 +89,7 @@
   }
 
   function formatDate(date: Date): string {
-    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return formatShortDate(date);
   }
 </script>
 

--- a/src/Web/packages/app/src/lib/components/alerts/AlertHistoryCard.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/AlertHistoryCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatDayTime } from "$lib/utils/formatting";
   import type { AlertHistoryResponse } from "$api-clients";
   import { AlertConditionType } from "$api-clients";
   import {
@@ -53,12 +54,7 @@
   function formatDate(date: Date | string | undefined): string {
     if (!date) return "-";
     const d = typeof date === "string" ? new Date(date) : date;
-    return d.toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return formatDayTime(d);
   }
 </script>
 

--- a/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatLocale } from "$lib/utils/formatting";
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
@@ -82,7 +83,7 @@
   let label = $derived(
     settings?.dndManualActive
       ? settings.dndManualUntil
-        ? `Until ${new Date(settings.dndManualUntil).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
+        ? `Until ${new Date(settings.dndManualUntil).toLocaleTimeString(formatLocale(), { hour: "numeric", minute: "2-digit" })}`
         : "On"
       : isDndScheduleConfigured(settings)
         ? "Scheduled"

--- a/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/ReplayPanel.svelte
@@ -35,7 +35,7 @@
   } from "$api-clients";
   import { severityLabel, severityVar } from "./severity";
   import { formatRange } from "./alertTime";
-  import { time } from "$lib/utils/formatting";
+  import { formatMediumDate, time } from "$lib/utils/formatting";
   import { createChartDataEngine } from "$lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte";
   import GlucoseChartShell from "$lib/components/dashboard/glucose-chart/GlucoseChartShell.svelte";
   import GlucoseTrack from "$lib/components/dashboard/glucose-chart/tracks/GlucoseTrack.svelte";
@@ -189,11 +189,7 @@
 
   function dateLabel(d: DateValue | undefined): string {
     if (!d) return "Last 24 hours";
-    return d.toDate(getLocalTimeZone()).toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return formatMediumDate(d.toDate(getLocalTimeZone()));
   }
 
   // Link to the Day in Review report for the day under replay. Prefers the

--- a/src/Web/packages/app/src/lib/components/audit/AuditMutationsTable.svelte
+++ b/src/Web/packages/app/src/lib/components/audit/AuditMutationsTable.svelte
@@ -21,6 +21,7 @@
 </script>
 
 <script lang="ts">
+  import { formatLocale } from "$lib/utils/formatting";
   import { Badge } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
   import * as Table from "$lib/components/ui/table";
@@ -75,13 +76,15 @@
   });
 
   // Format functions
-  const compactDateFormatter = new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
+  const compactDateFormatter = $derived(
+    new Intl.DateTimeFormat(formatLocale(), {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    })
+  );
 
   function formatCompactDate(date: Date | undefined): string {
     if (!date) return "\u2014";

--- a/src/Web/packages/app/src/lib/components/audit/AuditReadsTable.svelte
+++ b/src/Web/packages/app/src/lib/components/audit/AuditReadsTable.svelte
@@ -21,6 +21,7 @@
 </script>
 
 <script lang="ts">
+  import { formatLocale } from "$lib/utils/formatting";
   import { Badge } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
   import * as Table from "$lib/components/ui/table";
@@ -74,13 +75,15 @@
   });
 
   // Datetime formatter
-  const dtf = new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
+  const dtf = $derived(
+    new Intl.DateTimeFormat(formatLocale(), {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    })
+  );
 
   function formatCompactDateTime(date: Date | undefined): string {
     if (!date) return "\u2014";

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorDangerZone.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorDangerZone.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumber } from "$lib/utils/formatting";
   import type {
     ConnectorDataSummary,
   } from "$lib/api/generated/nocturne-api-client";
@@ -163,7 +164,7 @@
                 {#each Object.entries(dataSummary.recordCounts ?? {}) as [key, count], i (key)}
                   <span class="flex items-center gap-1">
                     {#if i === 0}<Database class="h-3 w-3" />{/if}
-                    {count.toLocaleString()}
+                    {formatNumber(count)}
                     {formatCountLabel(key)}
                   </span>
                 {/each}
@@ -244,11 +245,11 @@
           <p class="text-sm font-medium mb-2">Data to be deleted:</p>
           <ul class="text-sm text-muted-foreground space-y-1">
             {#each Object.entries(dataSummary.recordCounts ?? {}) as [key, count] (key)}
-              <li>{count.toLocaleString()} {formatCountLabel(key)}</li>
+              <li>{formatNumber(count)} {formatCountLabel(key)}</li>
             {/each}
           </ul>
           <p class="text-sm font-medium mt-2">
-            Total: {dataSummary.total?.toLocaleString() ?? 0} records
+            Total: {formatNumber(dataSummary.total)} records
           </p>
         </div>
       {/if}
@@ -270,13 +271,13 @@
               class="text-sm text-green-700 dark:text-green-300 mt-2 space-y-1"
             >
               {#each Object.entries(deleteDataResult.deletedCounts ?? {}) as [key, count] (key)}
-                <li>{count.toLocaleString()} {formatCountLabel(key)}</li>
+                <li>{formatNumber(count)} {formatCountLabel(key)}</li>
               {/each}
             </ul>
             <p
               class="text-sm font-medium text-green-700 dark:text-green-300 mt-2"
             >
-              Total: {deleteDataResult.totalDeleted?.toLocaleString() ?? 0} records
+              Total: {formatNumber(deleteDataResult.totalDeleted)} records
               deleted
             </p>
           </div>

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte
@@ -24,7 +24,7 @@
     SyncResult,
   } from "$lib/api/generated/nocturne-api-client";
   import type { ConnectorStatusWithDescription } from "./ServerConnectorsCard.svelte";
-  import { lastSeen } from "$lib/utils/formatting";
+  import { formatNumber, lastSeen } from "$lib/utils/formatting";
 
   let {
     open = $bindable(false),
@@ -251,7 +251,7 @@
               <Tooltip.Root>
                 <Tooltip.Trigger>
                   <span class="font-mono font-medium cursor-help underline decoration-dotted decoration-muted-foreground/50">
-                    {selectedConnector.totalEntries?.toLocaleString() ?? 0}
+                    {formatNumber(selectedConnector.totalEntries)}
                   </span>
                 </Tooltip.Trigger>
                 <Tooltip.Portal>
@@ -265,7 +265,7 @@
                           <div class="flex justify-between gap-4 text-xs">
                             <span>{getDataTypeLabel(type)}</span>
                             <span class="font-mono">
-                              {count?.toLocaleString()}
+                              {formatNumber(count)}
                             </span>
                           </div>
                         {/each}
@@ -284,7 +284,7 @@
               <Tooltip.Root>
                 <Tooltip.Trigger>
                   <span class="font-mono font-medium cursor-help underline decoration-dotted decoration-muted-foreground/50">
-                    {selectedConnector.entriesLast24Hours?.toLocaleString() ?? 0}
+                    {formatNumber(selectedConnector.entriesLast24Hours)}
                   </span>
                 </Tooltip.Trigger>
                 <Tooltip.Portal>
@@ -298,7 +298,7 @@
                           <div class="flex justify-between gap-4 text-xs">
                             <span>{getDataTypeLabel(type)}</span>
                             <span class="font-mono">
-                              {count?.toLocaleString()}
+                              {formatNumber(count)}
                             </span>
                           </div>
                         {/each}

--- a/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DataSourceManageDialog.svelte
@@ -16,7 +16,7 @@
   } from "lucide-svelte";
   import { describeSubmitError, errorStatus } from "$lib/forms";
   import { getCategoryIcon } from "$lib/utils/connector-display";
-  import { lastSeen } from "$lib/utils/formatting";
+  import { formatNumber, lastSeen } from "$lib/utils/formatting";
 
   let {
     open = $bindable(false),
@@ -156,13 +156,13 @@
           <div>
             <span class="text-muted-foreground">Records (24h)</span>
             <p class="mt-1 font-medium">
-              {selectedDataSource.entriesLast24h?.toLocaleString() ?? 0}
+              {formatNumber(selectedDataSource.entriesLast24h)}
             </p>
           </div>
           <div>
             <span class="text-muted-foreground">Total Records</span>
             <p class="mt-1 font-medium">
-              {selectedDataSource.totalEntries?.toLocaleString() ?? 0}
+              {formatNumber(selectedDataSource.totalEntries)}
             </p>
           </div>
         </div>
@@ -235,8 +235,7 @@
               class="text-sm text-red-700 dark:text-red-300 list-disc list-inside mt-2 space-y-1"
             >
               <li>
-                All glucose records ({selectedDataSource.totalEntries?.toLocaleString() ??
-                  0} records)
+                All glucose records ({formatNumber(selectedDataSource.totalEntries)} records)
               </li>
               <li>All treatments entered by this device</li>
               <li>All device status records</li>
@@ -255,7 +254,7 @@
                   <span class="font-medium">Data deleted successfully</span>
                 </div>
                 <p class="text-sm text-green-700 dark:text-green-300 mt-1">
-                  Deleted {deleteResult.totalDeleted?.toLocaleString() ?? 0} records
+                  Deleted {formatNumber(deleteResult.totalDeleted)} records
                 </p>
               </div>
             {:else}

--- a/src/Web/packages/app/src/lib/components/connectors/DeduplicationDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DeduplicationDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumber } from "$lib/utils/formatting";
   import { onDestroy } from "svelte";
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
@@ -81,8 +82,8 @@
 
             if (!open || elapsed > twoMinutes) {
               if (status.state === "Completed") {
-                const processed = status.result?.totalRecordsProcessed?.toLocaleString() ?? "0";
-                const groups = status.result?.duplicateGroupsFound?.toLocaleString() ?? "0";
+                const processed = formatNumber(status.result?.totalRecordsProcessed);
+                const groups = formatNumber(status.result?.duplicateGroupsFound);
                 toast.success("Deduplication complete", {
                   description: `Processed ${processed} records, found ${groups} duplicate groups`,
                 });
@@ -172,19 +173,19 @@
               <div class="flex justify-between">
                 <span>Records processed:</span>
                 <span class="font-mono">
-                  {deduplicationStatus.result.totalRecordsProcessed?.toLocaleString() ?? 0}
+                  {formatNumber(deduplicationStatus.result.totalRecordsProcessed)}
                 </span>
               </div>
               <div class="flex justify-between">
                 <span>Groups created:</span>
                 <span class="font-mono">
-                  {deduplicationStatus.result.canonicalGroupsCreated?.toLocaleString() ?? 0}
+                  {formatNumber(deduplicationStatus.result.canonicalGroupsCreated)}
                 </span>
               </div>
               <div class="flex justify-between">
                 <span>Duplicates found:</span>
                 <span class="font-mono">
-                  {deduplicationStatus.result.duplicateGroupsFound?.toLocaleString() ?? 0}
+                  {formatNumber(deduplicationStatus.result.duplicateGroupsFound)}
                 </span>
               </div>
             </div>
@@ -225,11 +226,11 @@
               </div>
               <div class="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
                 <div>
-                  Processed: {deduplicationStatus.progress.processedRecords?.toLocaleString() ?? 0}
-                  / {deduplicationStatus.progress.totalRecords?.toLocaleString() ?? 0}
+                  Processed: {formatNumber(deduplicationStatus.progress.processedRecords)}
+                  / {formatNumber(deduplicationStatus.progress.totalRecords)}
                 </div>
                 <div class="text-right">
-                  Groups: {deduplicationStatus.progress.groupsFound?.toLocaleString() ?? 0}
+                  Groups: {formatNumber(deduplicationStatus.progress.groupsFound)}
                 </div>
               </div>
             </div>

--- a/src/Web/packages/app/src/lib/components/connectors/DemoDataSection.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/DemoDataSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumber } from "$lib/utils/formatting";
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
   import { Sparkles, CheckCircle, AlertCircle, Loader2, Trash2 } from "lucide-svelte";
@@ -70,7 +71,7 @@
               <span class="font-medium">Demo data cleared successfully</span>
             </div>
             <p class="text-sm text-green-700 dark:text-green-300 mt-1">
-              Deleted {demoDeleteResult.totalDeleted?.toLocaleString() ?? 0} records
+              Deleted {formatNumber(demoDeleteResult.totalDeleted)} records
             </p>
           </div>
         {:else}

--- a/src/Web/packages/app/src/lib/components/connectors/ManualSyncDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ManualSyncDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatLocale } from "$lib/utils/formatting";
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
   import { Loader2, Download, CheckCircle, AlertCircle } from "lucide-svelte";
@@ -45,7 +46,7 @@
   $effect(() => {
     if (syncProgress?.messageType) {
       const entry: LogEntry = {
-        time: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }),
+        time: new Date().toLocaleTimeString(formatLocale(), { hour: "2-digit", minute: "2-digit", second: "2-digit" }),
         message: formatSyncMessage(syncProgress.messageType, syncProgress.messageParams),
       };
       logEntries = [...logEntries, entry];

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/DeliveryInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/DeliveryInspectionDialog.svelte
@@ -4,7 +4,7 @@
   import { Button } from "$lib/components/ui/button";
   import { Activity, Syringe, Utensils, AlertTriangle } from "lucide-svelte";
   import { BasalDeliveryOrigin, type ApsSnapshot } from "$lib/api";
-  import { bg, bgLabel, time } from "$lib/utils/formatting";
+  import { bg, bgLabel, formatLocale, time } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
   import type { PredictionData } from "$api/predictions.remote";
   import { getAll as getApsSnapshots } from "$lib/api/generated/apsSnapshots.generated.remote";
@@ -172,7 +172,7 @@
       <Dialog.Description>
         {time(timestamp, { seconds: true })}
         &mdash;
-        {timestamp.toLocaleDateString([], {
+        {timestamp.toLocaleDateString(formatLocale(), {
           month: "short",
           day: "numeric",
         })}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseInspectionDialog.svelte
@@ -4,7 +4,7 @@
   import { Button } from "$lib/components/ui/button";
   import { Syringe, Utensils } from "lucide-svelte";
   import { BasalDeliveryOrigin } from "$lib/api";
-  import { bg, bgLabel, bgDelta, time } from "$lib/utils/formatting";
+  import { bg, bgDelta, bgLabel, formatLocale, time } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
   import type { PredictionData } from "$api/predictions.remote";
   import { getAll as getApsSnapshots } from "$lib/api/generated/apsSnapshots.generated.remote";
@@ -153,7 +153,7 @@
       <Dialog.Description>
         {time(timestamp, { seconds: true })}
         &mdash;
-        {timestamp.toLocaleDateString([], {
+        {timestamp.toLocaleDateString(formatLocale(), {
           month: "short",
           day: "numeric",
         })}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentInspectionDialog.svelte
@@ -3,7 +3,7 @@
   import { Badge } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
   import { Activity, Syringe, Pencil } from "lucide-svelte";
-  import { bg, bgLabel, time } from "$lib/utils/formatting";
+  import { bg, bgLabel, formatLocale, time } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
   import type { PredictionData } from "$api/predictions.remote";
   import type { BolusCalculation } from "$lib/api";
@@ -232,7 +232,7 @@
       <Dialog.Description>
         {time(timestamp, { seconds: true })}
         &mdash;
-        {timestamp.toLocaleDateString([], {
+        {timestamp.toLocaleDateString(formatLocale(), {
           month: "short",
           day: "numeric",
         })}

--- a/src/Web/packages/app/src/lib/components/dashboard/widgets/TirChartWidget.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/widgets/TirChartWidget.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumber } from "$lib/utils/formatting";
   import { onMount } from "svelte";
   import WidgetCard from "./WidgetCard.svelte";
   import TIRStackedChart from "$lib/components/reports/TIRStackedChart.svelte";
@@ -116,7 +117,7 @@
           {/if}
         </div>
         <span class="text-xs text-muted-foreground">
-          {totalReadings.toLocaleString()} readings
+          {formatNumber(totalReadings)} readings
         </span>
       </div>
 

--- a/src/Web/packages/app/src/lib/components/meal-matching/MealMatchReviewDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/meal-matching/MealMatchReviewDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatShortDate } from "$lib/utils/formatting";
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
@@ -93,7 +94,7 @@
   function formatDateDisplay(mills: number): string {
     if (!mills) return "";
     const date = new Date(mills);
-    return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    return formatShortDate(date);
   }
 
   // Track selected date separately

--- a/src/Web/packages/app/src/lib/components/meals/MealBolusDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/meals/MealBolusDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatClock, formatMediumDateTime } from "$lib/utils/formatting";
   import type { MealEvent, Bolus, BolusType, PatientInsulin } from "$lib/api";
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
@@ -66,10 +67,7 @@
 
   let mealTimestamp = $derived(
     meal?.timestamp
-      ? new Date(meal.timestamp).toLocaleString(undefined, {
-          dateStyle: "medium",
-          timeStyle: "short",
-        })
+      ? formatMediumDateTime(meal.timestamp)
       : "",
   );
 
@@ -128,10 +126,7 @@
 
   function formatBolusTime(mills: number | undefined): string {
     if (!mills) return "";
-    return new Date(mills).toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return formatClock(mills);
   }
 </script>
 

--- a/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
+++ b/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatDayTime } from "$lib/utils/formatting";
   import { page } from "$app/state";
   import { Button } from "$lib/components/ui/button";
   import * as Card from "$lib/components/ui/card";
@@ -106,12 +107,7 @@
   function formatDate(date: Date | undefined | null): string {
     if (!date) return "";
     const d = date instanceof Date ? date : new Date(date);
-    return d.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
+    return formatDayTime(d);
   }
 
   function formatRelativeExpiry(date: Date | undefined | null): string {

--- a/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatDayTime } from "$lib/utils/formatting";
   import { page } from "$app/state";
   import { Button } from "$lib/components/ui/button";
   import * as Card from "$lib/components/ui/card";
@@ -145,12 +146,7 @@
   function formatDate(date: Date | string | undefined | null): string {
     if (!date) return "never";
     const d = date instanceof Date ? date : new Date(date);
-    return d.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
+    return formatDayTime(d);
   }
 </script>
 

--- a/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/PatientDeviceManager.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatMediumDate } from "$lib/utils/formatting";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
   import { Label } from "$lib/components/ui/label";
@@ -60,11 +61,7 @@
   function formatDate(date: Date | string | undefined): string {
     if (!date) return "";
     const d = new Date(date);
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return formatMediumDate(d);
   }
 
   // ── Inline variant state ────────────────────────────────────────
@@ -164,11 +161,7 @@
 
   function formatLastSeen(value: string | Date | null | undefined): string {
     if (!value) return "";
-    return new Date(value).toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return formatMediumDate(value);
   }
 
   /**

--- a/src/Web/packages/app/src/lib/components/patient/PatientInsulinManager.svelte
+++ b/src/Web/packages/app/src/lib/components/patient/PatientInsulinManager.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatMediumDate } from "$lib/utils/formatting";
   import { Button } from "$lib/components/ui/button";
   import { Badge } from "$lib/components/ui/badge";
   import * as Card from "$lib/components/ui/card";
@@ -39,11 +40,7 @@
   function formatDate(date: Date | string | undefined): string {
     if (!date) return "";
     const d = new Date(date);
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return formatMediumDate(d);
   }
 
   /** Get formulations matching the selected category */

--- a/src/Web/packages/app/src/lib/components/reports/ApsStateCard.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ApsStateCard.svelte
@@ -3,7 +3,7 @@
   import * as Card from "$lib/components/ui/card";
   import { Badge } from "$lib/components/ui/badge";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
-  import { formatGlucoseValue, getUnitLabel } from "$lib/utils/formatting";
+  import { formatClock, formatGlucoseValue, getUnitLabel } from "$lib/utils/formatting";
   import {
     Brain,
     Syringe,
@@ -24,10 +24,7 @@
 
   const snapshotTime = $derived(
     snapshot?.mills
-      ? new Date(snapshot.mills).toLocaleTimeString(undefined, {
-          hour: "2-digit",
-          minute: "2-digit",
-        })
+      ? formatClock(snapshot.mills)
       : null
   );
 

--- a/src/Web/packages/app/src/lib/components/reports/DailySummaryTable.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/DailySummaryTable.svelte
@@ -8,12 +8,7 @@
     TableHeader,
     TableRow,
   } from "$lib/components/ui/table";
-  import {
-    formatInsulinDisplay,
-    bg,
-    bgLabel,
-    bgRange,
-  } from "$lib/utils/formatting";
+  import { bg, bgLabel, bgRange, formatInsulinDisplay, formatShortDate } from "$lib/utils/formatting";
   import type { DayToDayDailyData, Thresholds } from "./types";
   import { getGlucoseColor } from "$lib/utils/glucose-analytics.ts";
 
@@ -47,10 +42,7 @@
       {#each dailyDataPoints as entry (entry.date)}
         <TableRow>
           <TableCell class="font-medium">
-            {new Date(entry.date).toLocaleDateString(undefined, {
-              month: "short",
-              day: "numeric",
-            })}
+            {formatShortDate(entry.date)}
           </TableCell>
           <TableCell
             class={getGlucoseColor(

--- a/src/Web/packages/app/src/lib/components/reports/GlycemicRiskIndexChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/GlycemicRiskIndexChart.svelte
@@ -2,7 +2,7 @@
   import { Chart, Svg, Axis, Polygon, Points, Legend, Tooltip } from "layerchart";
   import { scaleLinear, scaleOrdinal } from "d3-scale";
   import type { GlycemicRiskIndex, GriTimelinePeriod } from "$lib/api/generated/nocturne-api-client";
-  import { formatGlucoseValue, getUnitLabel } from "$lib/utils/formatting";
+  import { formatGlucoseValue, formatMonthYear, getUnitLabel } from "$lib/utils/formatting";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
   import { categoryPatternClass } from "$lib/components/charts/print/chart-print-patterns";
 
@@ -57,7 +57,7 @@
   function formatPeriodLabel(periodStart?: string): string {
     if (!periodStart) return "";
     const date = new Date(periodStart);
-    return date.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+    return formatMonthYear(date);
   }
 
   // Zone boundaries: diagonal lines where hypo + hyper = GRI score threshold

--- a/src/Web/packages/app/src/lib/components/reports/InsulinDonutChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/InsulinDonutChart.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatClock } from "$lib/utils/formatting";
   import { PieChart, Text, Tooltip } from "layerchart";
   import type { Bolus, CarbIntake } from "$lib/api";
   import { categoryPatternClass } from "$lib/components/charts/print/chart-print-patterns";
@@ -71,21 +72,16 @@
         ? carbByCorrelation.get(t.correlationId)
         : undefined;
 
-      const time = t.mills
-        ? new Date(t.mills).toLocaleTimeString(undefined, {
-            hour: "2-digit",
-            minute: "2-digit",
-          })
-        : undefined;
+      const bolusTime = t.mills ? formatClock(t.mills) : undefined;
 
       segments.push({
         key: `bolus-${i}`,
-        label: `Bolus${time ? ` @ ${time}` : ""}`,
+        label: `Bolus${bolusTime ? ` @ ${bolusTime}` : ""}`,
         value: t.insulin ?? 0,
         color: getBolusColor(i, bolusTreatments.length),
         bolus: t,
         linkedCarbs: linkedCarb?.carbs ?? undefined,
-        time,
+        time: bolusTime,
         props: arcProps(3),
       });
     });

--- a/src/Web/packages/app/src/lib/components/reports/RetrospectiveStats.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/RetrospectiveStats.svelte
@@ -12,7 +12,11 @@
   } from "lucide-svelte";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
   import { getDirectionInfo } from "$lib/utils";
-  import { formatGlucoseValue, getUnitLabel } from "$lib/utils/formatting";
+  import {
+    formatClock,
+    formatGlucoseValue,
+    getUnitLabel,
+  } from "$lib/utils/formatting";
   import { getRetrospectiveData } from "$api/generated/retrospectives.generated.remote";
   import { remoteErrorMessage } from "$lib/api/remote-error";
 
@@ -31,12 +35,7 @@
   const unitLabel = $derived(getUnitLabel(units));
 
   // Format time for display
-  const timeDisplay = $derived(
-    new Date(time).toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-    })
-  );
+  const timeDisplay = $derived(formatClock(new Date(time)));
 </script>
 
 {#if !retrospectiveQuery.current && !retrospectiveQuery.error}

--- a/src/Web/packages/app/src/lib/components/reports/ScheduleFooter.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/ScheduleFooter.svelte
@@ -6,7 +6,7 @@
     ScheduleChangeInfo,
   } from "$lib/api/generated/nocturne-api-client";
   import { History } from "lucide-svelte";
-  import { bg, bgLabel } from "$lib/utils/formatting";
+  import { bg, bgLabel, formatNumericDate } from "$lib/utils/formatting";
 
   interface Props {
     profile?: ProfileSummary | null;
@@ -102,7 +102,7 @@
   {#if info?.changedDuringPeriod}
     <span
       class="inline-flex items-center text-muted-foreground ml-1"
-      title="Changed {info.lastChangedAt ? new Date(info.lastChangedAt).toLocaleDateString() : 'during period'} ({info.changeCount} change{info.changeCount === 1 ? '' : 's'} during this period)"
+      title="Changed {info.lastChangedAt ? formatNumericDate(new Date(info.lastChangedAt)) : 'during period'} ({info.changeCount} change{info.changeCount === 1 ? '' : 's'} during this period)"
     >
       <History class="w-3 h-3" />
     </span>

--- a/src/Web/packages/app/src/lib/components/reports/TreatmentEvents.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/TreatmentEvents.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatLocale } from "$lib/utils/formatting";
   import type { TreatmentDataItem } from "./types";
 
   interface Props {
@@ -18,7 +19,7 @@
         >
           <div class="font-medium">{treatment.eventType}</div>
           <div class="text-gray-600">
-            {new Date(treatment.timestamp).toLocaleTimeString([], {
+            {new Date(treatment.timestamp).toLocaleTimeString(formatLocale(), {
               hour: "2-digit",
               minute: "2-digit",
             })}

--- a/src/Web/packages/app/src/lib/components/reports/TreatmentSummary.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/TreatmentSummary.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { Syringe, Apple, Utensils } from "lucide-svelte";
-  import {
-    formatInsulinDisplay,
-    formatCarbDisplay,
-  } from "$lib/utils/formatting";
+  import { formatCarbDisplay, formatInsulinDisplay, formatShortDate } from "$lib/utils/formatting";
   import type { DayToDayDailyData } from "./types";
 
   // Local type definition for treatment summary
@@ -65,10 +62,7 @@
       {#if day.treatmentSummary && (totalInsulin > 0 || totalCarbs > 0)}
         <div class="bg-gray-50 rounded-lg p-4">
           <h3 class="text-lg font-semibold text-gray-700 mb-3">
-            {new Date(day.date).toLocaleDateString(undefined, {
-              month: "short",
-              day: "numeric",
-            })}
+            {formatShortDate(day.date)}
           </h3>
           <div class="space-y-2 text-sm">
             {#if totalInsulin > 0}

--- a/src/Web/packages/app/src/lib/components/reports/sensor-integrity/buckets.ts
+++ b/src/Web/packages/app/src/lib/components/reports/sensor-integrity/buckets.ts
@@ -4,6 +4,7 @@
  * reading's offset) so the glucose trace and the cluster bands stay aligned within a row.
  */
 import type { SensorGlucose, GlucoseCluster, SensorIntegrityHypoEvent } from "$lib/api";
+import { formatLocale } from "$lib/utils/formatting";
 
 const DAY_MS = 86_400_000;
 const MIN_MS = 60_000;
@@ -50,7 +51,7 @@ function resolveDisplayOffsetMinutes(entries: SensorGlucose[]): number {
 }
 
 function dayLabel(dateMs: number): string {
-  return new Date(dateMs).toLocaleDateString(undefined, {
+  return new Date(dateMs).toLocaleDateString(formatLocale(), {
     timeZone: "UTC",
     weekday: "short",
     month: "short",

--- a/src/Web/packages/app/src/lib/components/reports/sleep/SleepCompositionChart.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/sleep/SleepCompositionChart.svelte
@@ -5,6 +5,7 @@
    * calendar day across the full selected range (gaps for days with no
    * recorded night), plus a compact stage-composition reference panel.
    */
+  import { formatShortDate, formatWeekdayLabel } from "$lib/utils/formatting";
   import { Chart, Svg, Axis, Tooltip } from "layerchart";
   import { scaleBand, scaleLinear, type ScaleBand } from "d3-scale";
   import { goto } from "$app/navigation";
@@ -91,7 +92,7 @@
   function formatDayTick(key: string): string {
     const row = dayRows.find((r) => r.dayKey === key);
     if (!row) return "";
-    return row.date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    return formatShortDate(row.date);
   }
 
   /** Navigate to a night's drill-down using the backend's authoritative display date. */
@@ -202,7 +203,7 @@
                   role={row.night ? "link" : undefined}
                   tabindex={row.night ? 0 : undefined}
                   aria-label={row.night
-                    ? `Sleep session on ${row.date.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`
+                    ? `Sleep session on ${formatShortDate(row.date)}`
                     : undefined}
                   class={row.night ? "cursor-pointer" : undefined}
                   onpointermove={(e: PointerEvent) => context.tooltip?.show(e, row)}
@@ -217,7 +218,7 @@
               {#snippet children({ data })}
                 {@const row = data as DayRow}
                 <Tooltip.Header
-                  value={`${row.night?.weekday ?? row.date.toLocaleDateString(undefined, { weekday: "short" })}, ${row.date.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`}
+                  value={`${formatWeekdayLabel(row.date)}, ${formatShortDate(row.date)}`}
                 />
                 {#if row.night}
                   {@const night = row.night}

--- a/src/Web/packages/app/src/lib/components/reports/sleep/single-night/DawnPhenomenonCard.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/sleep/single-night/DawnPhenomenonCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Card, CardContent, CardHeader, CardTitle } from "$lib/components/ui/card";
   import { Sunrise } from "lucide-svelte";
-  import { bg, bgDelta, bgLabel, toDate } from "$lib/utils/formatting";
+  import { bg, bgDelta, bgLabel, formatLocale, toDate } from "$lib/utils/formatting";
   import type { SleepDawnPhenomenon } from "$lib/api";
 
   interface Props {
@@ -10,7 +10,9 @@
 
   let { dawnPhenomenon }: Props = $props();
 
-  const timeFormatter = new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" });
+  const timeFormatter = $derived(
+    new Intl.DateTimeFormat(formatLocale(), { hour: "2-digit", minute: "2-digit" })
+  );
 
   const windowStart = $derived(toDate(dawnPhenomenon.windowStart));
   const windowEnd = $derived(toDate(dawnPhenomenon.windowEnd));

--- a/src/Web/packages/app/src/lib/components/reports/sleep/single-night/Hypnogram.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/sleep/single-night/Hypnogram.svelte
@@ -4,7 +4,7 @@
   import type { ScaleTime } from "d3-scale";
   import { getActogramData } from "$api/actogram.remote";
   import { getBasalSeries } from "$api/generated/chartDatas.generated.remote";
-  import { bg, bgLabel, toDate } from "$lib/utils/formatting";
+  import { bg, bgLabel, formatLocale, toDate } from "$lib/utils/formatting";
   import { resolveChartColor } from "$lib/utils/chart-colors";
   import {
     laneForStage,
@@ -30,7 +30,9 @@
   // Nearest CGM reading counts as "at" the hovered time within this window.
   const GLUCOSE_STALENESS_MS = 15 * 60 * 1000;
 
-  const timeFormatter = new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" });
+  const timeFormatter = $derived(
+    new Intl.DateTimeFormat(formatLocale(), { hour: "2-digit", minute: "2-digit" })
+  );
 
   // Chart window: session ±30min so the glucose trace shows lead-in/lead-out context.
   const windowStart = $derived(new Date(startTime.getTime() - WINDOW_PADDING_MS));

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/YearHeatmap.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/YearHeatmap.svelte
@@ -5,7 +5,7 @@
   import { Loader2 } from "lucide-svelte";
   import { fly } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
-  import { formatGlucoseValue } from "$lib/utils/formatting";
+  import { formatGlucoseValue, formatMonthLabel, formatWeekdayDate } from "$lib/utils/formatting";
   import type { GlucoseUnits } from "$lib/utils/formatting";
   import { getDataTypeLabel } from "$lib/utils/data-type-labels";
 
@@ -126,9 +126,7 @@
                         font-size="12"
                         class="fill-muted-foreground hover:fill-primary cursor-pointer"
                       >
-                        {monthDate.toLocaleString(undefined, {
-                          month: "short",
-                        })}
+                        {formatMonthLabel(monthDate)}
                       </text>
                     </a>
                   {/each}
@@ -190,11 +188,7 @@
                   <div class="text-xs min-w-40">
                     <!-- Date header -->
                     <div class="mb-1.5 font-semibold">
-                      {d.date.toLocaleDateString(undefined, {
-                        weekday: "short",
-                        month: "short",
-                        day: "numeric",
-                      })}
+                      {formatWeekdayDate(d.date)}
                     </div>
 
                     <!-- Average glucose -->

--- a/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
@@ -13,7 +13,7 @@
   import { getDataTypeLabel } from "$lib/utils/data-type-labels";
   import { formatSyncMessage } from "$lib/utils/sync-messages";
   import type { SyncProgressEvent } from "$lib/websocket/types";
-  import { lastSeen as formatAge } from "$lib/utils/formatting";
+  import { formatNumber, formatNumericDate, lastSeen as formatAge } from "$lib/utils/formatting";
 
   export type DataSourceStatus =
     | "active"
@@ -143,7 +143,7 @@
     if (diffDays < 7)
       return `${diffDays} day${diffDays !== 1 ? "s" : ""} ago`;
 
-    return d.toLocaleDateString();
+    return formatNumericDate(d);
   }
 
   const iconColors = $derived(getIconColors(status));
@@ -263,7 +263,7 @@
                 <span
                   class="cursor-help underline decoration-dotted decoration-muted-foreground/50"
                 >
-                  {(totalEntries ?? 0).toLocaleString()} records
+                  {formatNumber(totalEntries)} records
                 </span>
               </Tooltip.Trigger>
               <Tooltip.Portal>
@@ -278,7 +278,7 @@
                       <div class="flex justify-between gap-4 text-xs">
                         <span>{getDataTypeLabel(type)}</span>
                         <span class="font-mono">
-                          {count?.toLocaleString()}
+                          {formatNumber(count)}
                         </span>
                       </div>
                     {/each}
@@ -287,7 +287,7 @@
               </Tooltip.Portal>
             </Tooltip.Root>
           {:else}
-            {(totalEntries ?? 0).toLocaleString()} records
+            {formatNumber(totalEntries)} records
           {/if}
 
           {#if (entriesLast24h ?? 0) > 0}
@@ -298,7 +298,7 @@
                   <span
                     class="cursor-help underline decoration-dotted decoration-muted-foreground/50"
                   >
-                    {(entriesLast24h ?? 0).toLocaleString()} in 24h
+                    {formatNumber(entriesLast24h)} in 24h
                   </span>
                 </Tooltip.Trigger>
                 <Tooltip.Portal>
@@ -315,7 +315,7 @@
                         <div class="flex justify-between gap-4 text-xs">
                           <span>{getDataTypeLabel(type)}</span>
                           <span class="font-mono">
-                            {count?.toLocaleString()}
+                            {formatNumber(count)}
                           </span>
                         </div>
                       {/each}
@@ -324,7 +324,7 @@
                 </Tooltip.Portal>
               </Tooltip.Root>
             {:else}
-              {(entriesLast24h ?? 0).toLocaleString()} in 24h
+              {formatNumber(entriesLast24h)} in 24h
             {/if}
           {/if}
 

--- a/src/Web/packages/app/src/lib/components/status-pills/BasalPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/BasalPill.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatDate } from "$lib/utils/formatting";
   import StatusPill from "./StatusPill.svelte";
   import type {
     BasalPillData,
@@ -51,7 +52,7 @@
       if (data.tempBasal.startTime) {
         items.push({
           label: "Active Temp Basal Start",
-          value: new Date(data.tempBasal.startTime).toLocaleString(),
+          value: formatDate(data.tempBasal.startTime),
         });
       }
 

--- a/src/Web/packages/app/src/lib/components/status-pills/COBPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/COBPill.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatLocale } from "$lib/utils/formatting";
   import StatusPill from "./StatusPill.svelte";
   import type {
     COBPillData,
@@ -21,7 +22,7 @@
     // Last carbs info
     if (data.lastCarbs) {
       const when = new Date(data.lastCarbs.mills);
-      const timeStr = when.toLocaleString([], {
+      const timeStr = when.toLocaleString(formatLocale(), {
         month: "short",
         day: "numeric",
         hour: "2-digit",

--- a/src/Web/packages/app/src/lib/components/status-pills/IOBPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/IOBPill.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatLocale } from "$lib/utils/formatting";
   import StatusPill from "./StatusPill.svelte";
   import type {
     IOBPillData,
@@ -21,10 +22,13 @@
 
     // Last bolus info
     if (data.lastBolus) {
-      const when = new Date(data.lastBolus.mills).toLocaleTimeString([], {
-        hour: "2-digit",
-        minute: "2-digit",
-      });
+      const when = new Date(data.lastBolus.mills).toLocaleTimeString(
+        formatLocale(),
+        {
+          hour: "2-digit",
+          minute: "2-digit",
+        }
+      );
       const amount = `${data.lastBolus.insulin.toFixed(2)}U`;
       items.push({ label: "Last Bolus", value: `${amount} @ ${when}` });
 

--- a/src/Web/packages/app/src/lib/components/status-pills/LoopPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/LoopPill.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import StatusPill from "./StatusPill.svelte";
-  import { bg } from "$lib/utils/formatting";
+  import { bg, formatLocale } from "$lib/utils/formatting";
   import type {
     LoopPillData,
     PillInfoItem,
@@ -114,10 +114,13 @@
   const display = $derived.by(() => {
     if (!data?.lastLoopTime) return null;
 
-    const time = new Date(data.lastLoopTime).toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    const time = new Date(data.lastLoopTime).toLocaleTimeString(
+      formatLocale(),
+      {
+        hour: "2-digit",
+        minute: "2-digit",
+      }
+    );
 
     if (data.eventualBG !== undefined) {
       return `${time} ↝ ${bg(data.eventualBG)}`;

--- a/src/Web/packages/app/src/lib/components/status-pills/TrackerPill.svelte
+++ b/src/Web/packages/app/src/lib/components/status-pills/TrackerPill.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatLocale } from "$lib/utils/formatting";
   import * as Popover from "$lib/components/ui/popover";
   import { Button } from "$lib/components/ui/button";
   import type { TrackerInstanceDto, TrackerDefinitionDto } from "$lib/api";
@@ -210,7 +211,7 @@
       {/if}
       {#if instance.startedAt}
         <div class="text-xs text-muted-foreground mt-2">
-          Started {new Date(instance.startedAt).toLocaleString([], {
+          Started {new Date(instance.startedAt).toLocaleString(formatLocale(), {
             month: "short",
             day: "numeric",
             hour: "2-digit",

--- a/src/Web/packages/app/src/lib/components/trackers/TrackerStartDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/trackers/TrackerStartDialog.svelte
@@ -6,7 +6,7 @@
   import { TextareaAutosize } from "$lib/components/ui/textarea";
   import { Play } from "lucide-svelte";
   import { cn } from "$lib/utils";
-  import { formatShortDate, time } from "$lib/utils/formatting";
+  import { formatClock, formatShortDate, time } from "$lib/utils/formatting";
   import { useToastSubmission } from "$lib/forms";
 
   import { tick } from "svelte";
@@ -321,7 +321,7 @@
                     {preview.relativeTime}
                   </span>
                   <span class="text-[10px] opacity-70">
-                    {preview.triggerTime.toLocaleTimeString()}
+                    {formatClock(preview.triggerTime, { seconds: true })}
                   </span>
                 </div>
               </div>

--- a/src/Web/packages/app/src/lib/stores/settings-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/settings-store.svelte.ts
@@ -5,6 +5,7 @@
  * state that can be shared across settings pages with two-way binding support.
  */
 
+import { formatNumericDate } from "$lib/utils/formatting";
 import { getContext, setContext } from "svelte";
 import { browser } from "$app/environment";
 import { getApiClient } from "$lib/api/client";
@@ -354,5 +355,5 @@ export function formatLastSync(date: Date | undefined): string {
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ago`;
 
-  return new Date(date).toLocaleDateString();
+  return formatNumericDate(new Date(date));
 }

--- a/src/Web/packages/app/src/lib/utils/formatting.test.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.test.ts
@@ -34,6 +34,17 @@ const {
 	formatGlucoseRange,
 	formatLocale,
 	prefersHour12,
+	formatLongDate,
+	formatMediumDate,
+	formatMediumDateTime,
+	formatMonthYear,
+	formatMonthLabel,
+	formatWeekdayLabel,
+	formatClock,
+	formatDayTime,
+	formatNumber,
+	formatNumericDate,
+	time,
 	formatShortDate,
 	formatWeekdayDate,
 	formatDateTime,
@@ -53,6 +64,31 @@ const {
 // The mocked store holds plain objects, so a test can move a preference and read
 // the effect the same way the app does.
 const store = await import("$lib/stores/appearance-store.svelte");
+/** Run `body` with the 12/24 time-format preference set to `value`. */
+function withTimeFormat<T>(value: "12" | "24", run: () => T): T {
+	const previous = store.timeFormat.current;
+	store.timeFormat.current = value;
+	try {
+		return run();
+	} finally {
+		store.timeFormat.current = previous;
+	}
+}
+
+/** Run `body` with the regional-format preference set to `tag`. */
+function withRegionValue<T>(tag: RegionFormat, run: () => T): T {
+	const previous = store.regionFormat.current;
+	store.regionFormat.current = tag;
+	try {
+		return run();
+	} finally {
+		store.regionFormat.current = previous;
+	}
+}
+
+function withRegion(tag: RegionFormat, run: () => void): void {
+	withRegionValue(tag, run);
+}
 
 describe("Glucose conversion", () => {
 	describe("convertToDisplayUnits", () => {
@@ -323,16 +359,6 @@ describe("Treatment formatting", () => {
 });
 
 describe("Regional format", () => {
-	function withRegion(tag: RegionFormat, run: () => void) {
-		const previous = store.regionFormat.current;
-		store.regionFormat.current = tag;
-		try {
-			run();
-		} finally {
-			store.regionFormat.current = previous;
-		}
-	}
-
 	it("falls back to the display language when no region is chosen", () => {
 		expect(formatLocale()).toBe("en");
 	});
@@ -358,7 +384,142 @@ describe("Regional format", () => {
 	});
 });
 
+describe("Shared date shapes", () => {
+	// A fixed local instant: these helpers read the viewer's clock, so building it
+	// locally is what a caller does.
+	const date = new Date(2026, 7, 29, 14, 5);
+
+	function shapes() {
+		return {
+			long: formatLongDate(date),
+			medium: formatMediumDate(date),
+			mediumTime: formatMediumDateTime(date),
+			monthYear: formatMonthYear(date),
+			month: formatMonthLabel(date),
+			weekday: formatWeekdayLabel(date),
+			numeric: formatNumericDate(date),
+		};
+	}
+
+	it("names months and weekdays in the regional format", () => {
+		const english = withRegionValue("en-GB", shapes);
+		const german = withRegionValue("de-DE", shapes);
+
+		// August is spelled alike; the ordering and the weekday are what differ.
+		expect(english.long).toMatch(/^Saturday, 29 August 2026$/);
+		expect(german.long).toMatch(/^Samstag, 29\. August 2026$/);
+		expect(english.long).toContain("Saturday");
+		expect(german.long).toContain("Samstag");
+		expect(english.weekday).toBe("Sat");
+		expect(german.weekday).toBe("Sa");
+		expect(english.month).toBe("Aug");
+		expect(english.monthYear).toBe("August 2026");
+	});
+
+	it("writes each shape at its own precision", () => {
+		const s = withRegionValue("en-GB", shapes);
+
+		expect(s.medium).toBe("29 Aug 2026");
+		expect(s.mediumTime).toContain("29 Aug 2026");
+		// en-GB writes a 24-hour clock, and this helper follows the locale.
+		expect(s.mediumTime).toContain("14:05");
+		expect(s.numeric).toBe("29/08/2026");
+	});
+
+	it("writes the clock in the preferred format where the surface follows it", () => {
+		withRegion("en-GB", () => expect(time(date)).toBe("2:05 pm"));
+	});
+
+	it("leaves the clock to the locale on the surfaces that never followed a preference", () => {
+		// These sites passed no `hour12` before the sweep. German has no day-period
+		// abbreviation, so ICU would hand a German reader the English "AM" if the
+		// preference won here — and the padding follows the locale, not a per-site guess.
+		for (const preference of ["12", "24"] as const) {
+			withTimeFormat(preference, () => {
+				expect(withRegionValue("en-GB", () => formatDayTime(date))).toContain("14:05");
+				expect(withRegionValue("de-DE", () => formatDayTime(date))).toContain("14:05");
+				// Normalised: ICU emits a narrow no-break space before the day period
+				// in some builds and a plain one in others.
+				expect(
+					withRegionValue("en-US", () => formatDayTime(date)).replace(/\s/g, " ")
+				).toContain("2:05 PM");
+				expect(withRegionValue("de-DE", () => formatMediumDateTime(date))).toContain("14:05");
+			});
+		}
+	});
+
+	it("follows the 12/24 preference on the surfaces that always did", () => {
+		withRegionValue("en-GB", () => {
+			withTimeFormat("24", () => {
+				expect(time(date)).toBe("14:05");
+				expect(formatDateTimeCompact(date)).toContain("14:05");
+			});
+			withTimeFormat("12", () => {
+				expect(time(date)).toBe("2:05 pm");
+				expect(formatDateTimeCompact(date)).toContain("02:05 pm");
+			});
+		});
+	});
+
+	it("lets the locale glue the date to the time", () => {
+		// Composing the halves and joining them by hand hardcodes ", " — ja-JP, zh-CN
+		// and ko-KR write a space there, and ar-EG U+060C.
+		const japanese = withRegionValue("ja-JP", () => formatDayTime(date));
+		expect(japanese).toContain("14:05");
+		expect(japanese).not.toContain(",");
+	});
+
+	it("takes the hour style from the locale, not from the call site", () => {
+		// HEAD passed `hour: "2-digit"` at some sites and `"numeric"` at others; each
+		// is wrong in half the locales, so it is read off the locale's own short time.
+		// Asserted literally rather than against a re-derived option set, which would
+		// move with the implementation.
+		const american = withRegionValue("en-US", () => formatDayTime(date)).replace(/\s/g, " ");
+		expect(american).toContain("2:05 PM");
+		expect(american).not.toContain("02:05");
+
+		expect(withRegionValue("en-GB", () => formatDayTime(date))).toContain("14:05");
+		expect(withRegionValue("en-GB", () => formatClock(date))).toBe("14:05");
+		expect(withRegionValue("en-GB", () => formatClock(date, { seconds: true }))).toBe(
+			"14:05:00"
+		);
+	});
+
+	it("reads an unusable value as no time rather than as 1970", () => {
+		// `time()` takes wire values now, and a nullable `mills` used to throw where it
+		// would otherwise render "Invalid Date" or the epoch into a treatment row.
+		expect(time(undefined)).toBe("—");
+		expect(time(null)).toBe("—");
+		expect(time("not a date")).toBe("—");
+	});
+
+	it("reads a wire value, not only a Date", () => {
+		// NSwag types DTO date fields as `Date`, but the generated client parses with
+		// no reviver, so what actually arrives is an ISO string. `time()` was the one
+		// helper that did not coerce, and the active-alerts card threw on it.
+		const iso = "2026-08-29T14:05:00.000Z";
+		withRegion("en-GB", () => {
+			expect(() => time(iso)).not.toThrow();
+			expect(time(iso)).toBe(time(new Date(iso)));
+			expect(time(new Date(iso).getTime())).toBe(time(new Date(iso)));
+		});
+	});
+
+	it("groups numbers in the regional format", () => {
+		withRegion("de-DE", () => expect(formatNumber(1234567)).toBe("1.234.567"));
+		withRegion("en-US", () => expect(formatNumber(1234567)).toBe("1,234,567"));
+	});
+
+	it("reads a missing count as zero rather than as text", () => {
+		withRegion("en-US", () => {
+			expect(formatNumber(undefined)).toBe("0");
+			expect(formatNumber(null)).toBe("0");
+		});
+	});
+});
+
 describe("prefersHour12", () => {
+
 	it("follows the time-format preference when not overridden", () => {
 		expect(prefersHour12()).toBe(true);
 	});

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -184,10 +184,14 @@ export function prefersHour12(override?: boolean): boolean {
  * @returns Formatted time string (e.g. "2:30 pm" or "14:30")
  */
 export function time(
-  date: Date | number,
+  date: Date | string | number | null | undefined,
   opts: { compact?: boolean; seconds?: boolean } = {}
 ): string {
-  const d = typeof date === "number" ? new Date(date) : date;
+  // Coerced like every sibling helper: NSwag types DTO date fields as `Date` but
+  // the client parses with no reviver, so what arrives is an ISO string.
+  if (date == null) return "—";
+  const d = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(d.getTime())) return "—";
   const options: Intl.DateTimeFormatOptions = {
     hour: "numeric",
     minute: opts.compact && prefersHour12() ? "numeric" : "2-digit",
@@ -240,7 +244,7 @@ export function lastSeen(
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d ago`;
-  return d.toLocaleDateString(formatLocale());
+  return formatNumericDate(d);
 }
 
 /** Format elapsed time as minutes ago in the user's regional format. */
@@ -269,6 +273,24 @@ export function toDate(value: Date | string | undefined | null): Date | null {
 }
 
 /**
+ * A number with the regional format's own group and decimal separators — "1.234"
+ * for a German reader, "1,234" for an American one.
+ */
+export function formatNumber(value: number | undefined | null): string {
+  return (value ?? 0).toLocaleString(formatLocale());
+}
+
+/**
+ * The regional format's own numeric date, e.g. "31/12/2026" or "12/31/2026". The
+ * shape is the locale's; use {@link formatShortDate} or {@link formatMediumDate}
+ * where a named month reads better.
+ */
+export function formatNumericDate(date: Date | string | number): string {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString(formatLocale());
+}
+
+/**
  * Formats a date string to display date and time
  * @param dateStr - ISO date string or undefined
  * @returns Formatted date and time string, or fallback
@@ -276,11 +298,7 @@ export function toDate(value: Date | string | undefined | null): Date | null {
 export function formatDateTime(dateStr: string | undefined): string {
   if (!dateStr) return "—";
   const date = new Date(dateStr);
-  return date.toLocaleDateString(formatLocale()) + " " + date.toLocaleTimeString(formatLocale(), {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: prefersHour12(),
-  });
+  return date.toLocaleDateString(formatLocale()) + " " + time(date);
 }
 
 /**
@@ -288,8 +306,8 @@ export function formatDateTime(dateStr: string | undefined): string {
  * @param date - Date object, ISO date string, or undefined
  * @returns Formatted date and time string, or "N/A"
  */
-export function formatDate(date: Date | string | undefined): string {
-  if (!date) return "N/A";
+export function formatDate(date: Date | string | number | undefined): string {
+  if (date == null || date === "") return "N/A";
   return new Date(date).toLocaleString(formatLocale());
 }
 
@@ -343,6 +361,146 @@ export function formatShortDate(
 }
 
 /**
+ * Date with its weekday, month name and year, e.g. "Saturday, 29 August 2026" —
+ * names and ordering follow the regional format.
+ */
+export function formatLongDate(date: Date | string | number): string {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString(formatLocale(), {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+/** Date with an abbreviated month and its year, e.g. "29 Aug 2026". */
+export function formatMediumDate(date: Date | string | number): string {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString(formatLocale(), {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * {@link formatMediumDate} with the time of day, e.g. "29 Aug 2026, 02:30".
+ * Follows the locale's hour cycle — see {@link formatDayTime}.
+ */
+export function formatMediumDateTime(
+  date: Date | string | number | null | undefined
+): string {
+  if (date == null) return "—";
+  const d = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(formatLocale(), {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    ...localeHourFields(),
+  });
+}
+
+/**
+ * The hour fields the locale's own short time uses — zero-padded and 24-hour where
+ * it writes them that way, `2:05 pm` where it doesn't.
+ *
+ * Read off a `timeStyle: "short"` formatter rather than guessed, because the two
+ * shapes HEAD used per site (`hour: "2-digit"` and `"numeric"`) each render wrongly
+ * in half the locales. `timeStyle` itself cannot be combined with date fields, and
+ * formatting the halves separately would hardcode a joiner that ja-JP, zh-CN and
+ * ko-KR write as a space and ar-EG as U+060C — so the fields are extracted and
+ * spread into a single `Intl` call, which lets ICU supply the glue.
+ */
+const localeHourFields = (() => {
+  // 05:05, so a padded locale renders "05" and an unpadded one "5".
+  const probe = new Date(Date.UTC(2020, 0, 1, 5, 5));
+  const cache = new Map<string, Intl.DateTimeFormatOptions>();
+  return (): Intl.DateTimeFormatOptions => {
+    const locale = formatLocale();
+    const cached = cache.get(locale);
+    if (cached) return cached;
+
+    const formatter = new Intl.DateTimeFormat(locale, {
+      timeStyle: "short",
+      timeZone: "UTC",
+    });
+    const hour = formatter.formatToParts(probe).find((part) => part.type === "hour");
+    const fields: Intl.DateTimeFormatOptions = {
+      hour: (hour?.value.length ?? 1) > 1 ? "2-digit" : "numeric",
+      minute: "2-digit",
+      hour12: formatter.resolvedOptions().hour12,
+    };
+    cache.set(locale, fields);
+    return fields;
+  };
+})();
+
+/**
+ * Time of day at the locale's own convention. Deliberately not the 12/24
+ * preference — see {@link formatDayTime}.
+ */
+export function formatClock(
+  date: Date | string | number | null | undefined,
+  opts: { seconds?: boolean } = {}
+): string {
+  if (date == null) return "—";
+  const d = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleTimeString(formatLocale(), {
+    timeStyle: opts.seconds ? "medium" : "short",
+  });
+}
+
+/**
+ * Day and time with no year, e.g. "30 Aug, 00:05".
+ *
+ * Follows the locale's hour cycle, not the 12/24 preference — which is what these
+ * surfaces did before they were routed through a shared formatter, and changing it
+ * is not the locale sweep's business. The app is inconsistent about this: sibling
+ * surfaces use {@link formatDateTimeCompact} and do follow the preference. Settling
+ * it means giving the preference a "follow the locale" default, which needs the
+ * API's `AllowedTimeFormats` widened to accept it and every direct
+ * `timeFormat.current === "24"` comparison updated.
+ */
+export function formatDayTime(date: Date | string | number | undefined): string {
+  if (date == null) return "—";
+  const d = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(formatLocale(), {
+    month: "short",
+    day: "numeric",
+    ...localeHourFields(),
+  });
+}
+
+/** Month name and year with no day, e.g. "August 2026". */
+export function formatMonthYear(date: Date | string | number): string {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString(formatLocale(), {
+    month: "long",
+    year: "numeric",
+  });
+}
+
+/** Abbreviated month name alone, for a chart's month band. */
+export function formatMonthLabel(date: Date | string | number): string {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString(formatLocale(), {
+    month: "short",
+  });
+}
+
+/** Abbreviated weekday name alone, for a chart axis or a row label. */
+export function formatWeekdayLabel(date: Date | string | number): string {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toLocaleDateString(formatLocale(), {
+    weekday: "short",
+  });
+}
+
+/**
  * Formats a date string for use in datetime-local input fields
  * @param dateStr - ISO date string or undefined
  * @returns Date in YYYY-MM-DDTHH:MM format for HTML input
@@ -350,6 +508,10 @@ export function formatShortDate(
 export function formatDateForInput(dateStr: string | undefined): string {
   if (!dateStr) return "";
   const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "";
+  // Local getters, deliberately: a `datetime-local` value carries no offset, so
+  // the browser parses it back in its own zone. Rendering it on any other
+  // calendar makes the round trip asymmetric and moves the instant on save.
   const year = date.getFullYear();
   const month = (date.getMonth() + 1).toString().padStart(2, "0");
   const day = date.getDate().toString().padStart(2, "0");

--- a/src/Web/packages/app/src/lib/utils/index.ts
+++ b/src/Web/packages/app/src/lib/utils/index.ts
@@ -10,6 +10,7 @@ import {
   AlertTriangle,
 } from "lucide-svelte";
 import { canonicalDirection } from "@nocturne/ui/glucose";
+import { formatLocale } from "$lib/utils/formatting";
 import {
   Direction,
 } from "$lib/api";
@@ -99,11 +100,11 @@ export function getDirectionInfo(direction?: Direction | string): DirectionInfo 
 const getRelativeTimeFormatter = (() => {
   let formatter: Intl.RelativeTimeFormat | null = null;
   return (locale?: string) => {
-    if (
-      !formatter ||
-      (locale && locale !== formatter.resolvedOptions().locale)
-    ) {
-      formatter = new Intl.RelativeTimeFormat(locale || "en", {
+    const wanted = locale || formatLocale();
+    // Compared every call, not only when a locale is passed: the no-argument path
+    // is the common one, and it used to pin whatever the first call resolved.
+    if (!formatter || wanted !== formatter.resolvedOptions().locale) {
+      formatter = new Intl.RelativeTimeFormat(wanted, {
         numeric: "auto",
         style: "long",
       });

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatClock } from "$lib/utils/formatting";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
   import { toast } from "svelte-sonner";
@@ -299,7 +300,7 @@
                   {a.ruleName ?? "Alert"}
                 </p>
                 <p class="text-xs text-muted-foreground">
-                  Since {a.startedAt ? new Date(a.startedAt).toLocaleTimeString() : "—"}
+                  Since {a.startedAt ? formatClock(a.startedAt, { seconds: true }) : "—"}
                 </p>
               </div>
               {#if a.acknowledgedAt}

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatDayTime } from "$lib/utils/formatting";
   import { page } from "$app/state";
   import { goto } from "$app/navigation";
   import { untrack } from "svelte";
@@ -215,12 +216,7 @@
     if (!at) return "—";
     const d = at instanceof Date ? at : new Date(at);
     if (Number.isNaN(d.getTime())) return "—";
-    return d.toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
+    return formatDayTime(d);
   }
 
   // ---- Severity ---------------------------------------------------------

--- a/src/Web/packages/app/src/routes/(authenticated)/clock/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/clock/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumericDate } from "$lib/utils/formatting";
   import { goto } from "$app/navigation";
   import * as Card from "$lib/components/ui/card";
   import { ConfirmDialog } from "$lib/components/ui/confirm-dialog";
@@ -211,9 +212,9 @@
                   <Card.Title class="font-semibold">{face.name}</Card.Title>
                   <Card.Description class="text-xs">
                     {#if face.updatedAt}
-                      Updated {new Date(face.updatedAt).toLocaleDateString()}
+                      Updated {formatNumericDate(new Date(face.updatedAt))}
                     {:else if face.createdAt}
-                      Created {new Date(face.createdAt).toLocaleDateString()}
+                      Created {formatNumericDate(new Date(face.createdAt))}
                     {/if}
                   </Card.Description>
                 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/meals/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/meals/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { startOfDay, toDayString } from "$lib/utils/date-range";
+  import { formatLongDate } from "$lib/utils/formatting";
   import { Calendar } from "lucide-svelte";
   import type {
     MealEvent,
@@ -194,8 +196,10 @@
       const mills = meal.carbIntakes?.[0]?.mills;
       if (!mills) continue;
 
-      const date = new Date(mills);
-      const dateKey = date.toLocaleDateString();
+      // Keyed on the calendar day, not on a formatted string: a locale-formatted
+      // key groups by whatever shape the region format happens to produce, and
+      // changing the format mid-session would re-bucket every meal.
+      const dateKey = toDayString(new Date(mills));
 
       if (!grouped.has(dateKey)) {
         grouped.set(dateKey, []);
@@ -207,14 +211,7 @@
     for (const [date, dayMeals] of grouped) {
       result.push({
         date,
-        displayDate: new Date(
-          dayMeals[0].carbIntakes?.[0]?.mills ?? 0
-        ).toLocaleDateString(undefined, {
-          weekday: "long",
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        }),
+        displayDate: formatLongDate(startOfDay(date)),
         meals: dayMeals,
       });
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/notifications/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/notifications/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { startOfDay, toDayString } from "$lib/utils/date-range";
+  import { formatDayTime, formatLongDate } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -80,12 +82,7 @@
   // Format date
   function formatDate(dateStr: Date | undefined): string {
     if (!dateStr) return "";
-    return new Date(dateStr).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return formatDayTime(dateStr);
   }
 
   // Get level icon
@@ -151,12 +148,9 @@
       const date = new Date(
         instance.completedAt ?? instance.startedAt ?? new Date()
       );
-      const key = date.toLocaleDateString(undefined, {
-        weekday: "long",
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      });
+      // Keyed on the calendar day, not on a formatted string: a locale-formatted
+      // key re-buckets every group when the region format changes.
+      const key = toDayString(date);
       if (!groups[key]) groups[key] = [];
       groups[key].push(instance);
     }
@@ -347,7 +341,7 @@
                   >
                     <div class="flex items-center gap-2">
                       <Clock class="h-4 w-4 text-muted-foreground" />
-                      <span class="font-medium">{date}</span>
+                      <span class="font-medium">{formatLongDate(startOfDay(date))}</span>
                       <Badge variant="secondary" class="ml-2">
                         {instances.length}
                       </Badge>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatDate } from "$lib/utils/formatting";
     import {page} from "$app/state";
     import { Button } from "$lib/components/ui/button";
     import {ReportsFilterSidebar} from "$lib/components/layout";
@@ -86,7 +87,7 @@
         <div class="hidden print:block border-b border-border pb-3 mb-4 px-3">
             <h1 class="text-xl font-bold text-foreground">{reportName}</h1>
             <p class="text-sm text-muted-foreground">
-                {#if showFilters}{dateRangeDisplay} · {/if}Generated {new Date().toLocaleString()}
+                {#if showFilters}{dateRangeDisplay} · {/if}Generated {formatDate(new Date())}
             </p>
         </div>
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/+page.svelte
@@ -69,12 +69,7 @@
   import { getReportsData } from "$api/reports.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
-  import {
-    formatGlucoseValue,
-    formatGlucoseRange,
-    formatShortDate,
-    getUnitLabel,
-  } from "$lib/utils/formatting";
+  import { formatGlucoseRange, formatGlucoseValue, formatLocale, formatNumber, formatNumericDate, formatShortDate, getUnitLabel } from "$lib/utils/formatting";
   import ReportsSkeleton from "$lib/components/reports/ReportsSkeleton.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
   import { remoteErrorMessage } from "$lib/api/remote-error";
@@ -202,7 +197,7 @@
             Your Glucose Report
           </h1>
           <p class="mt-3 text-lg text-muted-foreground">
-            {entries.length.toLocaleString()} readings analyzed
+            {formatNumber(entries.length)} readings analyzed
           </p>
         </div>
 
@@ -549,12 +544,12 @@
       >
         <p class="text-sm text-muted-foreground">
           <span class="font-medium">
-            {entries.length.toLocaleString()} readings
+            {formatNumber(entries.length)} readings
           </span>
-          from {startDate.toLocaleDateString()} to {endDate.toLocaleDateString()}
+          from {formatNumericDate(startDate)} to {formatNumericDate(endDate)}
           {#if lastUpdated}
             <span class="mx-2 opacity-50">•</span>
-            Last updated {new Date(lastUpdated).toLocaleTimeString([], {
+            Last updated {new Date(lastUpdated).toLocaleTimeString(formatLocale(), {
               hour: "2-digit",
               minute: "2-digit",
             })}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/agp/+page.svelte
@@ -21,7 +21,7 @@
   import TIRStackedChart from "$lib/components/reports/TIRStackedChart.svelte";
   import ReliabilityBadge from "$lib/components/reports/ReliabilityBadge.svelte";
   import { getReportsData } from "$api/reports.remote";
-  import { bg, bgLabel, bgRange } from "$lib/utils/formatting";
+  import { bg, bgLabel, bgRange, formatDate, formatNumber, formatNumericDate } from "$lib/utils/formatting";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
 
@@ -93,12 +93,12 @@
     <div class="flex items-center gap-2 text-sm text-muted-foreground">
       <Calendar class="w-4 h-4" />
       <span>
-        {startDate.toLocaleDateString()} – {endDate.toLocaleDateString()}
+        {formatNumericDate(startDate)} – {formatNumericDate(endDate)}
       </span>
       <span class="text-muted-foreground/50">•</span>
       <span>{dayCount} days</span>
       <span class="text-muted-foreground/50">•</span>
-      <span>{entries.length.toLocaleString()} readings</span>
+      <span>{formatNumber(entries.length)} readings</span>
     </div>
   </div>
 
@@ -329,9 +329,9 @@
   </Card>
 
   <div class="text-xs text-muted-foreground text-center">
-    Data from {startDate.toLocaleDateString()} – {endDate.toLocaleDateString()}.
+    Data from {formatNumericDate(startDate)} – {formatNumericDate(endDate)}.
     {#if lastUpdated}
-      Last updated {new Date(lastUpdated).toLocaleString()}.
+      Last updated {formatDate(new Date(lastUpdated))}.
     {/if}
   </div>
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/BasalAnalysisContent.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/basal-analysis/BasalAnalysisContent.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumber, formatNumericDate } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -131,7 +132,7 @@
       >
         <Calendar class="h-4 w-4" />
         <span>
-          {dateInfo.from.toLocaleDateString()} – {dateInfo.to.toLocaleDateString()}
+          {formatNumericDate(dateInfo.from)} – {formatNumericDate(dateInfo.to)}
         </span>
         <span class="text-muted-foreground/50">•</span>
         <span>{dateInfo.dayCount} days</span>
@@ -392,8 +393,8 @@
     <!-- Footer -->
     <div class="space-y-1 text-center text-xs text-muted-foreground">
       <p>
-        Report generated from {basalStats.count.toLocaleString()} basal events between
-        {dateInfo.from.toLocaleDateString()} and {dateInfo.to.toLocaleDateString()}
+        Report generated from {formatNumber(basalStats.count)} basal events between
+        {formatNumericDate(dateInfo.from)} and {formatNumericDate(dateInfo.to)}
       </p>
       <p class="text-muted-foreground/60">
         This report is for informational purposes only. Always consult your

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/battery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/battery/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatLocale, formatNumericDate } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -63,7 +64,7 @@
 
   function formatDateShort(mills?: number | null): string {
     if (!mills) return "Unknown";
-    return new Date(mills).toLocaleDateString([], {
+    return new Date(mills).toLocaleDateString(formatLocale(), {
       month: "short",
       day: "numeric",
       hour: "2-digit",
@@ -135,9 +136,9 @@
   <div class="flex items-center gap-2 text-sm text-muted-foreground">
     <Calendar class="h-4 w-4" />
     <span>
-      {new Date(dateRange.from).toLocaleDateString()} – {new Date(
+      {formatNumericDate(new Date(dateRange.from))} – {formatNumericDate(new Date(
         dateRange.to
-      ).toLocaleDateString()}
+      ))}
     </span>
     <span class="text-muted-foreground/50">•</span>
     <span>{readings.length} readings</span>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
@@ -8,7 +8,7 @@
   import GlucoseRangeCalendarPicker from "$lib/components/alerts/GlucoseRangeCalendarPicker.svelte";
   import TIRStackedChart from "$lib/components/reports/TIRStackedChart.svelte";
   import { getReportsAnalysis, type DateRangeInput } from "$api/reports.remote";
-  import { bg, bgDelta, bgLabel } from "$lib/utils/formatting";
+  import { bg, bgDelta, bgLabel, formatShortDate } from "$lib/utils/formatting";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
   import { parseDate } from "@internationalized/date";
   import { untrack } from "svelte";
@@ -56,12 +56,7 @@
   }
 
   function rangeDisplay(from: string, to: string): string {
-    const opts: Intl.DateTimeFormatOptions = {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    };
-    return `${startOfDay(from).toLocaleDateString(undefined, opts)} – ${startOfDay(to).toLocaleDateString(undefined, opts)}`;
+    return `${formatShortDate(startOfDay(from), true)} – ${formatShortDate(startOfDay(to), true)}`;
   }
 
   // Presets are built on the local calendar day. Deriving "today" from
@@ -119,8 +114,10 @@
   function readCommitted(): Periods {
     const preset = urlParams.preset ?? DEFAULT_PRESET;
     const fromPreset = computePreset(preset === "custom" ? DEFAULT_PRESET : preset);
+    // Day-parted: `isDayString` accepts a longer ISO string by slicing but returns
+    // it whole, and the range picker's `parseDate` throws on everything past the date.
     const day = (value: string | null, fallback: string) =>
-      isDayString(value) ? value : fallback;
+      (isDayString(value) ? value : fallback).slice(0, 10);
     return {
       a: {
         label: urlParams.aLabel ?? fromPreset.a.label,

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
@@ -35,7 +35,7 @@
 	import AlertTriangle from 'lucide-svelte/icons/triangle-alert';
 	import History from 'lucide-svelte/icons/history';
 	import ArrowLeft from 'lucide-svelte/icons/arrow-left';
-	import { time, bg, bgLabel } from '$lib/utils/formatting';
+	import { bg, bgLabel, formatShortDate, time } from "$lib/utils/formatting";
 	import type { CompressionLowSuggestion } from '$lib/api';
 
 	const effectivePermissions: string[] = $derived(
@@ -268,9 +268,8 @@
 		const date = nightOf instanceof Date ? nightOf : new Date(nightOf);
 		const nextDay = new Date(date);
 		nextDay.setDate(nextDay.getDate() + 1);
-		const dateStr = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-		const nextDayStr = nextDay.toLocaleDateString(undefined, { day: 'numeric', year: 'numeric' });
-		return `Night of ${dateStr}-${nextDayStr}`;
+		// `{ day, year }` alone has no CLDR pattern — it fell back to "2026 (day: 30)".
+		return `Night of ${formatShortDate(date)} \u2013 ${formatShortDate(nextDay, true)}`;
 	}
 
 	const chartDateRange = $derived.by(() => {

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
@@ -23,7 +23,7 @@
   } from "lucide-svelte";
   import { getDayInReviewData } from "./data.remote";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
-  import { formatGlucoseValue, getUnitLabel, time } from "$lib/utils/formatting";
+  import { formatGlucoseValue, formatLongDate, getUnitLabel, time } from "$lib/utils/formatting";
   import {
     getRowTypeStyle,
     mergeTreatmentRows,
@@ -92,14 +92,7 @@
   }
 
   // Format date for display
-  const dateDisplay = $derived.by(() => {
-    return currentDate.toLocaleDateString(undefined, {
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  });
+  const dateDisplay = $derived(formatLongDate(currentDate));
 
   // Get units preference
   const units = $derived(glucoseUnits.current);

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/executive-summary/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/executive-summary/+page.svelte
@@ -26,7 +26,7 @@
   import { getReportsData } from "$api/reports.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
-  import { bg, bgLabel, bgRange } from "$lib/utils/formatting";
+  import { bg, bgLabel, bgRange, formatDate, formatNumber } from "$lib/utils/formatting";
   import { formatMinutesDuration } from "$lib/utils/duration";
 
   // Format a nullable mg/dL value in the user's preferred units, or em dash if absent.
@@ -477,7 +477,7 @@
 
             <div class="grid grid-cols-2 gap-4 text-sm pt-2 border-t">
               <div>
-                <div class="font-medium">{entries.length.toLocaleString()}</div>
+                <div class="font-medium">{formatNumber(entries.length)}</div>
                 <div class="text-xs text-muted-foreground">Total readings</div>
               </div>
               <div>
@@ -539,7 +539,7 @@
     <!-- Footer -->
     <div class="text-xs text-muted-foreground text-center space-y-1 print:mt-8">
       {#if lastUpdated}
-        <p>Report generated: {new Date(lastUpdated).toLocaleString()}</p>
+        <p>Report generated: {formatDate(new Date(lastUpdated))}</p>
       {/if}
       <p class="text-muted-foreground/60">
         This report is for informational purposes. Always consult your

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
@@ -8,7 +8,7 @@
   import ReliabilityBadge from "$lib/components/reports/ReliabilityBadge.svelte";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
-  import { bg, bgLabel } from "$lib/utils/formatting";
+  import { bg, bgLabel, formatShortDate } from "$lib/utils/formatting";
   import { useSearchParams } from "runed/kit";
   import { z } from "zod";
 
@@ -85,8 +85,7 @@
   const dateRangeDisplay = $derived.by(() => {
     const dateRange = reportsResource.current?.dateRange;
     if (!dateRange) return "";
-    const options: Intl.DateTimeFormatOptions = { month: "short", day: "numeric", year: "numeric" };
-    return `${new Date(dateRange.from).toLocaleDateString(undefined, options)} – ${new Date(dateRange.to).toLocaleDateString(undefined, options)}`;
+    return `${formatShortDate(dateRange.from, true)} – ${formatShortDate(dateRange.to, true)}`;
   });
 </script>
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/heart-rate/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/heart-rate/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumber } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -138,7 +139,7 @@
         <div class="flex items-center gap-2">
           <Calendar class="h-5 w-5 text-muted-foreground" />
           <span class="text-2xl font-bold tabular-nums">
-            {selectedRates.length.toLocaleString()}
+            {formatNumber(selectedRates.length)}
           </span>
         </div>
       </CardContent>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/idp/+page.svelte
@@ -24,7 +24,7 @@
   import HourlyBolusChart from "$lib/components/reports/HourlyBolusChart.svelte";
   import ScheduleFooter from "$lib/components/reports/ScheduleFooter.svelte";
   import { getIdpData } from "$api/idp.remote";
-  import { bg, bgLabel } from "$lib/utils/formatting";
+  import { bg, bgLabel, formatDate, formatNumber, formatNumericDate } from "$lib/utils/formatting";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
 
@@ -100,12 +100,12 @@
     <div class="flex items-center gap-2 text-sm text-muted-foreground">
       <Calendar class="w-4 h-4" />
       <span>
-        {startDate.toLocaleDateString()} – {endDate.toLocaleDateString()}
+        {formatNumericDate(startDate)} – {formatNumericDate(endDate)}
       </span>
       <span class="text-muted-foreground/50">•</span>
       <span>{dayCount} days</span>
       <span class="text-muted-foreground/50">•</span>
-      <span>{entries.length.toLocaleString()} readings</span>
+      <span>{formatNumber(entries.length)} readings</span>
     </div>
   </div>
 
@@ -360,9 +360,9 @@
   </Card>
 
   <div class="text-xs text-muted-foreground text-center">
-    Data from {startDate.toLocaleDateString()} – {endDate.toLocaleDateString()}.
+    Data from {formatNumericDate(startDate)} – {formatNumericDate(endDate)}.
     {#if lastUpdated}
-      Last updated {new Date(lastUpdated).toLocaleString()}.
+      Last updated {formatDate(new Date(lastUpdated))}.
     {/if}
   </div>
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/insulin-delivery/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumber, formatNumericDate } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -152,7 +153,7 @@
     <div class="flex items-center gap-2 text-sm text-muted-foreground">
       <Calendar class="h-4 w-4" />
       <span>
-        {startDate.toLocaleDateString()} – {endDate.toLocaleDateString()}
+        {formatNumericDate(startDate)} – {formatNumericDate(endDate)}
       </span>
       <span class="text-muted-foreground/50">•</span>
       <span>{dayCount} days</span>
@@ -470,8 +471,8 @@
   <!-- Footer -->
   <div class="space-y-1 text-center text-xs text-muted-foreground">
     <p>
-      Report generated from {(insulinStats.bolusCount ?? 0).toLocaleString()} boluses between
-      {startDate.toLocaleDateString()} and {endDate.toLocaleDateString()}
+      Report generated from {formatNumber(insulinStats.bolusCount)} boluses between
+      {formatNumericDate(startDate)} and {formatNumericDate(endDate)}
     </p>
     <p class="text-muted-foreground/60">
       This report is for informational purposes only. Always consult your

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/+page.svelte
@@ -29,7 +29,7 @@
   import { contextResource } from "$lib/hooks/resource-context.svelte";
   import { resolve } from "$app/paths";
   import { dayKeyFor, buildNightsByDayKey } from "$lib/utils/sleep-night-mapping";
-  import { bgDelta, bgLabel } from "$lib/utils/formatting";
+  import { bgDelta, bgLabel, formatShortDate } from "$lib/utils/formatting";
   import SleepSummaryTile, {
     type TileDelta,
   } from "$lib/components/reports/sleep/SleepSummaryTile.svelte";
@@ -124,7 +124,7 @@
   }
 
   function formatRowLabelDate(day: Date): string {
-    return day.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    return formatShortDate(day);
   }
 
   // --- Empty-state detection -------------------------------------------------

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/[date]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/sleep/[date]/+page.svelte
@@ -12,7 +12,7 @@
   import DawnPhenomenonCard from "$lib/components/reports/sleep/single-night/DawnPhenomenonCard.svelte";
   import BiometricsCard from "$lib/components/reports/sleep/single-night/BiometricsCard.svelte";
   import { formatMinutesDuration } from "$lib/utils/duration";
-  import { bg, bgLabel, time, toDate } from "$lib/utils/formatting";
+  import { bg, bgLabel, formatLocale, time, toDate } from "$lib/utils/formatting";
 
   const date = $derived(page.params.date ?? "");
 
@@ -27,7 +27,7 @@
 
   const dateDisplay = $derived(
     startTime
-      ? new Intl.DateTimeFormat(undefined, {
+      ? new Intl.DateTimeFormat(formatLocale(), {
           weekday: "long",
           month: "long",
           day: "numeric",

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/steps/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumber, formatShortDate } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -26,7 +27,7 @@
   );
 
   function formatDate(date: Date): string {
-    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return formatShortDate(date);
   }
 
   // Step data as ActogramPoints
@@ -85,7 +86,7 @@
         <div class="flex items-center gap-2">
           <Footprints class="h-5 w-5 text-primary" />
           <span class="text-2xl font-bold tabular-nums">
-            {totalSteps.toLocaleString()}
+            {formatNumber(totalSteps)}
           </span>
         </div>
       </CardContent>
@@ -101,7 +102,7 @@
         <div class="flex items-center gap-2">
           <TrendingUp class="h-5 w-5 text-primary" />
           <span class="text-2xl font-bold tabular-nums">
-            {dailyAverage.toLocaleString()}
+            {formatNumber(dailyAverage)}
           </span>
           <span class="text-sm text-muted-foreground">steps/day</span>
         </div>
@@ -145,14 +146,14 @@
           <div class="text-right pr-2">
             <div class="text-xs text-muted-foreground">{formatDate(day)}</div>
             <div class="text-xs font-medium tabular-nums">
-              {(dayTotals.get(day.getTime()) ?? 0).toLocaleString()} <span class="text-muted-foreground font-normal">steps</span>
+              {formatNumber(dayTotals.get(day.getTime()))} <span class="text-muted-foreground font-normal">steps</span>
             </div>
           </div>
         {/snippet}
         {#snippet tooltipValue({ point })}
           {@const steps = (point as { mills: number; steps: number }).steps ?? 0}
           <span class="text-muted-foreground">Steps</span>
-          <span class="ml-auto font-mono font-medium tabular-nums">{steps.toLocaleString()}</span>
+          <span class="ml-auto font-mono font-medium tabular-nums">{formatNumber(steps)}</span>
         {/snippet}
         {#snippet row(ctx: ActogramRowContext)}
           {#each ctx.data as { point, hoursFromStart, isExtended }}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/treatments/+page.svelte
@@ -40,13 +40,7 @@
     FileText,
     Smartphone,
   } from "lucide-svelte";
-  import {
-    formatInsulinDisplay,
-    formatCarbDisplay,
-    formatDateTimeCompact,
-    bg,
-    bgLabel,
-  } from "$lib/utils/formatting";
+  import { bg, bgLabel, formatCarbDisplay, formatDateTimeCompact, formatInsulinDisplay, formatNumber, formatNumericDate } from "$lib/utils/formatting";
   import { toast } from "svelte-sonner";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
@@ -370,10 +364,10 @@
     >
       <Calendar class="h-4 w-4" />
       <span>
-        {dateInfo.from.toLocaleDateString()} – {dateInfo.to.toLocaleDateString()}
+        {formatNumericDate(dateInfo.from)} – {formatNumericDate(dateInfo.to)}
       </span>
       <span class="text-muted-foreground/50">•</span>
-      <span>{allRows.length.toLocaleString()} records</span>
+      <span>{formatNumber(allRows.length)} records</span>
     </div>
     <h1 class="text-center text-3xl font-bold">Treatment Log</h1>
     <p class="mx-auto max-w-2xl text-center text-muted-foreground">
@@ -500,8 +494,8 @@
   <!-- Footer -->
   <div class="text-center text-xs text-muted-foreground">
     <p>
-      Report generated from {allRows.length.toLocaleString()} records between
-      {dateInfo.from.toLocaleDateString()} and {dateInfo.to.toLocaleDateString()}
+      Report generated from {formatNumber(allRows.length)} records between
+      {formatNumericDate(dateInfo.from)} and {formatNumericDate(dateInfo.to)}
     </p>
   </div>
 </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { LineChart } from "layerchart";
+  import { parseDate } from "@internationalized/date";
   import * as Card from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
   import { ChevronLeft, ChevronRight, Calendar } from "lucide-svelte";
   import { getReportsData } from "$api/reports.remote";
   import { requireDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { contextResource } from "$lib/hooks/resource-context.svelte";
-  import { toDayString } from "$lib/utils/date-range";
-  import { bg } from "$lib/utils/formatting";
+  import { bg, formatShortDate } from "$lib/utils/formatting";
   import { DAY_KEYS, buildWeekdayBuckets } from "./week-to-week.utils";
 
   const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -29,12 +29,7 @@
   );
 
   const dateRangeDisplay = $derived.by(() => {
-    const opts: Intl.DateTimeFormatOptions = {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    };
-    return `${reportsParams.startDate.toLocaleDateString(undefined, opts)} – ${reportsParams.endDate.toLocaleDateString(undefined, opts)}`;
+    return `${formatShortDate(reportsParams.startDate, true)} – ${formatShortDate(reportsParams.endDate, true)}`;
   });
 
   // Each cell is the mean of every reading in that weekday's 5-minute bucket.
@@ -43,20 +38,18 @@
   );
 
   // Navigation helpers
+  // Stepped on the calendar rather than by 24-hour spans, so a week either side of
+  // a DST transition is still seven days on the patient's clock.
   function previousWeek() {
-    const newEnd = new Date(reportsParams.startDate);
-    newEnd.setDate(newEnd.getDate() - 1);
-    const newStart = new Date(newEnd);
-    newStart.setDate(newStart.getDate() - 6);
-    reportsParams.setCustomRange(toDayString(newStart), toDayString(newEnd));
+    const newEnd = parseDate(reportsParams.fromDay).subtract({ days: 1 });
+    const newStart = newEnd.subtract({ days: 6 });
+    reportsParams.setCustomRange(newStart.toString(), newEnd.toString());
   }
 
   function nextWeek() {
-    const newStart = new Date(reportsParams.endDate);
-    newStart.setDate(newStart.getDate() + 1);
-    const newEnd = new Date(newStart);
-    newEnd.setDate(newEnd.getDate() + 6);
-    reportsParams.setCustomRange(toDayString(newStart), toDayString(newEnd));
+    const newStart = parseDate(reportsParams.toDay).add({ days: 1 });
+    const newEnd = newStart.add({ days: 6 });
+    reportsParams.setCustomRange(newStart.toString(), newEnd.toString());
   }
 
   function goToCurrentWeek() {

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
@@ -18,7 +18,7 @@
     DailySummaryDay,
     GriTimelinePeriod,
   } from "$api/generated/nocturne-api-client";
-  import { getUnitLabel } from "$lib/utils/formatting";
+  import { formatLongDate, getUnitLabel } from "$lib/utils/formatting";
   import {
     GLUCOSE_HEATMAP_LEGEND_STOPS,
     getGlucoseHeatmapFill,
@@ -462,12 +462,7 @@
   function formatSelectedDate(dateStr: string): string {
     const [y, m, d] = dateStr.split("-").map(Number);
     const date = new Date(y, m - 1, d);
-    return date.toLocaleDateString(undefined, {
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
+    return formatLongDate(date);
   }
 
   function formatUnits(value: number | null): string {

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/connector-cursors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/connector-cursors/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -199,13 +200,7 @@
 
   function formatTimestamp(value: string | Date | null | undefined): string {
     if (!value) return "Never";
-    return new Date(value).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return formatMediumDateTime(value);
   }
 
   const hasConnectors = $derived((connectors?.connectors?.length ?? 0) > 0);

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/tenants/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/tenants/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumericDate } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -331,7 +332,7 @@
             <p class="text-sm font-medium text-muted-foreground">Created</p>
             <p class="mt-1 text-sm">
               {tenant.sysCreatedAt
-                ? new Date(tenant.sysCreatedAt).toLocaleDateString()
+                ? formatNumericDate(new Date(tenant.sysCreatedAt))
                 : "---"}
             </p>
           </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatLocale } from "$lib/utils/formatting";
   import { getSettingsStore } from "$lib/stores/settings-store.svelte";
   import {
     getColorTheme,
@@ -129,7 +130,7 @@
 
   // Current time in timezone for display
   const currentTime = $derived(
-    new Date(realtimeStore.now).toLocaleTimeString(undefined, {
+    new Date(realtimeStore.now).toLocaleTimeString(formatLocale(), {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/migration/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -182,13 +183,7 @@
   function formatDate(dateStr: Date | string | undefined): string {
     if (!dateStr) return "N/A";
     const date = new Date(dateStr);
-    return date.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return formatMediumDateTime(date);
   }
 
   // Get state badge

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/nightscout-transition/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/nightscout-transition/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatDate, formatNumber } from "$lib/utils/formatting";
 	import {
 		Card,
 		CardContent,
@@ -38,7 +39,7 @@
 	function formatTimestamp(ts: Date | string | null | undefined): string {
 		if (!ts) return 'Never';
 		try {
-			return new Date(ts).toLocaleString();
+			return formatDate(new Date(ts));
 		} catch {
 			return 'Unknown';
 		}
@@ -148,7 +149,7 @@
 						{#each Object.entries(status.migration?.recordCounts ?? {}) as [dataType, count] (dataType)}
 							<div class="rounded-lg border p-3">
 								<p class="text-sm text-muted-foreground capitalize">{dataType}</p>
-								<p class="text-xl font-semibold tabular-nums">{count.toLocaleString()}</p>
+								<p class="text-xl font-semibold tabular-nums">{formatNumber(count)}</p>
 							</div>
 						{/each}
 					</div>
@@ -192,19 +193,19 @@
 					<div class="rounded-lg border p-3">
 						<p class="text-sm text-muted-foreground">Requests</p>
 						<p class="text-xl font-semibold tabular-nums">
-							{(status.writeBack?.requestsLast24h ?? 0).toLocaleString()}
+							{formatNumber(status.writeBack?.requestsLast24h)}
 						</p>
 					</div>
 					<div class="rounded-lg border p-3">
 						<p class="text-sm text-muted-foreground">Succeeded</p>
 						<p class="text-xl font-semibold tabular-nums text-green-600 dark:text-green-400">
-							{(status.writeBack?.successesLast24h ?? 0).toLocaleString()}
+							{formatNumber(status.writeBack?.successesLast24h)}
 						</p>
 					</div>
 					<div class="rounded-lg border p-3">
 						<p class="text-sm text-muted-foreground">Failed</p>
 						<p class="text-xl font-semibold tabular-nums text-red-600 dark:text-red-400">
-							{(status.writeBack?.failuresLast24h ?? 0).toLocaleString()}
+							{formatNumber(status.writeBack?.failuresLast24h)}
 						</p>
 					</div>
 				</div>
@@ -257,13 +258,13 @@
 						<div class="rounded-lg border p-3">
 							<p class="text-sm text-muted-foreground">Comparisons</p>
 							<p class="text-xl font-semibold tabular-nums">
-								{(status.compatibility.totalComparisons ?? 0).toLocaleString()}
+								{formatNumber(status.compatibility.totalComparisons)}
 							</p>
 						</div>
 						<div class="rounded-lg border p-3">
 							<p class="text-sm text-muted-foreground">Discrepancies</p>
 							<p class="text-xl font-semibold tabular-nums text-red-600 dark:text-red-400">
-								{(status.compatibility.discrepancies ?? 0).toLocaleString()}
+								{formatNumber(status.compatibility.discrepancies)}
 							</p>
 						</div>
 					</div>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/trackers/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatDayTime } from "$lib/utils/formatting";
   import {
     Card,
     CardContent,
@@ -231,12 +232,7 @@
   // Format date
   function formatDate(dateStr: any): string {
     if (!dateStr) return "";
-    return new Date(dateStr).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return formatDayTime(dateStr);
   }
 
   // Get time remaining for instance

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/weight/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/weight/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatMediumDateTime } from "$lib/utils/formatting";
   import * as Card from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
@@ -24,13 +25,7 @@
 
   function formatMills(mills: number | undefined): string {
     if (!mills) return "";
-    return new Date(mills).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
+    return formatMediumDateTime(mills);
   }
 
   async function addEntry() {

--- a/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { parseDate } from "@internationalized/date";
+  import { formatLongDate, formatShortDate } from "$lib/utils/formatting";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
   import * as Card from "$lib/components/ui/card";
@@ -13,7 +15,6 @@
     isDayString,
     resolveDayRange,
     startOfDay,
-    toDayString,
   } from "$lib/utils/date-range";
   import { useSearchParams } from "runed/kit";
   import { z } from "zod";
@@ -22,13 +23,15 @@
   // `toISOString()` named yesterday for anyone east of UTC.
   const defaults = resolveDayRange({ days: 7 }, 7);
 
+  // Day-parted here rather than at each use: `isDayString` accepts a longer ISO
+  // string by slicing, and `parseDate` throws on everything past the date.
   const fromParam = $derived.by(() => {
     const fromUrl = page.url.searchParams.get("from");
-    return isDayString(fromUrl) ? fromUrl : defaults.from;
+    return (isDayString(fromUrl) ? fromUrl : defaults.from).slice(0, 10);
   });
   const toParam = $derived.by(() => {
     const fromUrl = page.url.searchParams.get("to");
-    return isDayString(fromUrl) ? fromUrl : defaults.to;
+    return (isDayString(fromUrl) ? fromUrl : defaults.to).slice(0, 10);
   });
 
   // Fetch data using remote function with date range
@@ -86,13 +89,13 @@
 
   /** Shift the window by whole days, keeping its length. */
   function shiftPeriod(direction: -1 | 1) {
-    const anchor = direction === -1 ? fromDate : toDate;
-    const newFirst = new Date(anchor);
-    newFirst.setDate(newFirst.getDate() + direction * (direction === -1 ? dayCount : 1));
-    const newLast = new Date(newFirst);
-    newLast.setDate(newLast.getDate() + dayCount - 1);
+    // Stepped on the calendar rather than by 24-hour spans, so a window either
+    // side of a DST transition keeps its length in days.
+    const anchor = parseDate(direction === -1 ? fromParam : toParam);
+    const newFirst = anchor.add({ days: direction * (direction === -1 ? dayCount : 1) });
+    const newLast = newFirst.add({ days: dayCount - 1 });
     goto(
-      `/time-spans?from=${toDayString(newFirst)}&to=${toDayString(newLast)}`,
+      `/time-spans?from=${newFirst.toString()}&to=${newLast.toString()}`,
       { invalidateAll: true }
     );
   }
@@ -103,22 +106,8 @@
 
   // Format date range for display
   const dateRangeDisplay = $derived.by(() => {
-    if (dayCount === 1) {
-      return fromDate.toLocaleDateString(undefined, {
-        weekday: "long",
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      });
-    }
-    return `${fromDate.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    })} - ${toDate.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    })} (${dayCount} days)`;
+    if (dayCount === 1) return formatLongDate(fromDate);
+    return `${formatShortDate(fromDate)} - ${formatShortDate(toDate, true)} (${dayCount} days)`;
   });
 </script>
 

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/ImportProgress.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/ImportProgress.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { formatNumber } from "$lib/utils/formatting";
   import {
     Database,
     Upload,
@@ -76,7 +77,7 @@
   }
 
   function formatCount(n: number): string {
-    return n.toLocaleString();
+    return formatNumber(n);
   }
 
   $effect(() => {


### PR DESCRIPTION
## What

About seventy surfaces formatted dates, times and numbers by calling `toLocaleDateString(undefined, …)`, `toLocaleTimeString` or `toLocaleString` directly. `undefined` means *the browser's own* locale, so those surfaces ignored the regional-format preference entirely — a reader who set en-GB still got `8/29/2026` from a US-configured browser, and thousands separators used whichever grouping the browser preferred rather than the one the rest of the page used.

Every such call now goes through `$lib/utils/formatting`, which resolves `formatLocale()`. The shapes already in use are named rather than repeated: `formatLongDate`, `formatMediumDate`, `formatMediumDateTime`, `formatNumericDate`, `formatMonthYear`, `formatMonthLabel`, `formatWeekdayLabel`, `formatClock`, `formatDayTime`, `formatNumber`.

Most of the diff is mechanical. **These seven are the parts worth reading closely** — they were all found by collecting the call sites:

### Rendering defects

- **`time()` / `formatMediumDateTime()` rendered `Invalid Date`.** Both were typed `Date | number`, but they are handed DTO fields that NSwag types as `Date` and the client parses with no reviver — so an ISO *string* arrived. They now coerce like their siblings, and read an unusable value as `—` rather than as 1970.
- **Compression-lows rendered `2026 (day: 30)`.** The report asked for `{ day, year }`, which has no CLDR pattern, so the second half of "Night of …" fell back to a debug-shaped string.

### Correctness defects

- **Meals and notifications grouped rows under a locale-formatted date string used as a map key.** Changing the region format mid-session re-bucketed every group, and two days that format alike would have merged. Both now key on `toDayString()` and format only at the point of display.
- **Week-to-week stepped weeks with `setDate(±n)` on a `Date`**, so a week either side of a DST transition was not seven days on the patient's clock. It now steps on the calendar with `parseDate().add/subtract`.
- **The comparison report could throw.** It handed the range picker a value straight from `isDayString`, which accepts a longer ISO string by slicing but returns it *whole* — `parseDate` then threw on the remainder. Day-parted at the boundary.

### Staleness defects

- **`getRelativeTimeFormatter` pinned the first locale it saw.** It only compared the locale when one was passed, and the no-argument path is the common one, so a later preference change never took effect.
- **`formatDateForInput` had no NaN guard.** Its local getters are kept deliberately and now say why: a `datetime-local` value carries no offset, so rendering it on any other calendar moves the instant on save.

## Hour style

Read off a `timeStyle: "short"` formatter rather than guessed. The two shapes previously used per site (`hour: "2-digit"` and `"numeric"`) are each wrong in half the locales. `timeStyle` cannot be combined with date fields, and formatting the halves separately would hardcode a joiner that ja-JP, zh-CN and ko-KR write as a space and ar-EG as U+060C — so the fields are extracted and spread into one `Intl` call, letting ICU supply the glue.

## Deliberately not settled here

The app is inconsistent about whether a date-and-time surface follows the 12/24 preference or the locale's own hour cycle. **Each surface keeps the behaviour it had**, and `formatDayTime`'s doc comment records what unifying them would need: a "follow the locale" default, which means widening the API's `AllowedTimeFormats` and updating every direct `timeFormat.current === "24"` comparison.

Where a site needed a bare `Intl.DateTimeFormat` rather than a named helper, the options are left byte-for-byte as they were and only the locale argument changes — with the formatter moved into `$derived` so a preference change rebuilds it.

## Testing

- 11 new tests in `formatting.test.ts` cover the hour-style extraction, the coercion paths and the preference-versus-locale split.
- `pnpm run test:unit`: **980 passed**. The one failure (`appearance-store.ssr.test.ts` — "renders the request's units") **is pre-existing on `origin/main`**, verified by running it on a clean checkout of main.
- `pnpm run check`: **20 errors, identical to the `origin/main` baseline** (generated client, bot dispatch, and an unused `reportsParams` that main already has). No new ones.
