### PR TITLE
test(web): assert the last chart window, and give the getter rule one owner

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChart.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChart.svelte
@@ -81,9 +81,6 @@
   }: Props = $props();
 
   // ---- Engine ----
-  // Getters, not `{ dateRange, ... }`: a prop read into an object literal is read
-  // once, so an engine built that way freezes on the range it was created with —
-  // stepping the day on Day in Review left the chart drawing the day before.
   const engine = createChartDataEngine({
     get dateRange() { return dateRange; },
     get focusHours() { return focusHours; },

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartCard.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartCard.svelte
@@ -87,9 +87,6 @@
   const isMobile = new IsMobile();
 
   // ===== ENGINE =====
-  // Getters, not `{ dateRange, ... }`: a prop read into an object literal is read
-  // once, so an engine built that way freezes on the range it was created with —
-  // stepping the day on Day in Review left the chart drawing the day before.
   const engine = createChartDataEngine({
     get dateRange() { return dateRange; },
     get focusHours() { return defaultFocusHours; },

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartRangeHarness.test.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/GlucoseChartRangeHarness.test.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
-  // Test-only harness: mounts a real chart component so the props-to-engine wiring
-  // under test is the production one. A harness that built the engine itself would
-  // pass whether or not the component keeps its `dateRange` prop reactive.
-  //
-  // Both components are covered because each builds its own engine and a fix
-  // applied to one leaves the other frozen. `GlucoseChartCard` is what Day in
-  // Review, the readings report and the dashboard render; `GlucoseChart` is the
-  // shell they wrap, rendered by nothing else today.
+  // Mounts a real chart component so the props-to-engine wiring under test is the
+  // production one. A harness that built the engine itself would pass whether or
+  // not the component keeps its `dateRange` prop reactive.
   import { createRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import GlucoseChart from "./GlucoseChart.svelte";
   import GlucoseChartCard from "./GlucoseChartCard.svelte";
@@ -39,6 +34,10 @@
   {#if component === "card"}
     <GlucoseChartCard {dateRange} showPredictions={false} />
   {:else}
-    <GlucoseChart {dateRange} enablePredictions={false} enableInspection={false} />
+    <GlucoseChart
+      {dateRange}
+      enablePredictions={false}
+      enableInspection={false}
+    />
   {/if}
 </div>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/chart-date-range-reactivity.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/chart-date-range-reactivity.svelte.test.ts
@@ -1,15 +1,16 @@
 import { render } from "vitest-browser-svelte";
 import { describe, it, expect, vi } from "vitest";
 
-type ChartWindow = { startTime: number; endTime: number; intervalMinutes: number };
+type ChartWindow = {
+  startTime: number;
+  endTime: number;
+  intervalMinutes: number;
+};
 
 // `vi.mock` factories are hoisted above every other statement, so the spy has to
 // be created in a hoisted block for both the factory and the assertions to see it.
 const { getChartData } = vi.hoisted(() => ({
-  getChartData: vi.fn((window: ChartWindow) => {
-    void window;
-    return Promise.resolve(transformed());
-  }),
+  getChartData: vi.fn((_window: ChartWindow) => Promise.resolve(transformed())),
 }));
 
 vi.mock("$api/chart-data.remote", () => ({ getChartData }));
@@ -21,8 +22,7 @@ vi.mock("$api/predictions.remote", () => ({
 import { transformChartData } from "$lib/utils/chart-data-transform";
 import Harness from "./GlucoseChartRangeHarness.test.svelte";
 
-// The server half of the merge is deliberately empty: what is under test is which
-// window the chart asks for, not what comes back.
+// The payload is irrelevant: the assertion is on the request, not the response.
 function transformed() {
   return transformChartData({});
 }
@@ -34,17 +34,13 @@ function day(offsetDays: number): { from: Date; to: Date } {
   return { from, to: new Date(from.getTime() + DAY - 1) };
 }
 
-/** The window starts the chart has asked the server for. */
 function requestedStarts(): number[] {
   return getChartData.mock.calls.map(([window]) => window.startTime);
 }
 
 /**
- * Stepping a day on Day in Review swaps this prop and nothing else. Each component
- * builds its OWN engine, and an engine built from a flattened `{ dateRange }` object
- * literal reads the prop once — so the chart keeps drawing whichever day it was
- * mounted on. Both are asserted because fixing one leaves the other frozen, and Day
- * in Review — the surface this was reported on — renders the Card.
+ * Each component builds its own engine, so each has to keep its `dateRange`
+ * prop reactive independently — see `ChartDataEngineOptions.dateRange`.
  */
 describe.each([
   ["GlucoseChart", "chart"],
@@ -55,19 +51,21 @@ describe.each([
 
     let setRange!: (range: { from: Date; to: Date }) => void;
     render(Harness, {
-      props: { component, initialRange: day(0), onready: (set) => (setRange = set) },
+      props: {
+        component,
+        initialRange: day(0),
+        onready: (set) => (setRange = set),
+      },
     });
 
     await vi.waitFor(() =>
-      expect(requestedStarts()).toContain(day(0).from.getTime())
+      expect(requestedStarts().at(-1)).toBe(day(0).from.getTime())
     );
 
     setRange(day(-1));
 
-    // Asked for at all, rather than asked for last: the sibling case's chart is
-    // still mounted and can land a fetch of its own in between.
     await vi.waitFor(() =>
-      expect(requestedStarts()).toContain(day(-1).from.getTime())
+      expect(requestedStarts().at(-1)).toBe(day(-1).from.getTime())
     );
   });
 });

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte.ts
@@ -176,6 +176,13 @@ export const TREATMENT_PROXIMITY_MS = 5 * 60 * 1000;
 // ===== Options & Interfaces =====
 
 export interface ChartDataEngineOptions {
+  /**
+   * Pass as a getter (`get dateRange() { … }`) wherever this can change while the
+   * engine lives: read into a plain object literal it is captured once, and the
+   * engine goes on fetching and drawing the window it was constructed with. A
+   * consumer that instead re-creates the engine per window — `{#key}` around an
+   * `{@const}` — may pass the value directly.
+   */
   dateRange?: { from: Date | string; to: Date | string };
   focusHours?: number;
   initialChartData?: TransformedChartData | null;


### PR DESCRIPTION
Follow-up to a hostile review of #1071, which merged before the findings were applied. Test-only.

## The assertion rested on a mechanism that does not exist

The test asserted the new window appeared *anywhere* in the call history, justified by this comment:

> `// Asked for at all, rather than asked for last: the sibling case's chart is`
> `// still mounted and can land a fetch of its own in between.`

That is not so. `vitest-browser-svelte` registers `beforeEach(cleanup)`, and cleanup unmounts through `flushSync(unmount)` — the previous case is destroyed **synchronously** before the next body runs. There is no sibling fetch to tolerate.

Matching anywhere in the history is also the one assertion shape that hides a stray or duplicate request, so the comment was actively discouraging the tightening it should have had. It now asserts the **last** requested window, and the comment is gone.

Both cases remain mutation-proved after the change, and this time **both** were proved rather than just the Card — flattening `dateRange` in `GlucoseChart` fails the `chart` case (`expected 1787961600000 to be 1787875200000`) and leaves `card` passing, and vice versa.

## The getter rule had two owners and covered neither of the other four call sites

The same three-line comment was byte-identical in `GlucoseChart.svelte` and `GlucoseChartCard.svelte`. There are six `createChartDataEngine` call sites; a comment on two of them is both duplicated and under-inclusive.

It moves to `ChartDataEngineOptions.dateRange`, which every call site already reads. The note there also records the alternative the other sites legitimately use — re-creating the engine per window under `{#key}`, as `ReplayPanel` and `compression-lows` do — so the next reader does not "fix" a site that is already correct.

Both components are now **byte-identical to main**: this PR is purely additive.

## Formatting

Both files added in #1071 failed `prettier --check` (their direct siblings pass, so it was introduced, not inherited). Formatted.

## Not addressed here

**No CI job runs this suite.** `web-typecheck` excludes `@nocturne/app`, and `test:browser` is in neither `pnpm test` nor the workflow — so nothing but a hand-typed `pnpm --filter @nocturne/app run test:browser` ever executes it, and nothing typechecks the harness. That makes this developer-run-only cover. Gating it needs a chromium job that first runs the NSwag/Zod codegen, which is a CI change rather than a test change; flagging it rather than folding it in.

## Testing

`pnpm exec vitest --config vitest.browser.config.ts --run chart-date-range-reactivity`: 2 passed, against the current main.
