### PR TITLE
fix(web): cut a report's days on the patient's calendar, not a stale profile row

### DIFF
--- a/src/Web/packages/app/src/lib/api/report-range.ts
+++ b/src/Web/packages/app/src/lib/api/report-range.ts
@@ -1,16 +1,17 @@
 /**
  * Server-side resolution of a report's date range.
  *
- * A report's "day" is the patient's day, so the day boundaries are computed in
- * the timezone on their therapy settings rather than the container's timezone.
- * The window is inclusive: it runs from midnight opening `from` to the last
- * millisecond of `to`, both read in that timezone.
+ * A report's "day" is the patient's day, so the day boundaries are computed on
+ * the patient's calendar rather than the container's — see
+ * `$lib/server/patient-timezone`. The window is inclusive: it runs from midnight
+ * opening `from` to the last millisecond of `to`, both read in that timezone.
  */
 import { z } from "zod";
 import { error } from "@sveltejs/kit";
-import { getProfileSummary } from "$api/generated/profiles.generated.remote";
+import { getRequestEvent } from "$app/server";
 import { getLocalDayBoundariesUtc } from "$lib/utils/timezone";
-import { dayCount, isTimeZone, resolveDayRange } from "$lib/utils/date-range";
+import { dayCount, resolveDayRange } from "$lib/utils/date-range";
+import { resolvePatientTimeZone } from "$lib/server/patient-timezone";
 
 /**
  * Input schema for date range queries. Uses nullish() to accept both null and
@@ -32,30 +33,14 @@ export interface ReportRange {
   endDate: Date;
   /** Calendar days the window covers, counting both end days. */
   dayCount: number;
-  /** The patient's IANA timezone, or null when their profile does not set one. */
-  timeZone: string | null;
 }
 
 /**
- * The patient's configured IANA timezone, or null when it is unset, is a value this runtime
- * does not recognise, or the caller may not read it. Null means the day boundaries fall back
- * to UTC.
- *
- * Therapy settings are not a shareable data category, so an anonymous public-share viewer
- * gets 401/403 here; reports must still render for them (nightscout/nocturne#635), just with
- * UTC day boundaries.
+ * The patient's configured IANA timezone, or null when no source names one. See
+ * `$lib/server/patient-timezone` for where it comes from and what null means.
  */
 export async function getPatientTimeZone(): Promise<string | null> {
-  let profile: Awaited<ReturnType<typeof getProfileSummary>>;
-  try {
-    profile = await getProfileSummary(undefined);
-  } catch (err) {
-    const status = (err as { status?: number })?.status;
-    if (status === 401 || status === 403) return null;
-    throw err;
-  }
-  const timeZone = profile?.therapySettings?.[0]?.timezone;
-  return isTimeZone(timeZone) ? timeZone : null;
+  return resolvePatientTimeZone(getRequestEvent().locals);
 }
 
 /** Resolve a report window against the patient's timezone. */
@@ -73,5 +58,5 @@ export async function resolveReportRange(
     throw error(400, "Invalid date parameters provided");
   }
 
-  return { startDate, endDate, dayCount: dayCount(from, to), timeZone };
+  return { startDate, endDate, dayCount: dayCount(from, to) };
 }

--- a/src/Web/packages/app/src/lib/server/patient-timezone.test.ts
+++ b/src/Web/packages/app/src/lib/server/patient-timezone.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from "vitest";
+import type { RequestEvent } from "@sveltejs/kit";
+import { resolvePatientTimeZone } from "./patient-timezone";
+
+/**
+ * Either the value a source answers with, or a thrower standing in for a
+ * refusal.
+ */
+type Source = Record<string, unknown> | (() => never) | undefined;
+
+type Sources = { record?: Source; profile?: Source };
+
+interface Stub {
+  locals: RequestEvent["locals"];
+  getPatientRecord: ReturnType<typeof vi.fn>;
+  getProfileSummary: ReturnType<typeof vi.fn>;
+}
+
+/** One request's locals, answering only the two calls this resolver makes. */
+function request({ record, profile }: Sources): Stub {
+  const answer = (value: Source) =>
+    vi.fn(async () => (typeof value === "function" ? value() : value));
+  const getPatientRecord = answer(record);
+  const getProfileSummary = answer(profile);
+  return {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- two of ApiClient's methods; the rest is unreachable from this resolver
+    locals: {
+      apiClient: {
+        patientRecord: { getPatientRecord },
+        profile: { getProfileSummary },
+      },
+    } as unknown as RequestEvent["locals"],
+    getPatientRecord,
+    getProfileSummary,
+  };
+}
+
+const legacyProfile = (timezone: string) => ({
+  therapySettings: [{ timezone }],
+});
+
+describe("resolvePatientTimeZone", () => {
+  it("prefers the patient record, as the API's own resolver does", async () => {
+    // A patient lives in one timezone however many therapy profiles they have.
+    const stub = request({
+      record: { timezone: "Europe/Berlin" },
+      profile: legacyProfile("UTC"),
+    });
+
+    expect(await resolvePatientTimeZone(stub.locals)).toBe("Europe/Berlin");
+  });
+
+  it("does not read the profile summary when the record answers", async () => {
+    // `getProfileSummary` is five sequential repository reads and is served
+    // NoStore, so the common path must not touch it.
+    const stub = request({
+      record: { timezone: "Europe/Berlin" },
+      profile: legacyProfile("UTC"),
+    });
+
+    await resolvePatientTimeZone(stub.locals);
+
+    expect(stub.getProfileSummary).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a connector-imported therapy profile", async () => {
+    // Nightscout and Glooko imports wrote the zone here before the patient record
+    // became canonical, so it is all an un-migrated instance has.
+    const stub = request({
+      record: {},
+      profile: legacyProfile("Europe/Berlin"),
+    });
+
+    expect(await resolvePatientTimeZone(stub.locals)).toBe("Europe/Berlin");
+  });
+
+  it("rejects a zone this runtime does not know, rather than passing it on", async () => {
+    // A bad value reaching Intl throws where it is formatted, a page away from
+    // the setting that caused it.
+    const stub = request({
+      record: { timezone: "Middle/Earth" },
+      profile: legacyProfile("Europe/Berlin"),
+    });
+
+    expect(await resolvePatientTimeZone(stub.locals)).toBe("Europe/Berlin");
+  });
+
+  it("reads as no zone when the caller may not read either source", async () => {
+    // Neither is a shareable data category, so a public-share viewer gets 401 on
+    // both and the report still has to render.
+    const denied = () => {
+      throw { status: 403 };
+    };
+
+    expect(
+      await resolvePatientTimeZone(
+        request({ record: denied, profile: denied }).locals
+      )
+    ).toBeNull();
+  });
+
+  it("fails the read rather than reporting no zone, when the lookup breaks", async () => {
+    // Degrading a 500 or a timeout to "no zone" cuts the report's days on UTC and
+    // shows a clinician the wrong day with nothing on the page to say so.
+    const broken = () => {
+      throw { status: 500 };
+    };
+
+    await expect(
+      resolvePatientTimeZone(request({ record: broken }).locals)
+    ).rejects.toMatchObject({ status: 500 });
+
+    await expect(
+      resolvePatientTimeZone(request({ record: {}, profile: broken }).locals)
+    ).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("reads as no zone when neither source names one", async () => {
+    expect(
+      await resolvePatientTimeZone(request({ record: {}, profile: {} }).locals)
+    ).toBeNull();
+  });
+
+  it("resolves once per request, however many queries ask", async () => {
+    // Every report query calls resolveReportRange, and a report page fires several.
+    const stub = request({ record: { timezone: "Europe/Berlin" } });
+
+    const answers = await Promise.all([
+      resolvePatientTimeZone(stub.locals),
+      resolvePatientTimeZone(stub.locals),
+      resolvePatientTimeZone(stub.locals),
+    ]);
+
+    expect(answers).toEqual([
+      "Europe/Berlin",
+      "Europe/Berlin",
+      "Europe/Berlin",
+    ]);
+    expect(stub.getPatientRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps one request's answer out of the next", async () => {
+    const berlin = request({ record: { timezone: "Europe/Berlin" } });
+    const sydney = request({ record: { timezone: "Australia/Sydney" } });
+
+    expect(await resolvePatientTimeZone(berlin.locals)).toBe("Europe/Berlin");
+    expect(await resolvePatientTimeZone(sydney.locals)).toBe(
+      "Australia/Sydney"
+    );
+  });
+});

--- a/src/Web/packages/app/src/lib/server/patient-timezone.ts
+++ b/src/Web/packages/app/src/lib/server/patient-timezone.ts
@@ -1,0 +1,86 @@
+/**
+ * The calendar a report's days are cut on: the patient's, not the container's.
+ *
+ * Source order mirrors the API's own `TherapySettingsResolver` — the patient
+ * record is canonical, because a patient lives in one timezone however many
+ * therapy profiles they have, and the per-profile `TherapySettings.Timezone` is
+ * a legacy fallback that connector-imported profiles (Nightscout, Glooko) wrote
+ * into before that move. Reading them the other way round lets a stale imported
+ * `UTC` beat a correct patient record.
+ *
+ * The ORDER matches; the row selection does not. `getProfileSummary` returns
+ * therapy settings across every profile ordered by timestamp descending with no
+ * `<= now` bound, so `[0]` is the newest row anywhere — a future-dated or
+ * inactive-profile row wins, where the API resolves the active profile as of
+ * now. Only reachable for a patient whose record names no zone; fixing it needs
+ * an endpoint that exposes the API's own `GetTimezoneAsync` rather than this
+ * reconstruction.
+ *
+ * A zone the runtime cannot resolve is treated as unset, where the API takes
+ * any non-empty `patient.Timezone` as given: the two disagree for a record
+ * holding a garbage zone and a legacy row holding a real one.
+ *
+ * Null means no source names one, and the caller chooses what to do about it.
+ */
+import type { RequestEvent } from "@sveltejs/kit";
+import type { ApiClient } from "$lib/api";
+import { isTimeZone } from "$lib/utils/date-range";
+
+/**
+ * Read `fetch`, treating a refusal as "no zone named here" and nothing else.
+ *
+ * Neither the patient record nor therapy settings is a shareable data category,
+ * so an anonymous public-share viewer is refused both, and their reports must
+ * still render.
+ *
+ * Every other failure rethrows. A report that silently cut its days on UTC
+ * because this lookup timed out would show a clinician the wrong day with
+ * nothing on the page or in the logs to say so; failing the query says it.
+ */
+async function readable<T>(fetch: () => Promise<T>): Promise<T | null> {
+  try {
+    return await fetch();
+  } catch (err) {
+    const status = (err as { status?: number })?.status;
+    if (status === 401 || status === 403) return null;
+    throw err;
+  }
+}
+
+async function resolve(apiClient: ApiClient): Promise<string | null> {
+  const record = await readable(() =>
+    apiClient.patientRecord.getPatientRecord()
+  );
+  if (isTimeZone(record?.timezone)) return record.timezone;
+
+  // Only reached when the canonical source names nothing: `getProfileSummary` is
+  // five sequential repository reads and is served `NoStore`, so it stays off the
+  // path every request would otherwise take.
+  const profile = await readable(() =>
+    apiClient.profile.getProfileSummary(undefined, undefined)
+  );
+  const legacy = profile?.therapySettings?.[0]?.timezone;
+  return isTimeZone(legacy) ? legacy : null;
+}
+
+/**
+ * Resolved at most once per request. `resolveReportRange` runs for every query
+ * a report page fires, and each one would otherwise repeat the lookup against
+ * an endpoint the API explicitly declines to cache.
+ */
+const perRequest = new WeakMap<
+  RequestEvent["locals"],
+  Promise<string | null>
+>();
+
+/** The patient's IANA zone, or null when no source names one this runtime knows. */
+export function resolvePatientTimeZone(
+  locals: RequestEvent["locals"]
+): Promise<string | null> {
+  const cached = perRequest.get(locals);
+  if (cached) return cached;
+
+  const pending = resolve(locals.apiClient);
+  perRequest.set(locals, pending);
+  return pending;
+}


### PR DESCRIPTION
## The bug

`getPatientTimeZone` read the patient's zone straight off `getProfileSummary().therapySettings[0].timezone`. That is the **legacy per-profile field** that connector-imported profiles (Nightscout, Glooko) write into. The API's own `TherapySettingsResolver` reads the **patient record** first, because a patient lives in one timezone however many therapy profiles they have.

Reading them the other way round lets a stale imported `UTC` row beat a correct patient record — shifting every report's day boundaries for anyone who migrated in.

## What changed

Resolution moves into `$lib/server/patient-timezone`:

- **Patient record first**, legacy per-profile field only when it names nothing.
- **Memoised per request** via a `WeakMap` keyed on `locals`. `resolveReportRange` runs for every query a report page fires, and `getProfileSummary` is five sequential repository reads served `NoStore`.
- **Not held in module state.** Concurrent SSR renders share one process, so a module-level value leaks across tenants.
- **401/403 reads as "no zone"; everything else rethrows.** Neither source is a shareable data category, so a public-share viewer is refused both and their reports must still render. A 500 or a timeout is *not* degraded to "no zone" — that would cut the days on UTC and show a clinician the wrong day with nothing on the page or in the logs to say so.

`ReportRange.timeZone` is dropped — nothing read it; every caller destructures `{ startDate, endDate }`.

## Scope narrowed after review

An earlier revision of this PR also gave Day in Review a viewer-zone fallback, passing `timeZone: getLocalTimeZone()` into the query. **That has been removed**, because SvelteKit keys remote-query hydration on the arguments verbatim: `getLocalTimeZone()` resolves to the container's zone under SSR and the viewer's on the client, so the SSR result missed the client's cache key and **every** page load paid a discarded fetch plus a refetch — not just the unconfigured patients the original note claimed. Doing it properly needs the zone delivered in a cookie so both renders agree, which is separate work.

The date-stepping and `endOfDay` changes went with it: the DST justification for moving off `setDate` was wrong (`setDate` *is* calendar arithmetic and was already correct across a transition, verified under `TZ=Australia/Sydney`), so they were churn.

What remains is only the resolver and its caller.

## Documented divergences from the API

Both reachable only for a patient whose record names no zone:

1. **Row selection.** `getProfileSummary` returns therapy settings across every profile ordered by timestamp descending with **no `<= now` bound**, so `[0]` is the newest row anywhere — a future-dated or inactive-profile row can win, where the API resolves the active profile as of now. Fixing it properly needs an endpoint exposing the API's own `GetTimezoneAsync`.
2. **Validation.** This resolver treats a zone the runtime cannot resolve as unset; the API takes any non-empty `patient.Timezone` as given. They disagree for a record holding a garbage zone alongside a legacy row holding a real one.

Mitigating context: migration `20260515072942_AddPatientRecordTimezone` backfills `patient_records.timezone` from the newest legacy row per tenant, so the legacy path is not the common one.

## Known, not fixed here

`GetPatientRecord` is `GetOrCreateAsync` — a **write on GET**, gated only by class-level `[Authorize]`, which is satisfied by read-only credentials. That endpoint pre-exists, but this PR puts it on the hot path of every report render, so a guest-link viewer on a tenant with no record row now creates one plus an audit row. Benign data, but worth a follow-up on the backend rather than a workaround here.

## Testing

`patient-timezone.test.ts` — 9 tests covering source precedence, the invalid-zone fallthrough, refusal reading as null, **failure rethrowing**, once-per-request memoisation (three parallel callers, one fetch — so caching after `await` would fail it), and cross-request isolation.

The rethrow test is mutation-proved: restoring `catch { return null }` fails it with `promise resolved "null" instead of rejecting`.

`pnpm run check`: 20 errors, identical to the `origin/main` baseline. `pnpm run test:unit`: 989 passed, with the one pre-existing `appearance-store.ssr.test.ts` failure. Both new files are prettier-clean.
