### PR TITLE
fix(web): read a rejected remote function through one shared error-message core

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
@@ -60,7 +60,6 @@ public class PredictionController : ControllerBase
     [RemoteQuery]
     [RequireScope(Scope.GlucoseRead, Scope.TreatmentsRead)]
     [ProducesResponseType(typeof(GlucosePredictionResponse), 200)]
-    [ProducesResponseType(typeof(ProblemDetails), 400)]
     [ProducesResponseType(typeof(ProblemDetails), 404)]
     [ProducesResponseType(typeof(ProblemDetails), 500)]
     public async Task<ActionResult<GlucosePredictionResponse>> GetPredictions(

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/PredictionController.cs
@@ -60,9 +60,9 @@ public class PredictionController : ControllerBase
     [RemoteQuery]
     [RequireScope(Scope.GlucoseRead, Scope.TreatmentsRead)]
     [ProducesResponseType(typeof(GlucosePredictionResponse), 200)]
-    [ProducesResponseType(typeof(PredictionErrorResponse), 400)]
-    [ProducesResponseType(typeof(PredictionErrorResponse), 404)]
-    [ProducesResponseType(typeof(PredictionErrorResponse), 500)]
+    [ProducesResponseType(typeof(ProblemDetails), 400)]
+    [ProducesResponseType(typeof(ProblemDetails), 404)]
+    [ProducesResponseType(typeof(ProblemDetails), 500)]
     public async Task<ActionResult<GlucosePredictionResponse>> GetPredictions(
         [FromQuery] string? profileId = null,
         CancellationToken cancellationToken = default)
@@ -133,7 +133,7 @@ public class PredictionController : ControllerBase
     [RequireScope(Scope.TherapyRead)]
     [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
     [ProducesResponseType(typeof(ProfileSnapshotResponse), 200)]
-    [ProducesResponseType(typeof(PredictionErrorResponse), 500)]
+    [ProducesResponseType(typeof(ProblemDetails), 500)]
     public async Task<ActionResult<ProfileSnapshotResponse>> GetProfileSnapshot(
         [FromQuery] string? profileId = null,
         CancellationToken cancellationToken = default)
@@ -215,15 +215,6 @@ public class PredictionStatusResponse
 
     /// <summary>Configured prediction source (None, DeviceStatus, OrefWasm)</summary>
     public string Source { get; set; } = "None";
-}
-
-/// <summary>
-/// Error response for prediction failures.
-/// </summary>
-public class PredictionErrorResponse
-{
-    /// <summary>Error message</summary>
-    public string Error { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
@@ -302,12 +302,7 @@ public class AlertRulesController : ControllerBase
         // backfill. Delete the source config instead.
         if (rule.ManagedBy is not null)
         {
-            return Conflict(new
-            {
-                status = StatusCodes.Status409Conflict,
-                message = $"This rule is managed by '{rule.ManagedBy}' — delete the tracker notification threshold instead.",
-                managedBy = rule.ManagedBy,
-            });
+            return Conflict(new ReferencingRulesResponse([], rule.ManagedBy));
         }
 
         // Refuse to break the alert_state graph: if any other rule references this one, the
@@ -891,24 +886,28 @@ public class AlertRulesController : ControllerBase
 }
 
 /// <summary>
-/// 409 response body returned by <c>DELETE /api/v4/alert-rules/{id}</c> when other rules
-/// reference the target via <c>alert_state</c>. The FE uses this to either link to those
-/// rules or offer a cascade-delete confirmation.
+/// 409 response body returned by <c>DELETE /api/v4/alert-rules/{id}</c>. Either other rules
+/// reference the target via <c>alert_state</c> (<see cref="ReferencingRuleIds"/> is non-empty,
+/// and the FE can link to them or offer a cascade-delete confirmation), or the rule is owned
+/// by a source feature (<see cref="ManagedBy"/> is non-null) and must be deleted there.
 /// </summary>
 /// <remarks>
 /// <see cref="Status"/> and <see cref="Message"/> are carried in the body because the generated
 /// client reads both off the thrown value; a body declaring neither is flattened to a 500.
+/// One record covers both branches because an operation declares a single schema per status.
 /// </remarks>
-public record ReferencingRulesResponse(IReadOnlyList<Guid> ReferencingRuleIds)
+public record ReferencingRulesResponse(IReadOnlyList<Guid> ReferencingRuleIds, string? ManagedBy = null)
 {
     /// <summary>The status this body is returned with.</summary>
     public int Status => StatusCodes.Status409Conflict;
 
     /// <summary>The reason, worded for the person who asked for the deletion.</summary>
     public string Message =>
-        ReferencingRuleIds.Count == 1
-            ? "Another alert rule's condition refers to this one. Update that rule first."
-            : $"{ReferencingRuleIds.Count} other alert rules' conditions refer to this one. Update those rules first.";
+        ManagedBy is not null
+            ? $"This rule is managed by '{ManagedBy}' — delete the tracker notification threshold instead."
+            : ReferencingRuleIds.Count <= 1
+                ? "Another alert rule's condition refers to this one. Update that rule first."
+                : $"{ReferencingRuleIds.Count} other alert rules' conditions refer to this one. Update those rules first.";
 }
 
 #region DTOs

--- a/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Monitoring/AlertRulesController.cs
@@ -304,6 +304,7 @@ public class AlertRulesController : ControllerBase
         {
             return Conflict(new
             {
+                status = StatusCodes.Status409Conflict,
                 message = $"This rule is managed by '{rule.ManagedBy}' — delete the tracker notification threshold instead.",
                 managedBy = rule.ManagedBy,
             });
@@ -894,7 +895,21 @@ public class AlertRulesController : ControllerBase
 /// reference the target via <c>alert_state</c>. The FE uses this to either link to those
 /// rules or offer a cascade-delete confirmation.
 /// </summary>
-public record ReferencingRulesResponse(IReadOnlyList<Guid> ReferencingRuleIds);
+/// <remarks>
+/// <see cref="Status"/> and <see cref="Message"/> are carried in the body because the generated
+/// client reads both off the thrown value; a body declaring neither is flattened to a 500.
+/// </remarks>
+public record ReferencingRulesResponse(IReadOnlyList<Guid> ReferencingRuleIds)
+{
+    /// <summary>The status this body is returned with.</summary>
+    public int Status => StatusCodes.Status409Conflict;
+
+    /// <summary>The reason, worded for the person who asked for the deletion.</summary>
+    public string Message =>
+        ReferencingRuleIds.Count == 1
+            ? "Another alert rule's condition refers to this one. Update that rule first."
+            : $"{ReferencingRuleIds.Count} other alert rules' conditions refer to this one. Update those rules first.";
+}
 
 #region DTOs
 

--- a/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
+++ b/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import { transformWithEsbuild } from "vite";
 import { error, isHttpError } from "@sveltejs/kit";
@@ -360,11 +361,20 @@ describe("an error body that is not RFC-7807", () => {
  * Only a remote operation is covered: a status arm is the only thing that reads
  * these, and an endpoint the codegen does not wrap is answered by whatever
  * calls it directly.
+ *
+ * This guards the DECLARED spec only. The generated client casts the raw wire
+ * body (`typeStyle: "Interface"`, no DTO wrapping), so an action whose real
+ * body diverges from its declaration — an anonymous `BadRequest(new { error })`
+ * under an autofilled `ProblemDetails` declaration, or an undeclared status —
+ * passes here and still flattens at runtime. Keeping declarations truthful is
+ * on the controller and its tests.
  */
 describe("every typed error body a remote operation declares", () => {
-  const spec = JSON.parse(
-    readFileSync(new URL("./generated/openapi.json", import.meta.url), "utf8")
-  ) as {
+  const SPEC_URL = new URL("./generated/openapi.json", import.meta.url);
+  const SPEC_ABSENT =
+    "src/lib/api/generated/openapi.json is not present — run `dotnet build src/API/Nocturne.API/Nocturne.API.csproj -p:GenerateNSwagClient=true` first.";
+
+  type Spec = {
     paths: Record<string, Record<string, RemoteOperation>>;
     components: {
       schemas: Record<string, { properties?: Record<string, unknown> }>;
@@ -383,7 +393,7 @@ describe("every typed error body a remote operation declares", () => {
   const READ_BY_A_STATUS_ARM = (code: string) =>
     /^[45]/.test(code) && code !== "401" && code !== "403";
 
-  function declaredErrorBodies(): { where: string; schema: string }[] {
+  function declaredErrorBodies(spec: Spec): { where: string; schema: string }[] {
     const found: { where: string; schema: string }[] = [];
 
     for (const [path, methods] of Object.entries(spec.paths)) {
@@ -409,8 +419,11 @@ describe("every typed error body a remote operation declares", () => {
     return found;
   }
 
-  it("declares a status, so the status arm can forward it", () => {
-    const bodies = declaredErrorBodies();
+  it("declares a status, so the status arm can forward it", (ctx) => {
+    if (!existsSync(fileURLToPath(SPEC_URL))) ctx.skip(SPEC_ABSENT);
+    const spec = JSON.parse(readFileSync(SPEC_URL, "utf8")) as Spec;
+
+    const bodies = declaredErrorBodies(spec);
     expect(bodies.length).toBeGreaterThan(0);
 
     const missing = bodies

--- a/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
+++ b/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import { transformWithEsbuild } from "vite";
 import { error, isHttpError } from "@sveltejs/kit";
@@ -8,7 +9,7 @@ import {
   RATE_LIMITED_ERROR,
 } from "../forms/submit-error";
 import { remoteErrorMessage } from "./remote-error";
-import { TotpSetupFailure } from "$api-clients";
+import { TotpSetupFailure, type ReferencingRulesResponse } from "$api-clients";
 import {
   describeTotpSetupError,
   describeTotpSetupStartError,
@@ -20,7 +21,7 @@ import {
  * What a failed API call looks like by the time a page sees it.
  *
  * Every generated remote function ends in the catch block
- * openapi-remote-codegen 0.2.0 writes: the status is read off the thrown value,
+ * openapi-remote-codegen 0.5.0 writes: the status is read off the thrown value,
  * 401 and 403 get a line each, and everything else falls to
  * {@link config.errorHandling.on500} — which is ours. A status `on500` does not
  * name is flattened to a 500 and never reaches the browser, so a page cannot
@@ -314,5 +315,111 @@ describe("an authenticator setup that was refused before it started", () => {
 
     expect(describeTotpSetupStartError(crossed)).toBe(TOTP_SETUP_START_FALLBACK);
     expect(TOTP_SETUP_START_FALLBACK.trim()).not.toBe("");
+  });
+});
+
+/**
+ * The 409 the alert-rule delete sends when other rules point at the target, as
+ * NSwag throws it: the parsed body itself, because the operation declares a
+ * typed schema for that status.
+ */
+const referencingRules: ReferencingRulesResponse = {
+  referencingRuleIds: ["3f2a0000-0000-0000-0000-000000000000"],
+  status: 409,
+  message:
+    "Another alert rule's condition refers to this one. Update that rule first.",
+};
+
+describe("an error body that is not RFC-7807", () => {
+  it("reaches the status arm its endpoint declares", async () => {
+    const crossed = await crossTheBoundary(referencingRules);
+
+    expect(isHttpError(crossed) && crossed.status).toBe(409);
+  });
+
+  it("says which rules are in the way rather than that the delete failed", async () => {
+    const crossed = await crossTheBoundary(referencingRules);
+
+    expect(
+      describeSubmitError(crossed, "Failed to delete the alert rule.")
+    ).toBe(referencingRules.message);
+  });
+
+  it("flattens to a 500 when it declares no status of its own", async () => {
+    const { status: _status, ...withoutStatus } = referencingRules;
+
+    const crossed = await crossTheBoundary(withoutStatus);
+
+    expect((crossed as { status: number }).status).toBe(500);
+  });
+});
+
+/**
+ * The status arms read `err.status`, so a typed error body that declares no
+ * `status` of its own is flattened to a 500 no matter what the response said.
+ * Only a remote operation is covered: a status arm is the only thing that reads
+ * these, and an endpoint the codegen does not wrap is answered by whatever
+ * calls it directly.
+ */
+describe("every typed error body a remote operation declares", () => {
+  const spec = JSON.parse(
+    readFileSync(new URL("./generated/openapi.json", import.meta.url), "utf8")
+  ) as {
+    paths: Record<string, Record<string, RemoteOperation>>;
+    components: {
+      schemas: Record<string, { properties?: Record<string, unknown> }>;
+    };
+  };
+
+  type RemoteOperation = {
+    "x-remote-type"?: string;
+    responses?: Record<
+      string,
+      { content?: Record<string, { schema?: { $ref?: string } }> }
+    >;
+  };
+
+  /** 401 and 403 have arms of their own that never read a body's status. */
+  const READ_BY_A_STATUS_ARM = (code: string) =>
+    /^[45]/.test(code) && code !== "401" && code !== "403";
+
+  function declaredErrorBodies(): { where: string; schema: string }[] {
+    const found: { where: string; schema: string }[] = [];
+
+    for (const [path, methods] of Object.entries(spec.paths)) {
+      for (const [method, operation] of Object.entries(methods)) {
+        if (!operation?.["x-remote-type"]) continue;
+
+        for (const [code, response] of Object.entries(
+          operation.responses ?? {}
+        )) {
+          if (!READ_BY_A_STATUS_ARM(code)) continue;
+
+          const ref = response.content?.["application/json"]?.schema?.$ref;
+          if (!ref) continue;
+
+          found.push({
+            where: `${code} ${method.toUpperCase()} ${path}`,
+            schema: ref.split("/").pop()!,
+          });
+        }
+      }
+    }
+
+    return found;
+  }
+
+  it("declares a status, so the status arm can forward it", () => {
+    const bodies = declaredErrorBodies();
+    expect(bodies.length).toBeGreaterThan(0);
+
+    const missing = bodies
+      .filter(
+        ({ schema }) =>
+          !("status" in (spec.components.schemas[schema]?.properties ?? {}))
+      )
+      .map(({ where, schema }) => `${where} -> ${schema}`);
+
+    expect(missing).toEqual([]);
   });
 });

--- a/src/Web/packages/app/src/lib/api/remote-error.ts
+++ b/src/Web/packages/app/src/lib/api/remote-error.ts
@@ -1,48 +1,14 @@
-import {
-  MISSING_ITEM_ERROR,
-  RATE_LIMITED_ERROR,
-} from "$lib/forms/submit-error";
+import { describeRemoteError, READ_SURFACE } from "$lib/forms/submit-error";
 
 /**
- * Message to show for a rejected remote function call.
+ * Message to show for a rejected remote function call on a reading surface —
+ * a query whose rejection is rendered in place of the data it was going to
+ * show. A mutation takes `describeSubmitError` even where its fallback names a
+ * permission.
  *
- * SvelteKit rethrows the generated remote function's `error(status, message)` as
- * an `HttpError` — a plain `{ status, body: { message } }` object, not an
- * `Error`. A scope refusal is a bare `ForbidResult` with no body, so the 403
- * message is the HTTP client's own boilerplate; the caller's fallback names the
- * permission instead. A 429 is answered from the status for the same reason the
- * codegen forwards it with a fixed reason, and because a fallback naming the
- * permission the caller lacks describes the wrong refusal.
- *
- * A 404 is answered from the status as well, but with {@link MISSING_ITEM_ERROR}
- * rather than the fallback: the codegen forwards it with a fixed reason, so its
- * message names the status, and every caller here passes a sentence about a
- * missing permission — which a caller who holds the permission would be told
- * they lack the moment they act on an id someone else deleted.
- *
- * `describeSubmitError` (`$lib/forms/submit-error`) reads the same
- * `HttpError` shape for the other
- * half of the app, and the two differ on three points. Which one a call site
- * wants follows from what its fallback sentence says:
- *
- * - Use this one where the fallback names the permission or scope the call
- *   needs ("Changing alerts requires alerts.readwrite") — the reading surfaces,
- *   where a refusal is the expected failure and a 5xx body is the only clue why
- *   a panel is empty. It forwards a 5xx body, and always answers 403 with the
- *   fallback, which names the missing permission more precisely than any body
- *   the server could send.
- * - Use `describeSubmitError` where the fallback names the action the user took
- *   ("Failed to create invite") — the writing surfaces, where the person is
- *   mid-task and a server's internal 5xx text must not reach them. It suppresses
- *   a 5xx body, answers 404 with the fallback, and answers 403 with the fallback
- *   unless the server wrote the body rather than the HTTP client.
+ * @see {@link import("$lib/forms/submit-error").RemoteErrorPolicy} for how the
+ * two halves differ and which one a call site wants.
  */
 export function remoteErrorMessage(err: unknown, fallback: string): string {
-  const e = err as { status?: number; body?: { message?: unknown } } | null;
-  if (e?.status === 429) return RATE_LIMITED_ERROR;
-  if (e?.status === 404) return MISSING_ITEM_ERROR;
-  if (e?.status === 403) return fallback;
-
-  const message = e?.body?.message;
-  return typeof message === "string" && message.trim() ? message : fallback;
+  return describeRemoteError(err, fallback, READ_SURFACE);
 }

--- a/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
@@ -7,7 +7,7 @@
     update as updateDnd,
   } from "$api/generated/tenantAlertSettings.generated.remote";
   import type { TenantAlertSettingsResponse } from "$api-clients";
-  import { remoteErrorMessage } from "$lib/api/remote-error";
+  import { describeSubmitError } from "$lib/forms";
   import { Bell, BellOff, Settings as SettingsIcon, Loader2 } from "lucide-svelte";
   import { isDndActiveNow, isDndScheduleConfigured } from "./dnd";
 
@@ -62,7 +62,7 @@
       settings = r;
       expanded = false;
     } catch (e) {
-      errorMessage = remoteErrorMessage(
+      errorMessage = describeSubmitError(
         e,
         "Couldn't change Do Not Disturb. Please try again.",
       );

--- a/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
+++ b/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
@@ -30,6 +30,7 @@
     GuestLinkStatus,
   } from "$api/generated/nocturne-api-client";
   import { retainQuery } from "$lib/api/retain-query.svelte";
+  import { describeSubmitError } from "$lib/forms";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? []
@@ -172,8 +173,11 @@
       createdCode = result.code ?? null;
       createdUrl = result.fullUrl ? normalizeCreatedUrl(result.fullUrl) : null;
       await guestLinksQuery?.refresh();
-    } catch {
-      createError = "Failed to create guest link. Please try again.";
+    } catch (err) {
+      createError = describeSubmitError(
+        err,
+        "Failed to create guest link. Please try again."
+      );
     } finally {
       isCreating = false;
     }
@@ -236,9 +240,10 @@
       showCreateForm = true;
       await guestLinksQuery?.refresh();
     } catch (err) {
-      createError =
-        (err as any)?.body?.message ??
-        "Failed to create a new code. Active links are limited to 5 at a time.";
+      createError = describeSubmitError(
+        err,
+        "Failed to create a new code. Active links are limited to 5 at a time."
+      );
       showCreateForm = true;
     } finally {
       reissuingId = null;

--- a/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte.test.ts
@@ -1,0 +1,110 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { error } from "@sveltejs/kit";
+import { GuestLinkStatus, type GuestLinkInfo } from "$api-clients";
+import { remoteQuery } from "$lib/test-stubs/remote-resource";
+
+let createImpl: () => Promise<unknown>;
+let links: GuestLinkInfo[];
+
+vi.mock("$app/state", () => ({
+  page: { data: { effectivePermissions: ["*"] } },
+}));
+
+vi.mock("$api/generated/guestLinks.generated.remote", () => ({
+  getGuestLinks: () => remoteQuery(() => links),
+  createGuestLink: () => createImpl(),
+  revokeGuestLink: () => Promise.resolve(),
+  dismissGuestLink: () => Promise.resolve(),
+}));
+
+import GuestLinksSection from "./GuestLinksSection.svelte";
+
+const FALLBACK = "Failed to create guest link. Please try again.";
+const REISSUE_FALLBACK =
+  "Failed to create a new code. Active links are limited to 5 at a time.";
+
+const existingLink: GuestLinkInfo = {
+  id: "11111111-1111-1111-1111-111111111111",
+  label: "Dr Smith",
+  status: GuestLinkStatus.Active,
+  scopes: ["reports.read"],
+};
+
+async function attemptCreate() {
+  render(GuestLinksSection);
+
+  await page.getByRole("button", { name: "Create Guest Link" }).click();
+  await page.getByRole("textbox").fill("Dr Smith");
+  await page.getByRole("button", { name: "Create Link" }).click();
+}
+
+async function attemptReissue() {
+  links = [existingLink];
+  render(GuestLinksSection);
+
+  await page.getByRole("button", { name: "New code" }).click();
+}
+
+describe("GuestLinksSection", () => {
+  beforeEach(() => {
+    links = [];
+    createImpl = () =>
+      Promise.resolve({ code: "ABCD", fullUrl: "/guest/ABCD" });
+  });
+
+  it("shows the server's reason when the code could not be issued", async () => {
+    createImpl = async () => error(409, "You already have 5 active links.");
+
+    await attemptCreate();
+
+    await expect
+      .element(page.getByText("You already have 5 active links."))
+      .toBeInTheDocument();
+  });
+
+  it("keeps a server fault behind the section's own wording", async () => {
+    createImpl = async () => error(500, "npgsql: connection reset");
+
+    await attemptCreate();
+
+    await expect.element(page.getByText(FALLBACK)).toBeInTheDocument();
+    expect(page.getByText("npgsql: connection reset").elements()).toHaveLength(
+      0
+    );
+  });
+
+  it("reports a throttled attempt as throttled rather than as a failed create", async () => {
+    createImpl = async () => error(429, "Too many requests");
+
+    await attemptCreate();
+
+    await expect
+      .element(page.getByText("Too many attempts.", { exact: false }))
+      .toBeInTheDocument();
+    expect(page.getByText(FALLBACK).elements()).toHaveLength(0);
+  });
+
+  it("shows the server's reason when reissuing a code is refused", async () => {
+    createImpl = async () =>
+      error(409, "That guest has an unused code already.");
+
+    await attemptReissue();
+
+    await expect
+      .element(page.getByText("That guest has an unused code already."))
+      .toBeInTheDocument();
+  });
+
+  it("keeps a server fault behind the reissue wording", async () => {
+    createImpl = async () => error(500, "npgsql: connection reset");
+
+    await attemptReissue();
+
+    await expect.element(page.getByText(REISSUE_FALLBACK)).toBeInTheDocument();
+    expect(page.getByText("npgsql: connection reset").elements()).toHaveLength(
+      0
+    );
+  });
+});

--- a/src/Web/packages/app/src/lib/forms/index.ts
+++ b/src/Web/packages/app/src/lib/forms/index.ts
@@ -16,6 +16,7 @@ export {
   errorMessage,
   errorStatus,
   GENERIC_SUBMIT_ERROR,
+  permissionGatedMutationError,
 } from "./submit-error";
 export { default as FormField, type FormFieldControl } from "./FormField.svelte";
 export { default as FormError } from "./FormError.svelte";

--- a/src/Web/packages/app/src/lib/forms/submit-error.test.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.test.ts
@@ -3,10 +3,14 @@ import { transformWithEsbuild } from "vite";
 import { error } from "@sveltejs/kit";
 import config from "../../../../../remote-codegen.config";
 import {
+  describeRemoteError,
   describeSubmitError,
   GENERIC_SUBMIT_ERROR,
+  MISSING_ITEM_ERROR,
+  PERMISSION_GATED_MUTATION,
   RATE_LIMITED_ERROR,
 } from "./submit-error";
+import { remoteErrorMessage } from "$lib/api/remote-error";
 
 /**
  * What a 403 looks like by the time a page sees it: the thrown value put
@@ -51,6 +55,15 @@ function nswagApiException(status: number, message: string) {
     response: "",
     result: null,
   });
+}
+
+/** A SvelteKit `HttpError`, as an invalidated query's refresh throws it. */
+function httpError(status: number, message: string): unknown {
+  try {
+    error(status, message);
+  } catch (thrown) {
+    return thrown;
+  }
 }
 
 /** An RFC-7807 body, thrown as the parsed object when the 403 is declared. */
@@ -143,5 +156,125 @@ describe("describeSubmitError", () => {
   it("tolerates null and non-objects", () => {
     expect(describeSubmitError(null)).toBe(GENERIC_SUBMIT_ERROR);
     expect(describeSubmitError("string throw")).toBe(GENERIC_SUBMIT_ERROR);
+  });
+});
+
+describe("the 403 arm", () => {
+  it("forwards the reason when an invalidated query's refresh is what was refused", async () => {
+    const crossed = await crossThe403Arm(
+      httpError(403, "You can't manage members of this tenant.")
+    );
+
+    expect(describeSubmitError(crossed, "You can't change this setting.")).toBe(
+      "You can't manage members of this tenant."
+    );
+  });
+
+  it("prefers the sentence the server wrote to the status phrase beside it", async () => {
+    const crossed = await crossThe403Arm(problemDetails(403, NEEDS_SCOPE));
+
+    expect((crossed as { body: { message: string } }).body.message).toBe(
+      NEEDS_SCOPE
+    );
+  });
+});
+
+/**
+ * The three points on which the reading and writing halves differ. Each row is
+ * a decision recorded at `RemoteErrorPolicy`, so collapsing one reddens here.
+ */
+describe("the two halves of RemoteErrorPolicy", () => {
+  const WRITE_FALLBACK = "Failed to delete the alert rule.";
+  const READ_FALLBACK =
+    "Changing alerts requires the alerts.readwrite permission.";
+
+  it("differs on a 404", () => {
+    expect(describeSubmitError({ status: 404 }, WRITE_FALLBACK)).toBe(
+      WRITE_FALLBACK
+    );
+    expect(remoteErrorMessage({ status: 404 }, READ_FALLBACK)).toBe(
+      MISSING_ITEM_ERROR
+    );
+  });
+
+  it("differs on a 403 the server worded itself", () => {
+    const refusal = { status: 403, body: { message: NEEDS_SCOPE } };
+
+    expect(describeSubmitError(refusal, WRITE_FALLBACK)).toBe(NEEDS_SCOPE);
+    expect(remoteErrorMessage(refusal, READ_FALLBACK)).toBe(READ_FALLBACK);
+  });
+
+  it("differs on a body that did not come with a 4xx", () => {
+    const fault = {
+      status: 500,
+      body: { message: "npgsql: connection reset" },
+    };
+
+    expect(describeSubmitError(fault, WRITE_FALLBACK)).toBe(WRITE_FALLBACK);
+    expect(remoteErrorMessage(fault, READ_FALLBACK)).toBe(
+      "npgsql: connection reset"
+    );
+  });
+
+  it("agrees on a throttled attempt and on a 4xx the server worded", () => {
+    expect(describeSubmitError({ status: 429 }, WRITE_FALLBACK)).toBe(
+      RATE_LIMITED_ERROR
+    );
+    expect(remoteErrorMessage({ status: 429 }, READ_FALLBACK)).toBe(
+      RATE_LIMITED_ERROR
+    );
+
+    const rejected = { status: 409, body: { message: "Already redeemed." } };
+    expect(describeSubmitError(rejected, WRITE_FALLBACK)).toBe(
+      "Already redeemed."
+    );
+    expect(remoteErrorMessage(rejected, READ_FALLBACK)).toBe(
+      "Already redeemed."
+    );
+  });
+});
+
+describe("a mutation whose fallback names the permission its page is gated on", () => {
+  const NEEDS_ALERTS =
+    "Changing alerts requires the alerts.readwrite permission.";
+  const describe_ = (err: unknown) =>
+    describeRemoteError(err, NEEDS_ALERTS, PERMISSION_GATED_MUTATION);
+
+  it("says the rule is gone rather than that the permission is missing", () => {
+    expect(describe_({ status: 404, body: { message: "Not found" } })).toBe(
+      MISSING_ITEM_ERROR
+    );
+  });
+
+  it("does not blame the permission for a server fault", () => {
+    const answer = describe_({
+      status: 500,
+      body: { message: "npgsql: connection reset" },
+    });
+
+    expect(answer).toBe(GENERIC_SUBMIT_ERROR);
+    expect(answer).not.toBe(NEEDS_ALERTS);
+  });
+
+  it("keeps the server's internal text out of it either way", () => {
+    expect(
+      describe_({ status: 500, body: { message: "npgsql: connection reset" } })
+    ).not.toContain("npgsql");
+  });
+
+  it("does not blame the permission for a request that never got an answer", () => {
+    expect(describe_(new Error("fetch failed"))).toBe(GENERIC_SUBMIT_ERROR);
+  });
+
+  it("names the permission for the refusal the scope attribute produces", () => {
+    expect(describe_({ status: 403, body: { message: "Forbidden" } })).toBe(
+      NEEDS_ALERTS
+    );
+  });
+
+  it("still shows a refusal the server worded itself", () => {
+    expect(describe_({ status: 403, body: { message: NEEDS_SCOPE } })).toBe(
+      NEEDS_SCOPE
+    );
   });
 });

--- a/src/Web/packages/app/src/lib/forms/submit-error.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.ts
@@ -150,9 +150,9 @@ const WRITE_SURFACE: RemoteErrorPolicy = {
  * is gated on rather than the action. Everywhere the write half would answer
  * with that sentence and the failure is not a refusal — a stale id, a server
  * fault — it would tell someone who holds the permission that they lack it, so
- * those two answers are fixed instead. Pass it to {@link describeRemoteError}
- * directly; `describeSubmitError` covers every mutation whose fallback names
- * the action.
+ * those two answers are fixed instead. Reach it through
+ * {@link permissionGatedMutationError}; `describeSubmitError` covers every
+ * mutation whose fallback names the action.
  */
 export const PERMISSION_GATED_MUTATION: RemoteErrorPolicy = {
   missing: MISSING_ITEM_ERROR,
@@ -160,6 +160,15 @@ export const PERMISSION_GATED_MUTATION: RemoteErrorPolicy = {
   serverError: false,
   fault: GENERIC_SUBMIT_ERROR,
 };
+
+/**
+ * Message for a rejected mutation whose fallback names the missing permission.
+ * @see PERMISSION_GATED_MUTATION
+ */
+export const permissionGatedMutationError = (
+  err: unknown,
+  fallback: string
+): string => describeRemoteError(err, fallback, PERMISSION_GATED_MUTATION);
 
 /** @see RemoteErrorPolicy */
 export const READ_SURFACE: RemoteErrorPolicy = {

--- a/src/Web/packages/app/src/lib/forms/submit-error.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.ts
@@ -39,10 +39,10 @@ export function errorMessage(err: unknown): string | undefined {
  * The 403 bodies the client wrote itself rather than carried from the server.
  *
  * A scope refusal is usually a bare `ForbidResult`, which NSwag reports with one
- * of its own two `ApiException` messages, and the codegen's 403 arm falls back
- * to the status phrase when the thrown value carries neither a message nor a
- * detail. Only a `Problem(detail: …)` refusal — the per-record scope guards —
- * puts a sentence written for a person in the body.
+ * of its own two `ApiException` messages, and an RFC-7807 refusal carrying no
+ * `detail` reaches the 403 arm as its `title` — the status phrase. Only a
+ * `Problem(detail: …)` refusal — the per-record scope guards — puts a sentence
+ * written for a person in the body.
  *
  * Recognising the synthesized side is the only check that can be complete: these
  * three strings are constants of a pinned client and of our own codegen, while
@@ -65,41 +65,137 @@ function forbiddenReason(err: unknown): string | undefined {
 }
 
 /**
- * Turns a rejected form submission into a message for the user.
+ * How a surface answers a rejected remote function whose reason it cannot show
+ * verbatim.
  *
- * A remote `form()` handler that throws `error(status, message)` rejects the
- * client-side `submit()` with an `HttpError`, whose body carries the handler's
- * message. Those messages are written for the user, so a 4xx message is shown
- * verbatim; anything else (5xx, network failure, thrown `Error`) falls back to
- * {@link GENERIC_SUBMIT_ERROR} so internals aren't rendered.
+ * SvelteKit rethrows a generated remote function's `error(status, message)` as
+ * an `HttpError` — a plain `{ status, body: { message } }` object with no
+ * `Error` in its prototype chain — and every surface in the app reads it
+ * through {@link describeRemoteError}, under one of the three policies below.
+ * They agree on 429 and on a 4xx the server worded, and differ on four points.
  *
- * A 429 answers with {@link RATE_LIMITED_ERROR} ahead of either, because the
- * rate limiter's body carries no `message` and a caller's fallback describes
- * what it asked for — "this invite link is invalid" for a request the limiter
- * never let reach the invite.
+ * Which one a call site wants follows from the operation, not from the sentence
+ * it passes: `describeSubmitError` is the writing half, for a command, form or
+ * any other mutation, where a person is mid-task; `remoteErrorMessage`
+ * (`$lib/api/remote-error`) is the reading half, for a query whose rejection is
+ * rendered in place of the data it was going to show.
  *
- * A 404 answers with the caller's fallback for the same reason: the codegen
- * forwards it with a fixed reason, so its message names the status rather than
- * what was missing. A caller that can say something better ("already removed")
- * reads the status itself.
+ * The fallback sentence is the usual tell — a mutation's names the action the
+ * user took ("Failed to create invite"), a query's names the permission or
+ * scope the call needs ("Changing alerts requires alerts.readwrite") — but only
+ * a tell. A mutation on a page whose controls are gated on a permission passes
+ * that permission's sentence and still takes the writing half, because what
+ * must not reach the user is a server's internal 5xx text, and that follows
+ * from the operation alone. Only the two answers that would otherwise be the
+ * caller's own sentence follow the sentence, which is what
+ * {@link PERMISSION_GATED_MUTATION} is for; the two named exports cover the
+ * rest.
  *
- * A 403 answers with the caller's fallback unless the server wrote the body —
- * see {@link CLIENT_WRITTEN_FORBIDDEN}. "You don't have permission to save
- * this" beats "A server side error occurred.", and loses only to a refusal that
- * names the scope.
+ * - `missing` (404). The codegen forwards a 404 with a fixed reason, so its
+ *   message names the status rather than what was missing. A writer's fallback
+ *   usually says which action failed, so it wins; a reader's is rendered where
+ *   the data would have been, and a permission sentence there would tell
+ *   someone who holds the permission that they lack it the moment they act on
+ *   an id someone else deleted, so the reader answers with
+ *   {@link MISSING_ITEM_ERROR} instead. A caller that can say something better
+ *   ("already removed") reads the status itself.
+ * - `forbiddenReason` (403). A writer's fallback ("You don't have permission to
+ *   save this") beats the client's own boilerplate but loses to a refusal the
+ *   server worded, so the writer takes a server-written body when there is one
+ *   — see {@link CLIENT_WRITTEN_FORBIDDEN}. A reader's fallback names the exact
+ *   permission and beats any body the server could send, so the reader always
+ *   takes the fallback. A bare `ForbidResult` — what `[RequireScope]` produces,
+ *   and so the common refusal — is client-written either way, so both halves
+ *   answer it with the caller's sentence.
+ * - `serverError` (5xx, a network failure, a thrown `Error` — anything that is
+ *   not a 4xx). A person mid-task must not be shown a server's internal text,
+ *   so the writer suppresses it; for a reader the body is the only clue why a
+ *   panel is empty, so the reader surfaces it.
+ * - `fault`, the answer once a non-4xx is suppressed. Same reasoning as
+ *   `missing`, on the other axis: a writer's fallback names the action, which
+ *   is what failed, so it wins; a permission sentence would tell someone who
+ *   holds the permission that they lack it because the database hiccupped, so a
+ *   caller passing one answers with {@link GENERIC_SUBMIT_ERROR} instead.
+ *
+ * `missing` and `fault` are therefore the two axes the fallback sentence rather
+ * than the operation decides, and the two {@link PERMISSION_GATED_MUTATION}
+ * sets.
+ *
+ * A 429 answers with {@link RATE_LIMITED_ERROR} ahead of all of them, because
+ * the rate limiter's body carries no `message` and a caller's fallback
+ * describes what it asked for — "this invite link is invalid" for a request the
+ * limiter never let reach the invite.
+ */
+export interface RemoteErrorPolicy {
+  /** Answer for a 404, or the caller's fallback when absent. */
+  readonly missing?: string;
+  /** Whether a 403 the server worded itself outranks the caller's fallback. */
+  readonly forbiddenReason: boolean;
+  /** Whether a body that did not come with a 4xx outranks the caller's fallback. */
+  readonly serverError: boolean;
+  /**
+   * Answer once a body that did not come with a 4xx is suppressed, or the
+   * caller's fallback when absent. Read only when `serverError` is false.
+   */
+  readonly fault?: string;
+}
+
+const WRITE_SURFACE: RemoteErrorPolicy = {
+  forbiddenReason: true,
+  serverError: false,
+};
+
+/**
+ * The writing half, for a mutation whose fallback names the permission its page
+ * is gated on rather than the action. Everywhere the write half would answer
+ * with that sentence and the failure is not a refusal — a stale id, a server
+ * fault — it would tell someone who holds the permission that they lack it, so
+ * those two answers are fixed instead. Pass it to {@link describeRemoteError}
+ * directly; `describeSubmitError` covers every mutation whose fallback names
+ * the action.
+ */
+export const PERMISSION_GATED_MUTATION: RemoteErrorPolicy = {
+  missing: MISSING_ITEM_ERROR,
+  forbiddenReason: true,
+  serverError: false,
+  fault: GENERIC_SUBMIT_ERROR,
+};
+
+/** @see RemoteErrorPolicy */
+export const READ_SURFACE: RemoteErrorPolicy = {
+  missing: MISSING_ITEM_ERROR,
+  forbiddenReason: false,
+  serverError: true,
+};
+
+/** Turns a rejected remote function into a message for the user. */
+export function describeRemoteError(
+  err: unknown,
+  fallback: string,
+  policy: RemoteErrorPolicy
+): string {
+  const status = errorStatus(err);
+  if (status === 429) return RATE_LIMITED_ERROR;
+  if (status === 404) return policy.missing ?? fallback;
+  if (status === 403) {
+    return (
+      (policy.forbiddenReason ? forbiddenReason(err) : undefined) ?? fallback
+    );
+  }
+
+  const is4xx = status !== undefined && status >= 400 && status < 500;
+  if (is4xx || policy.serverError) return errorMessage(err) ?? fallback;
+
+  return policy.fault ?? fallback;
+}
+
+/**
+ * Turns a rejected form submission into a message for the user, on the writing
+ * half of {@link RemoteErrorPolicy}.
  */
 export function describeSubmitError(
   err: unknown,
   fallback = GENERIC_SUBMIT_ERROR
 ): string {
-  const status = errorStatus(err);
-  if (status === 429) return RATE_LIMITED_ERROR;
-  if (status === 404) return fallback;
-  if (status === 403) return forbiddenReason(err) ?? fallback;
-
-  if (status !== undefined && status >= 400 && status < 500) {
-    return errorMessage(err) ?? fallback;
-  }
-
-  return fallback;
+  return describeRemoteError(err, fallback, WRITE_SURFACE);
 }

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -3,10 +3,7 @@
   import { page } from "$app/state";
   import { toast } from "svelte-sonner";
   import { remoteErrorMessage } from "$lib/api/remote-error";
-  import {
-    describeRemoteError,
-    PERMISSION_GATED_MUTATION,
-  } from "$lib/forms/submit-error";
+  import { permissionGatedMutationError } from "$lib/forms";
   import {
     getRules,
     deleteRule,
@@ -56,7 +53,7 @@
     "Changing alerts requires the alerts.readwrite permission.";
 
   const mutationError = (err: unknown) =>
-    describeRemoteError(err, NEEDS_ALERTS_READWRITE, PERMISSION_GATED_MUTATION);
+    permissionGatedMutationError(err, NEEDS_ALERTS_READWRITE);
 
   // ---- Queries ----
   const rulesQuery = getRules();

--- a/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/alerts/+page.svelte
@@ -4,6 +4,10 @@
   import { toast } from "svelte-sonner";
   import { remoteErrorMessage } from "$lib/api/remote-error";
   import {
+    describeRemoteError,
+    PERMISSION_GATED_MUTATION,
+  } from "$lib/forms/submit-error";
+  import {
     getRules,
     deleteRule,
     toggleRule,
@@ -51,6 +55,9 @@
   const NEEDS_ALERTS_READWRITE =
     "Changing alerts requires the alerts.readwrite permission.";
 
+  const mutationError = (err: unknown) =>
+    describeRemoteError(err, NEEDS_ALERTS_READWRITE, PERMISSION_GATED_MUTATION);
+
   // ---- Queries ----
   const rulesQuery = getRules();
   const activeAlertsQuery = getActiveAlerts();
@@ -71,7 +78,7 @@
       await toggleRule(ruleId);
       await rulesQuery.refresh();
     } catch (err) {
-      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
+      toast.error(mutationError(err));
     } finally {
       togglingRuleId = null;
     }
@@ -83,7 +90,7 @@
       await deleteRule(ruleId);
       await rulesQuery.refresh();
     } catch (err) {
-      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
+      toast.error(mutationError(err));
     } finally {
       deletingRuleId = null;
     }
@@ -94,7 +101,7 @@
     try {
       await testFire(ruleId);
     } catch (err) {
-      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
+      toast.error(mutationError(err));
     } finally {
       testingRuleId = null;
     }
@@ -116,7 +123,7 @@
       });
       await dndQuery.refresh();
     } catch (err) {
-      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
+      toast.error(mutationError(err));
     } finally {
       disablingDnd = false;
     }
@@ -136,7 +143,7 @@
         ),
       );
     } catch (err) {
-      toast.error(remoteErrorMessage(err, NEEDS_ALERTS_READWRITE));
+      toast.error(mutationError(err));
     } finally {
       acknowledging = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { toast } from 'svelte-sonner';
-	import { describeRemoteError, PERMISSION_GATED_MUTATION } from '$lib/forms/submit-error';
+	import { permissionGatedMutationError } from '$lib/forms';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
@@ -51,7 +51,7 @@
 		'Reviewing compression lows requires the glucose.readwrite permission.';
 
 	const mutationError = (err: unknown) =>
-		describeRemoteError(err, NEEDS_GLUCOSE_READWRITE, PERMISSION_GATED_MUTATION);
+		permissionGatedMutationError(err, NEEDS_GLUCOSE_READWRITE);
 
 	// Create resource with automatic layout registration - load ALL suggestions
 	const suggestionsResource = contextResource(

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { toast } from 'svelte-sonner';
-	import { remoteErrorMessage } from '$lib/api/remote-error';
+	import { describeRemoteError, PERMISSION_GATED_MUTATION } from '$lib/forms/submit-error';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
 	import { Badge } from '$lib/components/ui/badge';
@@ -49,6 +49,9 @@
 	);
 	const NEEDS_GLUCOSE_READWRITE =
 		'Reviewing compression lows requires the glucose.readwrite permission.';
+
+	const mutationError = (err: unknown) =>
+		describeRemoteError(err, NEEDS_GLUCOSE_READWRITE, PERMISSION_GATED_MUTATION);
 
 	// Create resource with automatic layout registration - load ALL suggestions
 	const suggestionsResource = contextResource(
@@ -161,7 +164,7 @@
 			selectedSuggestions = new Set();
 			selectNextSuggestion(firstSelectedIndex);
 		} catch (err) {
-			toast.error(remoteErrorMessage(err, NEEDS_GLUCOSE_READWRITE));
+			toast.error(mutationError(err));
 		} finally {
 			isLoading = false;
 		}
@@ -180,7 +183,7 @@
 			selectedSuggestions = new Set();
 			selectNextSuggestion(firstSelectedIndex);
 		} catch (err) {
-			toast.error(remoteErrorMessage(err, NEEDS_GLUCOSE_READWRITE));
+			toast.error(mutationError(err));
 		} finally {
 			isLoading = false;
 		}
@@ -199,7 +202,7 @@
 			selectedSuggestions = new Set();
 			selectNextSuggestion(firstSelectedIndex);
 		} catch (err) {
-			toast.error(remoteErrorMessage(err, NEEDS_GLUCOSE_READWRITE));
+			toast.error(mutationError(err));
 		} finally {
 			isLoading = false;
 		}
@@ -234,7 +237,7 @@
 			detectionResult = result;
 			suggestionsResource.refresh();
 		} catch (err) {
-			toast.error(remoteErrorMessage(err, NEEDS_GLUCOSE_READWRITE));
+			toast.error(mutationError(err));
 		} finally {
 			isLoading = false;
 		}

--- a/src/Web/remote-codegen.config.ts
+++ b/src/Web/remote-codegen.config.ts
@@ -1,3 +1,24 @@
+/**
+ * The reason a rejected API call carried, read off the thrown value in one order
+ * for every status arm.
+ *
+ * NSwag throws the parsed error body itself (not wrapped in ApiException) for a
+ * response that declares a typed schema, so an RFC-7807 body arrives as the
+ * thrown value: `detail` carries the reason and `title` only the status phrase,
+ * which is why `detail` is read first. Without a typed schema NSwag throws an
+ * ApiException whose `message` is its own boilerplate and whose body is left
+ * unparsed, so that message is the last resort. `body.message` belongs to an
+ * `HttpError` — the only other thing these catches can see, thrown by an
+ * invalidated query's refresh — and is read first because a handler wrote it.
+ *
+ * That refresh runs inside the command's own `try`, so a write that succeeded
+ * and a refresh that was then refused reject the caller with a reason belonging
+ * to the read, not to the write: the arms cannot tell the two apart, and no
+ * ordering here can.
+ */
+const reason = (err: string) =>
+  `${err}?.body?.message ?? ${err}?.detail ?? ${err}?.title ?? ${err}?.message`;
+
 export default {
   openApiPath: './packages/app/src/lib/api/generated/openapi.json',
   outputDir: './packages/app/src/lib',
@@ -29,7 +50,7 @@ export default {
     // Forward the server's actual error message for 403 so the FE can show
     // a meaningful reason (e.g. "Insufficient permissions for …") instead of
     // a bare "Forbidden".
-    on403: `throw error(403, (err as any)?.message ?? (err as any)?.detail ?? 'Forbidden')`,
+    on403: `throw error(403, ${reason('(err as any)')} ?? 'Forbidden')`,
 
     // The default `on500` swallows every non-401/403 status as a 500 with a
     // generic message. Forward 400 (validation, e.g. cyclic alert_state
@@ -38,9 +59,9 @@ export default {
     // message to the user. Falls through to a 500 with the extracted message
     // so the real error is still visible in dev.
     //
-    // The status is read off the thrown value, so an error body that declares no
-    // `status` field of its own — `ReferencingRulesResponse`,
-    // `PredictionErrorResponse` — never reaches those arms.
+    // The status is read off the thrown value, so an error body must declare a
+    // `status` of its own to reach these arms — a plain payload flattens to a
+    // 500 no matter what the response said.
     //
     // 429 and 404 are forwarded too, and with a fixed reason rather than the
     // extracted message: the rate limiter's body declares no typed schema, so
@@ -57,20 +78,11 @@ export default {
     // command or form rejects its caller with an `HttpError(404)` — SvelteKit
     // renders an error page only for a failed load, so a dialog still gets to
     // show its own "already gone" wording.
-    //
-    // NSwag throws the parsed error body itself (not wrapped in ApiException) for
-    // a response that declares a typed schema, so an RFC-7807 body arrives as
-    // `err`: `detail` carries the reason and `title` only the status phrase,
-    // which is why `detail` is read first. Without a typed schema NSwag throws an
-    // ApiException whose `message` is its own boilerplate and whose body is left
-    // unparsed, so that message is the last resort. `err.body.message` belongs to
-    // an `HttpError` — the only other thing this catch can see, thrown by an
-    // invalidated query's refresh.
     on500: (functionName: string) =>
       `const e = err as any;\n` +
       `    const errors = e?.errors;\n` +
       `    const flat = errors ? Object.entries(errors).map(([, v]: [string, any]) => Array.isArray(v) ? v.join(', ') : v).join('; ') : undefined;\n` +
-      `    const message = flat ?? e?.body?.message ?? e?.detail ?? e?.title ?? e?.message;\n` +
+      `    const message = flat ?? ${reason('e')};\n` +
       `    if (status === 429) throw error(429, 'Too many requests');\n` +
       `    if (status === 404) throw error(404, 'Not found');\n` +
       `    if (status === 400 || status === 409) throw error(status, message ?? 'Request rejected');\n` +

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/ReferencingRulesResponseTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/ReferencingRulesResponseTests.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Nocturne.API.Controllers.V4.Monitoring;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Monitoring;
+
+/// <summary>
+/// Covers the 409 body <c>DELETE /api/v4/alert-rules/{id}</c> sends when other rules reference the
+/// target. The generated client reads the status and the reason off the thrown value, so both have
+/// to be on the wire and the reason has to read as a sentence for whichever count it describes.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ReferencingRulesResponseTests
+{
+    private static readonly Guid First = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Second = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static ReferencingRulesResponse For(params Guid[] ids) => new(ids);
+
+    [Fact]
+    public void Carries_the_status_the_action_answers_with()
+    {
+        For(First).Status.Should().Be(StatusCodes.Status409Conflict);
+        For(First, Second).Status.Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    [Fact]
+    public void Reads_as_one_rule_when_one_rule_refers_to_it()
+    {
+        For(First).Message.Should()
+            .Be("Another alert rule's condition refers to this one. Update that rule first.");
+    }
+
+    [Fact]
+    public void Counts_the_rules_when_more_than_one_refers_to_it()
+    {
+        For(First, Second).Message.Should()
+            .Be("2 other alert rules' conditions refer to this one. Update those rules first.");
+    }
+
+    [Fact]
+    public void Puts_the_status_the_reason_and_the_ids_on_the_wire()
+    {
+        var wire = JsonSerializer.SerializeToNode(
+            For(First),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+
+        wire["status"]!.GetValue<int>().Should().Be(StatusCodes.Status409Conflict);
+        wire["message"]!.GetValue<string>().Should().NotBeNullOrWhiteSpace();
+        wire["referencingRuleIds"]!.AsArray().Should().HaveCount(1);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/ReferencingRulesResponseTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/ReferencingRulesResponseTests.cs
@@ -7,9 +7,10 @@ using Xunit;
 namespace Nocturne.API.Tests.Controllers.V4.Monitoring;
 
 /// <summary>
-/// Covers the 409 body <c>DELETE /api/v4/alert-rules/{id}</c> sends when other rules reference the
-/// target. The generated client reads the status and the reason off the thrown value, so both have
-/// to be on the wire and the reason has to read as a sentence for whichever count it describes.
+/// Covers the 409 body <c>DELETE /api/v4/alert-rules/{id}</c> sends, for both conflict branches:
+/// other rules reference the target, or the rule is managed by a source feature. The generated
+/// client reads the status and the reason off the thrown value, so both have to be on the wire
+/// and the reason has to read as a sentence for whichever branch it describes.
 /// </summary>
 [Trait("Category", "Unit")]
 public class ReferencingRulesResponseTests
@@ -41,6 +42,13 @@ public class ReferencingRulesResponseTests
     }
 
     [Fact]
+    public void Names_the_owning_feature_when_the_rule_is_managed()
+    {
+        new ReferencingRulesResponse([], "tracker").Message.Should()
+            .Be("This rule is managed by 'tracker' — delete the tracker notification threshold instead.");
+    }
+
+    [Fact]
     public void Puts_the_status_the_reason_and_the_ids_on_the_wire()
     {
         var wire = JsonSerializer.SerializeToNode(
@@ -50,5 +58,18 @@ public class ReferencingRulesResponseTests
         wire["status"]!.GetValue<int>().Should().Be(StatusCodes.Status409Conflict);
         wire["message"]!.GetValue<string>().Should().NotBeNullOrWhiteSpace();
         wire["referencingRuleIds"]!.AsArray().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Keeps_the_ids_array_on_the_wire_for_a_managed_conflict()
+    {
+        // Serde-strict generated clients (rust) deserialize every declared field, so the
+        // referencing-ids array must be present (empty) even when the conflict is ownership.
+        var wire = JsonSerializer.SerializeToNode(
+            new ReferencingRulesResponse([], "tracker"),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+
+        wire["referencingRuleIds"]!.AsArray().Should().BeEmpty();
+        wire["managedBy"]!.GetValue<string>().Should().Be("tracker");
     }
 }


### PR DESCRIPTION
## What

Three same-subsystem fixes to how a rejected generated remote function reaches the user.

1. **One core behind the message helpers.** `remoteErrorMessage`
   (`$lib/api/remote-error`) and `describeSubmitError` (`$lib/forms/submit-error`)
   translated the same `HttpError` shape through two independent implementations
   with quietly different policies. Both now delegate to `describeRemoteError`,
   parameterised by a `RemoteErrorPolicy`, with each policy difference stated once
   at that type.
2. **The 403 arm reads the reason in the same order as the 500 arm.** The codegen
   config derives both from a single `reason()` expression:
   `body.message ?? detail ?? title ?? message`.
3. **Two 409 bodies that never reached their declared status arm.** The arms read
   `err.status` off the thrown value, so a typed error body that declares no
   `status` of its own is flattened to a 500 whatever the response said.

## Why

### Helper decision: (b), named exports over one core

Investigated all 80 call sites. The split is load-bearing and is kept, but the
policy differences are now data rather than duplicated control flow:

| | query (`remoteErrorMessage`) | mutation (`describeSubmitError`) |
|---|---|---|
| 404 | `MISSING_ITEM_ERROR` | caller's fallback |
| 403 the server worded | caller's fallback | the server's sentence |
| body with no 4xx | surfaced | suppressed |
| 429, 4xx the server worded | identical | identical |

Collapsing to one helper would have to pick a single answer per row, and each
answer is wrong for one half — a reader told "That item no longer exists" when it
holds the permission but the id is stale, versus a writer shown
`npgsql: connection reset` mid-task. The rows are asserted side by side in one
test so a future collapse reddens.

**The discriminator is the operation, not the fallback sentence.** Review found
ten mutation handlers whose fallback happens to name a permission, and which were
therefore on the query half — forwarding raw 5xx text to a mid-task user. They are
`alerts/+page.svelte` (toggle, delete, test-fire, disable-DND, acknowledge),
`reports/data-quality/compression-lows/+page.svelte` (accept, dismiss, delete,
trigger-detection) and `DndPanel.svelte` (update DND). The doc now says the
operation decides, and the fallback sentence is only the usual tell.

Converting them exposed a genuine third combination, caught by an existing test
(`alerts-page.svelte.test.ts` — "surfaces a stale rule as gone rather than as a
permission problem"): a mutation still wants the mutation 5xx and 403 answers, but
its 404 answer follows the *sentence*, and a permission sentence there tells
someone who holds the permission that they lack it. Hence
`PERMISSION_GATED_MUTATION`, a third policy value over the same core — not a third
implementation — passed to `describeRemoteError` at the nine sites whose fallback
is permission-shaped. `DndPanel`'s fallback names the action, so it takes plain
`describeSubmitError`.

The same reasoning applies on the other axis, so the policy has a fourth field:
once a non-4xx body is suppressed, answering with the permission sentence would
tell someone who holds the permission that they lack it because the database
hiccupped. `fault` fixes that answer to `GENERIC_SUBMIT_ERROR` for the gated
value and is absent — so still the caller's fallback — for `WRITE_SURFACE`,
whose callers name the action, which is the right attribution for a 500.

### DTO decision: add `status`, do not convert to ProblemDetails

- **`ReferencingRulesResponse`** (409 on `DELETE /api/v4/alert-rules/{id}`) gains
  `Status` and `Message`. Being honest about the ids: the codegen's 409 arm throws
  `error(status, message)` and **discards `referencingRuleIds` before any component
  sees them**, and there is no FE consumer today. The typed body is kept for the
  published spec and SDK contract (`sdk-publish.yml` consumes `openapi.json`), not
  for the current UI. In the same breath: removing `PredictionErrorResponse` is an
  SDK-visible delta, since it drops a schema the published clients currently expose.
- The options for the reason, and why (i):
  - **(i) server-authored `Message` — chosen.** Matches the app-wide reality where
    `Problem(detail: ...)` already flows server-authored English to the UI — 306
    occurrences across 58 files in `src/API`.
  - (ii) `Status` only. The arm then throws "Request rejected", which
    `describeSubmitError` treats as a server-worded 4xx and shows verbatim — worse
    copy than the fallback it replaces.
  - (iii) `Status` only plus a 409-specific, translatable fallback at the two call
    sites. Cleanest against the translation rule, most code, and duplicated.

  **This tensions with the documented "strings live on the frontend" rule.** It is
  flagged as a judgement call: overturning it is cheap — drop `Message` and take
  option (iii).
- **`PredictionErrorResponse`** is never constructed. Every arm of
  `PredictionController` returns `Problem(...)`, so the declaration was wrong and
  the runtime body — a `ProblemDetails` — already carried `status`. Correcting the
  four `ProducesResponseType`s and deleting the dead DTO is smaller than adding a
  property and is the only change that makes the declaration true.
- The managed-rule 409 on the same action gains `status`: same defect, same method,
  one word.

### The 403 ordering

`detail` before `message` mirrors what #937 settled for the other arms; deriving
both arms from one `reason()` removes the second copy. The concrete behaviour it
fixes: an `HttpError` thrown by an invalidated query's refresh inside the same
`try` carries its reason on `body.message` and nowhere else, so the old ordering
flattened it to the literal string "Forbidden". A comment at `reason()` records the
attribution limit that refresh creates — a write that succeeded and a refresh that
was then refused reject the caller with a reason belonging to the read.

## Scope: `instanceof Error` is done; bare `catch {}` is a separate class

The `instanceof Error` sweep this issue describes **is complete**. It landed in
#960; re-running the triage confirmed every remaining site is unreachable by an
`HttpError` — NSwag `ApiClient` call sites (`ApiException extends Error`), local
IndexedDB/localStorage work, a `<svelte:boundary>` over prop-driven children, and
the client/server error hooks.

A **separate** class does remain: bare `catch {}` handlers that discard a remote
function's reason outright — roughly 40 across ~18 files (`RolesSection.svelte`
:116/:139/:155, `PublicAccessCard`, `ClientDevices`, `settings/members`, the
Discord integration, `food-state.svelte.ts`, `UploaderSetupView`, ...). This PR
does **not** sweep them; the orchestrator is filing that as its own issue.
`GuestLinksSection` is converted here as the exemplar, because its second handler
(`handleReissue`) already hand-rolled `(err as any)?.body?.message` and so was
forwarding a 5xx body and the client's own 403 boilerplate.

## Verification

- `vitest --config vitest.config.ts run`: **1 failed | 983 passed | 1 skipped**.
  The failure is `appearance-store.ssr.test.ts`, which fails identically on a clean
  tree.
- `vitest --config vitest.browser.config.ts run`: **4 failed | 335 passed | 1
  skipped**, the four already failing on `main` (`CalendarHeader` x2,
  `OidcProviderDialog`, `CurrentBGDisplay`).
- `pnpm check`: **54 errors**, unchanged from the pre-change baseline of 54.
- `dotnet test --filter AlertRule|Prediction|ReferencingRules`: **107 passed, 0
  failed**.
- Mutations, each restored and re-run green:
  - `reason()` back to `message ?? detail` -> the 403-arm refresh test fails.
  - `READ_SURFACE` flipped to the mutation policy -> 4 tests fail across both files.
  - `status` removed from `ReferencingRulesResponse` in the spec -> the schema guard
    fails, naming the operation.
  - `ReferencingRulesResponse.Message` plural branch widened (`Count == 1` to
    `>= 1`) -> `ReferencingRulesResponseTests` fails 1/4, restored green 4/4.
  - `fault` dropped from `PERMISSION_GATED_MUTATION` -> the two "does not blame
    the permission" tests fail, restored green.

### What the spec guard is and is not

`generated-error-status.test.ts` asserts that every typed error body a remote
operation declares for a forwarded status declares a `status` property (301
responses, 0 violations). Three limits, on the record:

- **Local-advisory only.** CI runs no `@nocturne/app` vitest, so nothing enforces
  it on a PR.
- **Only as fresh as the last local build.** It reads the gitignored generated
  `openapi.json`.
- **Presence, not value.** It cannot tell `status: 409` from `status: 200`; the new
  C# `ReferencingRulesResponseTests` covers the value. It also cannot see an
  undeclared anonymous body such as the managed-rule 409.


## Review follow-ups (second commit)

A hostile review round produced these changes:

- **The managed-rule 409 is now typed.** It returned an anonymous object under a
  `ProducesResponseType` declaring `ReferencingRulesResponse`, so the published
  schema lied and serde-strict generated clients (rust) would hard-fail on it.
  One record now covers both conflict branches, with `referencingRuleIds` always
  on the wire and `managedBy` nullable.
- **The spec guard no longer takes out the file on a fresh clone.** The spec is
  read inside the test and skipped with the build hint when the generated tree
  is absent, matching `generated-request-body.test.ts`.
- **The guard's claim is narrowed in its doc comment.** It validates the
  *declared* spec only: the generated client casts the raw wire body, so an
  action whose real body diverges from its declaration passes the guard and
  still flattens at runtime. The live instance of that class — V4 actions
  returning `BadRequest(new { error = … })` under autofilled `ProblemDetails`
  declarations (CgmComparison, Statistics, Analytics, SensorIntegrity; ~40
  sites) — is out of scope here and needs its own pass.
- `GetPredictions` dropped a declared 400 no arm can send.
- `permissionGatedMutationError` is exported once instead of two pages each
  pairing `describeRemoteError` with the policy by hand.

Two disclosure corrections to the earlier commit messages:

- **DndPanel's messages do change**: its 404 answer moves from
  `MISSING_ITEM_ERROR` to the caller's sentence and its 403 now surfaces a
  server-worded reason. Harmless — DnD settings is a tenant singleton, so a 404
  there was never a stale id — but "takes describeSubmitError unchanged" oversold it.
- **`PredictionErrorResponse` disappears from the spec and therefore from all
  generated SDKs.** It was never constructed, so no consumer received one, but
  an SDK consumer may have imported the type; worth a release-notes line.
