### PR TITLE
test(web): cover the chart date-range reactivity that #1044 fixed

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChart.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChart.svelte
@@ -81,6 +81,9 @@
   }: Props = $props();
 
   // ---- Engine ----
+  // Getters, not `{ dateRange, ... }`: a prop read into an object literal is read
+  // once, so an engine built that way freezes on the range it was created with —
+  // stepping the day on Day in Review left the chart drawing the day before.
   const engine = createChartDataEngine({
     get dateRange() { return dateRange; },
     get focusHours() { return focusHours; },

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartCard.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartCard.svelte
@@ -87,6 +87,9 @@
   const isMobile = new IsMobile();
 
   // ===== ENGINE =====
+  // Getters, not `{ dateRange, ... }`: a prop read into an object literal is read
+  // once, so an engine built that way freezes on the range it was created with —
+  // stepping the day on Day in Review left the chart drawing the day before.
   const engine = createChartDataEngine({
     get dateRange() { return dateRange; },
     get focusHours() { return defaultFocusHours; },

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartRangeHarness.test.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartRangeHarness.test.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  // Test-only harness: mounts a real chart component so the props-to-engine wiring
+  // under test is the production one. A harness that built the engine itself would
+  // pass whether or not the component keeps its `dateRange` prop reactive.
+  //
+  // Both components are covered because each builds its own engine and a fix
+  // applied to one leaves the other frozen. `GlucoseChartCard` is what Day in
+  // Review, the readings report and the dashboard render; `GlucoseChart` is the
+  // shell they wrap, rendered by nothing else today.
+  import { createRealtimeStore } from "$lib/stores/realtime-store.svelte";
+  import GlucoseChart from "./GlucoseChart.svelte";
+  import GlucoseChartCard from "./GlucoseChartCard.svelte";
+
+  interface Props {
+    component: "chart" | "card";
+    initialRange: { from: Date; to: Date };
+    /** Hands the test the setter for the range the chart is mounted with. */
+    onready: (setRange: (range: { from: Date; to: Date }) => void) => void;
+  }
+
+  let { component, initialRange, onready }: Props = $props();
+
+  createRealtimeStore({
+    url: "",
+    reconnectAttempts: 0,
+    reconnectDelay: 0,
+    maxReconnectDelay: 0,
+    pingTimeout: 0,
+    pingInterval: 0,
+  });
+
+  // svelte-ignore state_referenced_locally
+  let dateRange = $state(initialRange);
+  // svelte-ignore state_referenced_locally
+  onready((range) => (dateRange = range));
+</script>
+
+<div style="width: 600px; height: 400px;">
+  {#if component === "card"}
+    <GlucoseChartCard {dateRange} showPredictions={false} />
+  {:else}
+    <GlucoseChart {dateRange} enablePredictions={false} enableInspection={false} />
+  {/if}
+</div>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/chart-date-range-reactivity.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/chart-date-range-reactivity.svelte.test.ts
@@ -1,0 +1,73 @@
+import { render } from "vitest-browser-svelte";
+import { describe, it, expect, vi } from "vitest";
+
+type ChartWindow = { startTime: number; endTime: number; intervalMinutes: number };
+
+// `vi.mock` factories are hoisted above every other statement, so the spy has to
+// be created in a hoisted block for both the factory and the assertions to see it.
+const { getChartData } = vi.hoisted(() => ({
+  getChartData: vi.fn((window: ChartWindow) => {
+    void window;
+    return Promise.resolve(transformed());
+  }),
+}));
+
+vi.mock("$api/chart-data.remote", () => ({ getChartData }));
+vi.mock("$api/predictions.remote", () => ({
+  getPredictions: vi.fn(async () => null),
+  getPredictionStatus: vi.fn(async () => ({ available: false })),
+}));
+
+import { transformChartData } from "$lib/utils/chart-data-transform";
+import Harness from "./GlucoseChartRangeHarness.test.svelte";
+
+// The server half of the merge is deliberately empty: what is under test is which
+// window the chart asks for, not what comes back.
+function transformed() {
+  return transformChartData({});
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function day(offsetDays: number): { from: Date; to: Date } {
+  const from = new Date(Date.UTC(2026, 7, 29) + offsetDays * DAY);
+  return { from, to: new Date(from.getTime() + DAY - 1) };
+}
+
+/** The window starts the chart has asked the server for. */
+function requestedStarts(): number[] {
+  return getChartData.mock.calls.map(([window]) => window.startTime);
+}
+
+/**
+ * Stepping a day on Day in Review swaps this prop and nothing else. Each component
+ * builds its OWN engine, and an engine built from a flattened `{ dateRange }` object
+ * literal reads the prop once — so the chart keeps drawing whichever day it was
+ * mounted on. Both are asserted because fixing one leaves the other frozen, and Day
+ * in Review — the surface this was reported on — renders the Card.
+ */
+describe.each([
+  ["GlucoseChart", "chart"],
+  ["GlucoseChartCard", "card"],
+] as const)("%s date range", (_name, component) => {
+  it("refetches when the range prop changes", async () => {
+    getChartData.mockClear();
+
+    let setRange!: (range: { from: Date; to: Date }) => void;
+    render(Harness, {
+      props: { component, initialRange: day(0), onready: (set) => (setRange = set) },
+    });
+
+    await vi.waitFor(() =>
+      expect(requestedStarts()).toContain(day(0).from.getTime())
+    );
+
+    setRange(day(-1));
+
+    // Asked for at all, rather than asked for last: the sibling case's chart is
+    // still mounted and can land a fetch of its own in between.
+    await vi.waitFor(() =>
+      expect(requestedStarts()).toContain(day(-1).from.getTime())
+    );
+  });
+});


### PR DESCRIPTION
## Why

#1044 made both chart components build their engine from **getters** rather than a flattened `{ dateRange, … }` object literal — but shipped **no test**, so the bug it fixed can come back unnoticed.

The bug: a prop read into an object literal is read *once*, so the engine froze on whichever range it was constructed with. Stepping the day on Day in Review left the chart drawing the previous day.

## What

A harness mounts each real component, so the props-to-engine wiring under test is the production one. A harness that built the engine itself would pass whether or not the component keeps its `dateRange` prop reactive.

The test swaps **only** the `dateRange` prop and asserts on which window the chart asks the server for.

Both components are covered because each builds its own engine and a fix applied to one leaves the other frozen. `GlucoseChartCard` is what Day in Review — the surface this was reported on — actually renders.

## Mutation proof

Flattening `dateRange` back into the object literal in `GlucoseChartCard`:

```
AssertionError: expected [ 1787961600000 ] to include 1787875200000
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

Exactly one case fails and `GlucoseChart`'s keeps passing — so each case genuinely pins its own component rather than both riding on one.

Restored and re-verified green: 2 passed.

## Also

Records at each call site *why* the getters are there, so the next reader does not tidy them back into shorthand. No other source change.
