### PR TITLE
fix(sdk): keep the Java OAuth sources on the OkHttp 3.12 floor

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -424,9 +424,11 @@ jobs:
         working-directory: sdk/java/out
         run: |
           # Android consumers (xDrip) exclude this SDK's OkHttp 4.x/gson transitives and
-          # supply OkHttp 3.12.x / gson 2.8.x. The ApiClient template override in
-          # sdk/java/templates keeps the generated code compatible with both OkHttp majors;
+          # supply OkHttp 3.12.x / gson 2.8.x. The template overrides in
+          # sdk/java/templates keep the generated code compatible with both OkHttp majors;
           # this compile gate stops a generator upgrade from silently regressing that.
+          # The classpath mirrors the generated build.gradle's compile dependencies —
+          # a spec change that reaches new generated sources needs its deps added here.
           mkdir -p /tmp/floor
           for dep in \
             com/squareup/okhttp3/okhttp/3.12.13/okhttp-3.12.13.jar \
@@ -436,6 +438,8 @@ jobs:
             io/gsonfire/gson-fire/1.9.0/gson-fire-1.9.0.jar \
             com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar \
             org/openapitools/jackson-databind-nullable/0.2.9/jackson-databind-nullable-0.2.9.jar \
+            org/apache/oltu/oauth2/org.apache.oltu.oauth2.client/1.0.2/org.apache.oltu.oauth2.client-1.0.2.jar \
+            org/apache/oltu/oauth2/org.apache.oltu.oauth2.common/1.0.2/org.apache.oltu.oauth2.common-1.0.2.jar \
             jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar; do
             curl -sfL -o "/tmp/floor/$(basename "$dep")" "https://repo1.maven.org/maven2/$dep"
           done

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -427,8 +427,10 @@ jobs:
           # supply OkHttp 3.12.x / gson 2.8.x. The template overrides in
           # sdk/java/templates keep the generated code compatible with both OkHttp majors;
           # this compile gate stops a generator upgrade from silently regressing that.
-          # The classpath mirrors the generated build.gradle's compile dependencies —
-          # a spec change that reaches new generated sources needs its deps added here.
+          # The classpath is the generated build.gradle's declarations with okhttp and
+          # gson pinned DOWN to the floor, plus the transitives javac needs. Do not
+          # "sync" it to build.gradle — raising okhttp or gson here defeats the gate.
+          # New generated sources may need their own dependencies added.
           mkdir -p /tmp/floor
           for dep in \
             com/squareup/okhttp3/okhttp/3.12.13/okhttp-3.12.13.jar \

--- a/sdk/java/config.yaml
+++ b/sdk/java/config.yaml
@@ -1,8 +1,6 @@
 generatorName: java
 outputDir: ./out
-# Overrides ApiClient.mustache so RequestBody.create uses the MediaType-first
-# argument order, which exists in both OkHttp 3.12.x and 4.x. Android consumers
-# (xDrip) pin OkHttp 3.12.x; the stock template's content-first order is 4.x-only.
+# Overrides and the reason for each: sdk/java/templates/README.md.
 # Path is relative to the CI working directory (repo root).
 templateDir: sdk/java/templates
 globalProperties:

--- a/sdk/java/templates/README.md
+++ b/sdk/java/templates/README.md
@@ -35,8 +35,13 @@ The single `RequestBody.create(content, mediaType)` call site is swapped to the
 This file is only generated when the spec carries an OAuth2 security scheme,
 which `openapi-v4.json` gained after v0.2.4 — so the `RequestBody` guarantee
 was reached by a source file that no override covered, and the floor gate
-caught it. It also pulls in Apache Oltu (`org.apache.oltu.oauth2.client`,
-declared by the generated `build.gradle`), which the gate's classpath needs.
+caught it.
+
+The same scheme also generates `auth/RetryingOAuth.java` and OAuth branches in
+`ApiClient.java`. Those need no override, but all three import Apache Oltu, so
+the floor gate's classpath carries `org.apache.oltu.oauth2.client` (declared by
+the generated `build.gradle`) and its `org.apache.oltu.oauth2.common`
+transitive.
 
 ## `libraries/okhttp-gson/build.gradle.mustache`
 
@@ -61,3 +66,8 @@ When bumping the pinned `openapitools/openapi-generator-cli` version:
    see exactly what was changed).
 3. The floor-compatibility CI step catches a missed `RequestBody.create`
    swap; a missed build.gradle change surfaces as a gradle build failure.
+4. Diff the new stock `build.gradle.mustache`'s dependency block against the
+   floor step's classpath in `sdk-publish.yml`. A generator bump can change a
+   dependency version or add one; the two lists are maintained by hand and
+   nothing checks that they agree. A stale entry fails loudly (missing
+   package), never silently.

--- a/sdk/java/templates/README.md
+++ b/sdk/java/templates/README.md
@@ -1,6 +1,6 @@
 # Java SDK template overrides
 
-Both files are the stock templates from openapi-generator **v7.21.0**
+All three files are the stock templates from openapi-generator **v7.21.0**
 (`modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/`)
 with minimal, documented changes. Together with `../.openapi-generator-ignore`
 they replace all post-generation shell edits — the generated project under
@@ -26,6 +26,17 @@ Note: `okHttpVersion` in `config.yaml` is **not** a supported
 openapi-generator option — it was silently ignored (versions ≤ 0.2.3
 shipped requiring OkHttp 4.12.0 despite it). The template override plus the
 CI gate is what actually provides 3.x compatibility.
+
+## `libraries/okhttp-gson/auth/OAuthOkHttpClient.mustache`
+
+The single `RequestBody.create(content, mediaType)` call site is swapped to the
+`RequestBody.create(mediaType, content)` order, for the reason above.
+
+This file is only generated when the spec carries an OAuth2 security scheme,
+which `openapi-v4.json` gained after v0.2.4 — so the `RequestBody` guarantee
+was reached by a source file that no override covered, and the floor gate
+caught it. It also pulls in Apache Oltu (`org.apache.oltu.oauth2.client`,
+declared by the generated `build.gradle`), which the gate's classpath needs.
 
 ## `libraries/okhttp-gson/build.gradle.mustache`
 

--- a/sdk/java/templates/libraries/okhttp-gson/auth/OAuthOkHttpClient.mustache
+++ b/sdk/java/templates/libraries/okhttp-gson/auth/OAuthOkHttpClient.mustache
@@ -1,0 +1,73 @@
+{{>licenseInfo}}
+
+{{#hasOAuthMethods}}
+package {{invokerPackage}}.auth;
+
+import okhttp3.OkHttpClient;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import org.apache.oltu.oauth2.client.HttpClient;
+import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
+import org.apache.oltu.oauth2.client.response.OAuthClientResponse;
+import org.apache.oltu.oauth2.client.response.OAuthClientResponseFactory;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class OAuthOkHttpClient implements HttpClient {
+    private OkHttpClient client;
+
+    public OAuthOkHttpClient() {
+        this.client = new OkHttpClient();
+    }
+
+    public OAuthOkHttpClient(OkHttpClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public <T extends OAuthClientResponse> T execute(OAuthClientRequest request, Map<String, String> headers,
+                                                     String requestMethod, Class<T> responseClass)
+            throws OAuthSystemException, OAuthProblemException {
+
+        MediaType mediaType = MediaType.parse("application/json");
+        Request.Builder requestBuilder = new Request.Builder().url(request.getLocationUri());
+
+        if(headers != null) {
+            for (Entry<String, String> entry : headers.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase("Content-Type")) {
+                    mediaType = MediaType.parse(entry.getValue());
+                } else {
+                    requestBuilder.addHeader(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        RequestBody body = request.getBody() != null ? RequestBody.create(mediaType, request.getBody()) : null;
+        requestBuilder.method(requestMethod, body);
+
+        try {
+            Response response = client.newCall(requestBuilder.build()).execute();
+            return OAuthClientResponseFactory.createCustomResponse(
+                    response.body().string(),
+                    response.body().contentType().toString(),
+                    response.code(),
+                    response.headers().toMultimap(),
+                    responseClass);
+        } catch (IOException e) {
+            throw new OAuthSystemException(e);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        // Nothing to do here
+    }
+}
+{{/hasOAuthMethods}}


### PR DESCRIPTION
Fixes the `publish-java` half of #1076. The other two failures in that issue are credential-side and are not touched here.

## What broke

`openapi-v4.json` gained an oauth2 security scheme (authorizationCode flow) after v0.2.4, so openapi-generator now emits `auth/OAuthOkHttpClient.java`, `auth/RetryingOAuth.java` and OAuth branches in `ApiClient.java`. Two things followed:

1. Those sources import Apache Oltu. The generated `build.gradle` declares `org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2`, so a real gradle build resolves it — but the "Verify OkHttp 3.12 floor compatibility" step builds its own classpath by hand and had no Oltu, so it failed on missing packages before checking anything.
2. With Oltu on the classpath, the gate then caught the regression it exists for: `OAuthOkHttpClient.java:62` calls `RequestBody.create(request.getBody(), mediaType)`, and the content-first order is OkHttp 4.x-only. `ApiClient.mustache` is already overridden for exactly this reason — the new OAuth source was simply a file no override covered.

## Changes

- `sdk-publish.yml`: add `org.apache.oltu.oauth2.client` and `org.apache.oltu.oauth2.common` 1.0.2 to the floor classpath, and note that the classpath mirrors the generated `build.gradle`.
- New `sdk/java/templates/libraries/okhttp-gson/auth/OAuthOkHttpClient.mustache` — stock v7.21.0 template with the single `RequestBody.create` argument swap, matching the existing `ApiClient.mustache` convention.
- `sdk/java/templates/README.md`: document the third override in the place that already documents the other two.

The override changes the published artifact  both the binary and, via `withSourcesJar()`, the sources jar.

## Verification

Regenerated the SDK from the failed run's own spec artifact (`gh run download 33502874810 -n openapi-v4-spec`) with the pinned `openapitools/openapi-generator-cli:v7.21.0`, then ran the workflow's floor step verbatim:

- before: `package org.apache.oltu.oauth2.client does not exist` (matching CI)
- with Oltu only: `OAuthOkHttpClient.java:62: error: no suitable method found for create(String,MediaType)`
- with both changes: **`javac` exit 0, 818 sources** against OkHttp 3.12.13 / gson 2.8.6

https://claude.ai/code/session_012GGjZBkf5LL5czb7ZHtDe2


## Hostile review

A fresh-context reviewer reproduced all three results below independently (including re-downloading the spec artifact and checksumming it), ran the mutation that matters  reverting the override to the stock template and confirming the gate FAILS again  and added a check I had not: compiling all 818 sources against OkHttp 4.12.0 (what gradle actually ships), then extracting every `okhttp3`/`okio` member reference from the 3075 resulting classes with `javap -c` and resolving each against okhttp-3.12.13. 83 unique descriptors, 0 unresolved, including the `create(MediaType, String)` one at issue. So the shipped bytecode links against the floor, not merely compiles against it.

Its findings on comment/doc accuracy are fixed in the follow-up commit. Its two structural findings  the hand-maintained classpath being the wrong design, and the Oltu dependency dragging `org.json`/`commons-codec` into Android consumers  are filed separately, since neither is caused by this diff.