### PR TITLE
refactor(api): share the decomposer upsert and publisher write shapes

### DIFF
--- a/src/API/Nocturne.API/Services/ConnectorPublishing/ConnectorPublisherBase.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/ConnectorPublisherBase.cs
@@ -1,0 +1,86 @@
+using Nocturne.API.Services.Audit;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+
+namespace Nocturne.API.Services.ConnectorPublishing;
+
+/// <summary>
+/// The write shape every connector publisher shares: materialise the batch, skip an empty one,
+/// bulk-create it under system audit attribution, and report a failure as <c>false</c> instead of
+/// propagating it into the connector's sync loop.
+/// </summary>
+internal abstract class ConnectorPublisherBase
+{
+    private readonly IAuditContext _auditContext;
+
+    protected ConnectorPublisherBase(IAuditContext auditContext, ILogger logger)
+    {
+        _auditContext = auditContext ?? throw new ArgumentNullException(nameof(auditContext));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected ILogger Logger { get; }
+
+    /// <summary>
+    /// <paramref name="beforeWrite"/> runs inside the system audit scope: a preparation step that
+    /// writes (an auto-created insulin, a reconcile of the source's window) is attributed to the sync,
+    /// and a user-attributed delete would permanently block re-import. <paramref name="afterWrite"/>
+    /// runs after a successful write, outside the scope.
+    /// </summary>
+    protected async Task<bool> PublishAsync<TRecord>(
+        IEnumerable<TRecord> records,
+        IBulkCreateRepository<TRecord> repository,
+        string source,
+        WriteOrigin origin,
+        CancellationToken ct,
+        Func<List<TRecord>, Task>? beforeWrite = null,
+        Func<Task>? afterWrite = null)
+    {
+        var recordType = typeof(TRecord).Name;
+        try
+        {
+            var recordList = records.ToList();
+            if (recordList.Count == 0) return true;
+
+            using (SystemAuditScope.Push(_auditContext))
+            {
+                if (beforeWrite is not null)
+                    await beforeWrite(recordList);
+
+                await repository.BulkCreateAsync(recordList, origin, ct);
+            }
+
+            if (afterWrite is not null)
+                await afterWrite();
+
+            Logger.LogDebug(
+                "Published {Count} {RecordType} records for {Source}", recordList.Count, recordType, source);
+            return true;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to publish {RecordType} records for {Source}", recordType, source);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The resume watermark for a connector sync whose legacy collection spans several stored record
+    /// types: the latest timestamp any of them holds for THIS source. Source-scoping is required for
+    /// multi-connector catch-up — a tenant-global latest mis-classifies a newly enabled connector's
+    /// first sync as incremental and skips its backfill.
+    /// </summary>
+    protected static async Task<DateTime?> LatestTimestampAsync(params Func<Task<DateTime?>>[] perType)
+    {
+        DateTime? latest = null;
+        foreach (var read in perType)
+        {
+            if (await read() is { } candidate && (latest is null || candidate > latest))
+                latest = candidate;
+        }
+
+        return latest;
+    }
+}

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/DevicePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/DevicePublisher.cs
@@ -1,6 +1,6 @@
-using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -13,32 +13,32 @@ namespace Nocturne.API.Services.ConnectorPublishing;
 /// the Nocturne domain via <see cref="IDeviceStatusDecomposer"/> and <see cref="IDeviceEventRepository"/>.
 /// </summary>
 /// <seealso cref="IDevicePublisher"/>
-internal sealed class DevicePublisher : IDevicePublisher
+internal sealed class DevicePublisher : ConnectorPublisherBase, IDevicePublisher
 {
     private readonly IDeviceStatusDecomposer _decomposer;
     private readonly IDeviceEventRepository _deviceEventRepository;
-    private readonly IAuditContext _auditContext;
+    private readonly IPatientDeviceStamper _patientDeviceStamper;
     private readonly IApsSnapshotRepository _apsSnapshotRepository;
     private readonly IPumpSnapshotRepository _pumpSnapshotRepository;
     private readonly IUploaderSnapshotRepository _uploaderSnapshotRepository;
-    private readonly ILogger<DevicePublisher> _logger;
 
     public DevicePublisher(
         IDeviceStatusDecomposer decomposer,
         IDeviceEventRepository deviceEventRepository,
+        IPatientDeviceStamper patientDeviceStamper,
         IAuditContext auditContext,
         IApsSnapshotRepository apsSnapshotRepository,
         IPumpSnapshotRepository pumpSnapshotRepository,
         IUploaderSnapshotRepository uploaderSnapshotRepository,
         ILogger<DevicePublisher> logger)
+        : base(auditContext, logger)
     {
         _decomposer = decomposer ?? throw new ArgumentNullException(nameof(decomposer));
         _deviceEventRepository = deviceEventRepository ?? throw new ArgumentNullException(nameof(deviceEventRepository));
-        _auditContext = auditContext;
+        _patientDeviceStamper = patientDeviceStamper ?? throw new ArgumentNullException(nameof(patientDeviceStamper));
         _apsSnapshotRepository = apsSnapshotRepository ?? throw new ArgumentNullException(nameof(apsSnapshotRepository));
         _pumpSnapshotRepository = pumpSnapshotRepository ?? throw new ArgumentNullException(nameof(pumpSnapshotRepository));
         _uploaderSnapshotRepository = uploaderSnapshotRepository ?? throw new ArgumentNullException(nameof(uploaderSnapshotRepository));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<bool> PublishDeviceStatusAsync(
@@ -57,53 +57,27 @@ internal sealed class DevicePublisher : IDevicePublisher
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to publish device status for {Source}", source);
+            Logger.LogError(ex, "Failed to publish device status for {Source}", source);
             return false;
         }
     }
 
-    public async Task<bool> PublishDeviceEventsAsync(
+    public Task<bool> PublishDeviceEventsAsync(
         IEnumerable<DeviceEvent> records,
         string source,
         WriteOrigin origin, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var recordList = records.ToList();
-            if (recordList.Count == 0) return true;
+        => PublishAsync(
+            records, _deviceEventRepository, source, origin, cancellationToken,
+            beforeWrite: recordList => _patientDeviceStamper.StampDeviceEventsAsync(
+                recordList, source, cancellationToken));
 
-            using (SystemAuditScope.Push(_auditContext))
-                await _deviceEventRepository.BulkCreateAsync(recordList, origin, cancellationToken);
-            _logger.LogDebug("Published {Count} DeviceEvent records for {Source}", recordList.Count, source);
-            return true;
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to publish DeviceEvent records for {Source}", source);
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Returns the resume watermark for the connector device-status sync: the latest stored snapshot
-    /// timestamp (across APS, pump, and uploader snapshots) for THIS source. Source-scoping is
-    /// required for multi-connector catch-up — a tenant-global latest mis-classifies a newly enabled
-    /// connector's first device-status sync as incremental and skips its backfill. Mirrors
-    /// <see cref="ITreatmentPublisher.GetLatestTreatmentTimestampAsync"/>.
-    /// </summary>
-    public async Task<DateTime?> GetLatestDeviceStatusTimestampAsync(
+    /// <inheritdoc cref="ConnectorPublisherBase.LatestTimestampAsync" />
+    /// <remarks>A device-status sync stores APS, pump, and uploader snapshots.</remarks>
+    public Task<DateTime?> GetLatestDeviceStatusTimestampAsync(
         string source,
         CancellationToken cancellationToken = default)
-    {
-        var candidates = new[]
-        {
-            await _apsSnapshotRepository.GetLatestTimestampAsync(source, cancellationToken),
-            await _pumpSnapshotRepository.GetLatestTimestampAsync(source, cancellationToken),
-            await _uploaderSnapshotRepository.GetLatestTimestampAsync(source, cancellationToken),
-        };
-
-        var present = candidates.Where(t => t.HasValue).Select(t => t!.Value).ToList();
-        return present.Count > 0 ? present.Max() : null;
-    }
+        => LatestTimestampAsync(
+            () => _apsSnapshotRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _pumpSnapshotRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _uploaderSnapshotRepository.GetLatestTimestampAsync(source, cancellationToken));
 }

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/GlucosePublisher.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
@@ -20,15 +19,13 @@ namespace Nocturne.API.Services.ConnectorPublishing;
 /// triggering alert evaluation via <see cref="IAlertOrchestrator"/> after each successful write.
 /// </summary>
 /// <seealso cref="IGlucosePublisher"/>
-internal sealed class GlucosePublisher : IGlucosePublisher
+internal sealed class GlucosePublisher : ConnectorPublisherBase, IGlucosePublisher
 {
     private readonly IEntryService _entryService;
     private readonly ISensorGlucoseRepository _sensorGlucoseRepository;
     private readonly IMeterGlucoseRepository _meterGlucoseRepository;
     private readonly IPatientDeviceStamper _patientDeviceStamper;
     private readonly ICanonicalAlertEvaluator _alertEvaluator;
-    private readonly IAuditContext _auditContext;
-    private readonly ILogger<GlucosePublisher> _logger;
 
     public GlucosePublisher(
         IEntryService entryService,
@@ -38,14 +35,13 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         ICanonicalAlertEvaluator alertEvaluator,
         IAuditContext auditContext,
         ILogger<GlucosePublisher> logger)
+        : base(auditContext, logger)
     {
         _entryService = entryService ?? throw new ArgumentNullException(nameof(entryService));
         _sensorGlucoseRepository = sensorGlucoseRepository ?? throw new ArgumentNullException(nameof(sensorGlucoseRepository));
         _meterGlucoseRepository = meterGlucoseRepository ?? throw new ArgumentNullException(nameof(meterGlucoseRepository));
         _patientDeviceStamper = patientDeviceStamper ?? throw new ArgumentNullException(nameof(patientDeviceStamper));
         _alertEvaluator = alertEvaluator ?? throw new ArgumentNullException(nameof(alertEvaluator));
-        _auditContext = auditContext;
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<bool> PublishEntriesAsync(
@@ -63,56 +59,36 @@ internal sealed class GlucosePublisher : IGlucosePublisher
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to publish entries for {Source}", source);
+            Logger.LogError(ex, "Failed to publish entries for {Source}", source);
             return false;
         }
     }
 
-    public async Task<bool> PublishSensorGlucoseAsync(
+    /// <remarks>
+    /// Alert evaluation after the write is this publisher's one addition to the shared shape: a CGM
+    /// reading is the trigger every glucose alert condition is written against.
+    /// </remarks>
+    public Task<bool> PublishSensorGlucoseAsync(
         IEnumerable<SensorGlucose> records,
         string source,
         WriteOrigin origin, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var recordList = records.ToList();
-            if (recordList.Count == 0) return true;
+        => PublishAsync(
+            records, _sensorGlucoseRepository, source, origin, cancellationToken,
+            beforeWrite: recordList => _patientDeviceStamper.StampAsync(
+                recordList, DeviceAttributionCategories.SensorGlucose, source, cancellationToken),
+            afterWrite: () => _alertEvaluator.EvaluateAsync(cancellationToken));
 
-            await _patientDeviceStamper.StampAsync(recordList, DeviceAttributionCategories.SensorGlucose, source, cancellationToken);
-            using (SystemAuditScope.Push(_auditContext))
-                await _sensorGlucoseRepository.BulkCreateAsync(recordList, origin, cancellationToken);
-            await _alertEvaluator.EvaluateAsync(cancellationToken);
-
-            _logger.LogDebug("Published {Count} SensorGlucose records for {Source}", recordList.Count, source);
-            return true;
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to publish SensorGlucose records for {Source}", source);
-            return false;
-        }
-    }
-
-    public async Task<DateTime?> GetLatestEntryTimestampAsync(
+    /// <inheritdoc cref="ConnectorPublisherBase.LatestTimestampAsync" />
+    /// <remarks>
+    /// The v1 <c>entries</c> collection spans CGM readings (sensor glucose) and manual BG checks
+    /// (meter glucose).
+    /// </remarks>
+    public Task<DateTime?> GetLatestEntryTimestampAsync(
         string source,
         CancellationToken cancellationToken = default)
-    {
-        // The v1 entries collection spans CGM readings (sensor glucose) and manual BG
-        // checks (meter glucose), so the resume watermark is the latest of either —
-        // scoped to THIS source. Never fall back across sources: when another uploader
-        // is already writing glucose (e.g. Trio pushing directly while a Nightscout
-        // migration runs), a cross-source "current entry" mis-classifies the
-        // connector's first-ever sync as incremental and skips its full-history
-        // backfill.
-        var sgTimestamp = await _sensorGlucoseRepository.GetLatestTimestampAsync(source, cancellationToken);
-        var mgTimestamp = await _meterGlucoseRepository.GetLatestTimestampAsync(source, cancellationToken);
-
-        if (sgTimestamp.HasValue && mgTimestamp.HasValue)
-            return sgTimestamp.Value > mgTimestamp.Value ? sgTimestamp.Value : mgTimestamp.Value;
-
-        return sgTimestamp ?? mgTimestamp;
-    }
+        => LatestTimestampAsync(
+            () => _sensorGlucoseRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _meterGlucoseRepository.GetLatestTimestampAsync(source, cancellationToken));
 
     public async Task<DateTime?> GetLatestSensorGlucoseTimestampAsync(
         string source,

--- a/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
+++ b/src/API/Nocturne.API/Services/ConnectorPublishing/TreatmentPublisher.cs
@@ -1,4 +1,3 @@
-using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
@@ -19,7 +18,7 @@ namespace Nocturne.API.Services.ConnectorPublishing;
 /// intakes, BG checks, bolus calculations, and temporary basals.
 /// </summary>
 /// <seealso cref="ITreatmentPublisher"/>
-internal sealed class TreatmentPublisher : ITreatmentPublisher
+internal sealed class TreatmentPublisher : ConnectorPublisherBase, ITreatmentPublisher
 {
     private readonly ITenantDbContextFactory _contextFactory;
     private readonly ITreatmentService _treatmentService;
@@ -35,8 +34,6 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
     private readonly IBasalRateResolver _basalRateResolver;
     private readonly ITherapySettingsResolver _therapySettingsResolver;
     private readonly IPatientDeviceStamper _patientDeviceStamper;
-    private readonly IAuditContext _auditContext;
-    private readonly ILogger<TreatmentPublisher> _logger;
 
     public TreatmentPublisher(
         ITenantDbContextFactory contextFactory,
@@ -55,6 +52,7 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         IPatientDeviceStamper patientDeviceStamper,
         IAuditContext auditContext,
         ILogger<TreatmentPublisher> logger)
+        : base(auditContext, logger)
     {
         _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _treatmentService = treatmentService ?? throw new ArgumentNullException(nameof(treatmentService));
@@ -70,8 +68,6 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         _basalRateResolver = basalRateResolver ?? throw new ArgumentNullException(nameof(basalRateResolver));
         _therapySettingsResolver = therapySettingsResolver ?? throw new ArgumentNullException(nameof(therapySettingsResolver));
         _patientDeviceStamper = patientDeviceStamper ?? throw new ArgumentNullException(nameof(patientDeviceStamper));
-        _auditContext = auditContext;
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<bool> PublishTreatmentsAsync(
@@ -87,158 +83,81 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to publish treatments for {Source}", source);
+            Logger.LogError(ex, "Failed to publish treatments for {Source}", source);
             return false;
         }
     }
 
-    public async Task<bool> PublishBolusesAsync(
+    public Task<bool> PublishBolusesAsync(
         IEnumerable<Bolus> records,
         string source,
         WriteOrigin origin, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var recordList = records.ToList();
-            if (recordList.Count == 0) return true;
+        => PublishAsync(
+            records, _bolusRepository, source, origin, cancellationToken,
+            beforeWrite: async recordList =>
+            {
+                await ResolvePatientInsulinsForBolusesAsync(recordList, origin, cancellationToken);
+                await _patientDeviceStamper.StampAsync(
+                    recordList, DeviceAttributionCategories.Bolus, source, cancellationToken);
+            });
 
-            await ResolvePatientInsulinsForBolusesAsync(recordList, origin, cancellationToken);
-            await _patientDeviceStamper.StampAsync(
-                recordList, DeviceAttributionCategories.Bolus, source, cancellationToken);
-            using (SystemAuditScope.Push(_auditContext))
-                await _bolusRepository.BulkCreateAsync(recordList, origin, cancellationToken);
-            _logger.LogDebug("Published {Count} Bolus records for {Source}", recordList.Count, source);
-            return true;
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to publish Bolus records for {Source}", source);
-            return false;
-        }
-    }
-
-    public async Task<bool> PublishCarbIntakesAsync(
+    public Task<bool> PublishCarbIntakesAsync(
         IEnumerable<CarbIntake> records,
         string source,
         WriteOrigin origin, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var recordList = records.ToList();
-            if (recordList.Count == 0) return true;
+        => PublishAsync(records, _carbIntakeRepository, source, origin, cancellationToken);
 
-            using (SystemAuditScope.Push(_auditContext))
-                await _carbIntakeRepository.BulkCreateAsync(recordList, origin, cancellationToken);
-            _logger.LogDebug("Published {Count} CarbIntake records for {Source}", recordList.Count, source);
-            return true;
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to publish CarbIntake records for {Source}", source);
-            return false;
-        }
-    }
-
-    public async Task<bool> PublishBGChecksAsync(
+    public Task<bool> PublishBGChecksAsync(
         IEnumerable<BGCheck> records,
         string source,
         WriteOrigin origin, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var recordList = records.ToList();
-            if (recordList.Count == 0) return true;
+        => PublishAsync(records, _bgCheckRepository, source, origin, cancellationToken);
 
-            using (SystemAuditScope.Push(_auditContext))
-                await _bgCheckRepository.BulkCreateAsync(recordList, origin, cancellationToken);
-            _logger.LogDebug("Published {Count} BGCheck records for {Source}", recordList.Count, source);
-            return true;
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to publish BGCheck records for {Source}", source);
-            return false;
-        }
-    }
-
-    public async Task<bool> PublishBolusCalculationsAsync(
+    public Task<bool> PublishBolusCalculationsAsync(
         IEnumerable<BolusCalculation> records,
         string source,
         WriteOrigin origin, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var recordList = records.ToList();
-            if (recordList.Count == 0) return true;
+        => PublishAsync(records, _bolusCalculationRepository, source, origin, cancellationToken);
 
-            using (SystemAuditScope.Push(_auditContext))
-                await _bolusCalculationRepository.BulkCreateAsync(recordList, origin, cancellationToken);
-            _logger.LogDebug("Published {Count} BolusCalculation records for {Source}", recordList.Count, source);
-            return true;
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to publish BolusCalculation records for {Source}", source);
-            return false;
-        }
-    }
-
-    public async Task<bool> PublishTempBasalsAsync(
+    public Task<bool> PublishTempBasalsAsync(
         IEnumerable<TempBasal> records,
         string source,
         WriteOrigin origin, CancellationToken cancellationToken = default)
+        => PublishAsync(
+            records, _tempBasalRepository, source, origin, cancellationToken,
+            beforeWrite: recordList => ReconcileTempBasalWindowAsync(recordList, source, cancellationToken));
+
+    /// <summary>
+    /// Attributes the incoming temp basals and reconciles the source's window against them:
+    /// soft-delete only the rows this source no longer reports, leaving still-reported rows active
+    /// so <c>BulkCreateAsync</c> (which skips already-active legacy ids) makes an unchanged resync a
+    /// no-op rather than a delete-the-window-then-reinsert sweep.
+    /// </summary>
+    private async Task ReconcileTempBasalWindowAsync(
+        List<TempBasal> recordList, string source, CancellationToken cancellationToken)
     {
-        try
-        {
-            var recordList = records.ToList();
-            if (recordList.Count == 0) return true;
+        await _patientDeviceStamper.StampAsync(
+            recordList, DeviceAttributionCategories.TempBasal, source, cancellationToken);
 
-            await _patientDeviceStamper.StampAsync(
-                recordList, DeviceAttributionCategories.TempBasal, source, cancellationToken);
+        var incomingLegacyIds = recordList
+            .Select(r => r.LegacyId)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Select(id => id!)
+            .ToHashSet();
 
-            var minTimestamp = recordList.Min(r => r.StartTimestamp);
-            var maxTimestamp = recordList.Max(r => r.StartTimestamp);
-            var incomingLegacyIds = recordList
-                .Select(r => r.LegacyId)
-                .Where(id => !string.IsNullOrEmpty(id))
-                .Select(id => id!)
-                .ToHashSet();
+        await _tempBasalRepository.SoftDeleteAbsentBySourceAndDateRangeAsync(
+            source,
+            recordList.Min(r => r.StartTimestamp),
+            recordList.Max(r => r.StartTimestamp),
+            incomingLegacyIds,
+            cancellationToken);
 
-            // Connector resync reconciles the window idempotently rather than deleting it wholesale
-            // and re-inserting: soft-delete only the rows this source no longer reports, leaving
-            // still-reported rows active so BulkCreateAsync (which skips already-active legacy ids)
-            // makes an unchanged resync a no-op. The reconcile delete runs under SystemAuditScope so
-            // its audit rows carry AuthType IS NULL — the dedup discriminator reads the delete, so a
-            // resync invoked under an actor context (e.g. a manual sync) must not write a
-            // user-attributed delete that would permanently block a later re-import of those temps.
-            using (SystemAuditScope.Push(_auditContext))
-            {
-                await _tempBasalRepository.SoftDeleteAbsentBySourceAndDateRangeAsync(
-                    source, minTimestamp, maxTimestamp, incomingLegacyIds, cancellationToken);
-
-                var reclassifiedCount = await ReclassifyScheduledAlgorithmicBasalsAsync(
-                    recordList, cancellationToken);
-                if (reclassifiedCount > 0)
-                    _logger.LogInformation(
-                        "Reclassified {Count}/{Total} TempBasal records from Scheduled to Algorithm "
-                        + "(rate differs from programmed basal schedule) for {Source}",
-                        reclassifiedCount, recordList.Count, source);
-
-                await _tempBasalRepository.BulkCreateAsync(recordList, origin, cancellationToken);
-            }
-            _logger.LogDebug("Published {Count} TempBasal records for {Source}", recordList.Count, source);
-            return true;
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to publish TempBasal records for {Source}", source);
-            return false;
-        }
+        var reclassifiedCount = await ReclassifyScheduledAlgorithmicBasalsAsync(recordList, cancellationToken);
+        if (reclassifiedCount > 0)
+            Logger.LogInformation(
+                "Reclassified {Count}/{Total} TempBasal records from Scheduled to Algorithm "
+                + "(rate differs from programmed basal schedule) for {Source}",
+                reclassifiedCount, recordList.Count, source);
     }
 
     /// <summary>
@@ -290,56 +209,33 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
         return reclassified;
     }
 
-    public async Task<bool> PublishBasalInjectionsAsync(
+    public Task<bool> PublishBasalInjectionsAsync(
         IEnumerable<BasalInjection> records,
         string source,
         WriteOrigin origin, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var recordList = records.ToList();
-            if (recordList.Count == 0) return true;
+        => PublishAsync(
+            records, _basalInjectionRepository, source, origin, cancellationToken,
+            beforeWrite: async recordList =>
+            {
+                await ResolvePatientInsulinsForBasalInjectionsAsync(recordList, origin, cancellationToken);
+                await _patientDeviceStamper.StampAsync(
+                    recordList, DeviceAttributionCategories.BasalInjection, source, cancellationToken);
+            });
 
-            await ResolvePatientInsulinsForBasalInjectionsAsync(recordList, origin, cancellationToken);
-            await _patientDeviceStamper.StampAsync(
-                recordList, DeviceAttributionCategories.BasalInjection, source, cancellationToken);
-            using (SystemAuditScope.Push(_auditContext))
-                await _basalInjectionRepository.BulkCreateAsync(recordList, origin, cancellationToken);
-
-            _logger.LogDebug("Published {Count} BasalInjection records for {Source}", recordList.Count, source);
-            return true;
-        }
-        catch (OperationCanceledException) { throw; }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to publish BasalInjection records for {Source}", source);
-            return false;
-        }
-    }
-
-    public async Task<DateTime?> GetLatestTreatmentTimestampAsync(
+    /// <inheritdoc cref="ConnectorPublisherBase.LatestTimestampAsync" />
+    /// <remarks>The v1 <c>treatments</c> collection spans every decomposed treatment type.</remarks>
+    public Task<DateTime?> GetLatestTreatmentTimestampAsync(
         string source,
         CancellationToken cancellationToken = default)
-    {
-        // The v1 "treatments" collection spans every decomposed treatment type, so the resume
-        // watermark is the latest stored record of any of them for THIS source. Source-scoping is
-        // required for multi-connector catch-up: a tenant-global latest mis-classifies a newly
-        // enabled connector's first sync as incremental and skips its backfill.
-        var candidates = new[]
-        {
-            await _bolusRepository.GetLatestTimestampAsync(source, cancellationToken),
-            await _carbIntakeRepository.GetLatestTimestampAsync(source, cancellationToken),
-            await _bgCheckRepository.GetLatestTimestampAsync(source, cancellationToken),
-            await _bolusCalculationRepository.GetLatestTimestampAsync(source, cancellationToken),
-            await _tempBasalRepository.GetLatestTimestampAsync(source, cancellationToken),
-            await _basalInjectionRepository.GetLatestTimestampAsync(source, cancellationToken),
-            await _noteRepository.GetLatestTimestampAsync(source, cancellationToken),
-            await _deviceEventRepository.GetLatestTimestampAsync(source, cancellationToken),
-        };
-
-        var present = candidates.Where(t => t.HasValue).Select(t => t!.Value).ToList();
-        return present.Count > 0 ? present.Max() : null;
-    }
+        => LatestTimestampAsync(
+            () => _bolusRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _carbIntakeRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _bgCheckRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _bolusCalculationRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _tempBasalRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _basalInjectionRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _noteRepository.GetLatestTimestampAsync(source, cancellationToken),
+            () => _deviceEventRepository.GetLatestTimestampAsync(source, cancellationToken));
 
     // ── Patient Insulin resolution helpers ──────────────────────────────
 
@@ -452,12 +348,10 @@ internal sealed class TreatmentPublisher : ITreatmentPublisher
             IsPrimary = !hasPrimary,
         };
 
-        PatientInsulin created;
-        using (SystemAuditScope.Push(_auditContext))
-            created = await _patientInsulinRepository.CreateAsync(newInsulin, origin, ct);
+        var created = await _patientInsulinRepository.CreateAsync(newInsulin, origin, ct);
         cache.Add(created);
 
-        _logger.LogInformation(
+        Logger.LogInformation(
             "Auto-created PatientInsulin '{Name}' (role={Role}, id={Id}) from connector import",
             created.Name, role, created.Id);
 

--- a/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ActivityDecomposer.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Models;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Mappers;
 
@@ -120,11 +121,15 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
 
         if (IsHeartRate(activity))
         {
-            await DecomposeHeartRateAsync(activity, result, origin, ct);
+            await UpsertByOriginalIdAsync(
+                _dbContext.HeartRates, MapToHeartRate(activity), HeartRateMapper.ToEntity,
+                HeartRateMapper.UpdateEntity, HeartRateMapper.ToDomainModel, result, ct);
         }
         else if (IsStepCount(activity))
         {
-            await DecomposeStepCountAsync(activity, result, origin, ct);
+            await UpsertByOriginalIdAsync(
+                _dbContext.StepCounts, MapToStepCount(activity), StepCountMapper.ToEntity,
+                StepCountMapper.UpdateEntity, StepCountMapper.ToDomainModel, result, ct);
         }
         else
         {
@@ -160,69 +165,13 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
                 regularActivities.Add(activity);
         }
 
-        if (heartRateList.Count > 0)
-        {
-            // Filter out records that already exist by OriginalId to avoid duplicates on re-migration
-            var hrOriginalIds = heartRateList
-                .Where(hr => hr.Id != null)
-                .Select(hr => hr.Id!)
-                .ToHashSet();
+        await BulkCreateNewByOriginalIdAsync(
+            _dbContext.HeartRates, heartRateList, HeartRateMapper.ToEntity,
+            HeartRateMapper.ToDomainModel, result, ct);
 
-            var existingHrIds = hrOriginalIds.Count > 0
-                ? (await _dbContext.HeartRates
-                    .Where(h => h.OriginalId != null && hrOriginalIds.Contains(h.OriginalId))
-                    .Select(h => h.OriginalId!)
-                    .ToListAsync(ct))
-                    .ToHashSet()
-                : new HashSet<string>();
-
-            var newHeartRates = heartRateList
-                .Where(hr => hr.Id == null || !existingHrIds.Contains(hr.Id))
-                .ToList();
-
-            if (newHeartRates.Count > 0)
-            {
-                var entities = newHeartRates.Select(HeartRateMapper.ToEntity).ToList();
-                await _dbContext.HeartRates.AddRangeAsync(entities, ct);
-                await _dbContext.SaveChangesAsync(ct);
-                result.CreatedRecords.AddRange(entities.Select(HeartRateMapper.ToDomainModel));
-            }
-
-            if (existingHrIds.Count > 0)
-                _logger.LogDebug("Skipped {Count} duplicate heart rate records by OriginalId", existingHrIds.Count);
-        }
-
-        if (stepCountList.Count > 0)
-        {
-            // Filter out records that already exist by OriginalId to avoid duplicates on re-migration
-            var scOriginalIds = stepCountList
-                .Where(sc => sc.Id != null)
-                .Select(sc => sc.Id!)
-                .ToHashSet();
-
-            var existingScIds = scOriginalIds.Count > 0
-                ? (await _dbContext.StepCounts
-                    .Where(s => s.OriginalId != null && scOriginalIds.Contains(s.OriginalId))
-                    .Select(s => s.OriginalId!)
-                    .ToListAsync(ct))
-                    .ToHashSet()
-                : new HashSet<string>();
-
-            var newStepCounts = stepCountList
-                .Where(sc => sc.Id == null || !existingScIds.Contains(sc.Id))
-                .ToList();
-
-            if (newStepCounts.Count > 0)
-            {
-                var entities = newStepCounts.Select(StepCountMapper.ToEntity).ToList();
-                await _dbContext.StepCounts.AddRangeAsync(entities, ct);
-                await _dbContext.SaveChangesAsync(ct);
-                result.CreatedRecords.AddRange(entities.Select(StepCountMapper.ToDomainModel));
-            }
-
-            if (existingScIds.Count > 0)
-                _logger.LogDebug("Skipped {Count} duplicate step count records by OriginalId", existingScIds.Count);
-        }
+        await BulkCreateNewByOriginalIdAsync(
+            _dbContext.StepCounts, stepCountList, StepCountMapper.ToEntity,
+            StepCountMapper.ToDomainModel, result, ct);
 
         if (regularActivities.Count > 0)
         {
@@ -342,78 +291,84 @@ public class ActivityDecomposer : IActivityDecomposer, IDecomposer<Activity>
 
     // --- Private decomposition methods ---
 
-    private async Task DecomposeHeartRateAsync(
-        Activity activity,
+    /// <summary>
+    /// Create-or-update keyed on the legacy <c>OriginalId</c>. Heart rates and step counts have no
+    /// V4 repository, so unlike its <see cref="DecomposerBase.UpsertByLegacyIdAsync"/> siblings this
+    /// writes the entity through the context.
+    /// </summary>
+    private async Task UpsertByOriginalIdAsync<TModel, TEntity>(
+        DbSet<TEntity> set,
+        TModel model,
+        Func<TModel, TEntity> toEntity,
+        Action<TEntity, TModel> applyUpdate,
+        Func<TEntity, object> toDomain,
         DecompositionResult result,
-        WriteOrigin origin, CancellationToken ct
-    )
+        CancellationToken ct)
+        where TModel : ProcessableDocumentBase
+        where TEntity : class, IOriginalIdentified
     {
-        var existing =
-            activity.Id != null
-                ? await _dbContext.HeartRates.FirstOrDefaultAsync(
-                    h => h.OriginalId == activity.Id,
-                    ct
-                )
-                : null;
-
-        var heartRate = MapToHeartRate(activity);
+        var recordType = typeof(TModel).Name;
+        var existing = model.Id != null
+            ? await set.FirstOrDefaultAsync(e => e.OriginalId == model.Id, ct)
+            : null;
 
         if (existing != null)
         {
-            HeartRateMapper.UpdateEntity(existing, heartRate);
+            applyUpdate(existing, model);
             await _dbContext.SaveChangesAsync(ct);
-            result.UpdatedRecords.Add(HeartRateMapper.ToDomainModel(existing));
+            result.UpdatedRecords.Add(toDomain(existing));
             _logger.LogDebug(
-                "Updated existing HeartRate {Id} from legacy activity {LegacyId}",
-                existing.Id,
-                activity.Id
-            );
+                "Updated existing {RecordType} {Id} from legacy activity {LegacyId}",
+                recordType, existing.Id, model.Id);
+            return;
         }
-        else
-        {
-            var entity = HeartRateMapper.ToEntity(heartRate);
-            await _dbContext.HeartRates.AddAsync(entity, ct);
-            await _dbContext.SaveChangesAsync(ct);
-            result.CreatedRecords.Add(HeartRateMapper.ToDomainModel(entity));
-            _logger.LogDebug("Created HeartRate from legacy activity {LegacyId}", activity.Id);
-        }
+
+        var entity = toEntity(model);
+        await set.AddAsync(entity, ct);
+        await _dbContext.SaveChangesAsync(ct);
+        result.CreatedRecords.Add(toDomain(entity));
+        _logger.LogDebug("Created {RecordType} from legacy activity {LegacyId}", recordType, model.Id);
     }
 
-    private async Task DecomposeStepCountAsync(
-        Activity activity,
+    /// <summary>
+    /// Inserts the records whose <c>OriginalId</c> is not already stored, skipping the rest so a
+    /// re-migration cannot duplicate them.
+    /// </summary>
+    private async Task BulkCreateNewByOriginalIdAsync<TModel, TEntity>(
+        DbSet<TEntity> set,
+        List<TModel> models,
+        Func<TModel, TEntity> toEntity,
+        Func<TEntity, object> toDomain,
         DecompositionResult result,
-        WriteOrigin origin, CancellationToken ct
-    )
+        CancellationToken ct)
+        where TModel : ProcessableDocumentBase
+        where TEntity : class, IOriginalIdentified
     {
-        var existing =
-            activity.Id != null
-                ? await _dbContext.StepCounts.FirstOrDefaultAsync(
-                    s => s.OriginalId == activity.Id,
-                    ct
-                )
-                : null;
+        if (models.Count == 0)
+            return;
 
-        var stepCount = MapToStepCount(activity);
+        var originalIds = models.Where(m => m.Id != null).Select(m => m.Id!).ToHashSet();
+        var stored = originalIds.Count > 0
+            ? (await set
+                .Where(e => e.OriginalId != null && originalIds.Contains(e.OriginalId))
+                .Select(e => e.OriginalId!)
+                .ToListAsync(ct))
+                .ToHashSet()
+            : new HashSet<string>();
 
-        if (existing != null)
+        var fresh = models.Where(m => m.Id == null || !stored.Contains(m.Id)).ToList();
+        if (fresh.Count > 0)
         {
-            StepCountMapper.UpdateEntity(existing, stepCount);
+            var entities = fresh.Select(toEntity).ToList();
+            await set.AddRangeAsync(entities, ct);
             await _dbContext.SaveChangesAsync(ct);
-            result.UpdatedRecords.Add(StepCountMapper.ToDomainModel(existing));
+            result.CreatedRecords.AddRange(entities.Select(toDomain));
+        }
+
+        if (stored.Count > 0)
             _logger.LogDebug(
-                "Updated existing StepCount {Id} from legacy activity {LegacyId}",
-                existing.Id,
-                activity.Id
-            );
-        }
-        else
-        {
-            var entity = StepCountMapper.ToEntity(stepCount);
-            await _dbContext.StepCounts.AddAsync(entity, ct);
-            await _dbContext.SaveChangesAsync(ct);
-            result.CreatedRecords.Add(StepCountMapper.ToDomainModel(entity));
-            _logger.LogDebug("Created StepCount from legacy activity {LegacyId}", activity.Id);
-        }
+                "Skipped {Count} {RecordType} records already stored by OriginalId",
+                stored.Count, typeof(TModel).Name);
     }
 
     // --- Mapping helpers ---

--- a/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
+++ b/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
@@ -1,0 +1,86 @@
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Services.V4;
+
+/// <summary>
+/// The create-or-update-by-<c>LegacyId</c> body and the bulk-insert tail shared by the
+/// repository-backed decomposers.
+/// </summary>
+public abstract class DecomposerBase
+{
+    protected ILogger Logger { get; }
+
+    protected DecomposerBase(ILogger logger) => Logger = logger;
+
+    /// <summary>
+    /// Create-or-update under <paramref name="legacyId"/>. <paramref name="beforeWrite"/> runs once the
+    /// stored record is known and before the write, so device-attributed types can settle their
+    /// attribution against it; see <see cref="StampAttributionAsync"/>.
+    /// </summary>
+    /// <returns>The persisted record, and whether it was inserted rather than updated.</returns>
+    protected async Task<(TRecord Record, bool Created)> UpsertByLegacyIdAsync<TRecord>(
+        ILegacyKeyedRepository<TRecord> repository,
+        string? legacyId,
+        TRecord model,
+        DecompositionResult result,
+        WriteOrigin origin,
+        CancellationToken ct,
+        Func<TRecord?, Task>? beforeWrite = null)
+        where TRecord : class, IV4Record
+    {
+        var existing = legacyId is null ? null : await repository.GetByLegacyIdAsync(legacyId, ct);
+
+        if (beforeWrite is not null)
+            await beforeWrite(existing);
+
+        var recordType = typeof(TRecord).Name;
+
+        if (existing is null)
+        {
+            var created = await repository.CreateAsync(model, origin, ct);
+            result.CreatedRecords.Add(created);
+            Logger.LogDebug("Created {RecordType} from legacy record {LegacyId}", recordType, legacyId);
+            return (created, true);
+        }
+
+        model.Id = existing.Id;
+        var updated = await repository.UpdateAsync(existing.Id, model, origin, ct);
+        result.UpdatedRecords.Add(updated);
+        Logger.LogDebug(
+            "Updated existing {RecordType} {Id} from legacy record {LegacyId}", recordType, existing.Id, legacyId);
+        return (updated, false);
+    }
+
+    /// <summary>
+    /// Carries the attribution stored under the same legacy id forward onto a rebuilt model, then
+    /// stamps whatever is still unattributed. A re-resolution that has since become ambiguous
+    /// therefore cannot displace a stored link.
+    /// </summary>
+    protected static Task StampAttributionAsync(
+        IPatientDeviceStamper stamper,
+        IDeviceAttributed model,
+        IDeviceAttributed? existing,
+        IReadOnlyList<DeviceCategory> categories,
+        CancellationToken ct)
+    {
+        model.PatientDeviceId ??= existing?.PatientDeviceId;
+        return stamper.StampAsync([model], categories, model.DataSource, ct);
+    }
+
+    protected static async Task BulkCreateAsync<TRecord>(
+        IBulkCreateRepository<TRecord> repository,
+        List<TRecord> records,
+        DecompositionResult result,
+        WriteOrigin origin,
+        CancellationToken ct)
+        where TRecord : class
+    {
+        if (records.Count == 0)
+            return;
+
+        result.CreatedRecords.AddRange(await repository.BulkCreateAsync(records, origin, ct));
+    }
+}

--- a/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
@@ -24,7 +24,7 @@ namespace Nocturne.API.Services.V4;
 /// </summary>
 /// <seealso cref="IDeviceStatusDecomposer"/>
 /// <seealso cref="IDecomposer{T}"/>
-public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<DeviceStatus>
+public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, IDecomposer<DeviceStatus>
 {
     private readonly IApsSnapshotRepository _apsRepo;
     private readonly IPumpSnapshotRepository _pumpRepo;
@@ -33,7 +33,6 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
     private readonly IStateSpanService _stateSpanService;
     private readonly IDeviceService _deviceService;
     private readonly IAuditContext _auditContext;
-    private readonly ILogger<DeviceStatusDecomposer> _logger;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -56,6 +55,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         IDeviceService deviceService,
         IAuditContext auditContext,
         ILogger<DeviceStatusDecomposer> logger)
+        : base(logger)
     {
         _apsRepo = apsRepo;
         _pumpRepo = pumpRepo;
@@ -64,7 +64,6 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
         _stateSpanService = stateSpanService;
         _deviceService = deviceService;
         _auditContext = auditContext;
-        _logger = logger;
     }
 
     /// <summary>
@@ -127,48 +126,32 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
     #region APS Decomposition
 
-    private async Task DecomposeApsFromOpenApsAsync(
+    private Task DecomposeApsFromOpenApsAsync(
         DeviceStatus ds, string? legacyId, string? source, V4Models.DecompositionResult result, Guid? pumpDeviceId, WriteOrigin origin, CancellationToken ct)
-    {
-        var model = MapToApsSnapshotFromOpenAps(ds, legacyId, source, result.CorrelationId);
+        => UpsertApsSnapshotAsync(
+            ds, legacyId, MapToApsSnapshotFromOpenAps(ds, legacyId, source, result.CorrelationId),
+            pumpDeviceId, result, origin, ct);
 
-        model.DeviceId = pumpDeviceId;
-        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
-
-        await UpsertApsSnapshotAsync(legacyId, model, result, origin, ct);
-    }
-
-    private async Task DecomposeApsFromLoopAsync(
+    private Task DecomposeApsFromLoopAsync(
         DeviceStatus ds, string? legacyId, string? source, V4Models.DecompositionResult result, Guid? pumpDeviceId, WriteOrigin origin, CancellationToken ct)
-    {
-        var model = MapToApsSnapshotFromLoop(ds, legacyId, source, result.CorrelationId);
-
-        model.DeviceId = pumpDeviceId;
-        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
-
-        await UpsertApsSnapshotAsync(legacyId, model, result, origin, ct);
-    }
+        => UpsertApsSnapshotAsync(
+            ds, legacyId, MapToApsSnapshotFromLoop(ds, legacyId, source, result.CorrelationId),
+            pumpDeviceId, result, origin, ct);
 
     private async Task UpsertApsSnapshotAsync(
-        string? legacyId, V4Models.ApsSnapshot model, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+        DeviceStatus ds, string? legacyId, V4Models.ApsSnapshot model, Guid? pumpDeviceId,
+        V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
-        var existing = legacyId != null
-            ? await _apsRepo.GetByLegacyIdAsync(legacyId, ct)
-            : null;
+        model.DeviceId = pumpDeviceId;
 
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _apsRepo.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing ApsSnapshot {Id} from legacy device status {LegacyId}", existing.Id, legacyId);
-        }
-        else
-        {
-            var created = await _apsRepo.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created ApsSnapshot from legacy device status {LegacyId}", legacyId);
-        }
+        await UpsertByLegacyIdAsync(
+            _apsRepo, legacyId, model, result, origin, ct,
+            beforeWrite: async existing =>
+            {
+                model.PatientDeviceId =
+                    await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct)
+                    ?? existing?.PatientDeviceId;
+            });
     }
 
     #endregion
@@ -196,26 +179,15 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             ds.Pump?.Manufacturer,
             PumpDeviceKey(ds),
             ds.Mills, ct);
-        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, ds.Mills, ct);
 
-        var existing = legacyId != null
-            ? await _pumpRepo.GetByLegacyIdAsync(legacyId, ct)
-            : null;
-
-        V4Models.PumpSnapshot persisted;
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            persisted = await _pumpRepo.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(persisted);
-            _logger.LogDebug("Updated existing PumpSnapshot {Id} from legacy device status {LegacyId}", existing.Id, legacyId);
-        }
-        else
-        {
-            persisted = await _pumpRepo.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(persisted);
-            _logger.LogDebug("Created PumpSnapshot from legacy device status {LegacyId}", legacyId);
-        }
+        var (persisted, _) = await UpsertByLegacyIdAsync(
+            _pumpRepo, legacyId, model, result, origin, ct,
+            beforeWrite: async existing =>
+            {
+                model.PatientDeviceId =
+                    await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, ds.Mills, ct)
+                    ?? existing?.PatientDeviceId;
+            });
 
         await DecomposePumpSuspensionAsync(ds, persisted, result, origin, ct);
         await DecomposePumpModeAsync(ds, persisted, result, origin, ct);
@@ -277,7 +249,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
             if (existingOpen.Any())
             {
-                _logger.LogDebug(
+                Logger.LogDebug(
                     "Skipped opening duplicate PumpMode/Suspended StateSpan for snapshot {SnapshotId}; a suspension is already active",
                     newSnapshot.Id);
                 return;
@@ -295,7 +267,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
             var upserted = await _stateSpanService.UpsertStateSpanAsync(span, ct);
             result.CreatedRecords.Add(upserted);
-            _logger.LogDebug(
+            Logger.LogDebug(
                 "Opened PumpMode/Suspended StateSpan for snapshot {SnapshotId} (legacy {LegacyId})",
                 newSnapshot.Id, newSnapshot.LegacyId);
         }
@@ -318,7 +290,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
                 // anchored at the prior snapshot's timestamp so the suspension timeline is complete.
                 if (prior is null)
                 {
-                    _logger.LogWarning(
+                    Logger.LogWarning(
                         "PumpMode/Suspended transition true→false detected but no prior snapshot or open StateSpan (snapshot {SnapshotId})",
                         newSnapshot.Id);
                     return;
@@ -337,7 +309,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
                 var upserted = await _stateSpanService.UpsertStateSpanAsync(backfilled, ct);
                 result.CreatedRecords.Add(upserted);
-                _logger.LogInformation(
+                Logger.LogInformation(
                     "Backfilled closed PumpMode/Suspended StateSpan from prior snapshot {PriorSnapshotId} to {EndTimestamp} (resume snapshot {SnapshotId})",
                     prior.Id, transitionAt, newSnapshot.Id);
                 return;
@@ -348,7 +320,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
                 openSpan.EndTimestamp = transitionAt;
                 var closed = await _stateSpanService.UpsertStateSpanAsync(openSpan, ct);
                 result.UpdatedRecords.Add(closed);
-                _logger.LogDebug(
+                Logger.LogDebug(
                     "Closed PumpMode/Suspended StateSpan {SpanId} at {EndTimestamp}",
                     openSpan.Id, transitionAt);
             }
@@ -411,7 +383,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             openSpan.EndTimestamp = transitionAt;
             var closed = await _stateSpanService.UpsertStateSpanAsync(openSpan, ct);
             result.UpdatedRecords.Add(closed);
-            _logger.LogDebug(
+            Logger.LogDebug(
                 "Closed PumpMode/{Mode} StateSpan {SpanId} at {EndTimestamp}",
                 oppositeMode, openSpan.Id, transitionAt);
         }
@@ -439,7 +411,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
         var upserted = await _stateSpanService.UpsertStateSpanAsync(span, ct);
         result.CreatedRecords.Add(upserted);
-        _logger.LogDebug(
+        Logger.LogDebug(
             "Opened PumpMode/{Mode} StateSpan for snapshot {SnapshotId} (legacy {LegacyId})",
             newMode.Value, newSnapshot.Id, newSnapshot.LegacyId);
     }
@@ -491,23 +463,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             ds.Uploader?.Type ?? "unknown",
             ds.Mills, ct);
 
-        var existing = legacyId != null
-            ? await _uploaderRepo.GetByLegacyIdAsync(legacyId, ct)
-            : null;
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _uploaderRepo.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing UploaderSnapshot {Id} from legacy device status {LegacyId}", existing.Id, legacyId);
-        }
-        else
-        {
-            var created = await _uploaderRepo.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created UploaderSnapshot from legacy device status {LegacyId}", legacyId);
-        }
+        await UpsertByLegacyIdAsync(_uploaderRepo, legacyId, model, result, origin, ct);
     }
 
     #endregion
@@ -533,7 +489,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
         var upserted = await _stateSpanService.UpsertStateSpanAsync(stateSpan, ct);
         result.CreatedRecords.Add(upserted);
-        _logger.LogDebug("Delegated Override from device status {LegacyId} to IStateSpanService", legacyId);
+        Logger.LogDebug("Delegated Override from device status {LegacyId} to IStateSpanService", legacyId);
     }
 
     #endregion
@@ -581,7 +537,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
 
         var created = await _extrasRepo.CreateAsync(model, origin, ct);
         result.CreatedRecords.Add(created);
-        _logger.LogDebug("Created DeviceStatusExtras with {Count} keys for correlation {CorrelationId}",
+        Logger.LogDebug("Created DeviceStatusExtras with {Count} keys for correlation {CorrelationId}",
             extras.Count, result.CorrelationId);
     }
 
@@ -685,32 +641,12 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             CollectExtras(ds, correlationId, extrasList);
         }
 
-        // Bulk-insert all snapshot types
         using (SystemAuditScope.Push(_auditContext))
         {
-            if (apsList.Count > 0)
-            {
-                var created = await _apsRepo.BulkCreateAsync(apsList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (pumpList.Count > 0)
-            {
-                var created = await _pumpRepo.BulkCreateAsync(pumpList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (uploaderList.Count > 0)
-            {
-                var created = await _uploaderRepo.BulkCreateAsync(uploaderList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (extrasList.Count > 0)
-            {
-                var created = await _extrasRepo.BulkCreateAsync(extrasList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
+            await BulkCreateAsync(_apsRepo, apsList, result, origin, ct);
+            await BulkCreateAsync(_pumpRepo, pumpList, result, origin, ct);
+            await BulkCreateAsync(_uploaderRepo, uploaderList, result, origin, ct);
+            await BulkCreateAsync(_extrasRepo, extrasList, result, origin, ct);
         }
 
         // Upsert override state spans individually — IStateSpanService only exposes
@@ -1043,7 +979,7 @@ public class DeviceStatusDecomposer : IDeviceStatusDecomposer, IDecomposer<Devic
             deleted += await _extrasRepo.DeleteByCorrelationIdAsync(correlationId.Value, ct);
 
         if (deleted > 0)
-            _logger.LogDebug("Deleted {Count} v4 snapshot records for legacy device status {LegacyId}", deleted, legacyId);
+            Logger.LogDebug("Deleted {Count} v4 snapshot records for legacy device status {LegacyId}", deleted, legacyId);
 
         return deleted;
     }

--- a/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
@@ -22,7 +22,7 @@ namespace Nocturne.API.Services.V4;
 /// </summary>
 /// <seealso cref="IEntryDecomposer"/>
 /// <seealso cref="IDecomposer{T}"/>
-public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
+public class EntryDecomposer : DecomposerBase, IEntryDecomposer, IDecomposer<Entry>
 {
     private readonly NocturneDbContext _dbContext;
     private readonly ISensorGlucoseRepository _sensorGlucoseRepository;
@@ -31,7 +31,6 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
     private readonly IGlucoseProcessingResolver _glucoseResolver;
     private readonly IPatientDeviceStamper _patientDeviceStamper;
     private readonly IAuditContext _auditContext;
-    private readonly ILogger<EntryDecomposer> _logger;
 
     /// <param name="dbContext">EF Core context used for entry bulk-delete operations.</param>
     /// <param name="sensorGlucoseRepository">Repository for <see cref="SensorGlucose"/> records.</param>
@@ -49,6 +48,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         IPatientDeviceStamper patientDeviceStamper,
         IAuditContext auditContext,
         ILogger<EntryDecomposer> logger)
+        : base(logger)
     {
         _dbContext = dbContext;
         _sensorGlucoseRepository = sensorGlucoseRepository;
@@ -57,7 +57,6 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         _glucoseResolver = glucoseResolver;
         _patientDeviceStamper = patientDeviceStamper;
         _auditContext = auditContext;
-        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -82,7 +81,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
                 await DecomposeCalAsync(entry, result, origin, ct);
                 break;
             default:
-                _logger.LogWarning("Unknown entry type '{Type}' for entry {Id}, skipping decomposition", entry.Type, entry.Id);
+                Logger.LogWarning("Unknown entry type '{Type}' for entry {Id}, skipping decomposition", entry.Type, entry.Id);
                 break;
         }
 
@@ -91,10 +90,6 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
 
     private async Task DecomposeSgvAsync(Entry entry, DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
-        var existing = entry.Id != null
-            ? await _sensorGlucoseRepository.GetByLegacyIdAsync(entry.Id, ct)
-            : null;
-
         var model = MapToSensorGlucose(entry, result.CorrelationId);
 
         // Extract glucose processing hints from v1/v3 additional properties
@@ -113,73 +108,26 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         }
 
         await _glucoseResolver.ResolveAsync(model, gpHint, smoothedHint, unsmoothedHint, ct);
-        // Carry an earlier attribution forward on re-upload: the rebuilt model starts null and a
-        // later ambiguous stamp (e.g. a second device registered since) must not wipe the stored FK.
-        model.PatientDeviceId = existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], DeviceAttributionCategories.SensorGlucose, model.DataSource, ct);
 
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _sensorGlucoseRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing SensorGlucose {Id} from legacy entry {LegacyId}", existing.Id, entry.Id);
-        }
-        else
-        {
-            var created = await _sensorGlucoseRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created SensorGlucose from legacy entry {LegacyId}", entry.Id);
-        }
+        await UpsertByLegacyIdAsync(
+            _sensorGlucoseRepository, entry.Id, model, result, origin, ct,
+            beforeWrite: existing => StampAttributionAsync(
+                _patientDeviceStamper, model, existing, DeviceAttributionCategories.SensorGlucose, ct));
     }
 
     private async Task DecomposeMbgAsync(Entry entry, DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
-        var existing = entry.Id != null
-            ? await _meterGlucoseRepository.GetByLegacyIdAsync(entry.Id, ct)
-            : null;
-
         var model = MapToMeterGlucose(entry, result.CorrelationId);
-        model.PatientDeviceId = existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], DeviceAttributionCategories.MeterGlucose, model.DataSource, ct);
 
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _meterGlucoseRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing MeterGlucose {Id} from legacy entry {LegacyId}", existing.Id, entry.Id);
-        }
-        else
-        {
-            var created = await _meterGlucoseRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created MeterGlucose from legacy entry {LegacyId}", entry.Id);
-        }
+        await UpsertByLegacyIdAsync(
+            _meterGlucoseRepository, entry.Id, model, result, origin, ct,
+            beforeWrite: existing => StampAttributionAsync(
+                _patientDeviceStamper, model, existing, DeviceAttributionCategories.MeterGlucose, ct));
     }
 
     private async Task DecomposeCalAsync(Entry entry, DecompositionResult result, WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = entry.Id != null
-            ? await _calibrationRepository.GetByLegacyIdAsync(entry.Id, ct)
-            : null;
-
-        var model = MapToCalibration(entry, result.CorrelationId);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _calibrationRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing Calibration {Id} from legacy entry {LegacyId}", existing.Id, entry.Id);
-        }
-        else
-        {
-            var created = await _calibrationRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created Calibration from legacy entry {LegacyId}", entry.Id);
-        }
-    }
+        => await UpsertByLegacyIdAsync(
+            _calibrationRepository, entry.Id, MapToCalibration(entry, result.CorrelationId), result, origin, ct);
 
     /// <inheritdoc />
     public async Task<DecompositionResult> DecomposeBatchAsync(
@@ -228,7 +176,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
                     calList.Add(MapToCalibration(entry, correlationId));
                     break;
                 default:
-                    _logger.LogDebug("Skipping entry with unknown type: {Type}", entry.Type);
+                    Logger.LogDebug("Skipping entry with unknown type: {Type}", entry.Type);
                     break;
             }
         }
@@ -240,23 +188,9 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
 
         using (SystemAuditScope.Push(_auditContext))
         {
-            if (sgvList.Count > 0)
-            {
-                var created = await _sensorGlucoseRepository.BulkCreateAsync(sgvList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (mbgList.Count > 0)
-            {
-                var created = await _meterGlucoseRepository.BulkCreateAsync(mbgList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (calList.Count > 0)
-            {
-                var created = await _calibrationRepository.BulkCreateAsync(calList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
+            await BulkCreateAsync(_sensorGlucoseRepository, sgvList, result, origin, ct);
+            await BulkCreateAsync(_meterGlucoseRepository, mbgList, result, origin, ct);
+            await BulkCreateAsync(_calibrationRepository, calList, result, origin, ct);
         }
 
         return result;
@@ -271,7 +205,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         deleted += await _calibrationRepository.DeleteByLegacyIdAsync(legacyId, origin, ct);
 
         if (deleted > 0)
-            _logger.LogDebug("Soft-deleted {Count} v4 records for legacy entry {LegacyId}", deleted, legacyId);
+            Logger.LogDebug("Soft-deleted {Count} v4 records for legacy entry {LegacyId}", deleted, legacyId);
 
         return deleted;
     }
@@ -292,7 +226,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
         var typeFilter = findQuery.GetEqualityValue("type");
         if (findQuery.HasFieldFiltersExcept("type"))
         {
-            _logger.LogWarning("BulkDelete refused: find query carries field filters the by-time sweep cannot honor. find={Find}", findForLog);
+            Logger.LogWarning("BulkDelete refused: find query carries field filters the by-time sweep cannot honor. find={Find}", findForLog);
             return 0;
         }
 
@@ -305,7 +239,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
 
         if (hasFind && !hasTimeBounds && typeFilter is null)
         {
-            _logger.LogWarning("BulkDelete refused: find query has no parseable time range, would delete all records. find={Find}", findForLog);
+            Logger.LogWarning("BulkDelete refused: find query has no parseable time range, would delete all records. find={Find}", findForLog);
             return 0;
         }
 
@@ -324,7 +258,7 @@ public class EntryDecomposer : IEntryDecomposer, IDecomposer<Entry>
             ? await _calibrationRepository.DeleteByTimeRangeAsync(from, to, ct) : 0;
 
         var total = (long)sgDeleted + mgDeleted + calDeleted;
-        _logger.LogInformation("BulkDelete: removed {Total} v4 records (sg={Sg}, mg={Mg}, cal={Cal}) for find={Find}",
+        Logger.LogInformation("BulkDelete: removed {Total} v4 records (sg={Sg}, mg={Mg}, cal={Cal}) for find={Find}",
             total, sgDeleted, mgDeleted, calDeleted, findForLog);
 
         return total;

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -20,14 +20,13 @@ namespace Nocturne.API.Services.V4;
 /// </summary>
 /// <seealso cref="IProfileDecomposer"/>
 /// <seealso cref="IDecomposer{T}"/>
-public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
+public class ProfileDecomposer : DecomposerBase, IProfileDecomposer, IDecomposer<Profile>
 {
     private readonly ITherapySettingsRepository _therapySettingsRepo;
     private readonly IBasalScheduleRepository _basalScheduleRepo;
     private readonly ICarbRatioScheduleRepository _carbRatioScheduleRepo;
     private readonly ISensitivityScheduleRepository _sensitivityScheduleRepo;
     private readonly ITargetRangeScheduleRepository _targetRangeScheduleRepo;
-    private readonly ILogger<ProfileDecomposer> _logger;
 
     /// <param name="therapySettingsRepo">Repository for <see cref="V4Models.TherapySettings"/> records.</param>
     /// <param name="basalScheduleRepo">Repository for <see cref="V4Models.BasalSchedule"/> records.</param>
@@ -42,13 +41,13 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         ISensitivityScheduleRepository sensitivityScheduleRepo,
         ITargetRangeScheduleRepository targetRangeScheduleRepo,
         ILogger<ProfileDecomposer> logger)
+        : base(logger)
     {
         _therapySettingsRepo = therapySettingsRepo;
         _basalScheduleRepo = basalScheduleRepo;
         _carbRatioScheduleRepo = carbRatioScheduleRepo;
         _sensitivityScheduleRepo = sensitivityScheduleRepo;
         _targetRangeScheduleRepo = targetRangeScheduleRepo;
-        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -61,7 +60,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
 
         if (profile.Store.Count == 0)
         {
-            _logger.LogWarning("Profile {Id} has no store entries, skipping decomposition", profile.Id);
+            Logger.LogWarning("Profile {Id} has no store entries, skipping decomposition", profile.Id);
             return result;
         }
 
@@ -75,150 +74,30 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
             var legacyId = $"{profile.Id}:{storeName}";
             var isDefault = string.Equals(storeName, profile.DefaultProfile, StringComparison.OrdinalIgnoreCase);
 
-            await DecomposeTherapySettingsAsync(profile, profileData, storeName, legacyId, isDefault, result, origin, ct);
-            await DecomposeBasalScheduleAsync(profile, profileData, storeName, legacyId, result, origin, ct);
-            await DecomposeCarbRatioScheduleAsync(profile, profileData, storeName, legacyId, result, origin, ct);
-            await DecomposeSensitivityScheduleAsync(profile, profileData, storeName, legacyId, result, origin, ct);
-            await DecomposeTargetRangeScheduleAsync(profile, profileData, storeName, legacyId, result, origin, ct);
+            await UpsertByLegacyIdAsync(
+                _therapySettingsRepo, legacyId,
+                MapToTherapySettings(profile, profileData, storeName, legacyId, isDefault, result.CorrelationId),
+                result, origin, ct);
+            await UpsertByLegacyIdAsync(
+                _basalScheduleRepo, legacyId,
+                MapToBasalSchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
+                result, origin, ct);
+            await UpsertByLegacyIdAsync(
+                _carbRatioScheduleRepo, legacyId,
+                MapToCarbRatioSchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
+                result, origin, ct);
+            await UpsertByLegacyIdAsync(
+                _sensitivityScheduleRepo, legacyId,
+                MapToSensitivitySchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
+                result, origin, ct);
+            await UpsertByLegacyIdAsync(
+                _targetRangeScheduleRepo, legacyId,
+                MapToTargetRangeSchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
+                result, origin, ct);
         }
 
         return result;
     }
-
-    #region Decomposition Methods
-
-    private async Task DecomposeTherapySettingsAsync(
-        Profile profile,
-        ProfileData profileData,
-        string storeName,
-        string legacyId,
-        bool isDefault,
-        V4Models.DecompositionResult result,
-        WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = await _therapySettingsRepo.GetByLegacyIdAsync(legacyId, ct);
-        var model = MapToTherapySettings(profile, profileData, storeName, legacyId, isDefault, result.CorrelationId);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _therapySettingsRepo.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing TherapySettings {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
-        }
-        else
-        {
-            var created = await _therapySettingsRepo.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created TherapySettings from legacy profile {LegacyId}", legacyId);
-        }
-    }
-
-    private async Task DecomposeBasalScheduleAsync(
-        Profile profile,
-        ProfileData profileData,
-        string storeName,
-        string legacyId,
-        V4Models.DecompositionResult result,
-        WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = await _basalScheduleRepo.GetByLegacyIdAsync(legacyId, ct);
-        var model = MapToBasalSchedule(profile, profileData, storeName, legacyId, result.CorrelationId);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _basalScheduleRepo.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing BasalSchedule {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
-        }
-        else
-        {
-            var created = await _basalScheduleRepo.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created BasalSchedule from legacy profile {LegacyId}", legacyId);
-        }
-    }
-
-    private async Task DecomposeCarbRatioScheduleAsync(
-        Profile profile,
-        ProfileData profileData,
-        string storeName,
-        string legacyId,
-        V4Models.DecompositionResult result,
-        WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = await _carbRatioScheduleRepo.GetByLegacyIdAsync(legacyId, ct);
-        var model = MapToCarbRatioSchedule(profile, profileData, storeName, legacyId, result.CorrelationId);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _carbRatioScheduleRepo.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing CarbRatioSchedule {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
-        }
-        else
-        {
-            var created = await _carbRatioScheduleRepo.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created CarbRatioSchedule from legacy profile {LegacyId}", legacyId);
-        }
-    }
-
-    private async Task DecomposeSensitivityScheduleAsync(
-        Profile profile,
-        ProfileData profileData,
-        string storeName,
-        string legacyId,
-        V4Models.DecompositionResult result,
-        WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = await _sensitivityScheduleRepo.GetByLegacyIdAsync(legacyId, ct);
-        var model = MapToSensitivitySchedule(profile, profileData, storeName, legacyId, result.CorrelationId);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _sensitivityScheduleRepo.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing SensitivitySchedule {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
-        }
-        else
-        {
-            var created = await _sensitivityScheduleRepo.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created SensitivitySchedule from legacy profile {LegacyId}", legacyId);
-        }
-    }
-
-    private async Task DecomposeTargetRangeScheduleAsync(
-        Profile profile,
-        ProfileData profileData,
-        string storeName,
-        string legacyId,
-        V4Models.DecompositionResult result,
-        WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = await _targetRangeScheduleRepo.GetByLegacyIdAsync(legacyId, ct);
-        var model = MapToTargetRangeSchedule(profile, profileData, storeName, legacyId, result.CorrelationId);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _targetRangeScheduleRepo.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing TargetRangeSchedule {Id} from legacy profile {LegacyId}", existing.Id, legacyId);
-        }
-        else
-        {
-            var created = await _targetRangeScheduleRepo.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created TargetRangeSchedule from legacy profile {LegacyId}", legacyId);
-        }
-    }
-
-    #endregion
 
     #region Mapping Methods
 
@@ -442,7 +321,7 @@ public class ProfileDecomposer : IProfileDecomposer, IDecomposer<Profile>
         deleted += await _targetRangeScheduleRepo.DeleteByLegacyIdPrefixAsync(prefix, origin, ct);
 
         if (deleted > 0)
-            _logger.LogDebug("Deleted {Count} V4 records for legacy profile {LegacyId}", deleted, legacyId);
+            Logger.LogDebug("Deleted {Count} V4 records for legacy profile {LegacyId}", deleted, legacyId);
 
         return deleted;
     }

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -38,7 +38,7 @@ namespace Nocturne.API.Services.V4;
 /// <seealso cref="ITreatmentDecomposer"/>
 /// <seealso cref="IDecomposer{T}"/>
 /// <seealso cref="IStateSpanService"/>
-public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
+public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomposer<Treatment>
 {
     private readonly NocturneDbContext _dbContext;
     private readonly IBolusRepository _bolusRepository;
@@ -56,7 +56,6 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
     private readonly IActiveProfileResolver _activeProfileResolver;
     private readonly IPatientInsulinRepository _insulinRepo;
     private readonly IAuditContext _auditContext;
-    private readonly ILogger<TreatmentDecomposer> _logger;
 
     /// <summary>
     /// Event types that indicate a temp basal treatment (case-insensitive comparison)
@@ -102,6 +101,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         IPatientInsulinRepository insulinRepo,
         IAuditContext auditContext,
         ILogger<TreatmentDecomposer> logger)
+        : base(logger)
     {
         _dbContext = dbContext;
         _bolusRepository = bolusRepository;
@@ -119,7 +119,6 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         _activeProfileResolver = activeProfileResolver;
         _insulinRepo = insulinRepo;
         _auditContext = auditContext;
-        _logger = logger;
     }
 
     /// <summary>
@@ -330,7 +329,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
             if (produceBolus || produceCarbIntake)
             {
-                _logger.LogInformation(
+                Logger.LogInformation(
                     "Unrecognized event type '{EventType}' for treatment {Id}, producing records based on data (insulin={HasInsulin}, carbs={HasCarbs})",
                     treatment.EventType, treatment.Id, hasInsulin, hasCarbs);
             }
@@ -434,7 +433,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         // If nothing was produced and there's no delegation, log a warning
         if (c.ProducesNothing)
         {
-            _logger.LogWarning(
+            Logger.LogWarning(
                 "Unknown event type '{EventType}' for treatment {Id} with no insulin/carbs, skipping decomposition",
                 treatment.EventType, treatment.Id);
         }
@@ -444,191 +443,79 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
     #region Decomposition Methods
 
+    /// <summary>
+    /// Whether the dose was delivered by an AID algorithm rather than the user, by the conventions
+    /// the uploaders use: the <c>isBasalInsulin</c> flag (legacy AAPS), <c>Correction Bolus</c> from
+    /// AAPS (BolusExtension.kt:28), <c>SMB</c> from Trio / iAPS, and <c>Automatic Bolus</c>.
+    /// </summary>
+    private static bool IsAlgorithmBolus(Treatment treatment) =>
+        (treatment.IsBasalInsulin == true && treatment.Insulin > 0)
+        || (string.Equals(treatment.EventType, "Correction Bolus", StringComparison.OrdinalIgnoreCase) && IsAapsUpload(treatment))
+        || string.Equals(treatment.EventType, "SMB", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(treatment.EventType, "Automatic Bolus", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The pump named by the upload's pump fields, created in the device registry if new.</summary>
+    private Task<Guid?> ResolvePumpDeviceAsync(Treatment treatment, CancellationToken ct) =>
+        _deviceService.ResolveAsync(
+            V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+
     private async Task DecomposeBolusAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
-        // Algorithm-delivered micro boluses:
-        //   - isBasalInsulin flag (legacy AAPS convention)
-        //   - "Correction Bolus" from AAPS (BolusExtension.kt:28)
-        //   - "SMB" from Trio / iAPS
-        //   - "Automatic Bolus" from AID systems
-        var isAlgorithmBolus = (treatment.IsBasalInsulin == true && treatment.Insulin > 0)
-            || (string.Equals(treatment.EventType, "Correction Bolus", StringComparison.OrdinalIgnoreCase) && IsAapsUpload(treatment))
-            || string.Equals(treatment.EventType, "SMB", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(treatment.EventType, "Automatic Bolus", StringComparison.OrdinalIgnoreCase);
-
-        if (isAlgorithmBolus)
-        {
-            await DecomposeMicroBolusAsync(treatment, result, origin, ct);
-            return;
-        }
-
-        var existing = treatment.Id != null
-            ? await _bolusRepository.GetByLegacyIdAsync(treatment.Id, ct)
-            : null;
-
         var model = MapToBolus(treatment, result.CorrelationId);
-        model.DeviceId = await _deviceService.ResolveAsync(
-            V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+
+        if (IsAlgorithmBolus(treatment))
+        {
+            model.Kind = V4Models.BolusKind.Algorithm;
+            model.Automatic = true;
+        }
+
+        model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
-        model.PatientDeviceId ??= existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], V4Models.DeviceAttributionCategories.Bolus, model.DataSource, ct);
 
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _bolusRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing Bolus {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
-        }
-        else
-        {
-            var created = await _bolusRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created Bolus from legacy treatment {LegacyId}", treatment.Id);
-        }
-    }
-
-    private async Task DecomposeMicroBolusAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = treatment.Id != null
-            ? await _bolusRepository.GetByLegacyIdAsync(treatment.Id, ct)
-            : null;
-
-        var model = MapToBolus(treatment, result.CorrelationId);
-        model.Kind = V4Models.BolusKind.Algorithm;
-        model.Automatic = true;
-        model.DeviceId = await _deviceService.ResolveAsync(
-            V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
-        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
-        model.PatientDeviceId ??= existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], V4Models.DeviceAttributionCategories.Bolus, model.DataSource, ct);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _bolusRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing algorithm Bolus {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
-        }
-        else
-        {
-            var created = await _bolusRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created algorithm Bolus from legacy treatment {LegacyId}", treatment.Id);
-        }
+        await UpsertByLegacyIdAsync(
+            _bolusRepository, treatment.Id, model, result, origin, ct,
+            beforeWrite: existing => StampAttributionAsync(
+                _patientDeviceStamper, model, existing, V4Models.DeviceAttributionCategories.Bolus, ct));
     }
 
     private async Task DecomposeCarbIntakeAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
-        var existing = treatment.Id != null
-            ? await _carbIntakeRepository.GetByLegacyIdAsync(treatment.Id, ct)
-            : null;
+        var (carbIntake, created) = await UpsertByLegacyIdAsync(
+            _carbIntakeRepository, treatment.Id, MapToCarbIntake(treatment, result.CorrelationId), result, origin, ct);
 
-        var model = MapToCarbIntake(treatment, result.CorrelationId);
-
-        Guid carbIntakeId;
-        if (existing != null)
+        // Preserve legacy FoodType as a TreatmentFood entry (log without saving)
+        if (created && !string.IsNullOrWhiteSpace(treatment.FoodType) && treatment.Carbs is > 0)
         {
-            model.Id = existing.Id;
-            var updated = await _carbIntakeRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            carbIntakeId = existing.Id;
-            _logger.LogDebug("Updated existing CarbIntake {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
-        }
-        else
-        {
-            var created = await _carbIntakeRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            carbIntakeId = created.Id;
-            _logger.LogDebug("Created CarbIntake from legacy treatment {LegacyId}", treatment.Id);
-
-            // Preserve legacy FoodType as a TreatmentFood entry (log without saving)
-            if (!string.IsNullOrWhiteSpace(treatment.FoodType) && treatment.Carbs is > 0)
+            await _treatmentFoodService.AddAsync(new TreatmentFood
             {
-                await _treatmentFoodService.AddAsync(new TreatmentFood
-                {
-                    CarbIntakeId = carbIntakeId,
-                    Portions = 0m,
-                    Carbs = (decimal)treatment.Carbs.Value,
-                    TimeOffsetMinutes = 0,
-                    Note = treatment.FoodType,
-                }, ct);
-            }
+                CarbIntakeId = carbIntake.Id,
+                Portions = 0m,
+                Carbs = (decimal)treatment.Carbs.Value,
+                TimeOffsetMinutes = 0,
+                Note = treatment.FoodType,
+            }, ct);
         }
     }
 
     private async Task DecomposeBGCheckAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = treatment.Id != null
-            ? await _bgCheckRepository.GetByLegacyIdAsync(treatment.Id, ct)
-            : null;
-
-        var model = MapToBGCheck(treatment, result.CorrelationId);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _bgCheckRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing BGCheck {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
-        }
-        else
-        {
-            var created = await _bgCheckRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created BGCheck from legacy treatment {LegacyId}", treatment.Id);
-        }
-    }
+        => await UpsertByLegacyIdAsync(
+            _bgCheckRepository, treatment.Id, MapToBGCheck(treatment, result.CorrelationId), result, origin, ct);
 
     private async Task DecomposeNoteAsync(Treatment treatment, V4Models.DecompositionResult result, bool isAnnouncement, WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = treatment.Id != null
-            ? await _noteRepository.GetByLegacyIdAsync(treatment.Id, ct)
-            : null;
-
-        var model = MapToNote(treatment, result.CorrelationId, isAnnouncement);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _noteRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing Note {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
-        }
-        else
-        {
-            var created = await _noteRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created Note from legacy treatment {LegacyId}", treatment.Id);
-        }
-    }
+        => await UpsertByLegacyIdAsync(
+            _noteRepository, treatment.Id, MapToNote(treatment, result.CorrelationId, isAnnouncement), result, origin, ct);
 
     private async Task DecomposeDeviceEventAsync(Treatment treatment, V4Models.DecompositionResult result, DeviceEventType deviceEventType, WriteOrigin origin, CancellationToken ct)
     {
-        var existing = treatment.Id != null
-            ? await _deviceEventRepository.GetByLegacyIdAsync(treatment.Id, ct)
-            : null;
-
         var model = MapToDeviceEvent(treatment, result.CorrelationId, deviceEventType);
-        model.DeviceId = await _deviceService.ResolveAsync(
-            V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+        model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
-        model.PatientDeviceId ??= existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], V4Models.DeviceAttributionCategories.DeviceEvent(model.EventType), model.DataSource, ct);
 
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _deviceEventRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing DeviceEvent {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
-        }
-        else
-        {
-            var created = await _deviceEventRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created DeviceEvent from legacy treatment {LegacyId}", treatment.Id);
-        }
+        await UpsertByLegacyIdAsync(
+            _deviceEventRepository, treatment.Id, model, result, origin, ct,
+            beforeWrite: existing => StampAttributionAsync(
+                _patientDeviceStamper, model, existing,
+                V4Models.DeviceAttributionCategories.DeviceEvent(model.EventType), ct));
     }
 
     /// <summary>
@@ -658,7 +545,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
             var upserted = await _stateSpanService.UpsertStateSpanAsync(span, ct);
             result.CreatedRecords.Add(upserted);
-            _logger.LogDebug(
+            Logger.LogDebug(
                 "Opened PumpMode/Suspended StateSpan from treatment {LegacyId}",
                 treatment.Id);
         }
@@ -675,7 +562,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             var openSpan = openSpans.FirstOrDefault();
             if (openSpan is null)
             {
-                _logger.LogWarning(
+                Logger.LogWarning(
                     "PumpResume treatment {LegacyId} but no open PumpMode/Suspended StateSpan to close",
                     treatment.Id);
                 return;
@@ -684,34 +571,15 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             openSpan.EndTimestamp = timestamp;
             var closed = await _stateSpanService.UpsertStateSpanAsync(openSpan, ct);
             result.UpdatedRecords.Add(closed);
-            _logger.LogDebug(
+            Logger.LogDebug(
                 "Closed PumpMode/Suspended StateSpan {SpanId} from treatment {LegacyId}",
                 openSpan.Id, treatment.Id);
         }
     }
 
     private async Task DecomposeBolusCalculationAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
-    {
-        var existing = treatment.Id != null
-            ? await _bolusCalculationRepository.GetByLegacyIdAsync(treatment.Id, ct)
-            : null;
-
-        var model = MapToBolusCalculation(treatment, result.CorrelationId);
-
-        if (existing != null)
-        {
-            model.Id = existing.Id;
-            var updated = await _bolusCalculationRepository.UpdateAsync(existing.Id, model, origin, ct);
-            result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing BolusCalculation {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
-        }
-        else
-        {
-            var created = await _bolusCalculationRepository.CreateAsync(model, origin, ct);
-            result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created BolusCalculation from legacy treatment {LegacyId}", treatment.Id);
-        }
-    }
+        => await UpsertByLegacyIdAsync(
+            _bolusCalculationRepository, treatment.Id, MapToBolusCalculation(treatment, result.CorrelationId), result, origin, ct);
 
     private async Task DecomposeTempBasalAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
@@ -720,11 +588,10 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             : null;
 
         var model = MapToTempBasal(treatment, result.CorrelationId);
-        model.DeviceId = await _deviceService.ResolveAsync(
-            V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+        model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
-        model.PatientDeviceId ??= existing?.PatientDeviceId;
-        await _patientDeviceStamper.StampAsync([model], V4Models.DeviceAttributionCategories.TempBasal, model.DataSource, ct);
+        await StampAttributionAsync(
+            _patientDeviceStamper, model, existing, V4Models.DeviceAttributionCategories.TempBasal, ct);
 
         // Resolve insulin context: active profile switch → primary insulin → null
         model.InsulinContext = await _activeProfileResolver.GetActiveInsulinContextAsync(treatment.Mills, ct);
@@ -750,13 +617,13 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             model.Id = existing.Id;
             var updated = await _tempBasalRepository.UpdateAsync(existing.Id, model, origin, ct);
             result.UpdatedRecords.Add(updated);
-            _logger.LogDebug("Updated existing TempBasal {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
+            Logger.LogDebug("Updated existing TempBasal {Id} from legacy treatment {LegacyId}", existing.Id, treatment.Id);
         }
         else
         {
             var created = await _tempBasalRepository.CreateAsync(model, origin, ct);
             result.CreatedRecords.Add(created);
-            _logger.LogDebug("Created TempBasal from legacy treatment {LegacyId}", treatment.Id);
+            Logger.LogDebug("Created TempBasal from legacy treatment {LegacyId}", treatment.Id);
         }
     }
 
@@ -777,7 +644,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
         var upserted = await _stateSpanService.UpsertStateSpanAsync(stateSpan, ct);
         result.CreatedRecords.Add(upserted);
-        _logger.LogDebug("Delegated ProfileSwitch treatment {LegacyId} to IStateSpanService", treatment.Id);
+        Logger.LogDebug("Delegated ProfileSwitch treatment {LegacyId} to IStateSpanService", treatment.Id);
 
         // If the treatment carries inline profile JSON, decompose it into V4 schedule records
         if (!string.IsNullOrEmpty(treatment.ProfileJson))
@@ -801,7 +668,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
                     result.CreatedRecords.AddRange(profileResult.CreatedRecords);
                     result.UpdatedRecords.AddRange(profileResult.UpdatedRecords);
 
-                    _logger.LogDebug(
+                    Logger.LogDebug(
                         "Decomposed inline ProfileJson from treatment {LegacyId} into {Count} V4 records",
                         treatment.Id,
                         profileResult.CreatedRecords.Count + profileResult.UpdatedRecords.Count);
@@ -809,7 +676,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             }
             catch (JsonException ex)
             {
-                _logger.LogWarning(ex,
+                Logger.LogWarning(ex,
                     "Failed to deserialize ProfileJson from treatment {LegacyId}, skipping profile decomposition",
                     treatment.Id);
             }
@@ -833,7 +700,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
         var upserted = await _stateSpanService.UpsertStateSpanAsync(stateSpan, ct);
         result.CreatedRecords.Add(upserted);
-        _logger.LogDebug("Delegated Temporary Override treatment {LegacyId} to IStateSpanService", treatment.Id);
+        Logger.LogDebug("Delegated Temporary Override treatment {LegacyId} to IStateSpanService", treatment.Id);
     }
 
     private async Task DecomposeTemporaryTargetAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
@@ -858,7 +725,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
         var upserted = await _stateSpanService.UpsertStateSpanAsync(stateSpan, ct);
         result.CreatedRecords.Add(upserted);
-        _logger.LogDebug("Delegated Temporary Target treatment {LegacyId} to IStateSpanService", treatment.Id);
+        Logger.LogDebug("Delegated Temporary Target treatment {LegacyId} to IStateSpanService", treatment.Id);
     }
 
     #endregion
@@ -1280,8 +1147,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
                 if (!c.IsProfileSwitch && !c.IsOverride && !c.IsTemporaryTarget)
                 {
                     var tempBasal = MapToTempBasal(treatment, correlationId);
-                    tempBasal.DeviceId = await _deviceService.ResolveAsync(
-                        V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+                    tempBasal.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
                     tempBasal.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(tempBasal.DeviceId, treatment.Mills, ct);
                     tempBasalList.Add(tempBasal);
                 }
@@ -1293,21 +1159,15 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
             if (c.ProduceBolus)
             {
-                var isAlgorithmBolus = (treatment.IsBasalInsulin == true && treatment.Insulin > 0)
-                    || (string.Equals(treatment.EventType, "Correction Bolus", StringComparison.OrdinalIgnoreCase) && IsAapsUpload(treatment))
-                    || string.Equals(treatment.EventType, "SMB", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(treatment.EventType, "Automatic Bolus", StringComparison.OrdinalIgnoreCase);
-
                 var model = MapToBolus(treatment, correlationId);
 
-                if (isAlgorithmBolus)
+                if (IsAlgorithmBolus(treatment))
                 {
                     model.Kind = V4Models.BolusKind.Algorithm;
                     model.Automatic = true;
                 }
 
-                model.DeviceId = await _deviceService.ResolveAsync(
-                    V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+                model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
                 model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
                 bolusList.Add(model);
             }
@@ -1327,8 +1187,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             if (c.ProduceDeviceEvent)
             {
                 var model = MapToDeviceEvent(treatment, correlationId, c.ParsedDeviceEventType);
-                model.DeviceId = await _deviceService.ResolveAsync(
-                    V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
+                model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
                 model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
                 deviceEventList.Add(model);
 
@@ -1345,7 +1204,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             // Log unrecognized treatments
             if (c.ProducesNothing)
             {
-                _logger.LogWarning(
+                Logger.LogWarning(
                     "Unknown event type '{EventType}' for treatment {Id} with no insulin/carbs, skipping decomposition",
                     treatment.EventType, treatment.Id);
             }
@@ -1356,15 +1215,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             await _patientDeviceStamper.StampAsync(bolusList, V4Models.DeviceAttributionCategories.Bolus, batchSource: null, ct);
         if (tempBasalList.Count > 0)
             await _patientDeviceStamper.StampAsync(tempBasalList, V4Models.DeviceAttributionCategories.TempBasal, batchSource: null, ct);
-        if (deviceEventList.Count > 0)
-        {
-            var sensorEvents = deviceEventList.Where(e => V4Models.DeviceAttributionCategories.IsSensorEvent(e.EventType)).ToList();
-            var pumpEvents = deviceEventList.Where(e => !V4Models.DeviceAttributionCategories.IsSensorEvent(e.EventType)).ToList();
-            if (sensorEvents.Count > 0)
-                await _patientDeviceStamper.StampAsync(sensorEvents, V4Models.DeviceAttributionCategories.SensorDeviceEvent, batchSource: null, ct);
-            if (pumpEvents.Count > 0)
-                await _patientDeviceStamper.StampAsync(pumpEvents, V4Models.DeviceAttributionCategories.PumpDeviceEvent, batchSource: null, ct);
-        }
+        await _patientDeviceStamper.StampDeviceEventsAsync(deviceEventList, batchSource: null, ct);
 
         // Pre-pass: upsert profile switch StateSpans first (temp basals depend on them for insulin context)
         var batchInsulinTimeline = new SortedDictionary<long, V4Models.TreatmentInsulinContext>();
@@ -1425,50 +1276,15 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
             tb.InsulinContext = icfg;
         }
 
-        // Bulk-insert all typed lists
         using (SystemAuditScope.Push(_auditContext))
         {
-            if (bolusList.Count > 0)
-            {
-                var created = await _bolusRepository.BulkCreateAsync(bolusList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (carbList.Count > 0)
-            {
-                var created = await _carbIntakeRepository.BulkCreateAsync(carbList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (bgCheckList.Count > 0)
-            {
-                var created = await _bgCheckRepository.BulkCreateAsync(bgCheckList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (noteList.Count > 0)
-            {
-                var created = await _noteRepository.BulkCreateAsync(noteList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (bolusCalcList.Count > 0)
-            {
-                var created = await _bolusCalculationRepository.BulkCreateAsync(bolusCalcList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (deviceEventList.Count > 0)
-            {
-                var created = await _deviceEventRepository.BulkCreateAsync(deviceEventList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
-
-            if (tempBasalList.Count > 0)
-            {
-                var created = await _tempBasalRepository.BulkCreateAsync(tempBasalList, origin, ct);
-                result.CreatedRecords.AddRange(created);
-            }
+            await BulkCreateAsync(_bolusRepository, bolusList, result, origin, ct);
+            await BulkCreateAsync(_carbIntakeRepository, carbList, result, origin, ct);
+            await BulkCreateAsync(_bgCheckRepository, bgCheckList, result, origin, ct);
+            await BulkCreateAsync(_noteRepository, noteList, result, origin, ct);
+            await BulkCreateAsync(_bolusCalculationRepository, bolusCalcList, result, origin, ct);
+            await BulkCreateAsync(_deviceEventRepository, deviceEventList, result, origin, ct);
+            await BulkCreateAsync(_tempBasalRepository, tempBasalList, result, origin, ct);
         }
 
         // Post-insert pump suspend/resume pass: sequential, order-dependent
@@ -1532,7 +1348,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         deleted += await DeleteRecordsByLegacyId(_dbContext.BolusCalculations, legacyId, scope, ct);
 
         if (deleted > 0)
-            _logger.LogDebug("Soft-deleted {Count} v4 records for legacy treatment {LegacyId}", deleted, legacyId);
+            Logger.LogDebug("Soft-deleted {Count} v4 records for legacy treatment {LegacyId}", deleted, legacyId);
 
         return deleted;
     }
@@ -1569,7 +1385,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         // non-matching records.
         if (findQuery.HasFieldFilters)
         {
-            _logger.LogWarning("BulkDelete refused: find query carries field filters the by-time sweep cannot honor. find={Find}", findForLog);
+            Logger.LogWarning("BulkDelete refused: find query carries field filters the by-time sweep cannot honor. find={Find}", findForLog);
             return 0;
         }
 
@@ -1578,7 +1394,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
 
         if (hasFind && !hasTimeBounds)
         {
-            _logger.LogWarning("BulkDelete refused: find query has no parseable time range. find={Find}", findForLog);
+            Logger.LogWarning("BulkDelete refused: find query has no parseable time range. find={Find}", findForLog);
             return 0;
         }
 
@@ -1600,7 +1416,7 @@ public class TreatmentDecomposer : ITreatmentDecomposer, IDecomposer<Treatment>
         total += await DeleteEntitiesByTimeRange(_dbContext.BolusCalculations, from, to, scope, ct);
         total += await DeleteSpansByTimeRange(from, to, scope, ct);
 
-        _logger.LogInformation("BulkDelete: removed {Total} v4 treatment records for find={Find}", total, findForLog);
+        Logger.LogInformation("BulkDelete: removed {Total} v4 treatment records for find={Find}", total, findForLog);
         return total;
     }
 

--- a/src/Core/Nocturne.Core.Contracts/Devices/PatientDeviceStamperExtensions.cs
+++ b/src/Core/Nocturne.Core.Contracts/Devices/PatientDeviceStamperExtensions.cs
@@ -1,0 +1,29 @@
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.Core.Contracts.Devices;
+
+/// <summary>
+/// Stamping shapes that more than one ingest path needs.
+/// </summary>
+public static class PatientDeviceStamperExtensions
+{
+    /// <summary>
+    /// Stamps a mixed batch of device events, split by the categories that can own each event type:
+    /// sensor-lifecycle events attribute to the CGM, every other event to the pump
+    /// (<see cref="DeviceAttributionCategories.DeviceEvent"/>).
+    /// </summary>
+    public static async Task StampDeviceEventsAsync(
+        this IPatientDeviceStamper stamper,
+        IReadOnlyList<DeviceEvent> events,
+        string? batchSource,
+        CancellationToken ct = default)
+    {
+        var sensorEvents = events.Where(e => DeviceAttributionCategories.IsSensorEvent(e.EventType)).ToList();
+        if (sensorEvents.Count > 0)
+            await stamper.StampAsync(sensorEvents, DeviceAttributionCategories.SensorDeviceEvent, batchSource, ct);
+
+        var pumpEvents = events.Where(e => !DeviceAttributionCategories.IsSensorEvent(e.EventType)).ToList();
+        if (pumpEvents.Count > 0)
+            await stamper.StampAsync(pumpEvents, DeviceAttributionCategories.PumpDeviceEvent, batchSource, ct);
+    }
+}

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
@@ -12,7 +12,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// </remarks>
 /// <seealso cref="ApsSnapshot"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
+public interface IApsSnapshotRepository : ILegacyKeyedRepository<ApsSnapshot>
 {
     /// <summary>
     /// Retrieve a page of <see cref="ApsSnapshot"/> records filtered by time range, device, and source.
@@ -41,43 +41,6 @@ public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
     /// <param name="ct">Cancellation token.</param>
     Task<IReadOnlyList<ApsIobCobPoint>> GetIobCobPointsAsync(DateTime from, DateTime to, CancellationToken ct = default);
 
-    /// <summary>Returns a single <see cref="ApsSnapshot"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<ApsSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>
-    /// Retrieve an <see cref="ApsSnapshot"/> by its original MongoDB ObjectId (preserved for migration compatibility).
-    /// </summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<ApsSnapshot?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="ApsSnapshot"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<ApsSnapshot> CreateAsync(ApsSnapshot model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="ApsSnapshot"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<ApsSnapshot> UpdateAsync(Guid id, ApsSnapshot model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete an <see cref="ApsSnapshot"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>
-    /// Delete the <see cref="ApsSnapshot"/> with the given legacy MongoDB ObjectId.
-    /// </summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>Retrieve <see cref="ApsSnapshot"/> records matching any of the given correlation IDs.</summary>
     /// <param name="correlationIds">Correlation IDs to match.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -88,12 +51,6 @@ public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
     /// <param name="limit">Maximum number of records to return (default 1000).</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<ApsSnapshot>> GetModifiedSinceAsync(long lastModifiedMills, int limit = 1000, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="ApsSnapshot"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
     /// <summary>
     /// Returns the timestamp of the most recent <see cref="ApsSnapshot"/> for the current tenant
@@ -138,16 +95,6 @@ public interface IApsSnapshotRepository : IV4Repository<ApsSnapshot>
     /// <param name="asOf">When non-null, restricts to snapshots with <c>Timestamp &lt;= asOf</c>.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<decimal?> GetLatestSensitivityRatioAsync(DateTime? asOf, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk-insert <see cref="ApsSnapshot"/> records with batch-level and DB-level deduplication by LegacyId.
-    /// </summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
-    Task<IEnumerable<ApsSnapshot>> BulkCreateAsync(
-        IEnumerable<ApsSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Bulk create-or-update by (DataSource, SyncIdentifier): rows matched by that key are updated

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBGCheckRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBGCheckRepository.cs
@@ -13,7 +13,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// </remarks>
 /// <seealso cref="BGCheck"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IBGCheckRepository : IV4Repository<BGCheck>
+public interface IBGCheckRepository : ILegacyKeyedRepository<BGCheck>
 {
     /// <summary>
     /// Retrieve a page of <see cref="BGCheck"/> records filtered by time range, device, source, and origin.
@@ -45,45 +45,6 @@ public interface IBGCheckRepository : IV4Repository<BGCheck>
         int limit, int offset, bool descending, CancellationToken ct)
         => GetAsync(from, to, device, source, limit, offset, descending, false, ct);
 
-    /// <summary>Returns a single <see cref="BGCheck"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<BGCheck?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="BGCheck"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<BGCheck?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="BGCheck"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<BGCheck> CreateAsync(BGCheck model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="BGCheck"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<BGCheck> UpdateAsync(Guid id, BGCheck model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="BGCheck"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="BGCheck"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="BGCheck"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
     /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="BGCheck"/>, optionally scoped to a data source.
     /// </summary>
@@ -98,14 +59,5 @@ public interface IBGCheckRepository : IV4Repository<BGCheck>
     Task<IEnumerable<BGCheck>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="BGCheck"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<BGCheck>> BulkCreateAsync(
-        IEnumerable<BGCheck> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalInjectionRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalInjectionRepository.cs
@@ -12,7 +12,8 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// </remarks>
 /// <seealso cref="BasalInjection"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IBasalInjectionRepository : IV4Repository<BasalInjection>, IDeviceAttributedRepository<BasalInjection>
+public interface IBasalInjectionRepository
+    : IV4Repository<BasalInjection>, IDeviceAttributedRepository<BasalInjection>, IBulkCreateRepository<BasalInjection>
 {
     /// <summary>Delete <see cref="BasalInjection"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
@@ -27,15 +28,6 @@ public interface IBasalInjectionRepository : IV4Repository<BasalInjection>, IDev
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The matching record, or <c>null</c> if not found.</returns>
     Task<BasalInjection?> FindBySyncIdentifierAsync(string dataSource, string syncIdentifier, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk-create basal injection records with LegacyId-based deduplication.
-    /// Records whose <see cref="BasalInjection.LegacyId"/> already exists for the tenant are skipped.
-    /// </summary>
-    /// <param name="records">The records to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The created records (excludes duplicates).</returns>
-    Task<IEnumerable<BasalInjection>> BulkCreateAsync(IEnumerable<BasalInjection> records, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="BasalInjection"/>, optionally scoped to a data source.

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalScheduleRepository.cs
@@ -12,7 +12,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// </remarks>
 /// <seealso cref="BasalSchedule"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IBasalScheduleRepository : IV4Repository<BasalSchedule>
+public interface IBasalScheduleRepository : ILegacyKeyedRepository<BasalSchedule>
 {
     /// <summary>Retrieve a page of <see cref="BasalSchedule"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -34,17 +34,6 @@ public interface IBasalScheduleRepository : IV4Repository<BasalSchedule>
         CancellationToken ct = default
     );
 
-    /// <summary>Returns a single <see cref="BasalSchedule"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<BasalSchedule?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="BasalSchedule"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<BasalSchedule?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="BasalSchedule"/> records that belong to a named basal profile.</summary>
     /// <param name="profileName">The profile name to filter by.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -59,28 +48,6 @@ public interface IBasalScheduleRepository : IV4Repository<BasalSchedule>
     /// <param name="ct">Cancellation token.</param>
     Task<BasalSchedule?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
 
-    /// <summary>Persist a new <see cref="BasalSchedule"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<BasalSchedule> CreateAsync(BasalSchedule model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="BasalSchedule"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<BasalSchedule> UpdateAsync(Guid id, BasalSchedule model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="BasalSchedule"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="BasalSchedule"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>
     /// Delete all <see cref="BasalSchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
     /// </summary>
@@ -90,26 +57,11 @@ public interface IBasalScheduleRepository : IV4Repository<BasalSchedule>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
-    /// <summary>Count <see cref="BasalSchedule"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="BasalSchedule"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records (e.g., from one upload).</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<BasalSchedule>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="BasalSchedule"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<BasalSchedule>> BulkCreateAsync(
-        IEnumerable<BasalSchedule> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusCalculationRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusCalculationRepository.cs
@@ -14,7 +14,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="BolusCalculation"/>
 /// <seealso cref="IBolusRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IBolusCalculationRepository : IV4Repository<BolusCalculation>
+public interface IBolusCalculationRepository : ILegacyKeyedRepository<BolusCalculation>
 {
     /// <summary>Retrieve a page of <see cref="BolusCalculation"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -36,49 +36,6 @@ public interface IBolusCalculationRepository : IV4Repository<BolusCalculation>
         CancellationToken ct = default
     );
 
-    /// <summary>Returns a single <see cref="BolusCalculation"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<BolusCalculation?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="BolusCalculation"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<BolusCalculation?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="BolusCalculation"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<BolusCalculation> CreateAsync(BolusCalculation model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="BolusCalculation"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<BolusCalculation> UpdateAsync(
-        Guid id,
-        BolusCalculation model,
-        WriteOrigin origin, CancellationToken ct = default
-    );
-
-    /// <summary>Delete a <see cref="BolusCalculation"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="BolusCalculation"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="BolusCalculation"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
     /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="BolusCalculation"/>, optionally scoped to a data source.
     /// </summary>
@@ -93,14 +50,5 @@ public interface IBolusCalculationRepository : IV4Repository<BolusCalculation>
     Task<IEnumerable<BolusCalculation>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="BolusCalculation"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<BolusCalculation>> BulkCreateAsync(
-        IEnumerable<BolusCalculation> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBolusRepository.cs
@@ -15,7 +15,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="BolusKind"/>
 /// <seealso cref="IBolusCalculationRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IBolusRepository : IV4Repository<Bolus>, IDeviceAttributedRepository<Bolus>
+public interface IBolusRepository : ILegacyKeyedRepository<Bolus>, IDeviceAttributedRepository<Bolus>
 {
     /// <summary>
     /// Retrieve a page of <see cref="Bolus"/> records filtered by time range, device, source, origin, and kind.
@@ -51,51 +51,12 @@ public interface IBolusRepository : IV4Repository<Bolus>, IDeviceAttributedRepos
         int limit, int offset, bool descending, CancellationToken ct)
         => GetAsync(from, to, device, source, limit, offset, descending, false, null, null, null, ct);
 
-    /// <summary>Returns a single <see cref="Bolus"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<Bolus?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="Bolus"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<Bolus?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="Bolus"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<Bolus> CreateAsync(Bolus model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="Bolus"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<Bolus> UpdateAsync(Guid id, Bolus model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="Bolus"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="Bolus"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>Delete <see cref="Bolus"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
     /// <param name="syncIdentifier">The external sync identifier (e.g., UUID from the uploading system).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="Bolus"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="Bolus"/>, optionally scoped to a data source.
@@ -111,14 +72,5 @@ public interface IBolusRepository : IV4Repository<Bolus>, IDeviceAttributedRepos
     Task<IEnumerable<Bolus>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="Bolus"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<Bolus>> BulkCreateAsync(
-        IEnumerable<Bolus> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICalibrationRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICalibrationRepository.cs
@@ -14,7 +14,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="Calibration"/>
 /// <seealso cref="IBGCheckRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ICalibrationRepository : IV4Repository<Calibration>
+public interface ICalibrationRepository : ILegacyKeyedRepository<Calibration>
 {
     /// <summary>Retrieve a page of <see cref="Calibration"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -26,45 +26,6 @@ public interface ICalibrationRepository : IV4Repository<Calibration>
     /// <param name="descending">When <c>true</c>, results are ordered newest-first (default).</param>
     /// <param name="ct">Cancellation token.</param>
     new Task<IEnumerable<Calibration>> GetAsync(DateTime? from, DateTime? to, string? device, string? source, int limit = 100, int offset = 0, bool descending = true, CancellationToken ct = default);
-
-    /// <summary>Returns a single <see cref="Calibration"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<Calibration?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="Calibration"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<Calibration?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="Calibration"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<Calibration> CreateAsync(Calibration model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="Calibration"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<Calibration> UpdateAsync(Guid id, Calibration model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="Calibration"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="Calibration"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="Calibration"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
     /// <summary>Retrieve all <see cref="Calibration"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records.</param>
@@ -103,14 +64,4 @@ public interface ICalibrationRepository : IV4Repository<Calibration>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByTimeRangeAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk-insert <see cref="Calibration"/> records with batch-level and DB-level deduplication by LegacyId.
-    /// </summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
-    Task<IEnumerable<Calibration>> BulkCreateAsync(
-        IEnumerable<Calibration> records,
-        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbIntakeRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbIntakeRepository.cs
@@ -14,7 +14,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="CarbIntake"/>
 /// <seealso cref="IBolusRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ICarbIntakeRepository : IV4Repository<CarbIntake>
+public interface ICarbIntakeRepository : ILegacyKeyedRepository<CarbIntake>
 {
     /// <summary>
     /// Retrieve a page of <see cref="CarbIntake"/> records filtered by time range, device, source, and origin.
@@ -48,51 +48,12 @@ public interface ICarbIntakeRepository : IV4Repository<CarbIntake>
         int limit, int offset, bool descending, CancellationToken ct)
         => GetAsync(from, to, device, source, limit, offset, descending, false, null, null, ct);
 
-    /// <summary>Returns a single <see cref="CarbIntake"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<CarbIntake?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="CarbIntake"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<CarbIntake?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="CarbIntake"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<CarbIntake> CreateAsync(CarbIntake model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="CarbIntake"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<CarbIntake> UpdateAsync(Guid id, CarbIntake model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="CarbIntake"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="CarbIntake"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>Delete <see cref="CarbIntake"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
     /// <param name="syncIdentifier">The external sync identifier (e.g., UUID from the uploading system).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="CarbIntake"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="CarbIntake"/>, optionally scoped to a data source.
@@ -108,14 +69,5 @@ public interface ICarbIntakeRepository : IV4Repository<CarbIntake>
     Task<IEnumerable<CarbIntake>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="CarbIntake"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<CarbIntake>> BulkCreateAsync(
-        IEnumerable<CarbIntake> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbRatioScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbRatioScheduleRepository.cs
@@ -15,7 +15,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="IBasalScheduleRepository"/>
 /// <seealso cref="ISensitivityScheduleRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ICarbRatioScheduleRepository : IV4Repository<CarbRatioSchedule>
+public interface ICarbRatioScheduleRepository : ILegacyKeyedRepository<CarbRatioSchedule>
 {
     /// <summary>Retrieve a page of <see cref="CarbRatioSchedule"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -37,17 +37,6 @@ public interface ICarbRatioScheduleRepository : IV4Repository<CarbRatioSchedule>
         CancellationToken ct = default
     );
 
-    /// <summary>Returns a single <see cref="CarbRatioSchedule"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<CarbRatioSchedule?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="CarbRatioSchedule"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<CarbRatioSchedule?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="CarbRatioSchedule"/> records belonging to a named therapy profile.</summary>
     /// <param name="profileName">The profile name to filter by.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -62,28 +51,6 @@ public interface ICarbRatioScheduleRepository : IV4Repository<CarbRatioSchedule>
     /// <param name="ct">Cancellation token.</param>
     Task<CarbRatioSchedule?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
 
-    /// <summary>Persist a new <see cref="CarbRatioSchedule"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<CarbRatioSchedule> CreateAsync(CarbRatioSchedule model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="CarbRatioSchedule"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<CarbRatioSchedule> UpdateAsync(Guid id, CarbRatioSchedule model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="CarbRatioSchedule"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="CarbRatioSchedule"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>
     /// Delete all <see cref="CarbRatioSchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
     /// </summary>
@@ -93,26 +60,11 @@ public interface ICarbRatioScheduleRepository : IV4Repository<CarbRatioSchedule>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
-    /// <summary>Count <see cref="CarbRatioSchedule"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="CarbRatioSchedule"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records (e.g., from one profile upload).</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<CarbRatioSchedule>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="CarbRatioSchedule"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<CarbRatioSchedule>> BulkCreateAsync(
-        IEnumerable<CarbRatioSchedule> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceEventRepository.cs
@@ -16,7 +16,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="DeviceEvent"/>
 /// <seealso cref="DeviceEventType"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IDeviceEventRepository : IV4Repository<DeviceEvent>, IDeviceAttributionWriter
+public interface IDeviceEventRepository : ILegacyKeyedRepository<DeviceEvent>, IDeviceAttributionWriter
 {
     /// <summary>
     /// Returns unattributed events (<c>PatientDeviceId == null</c>) of the given types within the time
@@ -64,51 +64,12 @@ public interface IDeviceEventRepository : IV4Repository<DeviceEvent>, IDeviceAtt
         int limit, int offset, bool descending, CancellationToken ct)
         => GetAsync(from, to, device, source, limit, offset, descending, nativeOnly: false, patientDeviceId: null, ct: ct);
 
-    /// <summary>Returns a single <see cref="DeviceEvent"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<DeviceEvent?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="DeviceEvent"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<DeviceEvent?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="DeviceEvent"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<DeviceEvent> CreateAsync(DeviceEvent model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="DeviceEvent"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<DeviceEvent> UpdateAsync(Guid id, DeviceEvent model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="DeviceEvent"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="DeviceEvent"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>Delete <see cref="DeviceEvent"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
     /// <param name="syncIdentifier">The external sync identifier (e.g., UUID from the uploading system).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="DeviceEvent"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="DeviceEvent"/>, optionally scoped to a data source.
@@ -124,15 +85,6 @@ public interface IDeviceEventRepository : IV4Repository<DeviceEvent>, IDeviceAtt
     Task<IEnumerable<DeviceEvent>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="DeviceEvent"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<DeviceEvent>> BulkCreateAsync(
-        IEnumerable<DeviceEvent> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceStatusExtrasRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IDeviceStatusExtrasRepository.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// Alpha-phase diagnostic data. Records are created during devicestatus decomposition
 /// and can be queried or deleted by their correlation ID.
 /// </remarks>
-public interface IDeviceStatusExtrasRepository
+public interface IDeviceStatusExtrasRepository : IBulkCreateRepository<DeviceStatusExtras>
 {
     /// <summary>Persist a new <see cref="DeviceStatusExtras"/> and return the saved entity.</summary>
     /// <param name="model">Record to create.</param>
@@ -27,14 +27,4 @@ public interface IDeviceStatusExtrasRepository
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByCorrelationIdAsync(Guid correlationId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk-insert <see cref="DeviceStatusExtras"/> records with batch-level and DB-level deduplication by CorrelationId.
-    /// </summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
-    Task<IEnumerable<DeviceStatusExtras>> BulkCreateAsync(
-        IEnumerable<DeviceStatusExtras> records,
-        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ILegacyKeyedRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ILegacyKeyedRepository.cs
@@ -1,0 +1,35 @@
+using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.Core.Contracts.V4.Repositories;
+
+/// <summary>
+/// Batch insert for one record type, deduplicated by the repository's own key.
+/// Separate from <see cref="ILegacyKeyedRepository{TRecord}"/> because
+/// <see cref="Nocturne.Core.Models.V4.DeviceStatusExtras"/>,
+/// <see cref="Nocturne.Core.Models.V4.BasalInjection"/> and
+/// <see cref="Nocturne.Core.Models.V4.TempBasal"/> take bulk writes without carrying the full
+/// legacy-keyed surface.
+/// </summary>
+/// <typeparam name="TRecord">The record type stored by this repository.</typeparam>
+public interface IBulkCreateRepository<TRecord>
+{
+    /// <returns>The inserted records with server-assigned fields populated.</returns>
+    Task<IEnumerable<TRecord>> BulkCreateAsync(
+        IEnumerable<TRecord> records, WriteOrigin origin, CancellationToken ct = default);
+}
+
+/// <summary>
+/// A V4 repository addressable by the legacy MongoDB <c>_id</c> its records were decomposed from.
+/// This is the surface the decomposers upsert through, so their create-or-update body can live in
+/// one generic place (<c>DecomposerBase.UpsertByLegacyIdAsync</c>).
+/// </summary>
+/// <typeparam name="TRecord">The V4 record type stored by this repository.</typeparam>
+public interface ILegacyKeyedRepository<TRecord> : IV4Repository<TRecord>, IBulkCreateRepository<TRecord>
+    where TRecord : class, IV4Record
+{
+    Task<TRecord?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
+
+    /// <returns>Number of records deleted.</returns>
+    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
+}

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IMeterGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IMeterGlucoseRepository.cs
@@ -14,7 +14,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="MeterGlucose"/>
 /// <seealso cref="IBGCheckRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IMeterGlucoseRepository : IV4Repository<MeterGlucose>, IDeviceAttributedRepository<MeterGlucose>
+public interface IMeterGlucoseRepository : ILegacyKeyedRepository<MeterGlucose>, IDeviceAttributedRepository<MeterGlucose>
 {
     /// <summary>Retrieve a page of <see cref="MeterGlucose"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -26,45 +26,6 @@ public interface IMeterGlucoseRepository : IV4Repository<MeterGlucose>, IDeviceA
     /// <param name="descending">When <c>true</c>, results are ordered newest-first (default).</param>
     /// <param name="ct">Cancellation token.</param>
     new Task<IEnumerable<MeterGlucose>> GetAsync(DateTime? from, DateTime? to, string? device, string? source, int limit = 100, int offset = 0, bool descending = true, CancellationToken ct = default);
-
-    /// <summary>Returns a single <see cref="MeterGlucose"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<MeterGlucose?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="MeterGlucose"/> record by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<MeterGlucose?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="MeterGlucose"/> record and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<MeterGlucose> CreateAsync(MeterGlucose model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="MeterGlucose"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<MeterGlucose> UpdateAsync(Guid id, MeterGlucose model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="MeterGlucose"/> record by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="MeterGlucose"/> record with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="MeterGlucose"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
     /// <summary>Retrieve all <see cref="MeterGlucose"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records.</param>
@@ -103,14 +64,4 @@ public interface IMeterGlucoseRepository : IV4Repository<MeterGlucose>, IDeviceA
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByTimeRangeAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk-insert <see cref="MeterGlucose"/> records with batch-level and DB-level deduplication by LegacyId.
-    /// </summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
-    Task<IEnumerable<MeterGlucose>> BulkCreateAsync(
-        IEnumerable<MeterGlucose> records,
-        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/INoteRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/INoteRepository.cs
@@ -14,7 +14,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// </remarks>
 /// <seealso cref="Note"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface INoteRepository : IV4Repository<Note>
+public interface INoteRepository : ILegacyKeyedRepository<Note>
 {
     /// <summary>
     /// Retrieve a page of <see cref="Note"/> records filtered by time range, device, source, and origin.
@@ -46,51 +46,12 @@ public interface INoteRepository : IV4Repository<Note>
         int limit, int offset, bool descending, CancellationToken ct)
         => GetAsync(from, to, device, source, limit, offset, descending, false, ct);
 
-    /// <summary>Returns a single <see cref="Note"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<Note?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="Note"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<Note?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="Note"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<Note> CreateAsync(Note model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="Note"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<Note> UpdateAsync(Guid id, Note model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="Note"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="Note"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>Delete <see cref="Note"/> records matching the given data source and sync identifier.</summary>
     /// <param name="dataSource">The external data source name.</param>
     /// <param name="syncIdentifier">The external sync identifier (e.g., UUID from the uploading system).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteBySyncIdentifierAsync(string dataSource, string syncIdentifier, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="Note"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve the timestamp of the most recently stored <see cref="Note"/>, optionally scoped to a data source.
@@ -106,14 +67,5 @@ public interface INoteRepository : IV4Repository<Note>
     Task<IEnumerable<Note>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="Note"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<Note>> BulkCreateAsync(
-        IEnumerable<Note> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
@@ -15,7 +15,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="IApsSnapshotRepository"/>
 /// <seealso cref="IUploaderSnapshotRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IPumpSnapshotRepository : IV4Repository<PumpSnapshot>
+public interface IPumpSnapshotRepository : ILegacyKeyedRepository<PumpSnapshot>
 {
     /// <summary>Retrieve a page of <see cref="PumpSnapshot"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -27,39 +27,6 @@ public interface IPumpSnapshotRepository : IV4Repository<PumpSnapshot>
     /// <param name="descending">When <c>true</c>, results are ordered newest-first (default).</param>
     /// <param name="ct">Cancellation token.</param>
     new Task<IEnumerable<PumpSnapshot>> GetAsync(DateTime? from, DateTime? to, string? device, string? source, int limit = 100, int offset = 0, bool descending = true, CancellationToken ct = default);
-
-    /// <summary>Returns a single <see cref="PumpSnapshot"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<PumpSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="PumpSnapshot"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<PumpSnapshot?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="PumpSnapshot"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<PumpSnapshot> CreateAsync(PumpSnapshot model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="PumpSnapshot"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<PumpSnapshot> UpdateAsync(Guid id, PumpSnapshot model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="PumpSnapshot"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="PumpSnapshot"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>Retrieve <see cref="PumpSnapshot"/> records matching any of the given correlation IDs.</summary>
     /// <param name="correlationIds">Correlation IDs to match.</param>
@@ -92,12 +59,6 @@ public interface IPumpSnapshotRepository : IV4Repository<PumpSnapshot>
     /// <param name="ct">Cancellation token.</param>
     Task<PumpSnapshot?> GetLatestAsync(DateTime? asOf, CancellationToken ct = default);
 
-    /// <summary>Count <see cref="PumpSnapshot"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Inclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
     /// <summary>
     /// Returns the timestamp of the most recent <see cref="PumpSnapshot"/> for the current tenant,
     /// optionally scoped to a single connector data source, or <c>null</c> if none exist. When
@@ -107,16 +68,6 @@ public interface IPumpSnapshotRepository : IV4Repository<PumpSnapshot>
     /// <param name="source">Optional connector data source filter.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk-insert <see cref="PumpSnapshot"/> records with batch-level and DB-level deduplication by LegacyId.
-    /// </summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
-    Task<IEnumerable<PumpSnapshot>> BulkCreateAsync(
-        IEnumerable<PumpSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Bulk create-or-update by (DataSource, SyncIdentifier): rows matched by that key are updated

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensitivityScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensitivityScheduleRepository.cs
@@ -16,7 +16,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="ICarbRatioScheduleRepository"/>
 /// <seealso cref="ITargetRangeScheduleRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ISensitivityScheduleRepository : IV4Repository<SensitivitySchedule>
+public interface ISensitivityScheduleRepository : ILegacyKeyedRepository<SensitivitySchedule>
 {
     /// <summary>Retrieve a page of <see cref="SensitivitySchedule"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -38,17 +38,6 @@ public interface ISensitivityScheduleRepository : IV4Repository<SensitivitySched
         CancellationToken ct = default
     );
 
-    /// <summary>Returns a single <see cref="SensitivitySchedule"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<SensitivitySchedule?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="SensitivitySchedule"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<SensitivitySchedule?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="SensitivitySchedule"/> records belonging to a named therapy profile.</summary>
     /// <param name="profileName">The profile name to filter by.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -63,28 +52,6 @@ public interface ISensitivityScheduleRepository : IV4Repository<SensitivitySched
     /// <param name="ct">Cancellation token.</param>
     Task<SensitivitySchedule?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
 
-    /// <summary>Persist a new <see cref="SensitivitySchedule"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<SensitivitySchedule> CreateAsync(SensitivitySchedule model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="SensitivitySchedule"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<SensitivitySchedule> UpdateAsync(Guid id, SensitivitySchedule model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="SensitivitySchedule"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="SensitivitySchedule"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>
     /// Delete all <see cref="SensitivitySchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
     /// </summary>
@@ -94,26 +61,11 @@ public interface ISensitivityScheduleRepository : IV4Repository<SensitivitySched
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
-    /// <summary>Count <see cref="SensitivitySchedule"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="SensitivitySchedule"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records (e.g., from one profile upload).</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<SensitivitySchedule>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="SensitivitySchedule"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<SensitivitySchedule>> BulkCreateAsync(
-        IEnumerable<SensitivitySchedule> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensorGlucoseRepository.cs
@@ -17,7 +17,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="IBGCheckRepository"/>
 /// <seealso cref="ICalibrationRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>, IDeviceAttributedRepository<SensorGlucose>
+public interface ISensorGlucoseRepository : ILegacyKeyedRepository<SensorGlucose>, IDeviceAttributedRepository<SensorGlucose>
 {
     /// <summary>
     /// Retrieve a page of <see cref="SensorGlucose"/> records filtered by time range, device, source, and origin.
@@ -56,60 +56,12 @@ public interface ISensorGlucoseRepository : IV4Repository<SensorGlucose>, IDevic
         int limit, int offset, bool descending, CancellationToken ct)
         => GetAsync(from, to, device, source, limit, offset, descending, false, null, null, ct);
 
-    /// <summary>Returns a single <see cref="SensorGlucose"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<SensorGlucose?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="SensorGlucose"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<SensorGlucose?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="SensorGlucose"/> record and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<SensorGlucose> CreateAsync(SensorGlucose model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="SensorGlucose"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<SensorGlucose> UpdateAsync(Guid id, SensorGlucose model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="SensorGlucose"/> record by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="SensorGlucose"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="SensorGlucose"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="SensorGlucose"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<SensorGlucose>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="SensorGlucose"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<SensorGlucose>> BulkCreateAsync(
-        IEnumerable<SensorGlucose> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITargetRangeScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITargetRangeScheduleRepository.cs
@@ -15,7 +15,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="IBasalScheduleRepository"/>
 /// <seealso cref="ISensitivityScheduleRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ITargetRangeScheduleRepository : IV4Repository<TargetRangeSchedule>
+public interface ITargetRangeScheduleRepository : ILegacyKeyedRepository<TargetRangeSchedule>
 {
     /// <summary>Retrieve a page of <see cref="TargetRangeSchedule"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -37,17 +37,6 @@ public interface ITargetRangeScheduleRepository : IV4Repository<TargetRangeSched
         CancellationToken ct = default
     );
 
-    /// <summary>Returns a single <see cref="TargetRangeSchedule"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<TargetRangeSchedule?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="TargetRangeSchedule"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<TargetRangeSchedule?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="TargetRangeSchedule"/> records belonging to a named therapy profile.</summary>
     /// <param name="profileName">The profile name to filter by.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -62,28 +51,6 @@ public interface ITargetRangeScheduleRepository : IV4Repository<TargetRangeSched
     /// <param name="ct">Cancellation token.</param>
     Task<TargetRangeSchedule?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
 
-    /// <summary>Persist a new <see cref="TargetRangeSchedule"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<TargetRangeSchedule> CreateAsync(TargetRangeSchedule model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="TargetRangeSchedule"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<TargetRangeSchedule> UpdateAsync(Guid id, TargetRangeSchedule model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="TargetRangeSchedule"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="TargetRangeSchedule"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>
     /// Delete all <see cref="TargetRangeSchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
     /// </summary>
@@ -93,26 +60,11 @@ public interface ITargetRangeScheduleRepository : IV4Repository<TargetRangeSched
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
-    /// <summary>Count <see cref="TargetRangeSchedule"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="TargetRangeSchedule"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records (e.g., from one profile upload).</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<TargetRangeSchedule>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="TargetRangeSchedule"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<TargetRangeSchedule>> BulkCreateAsync(
-        IEnumerable<TargetRangeSchedule> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITempBasalRepository.cs
@@ -17,7 +17,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="TempBasal"/>
 /// <seealso cref="Treatments.IIobCalculator"/>
 /// <seealso cref="IStateSpanService"/>
-public interface ITempBasalRepository : IDeviceAttributedRepository<TempBasal>
+public interface ITempBasalRepository : IDeviceAttributedRepository<TempBasal>, IBulkCreateRepository<TempBasal>
 {
     /// <summary>Retrieve a page of <see cref="TempBasal"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -95,15 +95,6 @@ public interface ITempBasalRepository : IDeviceAttributedRepository<TempBasal>
     /// <param name="source">Optional data source filter. Pass <c>null</c> to search across all sources.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
-
-    /// <summary>Insert multiple <see cref="TempBasal"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<TempBasal>> BulkCreateAsync(
-        IEnumerable<TempBasal> records,
-        WriteOrigin origin, CancellationToken ct = default
-    );
 
     /// <summary>
     /// Idempotently reconciles a source's temp basals within a date range: soft-deletes only the

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITherapySettingsRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITherapySettingsRepository.cs
@@ -17,7 +17,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="IBasalScheduleRepository"/>
 /// <seealso cref="ISensitivityScheduleRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ITherapySettingsRepository : IV4Repository<TherapySettings>
+public interface ITherapySettingsRepository : ILegacyKeyedRepository<TherapySettings>
 {
     /// <summary>Retrieve a page of <see cref="TherapySettings"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -39,17 +39,6 @@ public interface ITherapySettingsRepository : IV4Repository<TherapySettings>
         CancellationToken ct = default
     );
 
-    /// <summary>Returns a single <see cref="TherapySettings"/> record by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<TherapySettings?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve a <see cref="TherapySettings"/> record by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<TherapySettings?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="TherapySettings"/> records for a named therapy profile.</summary>
     /// <param name="profileName">The profile name to filter by.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -64,28 +53,6 @@ public interface ITherapySettingsRepository : IV4Repository<TherapySettings>
     /// <param name="ct">Cancellation token.</param>
     Task<TherapySettings?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
 
-    /// <summary>Persist a new <see cref="TherapySettings"/> record and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<TherapySettings> CreateAsync(TherapySettings model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="TherapySettings"/> record identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<TherapySettings> UpdateAsync(Guid id, TherapySettings model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete a <see cref="TherapySettings"/> record by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="TherapySettings"/> record with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>
     /// Delete all <see cref="TherapySettings"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
     /// </summary>
@@ -95,26 +62,11 @@ public interface ITherapySettingsRepository : IV4Repository<TherapySettings>
     /// <returns>Number of records deleted.</returns>
     Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
 
-    /// <summary>Count <see cref="TherapySettings"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
-
     /// <summary>Retrieve all <see cref="TherapySettings"/> records sharing the same correlation identifier.</summary>
     /// <param name="correlationId">Correlation ID linking related records (e.g., from one profile upload).</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<TherapySettings>> GetByCorrelationIdAsync(
         Guid correlationId,
         CancellationToken ct = default
-    );
-
-    /// <summary>Insert multiple <see cref="TherapySettings"/> records in a single batch operation.</summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The inserted records with server-assigned fields populated.</returns>
-    Task<IEnumerable<TherapySettings>> BulkCreateAsync(
-        IEnumerable<TherapySettings> records,
-        WriteOrigin origin, CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
@@ -15,7 +15,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="UploaderSnapshot"/>
 /// <seealso cref="IPumpSnapshotRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IUploaderSnapshotRepository : IV4Repository<UploaderSnapshot>
+public interface IUploaderSnapshotRepository : ILegacyKeyedRepository<UploaderSnapshot>
 {
     /// <summary>Retrieve a page of <see cref="UploaderSnapshot"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -28,49 +28,10 @@ public interface IUploaderSnapshotRepository : IV4Repository<UploaderSnapshot>
     /// <param name="ct">Cancellation token.</param>
     new Task<IEnumerable<UploaderSnapshot>> GetAsync(DateTime? from, DateTime? to, string? device, string? source, int limit = 100, int offset = 0, bool descending = true, CancellationToken ct = default);
 
-    /// <summary>Returns a single <see cref="UploaderSnapshot"/> by its UUID v7, or <c>null</c> if not found.</summary>
-    /// <param name="id">UUID v7 record identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<UploaderSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default);
-
-    /// <summary>Retrieve an <see cref="UploaderSnapshot"/> by its original MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The matching record, or <c>null</c> if not found.</returns>
-    Task<UploaderSnapshot?> GetByLegacyIdAsync(string legacyId, CancellationToken ct = default);
-
-    /// <summary>Persist a new <see cref="UploaderSnapshot"/> and return the saved entity.</summary>
-    /// <param name="model">Record to create.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<UploaderSnapshot> CreateAsync(UploaderSnapshot model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Replace an existing <see cref="UploaderSnapshot"/> identified by <paramref name="id"/>.</summary>
-    /// <param name="id">UUID v7 identifier of the record to update.</param>
-    /// <param name="model">Updated record data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<UploaderSnapshot> UpdateAsync(Guid id, UploaderSnapshot model, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete an <see cref="UploaderSnapshot"/> by its UUID v7.</summary>
-    /// <param name="id">UUID v7 identifier of the record to delete.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task DeleteAsync(Guid id, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Delete the <see cref="UploaderSnapshot"/> with the given legacy MongoDB ObjectId.</summary>
-    /// <param name="legacyId">Original MongoDB ObjectId string.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted (0 or 1).</returns>
-    Task<int> DeleteByLegacyIdAsync(string legacyId, WriteOrigin origin, CancellationToken ct = default);
-
     /// <summary>Retrieve <see cref="UploaderSnapshot"/> records matching any of the given correlation IDs.</summary>
     /// <param name="correlationIds">Correlation IDs to match.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IEnumerable<UploaderSnapshot>> GetByCorrelationIdsAsync(IEnumerable<Guid> correlationIds, CancellationToken ct = default);
-
-    /// <summary>Count <see cref="UploaderSnapshot"/> records within an optional time range.</summary>
-    /// <param name="from">Inclusive start, or <c>null</c> for no lower bound.</param>
-    /// <param name="to">Exclusive end, or <c>null</c> for no upper bound.</param>
-    /// <param name="ct">Cancellation token.</param>
-    new Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default);
 
     /// <summary>
     /// Returns the timestamp of the most recent <see cref="UploaderSnapshot"/> for the current
@@ -96,16 +57,6 @@ public interface IUploaderSnapshotRepository : IV4Repository<UploaderSnapshot>
     /// when <c>null</c>, returns the absolute latest snapshot per the lowest-battery rule.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<UploaderSnapshot?> GetLatestAsync(DateTime? asOf, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk-insert <see cref="UploaderSnapshot"/> records with batch-level and DB-level deduplication by LegacyId.
-    /// </summary>
-    /// <param name="records">Records to insert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The records that were actually inserted (duplicates excluded).</returns>
-    Task<IEnumerable<UploaderSnapshot>> BulkCreateAsync(
-        IEnumerable<UploaderSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default);
 
     /// <summary>
     /// Bulk create-or-update by (DataSource, SyncIdentifier): rows matched by that key are updated

--- a/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/DevicePublisherTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/ConnectorPublishing/DevicePublisherTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.ConnectorPublishing;
 using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
@@ -20,6 +21,7 @@ public class DevicePublisherTests
     private readonly Mock<IApsSnapshotRepository> _mockApsSnapshotRepository;
     private readonly Mock<IPumpSnapshotRepository> _mockPumpSnapshotRepository;
     private readonly Mock<IUploaderSnapshotRepository> _mockUploaderSnapshotRepository;
+    private readonly Mock<IPatientDeviceStamper> _mockPatientDeviceStamper;
     private readonly DevicePublisher _publisher;
 
     public DevicePublisherTests()
@@ -29,10 +31,12 @@ public class DevicePublisherTests
         _mockApsSnapshotRepository = new Mock<IApsSnapshotRepository>();
         _mockPumpSnapshotRepository = new Mock<IPumpSnapshotRepository>();
         _mockUploaderSnapshotRepository = new Mock<IUploaderSnapshotRepository>();
+        _mockPatientDeviceStamper = new Mock<IPatientDeviceStamper>();
 
         _publisher = new DevicePublisher(
             _mockDecomposer.Object,
             _mockDeviceEventRepository.Object,
+            _mockPatientDeviceStamper.Object,
             Mock.Of<IAuditContext>(),
             _mockApsSnapshotRepository.Object,
             _mockPumpSnapshotRepository.Object,
@@ -65,6 +69,34 @@ public class DevicePublisherTests
         var result = await _publisher.PublishDeviceStatusAsync(new List<DeviceStatus> { new() }, "test-source", WriteOrigin.Live);
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PublishDeviceEventsAsync_AttributesEachEventToTheDeviceCategoryThatOwnsIt()
+    {
+        var records = new List<DeviceEvent>
+        {
+            new() { EventType = DeviceEventType.SensorChange },
+            new() { EventType = DeviceEventType.SiteChange },
+        };
+
+        var result = await _publisher.PublishDeviceEventsAsync(records, "test-source", WriteOrigin.Live);
+
+        result.Should().BeTrue();
+        _mockPatientDeviceStamper.Verify(
+            s => s.StampAsync(
+                It.Is<IReadOnlyList<IDeviceAttributed>>(r => r.Count == 1 && r[0] == records[0]),
+                DeviceAttributionCategories.SensorDeviceEvent,
+                "test-source",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockPatientDeviceStamper.Verify(
+            s => s.StampAsync(
+                It.Is<IReadOnlyList<IDeviceAttributed>>(r => r.Count == 1 && r[0] == records[1]),
+                DeviceAttributionCategories.PumpDeviceEvent,
+                "test-source",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/DeviceStatusDecomposerTests.cs
@@ -221,6 +221,57 @@ public class DeviceStatusDecomposerTests : IDisposable
         pump.Clock.Should().Be("2023-11-14T12:00:00Z");
     }
 
+    [Fact]
+    public async Task DecomposeAsync_ReDecomposedPumpStatus_TakesAFreshResolutionOverTheStoredOne()
+    {
+        var first = Guid.CreateVersion7();
+        var second = Guid.CreateVersion7();
+        var ds = new DeviceStatus
+        {
+            Id = "pump-reattribution",
+            Mills = 1700000000000,
+            Device = "openaps://Samsung",
+            Pump = new PumpStatus { Manufacturer = "Insulet", Model = "Omnipod 5" }
+        };
+        _deviceServiceMock
+            .SetupSequence(s => s.ResolvePatientDeviceAsync(
+                It.IsAny<Guid?>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(first)
+            .ReturnsAsync(second);
+
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+
+        _context.PumpSnapshots.Single(p => p.LegacyId == "pump-reattribution").PatientDeviceId.Should().Be(second);
+    }
+
+    [Fact]
+    public async Task DecomposeAsync_ReDecomposedPumpStatus_KeepsTheStoredPatientDeviceAttribution()
+    {
+        var patientDeviceId = Guid.CreateVersion7();
+        var ds = new DeviceStatus
+        {
+            Id = "pump-attribution",
+            Mills = 1700000000000,
+            Device = "openaps://Samsung",
+            Pump = new PumpStatus { Manufacturer = "Insulet", Model = "Omnipod 5" }
+        };
+
+        // The second resolution is ambiguous (a second pump has been registered since), so it
+        // returns nothing and the stored attribution has to survive the re-decompose.
+        _deviceServiceMock
+            .SetupSequence(s => s.ResolvePatientDeviceAsync(
+                It.IsAny<Guid?>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(patientDeviceId)
+            .ReturnsAsync((Guid?)null);
+
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+        await _decomposer.DecomposeAsync(ds, WriteOrigin.Live);
+
+        var stored = _context.PumpSnapshots.Single(p => p.LegacyId == "pump-attribution");
+        stored.PatientDeviceId.Should().Be(patientDeviceId);
+    }
+
     #endregion
 
     #region Uploader → UploaderSnapshot

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerTests.cs
@@ -49,6 +49,24 @@ public class EntryDecomposerTests : IDisposable
     #region SGV Decomposition
 
     [Fact]
+    public async Task DecomposeAsync_ReDecomposedSgvEntry_KeepsTheStoredPatientDeviceAttribution()
+    {
+        var entry = new Entry { Id = "sgv-attribution", Type = "sgv", Mills = 1700000000000, Sgv = 120.0, DataSource = "dexcom-connector" };
+        await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
+        var patientDeviceId = Guid.CreateVersion7();
+        var stored = _context.SensorGlucose.Single(e => e.LegacyId == "sgv-attribution");
+        stored.PatientDeviceId = patientDeviceId;
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        // The stamper resolves nothing on the second pass; the rebuilt model must not wipe the stored link.
+        await _decomposer.DecomposeAsync(entry, WriteOrigin.Live);
+
+        _context.ChangeTracker.Clear();
+        _context.SensorGlucose.Single(e => e.LegacyId == "sgv-attribution").PatientDeviceId.Should().Be(patientDeviceId);
+    }
+
+    [Fact]
     public async Task DecomposeAsync_SgvEntry_CreatesSensorGlucoseWithCorrectFields()
     {
         // Arrange

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -2544,6 +2544,24 @@ public class TreatmentDecomposerTests : IDisposable
         bolus.PatientDeviceId.Should().Be(expectedPatientDeviceId);
     }
 
+    [Fact]
+    public async Task DecomposeAsync_ReDecomposedBolus_TakesAFreshResolutionOverTheStoredOne()
+    {
+        var first = Guid.CreateVersion7();
+        var second = Guid.CreateVersion7();
+        _deviceServiceMock
+            .SetupSequence(s => s.ResolvePatientDeviceAsync(
+                It.IsAny<Guid?>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(first)
+            .ReturnsAsync(second);
+        var treatment = new Treatment { Id = "bolus-reattribution", EventType = "Correction Bolus", Mills = 1700000000000, Insulin = 3.0 };
+
+        await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
+
+        result.UpdatedRecords.OfType<V4Models.Bolus>().Single().PatientDeviceId.Should().Be(second);
+    }
+
     #endregion
 
     #region ExtractAapsIcfg


### PR DESCRIPTION
Closes #1082.

The service tier between the V4 repositories and the controllers had no shared base: the create-or-update-by-`LegacyId` body was typed out 21 times across five decomposers, the bulk-insert tail 14 times, and the connector publishers repeated one try/materialise/empty-return/stamp/audit-scope/bulk-create/log shape eight times. Three different `PatientDeviceId` policies had grown inside the copies.

## What changes

- `DecomposerBase` owns `UpsertByLegacyIdAsync` (18 of the 21 copies), `BulkCreateAsync` (the 14 tails) and `StampAttributionAsync` (carry the stored attribution forward, then stamp what is still unattributed). `DecomposeBolusAsync`/`DecomposeMicroBolusAsync` collapse into one method keyed by `IsAlgorithmBolus`. Both bases expose one `Logger`; the derived classes drop their own fields.
- `ILegacyKeyedRepository<T>` / `IBulkCreateRepository<T>` name the surface the base upserts through. Twenty repository interfaces drop the `new` re-declarations of `IV4Repository<T>` members and their per-type `GetByLegacyIdAsync`/`DeleteByLegacyIdAsync`/`BulkCreateAsync` copies.
- `ConnectorPublisherBase.PublishAsync` owns the publisher shape; `LatestTimestampAsync` replaces the three hand-rolled "latest across repositories" helpers. `PatientDeviceStamperExtensions.StampDeviceEventsAsync` is the one sensor-vs-pump split for device events, shared by the decomposer batch path and the publisher.
- `ActivityDecomposer` keeps writing heart rates and step counts through the context (they have no V4 repository) but through one generic `UpsertByOriginalIdAsync`/`BulkCreateNewByOriginalIdAsync` pair instead of two copies each.

Net about −1,150 lines.

## Declared behavioural deltas

1. **One `PatientDeviceId` policy: `resolved ?? stored`.** `DeviceStatusDecomposer` previously replaced a stored attribution with whatever resolution returned now, including null, on every re-decompose; it now carries the stored value forward like the treatment and entry paths. Both halves are pinned: the stored value survives a null re-resolution (`DeviceStatusDecomposerTests…KeepsTheStoredPatientDeviceAttribution`, `EntryDecomposerTests…KeepsTheStoredPatientDeviceAttribution`) and a fresh resolution wins over the stored one (`…TakesAFreshResolutionOverTheStoredOne` in `DeviceStatusDecomposerTests` and `TreatmentDecomposerTests`). Each fails under the inverted policy.
2. **Connector-published device events are stamped.** `DevicePublisher.PublishDeviceEventsAsync` never referenced the stamper; it now stamps through the same split the decomposer uses. Pinned by `DevicePublisherTests.PublishDeviceEventsAsync_AttributesEachEventToTheDeviceCategoryThatOwnsIt`.
3. **Publisher preparation runs inside `SystemAuditScope`.** Stamping and patient-insulin auto-creation previously ran before the scope was pushed; they now run inside it alongside the write, so any row they create or touch is attributed to the sync rather than to whoever triggered it. The temp-basal reconcile delete was already inside the scope.

Not changed, deliberately: the single-vs-batch divergences (#1083), the audit-scope asymmetry between the two entry points, the create-branch-only `TreatmentFood` link, `batchSource: null` on the batch stamp. `DecomposeTempBasalAsync` remains the one hand-rolled legacy-id upsert (and the two Activity ones go through their own context-backed helper): `TempBasal` is not `IV4Record` and its repository lacks the `IV4Repository` surface, which is now recorded on #1066 rather than pulled into this PR.

Log wording at the converted sites is now uniform (`Created {RecordType} from legacy record {LegacyId}` / `Updated existing {RecordType} {Id} from legacy record {LegacyId}`); the per-type nouns ("legacy treatment", "legacy entry", "algorithm Bolus") are gone. The redundant `SystemAuditScope` push inside `ResolveOrCreatePatientInsulinAsync` is deleted; its only callers already run inside the publisher scope.

## Tests

`Nocturne.API.Tests`: 6256 passed, 0 failed, 5 skipped.

https://claude.ai/code/session_01DoFQ3xHL2WEamV1WUSyGAK
