### PR TITLE
fix(web): rebuild the relative-time formatter only when the locale changes

### DIFF
--- a/src/Web/packages/app/src/lib/components/meals/MealBolusDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/meals/MealBolusDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatClock, formatMediumDateTime } from "$lib/utils/formatting";
+  import { formatClock, formatLocale } from "$lib/utils/formatting";
   import type { MealEvent, Bolus, BolusType, PatientInsulin } from "$lib/api";
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
@@ -65,9 +65,15 @@
     }
   });
 
+  // The locale's own medium date with a short time. Not the shared
+  // `formatMediumDateTime`, whose explicit field set spells the month out where
+  // this shape stays numeric — de-DE, ja-JP, ko-KR and ar-EG all differ.
   let mealTimestamp = $derived(
     meal?.timestamp
-      ? formatMediumDateTime(meal.timestamp)
+      ? new Date(meal.timestamp).toLocaleString(formatLocale(), {
+          dateStyle: "medium",
+          timeStyle: "short",
+        })
       : "",
   );
 

--- a/src/Web/packages/app/src/lib/stores/settings-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/settings-store.svelte.ts
@@ -5,7 +5,6 @@
  * state that can be shared across settings pages with two-way binding support.
  */
 
-import { formatNumericDate } from "$lib/utils/formatting";
 import { getContext, setContext } from "svelte";
 import { browser } from "$app/environment";
 import { getApiClient } from "$lib/api/client";
@@ -337,23 +336,4 @@ export function formatTime(time: string | undefined): string {
   const period = hours >= 12 ? "PM" : "AM";
   const displayHours = hours % 12 || 12;
   return `${displayHours}:${minutes.toString().padStart(2, "0")} ${period}`;
-}
-
-/**
- * Helper to format last sync time
- */
-export function formatLastSync(date: Date | undefined): string {
-  if (!date) return "Never";
-  const now = Date.now();
-  const then = new Date(date).getTime();
-  const diff = now - then;
-  const minutes = Math.floor(diff / 60000);
-
-  if (minutes < 1) return "Just now";
-  if (minutes < 60) return `${minutes}m ago`;
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-
-  return formatNumericDate(new Date(date));
 }

--- a/src/Web/packages/app/src/lib/utils/date-range.ts
+++ b/src/Web/packages/app/src/lib/utils/date-range.ts
@@ -20,7 +20,13 @@ export type DayRangeInput = {
   to?: string | null;
 };
 
-/** `YYYY-MM-DD` for a Date read in the local calendar, not the UTC calendar. */
+/**
+ * `YYYY-MM-DD` for a Date read in the local calendar, not the UTC calendar.
+ *
+ * This is also the right key for grouping rows by day: a locale-formatted date
+ * groups by whatever shape the region format produces, so changing the format
+ * mid-session re-buckets every group, and two days that format alike merge.
+ */
 export function toDayString(date: Date = new Date()): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -28,8 +34,14 @@ export function toDayString(date: Date = new Date()): string {
   return `${year}-${month}-${day}`;
 }
 
-/** Day part of a day string; a longer ISO string keeps only its date. */
-function dayPart(value: string): string {
+/**
+ * Day part of a day string; a longer ISO string keeps only its date.
+ *
+ * {@link isDayString} admits a longer ISO string by day-parting it internally but
+ * returns it whole, so anything handing its result to a bare `parseDate` — a range
+ * picker, a date arrow — has to day-part it first or `parseDate` throws.
+ */
+export function dayPart(value: string): string {
   return value.length > 10 ? value.slice(0, 10) : value;
 }
 

--- a/src/Web/packages/app/src/lib/utils/formatting.test.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.test.ts
@@ -411,7 +411,7 @@ describe("Shared date shapes", () => {
 		expect(english.long).toContain("Saturday");
 		expect(german.long).toContain("Samstag");
 		expect(english.weekday).toBe("Sat");
-		expect(german.weekday).toBe("Sa");
+		expect(german.weekday).toMatch(/^Sa\.?$/);
 		expect(english.month).toBe("Aug");
 		expect(english.monthYear).toBe("August 2026");
 	});
@@ -431,9 +431,9 @@ describe("Shared date shapes", () => {
 	});
 
 	it("leaves the clock to the locale on the surfaces that never followed a preference", () => {
-		// These sites passed no `hour12` before the sweep. German has no day-period
-		// abbreviation, so ICU would hand a German reader the English "AM" if the
-		// preference won here — and the padding follows the locale, not a per-site guess.
+		// German has no day-period abbreviation, so ICU would hand a German reader the
+		// English "AM" if the preference won here. The second iteration is what pins it:
+		// making these helpers read `prefersHour12()` fails only under "12".
 		for (const preference of ["12", "24"] as const) {
 			withTimeFormat(preference, () => {
 				expect(withRegionValue("en-GB", () => formatDayTime(date))).toContain("14:05");
@@ -456,7 +456,7 @@ describe("Shared date shapes", () => {
 			});
 			withTimeFormat("12", () => {
 				expect(time(date)).toBe("2:05 pm");
-				expect(formatDateTimeCompact(date)).toContain("02:05 pm");
+				expect(formatDateTimeCompact(date)).toMatch(/02:05\s*pm/i);
 			});
 		});
 	});
@@ -470,8 +470,6 @@ describe("Shared date shapes", () => {
 	});
 
 	it("takes the hour style from the locale, not from the call site", () => {
-		// HEAD passed `hour: "2-digit"` at some sites and `"numeric"` at others; each
-		// is wrong in half the locales, so it is read off the locale's own short time.
 		// Asserted literally rather than against a re-derived option set, which would
 		// move with the implementation.
 		const american = withRegionValue("en-US", () => formatDayTime(date)).replace(/\s/g, " ");
@@ -486,8 +484,8 @@ describe("Shared date shapes", () => {
 	});
 
 	it("reads an unusable value as no time rather than as 1970", () => {
-		// `time()` takes wire values now, and a nullable `mills` used to throw where it
-		// would otherwise render "Invalid Date" or the epoch into a treatment row.
+		// A nullable `mills` would otherwise render "Invalid Date" or the epoch into a
+		// treatment row.
 		expect(time(undefined)).toBe("—");
 		expect(time(null)).toBe("—");
 		expect(time("not a date")).toBe("—");
@@ -495,8 +493,7 @@ describe("Shared date shapes", () => {
 
 	it("reads a wire value, not only a Date", () => {
 		// NSwag types DTO date fields as `Date`, but the generated client parses with
-		// no reviver, so what actually arrives is an ISO string. `time()` was the one
-		// helper that did not coerce, and the active-alerts card threw on it.
+		// no reviver, so what actually arrives is an ISO string.
 		const iso = "2026-08-29T14:05:00.000Z";
 		withRegion("en-GB", () => {
 			expect(() => time(iso)).not.toThrow();

--- a/src/Web/packages/app/src/lib/utils/formatting.ts
+++ b/src/Web/packages/app/src/lib/utils/formatting.ts
@@ -187,8 +187,7 @@ export function time(
   date: Date | string | number | null | undefined,
   opts: { compact?: boolean; seconds?: boolean } = {}
 ): string {
-  // Coerced like every sibling helper: NSwag types DTO date fields as `Date` but
-  // the client parses with no reviver, so what arrives is an ISO string.
+  // Coerced for the reason {@link toDate} gives.
   if (date == null) return "—";
   const d = date instanceof Date ? date : new Date(date);
   if (Number.isNaN(d.getTime())) return "—";
@@ -298,7 +297,8 @@ export function formatNumericDate(date: Date | string | number): string {
 export function formatDateTime(dateStr: string | undefined): string {
   if (!dateStr) return "—";
   const date = new Date(dateStr);
-  return date.toLocaleDateString(formatLocale()) + " " + time(date);
+  if (Number.isNaN(date.getTime())) return "—";
+  return formatNumericDate(date) + " " + time(date);
 }
 
 /**
@@ -308,7 +308,8 @@ export function formatDateTime(dateStr: string | undefined): string {
  */
 export function formatDate(date: Date | string | number | undefined): string {
   if (date == null || date === "") return "N/A";
-  return new Date(date).toLocaleString(formatLocale());
+  const d = new Date(date);
+  return Number.isNaN(d.getTime()) ? "N/A" : d.toLocaleString(formatLocale());
 }
 
 /**
@@ -406,11 +407,9 @@ export function formatMediumDateTime(
  * The hour fields the locale's own short time uses — zero-padded and 24-hour where
  * it writes them that way, `2:05 pm` where it doesn't.
  *
- * Read off a `timeStyle: "short"` formatter rather than guessed, because the two
- * shapes HEAD used per site (`hour: "2-digit"` and `"numeric"`) each render wrongly
- * in half the locales. `timeStyle` itself cannot be combined with date fields, and
- * formatting the halves separately would hardcode a joiner that ja-JP, zh-CN and
- * ko-KR write as a space and ar-EG as U+060C — so the fields are extracted and
+ * `timeStyle` cannot be combined with date fields, and formatting the halves
+ * separately would hardcode a joiner that ja-JP, zh-CN and ko-KR write as a space
+ * and ar-EG as U+060C — so the fields are read off a `timeStyle: "short"` probe and
  * spread into a single `Intl` call, which lets ICU supply the glue.
  */
 const localeHourFields = (() => {
@@ -430,7 +429,6 @@ const localeHourFields = (() => {
     const fields: Intl.DateTimeFormatOptions = {
       hour: (hour?.value.length ?? 1) > 1 ? "2-digit" : "numeric",
       minute: "2-digit",
-      hour12: formatter.resolvedOptions().hour12,
     };
     cache.set(locale, fields);
     return fields;
@@ -456,13 +454,9 @@ export function formatClock(
 /**
  * Day and time with no year, e.g. "30 Aug, 00:05".
  *
- * Follows the locale's hour cycle, not the 12/24 preference — which is what these
- * surfaces did before they were routed through a shared formatter, and changing it
- * is not the locale sweep's business. The app is inconsistent about this: sibling
- * surfaces use {@link formatDateTimeCompact} and do follow the preference. Settling
- * it means giving the preference a "follow the locale" default, which needs the
- * API's `AllowedTimeFormats` widened to accept it and every direct
- * `timeFormat.current === "24"` comparison updated.
+ * Follows the locale's hour cycle, not the 12/24 preference; sibling surfaces
+ * ({@link formatDateTimeCompact}) follow the preference. Unifying them needs a
+ * "follow the locale" value in the preference itself.
  */
 export function formatDayTime(date: Date | string | number | undefined): string {
   if (date == null) return "—";

--- a/src/Web/packages/app/src/lib/utils/index.ts
+++ b/src/Web/packages/app/src/lib/utils/index.ts
@@ -99,11 +99,14 @@ export function getDirectionInfo(direction?: Direction | string): DirectionInfo 
 /** Enhanced relative time formatting with internationalization support */
 const getRelativeTimeFormatter = (() => {
   let formatter: Intl.RelativeTimeFormat | null = null;
+  let cachedFor: string | null = null;
   return (locale?: string) => {
     const wanted = locale || formatLocale();
-    // Compared every call, not only when a locale is passed: the no-argument path
-    // is the common one, and it used to pin whatever the first call resolved.
-    if (!formatter || wanted !== formatter.resolvedOptions().locale) {
+    // Keyed on the requested tag, not on `resolvedOptions().locale`: ICU answers
+    // "nb-NO" with "nb", so comparing against the resolved tag never matches and
+    // rebuilds the formatter on every call.
+    if (!formatter || wanted !== cachedFor) {
+      cachedFor = wanted;
       formatter = new Intl.RelativeTimeFormat(wanted, {
         numeric: "auto",
         style: "long",

--- a/src/Web/packages/app/src/lib/utils/relative-time.test.ts
+++ b/src/Web/packages/app/src/lib/utils/relative-time.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { timeAgo } from "./index";
+
+const NOW = Date.UTC(2026, 7, 29, 14, 5);
+
+// `Intl.RelativeTimeFormat` is declared read-only, so the counting double is
+// installed through a mutable view of the namespace.
+const intl = Intl as { RelativeTimeFormat: typeof Intl.RelativeTimeFormat };
+
+/** How many `Intl.RelativeTimeFormat`s `run` constructs. */
+function countFormatters(run: () => void): number {
+  const real = intl.RelativeTimeFormat;
+  let built = 0;
+  intl.RelativeTimeFormat = class extends real {
+    constructor(...args: ConstructorParameters<typeof real>) {
+      built++;
+      super(...args);
+    }
+  };
+  try {
+    run();
+  } finally {
+    intl.RelativeTimeFormat = real;
+  }
+  return built;
+}
+
+describe("timeAgo", () => {
+  it("builds one formatter per locale, however many times it is called", () => {
+    // Once per call is a real cost: `timeAgo` is read from deriveds bound to a
+    // ticking clock, and once per row in a device list.
+    const built = countFormatters(() => {
+      for (let i = 0; i < 5; i++) timeAgo(NOW - 60_000, "en-GB", NOW);
+    });
+    expect(built).toBe(1);
+  });
+
+  it("caches a tag ICU answers under a shorter name", () => {
+    // `new Intl.RelativeTimeFormat("nb-NO").resolvedOptions().locale` is "nb", so a
+    // cache keyed on the resolved tag never matches what was asked for.
+    expect(new Intl.RelativeTimeFormat("nb-NO").resolvedOptions().locale).toBe(
+      "nb"
+    );
+
+    const built = countFormatters(() => {
+      for (let i = 0; i < 5; i++) timeAgo(NOW - 60_000, "nb-NO", NOW);
+    });
+    expect(built).toBe(1);
+  });
+
+  it("rebuilds when the locale actually changes", () => {
+    const built = countFormatters(() => {
+      timeAgo(NOW - 60_000, "en-GB", NOW);
+      timeAgo(NOW - 60_000, "de-DE", NOW);
+    });
+    expect(built).toBe(2);
+  });
+});

--- a/src/Web/packages/app/src/routes/(authenticated)/meals/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/meals/+page.svelte
@@ -196,9 +196,6 @@
       const mills = meal.carbIntakes?.[0]?.mills;
       if (!mills) continue;
 
-      // Keyed on the calendar day, not on a formatted string: a locale-formatted
-      // key groups by whatever shape the region format happens to produce, and
-      // changing the format mid-session would re-bucket every meal.
       const dateKey = toDayString(new Date(mills));
 
       if (!grouped.has(dateKey)) {

--- a/src/Web/packages/app/src/routes/(authenticated)/notifications/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/notifications/+page.svelte
@@ -148,8 +148,6 @@
       const date = new Date(
         instance.completedAt ?? instance.startedAt ?? new Date()
       );
-      // Keyed on the calendar day, not on a formatted string: a locale-formatted
-      // key re-buckets every group when the region format changes.
       const key = toDayString(date);
       if (!groups[key]) groups[key] = [];
       groups[key].push(instance);

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/comparison/+page.svelte
@@ -14,7 +14,13 @@
   import { untrack } from "svelte";
   import { useSearchParams } from "runed/kit";
   import { z } from "zod";
-  import { dayCount, isDayString, startOfDay, toDayString } from "$lib/utils/date-range";
+  import {
+    dayCount,
+    dayPart,
+    isDayString,
+    startOfDay,
+    toDayString,
+  } from "$lib/utils/date-range";
 
   const PRESETS = [
     "last7-prior7",
@@ -114,10 +120,8 @@
   function readCommitted(): Periods {
     const preset = urlParams.preset ?? DEFAULT_PRESET;
     const fromPreset = computePreset(preset === "custom" ? DEFAULT_PRESET : preset);
-    // Day-parted: `isDayString` accepts a longer ISO string by slicing but returns
-    // it whole, and the range picker's `parseDate` throws on everything past the date.
     const day = (value: string | null, fallback: string) =>
-      (isDayString(value) ? value : fallback).slice(0, 10);
+      dayPart(isDayString(value) ? value : fallback);
     return {
       a: {
         label: urlParams.aLabel ?? fromPreset.a.label,

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/data-quality/compression-lows/+page.svelte
@@ -268,7 +268,7 @@
 		const date = nightOf instanceof Date ? nightOf : new Date(nightOf);
 		const nextDay = new Date(date);
 		nextDay.setDate(nextDay.getDate() + 1);
-		// `{ day, year }` alone has no CLDR pattern — it fell back to "2026 (day: 30)".
+		// `{ day, year }` has no CLDR pattern; ICU renders it as "2026 (day: 30)".
 		return `Night of ${formatShortDate(date)} \u2013 ${formatShortDate(nextDay, true)}`;
 	}
 

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/week-to-week/+page.svelte
@@ -37,9 +37,6 @@
     buildWeekdayBuckets(reportsResource.current?.entries ?? [], (mgdl) => bg(mgdl))
   );
 
-  // Navigation helpers
-  // Stepped on the calendar rather than by 24-hour spans, so a week either side of
-  // a DST transition is still seven days on the patient's clock.
   function previousWeek() {
     const newEnd = parseDate(reportsParams.fromDay).subtract({ days: 1 });
     const newStart = newEnd.subtract({ days: 6 });

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatLocale } from "$lib/utils/formatting";
+  import { time } from "$lib/utils/formatting";
   import { getSettingsStore } from "$lib/stores/settings-store.svelte";
   import {
     getColorTheme,
@@ -128,14 +128,9 @@
     }
   });
 
-  // Current time in timezone for display
-  const currentTime = $derived(
-    new Date(realtimeStore.now).toLocaleTimeString(formatLocale(), {
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    })
-  );
+  // Follows the 12/24 preference, which the selector two cards below sets: this
+  // field is the only place a reader sees that choice take effect.
+  const currentTime = $derived(time(realtimeStore.now, { seconds: true }));
 
   /**
    * This page carries two scopes: units, formats, theme, chart style, widgets and language live on

--- a/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/time-spans/+page.svelte
@@ -12,6 +12,7 @@
   import { getTimeSpansData } from "./data.remote";
   import {
     dayCount as countDays,
+    dayPart,
     isDayString,
     resolveDayRange,
     startOfDay,
@@ -23,15 +24,13 @@
   // `toISOString()` named yesterday for anyone east of UTC.
   const defaults = resolveDayRange({ days: 7 }, 7);
 
-  // Day-parted here rather than at each use: `isDayString` accepts a longer ISO
-  // string by slicing, and `parseDate` throws on everything past the date.
   const fromParam = $derived.by(() => {
     const fromUrl = page.url.searchParams.get("from");
-    return (isDayString(fromUrl) ? fromUrl : defaults.from).slice(0, 10);
+    return dayPart(isDayString(fromUrl) ? fromUrl : defaults.from);
   });
   const toParam = $derived.by(() => {
     const fromUrl = page.url.searchParams.get("to");
-    return (isDayString(fromUrl) ? fromUrl : defaults.to).slice(0, 10);
+    return dayPart(isDayString(fromUrl) ? fromUrl : defaults.to);
   });
 
   // Fetch data using remote function with date range
@@ -89,8 +88,6 @@
 
   /** Shift the window by whole days, keeping its length. */
   function shiftPeriod(direction: -1 | 1) {
-    // Stepped on the calendar rather than by 24-hour spans, so a window either
-    // side of a DST transition keeps its length in days.
     const anchor = parseDate(direction === -1 ? fromParam : toParam);
     const newFirst = anchor.add({ days: direction * (direction === -1 ? dayCount : 1) });
     const newLast = newFirst.add({ days: dayCount - 1 });


### PR DESCRIPTION
Follow-up to a hostile review of #1069, which merged before the findings were applied. Two are user-visible.

## `nb-NO` rebuilt an `Intl.RelativeTimeFormat` on every call

`getRelativeTimeFormatter` compared the requested locale against `resolvedOptions().locale` — the canonicalised tag ICU actually has data for, not the tag asked for. Of the 22 tags in `REGION_FORMATS`, `nb-NO` is the only one that does not round-trip:

```
Intl.RelativeTimeFormat("nb-NO").resolvedOptions().locale === "nb"
```

So for a reader on that regional format the guard was permanently true, and every call constructed a fresh formatter — the most expensive of the Intl constructors. `timeAgo` is read from four `$derived`s bound to a ticking clock and once per row inside a device-list template. Now keyed on the requested tag.

`timeAgo` had **no tests at all**, which is exactly why this could regress unnoticed. Three new ones pin it, and the `nb-NO` case is mutation-proved: restoring the resolved-tag comparison fails it with `expected 5 to be 1` while the round-tripping locales keep passing.

## The appearance page contradicted its own 12/24 selector

"Current Time" followed the locale's hour cycle while the Time-format selector sat two cards below it. Choosing **12-hour** with regional format **United Kingdom** displayed `14:05:23` — a 24-hour clock on the one page where the reader had just chosen 12-hour. It now goes through `time()`.

## The meal dialog's timestamp changed shape in four locales

That site already used `{ dateStyle: "medium", timeStyle: "short" }` and needed only the locale argument. Routing it through `formatMediumDateTime`, whose explicit field set spells the month out, changed the output:

| locale | before | after #1069 |
|---|---|---|
| de-DE | `29.08.2026, 14:05` | `29. Aug. 2026, 14:05` |
| ja-JP | `2026/08/29 14:05` | `2026年8月29日 14:05` |
| ko-KR | `2026. 8. 29. 오후 2:05` | `2026년 8월 29일 오후 2:05` |
| ar-EG | `٢٩‏/٠٨‏/٢٠٢٦، ٢:٠٥ م` | `٢٩ أغسطس ٢٠٢٦، ٢:٠٥ م` |

Reverted to the original option set with `formatLocale()`.

## Smaller

- **`localeHourFields` no longer sets `hour12`.** It was read off the locale's own short-time formatter, so it could only restate the default (verified byte-identical for en-US, en-GB, de-DE, ja-JP, ar-EG, ko-KR, fi-FI) — while an explicit `hour12` *overrides* `hourCycle`, forcing h24→h23 and h11→h12.
- **`dayPart` is exported** rather than re-implemented as `.slice(0, 10)` at two call sites, and now owns the reason those sites need it.
- **`formatDateTime` / `formatDate`** read an unparseable value as absent instead of splicing `Invalid Date` into half the output.
- **`formatLastSync` deleted** — no callers anywhere in `src/Web`; #1069 had wired a fresh import into dead code.

## Corrected comments

- **A DST claim that was false.** The week-to-week and time-spans stepping comments said moving to `parseDate().add()` fixed arrows across a DST transition. `setDate` *is* calendar arithmetic and was already correct — verified under `TZ=Australia/Sydney` across the 2026-10-04 transition. The code is fine; the claim is gone.
- Duplicated grouping-key rationale (`meals` + `notifications`) moves to `toDayString`, which both call.
- Change-history narration removed from `formatting.ts` (×2), `utils/index.ts`, `compression-lows` and `formatting.test.ts` (×4) — "HEAD used", "did before they were routed through", "used to pin", "it fell back to".
- `formatDayTime`'s roadmap paragraph is cut to the invariant.

## Refuted

The review also flagged four sites where `{count?.toLocaleString()}` became `formatNumber(count)` as blank→`"0"`. Both records are typed `Record<string, number>` with non-nullable values, so the `?.` was dead and the two are exactly equivalent. Left alone.

## Testing

- `pnpm run check`: **20 errors, identical to the `origin/main` baseline.**
- `pnpm run test:unit`: **983 passed**; the single failure (`appearance-store.ssr.test.ts`) is pre-existing on main.
- `prettier --check`: the 13 touched files fail identically on main; **no new failures**, and the new test file is clean.
