### PR TITLE
Recover error details from unparsed API responses

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/GuestLinkController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/GuestLinkController.cs
@@ -42,7 +42,7 @@ public class GuestLinkController : ControllerBase
     [RemoteCommand(Invalidates = ["GetGuestLinks"])]
     [ProducesResponseType(typeof(GuestLinkCreationResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> CreateGuestLink(
         [FromBody] CreateGuestLinkRequest request,
         CancellationToken ct)
@@ -72,11 +72,11 @@ public class GuestLinkController : ControllerBase
         }
         catch (ArgumentException ex)
         {
-            return BadRequest(new { error = ex.Message });
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest, title: "Bad Request");
         }
         catch (InvalidOperationException ex)
         {
-            return BadRequest(new { error = ex.Message });
+            return Problem(detail: ex.Message, statusCode: StatusCodes.Status400BadRequest, title: "Bad Request");
         }
     }
 
@@ -157,7 +157,7 @@ public class GuestLinkController : ControllerBase
     [AllowAnonymous]
     [EnableRateLimiting("guest-activate")]
     [ProducesResponseType(typeof(ActivateGuestLinkResponse), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ActivateGuestLinkResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> ActivateGuestLink(
         [FromBody] ActivateGuestLinkRequest request,
         CancellationToken ct)
@@ -168,14 +168,17 @@ public class GuestLinkController : ControllerBase
         var result = await _guestLinkService.ActivateAsync(request.Code, ip, userAgent, ct);
 
         if (!result.Success || result.Session is null)
-            return BadRequest(new ActivateGuestLinkResponse(null, result.Error));
+            return Problem(
+                detail: result.Error ?? "That code could not be redeemed.",
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Bad Request");
 
         _guestSessionHandler.SetGuestSessionCookie(
             HttpContext,
             result.Session.GrantId,
             result.Session.ExpiresAt);
 
-        return Ok(new ActivateGuestLinkResponse(result.Session.ExpiresAt, null));
+        return Ok(new ActivateGuestLinkResponse(result.Session.ExpiresAt));
     }
 
 }
@@ -191,6 +194,8 @@ public record CreateGuestLinkRequest(string Label, List<string>? Scopes = null);
 public record ActivateGuestLinkRequest(string Code);
 
 /// <summary>
-/// Response from guest link activation.
+/// Response from a successful guest link activation. A refusal answers with
+/// <see cref="ProblemDetails"/>, so the caller reads the status rather than
+/// sniffing this shape for an error field.
 /// </summary>
-public record ActivateGuestLinkResponse(DateTime? ExpiresAt, string? Error);
+public record ActivateGuestLinkResponse(DateTime? ExpiresAt);

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/PlatformAccessController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/PlatformAccessController.cs
@@ -65,7 +65,7 @@ public class PlatformAccessController(
     public async Task<IActionResult> Access([FromQuery] string? tenant, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(tenant))
-            return BadRequest(new { error = "missing_tenant" });
+            return Problem(detail: "No tenant slug was given.", statusCode: StatusCodes.Status400BadRequest, title: "Bad Request");
 
         var auth = HttpContext.GetAuthContext();
 
@@ -84,7 +84,7 @@ public class PlatformAccessController(
                 detailsJson: JsonSerializer.Serialize(new { slug = tenant }));
             logger.LogWarning("Subject {SubjectId} attempted platform access to '{Slug}' without platform_admin",
                 auth.SubjectId, tenant);
-            return StatusCode(StatusCodes.Status403Forbidden, new { error = "forbidden" });
+            return Problem(detail: "Platform access requires a platform administrator session.", statusCode: StatusCodes.Status403Forbidden, title: "Forbidden");
         }
 
         // The tenants table is not RLS-scoped, so this resolves any tenant by slug.
@@ -94,10 +94,10 @@ public class PlatformAccessController(
             .FirstOrDefaultAsync(ct);
 
         if (target is null)
-            return NotFound(new { error = "tenant_not_found" });
+            return Problem(detail: $"No tenant is registered under the slug '{tenant}'.", statusCode: StatusCodes.Status404NotFound, title: "Not Found");
 
         if (!target.IsActive)
-            return StatusCode(StatusCodes.Status403Forbidden, new { error = "tenant_inactive" });
+            return Problem(detail: $"Tenant '{tenant}' is deactivated.", statusCode: StatusCodes.Status403Forbidden, title: "Forbidden");
 
         // Mint a tenant-pinned, platform-access-marked grant for the operator's real subject.
         var subject = new SubjectInfo

--- a/src/Web/package.json
+++ b/src/Web/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/node": "^24.10.1",
     "@typescript/native-preview": "7.0.0-dev.20260513.1",
-    "openapi-remote-codegen": "0.5.0",
+    "openapi-remote-codegen": "0.6.0",
     "prettier": "^3.7.2",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",

--- a/src/Web/packages/app/src/lib/api/error-body.test.ts
+++ b/src/Web/packages/app/src/lib/api/error-body.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { parseErrorBody } from "./error-body";
+
+/**
+ * An `ApiException` as NSwag throws it for a status the operation declares no
+ * `ProducesResponseType` for: its own boilerplate on `message`, the server's
+ * actual body left as raw text on `response`.
+ */
+function apiException(response: string, status = 403) {
+  return {
+    message: "A server side error occurred.",
+    status,
+    response,
+    headers: {},
+    result: null,
+  };
+}
+
+describe("parseErrorBody", () => {
+  it("recovers the detail of a curated refusal on an undeclared status", () => {
+    const body = parseErrorBody(
+      apiException(
+        JSON.stringify({
+          type: "https://tools.ietf.org/html/rfc9110#section-15.5.4",
+          title: "Forbidden",
+          status: 403,
+          detail: "This share does not include treatment data.",
+        })
+      )
+    );
+
+    expect(body?.detail).toBe("This share does not include treatment data.");
+    expect(body?.title).toBe("Forbidden");
+  });
+
+  it("recovers the validation map of an undeclared 400", () => {
+    const body = parseErrorBody(
+      apiException(JSON.stringify({ errors: { Label: ["The Label field is required."] } }), 400)
+    );
+
+    expect(body?.errors).toEqual({ Label: ["The Label field is required."] });
+  });
+
+  it("answers undefined for a body that is not JSON", () => {
+    expect(parseErrorBody(apiException("<html>502 Bad Gateway</html>"))).toBeUndefined();
+  });
+
+  it("answers undefined for an empty body", () => {
+    expect(parseErrorBody(apiException(""))).toBeUndefined();
+    expect(parseErrorBody(apiException("   "))).toBeUndefined();
+  });
+
+  it("answers undefined for JSON that is not an object", () => {
+    expect(parseErrorBody(apiException('"just a string"'))).toBeUndefined();
+    expect(parseErrorBody(apiException("[1, 2, 3]"))).toBeUndefined();
+    expect(parseErrorBody(apiException("null"))).toBeUndefined();
+  });
+
+  it("answers undefined for a thrown value carrying no response at all", () => {
+    // A status the operation declares is thrown as the parsed body itself, which
+    // has nothing left to recover.
+    expect(parseErrorBody({ status: 409, detail: "Already redeemed." })).toBeUndefined();
+    expect(parseErrorBody(new Error("network down"))).toBeUndefined();
+    expect(parseErrorBody(undefined)).toBeUndefined();
+    expect(parseErrorBody(null)).toBeUndefined();
+  });
+});

--- a/src/Web/packages/app/src/lib/api/error-body.test.ts
+++ b/src/Web/packages/app/src/lib/api/error-body.test.ts
@@ -35,14 +35,19 @@ describe("parseErrorBody", () => {
 
   it("recovers the validation map of an undeclared 400", () => {
     const body = parseErrorBody(
-      apiException(JSON.stringify({ errors: { Label: ["The Label field is required."] } }), 400)
+      apiException(
+        JSON.stringify({ errors: { Label: ["The Label field is required."] } }),
+        400
+      )
     );
 
     expect(body?.errors).toEqual({ Label: ["The Label field is required."] });
   });
 
   it("answers undefined for a body that is not JSON", () => {
-    expect(parseErrorBody(apiException("<html>502 Bad Gateway</html>"))).toBeUndefined();
+    expect(
+      parseErrorBody(apiException("<html>502 Bad Gateway</html>"))
+    ).toBeUndefined();
   });
 
   it("answers undefined for an empty body", () => {
@@ -56,10 +61,24 @@ describe("parseErrorBody", () => {
     expect(parseErrorBody(apiException("null"))).toBeUndefined();
   });
 
+  it("keeps a field the far end sent as the wrong type", () => {
+    // `Object.entries("boom")` is four entries, which would reach someone as
+    // their validation failure.
+    const body = parseErrorBody(
+      apiException(JSON.stringify({ detail: 42, title: "", errors: "boom" }))
+    );
+
+    expect(body?.detail).toBeUndefined();
+    expect(body?.title).toBeUndefined();
+    expect(body?.errors).toBeUndefined();
+  });
+
   it("answers undefined for a thrown value carrying no response at all", () => {
     // A status the operation declares is thrown as the parsed body itself, which
     // has nothing left to recover.
-    expect(parseErrorBody({ status: 409, detail: "Already redeemed." })).toBeUndefined();
+    expect(
+      parseErrorBody({ status: 409, detail: "Already redeemed." })
+    ).toBeUndefined();
     expect(parseErrorBody(new Error("network down"))).toBeUndefined();
     expect(parseErrorBody(undefined)).toBeUndefined();
     expect(parseErrorBody(null)).toBeUndefined();

--- a/src/Web/packages/app/src/lib/api/error-body.ts
+++ b/src/Web/packages/app/src/lib/api/error-body.ts
@@ -1,0 +1,46 @@
+/** The fields a parsed error body may carry that a status arm can route on. */
+export interface ParsedErrorBody {
+  /** RFC 7807 `detail` — the sentence written for a person. */
+  detail?: string;
+  /** RFC 7807 `title` — usually just the status phrase. */
+  title?: string;
+  /** The shape a typed error payload uses when the payload itself is the point. */
+  message?: string;
+  /** ASP.NET's per-field validation map. */
+  errors?: Record<string, unknown>;
+}
+
+/**
+ * The error body NSwag left unparsed on a thrown `ApiException`.
+ *
+ * NSwag parses an error response only for a status the operation declares a
+ * `ProducesResponseType` for; it then throws the parsed body itself. For any
+ * other status it throws an `ApiException` whose `message` is its own
+ * boilerplate and whose `response` holds the raw body text, parsed by nothing.
+ *
+ * So a curated `Problem(detail: …)` refusal on an undeclared status carries its
+ * reason only in that string. Reading it back is the only way the reason reaches
+ * the user; no ordering of reads off the exception can recover what the
+ * exception does not hold.
+ *
+ * Best-effort by construction: the body may be empty, HTML from a proxy, or a
+ * JSON scalar. Anything that is not a JSON object answers undefined, so a caller
+ * falls through to whatever it would have said otherwise.
+ */
+export function parseErrorBody(err: unknown): ParsedErrorBody | undefined {
+  if (!err || typeof err !== "object" || !("response" in err)) return undefined;
+
+  const { response } = err as { response?: unknown };
+  if (typeof response !== "string" || response.trim() === "") return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(response);
+  } catch {
+    return undefined;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+
+  return parsed as ParsedErrorBody;
+}

--- a/src/Web/packages/app/src/lib/api/error-body.ts
+++ b/src/Web/packages/app/src/lib/api/error-body.ts
@@ -1,36 +1,36 @@
-/** The fields a parsed error body may carry that a status arm can route on. */
+/** The fields of an error body a status arm can route on. */
 export interface ParsedErrorBody {
   /** RFC 7807 `detail` — the sentence written for a person. */
   detail?: string;
-  /** RFC 7807 `title` — usually just the status phrase. */
+  /** RFC 7807 `title`, usually only the status phrase. */
   title?: string;
-  /** The shape a typed error payload uses when the payload itself is the point. */
+  /**
+   * Carried instead of `detail` by a typed payload that declares its own
+   * status.
+   */
   message?: string;
   /** ASP.NET's per-field validation map. */
   errors?: Record<string, unknown>;
 }
 
 /**
- * The error body NSwag left unparsed on a thrown `ApiException`.
+ * Reads back the error body NSwag left unparsed on a thrown `ApiException`.
  *
  * NSwag parses an error response only for a status the operation declares a
- * `ProducesResponseType` for; it then throws the parsed body itself. For any
- * other status it throws an `ApiException` whose `message` is its own
- * boilerplate and whose `response` holds the raw body text, parsed by nothing.
+ * `ProducesResponseType` for, and throws the parsed body itself. For any other
+ * status it throws an `ApiException` whose `message` is its own boilerplate and
+ * whose `response` holds the raw body text, parsed by nothing — so a curated
+ * refusal on an undeclared status carries its reason in that string and nowhere
+ * else.
  *
- * So a curated `Problem(detail: …)` refusal on an undeclared status carries its
- * reason only in that string. Reading it back is the only way the reason reaches
- * the user; no ordering of reads off the exception can recover what the
- * exception does not hold.
- *
- * Best-effort by construction: the body may be empty, HTML from a proxy, or a
- * JSON scalar. Anything that is not a JSON object answers undefined, so a caller
- * falls through to whatever it would have said otherwise.
+ * Every field is checked rather than cast, because what arrives is whatever the
+ * far end sent: an `errors` that is a string would otherwise flatten to one
+ * character per field and be shown to someone as their validation failure.
  */
 export function parseErrorBody(err: unknown): ParsedErrorBody | undefined {
   if (!err || typeof err !== "object" || !("response" in err)) return undefined;
 
-  const { response } = err as { response?: unknown };
+  const { response } = err;
   if (typeof response !== "string" || response.trim() === "") return undefined;
 
   let parsed: unknown;
@@ -40,7 +40,20 @@ export function parseErrorBody(err: unknown): ParsedErrorBody | undefined {
     return undefined;
   }
 
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  if (!isPlainObject(parsed)) return undefined;
 
-  return parsed as ParsedErrorBody;
+  return {
+    detail: sentence(parsed.detail),
+    title: sentence(parsed.title),
+    message: sentence(parsed.message),
+    errors: isPlainObject(parsed.errors) ? parsed.errors : undefined,
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function sentence(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
 }

--- a/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
+++ b/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
@@ -37,8 +37,7 @@ async function crossTheBoundary(thrown: unknown): Promise<unknown> {
   );
   const source = compiled.code.trim().replace(/;$/, "");
 
-  // The arm is spliced into a generated file, so it reaches the helpers that
-  // file imports; they are passed in here for the same reason.
+  // The helpers are passed in because the real arm reaches them by import.
   const flatten = new Function(`return ${source}`)() as (
     err: unknown,
     status: unknown,
@@ -227,9 +226,7 @@ describe("the status a generated remote function lets through", () => {
   });
 
   it("recovers the reason from a body NSwag left unparsed", async () => {
-    // NSwag parses an error body only for a status the operation declares. On any
-    // other status the reason exists solely as raw text on `response`, so no
-    // ordering of reads off the exception can recover it.
+    // The reason exists only as raw text on `response`; see `$lib/api/error-body`.
     const crossed = await crossTheBoundary(
       nswagApiException(
         409,

--- a/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
+++ b/src/Web/packages/app/src/lib/api/generated-error-status.test.ts
@@ -8,6 +8,7 @@ import {
   RATE_LIMITED_ERROR,
 } from "../forms/submit-error";
 import { remoteErrorMessage } from "./remote-error";
+import { parseErrorBody } from "./error-body";
 import { TotpSetupFailure } from "$api-clients";
 import {
   describeTotpSetupError,
@@ -30,20 +31,23 @@ import {
  */
 async function crossTheBoundary(thrown: unknown): Promise<unknown> {
   const compiled = await transformWithEsbuild(
-    `(err, status, error) => { ${config.errorHandling.on500("get invite info")}; }`,
+    `(err, status, error, parseErrorBody) => { ${config.errorHandling.on500("get invite info")}; }`,
     "on500.ts",
     { loader: "ts" }
   );
   const source = compiled.code.trim().replace(/;$/, "");
 
+  // The arm is spliced into a generated file, so it reaches the helpers that
+  // file imports; they are passed in here for the same reason.
   const flatten = new Function(`return ${source}`)() as (
     err: unknown,
     status: unknown,
-    error: typeof import("@sveltejs/kit").error
+    error: typeof import("@sveltejs/kit").error,
+    parseErrorBody: typeof import("./error-body").parseErrorBody
   ) => never;
 
   try {
-    flatten(thrown, (thrown as { status?: number })?.status, error);
+    flatten(thrown, (thrown as { status?: number })?.status, error, parseErrorBody);
   } catch (crossed) {
     return crossed;
   }
@@ -220,6 +224,44 @@ describe("the status a generated remote function lets through", () => {
     expect(describeSubmitError(crossed, "Couldn't save your changes.")).toBe(
       "Another device changed this entry."
     );
+  });
+
+  it("recovers the reason from a body NSwag left unparsed", async () => {
+    // NSwag parses an error body only for a status the operation declares. On any
+    // other status the reason exists solely as raw text on `response`, so no
+    // ordering of reads off the exception can recover it.
+    const crossed = await crossTheBoundary(
+      nswagApiException(
+        409,
+        JSON.stringify(problemDetails(409, "Already redeemed.", "Conflict"))
+      )
+    );
+
+    expect((crossed as { status: number }).status).toBe(409);
+    expect(describeSubmitError(crossed, "Couldn't save your changes.")).toBe(
+      "Already redeemed."
+    );
+  });
+
+  it("recovers the validation map from a body NSwag left unparsed", async () => {
+    const crossed = await crossTheBoundary(
+      nswagApiException(
+        400,
+        JSON.stringify({ errors: { Label: ["The Label field is required."] } })
+      )
+    );
+
+    expect(describeSubmitError(crossed, "Couldn't save your changes.")).toBe(
+      "The Label field is required."
+    );
+  });
+
+  it("leaves NSwag's boilerplate in place when the unparsed body is not JSON", async () => {
+    const crossed = await crossTheBoundary(
+      nswagApiException(503, "<html>503 Service Unavailable</html>")
+    );
+
+    expect((crossed as { status: number }).status).toBe(500);
   });
 
   it("still flattens a status it does not forward", async () => {

--- a/src/Web/packages/app/src/lib/api/remote-catch-guard.test.ts
+++ b/src/Web/packages/app/src/lib/api/remote-catch-guard.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * A `catch` binding nothing around a generated remote call throws the server's
+ * reason away and assigns fixed copy in its place, so someone is told "please
+ * try again" about a duplicate name or a validation failure that retrying
+ * cannot fix. `describeSubmitError` and `remoteErrorMessage` both take that
+ * copy as their fallback, so converting a site never loses the wording it had.
+ *
+ * Swallowing is sometimes right — a poll that runs again, an optimistic
+ * rollback that reports itself by reappearing — and those say why in a comment
+ * on the first line of the catch. That is all this asks for, and it is worth
+ * knowing the limits:
+ *
+ * - It reads text, pairing a bare `catch` with the nearest `try` by brace depth,
+ *   so a brace inside a string or comment can mispair it.
+ * - A comment satisfies it. It cannot tell a reason from an excuse; a site that
+ *   keeps its fixed copy and adds a comment passes, and only review catches
+ *   that.
+ * - It sees calls to names imported from a `*.generated.remote` module, plus
+ *   `.run()` and `.refresh()`. A remote call reached any other way is
+ *   invisible.
+ */
+const SRC = fileURLToPath(new URL("../..", import.meta.url));
+
+/** Names imported from a generated remote module, which a `try` may be awaiting. */
+function remoteImports(source: string): string[] {
+  const names = new Set<string>();
+
+  for (const match of source.matchAll(
+    /import\s*(?:\*\s*as\s*(\w+)|\{([^}]*)\})\s*from\s*["'][^"']*generated\.remote[^"']*["']/g
+  )) {
+    const [, namespace, clause] = match;
+    if (namespace) {
+      names.add(namespace);
+      continue;
+    }
+    for (const entry of clause.split(",")) {
+      const name = entry
+        .trim()
+        .split(/\s+as\s+/)
+        .pop()
+        ?.trim();
+      if (name) names.add(name);
+    }
+  }
+
+  return [...names];
+}
+
+/** The body of the `try` a bare `catch` at `catchIndex` belongs to. */
+function tryBlockBefore(source: string, catchIndex: number): string {
+  let depth = 0;
+
+  for (let i = catchIndex - 1; i >= 0; i--) {
+    const char = source[i];
+    if (char === "}") depth++;
+    else if (char === "{") {
+      if (depth === 0) return source.slice(i, catchIndex);
+      depth--;
+    }
+  }
+
+  return source.slice(0, catchIndex);
+}
+
+function callsRemote(block: string, imported: string[]): boolean {
+  if (/\.(run|refresh)\s*\(/.test(block)) return true;
+  return imported.some((name) => new RegExp(`\\b${name}\\s*[(.]`).test(block));
+}
+
+/** Whether the catch body opens with a comment explaining the silence. */
+function explainsItself(source: string, catchIndex: number): boolean {
+  const body = source.slice(source.indexOf("{", catchIndex) + 1);
+  return /^\s*(\/\/|\/\*)/.test(body);
+}
+
+interface Offence {
+  file: string;
+  line: number;
+}
+
+function sourceFiles(): string[] {
+  return readdirSync(SRC, { recursive: true, encoding: "utf8" }).filter(
+    (file) =>
+      /\.(svelte|ts)$/.test(file) &&
+      !file.endsWith(".test.ts") &&
+      !/(^|\/)(generated|test-stubs)(\/|$)/.test(file)
+  );
+}
+
+function offences(): Offence[] {
+  const found: Offence[] = [];
+
+  for (const file of sourceFiles()) {
+    const source = readFileSync(`${SRC}/${file}`, "utf8");
+    const imported = remoteImports(source);
+    if (imported.length === 0) continue;
+
+    for (const match of source.matchAll(/\}\s*catch\s*\{/g)) {
+      const index = match.index!;
+      if (!callsRemote(tryBlockBefore(source, index), imported)) continue;
+      if (explainsItself(source, index)) continue;
+
+      found.push({
+        file,
+        line: source.slice(0, index).split("\n").length,
+      });
+    }
+  }
+
+  return found;
+}
+
+describe("catches around generated remote calls", () => {
+  it("bind the error, or say why they do not", () => {
+    expect(offences()).toEqual([]);
+  });
+
+  it("still recognises a discarded reason when it sees one", () => {
+    // The guard is only worth its cost if it fails on the shape it exists to
+    // catch, so exercise its parts on that shape directly.
+    const lossy = `
+      import { createRole } from "$api/generated/roles.generated.remote";
+      async function handle() {
+        try {
+          await createRole({ name });
+        } catch {
+          errorMessage = "Failed to create role. Please try again.";
+        }
+      }
+    `;
+
+    const index = lossy.indexOf("} catch {");
+    expect(remoteImports(lossy)).toContain("createRole");
+    expect(callsRemote(tryBlockBefore(lossy, index), ["createRole"])).toBe(
+      true
+    );
+    expect(explainsItself(lossy, index)).toBe(false);
+  });
+
+  it("passes a swallow that explains itself", () => {
+    const deliberate = `
+      import { getStatus } from "$api/generated/jobs.generated.remote";
+      async function poll() {
+        try {
+          await getStatus().refresh();
+        } catch {
+          // One failed poll says nothing; the next one runs in two seconds.
+        }
+      }
+    `;
+
+    const index = deliberate.indexOf("} catch {");
+    expect(explainsItself(deliberate, index)).toBe(true);
+  });
+
+  it("ignores a catch that has nothing to do with a remote call", () => {
+    const local = `
+      import { getStatus } from "$api/generated/jobs.generated.remote";
+      function parse(raw: string) {
+        try {
+          return JSON.parse(raw);
+        } catch {
+          return null;
+        }
+      }
+    `;
+
+    const index = local.indexOf("} catch {");
+    expect(callsRemote(tryBlockBefore(local, index), ["getStatus"])).toBe(
+      false
+    );
+  });
+});

--- a/src/Web/packages/app/src/lib/api/remote-catch-guard.test.ts
+++ b/src/Web/packages/app/src/lib/api/remote-catch-guard.test.ts
@@ -83,21 +83,27 @@ interface Offence {
 }
 
 function sourceFiles(): string[] {
-  return readdirSync(SRC, { recursive: true, encoding: "utf8" }).filter(
-    (file) =>
-      /\.(svelte|ts)$/.test(file) &&
-      !file.endsWith(".test.ts") &&
-      !/(^|\/)(generated|test-stubs)(\/|$)/.test(file)
-  );
+  // readdirSync yields the platform's separator, so the directory exclusions
+  // below would only bite on posix if the paths were left as they arrive.
+  return readdirSync(SRC, { recursive: true, encoding: "utf8" })
+    .map((file) => file.replaceAll("\\", "/"))
+    .filter(
+      (file) =>
+        /\.(svelte|ts)$/.test(file) &&
+        !file.endsWith(".test.ts") &&
+        !/(^|\/)(generated|test-stubs)(\/|$)/.test(file)
+    );
 }
 
-function offences(): Offence[] {
+function offences(): { found: Offence[]; scanned: number } {
   const found: Offence[] = [];
+  let scanned = 0;
 
   for (const file of sourceFiles()) {
     const source = readFileSync(`${SRC}/${file}`, "utf8");
     const imported = remoteImports(source);
     if (imported.length === 0) continue;
+    scanned++;
 
     for (const match of source.matchAll(/\}\s*catch\s*\{/g)) {
       const index = match.index!;
@@ -111,12 +117,18 @@ function offences(): Offence[] {
     }
   }
 
-  return found;
+  return { found, scanned };
 }
 
 describe("catches around generated remote calls", () => {
   it("bind the error, or say why they do not", () => {
-    expect(offences()).toEqual([]);
+    const { found, scanned } = offences();
+
+    // An empty result is the pass condition, so a walk that read nothing — a
+    // moved source root, a separator the filter did not expect — would pass
+    // for the wrong reason. Assert it found files to judge.
+    expect(scanned).toBeGreaterThan(20);
+    expect(found).toEqual([]);
   });
 
   it("still recognises a discarded reason when it sees one", () => {

--- a/src/Web/packages/app/src/lib/components/PreludeQuickConnect.svelte
+++ b/src/Web/packages/app/src/lib/components/PreludeQuickConnect.svelte
@@ -18,6 +18,7 @@
   import { getDeviceInfo } from "$routes/(authenticated)/oauth/oauth.remote";
   import { deviceApprove } from "$api/generated/oAuths.generated.remote";
   import { getOAuthScopeDescription } from "$lib/constants/oauth-scopes";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   interface Props {
     /** Origin URL of the Nocturne instance (trailing slash tolerated). */
@@ -86,8 +87,11 @@
         isKnown: info.isKnownClient ?? false,
         scopes: (info.scopes ?? []).filter(Boolean),
       };
-    } catch {
-      deviceLookupError = "Invalid or expired device code. Please check and try again.";
+    } catch (err) {
+      deviceLookupError = describeSubmitError(
+        err,
+        "Invalid or expired device code. Please check and try again."
+      );
     } finally {
       deviceLookupLoading = false;
     }
@@ -99,8 +103,8 @@
     try {
       await deviceApprove({ user_code: deviceInfo.userCode, approved: true });
       deviceApproved = true;
-    } catch {
-      deviceLookupError = "Failed to approve. The code may have expired.";
+    } catch (err) {
+      deviceLookupError = describeSubmitError(err, "Failed to approve. The code may have expired.");
     } finally {
       deviceApproveLoading = false;
     }
@@ -112,8 +116,8 @@
     try {
       await deviceApprove({ user_code: deviceInfo.userCode, approved: false });
       deviceDenied = true;
-    } catch {
-      deviceLookupError = "Failed to deny the request.";
+    } catch (err) {
+      deviceLookupError = describeSubmitError(err, "Failed to deny the request.");
     } finally {
       deviceApproveLoading = false;
     }

--- a/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
+++ b/src/Web/packages/app/src/lib/components/XdripQuickConnect.svelte
@@ -20,6 +20,7 @@
   import { getDeviceInfo } from "$routes/(authenticated)/oauth/oauth.remote";
   import { deviceApprove } from "$api/generated/oAuths.generated.remote";
   import { getOAuthScopeDescription } from "$lib/constants/oauth-scopes";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   interface Props {
     /** Origin URL of the Nocturne instance (trailing slash tolerated). */
@@ -146,8 +147,11 @@
         isKnown: info.isKnownClient ?? false,
         scopes: (info.scopes ?? []).filter(Boolean),
       };
-    } catch {
-      deviceLookupError = "Invalid or expired device code. Please check and try again.";
+    } catch (err) {
+      deviceLookupError = describeSubmitError(
+        err,
+        "Invalid or expired device code. Please check and try again."
+      );
     } finally {
       deviceLookupLoading = false;
     }
@@ -160,8 +164,8 @@
       await deviceApprove({ user_code: deviceInfo.userCode, approved: true });
       deviceApproved = true;
       startPolling();
-    } catch {
-      deviceLookupError = "Failed to approve. The code may have expired.";
+    } catch (err) {
+      deviceLookupError = describeSubmitError(err, "Failed to approve. The code may have expired.");
     } finally {
       deviceApproveLoading = false;
     }
@@ -173,8 +177,8 @@
     try {
       await deviceApprove({ user_code: deviceInfo.userCode, approved: false });
       deviceDenied = true;
-    } catch {
-      deviceLookupError = "Failed to deny the request.";
+    } catch (err) {
+      deviceLookupError = describeSubmitError(err, "Failed to deny the request.");
     } finally {
       deviceApproveLoading = false;
     }

--- a/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
@@ -9,6 +9,7 @@
   } from "$api/generated/tenantAlertSettings.generated.remote";
   import type { TenantAlertSettingsResponse } from "$api-clients";
   import { describeSubmitError } from "$lib/forms";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
   import { Bell, BellOff, Settings as SettingsIcon, Loader2 } from "lucide-svelte";
   import { isDndActiveNow, isDndScheduleConfigured } from "./dnd";
 

--- a/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/DndPanel.svelte
@@ -37,8 +37,9 @@
   async function load(): Promise<void> {
     try {
       settings = await getDnd().run();
-    } catch {
+    } catch (err) {
       settings = null;
+      errorMessage = remoteErrorMessage(err, "Couldn't load Do Not Disturb.");
     } finally {
       loading = false;
     }

--- a/src/Web/packages/app/src/lib/components/alerts/FiringToast.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/FiringToast.svelte
@@ -83,6 +83,8 @@
     try {
       await action();
     } catch {
+      // Restoring the card is the report: it reappears, so the alert is still
+      // outstanding and the action can be retried.
       queue = snapshot;
     }
   }

--- a/src/Web/packages/app/src/lib/components/alerts/SidebarDndToggle.svelte
+++ b/src/Web/packages/app/src/lib/components/alerts/SidebarDndToggle.svelte
@@ -37,6 +37,8 @@
     try {
       settings = await getDnd().run();
     } catch {
+      // A sidebar toggle has nowhere to put a sentence; the null state renders as
+      // "unknown" and the panel behind it reports the reason.
       settings = null;
     }
   }
@@ -55,6 +57,8 @@
       });
       settings = r;
     } catch {
+      // The toggle's own failed state is the report; a reason needs somewhere to
+      // sit, and /alerts/dnd is where it does.
       failed = true;
     } finally {
       saving = false;

--- a/src/Web/packages/app/src/lib/components/connectors/UploaderSetupView.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/UploaderSetupView.svelte
@@ -33,6 +33,7 @@
   import { copyToClipboard } from "$lib/utils";
 
   import { toast } from "svelte-sonner";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   interface Props {
     app: UploaderApp | null;
     setupResponse: UploaderSetupResponse | null;
@@ -81,8 +82,11 @@
         scopes: ["health.readwrite"],
       });
       apiToken = result.token ?? null;
-    } catch {
-      apiTokenError = "Failed to generate API key. You can create one manually in Settings.";
+    } catch (err) {
+      apiTokenError = describeSubmitError(
+        err,
+        "Failed to generate API key. You can create one manually in Settings."
+      );
     } finally {
       apiTokenLoading = false;
     }
@@ -118,6 +122,7 @@
         color: { dark: "#000000", light: "#ffffff" },
       });
     } catch {
+      // Local rendering, not a request — there is no server reason to surface.
       qrCodeDataUrl = null;
     }
   }
@@ -142,8 +147,11 @@
         isKnown: info.isKnownClient ?? false,
         scopes: (info.scopes ?? []).filter(Boolean),
       };
-    } catch {
-      deviceLookupError = "Invalid or expired device code. Please check and try again.";
+    } catch (err) {
+      deviceLookupError = describeSubmitError(
+        err,
+        "Invalid or expired device code. Please check and try again."
+      );
     } finally {
       deviceLookupLoading = false;
     }
@@ -156,8 +164,8 @@
       await deviceApprove({ user_code: deviceInfo.userCode, approved: true });
       deviceApproved = true;
       startPolling();
-    } catch {
-      deviceLookupError = "Failed to approve. The code may have expired.";
+    } catch (err) {
+      deviceLookupError = describeSubmitError(err, "Failed to approve. The code may have expired.");
     } finally {
       deviceApproveLoading = false;
     }
@@ -169,8 +177,8 @@
     try {
       await deviceApprove({ user_code: deviceInfo.userCode, approved: false });
       deviceDenied = true;
-    } catch {
-      deviceLookupError = "Failed to deny the request.";
+    } catch (err) {
+      deviceLookupError = describeSubmitError(err, "Failed to deny the request.");
     } finally {
       deviceApproveLoading = false;
     }

--- a/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
+++ b/src/Web/packages/app/src/lib/components/members/GuestLinksSection.svelte
@@ -30,6 +30,7 @@
     GuestLinkStatus,
   } from "$api/generated/nocturne-api-client";
   import { retainQuery } from "$lib/api/retain-query.svelte";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? []
@@ -172,8 +173,8 @@
       createdCode = result.code ?? null;
       createdUrl = result.fullUrl ? normalizeCreatedUrl(result.fullUrl) : null;
       await guestLinksQuery?.refresh();
-    } catch {
-      createError = "Failed to create guest link. Please try again.";
+    } catch (err) {
+      createError = describeSubmitError(err, "Failed to create guest link. Please try again.");
     } finally {
       isCreating = false;
     }

--- a/src/Web/packages/app/src/lib/components/members/MembershipRequestsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/MembershipRequestsCard.svelte
@@ -9,6 +9,7 @@
     getPendingRequests,
   } from "$api/generated/membershipRequests.generated.remote";
   import { retainQuery } from "$lib/api/retain-query.svelte";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],
@@ -36,8 +37,11 @@
     pendingAllow = v;
     try {
       await setMembershipRequestSettings({ allowRequests: v });
-    } catch {
-      errorMessage = "Couldn't update membership requests. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(
+        err,
+        "Couldn't update membership requests. Please try again."
+      );
     } finally {
       busy = false;
       pendingAllow = null;

--- a/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
+++ b/src/Web/packages/app/src/lib/components/members/PublicAccessCard.svelte
@@ -27,6 +27,7 @@
     formatList,
   } from "./public-data-categories";
   import { retainQuery } from "$lib/api/retain-query.svelte";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],
@@ -77,10 +78,13 @@
         await disableShareLink();
         revealedUrl = null;
       }
-    } catch {
-      errorMessage = on
-        ? "Couldn't create the link. Please try again."
-        : "Couldn't turn off public access. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(
+        err,
+        on
+          ? "Couldn't create the link. Please try again."
+          : "Couldn't turn off public access. Please try again."
+      );
     } finally {
       busy = false;
       pendingEnabled = null;
@@ -93,8 +97,8 @@
     confirmingRotate = false;
     try {
       revealedUrl = (await rotateShareLink()).url ?? null;
-    } catch {
-      errorMessage = "Couldn't regenerate the link. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Couldn't regenerate the link. Please try again.");
     } finally {
       busy = false;
     }
@@ -110,8 +114,8 @@
     scopeWritesInFlight++;
     try {
       await setShareLinkScopes({ scopes: list });
-    } catch {
-      errorMessage = "Couldn't update what's shared. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Couldn't update what's shared. Please try again.");
     } finally {
       // Hold the optimistic value until every concurrent toggle settles, then fall back to
       // server truth — the generated command already refreshed getShareLink.
@@ -125,8 +129,8 @@
     errorMessage = null;
     try {
       await setShareLinkFullHistory({ fullHistory: fh });
-    } catch {
-      errorMessage = "Couldn't update the time window. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Couldn't update the time window. Please try again.");
     } finally {
       pendingFullHistory = null;
     }

--- a/src/Web/packages/app/src/lib/components/members/RolesSection.svelte
+++ b/src/Web/packages/app/src/lib/components/members/RolesSection.svelte
@@ -7,6 +7,7 @@
   import { Label } from "$lib/components/ui/label";
   import PermissionCategorySelector from "$lib/components/rbac/PermissionCategorySelector.svelte";
   import PermissionSummary from "$lib/components/rbac/PermissionSummary.svelte";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import {
     Shield,
     Ban,
@@ -113,8 +114,8 @@
       successMessage = "Role created successfully.";
       resetCreateForm();
       clearMessages();
-    } catch {
-      errorMessage = "Failed to create role. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Failed to create role. Please try again.");
       clearMessages();
     } finally {
       isCreating = false;
@@ -136,8 +137,8 @@
       successMessage = "Role updated successfully.";
       isEditOpen = false;
       clearMessages();
-    } catch {
-      errorMessage = "Failed to update role. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Failed to update role. Please try again.");
       clearMessages();
     } finally {
       isEditing = false;
@@ -152,8 +153,8 @@
       successMessage = "Role deleted successfully.";
       isDeleteOpen = false;
       clearMessages();
-    } catch {
-      errorMessage = "Failed to delete role. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Failed to delete role. Please try again.");
       clearMessages();
     } finally {
       isDeleting = false;

--- a/src/Web/packages/app/src/lib/components/patient/state.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/patient/state.svelte.ts
@@ -8,7 +8,7 @@ import {
   type DiscoveredSource,
   DiabetesType,
 } from "$api";
-import { FormGuard } from "$lib/forms";
+import { FormGuard, describeSubmitError } from "$lib/forms";
 import { z } from "zod";
 
 /** Convert a date value from the API into a YYYY-MM-DD string for date inputs. */
@@ -214,8 +214,8 @@ export class WeightState {
       });
       this.#initialWeightKg = this.weightKg;
       return true;
-    } catch {
-      this.saveError = "Failed to save weight. Please try again.";
+    } catch (err) {
+      this.saveError = describeSubmitError(err, "Failed to save weight. Please try again.");
       return false;
     } finally {
       this.saving = false;

--- a/src/Web/packages/app/src/lib/components/settings/ApiReference.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ApiReference.svelte
@@ -8,6 +8,7 @@
     setPublicDocs,
   } from "$api/generated/tenantSettings.generated.remote";
   import { retainQuery } from "$lib/api/retain-query.svelte";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],
@@ -35,10 +36,13 @@
     pending = on;
     try {
       await setPublicDocs({ enabled: on });
-    } catch {
-      errorMessage = on
-        ? "Couldn't publish the API reference. Please try again."
-        : "Couldn't hide the API reference. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(
+        err,
+        on
+          ? "Couldn't publish the API reference. Please try again."
+          : "Couldn't hide the API reference. Please try again."
+      );
     } finally {
       busy = false;
       pending = null;

--- a/src/Web/packages/app/src/lib/components/settings/ClientDevices.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ClientDevices.svelte
@@ -20,6 +20,7 @@
 
   const now = new Now();
   import { deviceKindLabel } from "$lib/utils/device-kind-labels";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import {
     getDevices,
     getCapabilityCatalog,
@@ -74,8 +75,8 @@
       successMessage = "Device renamed.";
       editingId = null;
       clearMessages();
-    } catch {
-      errorMessage = "Failed to rename device. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Failed to rename device. Please try again.");
       clearMessages();
     } finally {
       isSaving = null;
@@ -89,8 +90,8 @@
       await revoke(id);
       successMessage = "Device revoked.";
       clearMessages();
-    } catch {
-      errorMessage = "Failed to revoke device. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Failed to revoke device. Please try again.");
       clearMessages();
     } finally {
       isRevoking = null;

--- a/src/Web/packages/app/src/lib/forms/submit-error.test.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.test.ts
@@ -146,10 +146,7 @@ describe("describeSubmitError", () => {
   });
 
   it("shows a refusal the server worded on a status the operation never declared", async () => {
-    // NSwag parses an error body only for a declared status; otherwise it throws
-    // an ApiException whose message is its own boilerplate and leaves the body
-    // as raw text. The reason exists only there, so an arm that reads the
-    // exception alone reports the boilerplate no matter how it orders its reads.
+    // The reason exists only as raw text on `response`; see `$lib/api/error-body`.
     const crossed = await crossThe403Arm(
       nswagApiException(
         403,

--- a/src/Web/packages/app/src/lib/forms/submit-error.test.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { transformWithEsbuild } from "vite";
 import { error } from "@sveltejs/kit";
 import config from "../../../../../remote-codegen.config";
+import { parseErrorBody } from "$lib/api/error-body";
 import {
   describeSubmitError,
   GENERIC_SUBMIT_ERROR,
@@ -12,10 +13,14 @@ import {
  * What a 403 looks like by the time a page sees it: the thrown value put
  * through the generated client's own 403 arm, compiled from the codegen config
  * the build reads, so the body is whichever field that arm picked.
+ *
+ * The arm is spliced into a generated file, so it reaches the helpers that file
+ * imports; they are passed in here for the same reason.
  */
 type ForbidArm = (
   err: unknown,
-  error: typeof import("@sveltejs/kit").error
+  error: typeof import("@sveltejs/kit").error,
+  parseErrorBody: typeof import("$lib/api/error-body").parseErrorBody
 ) => never;
 
 function compileArm(source: string): ForbidArm {
@@ -24,7 +29,7 @@ function compileArm(source: string): ForbidArm {
 
 async function crossThe403Arm(thrown: unknown): Promise<unknown> {
   const compiled = await transformWithEsbuild(
-    `(err, error) => { ${config.errorHandling.on403}; }`,
+    `(err, error, parseErrorBody) => { ${config.errorHandling.on403}; }`,
     "on403.ts",
     { loader: "ts" }
   );
@@ -32,7 +37,7 @@ async function crossThe403Arm(thrown: unknown): Promise<unknown> {
   const forbid = compileArm(compiled.code.trim().replace(/;$/, ""));
 
   try {
-    forbid(thrown, error);
+    forbid(thrown, error, parseErrorBody);
   } catch (crossed) {
     return crossed;
   }
@@ -45,10 +50,10 @@ const UNDECLARED_STATUS_MESSAGE = "An unexpected server error occurred.";
 const DECLARED_STATUS_MESSAGE = "A server side error occurred.";
 
 /** NSwag's ApiException, as a bare `ForbidResult` arrives. */
-function nswagApiException(status: number, message: string) {
+function nswagApiException(status: number, message: string, response = "") {
   return Object.assign(new Error(message), {
     status,
-    response: "",
+    response,
     result: null,
   });
 }
@@ -137,6 +142,34 @@ describe("describeSubmitError", () => {
 
     expect(describeSubmitError(crossed, "You can't change this setting.")).toBe(
       NEEDS_SCOPE
+    );
+  });
+
+  it("shows a refusal the server worded on a status the operation never declared", async () => {
+    // NSwag parses an error body only for a declared status; otherwise it throws
+    // an ApiException whose message is its own boilerplate and leaves the body
+    // as raw text. The reason exists only there, so an arm that reads the
+    // exception alone reports the boilerplate no matter how it orders its reads.
+    const crossed = await crossThe403Arm(
+      nswagApiException(
+        403,
+        UNDECLARED_STATUS_MESSAGE,
+        JSON.stringify(problemDetails(403, NEEDS_SCOPE))
+      )
+    );
+
+    expect(describeSubmitError(crossed, "You can't change this setting.")).toBe(
+      NEEDS_SCOPE
+    );
+  });
+
+  it("keeps the caller's wording when the undeclared body is not JSON", async () => {
+    const crossed = await crossThe403Arm(
+      nswagApiException(403, UNDECLARED_STATUS_MESSAGE, "<html>403</html>")
+    );
+
+    expect(describeSubmitError(crossed, "You can't change this setting.")).toBe(
+      "You can't change this setting."
     );
   });
 

--- a/src/Web/packages/app/src/routes/(authenticated)/food/food-state.svelte.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/food/food-state.svelte.ts
@@ -12,6 +12,7 @@ import {
   getFoodAttributionCount,
 } from '$api/generated/foods.generated.remote';
 import { deleteFood as deleteFoodRemote } from './data.remote';
+import { describeSubmitError } from '$lib/forms/submit-error';
 
 export class FoodState {
   foods = $state<Food[]>([]);
@@ -111,8 +112,8 @@ export class FoodState {
         this.favorites = new Set(this.favorites);
         await addFavoriteRemote(foodId);
       }
-    } catch {
-      toast.error('Failed to update favorite');
+    } catch (err) {
+      toast.error(describeSubmitError(err, 'Failed to update favorite'));
       const favs = await getFavorites(undefined).run();
       this.favorites = new Set(
         (favs ?? []).map((f: Food) => f._id).filter(Boolean) as string[]
@@ -128,8 +129,8 @@ export class FoodState {
         toast.success('Food created');
       }
       return result;
-    } catch {
-      toast.error('Failed to create food');
+    } catch (err) {
+      toast.error(describeSubmitError(err, 'Failed to create food'));
       return null;
     }
   }
@@ -143,8 +144,8 @@ export class FoodState {
         this.expandedId = null;
         toast.success('Food updated');
       }
-    } catch {
-      toast.error('Failed to update food');
+    } catch (err) {
+      toast.error(describeSubmitError(err, 'Failed to update food'));
     }
   }
 
@@ -153,6 +154,7 @@ export class FoodState {
       const result = await getFoodAttributionCount(foodId).run();
       return result?.count ?? 0;
     } catch {
+      // No copy to lose: the caller renders a count, and 0 reads as "none known".
       return 0;
     }
   }
@@ -165,8 +167,8 @@ export class FoodState {
       this.favorites = new Set(this.favorites);
       this.expandedId = null;
       toast.success('Food deleted');
-    } catch {
-      toast.error('Failed to delete food');
+    } catch (err) {
+      toast.error(describeSubmitError(err, 'Failed to delete food'));
     }
   }
 

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/access-requests/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/access-requests/+page.svelte
@@ -21,6 +21,7 @@
     deny,
   } from "$lib/api/generated/accessRequests.generated.remote";
   import { getRoles } from "$lib/api/generated/roles.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   // Queries
   const requestsQuery = getPendingRequests();
@@ -97,8 +98,8 @@
       });
       successMessage = "Access request approved.";
       clearMessages();
-    } catch {
-      errorMessage = "Failed to approve request. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Failed to approve request. Please try again.");
       clearMessages();
     } finally {
       approvingId = null;
@@ -112,8 +113,8 @@
       await deny(subjectId);
       successMessage = "Access request denied.";
       clearMessages();
-    } catch {
-      errorMessage = "Failed to deny request. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Failed to deny request. Please try again.");
       clearMessages();
     } finally {
       denyingId = null;

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/admin/tenants/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/admin/tenants/+page.svelte
@@ -34,6 +34,7 @@
   import { getCurrentTenantId } from "../../current-tenant.remote";
   import { getTransitionStatus } from "$api/generated/platforms.generated.remote";
   import { describeSubmitError, errorMessage } from "$lib/forms/submit-error";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
 
   const tenantIdQuery = getCurrentTenantId();
   const currentTenantId = $derived(tenantIdQuery.current ?? undefined);
@@ -79,8 +80,8 @@
     loadError = null;
     try {
       tenant = await tenantRemote.getById(currentTenantId).run();
-    } catch {
-      loadError = "Failed to load tenant details.";
+    } catch (err) {
+      loadError = remoteErrorMessage(err, "Failed to load tenant details.");
     } finally {
       loading = false;
     }

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -79,6 +79,7 @@
   import { WidgetId } from "$lib/api/generated/nocturne-api-client";
   import { page } from "$app/state";
   import { coachmark } from "@nocturne/coach";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   const store = getSettingsStore();
   const realtimeStore = getRealtimeStore();
@@ -181,8 +182,10 @@
       // The dashboard still reads these through the shared settings store; reload
       // it so the change it renders matches what was persisted.
       await store.reload();
-    } catch {
-      toast.error("Could not save. Check your connection and try again.");
+    } catch (err) {
+      toast.error(
+        describeSubmitError(err, "Could not save. Check your connection and try again.")
+      );
       await uiSettingsQuery?.refresh();
     }
   }

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/+page.svelte
@@ -14,6 +14,7 @@
 		revokeLink,
 	} from "$lib/api/generated/chatIdentities.generated.remote";
 	import { getDiscordConfig, initiateDiscordLink } from "./discord.remote";
+	import { describeSubmitError } from "$lib/forms/submit-error";
 
 	// Auth guard
 	$effect(() => {
@@ -58,8 +59,8 @@
 		actionError = null;
 		try {
 			await setDefault(id);
-		} catch {
-			actionError = "Failed to set default link.";
+		} catch (err) {
+			actionError = describeSubmitError(err, "Failed to set default link.");
 		} finally {
 			isSettingDefault = null;
 		}
@@ -77,8 +78,8 @@
 				},
 			});
 			cancelEdit();
-		} catch {
-			actionError = "Failed to update link.";
+		} catch (err) {
+			actionError = describeSubmitError(err, "Failed to update link.");
 		} finally {
 			isSavingEdit = false;
 		}
@@ -89,8 +90,8 @@
 		actionError = null;
 		try {
 			await revokeLink(id);
-		} catch {
-			actionError = "Failed to revoke link.";
+		} catch (err) {
+			actionError = describeSubmitError(err, "Failed to revoke link.");
 		} finally {
 			isRevoking = null;
 		}
@@ -107,8 +108,8 @@
 				window.location.href = result.redirectUrl;
 				return;
 			}
-		} catch {
-			actionError = "Failed to start Discord link flow.";
+		} catch (err) {
+			actionError = describeSubmitError(err, "Failed to start Discord link flow.");
 		} finally {
 			isLinking = false;
 		}

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
@@ -42,6 +42,7 @@
   import MembershipRequestsCard from "$lib/components/members/MembershipRequestsCard.svelte";
   import RolesSection from "$lib/components/members/RolesSection.svelte";
   import { retainQuery } from "$lib/api/retain-query.svelte";
+  import { describeSubmitError } from "$lib/forms/submit-error";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],
@@ -171,8 +172,8 @@
       await membersQuery.refresh();
       successMessage = "Membership request approved.";
       clearMessages();
-    } catch {
-      errorMessage = "Failed to approve request. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Failed to approve request. Please try again.");
       clearMessages();
     }
   }
@@ -183,8 +184,8 @@
       await denyRequest(requestId);
       successMessage = "Membership request denied.";
       clearMessages();
-    } catch {
-      errorMessage = "Failed to deny request. Please try again.";
+    } catch (err) {
+      errorMessage = describeSubmitError(err, "Failed to deny request. Please try again.");
       clearMessages();
     }
   }
@@ -363,8 +364,11 @@
               await revokeInvite(inviteId);
               successMessage = "Invite revoked successfully.";
               clearMessages();
-            } catch {
-              errorMessage = "Failed to revoke invite. Please try again.";
+            } catch (err) {
+              errorMessage = describeSubmitError(
+                err,
+                "Failed to revoke invite. Please try again."
+              );
               clearMessages();
             } finally {
               isRevokingInvite = null;

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/members/+page.svelte
@@ -42,7 +42,6 @@
   import MembershipRequestsCard from "$lib/components/members/MembershipRequestsCard.svelte";
   import RolesSection from "$lib/components/members/RolesSection.svelte";
   import { retainQuery } from "$lib/api/retain-query.svelte";
-  import { describeSubmitError } from "$lib/forms/submit-error";
 
   const effectivePermissions: string[] = $derived(
     (page.data as any).effectivePermissions ?? [],

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/support/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/support/+page.svelte
@@ -40,6 +40,7 @@
   import { getCoachMarkContext } from "@nocturne/coach";
   import { toast } from "svelte-sonner";
   import { copyToClipboard } from "$lib/utils";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import {
     buildDiagnosticReport,
     readDiagnosticDevice,
@@ -74,8 +75,8 @@
     try {
       await coachCtx.resetAll();
       toast.success("Tutorials reset — they'll appear as you navigate the app");
-    } catch {
-      toast.error("Failed to reset tutorials");
+    } catch (err) {
+      toast.error(describeSubmitError(err, "Failed to reset tutorials"));
     } finally {
       resettingTutorials = false;
     }

--- a/src/Web/packages/app/src/routes/(fullscreen)/setup/connect/+page.svelte
+++ b/src/Web/packages/app/src/routes/(fullscreen)/setup/connect/+page.svelte
@@ -63,6 +63,8 @@
       const result = app.id ? await getUploaderSetup(app.id).run() : null;
       setupResponse = result ?? null;
     } catch {
+      // The view renders its own "no setup available" state from a null response,
+      // and there is nowhere on this step to put a reason.
       setupResponse = null;
     }
   }

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/auth.remote.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/auth.remote.ts
@@ -375,6 +375,8 @@ export const setAuthCookies = command(
       const session = await api.oidc.getSession();
       return { success: session?.isAuthenticated ?? false };
     } catch {
+      // A session that will not validate is the answer, not an error to report:
+      // the caller's next step is to sign in either way.
       return { success: false };
     }
   }

--- a/src/Web/packages/app/src/routes/(unauthenticated)/auth/bot/authorize/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/auth/bot/authorize/+page.svelte
@@ -6,6 +6,7 @@
 	import { getBotAuthorizeContext, buildTenantRedirectUrl } from "../bot.remote";
 	import { getPending, claimLink } from "$lib/api/generated/chatIdentities.generated.remote";
 	import { retainQuery } from "$lib/api/retain-query.svelte";
+	import { describeSubmitError } from "$lib/forms/submit-error";
 
 	// Read state token from URL
 	const stateToken = $derived(page.url.searchParams.get("state") ?? "");
@@ -62,8 +63,8 @@
 				window.location.href = result.url;
 				return; // Don't reset loading state - we're navigating away
 			}
-		} catch {
-			slugError = "Failed to build redirect URL.";
+		} catch (err) {
+			slugError = describeSubmitError(err, "Failed to build redirect URL.");
 		}
 		isSubmittingSlug = false;
 	}
@@ -74,8 +75,8 @@
 		try {
 			await claimLink({ token: stateToken });
 			goto("/auth/bot/authorize/done");
-		} catch {
-			claimError = "Failed to link account. Please try again.";
+		} catch (err) {
+			claimError = describeSubmitError(err, "Failed to link account. Please try again.");
 			isClaiming = false;
 		}
 	}

--- a/src/Web/packages/app/src/routes/(unauthenticated)/guest/activation-error.test.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/guest/activation-error.test.ts
@@ -2,18 +2,17 @@ import { describe, it, expect } from "vitest";
 import { classifyActivationError } from "./activation-error";
 
 describe("classifyActivationError", () => {
-  it("treats the API's typed rejection body as a refused code", () => {
-    // The generated client throws the parsed 400 body itself, which carries no
-    // status — reading only `status` reported every wrong code as an outage.
+  it("treats the API's refusal as a refused code", () => {
+    // The API answers a refused code with ProblemDetails, which carries the
+    // status in its own body, so the generated client's parsed throw has one.
     expect(
-      classifyActivationError({ expiresAt: null, error: "Invalid or expired code" })
+      classifyActivationError({
+        type: "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+        title: "Bad Request",
+        status: 400,
+        detail: "Invalid or expired code",
+      })
     ).toBe("rejected");
-  });
-
-  it("treats a rejection body with a null error as a refused code", () => {
-    expect(classifyActivationError({ expiresAt: null, error: null })).toBe(
-      "rejected"
-    );
   });
 
   it("treats an explicit 400 as a refused code", () => {
@@ -25,15 +24,6 @@ describe("classifyActivationError", () => {
   it("recognises the rate limiter", () => {
     expect(
       classifyActivationError({ status: 429, message: "Too Many Requests" })
-    ).toBe("rate-limited");
-  });
-
-  it("does not read the rate limiter's body as a refused code", () => {
-    expect(
-      classifyActivationError({
-        status: 429,
-        error: "rate_limit_exceeded",
-      })
     ).toBe("rate-limited");
   });
 
@@ -49,5 +39,11 @@ describe("classifyActivationError", () => {
     );
     expect(classifyActivationError(null)).toBe("unavailable");
     expect(classifyActivationError("boom")).toBe("unavailable");
+  });
+
+  it("does not read a status-less body as a refused code", () => {
+    // Guards the regression the ProblemDetails change removes the need for: a
+    // body with no status is an outage we cannot classify, not a bad code.
+    expect(classifyActivationError({ expiresAt: null })).toBe("unavailable");
   });
 });

--- a/src/Web/packages/app/src/routes/(unauthenticated)/guest/activation-error.test.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/guest/activation-error.test.ts
@@ -3,8 +3,8 @@ import { classifyActivationError } from "./activation-error";
 
 describe("classifyActivationError", () => {
   it("treats the API's refusal as a refused code", () => {
-    // The API answers a refused code with ProblemDetails, which carries the
-    // status in its own body, so the generated client's parsed throw has one.
+    // ProblemDetails carries the status in its own body, so the parsed throw the
+    // generated client hands back has one.
     expect(
       classifyActivationError({
         type: "https://tools.ietf.org/html/rfc9110#section-15.5.1",
@@ -42,8 +42,7 @@ describe("classifyActivationError", () => {
   });
 
   it("does not read a status-less body as a refused code", () => {
-    // Guards the regression the ProblemDetails change removes the need for: a
-    // body with no status is an outage we cannot classify, not a bad code.
+    // A body with no status is an outage we cannot classify, not a bad code.
     expect(classifyActivationError({ expiresAt: null })).toBe("unavailable");
   });
 });

--- a/src/Web/packages/app/src/routes/(unauthenticated)/guest/activation-error.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/guest/activation-error.ts
@@ -18,17 +18,5 @@ export function classifyActivationError(err: unknown): ActivationFailure {
   if (status === 429) return "rate-limited";
   if (status === 400) return "rejected";
 
-  // The generated client throws the parsed response body for a status it has a
-  // response type for, so a refused code arrives as the API's
-  // `{ expiresAt, error }` shape with no status attached. Everything else
-  // arrives as an exception that does carry one.
-  if (status === undefined && hasErrorField(err)) return "rejected";
-
   return "unavailable";
-}
-
-function hasErrorField(err: unknown): boolean {
-  if (!err || typeof err !== "object" || !("error" in err)) return false;
-  const { error } = err;
-  return typeof error === "string" || error === null;
 }

--- a/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/ImportProgress.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/setup/steps/ImportProgress.svelte
@@ -11,6 +11,7 @@
   } from "lucide-svelte";
   import * as migrationRemote from "$api/generated/migrations.generated.remote";
   import { MigrationJobState } from "$api";
+  import { remoteErrorMessage } from "$lib/api/remote-error";
 
   let {
     jobId,
@@ -106,8 +107,8 @@
               resolvedJobId = completed.id;
             }
           }
-        } catch {
-          error = "Failed to find active migration";
+        } catch (err) {
+          error = remoteErrorMessage(err, "Failed to find active migration");
           loading = false;
           return;
         }
@@ -189,6 +190,8 @@
 
           await new Promise((resolve) => setTimeout(resolve, 2000));
         } catch {
+          // A single failed poll says nothing worth showing; the retry below is
+          // the response, and a run of them gets its own wording.
           if (!active) break;
           consecutiveFailures++;
           // Only give up — and tell the user — once polling has failed repeatedly. The import

--- a/src/Web/pnpm-lock.yaml
+++ b/src/Web/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 7.0.0-dev.20260513.1
         version: 7.0.0-dev.20260513.1
       openapi-remote-codegen:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       prettier:
         specifier: ^3.7.2
         version: 3.7.2
@@ -5412,8 +5412,8 @@ packages:
   one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
 
-  openapi-remote-codegen@0.5.0:
-    resolution: {integrity: sha512-T0dC4gxOKqil0llpeEgGfVvYcRSmGqg39u1EpPUEG6ko7VAlJ/nnINasTVVMJatf9xhqsRHjbZiNZpFcRvfNXQ==}
+  openapi-remote-codegen@0.6.0:
+    resolution: {integrity: sha512-1T55p/6TXmRKhvxeweoxvXrrvmiIKb/r6e9sgc/rgYkc8UrTA6KI9yxCKnMIMxv+cacJD3h8Nl+SLRBui/weWw==}
     hasBin: true
 
   openapi-types@12.1.3:
@@ -12041,7 +12041,7 @@ snapshots:
     dependencies:
       fn.name: 1.1.0
 
-  openapi-remote-codegen@0.5.0:
+  openapi-remote-codegen@0.6.0:
     dependencies:
       openapi-types: 12.1.3
 

--- a/src/Web/pnpm-workspace.yaml
+++ b/src/Web/pnpm-workspace.yaml
@@ -46,4 +46,4 @@ packageExtensions:
 # the wrappers this workspace generates, so waiting a day to adopt one buys nothing.
 # Drop an entry once its version ages past the cutoff.
 minimumReleaseAgeExclude:
-  - openapi-remote-codegen@0.5.0
+  - openapi-remote-codegen@0.6.0

--- a/src/Web/remote-codegen.config.ts
+++ b/src/Web/remote-codegen.config.ts
@@ -9,6 +9,10 @@ export default {
   },
   nswagClientPath: './generated/nocturne-api-client',
   errorHandling: {
+    // `parseErrorBody` recovers the reason from an error body NSwag left unparsed;
+    // both the 403 and 500 arms read it. See `$lib/api/error-body`.
+    imports: [`import { parseErrorBody } from '$lib/api/error-body';`],
+
     // The default redirects queries to /auth/login on 401. For a public share
     // host ({token}.share.{baseDomain}) the viewer is anonymous by design and has
     // no account to sign into — and the dashboard fetches categories the tenant
@@ -29,7 +33,18 @@ export default {
     // Forward the server's actual error message for 403 so the FE can show
     // a meaningful reason (e.g. "Insufficient permissions for …") instead of
     // a bare "Forbidden".
-    on403: `throw error(403, (err as any)?.message ?? (err as any)?.detail ?? 'Forbidden')`,
+    //
+    // `detail` is read ahead of `message` because the two have different authors.
+    // A status the operation declares a `ProducesResponseType` for is thrown by
+    // NSwag as the parsed body, so a `Problem(detail: …)` refusal arrives with the
+    // server's sentence on `detail`. An undeclared status is thrown as an
+    // `ApiException` whose `message` is NSwag's own boilerplate and whose body is
+    // left unparsed on `response` — so the boilerplate must lose to anything the
+    // server actually wrote, including a reason recovered from that raw body.
+    on403:
+      `const e403 = err as any;\n` +
+      `      const b403 = parseErrorBody(e403);\n` +
+      `      throw error(403, e403?.detail ?? b403?.detail ?? b403?.title ?? b403?.message ?? e403?.message ?? 'Forbidden')`,
 
     // The default `on500` swallows every non-401/403 status as a 500 with a
     // generic message. Forward 400 (validation, e.g. cyclic alert_state
@@ -63,14 +78,18 @@ export default {
     // `err`: `detail` carries the reason and `title` only the status phrase,
     // which is why `detail` is read first. Without a typed schema NSwag throws an
     // ApiException whose `message` is its own boilerplate and whose body is left
-    // unparsed, so that message is the last resort. `err.body.message` belongs to
-    // an `HttpError` — the only other thing this catch can see, thrown by an
-    // invalidated query's refresh.
+    // **unparsed** on `response`. Parsing that raw body is the only way a curated
+    // `Problem(detail: …)` on an undeclared status reaches the user at all — no
+    // ordering of reads off the exception can recover it, because the exception
+    // carries none of it. NSwag's boilerplate is therefore the last resort, behind
+    // everything the server wrote. `err.body.message` belongs to an `HttpError`,
+    // which is what a nested remote call rethrows.
     on500: (functionName: string) =>
       `const e = err as any;\n` +
-      `    const errors = e?.errors;\n` +
+      `    const b = parseErrorBody(e);\n` +
+      `    const errors = e?.errors ?? b?.errors;\n` +
       `    const flat = errors ? Object.entries(errors).map(([, v]: [string, any]) => Array.isArray(v) ? v.join(', ') : v).join('; ') : undefined;\n` +
-      `    const message = flat ?? e?.body?.message ?? e?.detail ?? e?.title ?? e?.message;\n` +
+      `    const message = flat ?? e?.body?.message ?? e?.detail ?? e?.title ?? b?.detail ?? b?.title ?? b?.message ?? e?.message;\n` +
       `    if (status === 429) throw error(429, 'Too many requests');\n` +
       `    if (status === 404) throw error(404, 'Not found');\n` +
       `    if (status === 400 || status === 409) throw error(status, message ?? 'Request rejected');\n` +

--- a/src/Web/remote-codegen.config.ts
+++ b/src/Web/remote-codegen.config.ts
@@ -62,13 +62,12 @@ export default {
     // a meaningful reason (e.g. "Insufficient permissions for …") instead of
     // a bare "Forbidden".
     //
-    // The generator inlines this arm as the single statement of its `if`, so the
-    // locals it needs sit in a block: without the braces the `const` would be a
-    // syntax error and the `throw` would run on every status.
+    // The generator emits this arm inside a block of its own, so it may declare
+    // the locals the read order needs.
     on403:
-      `{ const e403 = err as any;\n` +
+      `const e403 = err as any;\n` +
       `      const b403 = parseErrorBody(e403);\n` +
-      `      throw error(403, ${reason('e403', 'b403')} ?? 'Forbidden'); }`,
+      `      throw error(403, ${reason('e403', 'b403')} ?? 'Forbidden')`,
 
     // The default `on500` swallows every non-401/403 status as a 500 with a
     // generic message. Forward 400 (validation, e.g. cyclic alert_state

--- a/src/Web/remote-codegen.config.ts
+++ b/src/Web/remote-codegen.config.ts
@@ -34,13 +34,10 @@ export default {
     // a meaningful reason (e.g. "Insufficient permissions for …") instead of
     // a bare "Forbidden".
     //
-    // `detail` is read ahead of `message` because the two have different authors.
-    // A status the operation declares a `ProducesResponseType` for is thrown by
-    // NSwag as the parsed body, so a `Problem(detail: …)` refusal arrives with the
-    // server's sentence on `detail`. An undeclared status is thrown as an
-    // `ApiException` whose `message` is NSwag's own boilerplate and whose body is
-    // left unparsed on `response` — so the boilerplate must lose to anything the
-    // server actually wrote, including a reason recovered from that raw body.
+    // Read in author order: the server's own sentence, then one recovered from a
+    // body NSwag left unparsed (`$lib/api/error-body`), and only then `message`,
+    // which on an `ApiException` is NSwag's boilerplate rather than anything the
+    // server wrote.
     on403:
       `const e403 = err as any;\n` +
       `      const b403 = parseErrorBody(e403);\n` +
@@ -76,14 +73,10 @@ export default {
     // NSwag throws the parsed error body itself (not wrapped in ApiException) for
     // a response that declares a typed schema, so an RFC-7807 body arrives as
     // `err`: `detail` carries the reason and `title` only the status phrase,
-    // which is why `detail` is read first. Without a typed schema NSwag throws an
-    // ApiException whose `message` is its own boilerplate and whose body is left
-    // **unparsed** on `response`. Parsing that raw body is the only way a curated
-    // `Problem(detail: …)` on an undeclared status reaches the user at all — no
-    // ordering of reads off the exception can recover it, because the exception
-    // carries none of it. NSwag's boilerplate is therefore the last resort, behind
-    // everything the server wrote. `err.body.message` belongs to an `HttpError`,
-    // which is what a nested remote call rethrows.
+    // which is why `detail` is read first. A body NSwag left unparsed is read
+    // next (`$lib/api/error-body`), and its boilerplate `message` last.
+    // `err.body.message` belongs to an `HttpError`, which is what a nested remote
+    // call rethrows.
     on500: (functionName: string) =>
       `const e = err as any;\n` +
       `    const b = parseErrorBody(e);\n` +

--- a/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
+++ b/tests/Integration/Nocturne.API.Tests/Auth/GuestLinkLifecycleIntegrationTests.cs
@@ -203,6 +203,12 @@ public class GuestLinkLifecycleIntegrationTests : AspireIntegrationTestBase
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // A refusal answers with ProblemDetails, so the reason travels with a
+        // status the caller can route on rather than in a body it has to sniff.
+        var body = JsonSerializer.Deserialize<JsonElement>(await response.Content.ReadAsStringAsync());
+        body.GetProperty("status").GetInt32().Should().Be(400);
+        body.GetProperty("detail").GetString().Should().NotBeNullOrWhiteSpace();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

This change improves error handling for API responses that NSwag leaves unparsed. When the API returns an error on a status the operation doesn't declare, NSwag throws an `ApiException` with the raw response body as a string rather than parsing it. This PR adds infrastructure to recover the server's actual error message from that unparsed body and surface it to users instead of generic fallback text.

## Key Changes

- **New `error-body.ts` module**: Parses error response bodies that NSwag left as raw text, extracting RFC 7807 `detail`/`title` fields and ASP.NET validation error maps. Validates field types to prevent malformed responses from corrupting error display.

- **New `remote-catch-guard.test.ts` linter**: Enforces that bare `catch` blocks around generated remote calls either bind the error or include a comment explaining why the error is intentionally swallowed. Catches cases where server error reasons are silently discarded.

- **Updated error handling config**: Modified `remote-codegen.config.ts` to import `parseErrorBody` and use it in the 403 and 500 error arms, reading the server's sentence first, then recovered details from unparsed bodies, then NSwag's boilerplate as a last resort.

- **API response type declarations**: Updated `GuestLinkController` and `PlatformAccessController` to declare `ProblemDetails` as the response type for 400 errors, ensuring consistent RFC 7807 formatting across the API.

- **Component error handling**: Updated 15+ components and pages to use `describeSubmitError()` when catching remote calls, replacing generic fallback messages with server-provided reasons where available. Added explanatory comments to intentional error swallows (e.g., optimistic rollbacks, polling retries).

- **Test updates**: Modified `activation-error.ts` and related tests to expect `ProblemDetails` with a `status` field rather than custom shapes, simplifying error classification logic.

## Implementation Details

- `parseErrorBody()` is defensive: it checks every field type rather than casting, so a malformed `errors` field (e.g., a string instead of an object) won't corrupt validation display.
- The remote-catch-guard linter reads text and pairs bare `catch` with the nearest `try` by brace depth, so it can be fooled by braces in strings/comments—but review catches those cases.
- Error arms now read fields in author order: the server's own `detail`, then recovered `detail`/`title` from unparsed bodies, then NSwag's boilerplate, ensuring the most specific reason wins.
- Intentional error swallows (polls, optimistic rollbacks) are marked with first-line comments so the linter passes them.

https://claude.ai/code/session_01CMJeobtvZyomjJ6mWVaBgu