### PR TITLE
refactor(core,data): hoist the V4 record header onto shared bases

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -102,6 +102,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+    <PackageVersion Include="NJsonSchema.Annotations" Version="11.5.2" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.6.3" />
     <PackageVersion Include="OpenApiRemoteCodegen.Attributes" Version="0.1.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.6.3" />

--- a/src/Core/Nocturne.Core.Models/Nocturne.Core.Models.csproj
+++ b/src/Core/Nocturne.Core.Models/Nocturne.Core.Models.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="NJsonSchema.Annotations" />
         <ProjectReference Include="..\Nocturne.Core.Constants\Nocturne.Core.Constants.csproj" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Core/Nocturne.Core.Models/V4/ApsSnapshot.cs
+++ b/src/Core/Nocturne.Core.Models/V4/ApsSnapshot.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -25,23 +27,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="AidAlgorithm"/>
 /// <seealso cref="Bolus"/>
 /// <seealso cref="TempBasal"/>
-public class ApsSnapshot : IV4Record
+[JsonSchemaFlatten]
+public class ApsSnapshot : V4RecordBase
 {
-    /// <inheritdoc />
-    public Guid Id { get; set; }
-
-    /// <inheritdoc />
-    public DateTime Timestamp { get; set; }
-
-    /// <inheritdoc />
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <inheritdoc />
-    public int? UtcOffset { get; set; }
-
-    /// <inheritdoc />
-    public string? Device { get; set; }
-
     /// <summary>
     /// Foreign key to the <see cref="Device"/> table.
     /// </summary>
@@ -52,29 +40,11 @@ public class ApsSnapshot : IV4Record
     /// </summary>
     public Guid? PatientDeviceId { get; set; }
 
-    /// <inheritdoc />
-    public string? App { get; set; }
-
-    /// <inheritdoc />
-    public string? DataSource { get; set; }
-
     /// <summary>
     /// Stable per-source identifier. Records matched on (DataSource, SyncIdentifier) are updated in
     /// place on re-upload instead of duplicated, so uploader retries are idempotent.
     /// </summary>
     public string? SyncIdentifier { get; set; }
-
-    /// <inheritdoc />
-    public Guid? CorrelationId { get; set; }
-
-    /// <inheritdoc />
-    public string? LegacyId { get; set; }
-
-    /// <inheritdoc />
-    public DateTime CreatedAt { get; set; }
-
-    /// <inheritdoc />
-    public DateTime ModifiedAt { get; set; }
 
     /// <summary>
     /// Which AID algorithm produced this snapshot.
@@ -156,9 +126,4 @@ public class ApsSnapshot : IV4Record
 
     /// <summary>Algorithm version string (e.g. Trio app version).</summary>
     public string? AidVersion { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/BGCheck.cs
+++ b/src/Core/Nocturne.Core.Models/V4/BGCheck.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using Nocturne.Core.Constants;
 
 namespace Nocturne.Core.Models.V4;
@@ -24,63 +25,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="SensorGlucose"/>
 /// <seealso cref="GlucoseType"/>
 /// <seealso cref="GlucoseUnit"/>
-public class BGCheck : IV4Record
+[JsonSchemaFlatten]
+public class BGCheck : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that performed this check
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this check
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Glucose value as entered by the user (source of truth)
     /// </summary>
@@ -112,9 +59,4 @@ public class BGCheck : IV4Record
     /// APS system sync/deduplication identifier (used by Loop and AAPS)
     /// </summary>
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/BasalInjection.cs
+++ b/src/Core/Nocturne.Core.Models/V4/BasalInjection.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -9,28 +11,15 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="PatientInsulin"/>
 /// <seealso cref="TreatmentInsulinContext"/>
 /// <seealso cref="IV4Record"/>
-public class BasalInjection : IV4Record, IDeviceAttributed
+[JsonSchemaFlatten]
+public class BasalInjection : V4RecordBase, IDeviceAttributed
 {
-    public Guid Id { get; set; }
-    public DateTime Timestamp { get; set; }
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-    public int? UtcOffset { get; set; }
-
-    public string? Device { get; set; }
-    public string? App { get; set; }
-    public string? DataSource { get; set; }
     public string? SyncIdentifier { get; set; }
-
-    public Guid? CorrelationId { get; set; }
-    public string? LegacyId { get; set; }
 
     /// <summary>
     /// Foreign key to the <see cref="PatientDevice"/> (pen) this injection is attributed to.
     /// </summary>
     public Guid? PatientDeviceId { get; set; }
-
-    public DateTime CreatedAt { get; set; }
-    public DateTime ModifiedAt { get; set; }
 
     /// <summary>Insulin units injected.</summary>
     public double Units { get; set; }
@@ -45,9 +34,4 @@ public class BasalInjection : IV4Record, IDeviceAttributed
     /// about the patient's insulin catalog. Same shape as <see cref="Bolus.InsulinContext"/>.
     /// </summary>
     public TreatmentInsulinContext? InsulinContext { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns.
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/BasalSchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/BasalSchedule.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -19,63 +21,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="TherapySettings"/>
 /// <seealso cref="ProfileSummary"/>
 /// <seealso cref="TempBasal"/>
-public class BasalSchedule : IV4Record
+[JsonSchemaFlatten]
+public class BasalSchedule : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this record
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this record
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links all V4 records decomposed from the same legacy Profile record
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Composite legacy ID: "{profileId}:{storeName}" for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Named profile this schedule belongs to
     /// </summary>
@@ -85,9 +33,4 @@ public class BasalSchedule : IV4Record
     /// Basal rate entries throughout the day (time + U/hr value)
     /// </summary>
     public List<ScheduleEntry> Entries { get; set; } = [];
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/Bolus.cs
+++ b/src/Core/Nocturne.Core.Models/V4/Bolus.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -23,63 +25,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="BolusType"/>
 /// <seealso cref="ApsSnapshot"/>
 /// <seealso cref="TempBasal"/>
-public class Bolus : IV4Record, IDeviceAttributed
+[JsonSchemaFlatten]
+public class Bolus : V4RecordBase, IDeviceAttributed
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that delivered this bolus
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this bolus
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Insulin units delivered
     /// </summary>
@@ -161,9 +109,4 @@ public class Bolus : IV4Record, IDeviceAttributed
     /// FK to the <see cref="ApsSnapshot"/> whose algorithm decision triggered this bolus (for SMBs/auto-boluses).
     /// </summary>
     public Guid? ApsSnapshotId { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/BolusCalculation.cs
+++ b/src/Core/Nocturne.Core.Models/V4/BolusCalculation.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -12,63 +14,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="IV4Record"/>
 /// <seealso cref="Bolus"/>
 /// <seealso cref="CalculationType"/>
-public class BolusCalculation : IV4Record
+[JsonSchemaFlatten]
+public class BolusCalculation : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that performed this calculation
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this calculation
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Blood glucose input value used for the calculation
     /// </summary>
@@ -133,9 +81,4 @@ public class BolusCalculation : IV4Record
     /// Pre-bolus time in minutes
     /// </summary>
     public double? PreBolus { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/Calibration.cs
+++ b/src/Core/Nocturne.Core.Models/V4/Calibration.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -11,63 +13,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="Entry"/>
 /// <seealso cref="IV4Record"/>
 /// <seealso cref="SensorGlucose"/>
-public class Calibration : IV4Record
+[JsonSchemaFlatten]
+public class Calibration : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that produced this calibration
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this calibration
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Calibration slope value
     /// </summary>
@@ -82,9 +30,4 @@ public class Calibration : IV4Record
     /// Calibration scale value
     /// </summary>
     public double? Scale { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/CarbIntake.cs
+++ b/src/Core/Nocturne.Core.Models/V4/CarbIntake.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -18,63 +20,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="IV4Record"/>
 /// <seealso cref="Bolus"/>
 /// <seealso cref="MealEvent"/>
-public class CarbIntake : IV4Record
+[JsonSchemaFlatten]
+public class CarbIntake : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that recorded this intake
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this intake
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Carbohydrates in grams
     /// </summary>
@@ -106,9 +54,4 @@ public class CarbIntake : IV4Record
     /// Protein consumed in grams, when the source reports macros.
     /// </summary>
     public double? ProteinGrams { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/CarbRatioSchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/CarbRatioSchedule.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -16,63 +18,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="TargetRangeSchedule"/>
 /// <seealso cref="TherapySettings"/>
 /// <seealso cref="ProfileSummary"/>
-public class CarbRatioSchedule : IV4Record
+[JsonSchemaFlatten]
+public class CarbRatioSchedule : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this record
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this record
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links all V4 records decomposed from the same legacy Profile record
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Composite legacy ID: "{profileId}:{storeName}" for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Named profile this schedule belongs to
     /// </summary>
@@ -82,9 +30,4 @@ public class CarbRatioSchedule : IV4Record
     /// Carb ratio entries throughout the day (time + g/U value)
     /// </summary>
     public List<ScheduleEntry> Entries { get; set; } = [];
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/DeviceEvent.cs
+++ b/src/Core/Nocturne.Core.Models/V4/DeviceEvent.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -14,33 +16,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="DeviceEventType"/>
 /// <seealso cref="Device"/>
 /// <seealso cref="Note"/>
-public class DeviceEvent : IV4Record, IDeviceAttributed
+[JsonSchemaFlatten]
+public class DeviceEvent : V4RecordBase, IDeviceAttributed
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this record
-    /// </summary>
-    public string? Device { get; set; }
-
     /// <summary>
     /// Foreign key to the <see cref="Device"/> table.
     /// </summary>
@@ -50,36 +28,6 @@ public class DeviceEvent : IV4Record, IDeviceAttributed
     /// Foreign key to the <see cref="PatientDevice"/> table.
     /// </summary>
     public Guid? PatientDeviceId { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this record
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
 
     /// <summary>
     /// Type of device event (e.g. <see cref="DeviceEventType.SiteChange"/>,
@@ -96,9 +44,4 @@ public class DeviceEvent : IV4Record, IDeviceAttributed
     /// APS system sync/deduplication identifier (used by Loop and AAPS)
     /// </summary>
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/MeterGlucose.cs
+++ b/src/Core/Nocturne.Core.Models/V4/MeterGlucose.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using Nocturne.Core.Constants;
 
 namespace Nocturne.Core.Models.V4;
@@ -20,67 +21,13 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="IV4Record"/>
 /// <seealso cref="BGCheck"/>
 /// <seealso cref="SensorGlucose"/>
-public class MeterGlucose : IV4Record, IDeviceAttributed
+[JsonSchemaFlatten]
+public class MeterGlucose : V4RecordBase, IDeviceAttributed
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that produced this reading
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this reading
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
     /// <summary>
     /// Foreign key to the <see cref="PatientDevice"/> (meter) this reading is attributed to.
     /// </summary>
     public Guid? PatientDeviceId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
 
     /// <summary>
     /// Glucose value in mg/dL
@@ -94,9 +41,4 @@ public class MeterGlucose : IV4Record, IDeviceAttributed
     /// The mg/dL value is the source of truth.
     /// </remarks>
     public double Mmol => Mgdl / GlucoseConstants.MgdlPerMmol;
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/Note.cs
+++ b/src/Core/Nocturne.Core.Models/V4/Note.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -11,63 +13,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="Treatment"/>
 /// <seealso cref="IV4Record"/>
 /// <seealso cref="DeviceEvent"/>
-public class Note : IV4Record
+[JsonSchemaFlatten]
+public class Note : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this note
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this note
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Note text content
     /// </summary>
@@ -87,9 +35,4 @@ public class Note : IV4Record
     /// APS system sync/deduplication identifier (used by Loop and AAPS)
     /// </summary>
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/PumpSnapshot.cs
+++ b/src/Core/Nocturne.Core.Models/V4/PumpSnapshot.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -14,46 +16,14 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="ApsSnapshot"/>
 /// <seealso cref="UploaderSnapshot"/>
 /// <seealso cref="Device"/>
-public class PumpSnapshot : IV4Record
+[JsonSchemaFlatten]
+public class PumpSnapshot : V4RecordBase
 {
-    /// <inheritdoc />
-    public Guid Id { get; set; }
-
-    /// <inheritdoc />
-    public DateTime Timestamp { get; set; }
-
-    /// <inheritdoc />
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <inheritdoc />
-    public int? UtcOffset { get; set; }
-
-    /// <inheritdoc />
-    public string? Device { get; set; }
-
-    /// <inheritdoc />
-    public string? App { get; set; }
-
-    /// <inheritdoc />
-    public string? DataSource { get; set; }
-
     /// <summary>
     /// Stable per-source identifier. Records matched on (DataSource, SyncIdentifier) are updated in
     /// place on re-upload instead of duplicated, so uploader retries are idempotent.
     /// </summary>
     public string? SyncIdentifier { get; set; }
-
-    /// <inheritdoc />
-    public Guid? CorrelationId { get; set; }
-
-    /// <inheritdoc />
-    public string? LegacyId { get; set; }
-
-    /// <inheritdoc />
-    public DateTime CreatedAt { get; set; }
-
-    /// <inheritdoc />
-    public DateTime ModifiedAt { get; set; }
 
     /// <summary>
     /// Pump manufacturer name (e.g., "Insulet", "Medtronic", "Tandem").
@@ -128,9 +98,4 @@ public class PumpSnapshot : IV4Record
 
     /// <summary>Pump-reported bolus IOB.</summary>
     public double? BolusIob { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/SensitivitySchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/SensitivitySchedule.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -16,63 +18,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="TargetRangeSchedule"/>
 /// <seealso cref="TherapySettings"/>
 /// <seealso cref="ProfileSummary"/>
-public class SensitivitySchedule : IV4Record
+[JsonSchemaFlatten]
+public class SensitivitySchedule : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this record
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this record
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links all V4 records decomposed from the same legacy Profile record
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Composite legacy ID: "{profileId}:{storeName}" for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Named profile this schedule belongs to
     /// </summary>
@@ -82,9 +30,4 @@ public class SensitivitySchedule : IV4Record
     /// ISF entries throughout the day (time + mg/dL per U value)
     /// </summary>
     public List<ScheduleEntry> Entries { get; set; } = [];
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/SensorGlucose.cs
+++ b/src/Core/Nocturne.Core.Models/V4/SensorGlucose.cs
@@ -1,3 +1,4 @@
+using NJsonSchema.Annotations;
 using Nocturne.Core.Constants;
 
 namespace Nocturne.Core.Models.V4;
@@ -23,57 +24,13 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="GlucoseTrend"/>
 /// <seealso cref="MeterGlucose"/>
 /// <seealso cref="BGCheck"/>
-public class SensorGlucose : IV4Record, IDeviceAttributed
+[JsonSchemaFlatten]
+public class SensorGlucose : V4RecordBase, IDeviceAttributed
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that produced this reading
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this reading
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
     /// <summary>
     /// FK to the patient's registered CGM device (null if not yet resolved)
     /// </summary>
     public Guid? PatientDeviceId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
 
     /// <summary>
     /// Stable per-source identifier. Records matched on (DataSource, SyncIdentifier) are updated in
@@ -81,16 +38,6 @@ public class SensorGlucose : IV4Record, IDeviceAttributed
     /// moves the existing row instead of duplicating it.
     /// </summary>
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
 
     /// <summary>
     /// Glucose value in mg/dL
@@ -174,9 +121,4 @@ public class SensorGlucose : IV4Record, IDeviceAttributed
     /// </summary>
     public double? UnsmoothedMmol =>
         UnsmoothedMgdl.HasValue ? UnsmoothedMgdl.Value / GlucoseConstants.MgdlPerMmol : null;
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/TargetRangeSchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TargetRangeSchedule.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -17,63 +19,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="SensitivitySchedule"/>
 /// <seealso cref="TherapySettings"/>
 /// <seealso cref="ProfileSummary"/>
-public class TargetRangeSchedule : IV4Record
+[JsonSchemaFlatten]
+public class TargetRangeSchedule : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this record
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this record
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links all V4 records decomposed from the same legacy Profile record
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Composite legacy ID: "{profileId}:{storeName}" for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Named profile this schedule belongs to
     /// </summary>
@@ -83,9 +31,4 @@ public class TargetRangeSchedule : IV4Record
     /// Target range entries throughout the day (time + low/high bounds)
     /// </summary>
     public List<TargetRangeEntry> Entries { get; set; } = [];
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/TherapySettings.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TherapySettings.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -17,63 +19,9 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="SensitivitySchedule"/>
 /// <seealso cref="TargetRangeSchedule"/>
 /// <seealso cref="ProfileSummary"/>
-public class TherapySettings : IV4Record
+[JsonSchemaFlatten]
+public class TherapySettings : V4RecordBase
 {
-    /// <summary>
-    /// UUID v7 primary key
-    /// </summary>
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime
-    /// </summary>
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// Unix milliseconds (computed from Timestamp for v1/v3 compatibility)
-    /// </summary>
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this record
-    /// </summary>
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this record
-    /// </summary>
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links all V4 records decomposed from the same legacy Profile record
-    /// </summary>
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Composite legacy ID: "{profileId}:{storeName}" for migration traceability
-    /// </summary>
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// When this record was created
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// When this record was last modified
-    /// </summary>
-    public DateTime ModifiedAt { get; set; }
-
     /// <summary>
     /// Named profile this came from (e.g., "Default", "Weekday")
     /// </summary>
@@ -163,9 +111,4 @@ public class TherapySettings : IV4Record
     /// ISO format start date preserved from legacy profile
     /// </summary>
     public string? StartDate { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/UploaderSnapshot.cs
+++ b/src/Core/Nocturne.Core.Models/V4/UploaderSnapshot.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.Annotations;
+
 namespace Nocturne.Core.Models.V4;
 
 /// <summary>
@@ -14,46 +16,14 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="ApsSnapshot"/>
 /// <seealso cref="PumpSnapshot"/>
 /// <seealso cref="Device"/>
-public class UploaderSnapshot : IV4Record
+[JsonSchemaFlatten]
+public class UploaderSnapshot : V4RecordBase
 {
-    /// <inheritdoc />
-    public Guid Id { get; set; }
-
-    /// <inheritdoc />
-    public DateTime Timestamp { get; set; }
-
-    /// <inheritdoc />
-    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-    /// <inheritdoc />
-    public int? UtcOffset { get; set; }
-
-    /// <inheritdoc />
-    public string? Device { get; set; }
-
-    /// <inheritdoc />
-    public string? App { get; set; }
-
-    /// <inheritdoc />
-    public string? DataSource { get; set; }
-
     /// <summary>
     /// Stable per-source identifier. Records matched on (DataSource, SyncIdentifier) are updated in
     /// place on re-upload instead of duplicated, so uploader retries are idempotent.
     /// </summary>
     public string? SyncIdentifier { get; set; }
-
-    /// <inheritdoc />
-    public Guid? CorrelationId { get; set; }
-
-    /// <inheritdoc />
-    public string? LegacyId { get; set; }
-
-    /// <inheritdoc />
-    public DateTime CreatedAt { get; set; }
-
-    /// <inheritdoc />
-    public DateTime ModifiedAt { get; set; }
 
     /// <summary>
     /// Uploader device name (e.g., phone model or bridge device name).
@@ -89,9 +59,4 @@ public class UploaderSnapshot : IV4Record
     /// Foreign key to the <see cref="V4.Device"/> table.
     /// </summary>
     public Guid? DeviceId { get; set; }
-
-    /// <summary>
-    /// Catch-all for fields not mapped to dedicated columns
-    /// </summary>
-    public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/V4/V4RecordBase.cs
+++ b/src/Core/Nocturne.Core.Models/V4/V4RecordBase.cs
@@ -1,0 +1,52 @@
+namespace Nocturne.Core.Models.V4;
+
+/// <summary>
+/// Shared implementation of the <see cref="IV4Record"/> header carried by every V4 record type.
+/// </summary>
+/// <remarks>
+/// <inheritdoc cref="IV4Record" path="/remarks"/>
+/// <para>
+/// V4 records are API response types whose schemas are flat on the wire, so every derived record
+/// carries <c>[JsonSchemaFlatten]</c> — NSwag then inlines these members into that record's schema
+/// rather than emitting an <c>allOf</c> reference to a base schema. NJsonSchema reads the attribute
+/// off the type being generated and does not inherit it, so it cannot be declared here once.
+/// </para>
+/// </remarks>
+public abstract class V4RecordBase : IV4Record
+{
+    /// <inheritdoc />
+    public Guid Id { get; set; }
+
+    /// <inheritdoc />
+    public DateTime Timestamp { get; set; }
+
+    /// <inheritdoc />
+    public long Mills => new DateTimeOffset(Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+    /// <inheritdoc />
+    public int? UtcOffset { get; set; }
+
+    /// <inheritdoc />
+    public string? Device { get; set; }
+
+    /// <inheritdoc />
+    public string? App { get; set; }
+
+    /// <inheritdoc />
+    public string? DataSource { get; set; }
+
+    /// <inheritdoc />
+    public Guid? CorrelationId { get; set; }
+
+    /// <inheritdoc />
+    public string? LegacyId { get; set; }
+
+    /// <inheritdoc />
+    public DateTime CreatedAt { get; set; }
+
+    /// <inheritdoc />
+    public DateTime ModifiedAt { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, object?>? AdditionalProperties { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,88 +8,16 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.ApsSnapshot
 /// </summary>
 [Table("aps_snapshots")]
-public class ApsSnapshotEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class ApsSnapshotEntity : V4TimeSeriesEntityBase
 {
     /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that produced this snapshot
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Links records that were decomposed from the same legacy DeviceStatus
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// Connector data source that produced this snapshot (null for direct v1/v3 uploads).
-    /// </summary>
-    [Column("data_source")]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this snapshot
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Stable per-source identifier for synchronization. Unlike <see cref="LegacyId"/> (insert-only),
+    /// Stable per-source identifier for synchronization. Unlike <see cref="V4TimeSeriesEntityBase.LegacyId"/> (insert-only),
     /// a record matched by (DataSource, SyncIdentifier) is updated in place on re-upload — required so
     /// uploader retries of the same loop cycle don't duplicate the snapshot.
     /// </summary>
     [Column("sync_identifier")]
     [MaxLength(256)]
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// Which AID algorithm produced this snapshot (enum stored as string: Loop, Trio, ControlIQ, etc.)
@@ -250,18 +176,4 @@ public class ApsSnapshotEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4T
     /// </summary>
     [Column("patient_device_id")]
     public Guid? PatientDeviceId { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BGCheckEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,81 +8,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BGCheck
 /// </summary>
 [Table("bg_checks")]
-public class BGCheckEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class BGCheckEntity : V4TimeSeriesEntityBase
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that performed this check
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this check
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Glucose value as entered by the user
     /// </summary>
@@ -111,18 +36,4 @@ public class BGCheckEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeS
     [Column("sync_identifier")]
     [MaxLength(256)]
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalInjectionEntity.cs
@@ -10,53 +10,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BasalInjection.
 /// </summary>
 [Table("basal_injections")]
-public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, IDeviceAttributedEntity, ISystemTimestamped
+public class BasalInjectionEntity : V4TimeSeriesEntityBase, ISyncDedupable, IDeviceAttributedEntity
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that recorded this injection
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this injection
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
     /// <summary>
     /// Unique identifier for synchronization across platforms and devices.
     /// </summary>
@@ -65,38 +20,10 @@ public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, I
     public string? SyncIdentifier { get; set; }
 
     /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
     /// FK to the PatientDevice (pen) this injection is attributed to
     /// </summary>
     [Column("patient_device_id")]
     public Guid? PatientDeviceId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// Insulin units injected
@@ -118,18 +45,4 @@ public class BasalInjectionEntity : ITenantScoped, IAuditable, ISoftDeletable, I
     /// </summary>
     [Column("insulin_context", TypeName = "jsonb")]
     public string? InsulinContextJson { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null, the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BasalScheduleEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,81 +8,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BasalSchedule
 /// </summary>
 [Table("basal_schedules")]
-public class BasalScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class BasalScheduleEntity : V4TimeSeriesEntityBase
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this schedule record
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this schedule record
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Profile name this basal schedule belongs to
     /// </summary>
@@ -97,18 +22,4 @@ public class BasalScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV
     /// </summary>
     [Column("entries_json", TypeName = "jsonb")]
     public string EntriesJson { get; set; } = "[]";
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusCalculationEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,81 +8,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.BolusCalculation
 /// </summary>
 [Table("bolus_calculations")]
-public class BolusCalculationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class BolusCalculationEntity : V4TimeSeriesEntityBase
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that performed this calculation
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this calculation
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Blood glucose input value used for the calculation
     /// </summary>
@@ -164,18 +89,4 @@ public class BolusCalculationEntity : ITenantScoped, IAuditable, ISoftDeletable,
     /// </summary>
     [Column("pre_bolus")]
     public double? PreBolus { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/BolusEntity.cs
@@ -10,81 +10,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Bolus
 /// </summary>
 [Table("boluses")]
-public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, IDeviceAttributedEntity, ISystemTimestamped
+public class BolusEntity : V4TimeSeriesEntityBase, ISyncDedupable, IDeviceAttributedEntity
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that delivered this bolus
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this bolus
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Insulin units delivered
     /// </summary>
@@ -185,18 +112,4 @@ public class BolusEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSer
     /// </summary>
     [Column("aps_snapshot_id")]
     public Guid? ApsSnapshotId { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CalibrationEntity.cs
@@ -1,7 +1,4 @@
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-
-using Nocturne.Infrastructure.Data.Entities;
 
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -10,81 +7,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Calibration
 /// </summary>
 [Table("calibrations")]
-public class CalibrationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class CalibrationEntity : V4TimeSeriesEntityBase
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that produced this calibration
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this calibration
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Calibration slope value
     /// </summary>
@@ -102,18 +26,4 @@ public class CalibrationEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4T
     /// </summary>
     [Column("scale")]
     public double? Scale { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbIntakeEntity.cs
@@ -10,81 +10,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbIntake
 /// </summary>
 [Table("carb_intakes")]
-public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, ISystemTimestamped
+public class CarbIntakeEntity : V4TimeSeriesEntityBase, ISyncDedupable
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that recorded this intake
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this intake
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Carbohydrates in grams
     /// </summary>
@@ -121,18 +48,4 @@ public class CarbIntakeEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4Ti
     /// </summary>
     [Column("protein_grams")]
     public double? ProteinGrams { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/CarbRatioScheduleEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,81 +8,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.CarbRatioSchedule
 /// </summary>
 [Table("carb_ratio_schedules")]
-public class CarbRatioScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class CarbRatioScheduleEntity : V4TimeSeriesEntityBase
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this schedule record
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this schedule record
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Profile name this carb ratio schedule belongs to
     /// </summary>
@@ -97,18 +22,4 @@ public class CarbRatioScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable
     /// </summary>
     [Column("entries_json", TypeName = "jsonb")]
     public string EntriesJson { get; set; } = "[]";
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/DeviceEventEntity.cs
@@ -10,81 +10,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.DeviceEvent
 /// </summary>
 [Table("device_events")]
-public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, IDeviceAttributedEntity, ISystemTimestamped
+public class DeviceEventEntity : V4TimeSeriesEntityBase, ISyncDedupable, IDeviceAttributedEntity
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this record
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this record
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Type of device event stored as string (e.g. "SiteChange", "SensorStart")
     /// </summary>
@@ -117,18 +44,4 @@ public class DeviceEventEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4T
     /// </summary>
     [Column("patient_device_id")]
     public Guid? PatientDeviceId { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/MeterGlucoseEntity.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 using Nocturne.Infrastructure.Data.Entities;
@@ -10,67 +9,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.MeterGlucose
 /// </summary>
 [Table("meter_glucose")]
-public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, IDeviceAttributedEntity, ISystemTimestamped
+public class MeterGlucoseEntity : V4TimeSeriesEntityBase, IDeviceAttributedEntity
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that produced this reading
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this reading
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
     /// <summary>
     /// FK to the PatientDevice (meter) this reading is attributed to
     /// </summary>
@@ -78,36 +18,8 @@ public class MeterGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4
     public Guid? PatientDeviceId { get; set; }
 
     /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
     /// Glucose value in mg/dL
     /// </summary>
     [Column("mgdl")]
     public double Mgdl { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/NoteEntity.cs
@@ -10,81 +10,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.Note
 /// </summary>
 [Table("notes")]
-public class NoteEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, ISystemTimestamped
+public class NoteEntity : V4TimeSeriesEntityBase, ISyncDedupable
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this note
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this note
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Note text content
     /// </summary>
@@ -111,18 +38,4 @@ public class NoteEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeri
     [Column("sync_identifier")]
     [MaxLength(256)]
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,88 +8,16 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PumpSnapshot
 /// </summary>
 [Table("pump_snapshots")]
-public class PumpSnapshotEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class PumpSnapshotEntity : V4TimeSeriesEntityBase
 {
     /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that produced this snapshot
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Links records that were decomposed from the same legacy DeviceStatus
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// Connector data source that produced this snapshot (null for direct v1/v3 uploads).
-    /// </summary>
-    [Column("data_source")]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this snapshot
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Stable per-source identifier for synchronization. Unlike <see cref="LegacyId"/> (insert-only),
+    /// Stable per-source identifier for synchronization. Unlike <see cref="V4TimeSeriesEntityBase.LegacyId"/> (insert-only),
     /// a record matched by (DataSource, SyncIdentifier) is updated in place on re-upload — required so
     /// uploader retries of the same loop cycle don't duplicate the snapshot.
     /// </summary>
     [Column("sync_identifier")]
     [MaxLength(256)]
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// Pump manufacturer name
@@ -188,18 +114,4 @@ public class PumpSnapshotEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4
     /// </summary>
     [Column("bolus_iob")]
     public double? BolusIob { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensitivityScheduleEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,81 +8,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensitivitySchedule
 /// </summary>
 [Table("sensitivity_schedules")]
-public class SensitivityScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class SensitivityScheduleEntity : V4TimeSeriesEntityBase
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this schedule record
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this schedule record
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Profile name this sensitivity schedule belongs to
     /// </summary>
@@ -97,18 +22,4 @@ public class SensitivityScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// </summary>
     [Column("entries_json", TypeName = "jsonb")]
     public string EntriesJson { get; set; } = "[]";
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/SensorGlucoseEntity.cs
@@ -10,60 +10,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.SensorGlucose
 /// </summary>
 [Table("sensor_glucose")]
-public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISyncDedupable, IDeviceAttributedEntity, ISystemTimestamped
+public class SensorGlucoseEntity : V4TimeSeriesEntityBase, ISyncDedupable, IDeviceAttributedEntity
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that produced this reading
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this reading
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
     /// <summary>
     /// FK to the patient's registered device record (resolved at ingest time)
     /// </summary>
@@ -71,34 +19,13 @@ public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV
     public Guid? PatientDeviceId { get; set; }
 
     /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// Stable per-source identifier for synchronization. Unlike <see cref="LegacyId"/> (insert-only),
+    /// Stable per-source identifier for synchronization. Unlike <see cref="V4TimeSeriesEntityBase.LegacyId"/> (insert-only),
     /// a record matched by (DataSource, SyncIdentifier) is updated in place on re-import — required so
     /// timezone re-correction can move a reading's timestamp without duplicating it.
     /// </summary>
     [Column("sync_identifier")]
     [MaxLength(256)]
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// Glucose value in mg/dL
@@ -161,18 +88,4 @@ public class SensorGlucoseEntity : ITenantScoped, IAuditable, ISoftDeletable, IV
     /// </summary>
     [Column("unsmoothed_mgdl")]
     public double? UnsmoothedMgdl { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TargetRangeScheduleEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,81 +8,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TargetRangeSchedule
 /// </summary>
 [Table("target_range_schedules")]
-public class TargetRangeScheduleEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class TargetRangeScheduleEntity : V4TimeSeriesEntityBase
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this schedule record
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this schedule record
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Profile name this target range schedule belongs to
     /// </summary>
@@ -97,18 +22,4 @@ public class TargetRangeScheduleEntity : ITenantScoped, IAuditable, ISoftDeletab
     /// </summary>
     [Column("entries_json", TypeName = "jsonb")]
     public string EntriesJson { get; set; } = "[]";
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/TherapySettingsEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,81 +8,8 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.TherapySettings
 /// </summary>
 [Table("therapy_settings")]
-public class TherapySettingsEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class TherapySettingsEntity : V4TimeSeriesEntityBase
 {
-    /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that created this settings record
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this settings record
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Origin data source identifier
-    /// </summary>
-    [Column("data_source")]
-    [MaxLength(256)]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Links records that were split from the same legacy Treatment
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
-
     /// <summary>
     /// Profile name this therapy settings record belongs to
     /// </summary>
@@ -197,18 +122,4 @@ public class TherapySettingsEntity : ITenantScoped, IAuditable, ISoftDeletable, 
     [Column("start_date")]
     [MaxLength(50)]
     public string? StartDate { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-using Nocturne.Infrastructure.Data.Entities;
-
 namespace Nocturne.Infrastructure.Data.Entities.V4;
 
 /// <summary>
@@ -10,88 +8,16 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.UploaderSnapshot
 /// </summary>
 [Table("uploader_snapshots")]
-public class UploaderSnapshotEntity : ITenantScoped, IAuditable, ISoftDeletable, IV4TimeSeriesEntity, ISystemTimestamped
+public class UploaderSnapshotEntity : V4TimeSeriesEntityBase
 {
     /// <summary>
-    /// The unique identifier of the tenant this record belongs to.
-    /// </summary>
-    [Column("tenant_id")]
-    public Guid TenantId { get; set; }
-
-    /// <summary>
-    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
-    /// </summary>
-    [Key]
-    public Guid Id { get; set; }
-
-    /// <summary>
-    /// Canonical timestamp as UTC DateTime (timestamptz)
-    /// </summary>
-    [Column("timestamp")]
-    public DateTime Timestamp { get; set; }
-
-    /// <summary>
-    /// UTC offset in minutes
-    /// </summary>
-    [Column("utc_offset")]
-    public int? UtcOffset { get; set; }
-
-    /// <summary>
-    /// Device identifier that produced this snapshot
-    /// </summary>
-    [Column("device")]
-    [MaxLength(256)]
-    public string? Device { get; set; }
-
-    /// <summary>
-    /// Links records that were decomposed from the same legacy DeviceStatus
-    /// </summary>
-    [AuditIgnored]
-    [Column("correlation_id")]
-    public Guid? CorrelationId { get; set; }
-
-    /// <summary>
-    /// Original v1/v3 record ID for migration traceability
-    /// </summary>
-    [Column("legacy_id")]
-    [MaxLength(255)]
-    public string? LegacyId { get; set; }
-
-    /// <summary>
-    /// Connector data source that produced this snapshot (null for direct v1/v3 uploads).
-    /// </summary>
-    [Column("data_source")]
-    public string? DataSource { get; set; }
-
-    /// <summary>
-    /// Application that uploaded this snapshot
-    /// </summary>
-    [Column("app")]
-    [MaxLength(256)]
-    public string? App { get; set; }
-
-    /// <summary>
-    /// Stable per-source identifier for synchronization. Unlike <see cref="LegacyId"/> (insert-only),
+    /// Stable per-source identifier for synchronization. Unlike <see cref="V4TimeSeriesEntityBase.LegacyId"/> (insert-only),
     /// a record matched by (DataSource, SyncIdentifier) is updated in place on re-upload — required so
     /// uploader retries of the same loop cycle don't duplicate the snapshot.
     /// </summary>
     [Column("sync_identifier")]
     [MaxLength(256)]
     public string? SyncIdentifier { get; set; }
-
-    /// <summary>
-    /// System tracking: when record was inserted
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_created_at")]
-    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// System tracking: when record was last updated
-    /// </summary>
-    [AuditIgnored]
-    [Column("sys_updated_at")]
-    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
     /// Uploader/phone name
@@ -136,18 +62,4 @@ public class UploaderSnapshotEntity : ITenantScoped, IAuditable, ISoftDeletable,
     /// </summary>
     [Column("device_id")]
     public Guid? DeviceId { get; set; }
-
-    /// <summary>
-    /// Catch-all JSONB column for fields not mapped to dedicated columns
-    /// </summary>
-    [Column("additional_properties", TypeName = "jsonb")]
-    public string? AdditionalPropertiesJson { get; set; }
-
-    /// <summary>
-    /// Soft-delete timestamp. When non-null the record is treated as deleted
-    /// by the global query filter and is invisible above the repository layer.
-    /// </summary>
-    [AuditIgnored]
-    [Column("deleted_at")]
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/V4TimeSeriesEntityBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/V4TimeSeriesEntityBase.cs
@@ -1,0 +1,113 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Entities.V4;
+
+/// <summary>
+/// Persistence header shared by every V4 time-series entity: the tenant key, the canonical
+/// timestamp, the provenance columns, the system audit stamps, the catch-all JSONB column and the
+/// soft-delete tombstone.
+/// </summary>
+/// <remarks>
+/// Unmapped by EF — it carries no <c>DbSet</c> and no table, so each derived entity keeps its own
+/// table and simply inherits these columns.
+/// <see cref="ISyncDedupable.SyncIdentifier"/> and
+/// <see cref="IDeviceAttributedEntity.PatientDeviceId"/> stay off this type: only some of the
+/// derived tables carry those columns.
+/// </remarks>
+public abstract class V4TimeSeriesEntityBase
+    : ITenantScoped,
+        IAuditable,
+        ISoftDeletable,
+        IV4TimeSeriesEntity,
+        ISystemTimestamped
+{
+    /// <summary>
+    /// The unique identifier of the tenant this record belongs to.
+    /// </summary>
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    /// <summary>
+    /// Primary key - UUID Version 7 for time-ordered, globally unique identification
+    /// </summary>
+    [Key]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Canonical timestamp as UTC DateTime (timestamptz)
+    /// </summary>
+    [Column("timestamp")]
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// UTC offset in minutes
+    /// </summary>
+    [Column("utc_offset")]
+    public int? UtcOffset { get; set; }
+
+    /// <summary>
+    /// Device identifier that produced or uploaded this record
+    /// </summary>
+    [Column("device")]
+    [MaxLength(256)]
+    public string? Device { get; set; }
+
+    /// <summary>
+    /// Application that uploaded this record
+    /// </summary>
+    [Column("app")]
+    [MaxLength(256)]
+    public string? App { get; set; }
+
+    /// <summary>
+    /// Origin data source identifier
+    /// </summary>
+    [Column("data_source")]
+    [MaxLength(256)]
+    public string? DataSource { get; set; }
+
+    /// <summary>
+    /// Links records that were split from the same legacy Treatment
+    /// </summary>
+    [AuditIgnored]
+    [Column("correlation_id")]
+    public Guid? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Original v1/v3 record ID for migration traceability
+    /// </summary>
+    [Column("legacy_id")]
+    [MaxLength(255)]
+    public string? LegacyId { get; set; }
+
+    /// <summary>
+    /// System tracking: when record was inserted
+    /// </summary>
+    [AuditIgnored]
+    [Column("sys_created_at")]
+    public DateTime SysCreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// System tracking: when record was last updated
+    /// </summary>
+    [AuditIgnored]
+    [Column("sys_updated_at")]
+    public DateTime SysUpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Catch-all JSONB column for fields not mapped to dedicated columns
+    /// </summary>
+    [Column("additional_properties", TypeName = "jsonb")]
+    public string? AdditionalPropertiesJson { get; set; }
+
+    /// <summary>
+    /// Soft-delete timestamp. When non-null the record is treated as deleted
+    /// by the global query filter and is invisible above the repository layer.
+    /// </summary>
+    [AuditIgnored]
+    [Column("deleted_at")]
+    public DateTime? DeletedAt { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/ApsSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/ApsSnapshotMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,19 +17,9 @@ public static class ApsSnapshotMapper
     {
         return new ApsSnapshotEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
             DeviceId = model.DeviceId,
             PatientDeviceId = model.PatientDeviceId,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            DataSource = model.DataSource,
-            App = model.App,
             SyncIdentifier = model.SyncIdentifier,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             AidAlgorithm = model.AidAlgorithm.ToString(),
             Iob = model.Iob,
             BasalIob = model.BasalIob,
@@ -55,10 +44,7 @@ public static class ApsSnapshotMapper
             PredictedStartTimestamp = model.PredictedStartTimestamp,
             LoopJson = model.LoopJson,
             AidVersion = model.AidVersion,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -70,19 +56,9 @@ public static class ApsSnapshotMapper
     {
         return new ApsSnapshot
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
             DeviceId = entity.DeviceId,
             PatientDeviceId = entity.PatientDeviceId,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            DataSource = entity.DataSource,
-            App = entity.App,
             SyncIdentifier = entity.SyncIdentifier,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             AidAlgorithm = Enum.TryParse<AidAlgorithm>(entity.AidAlgorithm, out var sys) ? sys : AidAlgorithm.Unknown,
             Iob = entity.Iob,
             BasalIob = entity.BasalIob,
@@ -107,10 +83,7 @@ public static class ApsSnapshotMapper
             PredictedStartTimestamp = entity.PredictedStartTimestamp,
             LoopJson = entity.LoopJson,
             AidVersion = entity.AidVersion,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -120,15 +93,9 @@ public static class ApsSnapshotMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(ApsSnapshotEntity entity, ApsSnapshot model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.DeviceId = model.DeviceId;
         entity.PatientDeviceId = model.PatientDeviceId;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
-        entity.DataSource = model.DataSource;
-        entity.App = model.App;
         entity.SyncIdentifier = model.SyncIdentifier;
         entity.AidAlgorithm = model.AidAlgorithm.ToString();
         entity.Iob = model.Iob;
@@ -154,8 +121,5 @@ public static class ApsSnapshotMapper
         entity.PredictedStartTimestamp = model.PredictedStartTimestamp;
         entity.LoopJson = model.LoopJson;
         entity.AidVersion = model.AidVersion;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BGCheckMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BGCheckMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,24 +17,11 @@ public static class BGCheckMapper
     {
         return new BGCheckEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Glucose = model.Glucose,
             GlucoseType = model.GlucoseType?.ToString(),
             Units = model.Units?.ToString(),
             SyncIdentifier = model.SyncIdentifier,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -47,24 +33,11 @@ public static class BGCheckMapper
     {
         return new BGCheck
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Glucose = entity.Glucose,
             GlucoseType = Enum.TryParse<GlucoseType>(entity.GlucoseType, out var gt) ? gt : null,
             Units = Enum.TryParse<GlucoseUnit>(entity.Units, out var u) ? u : null,
             SyncIdentifier = entity.SyncIdentifier,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -74,19 +47,10 @@ public static class BGCheckMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(BGCheckEntity entity, BGCheck model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.Glucose = model.Glucose;
         entity.GlucoseType = model.GlucoseType?.ToString();
         entity.Units = model.Units?.ToString();
         entity.SyncIdentifier = model.SyncIdentifier;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
@@ -19,27 +19,14 @@ public static class BasalInjectionMapper
     {
         return new BasalInjectionEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
             SyncIdentifier = model.SyncIdentifier,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
             PatientDeviceId = model.PatientDeviceId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Units = model.Units,
             Notes = model.Notes,
             InsulinContextJson = model.InsulinContext is not null
                 ? JsonSerializer.Serialize(model.InsulinContext)
                 : null,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -51,27 +38,14 @@ public static class BasalInjectionMapper
     {
         return new BasalInjection
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
             SyncIdentifier = entity.SyncIdentifier,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
             PatientDeviceId = entity.PatientDeviceId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Units = entity.Units,
             Notes = entity.Notes,
             InsulinContext = !string.IsNullOrEmpty(entity.InsulinContextJson)
                 ? JsonSerializer.Deserialize<TreatmentInsulinContext>(entity.InsulinContextJson)
                 : null,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -81,22 +55,13 @@ public static class BasalInjectionMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(BasalInjectionEntity entity, BasalInjection model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.SyncIdentifier = model.SyncIdentifier;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
         entity.PatientDeviceId = model.PatientDeviceId;
         entity.Units = model.Units;
         entity.Notes = model.Notes;
         entity.InsulinContextJson = model.InsulinContext is not null
             ? JsonSerializer.Serialize(model.InsulinContext)
-            : null;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
             : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalScheduleMapper.cs
@@ -18,22 +18,9 @@ public static class BasalScheduleMapper
     {
         return new BasalScheduleEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             ProfileName = model.ProfileName,
             EntriesJson = JsonSerializer.Serialize(model.Entries),
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -45,22 +32,9 @@ public static class BasalScheduleMapper
     {
         return new BasalSchedule
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             ProfileName = entity.ProfileName,
             Entries = JsonSerializer.Deserialize<List<ScheduleEntry>>(entity.EntriesJson) ?? [],
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -70,17 +44,8 @@ public static class BasalScheduleMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(BasalScheduleEntity entity, BasalSchedule model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.ProfileName = model.ProfileName;
         entity.EntriesJson = JsonSerializer.Serialize(model.Entries);
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusCalculationMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusCalculationMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,16 +17,6 @@ public static class BolusCalculationMapper
     {
         return new BolusCalculationEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             BloodGlucoseInput = model.BloodGlucoseInput,
             BloodGlucoseInputSource = model.BloodGlucoseInputSource,
             CarbInput = model.CarbInput,
@@ -41,10 +30,7 @@ public static class BolusCalculationMapper
             SplitNow = model.SplitNow,
             SplitExt = model.SplitExt,
             PreBolus = model.PreBolus,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -56,16 +42,6 @@ public static class BolusCalculationMapper
     {
         return new BolusCalculation
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             BloodGlucoseInput = entity.BloodGlucoseInput,
             BloodGlucoseInputSource = entity.BloodGlucoseInputSource,
             CarbInput = entity.CarbInput,
@@ -79,10 +55,7 @@ public static class BolusCalculationMapper
             SplitNow = entity.SplitNow,
             SplitExt = entity.SplitExt,
             PreBolus = entity.PreBolus,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -92,13 +65,7 @@ public static class BolusCalculationMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(BolusCalculationEntity entity, BolusCalculation model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.BloodGlucoseInput = model.BloodGlucoseInput;
         entity.BloodGlucoseInputSource = model.BloodGlucoseInputSource;
         entity.CarbInput = model.CarbInput;
@@ -112,8 +79,5 @@ public static class BolusCalculationMapper
         entity.SplitNow = model.SplitNow;
         entity.SplitExt = model.SplitExt;
         entity.PreBolus = model.PreBolus;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusMapper.cs
@@ -18,16 +18,6 @@ public static class BolusMapper
     {
         return new BolusEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Insulin = model.Insulin,
             Programmed = model.Programmed,
             Delivered = model.Delivered,
@@ -46,10 +36,7 @@ public static class BolusMapper
             PumpRecordId = model.PumpRecordId,
             BolusCalculationId = model.BolusCalculationId,
             ApsSnapshotId = model.ApsSnapshotId,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -61,16 +48,6 @@ public static class BolusMapper
     {
         return new Bolus
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Insulin = entity.Insulin,
             Programmed = entity.Programmed,
             Delivered = entity.Delivered,
@@ -89,10 +66,7 @@ public static class BolusMapper
             PumpRecordId = entity.PumpRecordId,
             BolusCalculationId = entity.BolusCalculationId,
             ApsSnapshotId = entity.ApsSnapshotId,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -102,13 +76,7 @@ public static class BolusMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(BolusEntity entity, Bolus model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.Insulin = model.Insulin;
         entity.Programmed = model.Programmed;
         entity.Delivered = model.Delivered;
@@ -127,8 +95,5 @@ public static class BolusMapper
         entity.PumpRecordId = model.PumpRecordId;
         entity.BolusCalculationId = model.BolusCalculationId;
         entity.ApsSnapshotId = model.ApsSnapshotId;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CalibrationMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CalibrationMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,23 +17,10 @@ public static class CalibrationMapper
     {
         return new CalibrationEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Slope = model.Slope,
             Intercept = model.Intercept,
             Scale = model.Scale,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -46,23 +32,10 @@ public static class CalibrationMapper
     {
         return new Calibration
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Slope = entity.Slope,
             Intercept = entity.Intercept,
             Scale = entity.Scale,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -72,18 +45,9 @@ public static class CalibrationMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(CalibrationEntity entity, Calibration model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.Slope = model.Slope;
         entity.Intercept = model.Intercept;
         entity.Scale = model.Scale;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbIntakeMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbIntakeMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,26 +17,13 @@ public static class CarbIntakeMapper
     {
         return new CarbIntakeEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Carbs = model.Carbs,
             SyncIdentifier = model.SyncIdentifier,
             CarbTime = model.CarbTime,
             AbsorptionTime = model.AbsorptionTime,
             FatGrams = model.FatGrams,
             ProteinGrams = model.ProteinGrams,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -49,26 +35,13 @@ public static class CarbIntakeMapper
     {
         return new CarbIntake
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Carbs = entity.Carbs,
             SyncIdentifier = entity.SyncIdentifier,
             CarbTime = entity.CarbTime,
             AbsorptionTime = entity.AbsorptionTime,
             FatGrams = entity.FatGrams,
             ProteinGrams = entity.ProteinGrams,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -78,21 +51,12 @@ public static class CarbIntakeMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(CarbIntakeEntity entity, CarbIntake model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.Carbs = model.Carbs;
         entity.SyncIdentifier = model.SyncIdentifier;
         entity.CarbTime = model.CarbTime;
         entity.AbsorptionTime = model.AbsorptionTime;
         entity.FatGrams = model.FatGrams;
         entity.ProteinGrams = model.ProteinGrams;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbRatioScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbRatioScheduleMapper.cs
@@ -18,22 +18,9 @@ public static class CarbRatioScheduleMapper
     {
         return new CarbRatioScheduleEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             ProfileName = model.ProfileName,
             EntriesJson = JsonSerializer.Serialize(model.Entries),
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -45,22 +32,9 @@ public static class CarbRatioScheduleMapper
     {
         return new CarbRatioSchedule
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             ProfileName = entity.ProfileName,
             Entries = JsonSerializer.Deserialize<List<ScheduleEntry>>(entity.EntriesJson) ?? [],
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -70,17 +44,8 @@ public static class CarbRatioScheduleMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(CarbRatioScheduleEntity entity, CarbRatioSchedule model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.ProfileName = model.ProfileName;
         entity.EntriesJson = JsonSerializer.Serialize(model.Entries);
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceEventMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceEventMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
@@ -19,25 +18,12 @@ public static class DeviceEventMapper
     {
         return new DeviceEventEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
             DeviceId = model.DeviceId,
             PatientDeviceId = model.PatientDeviceId,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             EventType = model.EventType.ToString(),
             Notes = model.Notes,
             SyncIdentifier = model.SyncIdentifier,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -49,27 +35,14 @@ public static class DeviceEventMapper
     {
         return new DeviceEvent
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
             DeviceId = entity.DeviceId,
             PatientDeviceId = entity.PatientDeviceId,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             EventType = Enum.TryParse<DeviceEventType>(entity.EventType, ignoreCase: true, out var parsed)
                 ? parsed
                 : DeviceEventType.SiteChange,
             Notes = entity.Notes,
             SyncIdentifier = entity.SyncIdentifier,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -79,20 +52,11 @@ public static class DeviceEventMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(DeviceEventEntity entity, DeviceEvent model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.DeviceId = model.DeviceId;
         entity.PatientDeviceId = model.PatientDeviceId;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
         entity.EventType = model.EventType.ToString();
         entity.Notes = model.Notes;
         entity.SyncIdentifier = model.SyncIdentifier;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/MeterGlucoseMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/MeterGlucoseMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,22 +17,9 @@ public static class MeterGlucoseMapper
     {
         return new MeterGlucoseEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
             PatientDeviceId = model.PatientDeviceId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Mgdl = model.Mgdl,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -45,22 +31,9 @@ public static class MeterGlucoseMapper
     {
         return new MeterGlucose
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
             PatientDeviceId = entity.PatientDeviceId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Mgdl = entity.Mgdl,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -70,17 +43,8 @@ public static class MeterGlucoseMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(MeterGlucoseEntity entity, MeterGlucose model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.PatientDeviceId = model.PatientDeviceId;
         entity.Mgdl = model.Mgdl;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/NoteMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/NoteMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,24 +17,11 @@ public static class NoteMapper
     {
         return new NoteEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Text = model.Text,
             EventType = model.EventType,
             IsAnnouncement = model.IsAnnouncement,
             SyncIdentifier = model.SyncIdentifier,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -47,24 +33,11 @@ public static class NoteMapper
     {
         return new Note
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Text = entity.Text,
             EventType = entity.EventType,
             IsAnnouncement = entity.IsAnnouncement,
             SyncIdentifier = entity.SyncIdentifier,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -74,19 +47,10 @@ public static class NoteMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(NoteEntity entity, Note model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.Text = model.Text;
         entity.EventType = model.EventType;
         entity.IsAnnouncement = model.IsAnnouncement;
         entity.SyncIdentifier = model.SyncIdentifier;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PumpSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/PumpSnapshotMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,17 +17,7 @@ public static class PumpSnapshotMapper
     {
         return new PumpSnapshotEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            DataSource = model.DataSource,
-            App = model.App,
             SyncIdentifier = model.SyncIdentifier,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Manufacturer = model.Manufacturer,
             Model = model.Model,
             Reservoir = model.Reservoir,
@@ -44,10 +33,7 @@ public static class PumpSnapshotMapper
             PatientDeviceId = model.PatientDeviceId,
             Iob = model.Iob,
             BolusIob = model.BolusIob,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -59,17 +45,7 @@ public static class PumpSnapshotMapper
     {
         return new PumpSnapshot
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            DataSource = entity.DataSource,
-            App = entity.App,
             SyncIdentifier = entity.SyncIdentifier,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Manufacturer = entity.Manufacturer,
             Model = entity.Model,
             Reservoir = entity.Reservoir,
@@ -85,10 +61,7 @@ public static class PumpSnapshotMapper
             PatientDeviceId = entity.PatientDeviceId,
             Iob = entity.Iob,
             BolusIob = entity.BolusIob,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -98,13 +71,7 @@ public static class PumpSnapshotMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(PumpSnapshotEntity entity, PumpSnapshot model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
-        entity.DataSource = model.DataSource;
-        entity.App = model.App;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.SyncIdentifier = model.SyncIdentifier;
         entity.Manufacturer = model.Manufacturer;
         entity.Model = model.Model;
@@ -121,8 +88,5 @@ public static class PumpSnapshotMapper
         entity.PatientDeviceId = model.PatientDeviceId;
         entity.Iob = model.Iob;
         entity.BolusIob = model.BolusIob;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensitivityScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensitivityScheduleMapper.cs
@@ -18,22 +18,9 @@ public static class SensitivityScheduleMapper
     {
         return new SensitivityScheduleEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             ProfileName = model.ProfileName,
             EntriesJson = JsonSerializer.Serialize(model.Entries),
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -45,22 +32,9 @@ public static class SensitivityScheduleMapper
     {
         return new SensitivitySchedule
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             ProfileName = entity.ProfileName,
             Entries = JsonSerializer.Deserialize<List<ScheduleEntry>>(entity.EntriesJson) ?? [],
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -70,17 +44,8 @@ public static class SensitivityScheduleMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(SensitivityScheduleEntity entity, SensitivitySchedule model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.ProfileName = model.ProfileName;
         entity.EntriesJson = JsonSerializer.Serialize(model.Entries);
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensorGlucoseMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensorGlucoseMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,18 +17,8 @@ public static class SensorGlucoseMapper
     {
         return new SensorGlucoseEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
             PatientDeviceId = model.PatientDeviceId,
-            LegacyId = model.LegacyId,
             SyncIdentifier = model.SyncIdentifier,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Mgdl = model.Mgdl,
             Direction = model.Direction?.ToString(),
             TrendRate = model.TrendRate,
@@ -40,10 +29,7 @@ public static class SensorGlucoseMapper
             GlucoseProcessing = model.GlucoseProcessing?.ToString(),
             SmoothedMgdl = model.SmoothedMgdl,
             UnsmoothedMgdl = model.UnsmoothedMgdl,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -55,18 +41,8 @@ public static class SensorGlucoseMapper
     {
         return new SensorGlucose
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
             PatientDeviceId = entity.PatientDeviceId,
-            LegacyId = entity.LegacyId,
             SyncIdentifier = entity.SyncIdentifier,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Mgdl = entity.Mgdl,
             Direction = Enum.TryParse<GlucoseDirection>(entity.Direction, out var dir) ? dir : null,
             TrendRate = entity.TrendRate,
@@ -77,10 +53,7 @@ public static class SensorGlucoseMapper
             GlucoseProcessing = Enum.TryParse<GlucoseProcessing>(entity.GlucoseProcessing, out var gp) ? gp : null,
             SmoothedMgdl = entity.SmoothedMgdl,
             UnsmoothedMgdl = entity.UnsmoothedMgdl,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -90,14 +63,8 @@ public static class SensorGlucoseMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(SensorGlucoseEntity entity, SensorGlucose model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.PatientDeviceId = model.PatientDeviceId;
-        entity.LegacyId = model.LegacyId;
         entity.SyncIdentifier = model.SyncIdentifier;
         entity.Mgdl = model.Mgdl;
         entity.Direction = model.Direction?.ToString();
@@ -109,8 +76,5 @@ public static class SensorGlucoseMapper
         entity.GlucoseProcessing = model.GlucoseProcessing?.ToString();
         entity.SmoothedMgdl = model.SmoothedMgdl;
         entity.UnsmoothedMgdl = model.UnsmoothedMgdl;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TargetRangeScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TargetRangeScheduleMapper.cs
@@ -18,22 +18,9 @@ public static class TargetRangeScheduleMapper
     {
         return new TargetRangeScheduleEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             ProfileName = model.ProfileName,
             EntriesJson = JsonSerializer.Serialize(model.Entries),
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -45,22 +32,9 @@ public static class TargetRangeScheduleMapper
     {
         return new TargetRangeSchedule
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             ProfileName = entity.ProfileName,
             Entries = JsonSerializer.Deserialize<List<TargetRangeEntry>>(entity.EntriesJson) ?? [],
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -70,17 +44,8 @@ public static class TargetRangeScheduleMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(TargetRangeScheduleEntity entity, TargetRangeSchedule model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.ProfileName = model.ProfileName;
         entity.EntriesJson = JsonSerializer.Serialize(model.Entries);
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TherapySettingsMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TherapySettingsMapper.cs
@@ -19,16 +19,6 @@ public static class TherapySettingsMapper
     {
         return new TherapySettingsEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            App = model.App,
-            DataSource = model.DataSource,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             ProfileName = model.ProfileName,
             Timezone = model.Timezone,
             Units = model.Units,
@@ -49,10 +39,7 @@ public static class TherapySettingsMapper
             EnteredBy = model.EnteredBy,
             IsExternallyManaged = model.IsExternallyManaged,
             StartDate = model.StartDate,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -64,16 +51,6 @@ public static class TherapySettingsMapper
     {
         return new TherapySettings
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            App = entity.App,
-            DataSource = entity.DataSource,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             ProfileName = entity.ProfileName,
             Timezone = entity.Timezone,
             Units = entity.Units,
@@ -94,10 +71,7 @@ public static class TherapySettingsMapper
             EnteredBy = entity.EnteredBy,
             IsExternallyManaged = entity.IsExternallyManaged,
             StartDate = entity.StartDate,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -107,13 +81,7 @@ public static class TherapySettingsMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(TherapySettingsEntity entity, TherapySettings model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.App = model.App;
-        entity.DataSource = model.DataSource;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.ProfileName = model.ProfileName;
         entity.Timezone = model.Timezone;
         entity.Units = model.Units;
@@ -134,8 +102,5 @@ public static class TherapySettingsMapper
         entity.EnteredBy = model.EnteredBy;
         entity.IsExternallyManaged = model.IsExternallyManaged;
         entity.StartDate = model.StartDate;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/UploaderSnapshotMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/UploaderSnapshotMapper.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 
@@ -18,17 +17,7 @@ public static class UploaderSnapshotMapper
     {
         return new UploaderSnapshotEntity
         {
-            Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id,
-            Timestamp = model.Timestamp,
-            UtcOffset = model.UtcOffset,
-            Device = model.Device,
-            CorrelationId = model.CorrelationId,
-            LegacyId = model.LegacyId,
-            DataSource = model.DataSource,
-            App = model.App,
             SyncIdentifier = model.SyncIdentifier,
-            SysCreatedAt = DateTime.UtcNow,
-            SysUpdatedAt = DateTime.UtcNow,
             Name = model.Name,
             Battery = model.Battery,
             BatteryVoltage = model.BatteryVoltage,
@@ -36,10 +25,7 @@ public static class UploaderSnapshotMapper
             Temperature = model.Temperature,
             Type = model.Type,
             DeviceId = model.DeviceId,
-            AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-                ? JsonSerializer.Serialize(model.AdditionalProperties)
-                : null,
-        };
+        }.WithHeaderFrom(model);
     }
 
     /// <summary>
@@ -51,17 +37,7 @@ public static class UploaderSnapshotMapper
     {
         return new UploaderSnapshot
         {
-            Id = entity.Id,
-            Timestamp = entity.Timestamp,
-            UtcOffset = entity.UtcOffset,
-            Device = entity.Device,
-            CorrelationId = entity.CorrelationId,
-            LegacyId = entity.LegacyId,
-            DataSource = entity.DataSource,
-            App = entity.App,
             SyncIdentifier = entity.SyncIdentifier,
-            CreatedAt = entity.SysCreatedAt,
-            ModifiedAt = entity.SysUpdatedAt,
             Name = entity.Name,
             Battery = entity.Battery,
             BatteryVoltage = entity.BatteryVoltage,
@@ -69,10 +45,7 @@ public static class UploaderSnapshotMapper
             Temperature = entity.Temperature,
             Type = entity.Type,
             DeviceId = entity.DeviceId,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
-        };
+        }.WithHeaderFrom(entity);
     }
 
     /// <summary>
@@ -82,13 +55,7 @@ public static class UploaderSnapshotMapper
     /// <param name="model">The domain model containing updated data.</param>
     public static void UpdateEntity(UploaderSnapshotEntity entity, UploaderSnapshot model)
     {
-        entity.Timestamp = model.Timestamp;
-        entity.UtcOffset = model.UtcOffset;
-        entity.Device = model.Device;
-        entity.CorrelationId = model.CorrelationId;
-        entity.LegacyId = model.LegacyId;
-        entity.DataSource = model.DataSource;
-        entity.App = model.App;
+        V4RecordHeaderMapper.UpdateHeader(entity, model);
         entity.SyncIdentifier = model.SyncIdentifier;
         entity.Name = model.Name;
         entity.Battery = model.Battery;
@@ -97,8 +64,5 @@ public static class UploaderSnapshotMapper
         entity.Temperature = model.Temperature;
         entity.Type = model.Type;
         entity.DeviceId = model.DeviceId;
-        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
-            ? JsonSerializer.Serialize(model.AdditionalProperties)
-            : null;
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/V4RecordHeaderMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/V4RecordHeaderMapper.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities.V4;
+
+namespace Nocturne.Infrastructure.Data.Mappers.V4;
+
+/// <summary>
+/// Copies the <see cref="IV4Record"/> header between a V4 domain model and its entity, leaving each
+/// type's mapper to spell out only its own fields.
+/// </summary>
+internal static class V4RecordHeaderMapper
+{
+    /// <summary>
+    /// Stamp a newly built entity with the model's header, minting a UUID v7 when the model carries
+    /// no id and setting both system timestamps to now.
+    /// </summary>
+    public static TEntity WithHeaderFrom<TEntity>(this TEntity entity, V4RecordBase model)
+        where TEntity : V4TimeSeriesEntityBase
+    {
+        entity.Id = model.Id == Guid.Empty ? Guid.CreateVersion7() : model.Id;
+        entity.SysCreatedAt = DateTime.UtcNow;
+        entity.SysUpdatedAt = DateTime.UtcNow;
+        UpdateHeader(entity, model);
+        return entity;
+    }
+
+    /// <summary>
+    /// Fill a newly built domain model from the entity's header.
+    /// </summary>
+    public static TModel WithHeaderFrom<TModel>(this TModel model, V4TimeSeriesEntityBase entity)
+        where TModel : V4RecordBase
+    {
+        model.Id = entity.Id;
+        model.Timestamp = entity.Timestamp;
+        model.UtcOffset = entity.UtcOffset;
+        model.Device = entity.Device;
+        model.App = entity.App;
+        model.DataSource = entity.DataSource;
+        model.CorrelationId = entity.CorrelationId;
+        model.LegacyId = entity.LegacyId;
+        model.CreatedAt = entity.SysCreatedAt;
+        model.ModifiedAt = entity.SysUpdatedAt;
+        model.AdditionalProperties = MapperHelpers.DeserializeJson<Dictionary<string, object?>>(
+            entity.AdditionalPropertiesJson
+        );
+        return model;
+    }
+
+    /// <summary>
+    /// Overwrite a tracked entity's header from the model. The id and the system timestamps are
+    /// left alone: <see cref="NocturneDbContext"/> owns <c>sys_updated_at</c> on save.
+    /// </summary>
+    public static void UpdateHeader(V4TimeSeriesEntityBase entity, V4RecordBase model)
+    {
+        entity.Timestamp = model.Timestamp;
+        entity.UtcOffset = model.UtcOffset;
+        entity.Device = model.Device;
+        entity.App = model.App;
+        entity.DataSource = model.DataSource;
+        entity.CorrelationId = model.CorrelationId;
+        entity.LegacyId = model.LegacyId;
+        entity.AdditionalPropertiesJson = model.AdditionalProperties is { Count: > 0 }
+            ? JsonSerializer.Serialize(model.AdditionalProperties)
+            : null;
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260902035902_AlignSnapshotDataSourceLength.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260902035902_AlignSnapshotDataSourceLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260902035902_AlignSnapshotDataSourceLength")]
+    partial class AlignSnapshotDataSourceLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260902035902_AlignSnapshotDataSourceLength.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260902035902_AlignSnapshotDataSourceLength.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AlignSnapshotDataSourceLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // These three tables are the only ones whose data_source was ever unbounded, so a plain
+            // narrowing cast would abort the chain — and crash-loop the API — on any instance that
+            // accepted a longer value. USING left(...) makes the cast total; MigrationBuilder
+            // cannot express it. The truncation can also collide two rows under the filtered unique
+            // ix_<table>_tenant_source_sync_id index (values differing only past char 256), which the
+            // rewrite's index rebuild would then refuse — so the losers of each post-truncation key
+            // are soft-deleted first, newest row wins, in the idiom of
+            // 20260818102940_AddTenantScopedLegacyIdIndexesToSnapshots (FORCE ROW LEVEL SECURITY
+            // requires the per-tenant set_config loop).
+            foreach (var table in new[] { "uploader_snapshots", "pump_snapshots", "aps_snapshots" })
+            {
+                migrationBuilder.Sql($"""
+                    DO $$
+                    DECLARE
+                        t RECORD;
+                    BEGIN
+                        FOR t IN SELECT id FROM tenants LOOP
+                            PERFORM set_config('app.current_tenant_id', t.id::text, true);
+
+                            UPDATE {table}
+                            SET deleted_at = now()
+                            WHERE id IN (
+                                SELECT id
+                                FROM (
+                                    SELECT id,
+                                           row_number() OVER (
+                                               PARTITION BY tenant_id, left(data_source, 256), sync_identifier
+                                               ORDER BY sys_created_at DESC, id DESC) AS rn
+                                    FROM {table}
+                                    WHERE sync_identifier IS NOT NULL AND data_source IS NOT NULL AND deleted_at IS NULL
+                                ) ranked
+                                WHERE ranked.rn > 1);
+                        END LOOP;
+                    END $$;
+                    """);
+
+                migrationBuilder.Sql($"""
+                    ALTER TABLE "{table}"
+                        ALTER COLUMN "data_source" TYPE character varying(256)
+                        USING left("data_source", 256);
+                    """);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "data_source",
+                table: "uploader_snapshots",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "data_source",
+                table: "pump_snapshots",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "data_source",
+                table: "aps_snapshots",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/V4RecordHeaderMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/V4RecordHeaderMapperTests.cs
@@ -1,0 +1,184 @@
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Mappers.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.Mappers.V4;
+
+/// <summary>
+/// Every V4 mapper copies its record header through one shared helper, so these hold all of them
+/// to the same contract at once.
+/// </summary>
+[Trait("Category", "Unit")]
+public class V4RecordHeaderMapperTests
+{
+    public static TheoryData<string> V4EntityTypeNames()
+    {
+        var data = new TheoryData<string>();
+        foreach (var entityType in V4EntityTypes())
+        {
+            data.Add(entityType.Name);
+        }
+
+        return data;
+    }
+
+    [Fact]
+    public void EveryV4TimeSeriesEntityIsPairedWithAModelAndAMapper()
+    {
+        var entityTypes = V4EntityTypes().ToList();
+
+        entityTypes.Should().HaveCountGreaterThanOrEqualTo(18,
+            "an empty or shrunken discovery would make every theory below vacuous");
+        entityTypes.Should().OnlyContain(t => ModelType(t) != null && MapperType(t) != null);
+    }
+
+    [Theory]
+    [MemberData(nameof(V4EntityTypeNames))]
+    public void ToDomainModel_MalformedAdditionalPropertiesJson_YieldsNoAdditionalProperties(string entityTypeName)
+    {
+        var entityType = EntityType(entityTypeName);
+        var entity = NewEntity(entityType);
+        entity.AdditionalPropertiesJson = """{"unterminated":""";
+
+        var model = ToDomainModel(entityType, entity);
+
+        model.AdditionalProperties.Should().BeNull(
+            "one unparseable jsonb row must not fail the read of every record around it");
+    }
+
+    [Theory]
+    [MemberData(nameof(V4EntityTypeNames))]
+    public void HeaderRoundTripsThroughTheEntityAndBack(string entityTypeName)
+    {
+        var entityType = EntityType(entityTypeName);
+        var model = NewModel(entityType);
+        model.Id = Guid.CreateVersion7();
+        model.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000).UtcDateTime;
+        model.UtcOffset = -300;
+        model.Device = "dexcom";
+        model.App = "xdrip";
+        model.DataSource = "nightscout";
+        model.CorrelationId = Guid.NewGuid();
+        model.LegacyId = "abc123";
+        model.AdditionalProperties = new Dictionary<string, object?> { ["extra"] = "kept" };
+
+        var roundTripped = ToDomainModel(entityType, ToEntity(entityType, model));
+
+        roundTripped.Id.Should().Be(model.Id);
+        roundTripped.Timestamp.Should().Be(model.Timestamp);
+        roundTripped.Mills.Should().Be(1_700_000_000_000);
+        roundTripped.UtcOffset.Should().Be(model.UtcOffset);
+        roundTripped.Device.Should().Be(model.Device);
+        roundTripped.App.Should().Be(model.App);
+        roundTripped.DataSource.Should().Be(model.DataSource);
+        roundTripped.CorrelationId.Should().Be(model.CorrelationId);
+        roundTripped.LegacyId.Should().Be(model.LegacyId);
+        roundTripped.AdditionalProperties.Should().ContainKey("extra");
+        roundTripped.AdditionalProperties!["extra"]!.ToString().Should().Be("kept");
+    }
+
+    [Theory]
+    [MemberData(nameof(V4EntityTypeNames))]
+    public void ToEntity_EmptyModelId_MintsOne(string entityTypeName)
+    {
+        var entityType = EntityType(entityTypeName);
+
+        var entity = ToEntity(entityType, NewModel(entityType));
+
+        entity.Id.Should().NotBeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(V4EntityTypeNames))]
+    public void ToEntity_EmptyAdditionalProperties_WritesNoJson(string entityTypeName)
+    {
+        var entityType = EntityType(entityTypeName);
+        var model = NewModel(entityType);
+        model.AdditionalProperties = new Dictionary<string, object?>();
+
+        ToEntity(entityType, model).AdditionalPropertiesJson.Should().BeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(V4EntityTypeNames))]
+    public void UpdateEntity_LeavesTheIdAndTheSystemStampsAlone(string entityTypeName)
+    {
+        var entityType = EntityType(entityTypeName);
+        var stamped = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entity = NewEntity(entityType);
+        entity.Id = Guid.CreateVersion7();
+        entity.SysCreatedAt = stamped;
+        entity.SysUpdatedAt = stamped;
+        var originalId = entity.Id;
+
+        UpdateEntity(entityType, entity, NewModel(entityType));
+
+        entity.Id.Should().Be(originalId);
+        entity.SysCreatedAt.Should().Be(stamped);
+        entity.SysUpdatedAt.Should().Be(stamped);
+    }
+
+    [Theory]
+    [MemberData(nameof(V4EntityTypeNames))]
+    public void UpdateEntity_CopiesTheHeaderFromTheModel(string entityTypeName)
+    {
+        var entityType = EntityType(entityTypeName);
+        var entity = NewEntity(entityType);
+        entity.Device = "stale-device";
+        entity.AdditionalPropertiesJson = """{"stale":true}""";
+
+        var model = NewModel(entityType);
+        model.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000).UtcDateTime;
+        model.UtcOffset = 600;
+        model.Device = "fresh-device";
+        model.App = "fresh-app";
+        model.DataSource = "fresh-source";
+        model.CorrelationId = Guid.NewGuid();
+        model.LegacyId = "fresh-legacy";
+        model.AdditionalProperties = new Dictionary<string, object?> { ["fresh"] = 1 };
+
+        UpdateEntity(entityType, entity, model);
+
+        entity.Timestamp.Should().Be(model.Timestamp);
+        entity.UtcOffset.Should().Be(model.UtcOffset);
+        entity.Device.Should().Be(model.Device);
+        entity.App.Should().Be(model.App);
+        entity.DataSource.Should().Be(model.DataSource);
+        entity.CorrelationId.Should().Be(model.CorrelationId);
+        entity.LegacyId.Should().Be(model.LegacyId);
+        entity.AdditionalPropertiesJson.Should().Contain("fresh");
+    }
+
+    private static IEnumerable<Type> V4EntityTypes() =>
+        typeof(V4TimeSeriesEntityBase)
+            .Assembly.GetTypes()
+            .Where(t => !t.IsAbstract && t.IsSubclassOf(typeof(V4TimeSeriesEntityBase)))
+            .OrderBy(t => t.Name);
+
+    private static Type EntityType(string name) => V4EntityTypes().Single(t => t.Name == name);
+
+    private static string RecordName(Type entityType) => entityType.Name[..^"Entity".Length];
+
+    private static Type? ModelType(Type entityType) =>
+        typeof(V4RecordBase).Assembly.GetType($"Nocturne.Core.Models.V4.{RecordName(entityType)}");
+
+    private static Type? MapperType(Type entityType) =>
+        typeof(SensorGlucoseMapper).Assembly.GetType(
+            $"Nocturne.Infrastructure.Data.Mappers.V4.{RecordName(entityType)}Mapper"
+        );
+
+    private static V4TimeSeriesEntityBase NewEntity(Type entityType) =>
+        (V4TimeSeriesEntityBase)Activator.CreateInstance(entityType)!;
+
+    private static V4RecordBase NewModel(Type entityType) =>
+        (V4RecordBase)Activator.CreateInstance(ModelType(entityType)!)!;
+
+    private static V4RecordBase ToDomainModel(Type entityType, V4TimeSeriesEntityBase entity) =>
+        (V4RecordBase)MapperType(entityType)!.GetMethod("ToDomainModel")!.Invoke(null, [entity])!;
+
+    private static V4TimeSeriesEntityBase ToEntity(Type entityType, V4RecordBase model) =>
+        (V4TimeSeriesEntityBase)MapperType(entityType)!.GetMethod("ToEntity")!.Invoke(null, [model])!;
+
+    private static void UpdateEntity(Type entityType, V4TimeSeriesEntityBase entity, V4RecordBase model) =>
+        MapperType(entityType)!.GetMethod("UpdateEntity")!.Invoke(null, [entity, model]);
+}


### PR DESCRIPTION
Fixes #1058.

Every V4 record type re-declared the same header three times over — domain model, EF entity, and three mapper methods. This hoists it once per tier: `V4RecordBase` for the 18 models, `V4TimeSeriesEntityBase` for the 18 entities, `V4RecordHeaderMapper` for the mappers. Net **−2,641 lines** (654+/3,295−, excluding the migration's generated Designer/snapshot). `SyncIdentifier`/`PatientDeviceId` stay per-type opt-ins; `TempBasal` is untouched (it does not implement `IV4Record` — that seam is tracked in #1082).

## Wire contract: zero semantic delta

The models are API response types, so each derived type carries `[JsonSchemaFlatten]` (NSwag inlines the base members instead of emitting `allOf`). Proven against a pre-change baseline, twice independently: the generated `openapi.json` is **canonically identical** (property-order-only differences), the NSwag TS client is a pure line permutation (interface member order), all 770 Zod schemas semantically identical, all remote-function files byte-identical. A dedicated sweep found no consumer sensitive to V4 JSON property order (no V4 golden files, no hashing over serialized records, key-based dedup/compat readers only).

## Declared behaviour deltas

1. **Schema**: `data_source` on `aps_snapshots`/`pump_snapshots`/`uploader_snapshots` narrows from unbounded `text` to `varchar(256)`, aligning with the other fifteen tables (the drift #1058 documents). The migration narrows with `USING left(...,256)` so the cast is total, and first soft-deletes the losers of any post-truncation `(tenant_id, left(data_source,256), sync_identifier)` key — without that step, truncation collisions abort the rewrite's rebuild of the filtered unique index and crash-loop the API on startup. Verified end-to-end on Postgres 17 under FORCE RLS with the real policy shape: collision resolved (newest wins), non-colliding and NULL-`data_source` rows untouched, cross-tenant rows isolated by the per-tenant `set_config` loop (the `20260818102940` idiom).
2. **Mapper reads**: V4 mappers previously raw-deserialized `additional_properties_json` (one malformed row failed the whole read) while legacy mappers tolerated it. All V4 reads now go through the tolerant `MapperHelpers.DeserializeJson`, pinned for all 18 types by a reflection-driven theory. (`DeviceMapper`/`TempBasalMapper` — non-`IV4Record` — still raw-deserialize; follow-up tracked separately.)

## Tests

`V4RecordHeaderMapperTests` discovers all `V4TimeSeriesEntityBase` subclasses (guarded against vacuous discovery) and pins per type: header round-trip, id minting, malformed-JSON tolerance, update-in-place copying the header, and update leaving id/system stamps alone. Mutation-proven: dropping the header-copy call from a single mapper fails exactly that type's theory; reverting to raw deserialize fails 18; skipping a header field on update fails 44. Full unit suite green (API 6,245; Infrastructure.Data 835; 19 other projects).

Survived a hostile fresh-context review (two rounds): per-type absence-delta extraction over all 54 original mapper methods (zero deltas), independent baseline rebuild with sha256-matched spec, audit-attribute reflection semantics verified, and an independently reproduced migration-collision probe that motivated the cleanup step above.
