### PR TITLE
refactor(api): drive the data-overview fan-outs from one per-type table

### DIFF
--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
@@ -66,141 +66,26 @@ public class DataOverviewService : IDataOverviewService
         await using var context = await _factory.CreateAsync(cancellationToken);
 
         // Run all queries sequentially — DbContext is not thread-safe
-        var minMaxResults = new List<(long? Min, long? Max)>();
-
-        // V4 tables with Timestamp + DataSource
-        minMaxResults.Add(
-            await GetMinMaxTimestamp(
-                context.SensorGlucose.Select(e => (DateTime?)e.Timestamp),
-                cancellationToken
-            )
-        );
-        minMaxResults.Add(
-            await GetMinMaxTimestamp(
-                context.MeterGlucose.Select(e => (DateTime?)e.Timestamp),
-                cancellationToken
-            )
-        );
-        minMaxResults.Add(
-            await GetMinMaxTimestamp(
-                context.Boluses.Select(e => (DateTime?)e.Timestamp),
-                cancellationToken
-            )
-        );
-        minMaxResults.Add(
-            await GetMinMaxTimestamp(
-                context.CarbIntakes.Select(e => (DateTime?)e.Timestamp),
-                cancellationToken
-            )
-        );
-        minMaxResults.Add(
-            await GetMinMaxTimestamp(
-                context.BolusCalculations.Select(e => (DateTime?)e.Timestamp),
-                cancellationToken
-            )
-        );
-        minMaxResults.Add(
-            await GetMinMaxTimestamp(
-                context.Notes.Select(e => (DateTime?)e.Timestamp),
-                cancellationToken
-            )
-        );
-        minMaxResults.Add(
-            await GetMinMaxTimestamp(
-                context.DeviceEvents.Select(e => (DateTime?)e.Timestamp),
-                cancellationToken
-            )
-        );
-
-        // StateSpans uses StartTimestamp
-        minMaxResults.Add(
-            await GetMinMaxTimestamp(
-                context.StateSpans.Select(e => (DateTime?)e.StartTimestamp),
-                cancellationToken
-            )
-        );
-
-        // APS snapshots (V4 replacement for device statuses)
-        minMaxResults.Add(
-            await GetMinMaxMills(
-                context.ApsSnapshots.Select(e =>
-                    (long?)new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds()),
-                cancellationToken
-            )
-        );
-
-        // Collect data sources from tables that have DataSource
-        var allDataSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (
-            var ds in await GetDistinctDataSources(
-                context.SensorGlucose.Where(e => e.DataSource != null).Select(e => e.DataSource!),
-                cancellationToken
-            )
-        )
-            allDataSources.Add(ds);
-        foreach (
-            var ds in await GetDistinctDataSources(
-                context.MeterGlucose.Where(e => e.DataSource != null).Select(e => e.DataSource!),
-                cancellationToken
-            )
-        )
-            allDataSources.Add(ds);
-        foreach (
-            var ds in await GetDistinctDataSources(
-                context.Boluses.Where(e => e.DataSource != null).Select(e => e.DataSource!),
-                cancellationToken
-            )
-        )
-            allDataSources.Add(ds);
-        foreach (
-            var ds in await GetDistinctDataSources(
-                context.CarbIntakes.Where(e => e.DataSource != null).Select(e => e.DataSource!),
-                cancellationToken
-            )
-        )
-            allDataSources.Add(ds);
-        foreach (
-            var ds in await GetDistinctDataSources(
-                context
-                    .BolusCalculations.Where(e => e.DataSource != null)
-                    .Select(e => e.DataSource!),
-                cancellationToken
-            )
-        )
-            allDataSources.Add(ds);
-        foreach (
-            var ds in await GetDistinctDataSources(
-                context.Notes.Where(e => e.DataSource != null).Select(e => e.DataSource!),
-                cancellationToken
-            )
-        )
-            allDataSources.Add(ds);
-        foreach (
-            var ds in await GetDistinctDataSources(
-                context.DeviceEvents.Where(e => e.DataSource != null).Select(e => e.DataSource!),
-                cancellationToken
-            )
-        )
-            allDataSources.Add(ds);
-        // StateSpans uses Source (not DataSource)
-        foreach (
-            var ds in await GetDistinctDataSources(
-                context.StateSpans.Where(e => e.Source != null).Select(e => e.Source!),
-                cancellationToken
-            )
-        )
-            allDataSources.Add(ds);
-        // Derive year range from all min/max mills
         long? globalMin = null;
         long? globalMax = null;
+        var allDataSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var (min, max) in minMaxResults)
+        foreach (var table in DataOverviewTables.All)
         {
+            var (min, max) = await GetMinMaxTimestamp(
+                table.Timestamps(context),
+                cancellationToken
+            );
             if (min.HasValue && (!globalMin.HasValue || min.Value < globalMin.Value))
                 globalMin = min.Value;
             if (max.HasValue && (!globalMax.HasValue || max.Value > globalMax.Value))
                 globalMax = max.Value;
+
+            if (table.Sources(context) is not { } sources)
+                continue;
+
+            foreach (var ds in await GetDistinctDataSources(sources, cancellationToken))
+                allDataSources.Add(ds);
         }
 
         var tz = await GetUserTimeZoneAsync(cancellationToken);
@@ -253,8 +138,6 @@ public class DataOverviewService : IDataOverviewService
 
         var tz = await GetUserTimeZoneAsync(cancellationToken);
         var (startUtc, endUtc) = LocalYearBoundsUtc(year, tz);
-        var startMills = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-        var endMills = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
 
         var hasFilter = dataSources is { Length: > 0 };
 
@@ -262,137 +145,25 @@ public class DataOverviewService : IDataOverviewService
         var dayMap = new Dictionary<string, DailySummaryDay>();
 
         // Run all queries sequentially — DbContext is not thread-safe
-
-        // Exclude non-primary duplicates from cross-connector deduplication
-        var npSensorGlucose = context
-            .LinkedRecords.Where(lr => lr.RecordType == "sensorglucose" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-        var npBolus = context
-            .LinkedRecords.Where(lr => lr.RecordType == "bolus" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-        var npCarbIntake = context
-            .LinkedRecords.Where(lr => lr.RecordType == "carbintake" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-        var npBolusCalc = context
-            .LinkedRecords.Where(lr => lr.RecordType == "boluscalculation" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-        var npNote = context
-            .LinkedRecords.Where(lr => lr.RecordType == "note" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-        var npDeviceEvent = context
-            .LinkedRecords.Where(lr => lr.RecordType == "deviceevent" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-        var npStateSpan = context
-            .LinkedRecords.Where(lr => lr.RecordType == "statespan" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-
-        // V4 tables with Timestamp + DataSource
-        await CollectCountsFromTimestampTable(
-            "Glucose",
-            context
-                .SensorGlucose.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
-                .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
-                .Where(e => !npSensorGlucose.Contains(e.Id))
-                .Select(e => e.Timestamp),
-            dayMap,
-            tz,
-            cancellationToken
-        );
-
-        await CollectCountsFromTimestampTable(
-            "ManualBG",
-            context
-                .MeterGlucose.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
-                .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
-                .Select(e => e.Timestamp),
-            dayMap,
-            tz,
-            cancellationToken
-        );
-
-        await CollectCountsFromTimestampTable(
-            "Boluses",
-            context
-                .Boluses.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
-                .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
-                .Where(e => !npBolus.Contains(e.Id))
-                .Select(e => e.Timestamp),
-            dayMap,
-            tz,
-            cancellationToken
-        );
-
-        await CollectCountsFromTimestampTable(
-            "CarbIntake",
-            context
-                .CarbIntakes.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
-                .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
-                .Where(e => !npCarbIntake.Contains(e.Id))
-                .Select(e => e.Timestamp),
-            dayMap,
-            tz,
-            cancellationToken
-        );
-
-        await CollectCountsFromTimestampTable(
-            "BolusCalculations",
-            context
-                .BolusCalculations.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
-                .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
-                .Where(e => !npBolusCalc.Contains(e.Id))
-                .Select(e => e.Timestamp),
-            dayMap,
-            tz,
-            cancellationToken
-        );
-
-        await CollectCountsFromTimestampTable(
-            "Notes",
-            context
-                .Notes.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
-                .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
-                .Where(e => !npNote.Contains(e.Id))
-                .Select(e => e.Timestamp),
-            dayMap,
-            tz,
-            cancellationToken
-        );
-
-        await CollectCountsFromTimestampTable(
-            "DeviceEvents",
-            context
-                .DeviceEvents.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
-                .Where(e => !hasFilter || dataSources!.Contains(e.DataSource!))
-                .Where(e => !npDeviceEvent.Contains(e.Id))
-                .Select(e => e.Timestamp),
-            dayMap,
-            tz,
-            cancellationToken
-        );
-
-        // StateSpans: uses StartTimestamp and Source (not Timestamp/DataSource)
-        await CollectCountsFromTimestampTable(
-            "StateSpans",
-            context
-                .StateSpans.Where(e => e.StartTimestamp >= startUtc && e.StartTimestamp < endUtc)
-                .Where(e => !hasFilter || dataSources!.Contains(e.Source!))
-                .Where(e => !npStateSpan.Contains(e.Id))
-                .Select(e => e.StartTimestamp),
-            dayMap,
-            tz,
-            cancellationToken
-        );
-
-        // APS snapshots: V4 replacement for device statuses - skip when filter is active
-        if (!hasFilter)
+        foreach (var table in DataOverviewTables.All)
         {
-            var apsStartUtc = DateTimeOffset.FromUnixTimeMilliseconds(startMills).UtcDateTime;
-            var apsEndUtc = DateTimeOffset.FromUnixTimeMilliseconds(endMills).UtcDateTime;
+            var nonPrimaryIds = table.DedupRecordType is { } recordType
+                ? NonPrimaryRecordIds(context, recordType)
+                : null;
+
+            var timestamps = table.TimestampsInRange(
+                context,
+                startUtc,
+                endUtc,
+                dataSources,
+                nonPrimaryIds
+            );
+            if (timestamps is null)
+                continue;
+
             await CollectCountsFromTimestampTable(
-                "DeviceStatus",
-                context
-                    .ApsSnapshots.Where(e => e.Timestamp >= apsStartUtc && e.Timestamp < apsEndUtc)
-                    .Select(e => e.Timestamp),
+                table.CountsKey,
+                timestamps,
                 dayMap,
                 tz,
                 cancellationToken
@@ -777,29 +548,18 @@ public class DataOverviewService : IDataOverviewService
     }
 
     /// <summary>
-    /// Gets min and max from an IQueryable of nullable longs, with exception handling per table.
+    /// The ids of records deduplication resolved to a non-primary member of a canonical group, so
+    /// one real-world event contributes once however many connectors reported it.
     /// </summary>
-    private async Task<(long? Min, long? Max)> GetMinMaxMills(
-        IQueryable<long?> millsQuery,
-        CancellationToken cancellationToken
+    private static IQueryable<Guid> NonPrimaryRecordIds(
+        NocturneDbContext context,
+        RecordType recordType
     )
     {
-        try
-        {
-            var min = await millsQuery.MinAsync(cancellationToken);
-            var max = await millsQuery.MaxAsync(cancellationToken);
-            return (min, max);
-        }
-        catch (InvalidOperationException)
-        {
-            // Table is empty - Min/Max on empty sequence
-            return (null, null);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to get min/max mills from table");
-            return (null, null);
-        }
+        var key = recordType.ToString().ToLowerInvariant();
+        return context
+            .LinkedRecords.Where(lr => lr.RecordType == key && !lr.IsPrimary)
+            .Select(lr => lr.RecordId);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
@@ -250,18 +250,10 @@ public class DataOverviewService : IDataOverviewService
         var (startUtc, endUtc) = LocalYearBoundsUtc(year, tz);
 
         // Hoist LinkedRecord subqueries — IQueryable construction is free
-        var npSensorGlucoseIds = context
-            .LinkedRecords.Where(lr => lr.RecordType == "sensorglucose" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-        var nonPrimaryBolusIds = context
-            .LinkedRecords.Where(lr => lr.RecordType == "bolus" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-        var nonPrimaryTempBasalIds = context
-            .LinkedRecords.Where(lr => lr.RecordType == "tempbasal" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
-        var nonPrimaryCarbIds = context
-            .LinkedRecords.Where(lr => lr.RecordType == "carbintake" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
+        var npSensorGlucoseIds = NonPrimaryRecordIds(context, RecordType.SensorGlucose);
+        var nonPrimaryBolusIds = NonPrimaryRecordIds(context, RecordType.Bolus);
+        var nonPrimaryTempBasalIds = NonPrimaryRecordIds(context, RecordType.TempBasal);
+        var nonPrimaryCarbIds = NonPrimaryRecordIds(context, RecordType.CarbIntake);
 
         // --- Collect glucose readings by month (CGM + meter) ---
         // Each source is queried independently so one failure doesn't prevent the others.
@@ -548,8 +540,7 @@ public class DataOverviewService : IDataOverviewService
     }
 
     /// <summary>
-    /// The ids of records deduplication resolved to a non-primary member of a canonical group, so
-    /// one real-world event contributes once however many connectors reported it.
+    /// The ids of records deduplication resolved to a non-primary member of a canonical group.
     /// </summary>
     private static IQueryable<Guid> NonPrimaryRecordIds(
         NocturneDbContext context,
@@ -614,43 +605,6 @@ public class DataOverviewService : IDataOverviewService
     }
 
     /// <summary>
-    /// Materializes mills values from a table, groups by date in-memory, and merges counts into the dayMap.
-    /// </summary>
-    private async Task CollectCountsFromMillsTable(
-        string dataType,
-        IQueryable<long> millsQuery,
-        Dictionary<string, DailySummaryDay> dayMap,
-        TimeZoneInfo tz,
-        CancellationToken cancellationToken
-    )
-    {
-        try
-        {
-            var millsList = await millsQuery.ToListAsync(cancellationToken);
-
-            var grouped = millsList
-                .GroupBy(m => MillsToDateString(m, tz))
-                .Select(g => new { Date = g.Key, Count = g.Count() });
-
-            foreach (var group in grouped)
-            {
-                if (!dayMap.TryGetValue(group.Date, out var day))
-                {
-                    day = new DailySummaryDay { Date = group.Date };
-                    dayMap[group.Date] = day;
-                }
-
-                day.Counts.TryGetValue(dataType, out var existing);
-                day.Counts[dataType] = existing + group.Count;
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to collect counts for {DataType}", dataType);
-        }
-    }
-
-    /// <summary>
     /// Collects glucose averages from SensorGlucose and MeterGlucose.
     /// Each source is queried independently so one failure doesn't prevent the others.
     /// </summary>
@@ -671,9 +625,7 @@ public class DataOverviewService : IDataOverviewService
         // SensorGlucose (CGM) - V4 entity uses Timestamp
         try
         {
-            var npSensorGlucoseIds = context
-                .LinkedRecords.Where(lr => lr.RecordType == "sensorglucose" && !lr.IsPrimary)
-                .Select(lr => lr.RecordId);
+            var npSensorGlucoseIds = NonPrimaryRecordIds(context, RecordType.SensorGlucose);
 
             var sensorReadings = await context
                 .SensorGlucose.Where(e => e.Timestamp >= startUtc && e.Timestamp < endUtc)
@@ -763,10 +715,7 @@ public class DataOverviewService : IDataOverviewService
         CancellationToken cancellationToken
     )
     {
-        // Exclude non-primary duplicates from cross-connector deduplication
-        var nonPrimaryBolusIds = context
-            .LinkedRecords.Where(lr => lr.RecordType == "bolus" && !lr.IsPrimary)
-            .Select(lr => lr.RecordId);
+        var nonPrimaryBolusIds = NonPrimaryRecordIds(context, RecordType.Bolus);
 
         // Manual bolus records — only user-initiated boluses count as bolus insulin
         try
@@ -847,9 +796,7 @@ public class DataOverviewService : IDataOverviewService
         // TempBasal records (pump basal delivery with rate x duration)
         try
         {
-            var nonPrimaryTempBasalIds = context
-                .LinkedRecords.Where(lr => lr.RecordType == "tempbasal" && !lr.IsPrimary)
-                .Select(lr => lr.RecordId);
+            var nonPrimaryTempBasalIds = NonPrimaryRecordIds(context, RecordType.TempBasal);
 
             var tempBasalRecords = await context
                 .TempBasals.Where(e =>
@@ -925,9 +872,7 @@ public class DataOverviewService : IDataOverviewService
     {
         try
         {
-            var nonPrimaryCarbIds = context
-                .LinkedRecords.Where(lr => lr.RecordType == "carbintake" && !lr.IsPrimary)
-                .Select(lr => lr.RecordId);
+            var nonPrimaryCarbIds = NonPrimaryRecordIds(context, RecordType.CarbIntake);
 
             var carbRecords = await context
                 .CarbIntakes.Where(e =>
@@ -960,16 +905,6 @@ public class DataOverviewService : IDataOverviewService
         {
             _logger.LogWarning(ex, "Failed to collect carb totals");
         }
-    }
-
-    /// <summary>
-    /// Converts Unix milliseconds to a local date string in "yyyy-MM-dd" format using the given timezone.
-    /// </summary>
-    private static string MillsToDateString(long mills, TimeZoneInfo tz)
-    {
-        var utc = DateTimeOffset.FromUnixTimeMilliseconds(mills);
-        var local = TimeZoneInfo.ConvertTime(utc, tz);
-        return local.ToString("yyyy-MM-dd");
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewTables.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewTables.cs
@@ -8,18 +8,14 @@ using Nocturne.Infrastructure.Data.Entities.V4;
 namespace Nocturne.API.Services.Analytics;
 
 /// <summary>
-/// One table behind the data overview, described in the terms its surfaces need: the
-/// <see cref="SyncDataType"/> name per-day counts are keyed by, the domain timestamp, the source
-/// handle, and the <see cref="RecordType"/> whose non-primary <see cref="LinkedRecord"/>s stand for
-/// cross-connector duplicates.
+/// One table behind the data overview, in the terms its year-range, data-source and
+/// per-day-count surfaces need.
 /// </summary>
 /// <seealso cref="DataOverviewTables"/>
 internal interface IDataOverviewTable
 {
-    /// <summary>Key this table's rows are counted under in <see cref="Core.Models.Services.DailySummaryDay.Counts"/>.</summary>
     string CountsKey { get; }
 
-    /// <summary>Null when the table takes no part in deduplication.</summary>
     RecordType? DedupRecordType { get; }
 
     /// <summary>
@@ -46,13 +42,6 @@ internal interface IDataOverviewTable
 }
 
 /// <inheritdoc cref="IDataOverviewTable"/>
-/// <typeparam name="TEntity">The mapped entity behind the table.</typeparam>
-/// <param name="countsKey">Names the key <see cref="CountsKey"/> reports.</param>
-/// <param name="table">Leases the table's <see cref="Microsoft.EntityFrameworkCore.DbSet{TEntity}"/> from a context.</param>
-/// <param name="timestamp">The column the overview treats as the row's moment in time.</param>
-/// <param name="id">The column <see cref="LinkedRecord.RecordId"/> refers to.</param>
-/// <param name="source">The column holding the data-source handle, or null when the table has none.</param>
-/// <param name="dedupRecordType">Names the record type as deduplication knows it, or null.</param>
 internal sealed class DataOverviewTable<TEntity>(
     SyncDataType countsKey,
     Func<NocturneDbContext, IQueryable<TEntity>> table,
@@ -107,9 +96,8 @@ internal sealed class DataOverviewTable<TEntity>(
     }
 
     /// <summary>
-    /// Reads <paramref name="predicate"/> against the column <paramref name="selector"/> picks, so
-    /// the resulting tree is the one a hand-written lambda over that column would have produced and
-    /// its captured values still reach the provider as query parameters.
+    /// Substituting into a written lambda, rather than assembling the tree node by node, keeps the
+    /// values that lambda captures reaching the provider as query parameters.
     /// </summary>
     private static Expression<Func<TEntity, bool>> Compose<TValue>(
         Expression<Func<TEntity, TValue>> selector,
@@ -120,10 +108,6 @@ internal sealed class DataOverviewTable<TEntity>(
             selector.Parameters
         );
 
-    /// <summary>
-    /// Applies <paramref name="projection"/> to the column <paramref name="selector"/> picks, on the
-    /// same terms as <see cref="Compose{TValue}"/>.
-    /// </summary>
     private static Expression<Func<TEntity, TResult>> Project<TValue, TResult>(
         Expression<Func<TEntity, TValue>> selector,
         Expression<Func<TValue, TResult>> projection

--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewTables.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewTables.cs
@@ -1,0 +1,205 @@
+using System.Linq.Expressions;
+using Nocturne.Connectors.Core.Models;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+
+namespace Nocturne.API.Services.Analytics;
+
+/// <summary>
+/// One table behind the data overview, described in the terms its surfaces need: the
+/// <see cref="SyncDataType"/> name per-day counts are keyed by, the domain timestamp, the source
+/// handle, and the <see cref="RecordType"/> whose non-primary <see cref="LinkedRecord"/>s stand for
+/// cross-connector duplicates.
+/// </summary>
+/// <seealso cref="DataOverviewTables"/>
+internal interface IDataOverviewTable
+{
+    /// <summary>Key this table's rows are counted under in <see cref="Core.Models.Services.DailySummaryDay.Counts"/>.</summary>
+    string CountsKey { get; }
+
+    /// <summary>Null when the table takes no part in deduplication.</summary>
+    RecordType? DedupRecordType { get; }
+
+    /// <summary>
+    /// Every row's timestamp, with neither a source filter nor duplicate exclusion applied — the
+    /// overview's year range spans whatever the tenant holds.
+    /// </summary>
+    IQueryable<DateTime?> Timestamps(NocturneDbContext context);
+
+    /// <summary>Null when the overview does not attribute this table to a data source.</summary>
+    IQueryable<string>? Sources(NocturneDbContext context);
+
+    /// <summary>
+    /// Timestamps within the half-open UTC interval, less any row whose id is in
+    /// <paramref name="nonPrimaryIds"/>. Null when <paramref name="dataSources"/> constrains a
+    /// table the overview does not attribute to a data source.
+    /// </summary>
+    IQueryable<DateTime>? TimestampsInRange(
+        NocturneDbContext context,
+        DateTime startUtc,
+        DateTime endUtc,
+        string[]? dataSources,
+        IQueryable<Guid>? nonPrimaryIds
+    );
+}
+
+/// <inheritdoc cref="IDataOverviewTable"/>
+/// <typeparam name="TEntity">The mapped entity behind the table.</typeparam>
+/// <param name="countsKey">Names the key <see cref="CountsKey"/> reports.</param>
+/// <param name="table">Leases the table's <see cref="Microsoft.EntityFrameworkCore.DbSet{TEntity}"/> from a context.</param>
+/// <param name="timestamp">The column the overview treats as the row's moment in time.</param>
+/// <param name="id">The column <see cref="LinkedRecord.RecordId"/> refers to.</param>
+/// <param name="source">The column holding the data-source handle, or null when the table has none.</param>
+/// <param name="dedupRecordType">Names the record type as deduplication knows it, or null.</param>
+internal sealed class DataOverviewTable<TEntity>(
+    SyncDataType countsKey,
+    Func<NocturneDbContext, IQueryable<TEntity>> table,
+    Expression<Func<TEntity, DateTime>> timestamp,
+    Expression<Func<TEntity, Guid>> id,
+    Expression<Func<TEntity, string?>>? source,
+    RecordType? dedupRecordType = null
+) : IDataOverviewTable
+    where TEntity : class
+{
+    /// <inheritdoc />
+    public string CountsKey { get; } = countsKey.ToString();
+
+    /// <inheritdoc />
+    public RecordType? DedupRecordType { get; } = dedupRecordType;
+
+    /// <inheritdoc />
+    public IQueryable<DateTime?> Timestamps(NocturneDbContext context) =>
+        table(context).Select(Project(timestamp, t => (DateTime?)t));
+
+    /// <inheritdoc />
+    public IQueryable<string>? Sources(NocturneDbContext context) =>
+        source is null
+            ? null
+            : table(context)
+                .Where(Compose(source, s => s != null))
+                .Select(Project(source, s => s!));
+
+    /// <inheritdoc />
+    public IQueryable<DateTime>? TimestampsInRange(
+        NocturneDbContext context,
+        DateTime startUtc,
+        DateTime endUtc,
+        string[]? dataSources,
+        IQueryable<Guid>? nonPrimaryIds
+    )
+    {
+        var query = table(context).Where(Compose(timestamp, t => t >= startUtc && t < endUtc));
+
+        if (dataSources is { Length: > 0 } wanted)
+        {
+            if (source is null)
+                return null;
+
+            query = query.Where(Compose(source, s => wanted.Contains(s!)));
+        }
+
+        if (nonPrimaryIds is { } duplicates)
+            query = query.Where(Compose(id, recordId => !duplicates.Contains(recordId)));
+
+        return query.Select(timestamp);
+    }
+
+    /// <summary>
+    /// Reads <paramref name="predicate"/> against the column <paramref name="selector"/> picks, so
+    /// the resulting tree is the one a hand-written lambda over that column would have produced and
+    /// its captured values still reach the provider as query parameters.
+    /// </summary>
+    private static Expression<Func<TEntity, bool>> Compose<TValue>(
+        Expression<Func<TEntity, TValue>> selector,
+        Expression<Func<TValue, bool>> predicate
+    ) =>
+        Expression.Lambda<Func<TEntity, bool>>(
+            Substitute(predicate.Body, predicate.Parameters[0], selector.Body),
+            selector.Parameters
+        );
+
+    /// <summary>
+    /// Applies <paramref name="projection"/> to the column <paramref name="selector"/> picks, on the
+    /// same terms as <see cref="Compose{TValue}"/>.
+    /// </summary>
+    private static Expression<Func<TEntity, TResult>> Project<TValue, TResult>(
+        Expression<Func<TEntity, TValue>> selector,
+        Expression<Func<TValue, TResult>> projection
+    ) =>
+        Expression.Lambda<Func<TEntity, TResult>>(
+            Substitute(projection.Body, projection.Parameters[0], selector.Body),
+            selector.Parameters
+        );
+
+    private static Expression Substitute(
+        Expression body,
+        ParameterExpression parameter,
+        Expression replacement
+    ) => new ParameterSubstitution(parameter, replacement).Visit(body);
+
+    private sealed class ParameterSubstitution(ParameterExpression parameter, Expression replacement)
+        : ExpressionVisitor
+    {
+        protected override Expression VisitParameter(ParameterExpression node) =>
+            node == parameter ? replacement : base.VisitParameter(node);
+    }
+}
+
+/// <summary>
+/// Every table the data overview aggregates, driving its year range, its data-source list and its
+/// per-day counts. Order is significant: it fixes the insertion order of
+/// <see cref="Core.Models.Services.DailySummaryDay.Counts"/>, which survives into the serialized
+/// response.
+/// </summary>
+internal static class DataOverviewTables
+{
+    internal static readonly IReadOnlyList<IDataOverviewTable> All =
+    [
+        new DataOverviewTable<SensorGlucoseEntity>(
+            SyncDataType.Glucose,
+            c => c.SensorGlucose, e => e.Timestamp, e => e.Id, e => e.DataSource,
+            RecordType.SensorGlucose),
+        new DataOverviewTable<MeterGlucoseEntity>(
+            SyncDataType.ManualBG,
+            c => c.MeterGlucose, e => e.Timestamp, e => e.Id, e => e.DataSource),
+        new DataOverviewTable<BolusEntity>(
+            SyncDataType.Boluses,
+            c => c.Boluses, e => e.Timestamp, e => e.Id, e => e.DataSource,
+            RecordType.Bolus),
+        new DataOverviewTable<CarbIntakeEntity>(
+            SyncDataType.CarbIntake,
+            c => c.CarbIntakes, e => e.Timestamp, e => e.Id, e => e.DataSource,
+            RecordType.CarbIntake),
+        new DataOverviewTable<BolusCalculationEntity>(
+            SyncDataType.BolusCalculations,
+            c => c.BolusCalculations, e => e.Timestamp, e => e.Id, e => e.DataSource,
+            RecordType.BolusCalculation),
+        new DataOverviewTable<NoteEntity>(
+            SyncDataType.Notes,
+            c => c.Notes, e => e.Timestamp, e => e.Id, e => e.DataSource,
+            RecordType.Note),
+        new DataOverviewTable<DeviceEventEntity>(
+            SyncDataType.DeviceEvents,
+            c => c.DeviceEvents, e => e.Timestamp, e => e.Id, e => e.DataSource,
+            RecordType.DeviceEvent),
+        new DataOverviewTable<StateSpanEntity>(
+            SyncDataType.StateSpans,
+            c => c.StateSpans, e => e.StartTimestamp, e => e.Id, e => e.Source,
+            RecordType.StateSpan),
+        // ApsSnapshots carries a DataSource column the overview does not surface, so a source
+        // filter drops the table rather than narrowing it.
+        new DataOverviewTable<ApsSnapshotEntity>(
+            SyncDataType.DeviceStatus,
+            c => c.ApsSnapshots, e => e.Timestamp, e => e.Id, source: null),
+        new DataOverviewTable<BGCheckEntity>(
+            SyncDataType.BGChecks,
+            c => c.BGChecks, e => e.Timestamp, e => e.Id, e => e.DataSource,
+            RecordType.BGCheck),
+        new DataOverviewTable<TempBasalEntity>(
+            SyncDataType.TempBasals,
+            c => c.TempBasals, e => e.StartTimestamp, e => e.Id, e => e.DataSource,
+            RecordType.TempBasal),
+    ];
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
@@ -69,11 +69,13 @@
   const ALL_DATA_TYPES = [
     "Glucose",
     "ManualBG",
+    "BGChecks",
     "Boluses",
     "CarbIntake",
     "BolusCalculations",
     "Notes",
     "DeviceEvents",
+    "TempBasals",
     "StateSpans",
     "Activity",
     "DeviceStatus",

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewServiceTests.cs
@@ -876,6 +876,132 @@ public class DataOverviewServiceTests : IDisposable
         day.Counts["Boluses"].Should().Be(1);
     }
 
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetDailySummaryAsync_BGChecks_CountedAndFilteredByDataSource()
+    {
+        await SeedTwoBGChecksAsync();
+
+        var result = await _service.GetDailySummaryAsync(2024);
+
+        result.Days.Should().ContainSingle();
+        var day = result.Days[0];
+        day.Counts["BGChecks"].Should().Be(2);
+        day.TotalCount.Should().Be(2);
+
+        var filtered = await _service.GetDailySummaryAsync(2024, ["contour"]);
+
+        filtered.Days.Should().ContainSingle();
+        filtered.Days[0].Counts["BGChecks"].Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetAvailableYearsAsync_BGChecks_ContributeYearAndDataSources()
+    {
+        await SeedTwoBGChecksAsync();
+
+        var result = await _service.GetAvailableYearsAsync();
+
+        result.Years.Should().ContainSingle().Which.Should().Be(2024);
+        result.AvailableDataSources.Should().BeEquivalentTo(["accu-chek", "contour"]);
+    }
+
+    private async Task SeedTwoBGChecksAsync()
+    {
+        _dbContext.BGChecks.Add(new BGCheckEntity
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(June15_2024_Noon).UtcDateTime,
+            Glucose = 96.0,
+            DataSource = "contour"
+        });
+        _dbContext.BGChecks.Add(new BGCheckEntity
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(June15_2024_Noon + 600000).UtcDateTime,
+            Glucose = 143.0,
+            DataSource = "accu-chek"
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetDailySummaryAsync_TempBasals_CountedByStartTimestamp()
+    {
+        _dbContext.TempBasals.Add(new TempBasalEntity
+        {
+            Id = Guid.NewGuid(),
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(June15_2024_Noon).UtcDateTime,
+            EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(June15_2024_Noon + 3600000).UtcDateTime,
+            Rate = 1.0,
+            Origin = "Scheduled",
+            DataSource = "glooko"
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDailySummaryAsync(2024);
+
+        result.Days.Should().ContainSingle();
+        var day = result.Days[0];
+        day.Counts["TempBasals"].Should().Be(1);
+        day.TotalCount.Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetDailySummaryAsync_NonPrimaryBGCheckAndTempBasal_ExcludedFromCounts()
+    {
+        var bgCheckId = Guid.NewGuid();
+        var tempBasalId = Guid.NewGuid();
+
+        _dbContext.BGChecks.Add(new BGCheckEntity
+        {
+            Id = bgCheckId,
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(June15_2024_Noon).UtcDateTime,
+            Glucose = 96.0,
+            DataSource = "contour"
+        });
+        _dbContext.TempBasals.Add(new TempBasalEntity
+        {
+            Id = tempBasalId,
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(June15_2024_Noon).UtcDateTime,
+            Rate = 1.0,
+            Origin = "Scheduled",
+            DataSource = "glooko"
+        });
+        _dbContext.Notes.Add(new NoteEntity
+        {
+            Id = Guid.NewGuid(),
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(June15_2024_Noon).UtcDateTime,
+            Text = "anchors the day",
+            DataSource = "glooko"
+        });
+        AddNonPrimaryLink("bgcheck", bgCheckId);
+        AddNonPrimaryLink("tempbasal", tempBasalId);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDailySummaryAsync(2024);
+
+        result.Days.Should().ContainSingle();
+        result.Days[0].Counts.Should().NotContainKeys("BGChecks", "TempBasals");
+        result.Days[0].TotalCount.Should().Be(1);
+    }
+
+    private void AddNonPrimaryLink(string recordType, Guid recordId) =>
+        _dbContext.LinkedRecords.Add(new LinkedRecordEntity
+        {
+            Id = Guid.CreateVersion7(),
+            CanonicalId = Guid.NewGuid(),
+            RecordType = recordType,
+            RecordId = recordId,
+            SourceTimestamp = June15_2024_Noon,
+            DataSource = "duplicate",
+            IsPrimary = false,
+            SysCreatedAt = DateTime.UtcNow,
+        });
+
     #endregion
 
     #region Insulin Totals Tests

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewTablesTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/DataOverviewTablesTests.cs
@@ -1,0 +1,40 @@
+using Nocturne.API.Services.Analytics;
+using Nocturne.Core.Models;
+
+namespace Nocturne.API.Tests.Services.Analytics;
+
+public class DataOverviewTablesTests
+{
+    /// <summary>
+    /// <see cref="RecordType.Entry"/> and <see cref="RecordType.Treatment"/> name the legacy tables;
+    /// no repository writes either into <c>linked_records</c>, so no overview row describes them.
+    /// Every other value is written by a repository's <c>DeduplicateBatchAsync</c> call and has a
+    /// V4 table behind it.
+    /// </summary>
+    private static readonly RecordType[] LegacyRecordTypes =
+    [
+        RecordType.Entry,
+        RecordType.Treatment,
+    ];
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void All_CoversEveryDedupRecordTypeWithAV4Table()
+    {
+        var expected = Enum.GetValues<RecordType>().Except(LegacyRecordTypes).ToArray();
+        expected.Should().NotBeEmpty();
+
+        var covered = DataOverviewTables
+            .All.Where(t => t.DedupRecordType.HasValue)
+            .Select(t => t.DedupRecordType!.Value);
+
+        covered.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void All_KeysEveryTableUniquely()
+    {
+        DataOverviewTables.All.Select(t => t.CountsKey).Should().OnlyHaveUniqueItems();
+    }
+}


### PR DESCRIPTION
Closes #1085.

`DataOverviewService` walked the V4 tables by hand four times (min/max timestamps, distinct data sources, dedup-exclusion sets, per-day counts), and the hand-rolling hid that BG checks appeared in none of them and temp basals in none of the overview surfaces.

## What changes

- `DataOverviewTables.All` is one per-type table (counts key, DbSet, timestamp/id/source columns, dedup `RecordType` or null) that drives all four fan-outs. Row order fixes the `Counts` insertion order, which the JSON preserves; the nine pre-existing rows keep their order and the two new ones are appended.
- `BGChecks` and `TempBasals` rows added, both with non-primary duplicates excluded; temp basals key on `StartTimestamp`, as the insulin and GRI paths already do.
- `NonPrimaryRecordIds(context, recordType)` replaces the seven exclusion-set subqueries in the fan-outs and the eight byte-identical ones in the GRI timeline, glucose averages, insulin totals and carb totals.
- Dead `CollectCountsFromMillsTable` and `MillsToDateString` deleted (zero callers).
- Web: `ALL_DATA_TYPES` on the year-overview page gains the two keys so they can be toggled like the rest.

Net −160 production lines while covering two more record types.

## Declared behavioural deltas

1. The overview's year range, data-source list and per-day counts now include BG checks and temp basals. `TotalCount` sums the counts, so on closed-loop days (AAPS/Loop write ~288 temp basals a day) the heatmap's relative intensity changes materially; the type is hideable through the existing filter. No wire-contract change: `Counts` is `Dictionary<string,int>`, so the two keys need no new DTO members and nothing SDK-visible widens.
2. The `ApsSnapshots` min/max query previously projected `(long?)new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds()` and aggregated over it, which Npgsql cannot translate and `MinAsync`/`MaxAsync` cannot client-evaluate, so on PostgreSQL it threw and was swallowed by the `catch (InvalidOperationException)` branch labelled "Table is empty": APS snapshots never widened the reported year range in production. Routing that table through the same `DateTime` min/max path as every other row makes them contribute, which is what `GetAvailableYearsAsync_ApsSnapshotsIncludedInYears` already asserts. This was reasoned from the provider's translation surface rather than measured, since the unit test project has no Npgsql reference; behaviour under the InMemory provider is unchanged either way.

## Follow-up left out

`GetMinMaxTimestamp`'s `catch (InvalidOperationException)` now guards nothing (`MinAsync` over `DateTime?` returns null on an empty table) and would only swallow the next translation failure the way it swallowed this one; it can go in a follow-up.

## Discrepancy with the issue text

The issue cites `SoftDeleteCleanupService` as holding the nine-type dedup vocabulary. That map holds five types and is itself incomplete (#1095). The table and its completeness guard are driven from the nine `DeduplicateBatchAsync(RecordType.X, …)` repository call sites instead; `RecordType.Entry` and `RecordType.Treatment` are excluded because no repository writes them into `linked_records`.

## Tests

`DataOverviewTablesTests`: every `RecordType` except Entry/Treatment has a row (derived from the enum, asserted non-empty); counts keys unique. `DataOverviewServiceTests`: BG checks counted and source-filtered; BG checks contribute year and sources; temp basals counted by start timestamp; non-primary BG checks and temp basals excluded. Each was confirmed against a mutation (row deleted, dedup type dropped, key collided, lowercasing removed).

`Nocturne.API.Tests`: 6257 passed, 0 failed, 5 skipped.

https://claude.ai/code/session_01DoFQ3xHL2WEamV1WUSyGAK
