### PR TITLE
fix(web): batch realtime entry creates during catch-up

### DIFF
--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -649,7 +649,7 @@ export class RealtimeStore {
     });
 
     if (additions.length > 0) {
-      this.entries = [...this.entries, ...additions]
+      this.entries = [...additions.reverse(), ...this.entries]
         .sort((a, b) => (b.mills || 0) - (a.mills || 0))
         .slice(0, 1000);
     }

--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -74,6 +74,16 @@ export class RealtimeStore {
   private websocketClient!: WebSocketClient;
   private _initStarted = false;
 
+  /**
+   * Storage creates can arrive as hundreds of individual Socket.IO messages
+   * during connector catch-up. Applying each one immediately replaces and
+   * sorts the full entries array, which also recomputes every chart derived
+   * from it. Buffer a short burst and commit it as one reactive update.
+   */
+  private pendingEntryCreates = new Map<string, Entry>();
+  private entryCreateFlushTimeout: ReturnType<typeof setTimeout> | null = null;
+  private static readonly ENTRY_CREATE_BATCH_MS = 100;
+
   /** Loading state - false until initial data is loaded */
   isReady = $state(false);
 
@@ -569,18 +579,7 @@ export class RealtimeStore {
     this.updateLastDataReceived();
 
     if (colName === "entries" && this.isEntry(doc)) {
-      // Check for duplicates
-      const exists = this.entries.some(
-        (entry) =>
-          entry._id === doc._id ||
-          (entry.mills === doc.mills && entry.sgv === doc.sgv)
-      );
-
-      if (!exists) {
-        this.entries = [doc, ...this.entries]
-          .sort((a, b) => (b.mills || 0) - (a.mills || 0))
-          .slice(0, 1000);
-      }
+      this.queueEntryCreate(doc);
     } else if (colName === "devicestatus" && this.isDeviceStatus(doc)) {
       const exists = this.deviceStatuses.some(
         (ds) => ds._id === doc._id
@@ -593,6 +592,66 @@ export class RealtimeStore {
       }
 
       this.scheduleDecompositionRefresh();
+    }
+  }
+
+  private entryIdentity(entry: Entry): string {
+    return entry._id
+      ? `id:${entry._id}`
+      : this.entryReadingIdentity(entry);
+  }
+
+  private entryReadingIdentity(entry: Entry): string {
+    return `reading:${entry.mills ?? ""}:${entry.sgv ?? ""}`;
+  }
+
+  private queueEntryCreate(entry: Entry): void {
+    // A later event with the same identity wins. This also makes an update that
+    // arrives before the batch flush replace the pending create cleanly.
+    this.pendingEntryCreates.set(this.entryIdentity(entry), entry);
+    if (this.entryCreateFlushTimeout !== null) {
+      clearTimeout(this.entryCreateFlushTimeout);
+    }
+
+    this.entryCreateFlushTimeout = setTimeout(
+      () => this.flushPendingEntryCreates(),
+      RealtimeStore.ENTRY_CREATE_BATCH_MS,
+    );
+  }
+
+  private flushPendingEntryCreates(): void {
+    this.entryCreateFlushTimeout = null;
+    if (this.pendingEntryCreates.size === 0) return;
+
+    const pending = [...this.pendingEntryCreates.values()];
+    this.pendingEntryCreates.clear();
+
+    const knownIds = new Set(
+      this.entries
+        .map((entry) => entry._id)
+        .filter((id): id is string => typeof id === "string"),
+    );
+    const knownReadings = new Set(
+      this.entries.map((entry) => this.entryReadingIdentity(entry)),
+    );
+    const additions = pending.filter((entry) => {
+      const readingIdentity = this.entryReadingIdentity(entry);
+      if (
+        (typeof entry._id === "string" && knownIds.has(entry._id)) ||
+        knownReadings.has(readingIdentity)
+      ) {
+        return false;
+      }
+
+      if (typeof entry._id === "string") knownIds.add(entry._id);
+      knownReadings.add(readingIdentity);
+      return true;
+    });
+
+    if (additions.length > 0) {
+      this.entries = [...this.entries, ...additions]
+        .sort((a, b) => (b.mills || 0) - (a.mills || 0))
+        .slice(0, 1000);
     }
   }
 
@@ -620,6 +679,7 @@ export class RealtimeStore {
     const { colName, doc } = event;
 
     if (colName === "entries") {
+      this.pendingEntryCreates.delete(this.entryIdentity(doc));
       this.entries = this.entries.filter((entry) => entry._id !== doc._id);
     }
   }
@@ -897,6 +957,12 @@ export class RealtimeStore {
       }
     }
     this.websocketClient.destroy();
+
+    if (this.entryCreateFlushTimeout !== null) {
+      clearTimeout(this.entryCreateFlushTimeout);
+      this.entryCreateFlushTimeout = null;
+    }
+    this.pendingEntryCreates.clear();
 
     // Clear the module-level singleton so the next createRealtimeStore() builds
     // a fresh store rather than resurrecting this torn-down instance with stale

--- a/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
@@ -173,6 +173,52 @@ describe("RealtimeStore direction", () => {
   });
 });
 
+describe("RealtimeStore entry create batching", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces a connector catch-up burst into one entry update", async () => {
+    const store = makeStore();
+
+    for (let index = 0; index < 100; index += 1) {
+      store.handleCreate({
+        colName: "entries",
+        doc: {
+          _id: `reading-${index}`,
+          type: "sgv",
+          sgv: 100 + (index % 20),
+          mills: 1_000_000 + index,
+        },
+      });
+      await vi.advanceTimersByTimeAsync(2);
+    }
+
+    // Preserve the existing duplicate rule when IDs differ but the timestamp
+    // and glucose value identify the same reading.
+    store.handleCreate({
+      colName: "entries",
+      doc: {
+        _id: "duplicate-reading-42",
+        type: "sgv",
+        sgv: 102,
+        mills: 1_000_042,
+      },
+    });
+
+    expect(store.entries).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(store.entries).toHaveLength(100);
+    expect(store.entries[0]._id).toBe("reading-99");
+
+    store.destroy();
+  });
+});
+
 describe("RealtimeStore sync progress", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.test.ts
@@ -217,6 +217,32 @@ describe("RealtimeStore entry create batching", () => {
 
     store.destroy();
   });
+
+  it("keeps later creates first when timestamps are equal", async () => {
+    const store = makeStore();
+    store.entries = [
+      { _id: "existing", type: "sgv", sgv: 90, mills: 1_000 },
+    ];
+
+    store.handleCreate({
+      colName: "entries",
+      doc: { _id: "first-create", type: "sgv", sgv: 100, mills: 1_000 },
+    });
+    store.handleCreate({
+      colName: "entries",
+      doc: { _id: "second-create", type: "sgv", sgv: 110, mills: 1_000 },
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(store.entries.map((entry) => entry._id)).toEqual([
+      "second-create",
+      "first-create",
+      "existing",
+    ]);
+
+    store.destroy();
+  });
 });
 
 describe("RealtimeStore sync progress", () => {

--- a/src/Web/packages/bridge/src/lib/socketio-server.ts
+++ b/src/Web/packages/bridge/src/lib/socketio-server.ts
@@ -468,7 +468,10 @@ class SocketIOServer {
     logger.debug(`Broadcasting storage ${eventType} event to ${clientCount} connected clients${tenantSlug ? ` (tenant: ${tenantSlug})` : ''}`);
 
     if (clientCount === 0) {
-      logger.warn('No Socket.IO clients connected - events will not be delivered to frontend');
+      // This is normal while the service starts or a connector catches up
+      // before anyone opens the UI. Keep it at debug level so a backfill does
+      // not turn hundreds of harmless undeliverable events into a log storm.
+      logger.debug('No Socket.IO clients connected - event will not be delivered to frontend');
     }
 
     target.emit(eventType, data);


### PR DESCRIPTION
## What

- Buffer short bursts of realtime `entries` create events and apply them in one reactive update.
- Preserve the existing ID and `(mills, sgv)` deduplication, newest-first ordering (including equal timestamps), and 1,000-entry cap.
- Treat the expected zero-Socket.IO-client state as debug information instead of emitting one warning per backfilled event.
- Add regression tests for a sustained 100-reading catch-up burst, duplicate readings with different IDs, and equal-timestamp tie ordering.

## Why

Connector catch-up sends each imported reading as an individual Socket.IO create event. The store previously copied and sorted the entire entries array for every message. Each assignment also retriggered chart derivations, so a few hundred imported readings could make the Readings report unresponsive even while the host was otherwise idle.

I reproduced this with a 497-entry catch-up. Before the change, the report's DOM did not settle within 20 seconds and the bridge emitted dozens of expected no-client warnings per second. With the batched store deployed, fresh Readings loads settled in roughly 0.68–1.15 seconds.

## Verification

- `vitest run --config vitest.config.ts --maxWorkers=1 --no-file-parallelism src/lib/stores/realtime-store.test.ts`: 16 passed
- `pnpm --filter @nocturne/bridge test`: 51 passed
- `pnpm --filter @nocturne/bridge build`: passed
- `pnpm --filter @nocturne/bot build`: passed
- Release API build with generated clients: 0 errors
- `git diff --check`: passed

The full SvelteKit production build reached application transformation but could not finish on this local host after it exhausted available memory. No application compile error was reported before the resource failure.