### PR TITLE
refactor(data): hoist the sync-key upsert, lookup and delete onto a shared repository base

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISyncDedupable.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISyncDedupable.cs
@@ -1,23 +1,23 @@
 namespace Nocturne.Infrastructure.Data.Entities;
 
 /// <summary>
-/// Marks an entity whose creates should be deduplicated by an upstream sync key.
-/// When both <see cref="DataSource"/> and <see cref="SyncIdentifier"/> are present,
-/// a create that matches an existing (non-deleted) row for the same tenant updates
-/// that row in place rather than inserting a duplicate — making repeated uploads of
-/// the same measurement idempotent.
+/// Marks an entity keyed by an upstream sync key: the <see cref="ISourcedEntity.DataSource"/> the row
+/// came from plus that source's own <see cref="SyncIdentifier"/> for the record. When both are present
+/// the pair names the record across re-uploads, so a create matching an existing (non-deleted) row for
+/// the same tenant updates that row in place rather than inserting a duplicate — making repeated
+/// uploads of the same measurement idempotent — and a delete can be issued against the upstream key
+/// alone, without knowing the Nocturne id.
 /// </summary>
 /// <remarks>
-/// Backed by a partial unique index on <c>(tenant_id, data_source, sync_identifier)</c>
-/// filtered to <c>sync_identifier IS NOT NULL AND deleted_at IS NULL</c>, mirroring the
-/// V4 treatment entities. <c>SimpleEntityService</c> performs the upsert for any entity
-/// implementing this interface.
+/// The types that upsert on the key back it with a partial unique index on
+/// <c>(tenant_id, data_source, sync_identifier)</c> filtered to
+/// <c>sync_identifier IS NOT NULL AND deleted_at IS NULL</c>;
+/// <see cref="NocturneDbContext.SyncDedupedEntities"/> is the authoritative list. <c>SimpleEntityService</c>
+/// and <see cref="Repositories.V4.SyncUpsertRepositoryBase{TModel,TEntity}"/> perform the upsert;
+/// <see cref="Repositories.V4.SyncKeyedRepositoryBase{TModel,TEntity}"/> the keyed lookup and delete.
 /// </remarks>
-public interface ISyncDedupable
+public interface ISyncDedupable : ISourcedEntity
 {
-    /// <summary>Origin data source identifier (the first half of the dedup key).</summary>
-    string? DataSource { get; set; }
-
     /// <summary>Stable per-source identifier for the measurement (the second half of the dedup key).</summary>
     string? SyncIdentifier { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISyncDedupable.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/ISyncDedupable.cs
@@ -3,10 +3,10 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// <summary>
 /// Marks an entity keyed by an upstream sync key: the <see cref="ISourcedEntity.DataSource"/> the row
 /// came from plus that source's own <see cref="SyncIdentifier"/> for the record. When both are present
-/// the pair names the record across re-uploads, so a create matching an existing (non-deleted) row for
-/// the same tenant updates that row in place rather than inserting a duplicate — making repeated
-/// uploads of the same measurement idempotent — and a delete can be issued against the upstream key
-/// alone, without knowing the Nocturne id.
+/// the pair names the record across re-uploads, so a create matching an existing row for the same
+/// tenant updates that row in place rather than inserting a duplicate — making repeated uploads of the
+/// same measurement idempotent — and a delete can be issued against the upstream key alone, without
+/// knowing the Nocturne id.
 /// </summary>
 /// <remarks>
 /// The types that upsert on the key back it with a partial unique index on

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BasalInjection.
 /// </summary>
 [Table("basal_injections")]
-public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
+public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Bolus
 /// </summary>
 [Table("boluses")]
-public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
+public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbIntake
 /// </summary>
 [Table("carb_intakes")]
-public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.DeviceEvent
 /// </summary>
 [Table("device_events")]
-public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
+public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Note
 /// </summary>
 [Table("notes")]
-public class NoteEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class NoteEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensorGlucose
 /// </summary>
 [Table("sensor_glucose")]
-public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
+public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, IDeviceAttributedEntity, ISystemTimestamped
 {
     /// <summary>
     /// The unique identifier of the tenant this record belongs to.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/AuditedBulkDeleteExtensions.cs
@@ -31,9 +31,13 @@ public readonly record struct AuditedSoftDeleteResult<T>(int Count, List<T> Enti
 /// <remarks>
 /// A soft delete leaves the row in place, so a per-row snapshot would be a verbatim copy of data that
 /// is still readable and the dedup discriminator lives on the row itself
-/// (<see cref="SoftDeleteDedupExtensions"/>) — soft deletes therefore record one <c>bulk_delete</c>
-/// summary row naming the scope they were issued against. A hard delete destroys the row, so its
-/// per-row snapshots are the only surviving copy and are kept.
+/// (<see cref="SoftDeleteDedupExtensions"/>) — <see cref="AuditedSoftDeleteAsync{T}"/> therefore
+/// records one <c>bulk_delete</c> summary row naming the scope it was issued against. A caller that
+/// needs per-record realtime events has to materialize the rows anyway, so
+/// <see cref="AuditedSoftDeleteWithEntitiesAsync{T}"/> spends the snapshot it has already loaded and
+/// writes a row each, collapsing to the summary only past
+/// <see cref="BroadcastMaterializationCap"/>. A hard delete destroys the row, so its per-row snapshots
+/// are the only surviving copy and are kept.
 /// </remarks>
 public static class AuditedBulkDeleteExtensions
 {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -507,9 +507,10 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
     /// <summary>
     /// Tables carrying the <see cref="ISyncDedupable"/> upsert key. Listed rather than discovered
-    /// from the interface: some carry the key without it (TempBasal, the snapshots), and
-    /// <see cref="DeviceEventEntity"/> and <see cref="NoteEntity"/> implement it for keyed lookup and
-    /// delete without ever upserting on it, so they need no uniqueness.
+    /// from the interface, which neither implies the index nor is implied by it: several tables carry
+    /// the two columns without declaring the interface, and <see cref="DeviceEventEntity"/> and
+    /// <see cref="NoteEntity"/> declare it for keyed lookup and delete without ever upserting on the
+    /// key, so they need no uniqueness. Adding a table here is a migration.
     /// </summary>
     internal static readonly Type[] SyncDedupedEntities =
     [

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -507,7 +507,9 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
     /// <summary>
     /// Tables carrying the <see cref="ISyncDedupable"/> upsert key. Listed rather than discovered
-    /// from the interface, which only three of them implement.
+    /// from the interface: some carry the key without it (TempBasal, the snapshots), and
+    /// <see cref="DeviceEventEntity"/> and <see cref="NoteEntity"/> implement it for keyed lookup and
+    /// delete without ever upserting on it, so they need no uniqueness.
     /// </summary>
     internal static readonly Type[] SyncDedupedEntities =
     [

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -15,7 +15,7 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 /// Repository for <see cref="BasalInjection"/> records (discrete long-acting basal insulin
 /// injections, MDI). SyncId-upsert keyed; never cross-connector dedup-linked.
 /// </summary>
-public class BasalInjectionRepository : V4RepositoryBase<BasalInjection, BasalInjectionEntity>, IBasalInjectionRepository
+public class BasalInjectionRepository : SyncUpsertRepositoryBase<BasalInjection, BasalInjectionEntity>, IBasalInjectionRepository
 {
     /// <inheritdoc />
     public BasalInjectionRepository(
@@ -34,134 +34,6 @@ public class BasalInjectionRepository : V4RepositoryBase<BasalInjection, BasalIn
 
     /// <inheritdoc />
     protected override void ApplyUpdate(BasalInjectionEntity target, BasalInjection source) => BasalInjectionMapper.UpdateEntity(target, source);
-
-    /// <summary>
-    /// Creates a new basal injection record. When <c>DataSource</c> and <c>SyncIdentifier</c>
-    /// match an existing row for this tenant, the record is updated in place (upsert) rather
-    /// than inserted — making the operation idempotent for connector replays.
-    /// </summary>
-    /// <remarks>
-    /// The controller layer has its own idempotency check that returns the existing record
-    /// unchanged (HTTP semantics). This repository-level upsert exists for non-HTTP callers
-    /// (connectors, background services) that need "latest wins" semantics on replay.
-    /// </remarks>
-    public override async Task<BasalInjection> CreateAsync(BasalInjection model, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
-        {
-            var existing = await ctx.BasalInjections
-                .FirstOrDefaultAsync(
-                    e => e.DataSource == model.DataSource && e.SyncIdentifier == model.SyncIdentifier,
-                    ct);
-            if (existing != null)
-            {
-                BasalInjectionMapper.UpdateEntity(existing, model);
-                await ctx.SaveChangesAsync(ct);
-                var upserted = BasalInjectionMapper.ToDomainModel(existing);
-                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
-                return upserted;
-            }
-        }
-
-        var entity = BasalInjectionMapper.ToEntity(model);
-        ctx.BasalInjections.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        var created = BasalInjectionMapper.ToDomainModel(entity);
-        await RaiseBroadcastAsync([created], [], [], origin, ct);
-        return created;
-    }
-
-    /// <summary>
-    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
-    /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
-    /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
-    /// </summary>
-    protected override async Task<UpsertSplit> SplitUpsertsAsync(
-        NocturneDbContext ctx, List<BasalInjectionEntity> entities, CancellationToken ct)
-    {
-        // Records without both keys keep a unique grouping key so they're not collapsed.
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                : $"id|{e.Id}")
-            .Select(g => g.Last())
-            .ToList();
-
-        var syncKeyed = entities
-            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-            .ToList();
-
-        var updatedEntities = new List<BasalInjectionEntity>();
-        var materiallyChanged = new List<BasalInjectionEntity>();
-        if (syncKeyed.Count == 0)
-            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
-
-        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-        var existingRows = await ctx.BasalInjections.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId)
-            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-            .ToListAsync(ct);
-
-        var existingByKey = existingRows
-            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-            .ToDictionary(g => g.Key, g => g.First());
-
-        var toInsert = new List<BasalInjectionEntity>();
-        foreach (var entity in entities)
-        {
-            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                && !string.IsNullOrEmpty(entity.SyncIdentifier);
-            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-            {
-                // Update in place — mirror the single-record CreateAsync path via the mapper.
-                BasalInjectionMapper.UpdateEntity(existing, BasalInjectionMapper.ToDomainModel(entity));
-                updatedEntities.Add(existing);
-                if (HasMaterialChange(ctx, existing))
-                    materiallyChanged.Add(existing);
-            }
-            else
-            {
-                toInsert.Add(entity);
-            }
-        }
-
-        if (updatedEntities.Count > 0)
-        {
-            // Persist updates before the insert-chunking loop clears the tracker.
-            await ctx.SaveChangesAsync(ct);
-        }
-
-        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
-    }
-
-    /// <summary>
-    /// Soft-deletes every live basal injection matching the given (data source, sync identifier)
-    /// pair. The global query filter scopes the lookup to the current tenant and skips rows already
-    /// soft-deleted, so a repeat call for the same key returns 0.
-    /// </summary>
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await AuditedSoftDeleteAndBroadcastAsync(
-            ctx,
-            ctx.BasalInjections.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            $"sync_identifier={dataSource}/{syncIdentifier}", origin, ct);
-    }
-
-    /// <summary>
-    /// Finds a single basal injection by data source and sync identifier. The global query
-    /// filter automatically scopes the lookup to the current tenant and excludes soft-deleted rows.
-    /// </summary>
-    public async Task<BasalInjection?> FindBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        var entity = await ctx.BasalInjections
-            .FirstOrDefaultAsync(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier, ct);
-        return entity is null ? null : BasalInjectionMapper.ToDomainModel(entity);
-    }
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<BasalInjection>> GetUnattributedAsync(DateTime? from, DateTime? to, int limit, CancellationToken ct = default)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BasalInjectionRepository.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.V4.Repositories;
@@ -7,7 +6,6 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;
-using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -16,13 +16,12 @@ using Nocturne.Core.Contracts.V4;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing bolus records. A SyncId-upsert + DeduplicationService participant, so it
-/// inherits the shared CRUD/soft-delete surface from <see cref="V4RepositoryBase{TModel,TEntity}"/>
-/// and keeps only the dedup-specific behaviour as overrides (extended <c>GetAsync</c> with the
-/// non-primary LinkedRecords filter + keyset cursor, SyncId-upsert <c>CreateAsync</c>/
-/// <c>BulkCreateAsync</c>, and audited soft-deletes).
+/// Repository for managing bolus records. A DeduplicationService participant on top of the sync-key
+/// upsert and keyed delete of <see cref="SyncUpsertRepositoryBase{TModel,TEntity}"/>, so it keeps only
+/// the extended <c>GetAsync</c> (non-primary LinkedRecords filter + keyset cursor), the read-visibility
+/// filter behind <c>CountAsync</c>, and the post-commit dedup linking.
 /// </summary>
-public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepository
+public class BolusRepository : SyncUpsertRepositoryBase<Bolus, BolusEntity>, IBolusRepository
 {
     private readonly IDeduplicationService _deduplicationService;
     private readonly ILogger<BolusRepository> _logger;
@@ -149,58 +148,6 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
     }
 
     /// <summary>
-    /// Creates a new bolus record. When <c>DataSource</c> and <c>SyncIdentifier</c>
-    /// match an existing row for this tenant, the record is updated in place rather
-    /// than inserted — making the operation idempotent for connector replays.
-    /// Tenant scoping is implicit via the DbContext's RLS-equivalent query filter.
-    /// </summary>
-    /// <param name="model">The bolus to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created or updated bolus record.</returns>
-    public override async Task<Bolus> CreateAsync(Bolus model, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
-        {
-            var existing = await ctx.Boluses
-                .FirstOrDefaultAsync(
-                    e => e.DataSource == model.DataSource && e.SyncIdentifier == model.SyncIdentifier,
-                    ct);
-            if (existing != null)
-            {
-                BolusMapper.UpdateEntity(existing, model);
-                await ctx.SaveChangesAsync(ct);
-                var upserted = BolusMapper.ToDomainModel(existing);
-                // A single explicit upsert always broadcasts (no material-change gate on the single path).
-                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
-                return upserted;
-            }
-        }
-
-        var entity = BolusMapper.ToEntity(model);
-        ctx.Boluses.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        var created = BolusMapper.ToDomainModel(entity);
-        await RaiseBroadcastAsync([created], [], [], origin, ct);
-        return created;
-    }
-
-    /// <summary>
-    /// Deletes bolus records matching the given data source and sync identifier.
-    /// </summary>
-    /// <param name="dataSource">The external data source name.</param>
-    /// <param name="syncIdentifier">The external sync identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.Boluses.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            AuditContext, $"sync_identifier={dataSource}/{syncIdentifier}", ct);
-    }
-
-    /// <summary>
     /// Gets bolus records by correlation identifier.
     /// </summary>
     /// <param name="correlationId">The correlation identifier.</param>
@@ -217,80 +164,6 @@ public class BolusRepository : V4RepositoryBase<Bolus, BolusEntity>, IBolusRepos
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(BolusMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
-    /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
-    /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
-    /// </summary>
-    protected override async Task<UpsertSplit> SplitUpsertsAsync(
-        NocturneDbContext ctx, List<BolusEntity> entities, CancellationToken ct)
-    {
-        // Intra-batch SyncIdentifier dedup: keep last occurrence per
-        // (DataSource, SyncIdentifier). Records without both keys keep a
-        // unique grouping key so they're not collapsed.
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                : $"id|{e.Id}")
-            .Select(g => g.Last())
-            .ToList();
-
-        // DB-level SyncIdentifier upsert: match any existing rows keyed by
-        // (DataSource, SyncIdentifier) and update them in place. Everything
-        // else falls through to the insert path below.
-        var syncKeyed = entities
-            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-            .ToList();
-
-        var updatedEntities = new List<BolusEntity>();
-        var materiallyChanged = new List<BolusEntity>();
-        if (syncKeyed.Count == 0)
-            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
-
-        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-        // Over-fetches by a Cartesian amount; the partial unique index
-        // on (tenant_id, data_source, sync_identifier) keeps this cheap.
-        var existingRows = await ctx.Boluses.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId)
-            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-            .ToListAsync(ct);
-
-        var existingByKey = existingRows
-            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-            .ToDictionary(g => g.Key, g => g.First());
-
-        var toInsert = new List<BolusEntity>();
-        foreach (var entity in entities)
-        {
-            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                && !string.IsNullOrEmpty(entity.SyncIdentifier);
-            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-            {
-                // Update in place — mirror the single-record CreateAsync path via the mapper.
-                var domain = BolusMapper.ToDomainModel(entity);
-                BolusMapper.UpdateEntity(existing, domain);
-                updatedEntities.Add(existing);
-                // Capture material changes now, before SaveChanges clears the modified flags.
-                if (HasMaterialChange(ctx, existing))
-                    materiallyChanged.Add(existing);
-            }
-            else
-            {
-                toInsert.Add(entity);
-            }
-        }
-
-        if (updatedEntities.Count > 0)
-        {
-            // Persist updates before the insert-chunking loop clears the tracker.
-            await ctx.SaveChangesAsync(ct);
-        }
-
-        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -16,14 +16,13 @@ using Nocturne.Core.Contracts.V4;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing carbohydrate intake records in the database. A SyncId-upsert +
-/// DeduplicationService participant, so it inherits the shared CRUD/soft-delete surface from
-/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the dedup-specific behaviour as
-/// overrides (extended <c>GetAsync</c> with the non-primary LinkedRecords filter + keyset cursor,
-/// SyncId-upsert <c>CreateAsync</c>/<c>BulkCreateAsync</c>, the non-primary-excluding <c>CountAsync</c>,
-/// and audited soft-deletes).
+/// Repository for managing carbohydrate intake records in the database. A DeduplicationService
+/// participant on top of the sync-key upsert and keyed delete of
+/// <see cref="SyncUpsertRepositoryBase{TModel,TEntity}"/>, so it keeps only the extended <c>GetAsync</c>
+/// (non-primary LinkedRecords filter + keyset cursor), the read-visibility filter behind
+/// <c>CountAsync</c>, and the post-commit dedup linking.
 /// </summary>
-public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntity>, ICarbIntakeRepository
+public class CarbIntakeRepository : SyncUpsertRepositoryBase<CarbIntake, CarbIntakeEntity>, ICarbIntakeRepository
 {
     private readonly IDeduplicationService _deduplicationService;
     private readonly ILogger<CarbIntakeRepository> _logger;
@@ -147,44 +146,6 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
     }
 
     /// <summary>
-    /// Creates a new carbohydrate intake record. When <c>DataSource</c> and
-    /// <c>SyncIdentifier</c> match an existing row for this tenant, the record is
-    /// updated in place rather than inserted — making the operation idempotent
-    /// for connector replays. Tenant scoping is implicit via the DbContext's
-    /// RLS-equivalent query filter.
-    /// </summary>
-    /// <param name="model">The carbohydrate intake to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created or updated carbohydrate intake.</returns>
-    public override async Task<CarbIntake> CreateAsync(CarbIntake model, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
-        {
-            var existing = await ctx.CarbIntakes
-                .FirstOrDefaultAsync(
-                    e => e.DataSource == model.DataSource && e.SyncIdentifier == model.SyncIdentifier,
-                    ct);
-            if (existing != null)
-            {
-                CarbIntakeMapper.UpdateEntity(existing, model);
-                await ctx.SaveChangesAsync(ct);
-                var upserted = CarbIntakeMapper.ToDomainModel(existing);
-                // A single explicit upsert always broadcasts (no material-change gate on the single path).
-                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
-                return upserted;
-            }
-        }
-
-        var entity = CarbIntakeMapper.ToEntity(model);
-        ctx.CarbIntakes.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        var created = CarbIntakeMapper.ToDomainModel(entity);
-        await RaiseBroadcastAsync([created], [], [], origin, ct);
-        return created;
-    }
-
-    /// <summary>
     /// Gets carbohydrate intake records by correlation identifier.
     /// </summary>
     /// <param name="correlationId">The correlation identifier.</param>
@@ -201,95 +162,6 @@ public class CarbIntakeRepository : V4RepositoryBase<CarbIntake, CarbIntakeEntit
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(CarbIntakeMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Deletes carbohydrate intake records matching the given data source and sync identifier.
-    /// </summary>
-    /// <param name="dataSource">The external data source name.</param>
-    /// <param name="syncIdentifier">The external sync identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.CarbIntakes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            AuditContext, $"sync_identifier={dataSource}/{syncIdentifier}", ct);
-    }
-
-    /// <summary>
-    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
-    /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
-    /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
-    /// </summary>
-    protected override async Task<UpsertSplit> SplitUpsertsAsync(
-        NocturneDbContext ctx, List<CarbIntakeEntity> entities, CancellationToken ct)
-    {
-        // Intra-batch SyncIdentifier dedup: keep last occurrence per
-        // (DataSource, SyncIdentifier). Records without both keys keep a
-        // unique grouping key so they're not collapsed.
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                : $"id|{e.Id}")
-            .Select(g => g.Last())
-            .ToList();
-
-        // DB-level SyncIdentifier upsert: match any existing rows keyed by
-        // (DataSource, SyncIdentifier) and update them in place. Everything
-        // else falls through to the insert path below.
-        var syncKeyed = entities
-            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-            .ToList();
-
-        var updatedEntities = new List<CarbIntakeEntity>();
-        var materiallyChanged = new List<CarbIntakeEntity>();
-        if (syncKeyed.Count == 0)
-            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
-
-        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-        // Over-fetches by a Cartesian amount; the partial unique index
-        // on (tenant_id, data_source, sync_identifier) keeps this cheap.
-        var existingRows = await ctx.CarbIntakes.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId)
-            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-            .ToListAsync(ct);
-
-        var existingByKey = existingRows
-            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-            .ToDictionary(g => g.Key, g => g.First());
-
-        var toInsert = new List<CarbIntakeEntity>();
-        foreach (var entity in entities)
-        {
-            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                && !string.IsNullOrEmpty(entity.SyncIdentifier);
-            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-            {
-                // Update in place — mirror the single-record CreateAsync path via the mapper.
-                var domain = CarbIntakeMapper.ToDomainModel(entity);
-                CarbIntakeMapper.UpdateEntity(existing, domain);
-                updatedEntities.Add(existing);
-                // Capture material changes now, before SaveChanges clears the modified flags.
-                if (HasMaterialChange(ctx, existing))
-                    materiallyChanged.Add(existing);
-            }
-            else
-            {
-                toInsert.Add(entity);
-            }
-        }
-
-        if (updatedEntities.Count > 0)
-        {
-            // Persist updates before the insert-chunking loop clears the tracker.
-            await ctx.SaveChangesAsync(ct);
-        }
-
-        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -16,13 +16,12 @@ using Nocturne.Core.Contracts.V4;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing device event records in the database. A DeduplicationService participant,
-/// so it inherits the shared CRUD/soft-delete surface from
-/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the dedup-specific behaviour as
-/// overrides (extended <c>GetAsync</c> with the non-primary LinkedRecords filter, dedup
-/// <c>BulkCreateAsync</c>, audited soft-deletes) plus the event-type query helpers.
+/// Repository for managing device event records in the database. A DeduplicationService participant on
+/// top of the keyed delete of <see cref="SyncKeyedRepositoryBase{TModel,TEntity}"/>, so it keeps only
+/// the extended <c>GetAsync</c> (non-primary LinkedRecords filter), the read-visibility filter behind
+/// <c>CountAsync</c>, the post-commit dedup linking, and the event-type query helpers.
 /// </summary>
-public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEntity>, IDeviceEventRepository
+public class DeviceEventRepository : SyncKeyedRepositoryBase<DeviceEvent, DeviceEventEntity>, IDeviceEventRepository
 {
     private readonly IDeduplicationService _deduplicationService;
     private readonly ILogger<DeviceEventRepository> _logger;
@@ -141,21 +140,6 @@ public class DeviceEventRepository : V4RepositoryBase<DeviceEvent, DeviceEventEn
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(DeviceEventMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Deletes device event records matching the given data source and sync identifier.
-    /// </summary>
-    /// <param name="dataSource">The external data source name.</param>
-    /// <param name="syncIdentifier">The external sync identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.DeviceEvents.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            AuditContext, $"sync_identifier={dataSource}/{syncIdentifier}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -7,7 +7,6 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
-using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Mappers;
 using Nocturne.Infrastructure.Data.Mappers.V4;
 using Nocturne.Infrastructure.Data.Services;

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -16,13 +16,12 @@ using Nocturne.Core.Contracts.V4;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing note records in the database. A DeduplicationService participant, so it
-/// inherits the shared CRUD/soft-delete surface from <see cref="V4RepositoryBase{TModel,TEntity}"/>
-/// and keeps only the dedup-specific behaviour as overrides (extended <c>GetAsync</c> with the
-/// non-primary LinkedRecords filter, dedup <c>BulkCreateAsync</c>). Soft-deletes inherit the base's
-/// audited path.
+/// Repository for managing note records in the database. A DeduplicationService participant on top of
+/// the keyed delete of <see cref="SyncKeyedRepositoryBase{TModel,TEntity}"/>, so it keeps only the
+/// extended <c>GetAsync</c> (non-primary LinkedRecords filter), the read-visibility filter behind
+/// <c>CountAsync</c>, and the post-commit dedup linking.
 /// </summary>
-public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepository
+public class NoteRepository : SyncKeyedRepositoryBase<Note, NoteEntity>, INoteRepository
 {
     private readonly IDeduplicationService _deduplicationService;
     private readonly ILogger<NoteRepository> _logger;
@@ -137,21 +136,6 @@ public class NoteRepository : V4RepositoryBase<Note, NoteEntity>, INoteRepositor
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(NoteMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// Deletes note records matching the given data source and sync identifier.
-    /// </summary>
-    /// <param name="dataSource">The external data source name.</param>
-    /// <param name="syncIdentifier">The external sync identifier.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The number of deleted records.</returns>
-    public async Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
-    {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        return await ctx.AuditedSoftDeleteAsync(
-            ctx.Notes.Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
-            AuditContext, $"sync_identifier={dataSource}/{syncIdentifier}", ct);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -18,13 +18,13 @@ using Nocturne.Core.Models.Projections;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing sensor glucose (CGM) records in the database. A SyncId-upsert (bulk) +
-/// DeduplicationService participant, so it inherits the shared CRUD/soft-delete surface from
-/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the dedup-specific behaviour as
-/// overrides (extended <c>GetAsync</c> with the non-primary LinkedRecords filter + keyset cursor,
-/// SyncId-upsert <c>BulkCreateAsync</c>, audited soft-deletes, and source/time-range deletes).
+/// Repository for managing sensor glucose (CGM) records in the database. A DeduplicationService
+/// participant on top of the sync-key upsert and keyed delete of
+/// <see cref="SyncUpsertRepositoryBase{TModel,TEntity}"/>, so it keeps only the extended <c>GetAsync</c>
+/// (non-primary LinkedRecords filter + keyset cursor), the legacy entries projection, the tenant
+/// last-reading watermark, the post-commit dedup linking, and the source/time-range deletes.
 /// </summary>
-public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlucoseEntity>, ISensorGlucoseRepository
+public class SensorGlucoseRepository : SyncUpsertRepositoryBase<SensorGlucose, SensorGlucoseEntity>, ISensorGlucoseRepository
 {
     private readonly IDeduplicationService _deduplicationService;
     private readonly ILogger<SensorGlucoseRepository> _logger;
@@ -213,43 +213,12 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
         return entities.Select(SensorGlucoseMapper.ToDomainModel);
     }
 
-    /// <summary>
-    /// Creates a new sensor glucose record. When <c>DataSource</c> and <c>SyncIdentifier</c>
-    /// match an existing row for this tenant, the record is updated in place rather than
-    /// inserted — making the operation idempotent for connector replays. Tenant scoping is
-    /// implicit via the DbContext's RLS-equivalent query filter. Mirrors BolusRepository.
-    /// </summary>
-    /// <param name="model">The sensor glucose record to create.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The created or updated sensor glucose record.</returns>
+    /// <inheritdoc />
     public override async Task<SensorGlucose> CreateAsync(SensorGlucose model, WriteOrigin origin, CancellationToken ct = default)
     {
-        await using var ctx = await ContextFactory.CreateAsync(ct);
-        if (!string.IsNullOrEmpty(model.DataSource) && !string.IsNullOrEmpty(model.SyncIdentifier))
-        {
-            var existing = await ctx.SensorGlucose
-                .FirstOrDefaultAsync(
-                    e => e.DataSource == model.DataSource && e.SyncIdentifier == model.SyncIdentifier,
-                    ct);
-            if (existing != null)
-            {
-                SensorGlucoseMapper.UpdateEntity(existing, model);
-                await ctx.SaveChangesAsync(ct);
-                var upserted = SensorGlucoseMapper.ToDomainModel(existing);
-                // A single explicit upsert always broadcasts (no material-change gate on the single path).
-                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
-                await AdvanceTenantLastReadingAsync([upserted], ct);
-                return upserted;
-            }
-        }
-
-        var entity = SensorGlucoseMapper.ToEntity(model);
-        ctx.SensorGlucose.Add(entity);
-        await ctx.SaveChangesAsync(ct);
-        var created = SensorGlucoseMapper.ToDomainModel(entity);
-        await RaiseBroadcastAsync([created], [], [], origin, ct);
-        await AdvanceTenantLastReadingAsync([created], ct);
-        return created;
+        var written = await base.CreateAsync(model, origin, ct);
+        await AdvanceTenantLastReadingAsync([written], ct);
+        return written;
     }
 
     /// <inheritdoc />
@@ -344,73 +313,6 @@ public class SensorGlucoseRepository : V4RepositoryBase<SensorGlucose, SensorGlu
             .Where(e => e.CorrelationId == correlationId)
             .ToListAsync(ct);
         return entities.Select(SensorGlucoseMapper.ToDomainModel);
-    }
-
-    /// <summary>
-    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
-    /// rows in the DB by that key and update them in place — so timezone re-correction moves a reading's
-    /// timestamp instead of duplicating it. Persists the updates inside the transaction before returning
-    /// so the base's insert loop (which clears the tracker) doesn't lose them. Mirrors BolusRepository.
-    /// </summary>
-    protected override async Task<UpsertSplit> SplitUpsertsAsync(
-        NocturneDbContext ctx, List<SensorGlucoseEntity> entities, CancellationToken ct)
-    {
-        // Intra-batch SyncIdentifier dedup: keep last occurrence per (DataSource, SyncIdentifier).
-        // Records without both keys keep a unique grouping key so they're not collapsed.
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                : $"id|{e.Id}")
-            .Select(g => g.Last())
-            .ToList();
-
-        // DB-level SyncIdentifier upsert: rows matched by (DataSource, SyncIdentifier) are updated
-        // in place. Everything else falls through to the LegacyId/insert path below.
-        var updatedEntities = new List<SensorGlucoseEntity>();
-        var materiallyChanged = new List<SensorGlucoseEntity>();
-        var syncKeyed = entities
-            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-            .ToList();
-
-        if (syncKeyed.Count == 0)
-            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
-
-        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-        var existingRows = await ctx.SensorGlucose.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId)
-            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-            .ToListAsync(ct);
-
-        var existingByKey = existingRows
-            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-            .ToDictionary(g => g.Key, g => g.First());
-
-        var toInsert = new List<SensorGlucoseEntity>();
-        foreach (var entity in entities)
-        {
-            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                && !string.IsNullOrEmpty(entity.SyncIdentifier);
-            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-            {
-                var domain = SensorGlucoseMapper.ToDomainModel(entity);
-                SensorGlucoseMapper.UpdateEntity(existing, domain);
-                updatedEntities.Add(existing);
-                // Capture material changes now, before SaveChanges clears the modified flags.
-                if (HasMaterialChange(ctx, existing))
-                    materiallyChanged.Add(existing);
-            }
-            else
-            {
-                toInsert.Add(entity);
-            }
-        }
-
-        if (updatedEntities.Count > 0)
-            await ctx.SaveChangesAsync(ct);
-
-        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncKeyedRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncKeyedRepositoryBase.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Services;
+
+namespace Nocturne.Infrastructure.Data.Repositories.V4;
+
+/// <summary>
+/// <see cref="V4RepositoryBase{TModel,TEntity}"/> for the record types the upstream source names by an
+/// <see cref="ISyncDedupable"/> key, adding the lookup and the delete issued against that key rather
+/// than a Nocturne id — the surface a connector needs to reconcile its own records.
+/// </summary>
+/// <typeparam name="TModel">The V4 domain record type.</typeparam>
+/// <typeparam name="TEntity">The EF entity type backing <typeparamref name="TModel"/>.</typeparam>
+public abstract class SyncKeyedRepositoryBase<TModel, TEntity> : V4RepositoryBase<TModel, TEntity>
+    where TModel : class, IV4Record
+    where TEntity : class, IV4TimeSeriesEntity, IAuditable, ISyncDedupable
+{
+    /// <summary>Initializes the base with the tenant-scoped context factory, audit context, (optional) broadcaster, and (optional) legacy entry sink.</summary>
+    protected SyncKeyedRepositoryBase(
+        ITenantDbContextFactory contextFactory,
+        IAuditContext auditContext,
+        IV4RecordBroadcaster<TModel>? broadcaster = null,
+        IDataEventSink<Entry>? entrySink = null)
+        : base(contextFactory, auditContext, broadcaster, entrySink)
+    {
+    }
+
+    /// <summary>
+    /// Soft-deletes every live record matching the given (data source, sync identifier) pair. The
+    /// global query filter scopes the lookup to the current tenant and skips rows already
+    /// soft-deleted, so a repeat call for the same key returns 0.
+    /// </summary>
+    /// <param name="dataSource">The external data source name.</param>
+    /// <param name="syncIdentifier">The external sync identifier.</param>
+    /// <param name="origin">Whether the write is live or a backfill import.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The number of records soft-deleted.</returns>
+    public async Task<int> DeleteBySyncIdentifierAsync(
+        string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        return await AuditedSoftDeleteAndBroadcastAsync(
+            ctx,
+            ctx.Set<TEntity>().Where(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier),
+            $"sync_identifier={dataSource}/{syncIdentifier}", origin, ct);
+    }
+
+    /// <summary>
+    /// Finds a single record by data source and sync identifier. The global query filter
+    /// automatically scopes the lookup to the current tenant and excludes soft-deleted rows.
+    /// </summary>
+    /// <param name="dataSource">The external data source name.</param>
+    /// <param name="syncIdentifier">The external sync identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The matching record, or <see langword="null"/> when none matches.</returns>
+    public async Task<TModel?> FindBySyncIdentifierAsync(
+        string dataSource, string syncIdentifier, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        var entity = await ctx.Set<TEntity>()
+            .FirstOrDefaultAsync(e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier, ct);
+        return entity is null ? null : ToDomain(entity);
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncKeyedRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncKeyedRepositoryBase.cs
@@ -20,7 +20,7 @@ public abstract class SyncKeyedRepositoryBase<TModel, TEntity> : V4RepositoryBas
     where TModel : class, IV4Record
     where TEntity : class, IV4TimeSeriesEntity, IAuditable, ISyncDedupable
 {
-    /// <summary>Initializes the base with the tenant-scoped context factory, audit context, (optional) broadcaster, and (optional) legacy entry sink.</summary>
+    /// <inheritdoc />
     protected SyncKeyedRepositoryBase(
         ITenantDbContextFactory contextFactory,
         IAuditContext auditContext,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
@@ -22,7 +22,7 @@ public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepos
     where TModel : class, IV4Record
     where TEntity : class, IV4TimeSeriesEntity, IAuditable, ISyncDedupable
 {
-    /// <summary>Initializes the base with the tenant-scoped context factory, audit context, (optional) broadcaster, and (optional) legacy entry sink.</summary>
+    /// <inheritdoc />
     protected SyncUpsertRepositoryBase(
         ITenantDbContextFactory contextFactory,
         IAuditContext auditContext,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
@@ -16,6 +16,14 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 /// its catch-up window is idempotent and a re-corrected value moves the stored record rather than
 /// doubling it. Tenant scoping is implicit via the DbContext's RLS-equivalent query filter.
 /// </summary>
+/// <remarks>
+/// The two paths disagree on soft-deleted rows: <see cref="CreateAsync"/> reads through the query
+/// filter and so inserts afresh past a tombstone, while <see cref="SplitUpsertsAsync"/> lifts the
+/// filter to restore tenant scoping and matches the tombstone, writing the re-upload into a row that
+/// stays invisible. The snapshot repositories' own copies of the split exclude deleted rows for
+/// exactly that reason. Preserved as-is here — it predates the shared base and correcting it is a
+/// behaviour change, not a refactor.
+/// </remarks>
 /// <typeparam name="TModel">The V4 domain record type.</typeparam>
 /// <typeparam name="TEntity">The EF entity type backing <typeparamref name="TModel"/>.</typeparam>
 public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepositoryBase<TModel, TEntity>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
@@ -1,0 +1,139 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Services;
+
+namespace Nocturne.Infrastructure.Data.Repositories.V4;
+
+/// <summary>
+/// <see cref="SyncKeyedRepositoryBase{TModel,TEntity}"/> for the record types whose creates upsert on
+/// the sync key: a create — single or bulk — whose (DataSource, SyncIdentifier) matches a stored row
+/// for the tenant updates that row in place instead of inserting a duplicate, so a connector replaying
+/// its catch-up window is idempotent and a re-corrected value moves the stored record rather than
+/// doubling it. Tenant scoping is implicit via the DbContext's RLS-equivalent query filter.
+/// </summary>
+/// <typeparam name="TModel">The V4 domain record type.</typeparam>
+/// <typeparam name="TEntity">The EF entity type backing <typeparamref name="TModel"/>.</typeparam>
+public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepositoryBase<TModel, TEntity>
+    where TModel : class, IV4Record
+    where TEntity : class, IV4TimeSeriesEntity, IAuditable, ISyncDedupable
+{
+    /// <summary>Initializes the base with the tenant-scoped context factory, audit context, (optional) broadcaster, and (optional) legacy entry sink.</summary>
+    protected SyncUpsertRepositoryBase(
+        ITenantDbContextFactory contextFactory,
+        IAuditContext auditContext,
+        IV4RecordBroadcaster<TModel>? broadcaster = null,
+        IDataEventSink<Entry>? entrySink = null)
+        : base(contextFactory, auditContext, broadcaster, entrySink)
+    {
+    }
+
+    /// <summary>
+    /// Creates a record, or updates in place the stored row carrying the same
+    /// (DataSource, SyncIdentifier).
+    /// </summary>
+    /// <param name="model">The record to create.</param>
+    /// <param name="origin">Whether the write is live or a backfill import.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The created or updated record.</returns>
+    public override async Task<TModel> CreateAsync(TModel model, WriteOrigin origin, CancellationToken ct = default)
+    {
+        await using var ctx = await ContextFactory.CreateAsync(ct);
+        // The domain models carry no sync-key contract, so the key is read off the mapped entity.
+        var entity = ToEntity(model);
+        var dataSource = entity.DataSource;
+        var syncIdentifier = entity.SyncIdentifier;
+        if (!string.IsNullOrEmpty(dataSource) && !string.IsNullOrEmpty(syncIdentifier))
+        {
+            var existing = await ctx.Set<TEntity>()
+                .FirstOrDefaultAsync(
+                    e => e.DataSource == dataSource && e.SyncIdentifier == syncIdentifier, ct);
+            if (existing != null)
+            {
+                ApplyUpdate(existing, model);
+                await ctx.SaveChangesAsync(ct);
+                var upserted = ToDomain(existing);
+                // A single explicit upsert always broadcasts (no material-change gate on the single path).
+                await RaiseBroadcastAsync([], [upserted], [], origin, ct);
+                return upserted;
+            }
+        }
+
+        ctx.Set<TEntity>().Add(entity);
+        await ctx.SaveChangesAsync(ct);
+        var created = ToDomain(entity);
+        await RaiseBroadcastAsync([created], [], [], origin, ct);
+        return created;
+    }
+
+    /// <summary>
+    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
+    /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
+    /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
+    /// </summary>
+    protected override async Task<UpsertSplit> SplitUpsertsAsync(
+        NocturneDbContext ctx, List<TEntity> entities, CancellationToken ct)
+    {
+        // Records without both keys keep a unique grouping key so they're not collapsed.
+        entities = entities
+            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
+                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
+                : $"id|{e.Id}")
+            .Select(g => g.Last())
+            .ToList();
+
+        var syncKeyed = entities
+            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
+            .ToList();
+
+        var updatedEntities = new List<TEntity>();
+        var materiallyChanged = new List<TEntity>();
+        if (syncKeyed.Count == 0)
+            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
+
+        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
+        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
+
+        // Over-fetches by a Cartesian amount; the partial unique index
+        // on (tenant_id, data_source, sync_identifier) keeps this cheap.
+        var existingRows = await ctx.Set<TEntity>().IgnoreQueryFilters()
+            .Where(e => e.TenantId == ctx.TenantId)
+            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
+            .ToListAsync(ct);
+
+        var existingByKey = existingRows
+            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var toInsert = new List<TEntity>();
+        foreach (var entity in entities)
+        {
+            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
+                && !string.IsNullOrEmpty(entity.SyncIdentifier);
+            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
+            {
+                ApplyUpdate(existing, ToDomain(entity));
+                updatedEntities.Add(existing);
+                // Capture material changes now, before SaveChanges clears the modified flags.
+                if (HasMaterialChange(ctx, existing))
+                    materiallyChanged.Add(existing);
+            }
+            else
+            {
+                toInsert.Add(entity);
+            }
+        }
+
+        if (updatedEntities.Count > 0)
+        {
+            // Persist updates before the insert-chunking loop clears the tracker.
+            await ctx.SaveChangesAsync(ct);
+        }
+
+        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -214,7 +214,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CreateAsync" />
-    /// <remarks>Virtual: SyncId-upsert types (Bolus, CarbIntake) override to upsert in place.</remarks>
+    /// <remarks>Virtual: <see cref="SyncUpsertRepositoryBase{TModel,TEntity}"/> overrides it to upsert in place.</remarks>
     public virtual async Task<TModel> CreateAsync(TModel model, WriteOrigin origin, CancellationToken ct = default)
     {
         await using var ctx = await ContextFactory.CreateAsync(ct);
@@ -373,8 +373,8 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         List<TEntity> MateriallyChanged,
         List<TEntity> ToInsert);
 
-    /// <summary>SyncId-upsert types override: match existing rows by (DataSource, SyncIdentifier), update them in
-    /// place, and return the upserted rows, those that changed materially, and the rows still to insert.
+    /// <summary>Upsert participants override: match existing rows by their key, update them in place, and
+    /// return the upserted rows, those that changed materially, and the rows still to insert.
     /// Default: nothing upserted.</summary>
     protected virtual Task<UpsertSplit> SplitUpsertsAsync(
         NocturneDbContext ctx, List<TEntity> entities, CancellationToken ct)

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/AuditDeltaGoldenTests.cs
@@ -19,6 +19,12 @@ namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 ///     is already on the record (data_source); recording it grew mutation_audit_log to 24GB.
 /// The <c>MutationAuditInterceptor</c> never contributes here: the helper detaches the entities and
 /// issues the soft-delete as a bulk update, so every row below comes from the helper itself.
+/// <para>
+/// Delta D8 is D5's twin for <c>DeleteBySyncIdentifierAsync</c>: hoisting it onto
+/// <c>SyncKeyedRepositoryBase</c> put every keyed delete on the broadcasting helper, which has to
+/// materialize the matched rows and therefore audits each one instead of writing the count-only
+/// <c>bulk_delete</c> summary the non-broadcasting helper wrote. Same system skip.
+/// </para>
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("V4 goldens")]
@@ -111,6 +117,42 @@ public class AuditDeltaGoldenTests
             WriteOrigin.Live, CancellationToken.None);
 
         var deleted = await repo.DeleteByLegacyIdAsync("de-sys-del", WriteOrigin.Live, CancellationToken.None);
+        deleted.Should().Be(1, "the sweep still soft-deletes the row");
+
+        (await AuditRowCountAsync(tenant, "DeviceEvent", created.Id)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task D8_DeviceEvent_DeleteBySyncIdentifier_WritesPerRecordAuditRow()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        AttributeScopeToUser(scope);
+        var repo = scope.ServiceProvider.GetRequiredService<IDeviceEventRepository>();
+
+        var created = await repo.CreateAsync(
+            new DeviceEvent { Timestamp = T0, EventType = DeviceEventType.SiteChange, DataSource = "aaps", SyncIdentifier = "de-sync-del" },
+            WriteOrigin.Live, CancellationToken.None);
+
+        var deleted = await repo.DeleteBySyncIdentifierAsync("aaps", "de-sync-del", WriteOrigin.Live, CancellationToken.None);
+        deleted.Should().Be(1);
+
+        // D8 re-baseline (was one count-only bulk_delete summary row, and none carrying the record id).
+        (await AuditRowCountAsync(tenant, "DeviceEvent", created.Id)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task D8_DeviceEvent_SystemDeleteBySyncIdentifier_WritesNoAuditRow()
+    {
+        var tenant = Guid.NewGuid();
+        using var scope = await _fx.BeginTenantScopeAsync(tenant);
+        var repo = scope.ServiceProvider.GetRequiredService<IDeviceEventRepository>();
+
+        var created = await repo.CreateAsync(
+            new DeviceEvent { Timestamp = T0, EventType = DeviceEventType.SiteChange, DataSource = "nightscout", SyncIdentifier = "de-sys-sync-del" },
+            WriteOrigin.Live, CancellationToken.None);
+
+        var deleted = await repo.DeleteBySyncIdentifierAsync("nightscout", "de-sys-sync-del", WriteOrigin.Live, CancellationToken.None);
         deleted.Should().Be(1, "the sweep still soft-deletes the row");
 
         (await AuditRowCountAsync(tenant, "DeviceEvent", created.Id)).Should().Be(0);

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BolusGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/BolusGoldenTests.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 /// <summary>
 /// Golden tests pinning the CURRENT dedup behaviour of <c>BolusRepository</c> (the hardest case:
 /// SyncId-upsert + DeduplicationService + value-tolerance MatchCriteria). Held identical across the
-/// V4RepositoryBase refactor; intentional deltas (D1–D7) are re-baselined explicitly.
+/// V4RepositoryBase refactor; intentional deltas (D1–D8) are re-baselined explicitly.
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("V4 goldens")]

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupParticipantGoldenTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/DedupParticipantGoldenTests.cs
@@ -11,7 +11,7 @@ namespace Nocturne.Infrastructure.Data.Tests.V4Goldens;
 /// DeduplicationService participants (Bolus is covered in <see cref="BolusGoldenTests"/>). Each type
 /// links two within-window records that match its per-type MatchCriteria into a single canonical
 /// group; the SyncId-upsert types also upsert in place on replay. Held identical across the
-/// V4RepositoryBase refactor; intentional deltas (D1–D7) are re-baselined explicitly.
+/// V4RepositoryBase refactor; intentional deltas (D1–D8) are re-baselined explicitly.
 /// </summary>
 [Trait("Category", "Integration")]
 [Collection("V4 goldens")]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
@@ -228,44 +228,93 @@ public class TherapySettingsRepositoryPrefixDeleteTests
 }
 
 /// <summary>
-/// The connector-facing note delete. Both halves of the key are load-bearing, so the near misses
-/// vary one at a time: same sync identifier under another source, and another sync identifier under
-/// the same source.
+/// The connector-facing delete keyed on (data source, sync identifier), shared by every repository
+/// that offers one. Both halves of the key are load-bearing, so the near misses vary one at a time.
+/// These deletes materialize their matched rows in order to broadcast them, which also means each row
+/// is audited individually instead of collapsing into a <c>bulk_delete</c> summary.
 /// </summary>
-[Trait("Category", "Unit")]
-[Trait("Category", "Repository")]
-public class NoteRepositorySyncIdentifierDeleteTests : KeyedSoftDeleteAuditTests<NoteEntity>
+public abstract class SyncIdentifierDeleteAuditTests<TModel, TEntity> : KeyedSoftDeleteAuditTests<TEntity>
+    where TModel : class
+    where TEntity : class, ISoftDeletable
 {
-    private const string DataSource = "dexcom";
-    private const string SyncIdentifier = "note-42";
+    protected const string DataSource = "dexcom";
+    protected const string SyncIdentifier = "sync-42";
 
-    private readonly RecordingBroadcaster _broadcaster = new();
-
-    private NoteRepository _repository = null!;
-
-    protected override string AuditEntityType => "Note";
+    /// <summary>Wired into the repository under test so the delete's broadcast can be asserted.</summary>
+    protected readonly RecordingBroadcaster Broadcaster = new();
 
     protected override string ExpectedScope => $"sync_identifier={DataSource}/{SyncIdentifier}";
 
-    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
-        _repository = new NoteRepository(
-            contextFactory,
-            new Mock<IDeduplicationService>().Object,
-            auditContext,
-            Logger<NoteRepository>(),
-            _broadcaster);
+    /// <summary>A row of the repository's type carrying the given key halves, unsaved.</summary>
+    protected abstract TEntity NewRow(string? dataSource, string? syncIdentifier);
 
-    /// <summary>
-    /// The matched rows are materialized so they can be broadcast, and each one is audited
-    /// individually rather than collapsed into a <c>bulk_delete</c> summary.
-    /// </summary>
+    /// <summary>Issues the keyed delete for <see cref="DataSource"/>/<see cref="SyncIdentifier"/>.</summary>
+    protected abstract Task<int> DeleteAsync(WriteOrigin origin);
+
+    protected override Task<int> DeleteAsync() => DeleteAsync(WriteOrigin.Live);
+
+    protected override Guid SeedMatch() => Add(NewRow(DataSource, SyncIdentifier));
+
+    protected override IReadOnlyList<Guid> SeedNearMisses() =>
+    [
+        Add(NewRow("libre", SyncIdentifier)),
+        Add(NewRow(DataSource, "sync-43")),
+        Add(NewRow(DataSource, null)),
+        Add(NewRow(null, SyncIdentifier)),
+    ];
+
     protected override void AssertUserDeleteAuditRow(MutationAuditLogEntity log, Guid match)
     {
         log.Action.Should().Be("delete");
         log.EntityId.Should().Be(match);
     }
 
-    private NoteEntity NewRow(string? dataSource, string? syncIdentifier) =>
+    [Fact]
+    public async Task Delete_BroadcastsTheRemovedRecord()
+    {
+        var match = SeedMatch();
+        SeedNearMisses();
+
+        await DeleteAsync();
+
+        Broadcaster.Deleted.Should().Equal(match);
+    }
+
+    [Fact]
+    public async Task Delete_Backfill_BroadcastsNothing()
+    {
+        SeedMatch();
+
+        await DeleteAsync(WriteOrigin.Backfill);
+
+        Broadcaster.Deleted.Should().BeEmpty();
+    }
+
+    protected sealed class RecordingBroadcaster : IV4RecordBroadcaster<TModel>
+    {
+        public List<Guid> Deleted { get; } = [];
+
+        public Task BroadcastDeletedAsync(IReadOnlyList<Guid> ids, CancellationToken ct = default)
+        {
+            Deleted.AddRange(ids);
+            return Task.CompletedTask;
+        }
+    }
+}
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class NoteRepositorySyncIdentifierDeleteTests : SyncIdentifierDeleteAuditTests<Note, NoteEntity>
+{
+    private NoteRepository _repository = null!;
+
+    protected override string AuditEntityType => "Note";
+
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new NoteRepository(
+            contextFactory, new Mock<IDeduplicationService>().Object, auditContext, Logger<NoteRepository>(), Broadcaster);
+
+    protected override NoteEntity NewRow(string? dataSource, string? syncIdentifier) =>
         new()
         {
             Id = Guid.CreateVersion7(),
@@ -276,50 +325,89 @@ public class NoteRepositorySyncIdentifierDeleteTests : KeyedSoftDeleteAuditTests
             SyncIdentifier = syncIdentifier,
         };
 
-    protected override Guid SeedMatch() => Add(NewRow(DataSource, SyncIdentifier));
+    protected override Task<int> DeleteAsync(WriteOrigin origin) =>
+        _repository.DeleteBySyncIdentifierAsync(DataSource, SyncIdentifier, origin);
+}
 
-    protected override IReadOnlyList<Guid> SeedNearMisses() =>
-    [
-        Add(NewRow("libre", SyncIdentifier)),
-        Add(NewRow(DataSource, "note-43")),
-        Add(NewRow(DataSource, null)),
-        Add(NewRow(null, SyncIdentifier)),
-    ];
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class BolusRepositorySyncIdentifierDeleteTests : SyncIdentifierDeleteAuditTests<Bolus, BolusEntity>
+{
+    private BolusRepository _repository = null!;
 
-    protected override Task<int> DeleteAsync() =>
-        _repository.DeleteBySyncIdentifierAsync(DataSource, SyncIdentifier, WriteOrigin.Live);
+    protected override string AuditEntityType => "Bolus";
 
-    [Fact]
-    public async Task Delete_BroadcastsTheRemovedRecord()
-    {
-        var match = SeedMatch();
-        SeedNearMisses();
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new BolusRepository(
+            contextFactory, new Mock<IDeduplicationService>().Object, auditContext, Logger<BolusRepository>(), Broadcaster);
 
-        await DeleteAsync();
-
-        _broadcaster.Deleted.Should().Equal(match);
-    }
-
-    [Fact]
-    public async Task Delete_Backfill_BroadcastsNothing()
-    {
-        SeedMatch();
-
-        await _repository.DeleteBySyncIdentifierAsync(DataSource, SyncIdentifier, WriteOrigin.Backfill);
-
-        _broadcaster.Deleted.Should().BeEmpty();
-    }
-
-    private sealed class RecordingBroadcaster : IV4RecordBroadcaster<Note>
-    {
-        public List<Guid> Deleted { get; } = [];
-
-        public Task BroadcastDeletedAsync(IReadOnlyList<Guid> ids, CancellationToken ct = default)
+    protected override BolusEntity NewRow(string? dataSource, string? syncIdentifier) =>
+        new()
         {
-            Deleted.AddRange(ids);
-            return Task.CompletedTask;
-        }
-    }
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc),
+            Insulin = 2.5,
+            DataSource = dataSource,
+            SyncIdentifier = syncIdentifier,
+        };
+
+    protected override Task<int> DeleteAsync(WriteOrigin origin) =>
+        _repository.DeleteBySyncIdentifierAsync(DataSource, SyncIdentifier, origin);
+}
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class CarbIntakeRepositorySyncIdentifierDeleteTests : SyncIdentifierDeleteAuditTests<CarbIntake, CarbIntakeEntity>
+{
+    private CarbIntakeRepository _repository = null!;
+
+    protected override string AuditEntityType => "CarbIntake";
+
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new CarbIntakeRepository(
+            contextFactory, new Mock<IDeduplicationService>().Object, auditContext, Logger<CarbIntakeRepository>(), Broadcaster);
+
+    protected override CarbIntakeEntity NewRow(string? dataSource, string? syncIdentifier) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc),
+            Carbs = 30,
+            DataSource = dataSource,
+            SyncIdentifier = syncIdentifier,
+        };
+
+    protected override Task<int> DeleteAsync(WriteOrigin origin) =>
+        _repository.DeleteBySyncIdentifierAsync(DataSource, SyncIdentifier, origin);
+}
+
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class DeviceEventRepositorySyncIdentifierDeleteTests : SyncIdentifierDeleteAuditTests<DeviceEvent, DeviceEventEntity>
+{
+    private DeviceEventRepository _repository = null!;
+
+    protected override string AuditEntityType => "DeviceEvent";
+
+    protected override void CreateRepository(ITenantDbContextFactory contextFactory, IAuditContext auditContext) =>
+        _repository = new DeviceEventRepository(
+            contextFactory, new Mock<IDeduplicationService>().Object, auditContext, Logger<DeviceEventRepository>(), Broadcaster);
+
+    protected override DeviceEventEntity NewRow(string? dataSource, string? syncIdentifier) =>
+        new()
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TestTenantId,
+            Timestamp = new DateTime(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc),
+            EventType = nameof(DeviceEventType.SiteChange),
+            DataSource = dataSource,
+            SyncIdentifier = syncIdentifier,
+        };
+
+    protected override Task<int> DeleteAsync(WriteOrigin origin) =>
+        _repository.DeleteBySyncIdentifierAsync(DataSource, SyncIdentifier, origin);
 }
 
 [Trait("Category", "Unit")]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
@@ -1,6 +1,8 @@
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Infrastructure.Data.Services;
@@ -11,9 +13,8 @@ namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 /// The delete contract owed by the repositories whose delete is keyed on something other than the
 /// data source — a legacy-id prefix, a (data source, sync identifier) pair, a correlation id. Each
 /// must reach exactly the rows its key names, and must run through the audited path so a user delete
-/// stamps <c>deleted_by_user</c> and records one <c>bulk_delete</c> summary row while a system sweep
-/// leaves the rows re-importable
-/// (<see cref="Nocturne.Infrastructure.Data.Extensions.SoftDeleteDedupExtensions"/>).
+/// stamps <c>deleted_by_user</c> and records the delete while a system sweep leaves the rows
+/// re-importable (<see cref="Nocturne.Infrastructure.Data.Extensions.SoftDeleteDedupExtensions"/>).
 /// </summary>
 public abstract class KeyedSoftDeleteAuditTests<TEntity> : AuditedSoftDeleteTestBase<TEntity>
     where TEntity : class, ISoftDeletable
@@ -30,8 +31,19 @@ public abstract class KeyedSoftDeleteAuditTests<TEntity> : AuditedSoftDeleteTest
     /// <summary>Issues the delete for the key <see cref="SeedMatch"/> seeds against.</summary>
     protected abstract Task<int> DeleteAsync();
 
-    /// <summary>The scope string the summary row must carry for that key.</summary>
+    /// <summary>The scope string a collapsed <c>bulk_delete</c> summary row must carry for that key.</summary>
     protected abstract string ExpectedScope { get; }
+
+    /// <summary>
+    /// Asserts the audit row a single-row user delete records. Deletes that materialize their matched
+    /// rows to broadcast them get one per-record <c>delete</c> row instead of the collapsed summary.
+    /// </summary>
+    protected virtual void AssertUserDeleteAuditRow(MutationAuditLogEntity log, Guid match)
+    {
+        log.Action.Should().Be("bulk_delete");
+        log.EntityId.Should().BeNull();
+        ReadSummary(log.ChangesJson).Should().Be((1, ExpectedScope));
+    }
 
     [Fact]
     public async Task Delete_ReachesTheKeyedRow_AndSparesTheNearMisses()
@@ -49,7 +61,7 @@ public abstract class KeyedSoftDeleteAuditTests<TEntity> : AuditedSoftDeleteTest
     }
 
     [Fact]
-    public async Task Delete_UserContext_StampsDeletedByUserAndWritesSummaryRow()
+    public async Task Delete_UserContext_StampsDeletedByUserAndWritesAuditRow()
     {
         var match = SeedMatch();
 
@@ -59,11 +71,9 @@ public abstract class KeyedSoftDeleteAuditTests<TEntity> : AuditedSoftDeleteTest
         (await ReadDeleteStateAsync(match)).DeletedByUser.Should().BeTrue();
 
         var log = (await ReadAuditLogAsync()).Should().ContainSingle().Subject;
-        log.Action.Should().Be("bulk_delete");
         log.EntityType.Should().Be(AuditEntityType);
-        log.EntityId.Should().BeNull();
         log.SubjectName.Should().Be("tester");
-        ReadSummary(log.ChangesJson).Should().Be((1, ExpectedScope));
+        AssertUserDeleteAuditRow(log, match);
     }
 
     [Fact]
@@ -229,6 +239,8 @@ public class NoteRepositorySyncIdentifierDeleteTests : KeyedSoftDeleteAuditTests
     private const string DataSource = "dexcom";
     private const string SyncIdentifier = "note-42";
 
+    private readonly RecordingBroadcaster _broadcaster = new();
+
     private NoteRepository _repository = null!;
 
     protected override string AuditEntityType => "Note";
@@ -240,7 +252,18 @@ public class NoteRepositorySyncIdentifierDeleteTests : KeyedSoftDeleteAuditTests
             contextFactory,
             new Mock<IDeduplicationService>().Object,
             auditContext,
-            Logger<NoteRepository>());
+            Logger<NoteRepository>(),
+            _broadcaster);
+
+    /// <summary>
+    /// The matched rows are materialized so they can be broadcast, and each one is audited
+    /// individually rather than collapsed into a <c>bulk_delete</c> summary.
+    /// </summary>
+    protected override void AssertUserDeleteAuditRow(MutationAuditLogEntity log, Guid match)
+    {
+        log.Action.Should().Be("delete");
+        log.EntityId.Should().Be(match);
+    }
 
     private NoteEntity NewRow(string? dataSource, string? syncIdentifier) =>
         new()
@@ -265,6 +288,38 @@ public class NoteRepositorySyncIdentifierDeleteTests : KeyedSoftDeleteAuditTests
 
     protected override Task<int> DeleteAsync() =>
         _repository.DeleteBySyncIdentifierAsync(DataSource, SyncIdentifier, WriteOrigin.Live);
+
+    [Fact]
+    public async Task Delete_BroadcastsTheRemovedRecord()
+    {
+        var match = SeedMatch();
+        SeedNearMisses();
+
+        await DeleteAsync();
+
+        _broadcaster.Deleted.Should().Equal(match);
+    }
+
+    [Fact]
+    public async Task Delete_Backfill_BroadcastsNothing()
+    {
+        SeedMatch();
+
+        await _repository.DeleteBySyncIdentifierAsync(DataSource, SyncIdentifier, WriteOrigin.Backfill);
+
+        _broadcaster.Deleted.Should().BeEmpty();
+    }
+
+    private sealed class RecordingBroadcaster : IV4RecordBroadcaster<Note>
+    {
+        public List<Guid> Deleted { get; } = [];
+
+        public Task BroadcastDeletedAsync(IReadOnlyList<Guid> ids, CancellationToken ct = default)
+        {
+            Deleted.AddRange(ids);
+            return Task.CompletedTask;
+        }
+    }
 }
 
 [Trait("Category", "Unit")]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTenantScopeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTenantScopeTests.cs
@@ -1,0 +1,139 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// The tenant guard on <c>SyncUpsertRepositoryBase.SplitUpsertsAsync</c>. The split matches stored
+/// rows through <c>IgnoreQueryFilters()</c> — lifting the soft-delete filter also lifts the tenant
+/// one — so its explicit <c>TenantId</c> predicate is the only thing keeping one tenant's connector
+/// replay out of another tenant's rows. The sync key is unique per tenant, not globally: two tenants
+/// uploading from the same connector routinely share a (DataSource, SyncIdentifier) pair, and the
+/// partial unique index leads with <c>tenant_id</c> precisely so they can.
+/// </summary>
+/// <remarks>
+/// Deliberately a unit test on SQLite rather than a golden: the integration fixture runs under real
+/// Postgres RLS, which masks a missing predicate here. This is the only level at which the guard is
+/// observable.
+/// </remarks>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class SyncUpsertTenantScopeTests : IDisposable
+{
+    private const string DataSource = "aaps";
+    private const string SyncIdentifier = "sync-1";
+
+    private static readonly Guid TenantA = Guid.Parse("00000000-0000-0000-0000-00000000000a");
+    private static readonly Guid TenantB = Guid.Parse("00000000-0000-0000-0000-00000000000b");
+    private static readonly DateTime T0 = new(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc);
+
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _options;
+    private readonly NocturneDbContext _contextA;
+    private readonly BolusRepository _repoA;
+
+    public SyncUpsertTenantScopeTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seed = new NocturneDbContext(_options) { TenantId = TenantA })
+        {
+            seed.Database.EnsureCreated();
+            seed.Tenants.Add(new TenantEntity { Id = TenantA, Slug = "tenant-a" });
+            seed.Tenants.Add(new TenantEntity { Id = TenantB, Slug = "tenant-b" });
+            seed.SaveChanges();
+        }
+
+        _contextA = new NocturneDbContext(_options) { TenantId = TenantA };
+        _repoA = new BolusRepository(
+            new TestTenantDbContextFactory(_contextA),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<BolusRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _contextA.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Persists a bolus on the sync key for <paramref name="tenant"/> and returns its id.</summary>
+    private Guid Seed(Guid tenant, double insulin)
+    {
+        using var ctx = new NocturneDbContext(_options) { TenantId = tenant };
+        var entity = new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenant,
+            Timestamp = T0,
+            Insulin = insulin,
+            DataSource = DataSource,
+            SyncIdentifier = SyncIdentifier,
+        };
+        ctx.Boluses.Add(entity);
+        ctx.SaveChanges();
+        return entity.Id;
+    }
+
+    private async Task<BolusEntity> ReadAsync(Guid id)
+    {
+        await using var verify = new NocturneDbContext(_options) { TenantId = TenantA };
+        return await verify.Boluses.IgnoreQueryFilters().AsNoTracking().SingleAsync(e => e.Id == id);
+    }
+
+    private async Task<int> CountAsync()
+    {
+        await using var verify = new NocturneDbContext(_options) { TenantId = TenantA };
+        return await verify.Boluses.IgnoreQueryFilters().CountAsync();
+    }
+
+    private Task<IEnumerable<Bolus>> UpsertFromTenantAAsync(double insulin) =>
+        _repoA.BulkCreateAsync(
+            [new Bolus { Timestamp = T0, DataSource = DataSource, SyncIdentifier = SyncIdentifier, Insulin = insulin }],
+            WriteOrigin.Live);
+
+    [Fact]
+    public async Task BulkCreate_WhenAnotherTenantHoldsTheSameKey_UpsertsOnlyTheCallersRow()
+    {
+        var rowB = Seed(TenantB, insulin: 1.0);
+        var rowA = Seed(TenantA, insulin: 5.0);
+
+        await UpsertFromTenantAAsync(insulin: 9.0);
+
+        (await ReadAsync(rowA)).Insulin.Should().Be(9.0);
+        (await ReadAsync(rowB)).Insulin.Should().Be(1.0, "another tenant's row is not the caller's to update");
+        (await CountAsync()).Should().Be(2, "the upsert matched in place rather than inserting");
+    }
+
+    [Fact]
+    public async Task BulkCreate_WhenOnlyAnotherTenantHoldsTheKey_InsertsRatherThanMatchingIt()
+    {
+        var rowB = Seed(TenantB, insulin: 1.0);
+
+        await UpsertFromTenantAAsync(insulin: 9.0);
+
+        (await ReadAsync(rowB)).Insulin.Should().Be(1.0, "another tenant's row is not a match candidate");
+        (await CountAsync()).Should().Be(2, "the caller has no row on this key, so one is inserted");
+
+        await using var verify = new NocturneDbContext(_options) { TenantId = TenantA };
+        var inserted = await verify.Boluses.SingleAsync();
+        inserted.TenantId.Should().Be(TenantA);
+        inserted.Insulin.Should().Be(9.0);
+    }
+}


### PR DESCRIPTION
# What

Closes #1047.

`CreateAsync`, `SplitUpsertsAsync`, `DeleteBySyncIdentifierAsync` and `FindBySyncIdentifierAsync`
were typed out per repository under `Repositories/V4/`. On `main`:

| member | copies on `main` |
|---|---|
| `CreateAsync` sync-key upsert | 4 — Bolus, CarbIntake, BasalInjection, SensorGlucose |
| `SplitUpsertsAsync` | 4 — the same four |
| `DeleteBySyncIdentifierAsync` | **5** — Bolus, CarbIntake, BasalInjection, DeviceEvent, Note (**not** SensorGlucose) |
| `FindBySyncIdentifierAsync` | **1** — BasalInjection only |

The upsert pair was *semantically* identical across the four, differing only in the `DbSet` property
name, comment wording, the declaration order of two locals and brace style in SensorGlucose, and —
in SensorGlucose's `CreateAsync` only — the two `AdvanceTenantLastReadingAsync` watermark calls.

They now live once, on two new bases between `V4RepositoryBase` and the concrete repositories:

| | provides | applied to |
|---|---|---|
| `SyncKeyedRepositoryBase<TModel,TEntity>` | `DeleteBySyncIdentifierAsync`, `FindBySyncIdentifierAsync` | all six |
| `SyncUpsertRepositoryBase<TModel,TEntity>` | plus the single-record `CreateAsync` upsert and the `SplitUpsertsAsync` batch split | Bolus, CarbIntake, BasalInjection, SensorGlucose |

The split into two levels is deliberate: `DeviceEvent` and `Note` support the keyed delete but must
**not** inherit upsert-on-create semantics — they carry no partial unique index on the key and their
creates are inserts.

`SensorGlucoseRepository` keeps only a three-line `CreateAsync` override that advances the tenant
`LastReadingAt` watermark after the base write, mirroring what its `BulkCreateAsync` override
already does. The issue expected a `LegacyId` tail on its split as the one genuine variation; that
tail no longer exists — it moved into `V4RepositoryBase.BulkWriteAsync` in an earlier refactor, so
its split was equivalent to the other three.

`ISyncDedupable` now extends `ISourcedEntity` instead of redeclaring `DataSource`. Without that, a
type parameter constrained to both `IV4TimeSeriesEntity` (which already reaches `ISourcedEntity`)
and `ISyncDedupable` cannot resolve `e.DataSource` — the member is ambiguous (CS0229). The six
entities gain the interface. The side effect worth owning: `ISyncDedupable` now also mandates
`Device`. Every current implementer already has it.

**No migration, no schema change.** The columns and the partial unique index already exist and
`NocturneDbContext.SyncDedupedEntities` remains the authoritative index list (it is a hand-written
list, not discovered from the interface, so adding the interface adds no index).

## New dormant public surface

Putting the keyed members on a shared base grants them to types that did not declare them. Nothing
calls any of these and no interface exposes them, but they are new public API on production
repositories and are listed here rather than discovered later:

- **`SensorGlucoseRepository` gains both** — a public, audited, **broadcasting** soft-delete by sync
  key, and a keyed find. `ISensorGlucoseRepository` declares neither; there are zero callers and
  zero tests. This is the largest single piece of new reachable behaviour in the PR.
- **`FindBySyncIdentifierAsync` newly appears on Bolus, CarbIntake, DeviceEvent and Note.** On
  DeviceEvent and Note the key carries no uniqueness, so the inherited `FirstOrDefaultAsync` has no
  `OrderBy` and would return an arbitrary row among duplicates. Its doc says "a single record",
  which holds only for the indexed types.

Avoiding this would mean a third base or per-type shims, which costs more than it buys while the
methods are uncalled — but it is a real widening, not a pure hoist.

# Behavioural delta — read this bit

`DeleteBySyncIdentifierAsync` **now broadcasts** for `Bolus`, `CarbIntake`, `DeviceEvent` and
`Note`. Those four previously deleted silently via `AuditedSoftDeleteAsync`; `BasalInjection`
already broadcast via `AuditedSoftDeleteAndBroadcastAsync` (since #1037). The five copies had
diverged, and consolidating onto the broadcasting implementation is consistent with
`DeleteByLegacyIdAsync`, which every V4 type already routes through the broadcasting path.

Two consequences follow from the same change, because a broadcast requires the matched rows to be
materialized:

1. **Audit-row shape.** A user-context sync-identifier delete of those four types now records one
   per-record `delete` row (with the row snapshot) instead of a single collapsed `bulk_delete`
   summary row. This is the shape `BasalInjection` and every `DeleteByLegacyIdAsync` already
   produce — it is delta **D5** applied to the keyed delete, and is pinned here as **D8**. Volume is
   unchanged for the normal single-row delete (one audit row either way), though the row is larger
   because it carries the snapshot; for `Note` that snapshot includes `Text`, exactly as
   `DeleteByLegacyIdAsync` already does. Over
   `AuditedBulkDeleteExtensions.BroadcastMaterializationCap` (500) matches it still collapses to the
   summary row. System/unattributed deletes still write no audit row at all.
2. **Row materialization.** The delete now loads up to 501 matching rows before updating them. For a
   sync-identifier delete that is at most a handful of rows.

`DeviceEvent` and `Note` are the two types with no uniqueness on the key, so their keyed delete can
match N rows and now audits each. That is a conscious call, not an oversight.

One existing test changed as a direct result: `NoteRepositorySyncIdentifierDeleteTests`'s inherited
`Delete_UserContext_StampsDeletedByUser…` assertion pinned `bulk_delete`. `KeyedSoftDeleteAuditTests`
now exposes the audit-row assertion as an overridable hook and the five bulk-path suites keep the
summary-row expectation unchanged.

# Semantics held constant

- intra-batch keep-last per `(DataSource, SyncIdentifier)`, with keyless rows kept distinct by id
- the `HasMaterialChange` capture *before* `SaveChanges` clears the modified flags
- the `SaveChangesAsync` of upserted rows *before* the base's insert-chunking loop clears the tracker
- timestamp handling: the update path still goes through the type's `Mapper.UpdateEntity` (via
  `ApplyUpdate`) and nothing else, so exactly the same columns are touched as before. No
  `UpdateEntity` touches `Id`, `SysCreatedAt`, `SysUpdatedAt` or `DeletedAt`
- the single-record upsert still broadcasts unconditionally (no material-change gate on that path)
- the split's tenant predicate, now pinned by a test (below)
- return values and counts

The single-record `CreateAsync` reads the sync key off the mapped entity rather than the model,
because `IV4Record` declares `DataSource` but not `SyncIdentifier`. All four mappers copy both
fields straight through (`entity.SyncIdentifier = model.SyncIdentifier`, no trimming or
normalisation), so the key is identical.

# Pre-existing behaviour the hoist canonicalises — flagged, not changed

`SplitUpsertsAsync` calls `IgnoreQueryFilters()` and restores only the tenant filter, so the batch
upsert **matches a soft-deleted row** and writes the re-upload into it; `DeletedAt` and
`deleted_by_user` stay set and the record remains invisible. The single-record `CreateAsync` reads
through the query filter and inserts afresh past the tombstone, so the two paths disagree. The
snapshot repositories' near-identical splitters (`ApsSnapshotRepository.cs:186`,
`PumpSnapshotRepository.cs:130`, `UploaderSnapshotRepository.cs:120`) add `&& e.DeletedAt == null`
for exactly this reason.

This is faithful to `origin/main` for all four types, so it is not a regression — but it is now
stated once, in the base, rather than implied four times. Correcting it is a behaviour change and
belongs in its own issue.

# Verification

Built with `dotnet build nocturne.sln -p:GenerateNSwagClient=false`: **0 errors**; no warning on any
file this branch touches (checked against a forced rebuild).

| suite | result |
|---|---|
| `tests/Unit/Nocturne.Infrastructure.Data.Tests` | **726 passed, 0 failed** (707 on base + 19 added) |
| `tests/Unit/Nocturne.API.Tests` | **6226 passed, 0 failed, 5 skipped** |
| the other 19 unit projects | **1645 passed, 0 failed, 14 skipped** |
| `tests/Integration/Nocturne.Infrastructure.Data.Tests` (real Postgres 17.6 via Testcontainers, includes the V4 goldens) | **97 passed, 0 failed** (95 on base + the D8 pair) |

The V4 golden suite is the one that holds the pre-refactor repository behaviour constant, and it is
green with the pre-existing 55 goldens unmodified.

`tests/Integration/Nocturne.API.Tests` was **not** run: it hangs on this machine before emitting a
single result, including with a filter narrowed to one in-memory test, with the test host idle. That
reproduces independently of this branch and is left to CI.

**Mutation checks.** Three, each pinning a distinct claim:

| mutation | result |
|---|---|
| invert the `HasMaterialChange` gate in `SplitUpsertsAsync` | goldens **53 passed / 2 failed** — exactly `BroadcastGoldenTests.MaterialUpsert_BroadcastsUpdated_IdenticalReuploadDoesNot` and `…JsonbRoundTrip_IdenticalReupload_IsSilent_AndDoesNotRewriteTheRow` |
| revert `DeleteBySyncIdentifierAsync` to the non-broadcasting `AuditedSoftDeleteAsync` | **9 unit tests + golden D8** fail |
| replace the split's `.Where(e => e.TenantId == ctx.TenantId)` with `.Where(e => true)` | **726 → 724 passed / 2 failed**, exactly the two new `SyncUpsertTenantScopeTests` |

Each was reverted, the assembly forced to recompile, and the suites re-run green (726 + 97).

The third mutation closes a gap that predates this PR: with the tenant predicate deleted, the whole
suite was green. The integration goldens run under real Postgres RLS, which masks a missing
predicate there, and no test seeded two tenants through the split path — so once
`IgnoreQueryFilters()` lifts the tenant filter, that one clause was the only guard and nothing
observed it. Hoisting the split makes it a single edit away from de-guarding four types at once, on
health data, so `SyncUpsertTenantScopeTests` now pins it: a tenant's bulk upsert on a
(DataSource, SyncIdentifier) another tenant also holds updates only its own row, and inserts rather
than matching the other tenant's when it holds none.
