### PR TITLE
refactor(connectors): collapse the nine pattern connector installers onto a shared base

### DIFF
--- a/src/Connectors/Nocturne.Connectors.CareLink/CareLinkConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.CareLink/CareLinkConnectorInstaller.cs
@@ -1,42 +1,19 @@
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.CareLink.Configurations;
 using Nocturne.Connectors.CareLink.Services;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 
 namespace Nocturne.Connectors.CareLink;
 
-public class CareLinkConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "CareLink";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnector<CareLinkConnectorConfiguration, CareLinkConnectorService, CareLinkAuthTokenProvider>(
-            configuration,
-            new CareLinkConnectorOptions());
-
-        if (config == null) return;
-
-        services.AddConnectorTokenProvider<CareLinkAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<CareLinkConnectorService, CareLinkConnectorConfiguration>>();
-    }
-
-    private sealed class CareLinkConnectorOptions : ConnectorOptions
-    {
-        [SetsRequiredMembers]
-        public CareLinkConnectorOptions()
+public class CareLinkConnectorInstaller()
+    : ConnectorInstaller<CareLinkConnectorConfiguration, CareLinkConnectorService, CareLinkAuthTokenProvider>(
+        new ConnectorOptions
         {
-            ConnectorName = "CareLink";
+            ConnectorName = "CareLink",
             ServerMapping = new Dictionary<string, string>
             {
                 ["EU"] = $"https://{CareLinkConstants.Servers.Eu}",
                 ["US"] = $"https://{CareLinkConstants.Servers.Us}",
-            };
-            GetServerRegion = config => ((CareLinkConnectorConfiguration)config).Server;
-        }
-    }
-}
+            },
+            GetServerRegion = config => ((CareLinkConnectorConfiguration)config).Server,
+        });

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ namespace Nocturne.Connectors.Core.Extensions;
 /// <summary>
 ///     Options for configuring a connector via AddConnector
 /// </summary>
-public abstract class ConnectorOptions
+public sealed class ConnectorOptions
 {
     /// <summary>
     ///     The connector name used in configuration paths (e.g., "Dexcom", "LibreLinkUp")
@@ -91,8 +91,8 @@ public static class ConnectorServiceCollectionExtensions
         }
 
         /// <summary>
-        ///     Registers a connector with its configuration, service, and token provider.
-        ///     This is the preferred method for registering new connectors.
+        ///     Registers a connector with its configuration, service, token provider and sync
+        ///     executor. This is the preferred method for registering new connectors.
         /// </summary>
         /// <typeparam name="TConfig">Configuration type</typeparam>
         /// <typeparam name="TService">Connector service type</typeparam>
@@ -103,7 +103,7 @@ public static class ConnectorServiceCollectionExtensions
         public TConfig? AddConnector<TConfig, TService, TTokenProvider>(IConfiguration configuration,
             ConnectorOptions options)
             where TConfig : BaseConnectorConfiguration, new()
-            where TService : class
+            where TService : class, IConnectorService<TConfig>
             where TTokenProvider : class
         {
             // Register configuration
@@ -151,51 +151,8 @@ public static class ConnectorServiceCollectionExtensions
                     options.AddResilience
                 );
 
-            return config;
-        }
-
-        /// <summary>
-        ///     Simplified connector registration for connectors without token providers.
-        /// </summary>
-        public TConfig? AddConnector<TConfig, TService>(IConfiguration configuration,
-            ConnectorOptions options)
-            where TConfig : BaseConnectorConfiguration, new()
-            where TService : class
-        {
-            // Register configuration
-            var config = services.AddConnectorConfiguration<TConfig>(
-                configuration,
-                options.ConnectorName
-            );
-
-            // Skip registration if disabled
-            if (!config.Enabled)
-                return null;
-
-            // Register server resolver
-            services.AddSingleton<IConnectorServerResolver<TConfig>>(
-                new ConnectorServerResolver<TConfig>(
-                    options.ServerMapping,
-                    options.GetServerRegion,
-                    options.DefaultServer));
-
-            // Register config loader
-            services.AddScoped<IConnectorConfigurationLoader<TConfig>, ConnectorConfigurationLoader<TConfig>>();
-
-            // Register token cache (shared singleton across all connectors)
-            services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
-            services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());
-
-            // Register HttpClient WITHOUT BaseAddress (server resolved per-tenant at call time)
-            services.AddHttpClient<TService>()
-                .ConfigureConnectorClient(
-                    null,
-                    options.AdditionalHeaders,
-                    options.UserAgent,
-                    options.Timeout,
-                    options.ConnectTimeout,
-                    options.AddResilience
-                );
+            services.AddConnectorTokenProvider<TTokenProvider>();
+            services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TService, TConfig>>();
 
             return config;
         }

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorInstaller.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+
+namespace Nocturne.Connectors.Core.Services;
+
+/// <summary>
+///     Installs a connector whose registration is entirely standard — configuration, service,
+///     token provider and the generic sync executor — so that all it has to state is
+///     <paramref name="options"/> and its three types. A connector that needs anything else
+///     (a hand-rolled client, extra services, no token provider) implements
+///     <see cref="IConnectorInstaller"/> directly and calls the pieces itself.
+/// </summary>
+/// <typeparam name="TConfig">Configuration type</typeparam>
+/// <typeparam name="TService">Connector service type</typeparam>
+/// <typeparam name="TTokenProvider">Token provider type</typeparam>
+/// <param name="options">Connector options</param>
+public abstract class ConnectorInstaller<TConfig, TService, TTokenProvider>(ConnectorOptions options)
+    : IConnectorInstaller
+    where TConfig : BaseConnectorConfiguration, new()
+    where TService : class, IConnectorService<TConfig>
+    where TTokenProvider : class
+{
+    /// <inheritdoc />
+    public string ConnectorName => options.ConnectorName;
+
+    /// <inheritdoc />
+    public void Install(IServiceCollection services, IConfiguration configuration) =>
+        services.AddConnector<TConfig, TService, TTokenProvider>(configuration, options);
+}

--- a/src/Connectors/Nocturne.Connectors.Dexcom/DexcomConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/DexcomConnectorInstaller.cs
@@ -1,47 +1,20 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Dexcom.Configurations;
 using Nocturne.Connectors.Dexcom.Services;
 
-[assembly: InternalsVisibleTo("Nocturne.Connectors.Dexcom.Tests")]
-
 namespace Nocturne.Connectors.Dexcom;
 
-public class DexcomConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "Dexcom";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnector<DexcomConnectorConfiguration, DexcomConnectorService, DexcomAuthTokenProvider>(
-            configuration,
-            new DexcomConnectorOptions());
-
-        if (config == null)
-            return;
-
-        services.AddConnectorTokenProvider<DexcomAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<DexcomConnectorService, DexcomConnectorConfiguration>>();
-    }
-
-    private sealed class DexcomConnectorOptions : ConnectorOptions
-    {
-        [SetsRequiredMembers]
-        public DexcomConnectorOptions()
+public class DexcomConnectorInstaller()
+    : ConnectorInstaller<DexcomConnectorConfiguration, DexcomConnectorService, DexcomAuthTokenProvider>(
+        new ConnectorOptions
         {
-            ConnectorName = "Dexcom";
+            ConnectorName = "Dexcom",
             ServerMapping = new Dictionary<string, string>
             {
                 ["US"] = DexcomConstants.Servers.Us,
                 ["EU"] = DexcomConstants.Servers.Ous,
                 ["OUS"] = DexcomConstants.Servers.Ous
-            };
-            GetServerRegion = config => ((DexcomConnectorConfiguration)config).Server;
-        }
-    }
-}
+            },
+            GetServerRegion = config => ((DexcomConnectorConfiguration)config).Server,
+        });

--- a/src/Connectors/Nocturne.Connectors.Dexcom/Nocturne.Connectors.Dexcom.csproj
+++ b/src/Connectors/Nocturne.Connectors.Dexcom/Nocturne.Connectors.Dexcom.csproj
@@ -8,6 +8,9 @@
         <Product>Nocturne Connectors</Product>
     </PropertyGroup>
     <ItemGroup>
+        <InternalsVisibleTo Include="Nocturne.Connectors.Dexcom.Tests" />
+    </ItemGroup>
+    <ItemGroup>
         <ProjectReference Include="..\..\Core\Nocturne.Core.Models\Nocturne.Core.Models.csproj"/>
         <ProjectReference Include="..\Nocturne.Connectors.Core\Nocturne.Connectors.Core.csproj"/>
         <ProjectReference Include="..\..\Infrastructure\Nocturne.Infrastructure.Data\Nocturne.Infrastructure.Data.csproj"/>

--- a/src/Connectors/Nocturne.Connectors.Eversense/EversenseConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Eversense/EversenseConnectorInstaller.cs
@@ -1,42 +1,18 @@
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Eversense.Configurations;
 using Nocturne.Connectors.Eversense.Services;
 
 namespace Nocturne.Connectors.Eversense;
 
-public class EversenseConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "Eversense";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnector<EversenseConnectorConfiguration, EversenseConnectorService, EversenseAuthTokenProvider>(
-            configuration,
-            new EversenseConnectorOptions());
-
-        if (config == null)
-            return;
-
-        services.AddConnectorTokenProvider<EversenseAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<EversenseConnectorService, EversenseConnectorConfiguration>>();
-    }
-
-    private sealed class EversenseConnectorOptions : ConnectorOptions
-    {
-        [SetsRequiredMembers]
-        public EversenseConnectorOptions()
+public class EversenseConnectorInstaller()
+    : ConnectorInstaller<EversenseConnectorConfiguration, EversenseConnectorService, EversenseAuthTokenProvider>(
+        new ConnectorOptions
         {
-            ConnectorName = "Eversense";
+            ConnectorName = "Eversense",
             ServerMapping = new Dictionary<string, string>
             {
                 ["US"] = EversenseConstants.Servers.UsData
-            };
-            GetServerRegion = config => ((EversenseConnectorConfiguration)config).Server;
-        }
-    }
-}
+            },
+            GetServerRegion = config => ((EversenseConnectorConfiguration)config).Server,
+        });

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/FreeStyleConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/FreeStyleConnectorInstaller.cs
@@ -1,38 +1,16 @@
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.FreeStyle.Configurations;
 using Nocturne.Connectors.FreeStyle.Services;
 
 namespace Nocturne.Connectors.FreeStyle;
 
-public class FreeStyleConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "LibreLinkUp";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnector<LibreLinkUpConnectorConfiguration, LibreConnectorService, LibreLinkAuthTokenProvider>(
-            configuration,
-            new LibreLinkUpConnectorOptions());
-
-        if (config == null)
-            return;
-
-        services.AddConnectorTokenProvider<LibreLinkAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<LibreConnectorService, LibreLinkUpConnectorConfiguration>>();
-    }
-
-    private sealed class LibreLinkUpConnectorOptions : ConnectorOptions
-    {
-        [SetsRequiredMembers]
-        public LibreLinkUpConnectorOptions()
+public class FreeStyleConnectorInstaller()
+    : ConnectorInstaller<LibreLinkUpConnectorConfiguration, LibreConnectorService, LibreLinkAuthTokenProvider>(
+        new ConnectorOptions
         {
-            ConnectorName = "LibreLinkUp";
-            DefaultServer = LibreLinkUpConstants.Endpoints.Eu;
+            ConnectorName = "LibreLinkUp",
+            DefaultServer = LibreLinkUpConstants.Endpoints.Eu,
             ServerMapping = new Dictionary<string, string>
             {
                 ["AE"] = LibreLinkUpConstants.Endpoints.Ae,
@@ -45,13 +23,11 @@ public class FreeStyleConnectorInstaller : IConnectorInstaller
                 ["FR"] = LibreLinkUpConstants.Endpoints.Fr,
                 ["JP"] = LibreLinkUpConstants.Endpoints.Jp,
                 ["US"] = LibreLinkUpConstants.Endpoints.Us
-            };
-            GetServerRegion = config => ((LibreLinkUpConnectorConfiguration)config).Region;
+            },
+            GetServerRegion = config => ((LibreLinkUpConnectorConfiguration)config).Region,
             AdditionalHeaders = new Dictionary<string, string>
             {
                 ["Version"] = "4.16.0",
                 ["Product"] = "llu.android"
-            };
-        }
-    }
-}
+            },
+        });

--- a/src/Connectors/Nocturne.Connectors.Glooko/GlookoConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/GlookoConnectorInstaller.cs
@@ -1,40 +1,16 @@
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Glooko.Configurations;
 using Nocturne.Connectors.Glooko.Services;
 
 namespace Nocturne.Connectors.Glooko;
 
-public class GlookoConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "Glooko";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnector<GlookoConnectorConfiguration, GlookoConnectorService, GlookoAuthTokenProvider>(
-            configuration,
-            new GlookoConnectorOptions());
-
-        if (config == null)
-            return;
-
-        services.AddConnectorTokenProvider<GlookoAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<GlookoConnectorService, GlookoConnectorConfiguration>>();
-    }
-
-    private sealed class GlookoConnectorOptions : ConnectorOptions
-    {
-        [SetsRequiredMembers]
-        public GlookoConnectorOptions()
+public class GlookoConnectorInstaller()
+    : ConnectorInstaller<GlookoConnectorConfiguration, GlookoConnectorService, GlookoAuthTokenProvider>(
+        new ConnectorOptions
         {
-            ConnectorName = "Glooko";
-            Timeout = TimeSpan.FromMinutes(5);
-            ConnectTimeout = TimeSpan.FromSeconds(15);
-            AddResilience = true;
-        }
-    }
-}
+            ConnectorName = "Glooko",
+            Timeout = TimeSpan.FromMinutes(5),
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+            AddResilience = true,
+        });

--- a/src/Connectors/Nocturne.Connectors.MyFitnessPal/MyFitnessPalConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.MyFitnessPal/MyFitnessPalConnectorInstaller.cs
@@ -1,40 +1,16 @@
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.MyFitnessPal.Configurations;
 using Nocturne.Connectors.MyFitnessPal.Services;
 
 namespace Nocturne.Connectors.MyFitnessPal;
 
-public class MyFitnessPalConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "MyFitnessPal";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnector<MyFitnessPalConnectorConfiguration, MyFitnessPalConnectorService, MyFitnessPalAuthTokenProvider>(
-            configuration,
-            new MyFitnessPalConnectorOptions());
-
-        if (config == null)
-            return;
-
-        services.AddConnectorTokenProvider<MyFitnessPalAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<MyFitnessPalConnectorService, MyFitnessPalConnectorConfiguration>>();
-    }
-
-    private sealed class MyFitnessPalConnectorOptions : ConnectorOptions
-    {
-        [SetsRequiredMembers]
-        public MyFitnessPalConnectorOptions()
+public class MyFitnessPalConnectorInstaller()
+    : ConnectorInstaller<MyFitnessPalConnectorConfiguration, MyFitnessPalConnectorService, MyFitnessPalAuthTokenProvider>(
+        new ConnectorOptions
         {
-            ConnectorName = "MyFitnessPal";
+            ConnectorName = "MyFitnessPal",
             // Fixed hosts rather than a region mapping; both call sites use absolute URLs.
-            DefaultServer = MyFitnessPalConstants.Servers.GraphQl;
-            UserAgent = $"MyFitnessPal/{MyFitnessPalConstants.AppVersion} Android";
-        }
-    }
-}
+            DefaultServer = MyFitnessPalConstants.Servers.GraphQl,
+            UserAgent = $"MyFitnessPal/{MyFitnessPalConstants.AppVersion} Android",
+        });

--- a/src/Connectors/Nocturne.Connectors.Tandem/TandemConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/TandemConnectorInstaller.cs
@@ -1,41 +1,17 @@
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Tandem.Configurations;
 using Nocturne.Connectors.Tandem.Services;
 
 namespace Nocturne.Connectors.Tandem;
 
-public class TandemConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "Tandem";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnector<TandemConnectorConfiguration, TandemConnectorService, TandemAuthTokenProvider>(
-            configuration,
-            new TandemConnectorOptions());
-
-        if (config == null)
-            return;
-
-        services.AddConnectorTokenProvider<TandemAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TandemConnectorService, TandemConnectorConfiguration>>();
-    }
-
-    private sealed class TandemConnectorOptions : ConnectorOptions
-    {
-        [SetsRequiredMembers]
-        public TandemConnectorOptions()
+public class TandemConnectorInstaller()
+    : ConnectorInstaller<TandemConnectorConfiguration, TandemConnectorService, TandemAuthTokenProvider>(
+        new ConnectorOptions
         {
-            ConnectorName = "Tandem";
+            ConnectorName = "Tandem",
             // Long-running history fetches; allow generous timeouts and resilience policies.
-            Timeout = TimeSpan.FromMinutes(5);
-            ConnectTimeout = TimeSpan.FromSeconds(15);
-            AddResilience = true;
-        }
-    }
-}
+            Timeout = TimeSpan.FromMinutes(5),
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+            AddResilience = true,
+        });

--- a/src/Connectors/Nocturne.Connectors.Tidepool/TidepoolConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Tidepool/TidepoolConnectorInstaller.cs
@@ -1,43 +1,19 @@
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Tidepool.Configurations;
 using Nocturne.Connectors.Tidepool.Services;
 
 namespace Nocturne.Connectors.Tidepool;
 
-public class TidepoolConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "Tidepool";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnector<TidepoolConnectorConfiguration, TidepoolConnectorService, TidepoolAuthTokenProvider>(
-            configuration,
-            new TidepoolConnectorOptions());
-
-        if (config == null)
-            return;
-
-        services.AddConnectorTokenProvider<TidepoolAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TidepoolConnectorService, TidepoolConnectorConfiguration>>();
-    }
-
-    private sealed class TidepoolConnectorOptions : ConnectorOptions
-    {
-        [SetsRequiredMembers]
-        public TidepoolConnectorOptions()
+public class TidepoolConnectorInstaller()
+    : ConnectorInstaller<TidepoolConnectorConfiguration, TidepoolConnectorService, TidepoolAuthTokenProvider>(
+        new ConnectorOptions
         {
-            ConnectorName = "Tidepool";
+            ConnectorName = "Tidepool",
             ServerMapping = new Dictionary<string, string>
             {
                 ["US"] = TidepoolConstants.Servers.Us,
                 ["Development"] = TidepoolConstants.Servers.Development
-            };
-            GetServerRegion = config => ((TidepoolConnectorConfiguration)config).Server;
-        }
-    }
-}
+            },
+            GetServerRegion = config => ((TidepoolConnectorConfiguration)config).Server,
+        });

--- a/src/Connectors/Nocturne.Connectors.Twiist/TwiistConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Twiist/TwiistConnectorInstaller.cs
@@ -1,37 +1,10 @@
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Twiist.Configurations;
 using Nocturne.Connectors.Twiist.Services;
 
 namespace Nocturne.Connectors.Twiist;
 
-public class TwiistConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "Twiist";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnector<TwiistConnectorConfiguration, TwiistConnectorService, TwiistAuthTokenProvider>(
-            configuration,
-            new TwiistConnectorOptions());
-
-        if (config == null)
-            return;
-
-        services.AddConnectorTokenProvider<TwiistAuthTokenProvider>();
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TwiistConnectorService, TwiistConnectorConfiguration>>();
-    }
-
-    private sealed class TwiistConnectorOptions : ConnectorOptions
-    {
-        [SetsRequiredMembers]
-        public TwiistConnectorOptions()
-        {
-            ConnectorName = "Twiist";
-        }
-    }
-}
+public class TwiistConnectorInstaller()
+    : ConnectorInstaller<TwiistConnectorConfiguration, TwiistConnectorService, TwiistAuthTokenProvider>(
+        new ConnectorOptions { ConnectorName = "Twiist" });

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorClientGuardCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorClientGuardCoverageTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,7 +35,7 @@ public class ConnectorClientGuardCoverageTests
     public static TheoryData<string> Installers()
     {
         var data = new TheoryData<string>();
-        foreach (var installer in DiscoverInstallers())
+        foreach (var installer in ConnectorInstallers.Discover())
             data.Add(installer.ConnectorName);
         return data;
     }
@@ -46,7 +45,7 @@ public class ConnectorClientGuardCoverageTests
     {
         // Guards the guard: if reflection finds nothing, every theory case below silently vanishes
         // and this file would pass while testing nothing at all.
-        DiscoverInstallers().Should().HaveCountGreaterThan(5,
+        ConnectorInstallers.Discover().Should().HaveCountGreaterThan(5,
             "the connector installers are discovered by reflection; finding none would make the " +
             "coverage theory vacuous");
     }
@@ -70,7 +69,7 @@ public class ConnectorClientGuardCoverageTests
     public void EveryClientAConnectorRegisters_CarriesTheGuardAndNoTransportRedirects(
         string connectorName)
     {
-        var installer = DiscoverInstallers().Single(i => i.ConnectorName == connectorName);
+        var installer = ConnectorInstallers.Discover().Single(i => i.ConnectorName == connectorName);
 
         var services = new ServiceCollection();
         services.AddLogging();
@@ -123,46 +122,6 @@ public class ConnectorClientGuardCoverageTests
                 "{0}'s '{1}' client is a connector: private and LAN targets are supported and only " +
                 "link-local is refused",
                 connectorName, clientName);
-        }
-    }
-
-    private static List<IConnectorInstaller> DiscoverInstallers()
-    {
-        // Touch one type per connector assembly so they are loaded before the scan.
-        _ = typeof(LinkLocalGuardHandler);
-        foreach (var path in Directory.GetFiles(
-                     AppContext.BaseDirectory, "Nocturne.Connectors.*.dll"))
-        {
-            try
-            {
-                Assembly.LoadFrom(path);
-            }
-            catch (BadImageFormatException)
-            {
-                // Not a managed assembly; nothing to scan.
-            }
-        }
-
-        return [.. AppDomain.CurrentDomain.GetAssemblies()
-            .Where(a => a.GetName().Name?.StartsWith("Nocturne.Connectors.", StringComparison.Ordinal) == true)
-            .SelectMany(SafeTypes)
-            .Where(t => typeof(IConnectorInstaller).IsAssignableFrom(t)
-                        && t is { IsAbstract: false, IsInterface: false }
-                        && t.GetConstructor(Type.EmptyTypes) is not null)
-            .Select(t => (IConnectorInstaller)Activator.CreateInstance(t)!)
-            .GroupBy(i => i.ConnectorName)
-            .Select(g => g.First())];
-    }
-
-    private static IEnumerable<Type> SafeTypes(Assembly assembly)
-    {
-        try
-        {
-            return assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            return ex.Types.Where(t => t is not null)!;
         }
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorInstallers.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorInstallers.cs
@@ -1,0 +1,61 @@
+using System.Reflection;
+using Nocturne.Connectors.Core.Interfaces;
+
+namespace Nocturne.API.Tests.Connectors;
+
+/// <summary>
+/// Finds the shipped connectors by reflection. The connector projects are references of this test
+/// project without any test naming their types, so nothing has loaded them by the time a test asks
+/// what connectors exist — they have to be pulled off disk first.
+/// </summary>
+internal static class ConnectorInstallers
+{
+    /// <summary>
+    /// One installer per connector, discovered rather than listed so a new connector project is
+    /// covered without editing a test.
+    /// </summary>
+    internal static List<IConnectorInstaller> Discover() =>
+        [.. Types()
+            .Where(t => typeof(IConnectorInstaller).IsAssignableFrom(t)
+                        && t is { IsAbstract: false, IsInterface: false }
+                        && t.GetConstructor(Type.EmptyTypes) is not null)
+            .Select(t => (IConnectorInstaller)Activator.CreateInstance(t)!)
+            .GroupBy(i => i.ConnectorName)
+            .Select(g => g.First())];
+
+    /// <summary>
+    /// Every type across the connector assemblies.
+    /// </summary>
+    internal static IEnumerable<Type> Types()
+    {
+        // Touch one type per connector assembly so they are loaded before the scan.
+        _ = typeof(IConnectorInstaller);
+        foreach (var path in Directory.GetFiles(AppContext.BaseDirectory, "Nocturne.Connectors.*.dll"))
+        {
+            try
+            {
+                Assembly.LoadFrom(path);
+            }
+            catch (BadImageFormatException)
+            {
+                // Not a managed assembly; nothing to scan.
+            }
+        }
+
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => a.GetName().Name?.StartsWith("Nocturne.Connectors.", StringComparison.Ordinal) == true)
+            .SelectMany(SafeTypes);
+    }
+
+    private static IEnumerable<Type> SafeTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t is not null)!;
+        }
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorPollingRegistrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorPollingRegistrationTests.cs
@@ -182,41 +182,11 @@ public class ConnectorPollingRegistrationTests
         throw new InvalidOperationException($"{poller.Name} is not a connector poller.");
     }
 
-    private static List<string> InstalledConnectorNames()
-    {
-        // Touch one type per connector assembly so they are loaded before the scan.
-        _ = typeof(ConnectorRegistrationAttribute);
-        foreach (var path in Directory.GetFiles(AppContext.BaseDirectory, "Nocturne.Connectors.*.dll"))
-        {
-            try
-            {
-                Assembly.LoadFrom(path);
-            }
-            catch (BadImageFormatException)
-            {
-                // Not a managed assembly; nothing to scan.
-            }
-        }
-
-        return [.. AppDomain.CurrentDomain.GetAssemblies()
-            .Where(a => a.GetName().Name?.StartsWith("Nocturne.Connectors.", StringComparison.Ordinal) == true)
-            .SelectMany(SafeTypes)
+    private static List<string> InstalledConnectorNames() =>
+        [.. ConnectorInstallers.Types()
             .Select(t => t.GetCustomAttribute<ConnectorRegistrationAttribute>(inherit: false)?.ConnectorName)
             .Where(name => name is not null)
             .Distinct()!];
-    }
-
-    private static IEnumerable<Type> SafeTypes(Assembly assembly)
-    {
-        try
-        {
-            return assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException ex)
-        {
-            return ex.Types.Where(t => t is not null)!;
-        }
-    }
 
     [ConnectorRegistration("PollingTest", "polling-test", "POLLINGTEST", "PollingTest")]
     private sealed class PollingTestConfiguration : BaseConnectorConfiguration

--- a/tests/Unit/Nocturne.API.Tests/Connectors/PatternConnectorInstallerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/PatternConnectorInstallerTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Xunit;
+
+namespace Nocturne.API.Tests.Connectors;
+
+/// <summary>
+/// Pins what <c>AddConnector</c> registers for the connectors that install through
+/// <see cref="ConnectorInstaller{TConfig,TService,TTokenProvider}"/>. One body serves all nine, so a
+/// single edit there arms or disarms every one of them at once, and neither outcome shows up until
+/// a sync runs.
+/// </summary>
+public class PatternConnectorInstallerTests
+{
+    private static readonly string[] Pattern =
+    [
+        "CareLink", "Dexcom", "Eversense", "Glooko", "LibreLinkUp", "MyFitnessPal", "Tandem",
+        "Tidepool", "Twiist",
+    ];
+
+    public static TheoryData<string> PatternConnectors() => [.. Pattern];
+
+    [Fact]
+    public void TheStandardConnectors_InstallThroughTheSharedBase()
+    {
+        // Also guards the theories: a connector that stops deriving from the base drops out of
+        // every case below rather than failing one.
+        PatternInstallers().Select(installer => installer.ConnectorName)
+            .Should().BeEquivalentTo(Pattern);
+    }
+
+    /// <summary>
+    /// The token provider has to come out of the sync's own scope, and only
+    /// <c>AddConnectorTokenProvider</c> registers it that way.
+    /// <c>AddHttpClient&lt;TTokenProvider&gt;</c> has already registered the same type as transient,
+    /// so dropping the scoped registration leaves one that still resolves — with the framework's
+    /// bare HttpClient injection instead of the named client and the DI dependencies the provider
+    /// declares.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(PatternConnectors))]
+    public void AnEnabledConnector_RegistersItsTokenProviderScoped(string connectorName)
+    {
+        var installer = PatternInstallers().Single(i => i.ConnectorName == connectorName);
+
+        var services = new ServiceCollection();
+        installer.Install(services, Configuration(connectorName, enabled: true));
+
+        var registrations = services
+            .Where(descriptor => descriptor.ServiceType == TypeArgument(installer, 2))
+            .ToList();
+
+        registrations.Should().NotBeEmpty("{0} registers a token provider", connectorName);
+
+        // Last registration wins on resolution, so that is the one whose lifetime the sync gets.
+        registrations[^1].Lifetime.Should().Be(ServiceLifetime.Scoped,
+            "{0}'s token provider must resolve from the sync scope; the transient AddHttpClient " +
+            "registration underneath it resolves too, so losing the scoped one is silent",
+            connectorName);
+    }
+
+    /// <summary>
+    /// A connector nobody turned on must register nothing a sync could reach. The frozen startup
+    /// defaults are the exception: they are recorded whatever the connector's state, because the
+    /// configuration surface reads them to show what could be enabled.
+    /// </summary>
+    /// <remarks>
+    /// A sync executor is what a manual trigger and the poller both dispatch on, so one registered
+    /// for a disabled connector runs a sync with no credentials configured, and the poller check is
+    /// no protection — it re-reads the configuration itself and would stand its own loop down while
+    /// the trigger route stayed live.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(PatternConnectors))]
+    public void ADisabledConnector_RegistersOnlyItsFrozenConfiguration(string connectorName)
+    {
+        var installer = PatternInstallers().Single(i => i.ConnectorName == connectorName);
+
+        var services = new ServiceCollection();
+        installer.Install(services, Configuration(connectorName, enabled: false));
+
+        services.Should().ContainSingle(
+                "a disabled {0} registers nothing beyond its frozen startup defaults", connectorName)
+            .Which.ServiceType.Should().Be(
+                typeof(IConnectorRegistration<>).MakeGenericType(TypeArgument(installer, 0)));
+    }
+
+    private static IConfiguration Configuration(string connectorName, bool enabled) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"Parameters:Connectors:{connectorName}:Enabled"] = enabled.ToString(),
+                [$"Connectors:{connectorName}:Enabled"] = enabled.ToString(),
+            })
+            .Build();
+
+    private static List<IConnectorInstaller> PatternInstallers() =>
+        [.. ConnectorInstallers.Discover().Where(i => SharedBaseOf(i.GetType()) is not null)];
+
+    /// <summary>
+    /// The installer's shared-base type arguments: configuration at 0, service at 1, token provider
+    /// at 2.
+    /// </summary>
+    private static Type TypeArgument(IConnectorInstaller installer, int index) =>
+        SharedBaseOf(installer.GetType())!.GetGenericArguments()[index];
+
+    private static Type? SharedBaseOf(Type installer)
+    {
+        for (var current = installer; current is not null; current = current.BaseType)
+            if (current.IsGenericType
+                && current.GetGenericTypeDefinition() == typeof(ConnectorInstaller<,,>))
+                return current;
+
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #1048.

## What

Nine of the fourteen `*ConnectorInstaller.cs` files under `src/Connectors/` were
the same `Install` body typed out per vendor — CareLink, Dexcom, Eversense,
FreeStyle, Glooko, MyFitnessPal, Tandem, Tidepool, Twiist:

```csharp
var config = services.AddConnector<TConfig, TService, TTokenProvider>(configuration, new XOptions());
if (config == null)
    return;
services.AddConnectorTokenProvider<TTokenProvider>();
services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TService, TConfig>>();
```

Only the private `XConnectorOptions : ConnectorOptions` differed, and that is
pure data.

- The token provider and the sync executor are unconditional for every caller of
  the three-argument `AddConnector`, so they move inside it, after the early
  return. `TService` picks up the `IConnectorService<TConfig>` constraint that
  `ConnectorSyncExecutor<TService, TConfig>` already required.
- A new `ConnectorInstaller<TConfig, TService, TTokenProvider>` base
  (`src/Connectors/Nocturne.Connectors.Core/Services/ConnectorInstaller.cs`)
  takes the options through its constructor and supplies both `ConnectorName`
  and `Install`. Each of the nine is now its three type arguments plus its
  options object; Twiist is three lines.
- `ConnectorOptions` is sealed, since nothing derives from it any more.
- The dead `AddConnector<TConfig, TService>` overload (no token provider) is
  deleted. Grep confirmed zero callers across `src/` and `tests/` before and
  after.
- Dexcom's `[assembly: InternalsVisibleTo]` moves from source into the
  `<InternalsVisibleTo>` csproj item, matching Glooko/MyLife/Tandem.

The five divergent installers — Gluroo, HomeAssistant, MyLife, Nightscout,
NocturneRemote — are untouched and still call the pieces individually, so both
helpers stay public: MyLife is the sole remaining caller of
`AddConnectorTokenProvider`, and Gluroo, MyLife, Nightscout and NocturneRemote
each call `AddConnectorSyncExecutor` (HomeAssistant, a push-only notify target,
calls neither and only registers its configuration).

## Why

126 lines of identical registration code, nine copies of a four-line body, and a
45-line overload nothing called.

## Semantics preserved

- The `config == null` early return still short-circuits everything: a disabled
  or unconfigured connector registers no token provider and no sync executor,
  because both registrations sit after the `if (!config.Enabled) return null;`
  inside `AddConnector`. This is now pinned by a test (see below) — it was not
  covered before.
- Registration order is unchanged — configuration, server resolver, config
  loader, token cache, the two HTTP clients, then token provider, then sync
  executor — as are all lifetimes.
- The generic-poller behaviour from #1052 is untouched: `AddConnectors` still
  derives each connector's scheduled sync from the installed
  `IConnectorSyncExecutor` descriptors.

## Tests added

`AddConnector` is now the single site where one bad edit arms or disarms all
nine connectors at once, and two edits to it were not covered by anything.
`tests/Unit/Nocturne.API.Tests/Connectors/PatternConnectorInstallerTests.cs`
adds two theories over the nine, plus a fact pinning which connectors install
through the shared base so that one leaving it fails instead of silently
dropping out of the cases:

- **An enabled connector registers its token provider scoped.**
  `AddHttpClient<TTokenProvider>` has already registered the same type as
  transient, so losing the scoped registration from `AddConnectorTokenProvider`
  leaves one that still resolves — with the framework's bare `HttpClient`
  instead of the named client and the DI dependencies the provider declares.
- **A disabled connector registers only its frozen startup defaults.** Nothing
  previously installed a disabled connector, and the poller's own enablement
  check re-reads configuration independently, so it would stand its loop down
  while a sync executor registered for a disabled connector left the manual
  trigger route live.

The assembly loading and installer discovery that `ConnectorClientGuardCoverageTests`
and `ConnectorPollingRegistrationTests` each carried their own copy of moves to a
shared `ConnectorInstallers` helper rather than being copied a third time.

## Verification

`dotnet build nocturne.sln -p:GenerateNSwagClient=false` — succeeded, 0 errors.
The 3 nullable warnings in the touched test files are pre-existing (`.Distinct()!`
inside a collection-expression spread, unchanged code).

Connector unit test projects, all green:

| Project | Passed |
| --- | --- |
| Connectors.Core.Tests | 155 |
| Connectors.CareLink.Tests | 96 |
| Connectors.Dexcom.Tests | 6 |
| Connectors.Eversense.Tests | 24 |
| Connectors.Glooko.Tests | 126 |
| Connectors.MyFitnessPal.Tests | 54 |
| Connectors.MyLife.Tests | 39 |
| Connectors.Nightscout.Tests | 69 |
| Connectors.NocturneRemote.Tests | 25 |
| Connectors.Tandem.Tests | 68 |
| Connectors.Tidepool.Tests | 14 |
| Connectors.Twiist.Tests | 32 |
| **Total** | **708 passed, 0 failed** |

`Nocturne.API.Tests` (holds the composition-root tests —
`ConnectorPollingRegistrationTests`, `ConnectorSyncExecutorRegistrationTests`,
`ConnectorClientGuardCoverageTests`, and the new
`PatternConnectorInstallerTests`): **6245 passed, 0 failed, 5 skipped**, up from
6226 on the base commit by the 19 new cases. The two tests known to be flaky on
main (ConnectorCursorReset, the PasskeyController UUIDv7 case) passed.

### Mutation checks

Each mutation was applied to `AddConnector`, rebuilt, run, then reverted with a
forced recompile and re-run green.

| Mutation | Result | Caught by |
| --- | --- | --- |
| Drop `AddConnectorSyncExecutor` | 22 failed / 15 passed of the 37 registration cases | `ConnectorPollingRegistrationTests`, `ConnectorSyncExecutorRegistrationTests` |
| Drop `AddConnectorTokenProvider` | 9 failed / 343 passed of 352 | the new enabled-connector theory, and nothing else |
| Also register both in the `!config.Enabled` branch | 9 failed / 343 passed of 352 | the new disabled-connector theory, and nothing else |

The second and third both ran fully green before this PR's tests existed, which
is why they were added. After restoring, the `~Connector` filter is **352
passed, 0 failed**, and the full suite is green as above.

### Sanity grep

`AddConnector<` appears at exactly two sites: the definition in
`ConnectorServiceCollectionExtensions.cs` and the single call in the
`ConnectorInstaller` base. No type derives from `ConnectorOptions`.
