### PR TITLE
refactor(api): give the OAuth subject guard one implementation

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -178,21 +179,16 @@ public class OAuthController : ControllerBase
             return Redirect($"/auth/login?returnUrl={Uri.EscapeDataString(returnUrl)}");
         }
 
-        var subjectId = HttpContext.GetSubjectId();
-        if (subjectId == null)
+        if (!TryGetSubject(out var subjectId, out var subjectError))
         {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "Could not determine authenticated user.",
-            });
+            return subjectError;
         }
 
         // Normalize the requested scopes
         var normalizedScopes = Scope.Normalize(requestedScopes);
 
         // Check if an active grant exists with sufficient scopes
-        var existingGrant = await _grantService.GetActiveGrantAsync(client.Id, subjectId.Value);
+        var existingGrant = await _grantService.GetActiveGrantAsync(client.Id, subjectId);
         if (existingGrant != null)
         {
             var existingSet = new HashSet<string>(existingGrant.Scopes);
@@ -203,7 +199,7 @@ public class OAuthController : ControllerBase
                 // Silent approval: existing grant covers all requested scopes
                 return await IssueAuthorizationCode(
                     client.Id,
-                    subjectId.Value,
+                    subjectId,
                     normalizedScopes,
                     redirect_uri,
                     code_challenge,
@@ -230,23 +226,9 @@ public class OAuthController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> ApproveConsent([FromForm] ConsentApprovalRequest request)
     {
-        if (!HttpContext.IsAuthenticated())
+        if (!TryGetSubject(out var subjectId, out var subjectError))
         {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "User is not authenticated.",
-            });
-        }
-
-        var subjectId = HttpContext.GetSubjectId();
-        if (subjectId == null)
-        {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "Could not determine authenticated user.",
-            });
+            return subjectError;
         }
 
         // Find the client. Resolved before the approval decision is read: every exit from this
@@ -321,7 +303,7 @@ public class OAuthController : ControllerBase
         // Generate authorization code
         return await IssueAuthorizationCode(
             client.Id,
-            subjectId.Value,
+            subjectId,
             normalizedScopes,
             request.RedirectUri,
             request.CodeChallenge,
@@ -576,23 +558,9 @@ public class OAuthController : ControllerBase
         [FromForm] DeviceApprovalRequest request
     )
     {
-        if (!HttpContext.IsAuthenticated())
+        if (!TryGetSubject(out var subjectId, out var subjectError))
         {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "User is not authenticated.",
-            });
-        }
-
-        var subjectId = HttpContext.GetSubjectId();
-        if (subjectId == null)
-        {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "Could not determine authenticated user.",
-            });
+            return subjectError;
         }
 
         if (string.IsNullOrEmpty(request.UserCode))
@@ -605,7 +573,7 @@ public class OAuthController : ControllerBase
         }
 
         var success = request.Approved
-            ? await _deviceCodeService.ApproveDeviceCodeAsync(request.UserCode, subjectId.Value)
+            ? await _deviceCodeService.ApproveDeviceCodeAsync(request.UserCode, subjectId)
             : await _deviceCodeService.DenyDeviceCodeAsync(request.UserCode);
 
         if (!success)
@@ -674,6 +642,46 @@ public class OAuthController : ControllerBase
             Homepage = client.ClientUri,
             LogoUri = client.LogoUri,
         });
+    }
+
+    /// <summary>
+    /// Resolves the subject the request is authenticated as.
+    /// </summary>
+    /// <param name="subjectId">The caller's subject, set only when this returns <c>true</c>.</param>
+    /// <param name="error">The response to return in place of the action's own, set only when this returns <c>false</c>.</param>
+    /// <remarks>
+    /// Authentication and a subject are separate questions: a guest, instance-key or dev-auth
+    /// principal is authenticated but carries no subject of its own, and the public share subject is
+    /// the reverse — a subject id on an unauthenticated context. Both are refused here.
+    /// </remarks>
+    private bool TryGetSubject(out Guid subjectId, [NotNullWhen(false)] out ActionResult? error)
+    {
+        subjectId = default;
+
+        if (!HttpContext.IsAuthenticated())
+        {
+            error = Unauthorized(new OAuthError
+            {
+                Error = "access_denied",
+                ErrorDescription = "User is not authenticated.",
+            });
+            return false;
+        }
+
+        var authenticatedSubjectId = HttpContext.GetSubjectId();
+        if (authenticatedSubjectId == null)
+        {
+            error = Unauthorized(new OAuthError
+            {
+                Error = "access_denied",
+                ErrorDescription = "Could not determine authenticated user.",
+            });
+            return false;
+        }
+
+        subjectId = authenticatedSubjectId.Value;
+        error = null;
+        return true;
     }
 
     private async Task<ActionResult> IssueAuthorizationCode(
@@ -765,26 +773,12 @@ public class OAuthController : ControllerBase
     [ProducesResponseType(typeof(OAuthGrantListResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<OAuthGrantListResponse>> GetGrants()
     {
-        if (!HttpContext.IsAuthenticated())
+        if (!TryGetSubject(out var subjectId, out var subjectError))
         {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "User is not authenticated.",
-            });
+            return subjectError;
         }
 
-        var subjectId = HttpContext.GetSubjectId();
-        if (subjectId == null)
-        {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "Could not determine authenticated user.",
-            });
-        }
-
-        var grants = await _grantService.GetGrantsForSubjectAsync(subjectId.Value);
+        var grants = await _grantService.GetGrantsForSubjectAsync(subjectId);
         var dtos = grants.Select(MapToDto).ToList();
 
         return Ok(new OAuthGrantListResponse { Grants = dtos });
@@ -800,27 +794,13 @@ public class OAuthController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteGrant(Guid grantId)
     {
-        if (!HttpContext.IsAuthenticated())
+        if (!TryGetSubject(out var subjectId, out var subjectError))
         {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "User is not authenticated.",
-            });
-        }
-
-        var subjectId = HttpContext.GetSubjectId();
-        if (subjectId == null)
-        {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "Could not determine authenticated user.",
-            });
+            return subjectError;
         }
 
         // Verify ownership: load all grants for the subject and check if grantId is among them
-        var grants = await _grantService.GetGrantsForSubjectAsync(subjectId.Value);
+        var grants = await _grantService.GetGrantsForSubjectAsync(subjectId);
         if (grants.All(g => g.Id != grantId))
         {
             return NotFound(new OAuthError
@@ -850,30 +830,16 @@ public class OAuthController : ControllerBase
         [FromBody] UpdateGrantRequest request
     )
     {
-        if (!HttpContext.IsAuthenticated())
+        if (!TryGetSubject(out var subjectId, out var subjectError))
         {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "User is not authenticated.",
-            });
-        }
-
-        var subjectId = HttpContext.GetSubjectId();
-        if (subjectId == null)
-        {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "Could not determine authenticated user.",
-            });
+            return subjectError;
         }
 
         try
         {
             var updated = await _grantService.UpdateGrantAsync(
                 grantId,
-                subjectId.Value,
+                subjectId,
                 request.Label,
                 request.Scopes
             );
@@ -928,23 +894,9 @@ public class OAuthController : ControllerBase
         [FromForm] string token,
         [FromForm] string? token_type_hint = null)
     {
-        if (!HttpContext.IsAuthenticated())
+        if (!TryGetSubject(out var callerSubjectId, out var subjectError))
         {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "User is not authenticated.",
-            });
-        }
-
-        var callerSubjectId = HttpContext.GetSubjectId();
-        if (callerSubjectId == null)
-        {
-            return Unauthorized(new OAuthError
-            {
-                Error = "access_denied",
-                ErrorDescription = "Could not determine authenticated user.",
-            });
+            return subjectError;
         }
 
         if (string.IsNullOrEmpty(token))
@@ -981,7 +933,7 @@ public class OAuthController : ControllerBase
                 // resolve its tenant-B token here. A non-pinned token (legacy session JWT, no
                 // TenantId claim) carries no such restriction and is matched on subject alone.
                 var callerTenantId = HttpContext.GetAuthContext()?.TenantId;
-                if (claims.SubjectId != callerSubjectId.Value
+                if (claims.SubjectId != callerSubjectId
                     || (claims.TenantId.HasValue && claims.TenantId != callerTenantId))
                 {
                     return Ok(new TokenIntrospectionResponse { Active = false });

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerSubjectGuardTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerSubjectGuardTests.cs
@@ -1,0 +1,233 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Models.OAuth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// The consent, device-approval and grant-management endpoints all act on behalf of a subject, and
+/// each one refuses a caller it cannot resolve to one. The refusal, its status and its payload are
+/// pinned at every endpoint behind the guard rather than at one of them, because they share a single
+/// implementation: a change there reaches all of these surfaces at once.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "OAuth")]
+public class OAuthControllerSubjectGuardTests
+{
+    private const string ClientId = "test-client-id";
+    private const string RedirectUri = "org.nightscout.trio://oauth/callback";
+    private const string CodeChallenge = "a-code-challenge";
+
+    private readonly Mock<IOAuthClientService> _clientService = new();
+    private readonly Mock<IOAuthGrantService> _grantService = new();
+
+    public OAuthControllerSubjectGuardTests()
+    {
+        _grantService
+            .Setup(s => s.GetGrantsForSubjectAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _clientService
+            .Setup(s => s.GetClientAsync(ClientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OAuthClientInfo
+            {
+                Id = Guid.CreateVersion7(),
+                ClientId = ClientId,
+                DisplayName = "Trio",
+            });
+        _clientService
+            .Setup(s => s.ValidateRedirectUriAsync(ClientId, RedirectUri, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+    }
+
+    /// <summary>
+    /// Every endpoint that resolves the caller to a subject, invoked with arguments that reach the
+    /// guard. <c>GET /api/oauth/authorize</c> is absent because it answers an unauthenticated
+    /// caller with a redirect to login rather than a refusal; it is covered separately below.
+    /// </summary>
+    public static TheoryData<string, Func<OAuthController, Task<ActionResult?>>> GuardedEndpoints =>
+        new()
+        {
+            {
+                "POST /api/oauth/authorize",
+                async c => await c.ApproveConsent(new ConsentApprovalRequest
+                {
+                    ClientId = ClientId,
+                    RedirectUri = RedirectUri,
+                    Scope = Scope.GlucoseRead,
+                    CodeChallenge = CodeChallenge,
+                    Approved = true,
+                })
+            },
+            {
+                "POST /api/oauth/device-approve",
+                async c => await c.DeviceApprove(new DeviceApprovalRequest
+                {
+                    UserCode = "ABCD-EFGH",
+                    Approved = true,
+                })
+            },
+            { "GET /api/oauth/grants", async c => (await c.GetGrants()).Result },
+            { "DELETE /api/oauth/grants/id", async c => await c.DeleteGrant(Guid.CreateVersion7()) },
+            {
+                "PATCH /api/oauth/grants/id",
+                async c => (await c.UpdateGrant(Guid.CreateVersion7(), new UpdateGrantRequest())).Result
+            },
+            {
+                "POST /api/oauth/introspect",
+                async c => (await c.Introspect("header.payload.signature")).Result
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(GuardedEndpoints))]
+    public async Task An_unauthenticated_caller_is_refused(
+        string endpoint, Func<OAuthController, Task<ActionResult?>> invoke)
+    {
+        var result = await invoke(CreateController(authContext: null));
+
+        RefusalOf(result, endpoint).ErrorDescription.Should().Be("User is not authenticated.");
+    }
+
+    /// <summary>
+    /// The public share subject is carried as an unauthenticated context with a subject id
+    /// attached, so the gate has to read the flag rather than the presence of an id.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GuardedEndpoints))]
+    public async Task An_unauthenticated_caller_carrying_a_subject_id_is_refused(
+        string endpoint, Func<OAuthController, Task<ActionResult?>> invoke)
+    {
+        var result = await invoke(CreateController(new AuthContext
+        {
+            IsAuthenticated = false,
+            AuthType = AuthType.None,
+            SubjectId = Guid.CreateVersion7(),
+        }));
+
+        RefusalOf(result, endpoint).ErrorDescription.Should().Be("User is not authenticated.");
+    }
+
+    [Theory]
+    [MemberData(nameof(GuardedEndpoints))]
+    public async Task An_authenticated_caller_with_no_subject_is_refused(
+        string endpoint, Func<OAuthController, Task<ActionResult?>> invoke)
+    {
+        var result = await invoke(CreateController(new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.Guest,
+            SubjectId = null,
+            ActingAsSubjectId = Guid.CreateVersion7(),
+        }));
+
+        RefusalOf(result, endpoint).ErrorDescription
+            .Should().Be("Could not determine authenticated user.");
+    }
+
+    /// <summary>
+    /// The guard resolves the caller's own <see cref="AuthContext.SubjectId"/>, never
+    /// <see cref="AuthContext.EffectiveSubjectId"/>. A follower acting on a data owner's behalf
+    /// carries both, and these endpoints are the follower's own consent, devices and grants — an
+    /// approval attributed to the data owner would hand the follower's client an authorization the
+    /// data owner never gave.
+    /// </summary>
+    [Fact]
+    public async Task A_follower_resolves_to_its_own_subject_not_the_owner_it_acts_for()
+    {
+        var callerSubjectId = Guid.CreateVersion7();
+        var dataOwnerSubjectId = Guid.CreateVersion7();
+
+        var result = await CreateController(new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.SessionCookie,
+            SubjectId = callerSubjectId,
+            ActingAsSubjectId = dataOwnerSubjectId,
+        }).GetGrants();
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        _grantService.Verify(
+            s => s.GetGrantsForSubjectAsync(callerSubjectId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _grantService.Verify(
+            s => s.GetGrantsForSubjectAsync(
+                It.Is<Guid>(id => id != callerSubjectId), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// <c>GET /api/oauth/authorize</c> is the one entry point a browser reaches without a session:
+    /// an unauthenticated caller is sent to login with the OAuth parameters preserved, not refused.
+    /// </summary>
+    [Fact]
+    public async Task The_authorize_entry_point_sends_an_unauthenticated_caller_to_login()
+    {
+        var result = await Authorize(CreateController(authContext: null));
+
+        result.Should().BeOfType<RedirectResult>()
+            .Which.Url.Should().StartWith("/auth/login?returnUrl=");
+    }
+
+    [Fact]
+    public async Task The_authorize_entry_point_refuses_an_authenticated_caller_with_no_subject()
+    {
+        var result = await Authorize(CreateController(new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.Guest,
+            SubjectId = null,
+            ActingAsSubjectId = Guid.CreateVersion7(),
+        }));
+
+        RefusalOf(result, "GET /api/oauth/authorize").ErrorDescription
+            .Should().Be("Could not determine authenticated user.");
+    }
+
+    private static Task<ActionResult> Authorize(OAuthController controller) => controller.Authorize(
+        client_id: ClientId,
+        redirect_uri: RedirectUri,
+        response_type: "code",
+        scope: Scope.GlucoseRead,
+        state: "opaque-state",
+        code_challenge: CodeChallenge,
+        code_challenge_method: "S256");
+
+    private static OAuthError RefusalOf(ActionResult? result, string endpoint)
+    {
+        var unauthorized = result.Should().BeOfType<UnauthorizedObjectResult>(
+            "{0} refuses a caller it cannot resolve to a subject", endpoint).Subject;
+        var error = unauthorized.Value.Should().BeOfType<OAuthError>().Subject;
+        error.Error.Should().Be("access_denied");
+        return error;
+    }
+
+    private OAuthController CreateController(AuthContext? authContext)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (authContext != null)
+        {
+            httpContext.Items["AuthContext"] = authContext;
+        }
+
+        return new OAuthController(
+            _clientService.Object,
+            _grantService.Object,
+            Mock.Of<IOAuthTokenService>(),
+            Mock.Of<IOAuthDeviceCodeService>(),
+            Mock.Of<ISubjectService>(),
+            Mock.Of<IJwtService>(),
+            Mock.Of<IOAuthTokenRevocationCache>(),
+            NullLogger<OAuthController>.Instance
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+}


### PR DESCRIPTION
Fixes #1060.

The authenticated-subject guard on OAuthController's consent, device-approval, grant-management and introspection endpoints was maintained as seven verbatim copies — the shape that eventually produces a fix applied to six of seven. All seven now route through one `private bool TryGetSubject(out Guid subjectId, [NotNullWhen(false)] out ActionResult? error)`; each call site is three lines, and `out Guid` removed six `.Value` dereferences. Controller net −48 lines.

Wire behaviour is byte-identical: same 401s, same `OAuthError` payloads, same strings — verified by extracting and diffing all seven original blocks (five byte-identical, one differing only in a local variable name), and re-verified independently by a hostile review that also confirmed no statement moved across any guard and the guard's position relative to each action's other validation is unchanged.

One deviation the issue's "copies are verbatim" claim missed: `GET /api/oauth/authorize` answers an unauthenticated browser with a redirect to login (preserving the OAuth query string), not a 401. That arm is untouched; only its subject-null half uses the helper, whose re-check of `IsAuthenticated()` is provably unreachable there (both reads are pure `HttpContext.Items` lookups). Two dedicated tests pin the redirect and the 401 so a future cleanup cannot collapse them.

## Tests

`OAuthControllerSubjectGuardTests` (21 tests): the six refusing endpoints × three caller shapes — unauthenticated, unauthenticated-carrying-a-subject-id (the public-share shape, which must be refused on the flag rather than the id), and authenticated-with-no-subject (guest) — each asserting the exact status, `error` and `error_description`; the two authorize facts; and a follower-shaped success-path test pinning that the helper resolves `AuthContext.SubjectId` and not `ActingAsSubjectId` — on these surfaces a follower acts on its own consent and grants, and resolving the acted-for owner would mint the follower's client an authorization the owner never granted (the doc on the helper records why this is the exception to `EffectiveSubjectId` guidance).

Mutation-proven from both sides: guard removed → 23 failures; error strings swapped → 19; bodyless 401 → 12; identity corrupted to `Guid.Empty` → caught; resolution drifted to `EffectiveSubjectId` → 9 failures including all six guest-refusal rows. Full unit suite green (6,266). Prior coverage pinned only Introspect's status; consent, device-approve and the grant endpoints had none.
