### PR TITLE
fix(data): follow the user-delete guard in the bulk sync upsert

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
@@ -98,10 +98,9 @@ public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepos
         var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
         var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
 
-        // Over-fetches by a Cartesian amount; the partial unique index
-        // on (tenant_id, data_source, sync_identifier) keeps this cheap.
-        // Soft-deleted rows are excluded: the index ignores them, so a re-upload after a delete
-        // inserts a fresh row instead of writing into the invisible one.
+        // Over-fetches by a Cartesian amount; the partial unique index on
+        // (tenant_id, data_source, sync_identifier) keeps this cheap. Tombstones are excluded as
+        // the index excludes them, so a re-upload after a delete inserts afresh.
         var existingRows = await ctx.Set<TEntity>().IgnoreQueryFilters()
             .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
             .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
@@ -75,8 +75,8 @@ public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepos
     /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
     /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
     /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
-    /// A key held by a row the user deleted is dropped from the batch — neither updated nor inserted
-    /// beside, per <see cref="SoftDeleteDedupExtensions.WhereBlocksRecreation{TEntity}"/>.
+    /// A key held by a row the user deleted drops the record from the batch, per
+    /// <see cref="SoftDeleteDedupExtensions.WhereBlocksRecreation{TEntity}"/>.
     /// </summary>
     protected override async Task<UpsertSplit> SplitUpsertsAsync(
         NocturneDbContext ctx, List<TEntity> entities, CancellationToken ct)
@@ -122,9 +122,6 @@ public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepos
                 && !string.IsNullOrEmpty(entity.SyncIdentifier);
             if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
             {
-                // The user deleted this record, so the re-upload is dropped rather than written into
-                // the tombstone or inserted beside it — as GetBlockingLegacyIdsAsync drops it on the
-                // legacy-id key.
                 if (existing.DeletedAt != null)
                     continue;
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
@@ -5,6 +5,7 @@ using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
@@ -74,6 +75,8 @@ public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepos
     /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
     /// rows in the DB by that key and update them in place. Persists the updates inside the transaction
     /// before returning so the base's insert loop (which clears the tracker) doesn't lose them.
+    /// A key held by a row the user deleted is dropped from the batch — neither updated nor inserted
+    /// beside, per <see cref="SoftDeleteDedupExtensions.WhereBlocksRecreation{TEntity}"/>.
     /// </summary>
     protected override async Task<UpsertSplit> SplitUpsertsAsync(
         NocturneDbContext ctx, List<TEntity> entities, CancellationToken ct)
@@ -99,16 +102,18 @@ public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepos
         var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
 
         // Over-fetches by a Cartesian amount; the partial unique index on
-        // (tenant_id, data_source, sync_identifier) keeps this cheap. Tombstones are excluded as
-        // the index excludes them, so a re-upload after a delete inserts afresh.
+        // (tenant_id, data_source, sync_identifier) keeps this cheap. Tombstones follow
+        // WhereBlocksRecreation: a user delete holds the key, a system sweep does not.
         var existingRows = await ctx.Set<TEntity>().IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
+            .Where(e => e.TenantId == ctx.TenantId)
+            .WhereBlocksRecreation()
             .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
             .ToListAsync(ct);
 
+        // The unique index counts live rows only, so a user tombstone and a live row can share a key.
         var existingByKey = existingRows
             .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-            .ToDictionary(g => g.Key, g => g.First());
+            .ToDictionary(g => g.Key, g => g.FirstOrDefault(e => e.DeletedAt == null) ?? g.First());
 
         var toInsert = new List<TEntity>();
         foreach (var entity in entities)
@@ -117,6 +122,12 @@ public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepos
                 && !string.IsNullOrEmpty(entity.SyncIdentifier);
             if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
             {
+                // The user deleted this record, so the re-upload is dropped rather than written into
+                // the tombstone or inserted beside it — as GetBlockingLegacyIdsAsync drops it on the
+                // legacy-id key.
+                if (existing.DeletedAt != null)
+                    continue;
+
                 ApplyUpdate(existing, ToDomain(entity));
                 updatedEntities.Add(existing);
                 // Capture material changes now, before SaveChanges clears the modified flags.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SyncUpsertRepositoryBase.cs
@@ -16,14 +16,6 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 /// its catch-up window is idempotent and a re-corrected value moves the stored record rather than
 /// doubling it. Tenant scoping is implicit via the DbContext's RLS-equivalent query filter.
 /// </summary>
-/// <remarks>
-/// The two paths disagree on soft-deleted rows: <see cref="CreateAsync"/> reads through the query
-/// filter and so inserts afresh past a tombstone, while <see cref="SplitUpsertsAsync"/> lifts the
-/// filter to restore tenant scoping and matches the tombstone, writing the re-upload into a row that
-/// stays invisible. The snapshot repositories' own copies of the split exclude deleted rows for
-/// exactly that reason. Preserved as-is here — it predates the shared base and correcting it is a
-/// behaviour change, not a refactor.
-/// </remarks>
 /// <typeparam name="TModel">The V4 domain record type.</typeparam>
 /// <typeparam name="TEntity">The EF entity type backing <typeparamref name="TModel"/>.</typeparam>
 public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepositoryBase<TModel, TEntity>
@@ -108,8 +100,10 @@ public abstract class SyncUpsertRepositoryBase<TModel, TEntity> : SyncKeyedRepos
 
         // Over-fetches by a Cartesian amount; the partial unique index
         // on (tenant_id, data_source, sync_identifier) keeps this cheap.
+        // Soft-deleted rows are excluded: the index ignores them, so a re-upload after a delete
+        // inserts a fresh row instead of writing into the invisible one.
         var existingRows = await ctx.Set<TEntity>().IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId)
+            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
             .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
             .ToListAsync(ct);
 

--- a/tests/Shared/Nocturne.Tests.Shared/Mocks/RecordingV4RecordBroadcaster.cs
+++ b/tests/Shared/Nocturne.Tests.Shared/Mocks/RecordingV4RecordBroadcaster.cs
@@ -1,0 +1,29 @@
+using Nocturne.Core.Contracts.Events;
+
+namespace Nocturne.Tests.Shared.Mocks;
+
+public sealed class RecordingV4RecordBroadcaster<TModel> : IV4RecordBroadcaster<TModel>
+    where TModel : class
+{
+    public List<TModel> Created { get; } = [];
+    public List<TModel> Updated { get; } = [];
+    public List<Guid> Deleted { get; } = [];
+
+    public Task BroadcastCreatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
+    {
+        Created.AddRange(items);
+        return Task.CompletedTask;
+    }
+
+    public Task BroadcastUpdatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
+    {
+        Updated.AddRange(items);
+        return Task.CompletedTask;
+    }
+
+    public Task BroadcastDeletedAsync(IReadOnlyList<Guid> ids, CancellationToken ct = default)
+    {
+        Deleted.AddRange(ids);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
@@ -6,6 +6,7 @@ using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 using Nocturne.Core.Contracts.V4;
+using Nocturne.Tests.Shared.Mocks;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -151,28 +152,10 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
         _context.ApsSnapshots.Count().Should().Be(0);
     }
 
-    private sealed class RecordingBroadcaster : Core.Contracts.Events.IV4RecordBroadcaster<ApsSnapshot>
-    {
-        public List<ApsSnapshot> Created { get; } = [];
-        public List<ApsSnapshot> Updated { get; } = [];
-
-        public Task BroadcastCreatedAsync(IReadOnlyList<ApsSnapshot> items, CancellationToken ct = default)
-        {
-            Created.AddRange(items);
-            return Task.CompletedTask;
-        }
-
-        public Task BroadcastUpdatedAsync(IReadOnlyList<ApsSnapshot> items, CancellationToken ct = default)
-        {
-            Updated.AddRange(items);
-            return Task.CompletedTask;
-        }
-    }
-
     [Fact]
     public async Task BulkUpsertAsync_ByteIdenticalRetry_DoesNotBroadcastUpdates()
     {
-        var broadcaster = new RecordingBroadcaster();
+        var broadcaster = new RecordingV4RecordBroadcaster<ApsSnapshot>();
         var repository = new ApsSnapshotRepository(
             new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<ApsSnapshotRepository>.Instance, broadcaster);
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
@@ -1,5 +1,4 @@
 using Nocturne.Core.Contracts.Audit;
-using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models.V4;

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/KeyedSoftDeleteAuditTests.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Tests.Shared.Mocks;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
@@ -241,7 +242,7 @@ public abstract class SyncIdentifierDeleteAuditTests<TModel, TEntity> : KeyedSof
     protected const string SyncIdentifier = "sync-42";
 
     /// <summary>Wired into the repository under test so the delete's broadcast can be asserted.</summary>
-    protected readonly RecordingBroadcaster Broadcaster = new();
+    protected readonly RecordingV4RecordBroadcaster<TModel> Broadcaster = new();
 
     protected override string ExpectedScope => $"sync_identifier={DataSource}/{SyncIdentifier}";
 
@@ -288,17 +289,6 @@ public abstract class SyncIdentifierDeleteAuditTests<TModel, TEntity> : KeyedSof
         await DeleteAsync(WriteOrigin.Backfill);
 
         Broadcaster.Deleted.Should().BeEmpty();
-    }
-
-    protected sealed class RecordingBroadcaster : IV4RecordBroadcaster<TModel>
-    {
-        public List<Guid> Deleted { get; } = [];
-
-        public Task BroadcastDeletedAsync(IReadOnlyList<Guid> ids, CancellationToken ct = default)
-        {
-            Deleted.AddRange(ids);
-            return Task.CompletedTask;
-        }
     }
 }
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
@@ -1,0 +1,172 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Events;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// The soft-delete guard on <c>SyncUpsertRepositoryBase.SplitUpsertsAsync</c>. A connector replaying
+/// its catch-up window re-uploads records the member has since deleted; the split must not match the
+/// tombstone, or the re-upload lands in a row no read returns and the record is lost while the sync
+/// reports success. Matches the single-record <c>CreateAsync</c> path, which reads through the query
+/// filter and inserts afresh.
+/// </summary>
+/// <remarks>
+/// Deliberately a unit test on SQLite rather than the in-memory provider: <c>EnsureCreated</c> builds
+/// the partial unique index filtered to <c>deleted_at IS NULL</c>, so the insert past the tombstone
+/// is only proven legal against a store that enforces it.
+/// </remarks>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class SyncUpsertTombstoneTests : IDisposable
+{
+    private const string DataSource = "aaps";
+    private const string SyncIdentifier = "sync-1";
+
+    private static readonly Guid Tenant = Guid.Parse("00000000-0000-0000-0000-00000000000a");
+    private static readonly DateTime T0 = new(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime DeletedOn = new(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc);
+
+    private readonly DbConnection _connection;
+    private readonly DbContextOptions<NocturneDbContext> _options;
+    private readonly NocturneDbContext _context;
+
+    public SyncUpsertTombstoneTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seed = new NocturneDbContext(_options) { TenantId = Tenant })
+        {
+            seed.Database.EnsureCreated();
+            seed.Tenants.Add(new TenantEntity { Id = Tenant, Slug = "tenant-a" });
+            seed.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(_options) { TenantId = Tenant };
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private NocturneDbContext NewContext() => new(_options) { TenantId = Tenant };
+
+    /// <summary>Persists <paramref name="entity"/> already soft-deleted and returns its id.</summary>
+    private Guid SeedTombstone<TEntity>(TEntity entity)
+        where TEntity : class, IV4TimeSeriesEntity, ISyncDedupable
+    {
+        entity.Id = Guid.CreateVersion7();
+        entity.TenantId = Tenant;
+        entity.Timestamp = T0;
+        entity.DataSource = DataSource;
+        entity.SyncIdentifier = SyncIdentifier;
+        entity.DeletedAt = DeletedOn;
+
+        using var ctx = NewContext();
+        ctx.Set<TEntity>().Add(entity);
+        ctx.SaveChanges();
+        return entity.Id;
+    }
+
+    /// <summary>
+    /// Asserts the re-upload inserted a fresh live row carrying <paramref name="reuploaded"/> and left
+    /// the tombstone deleted and carrying <paramref name="deletedValue"/>.
+    /// </summary>
+    private async Task AssertInsertedPastTombstoneAsync<TEntity>(
+        Guid tombstoneId, Func<TEntity, double> value, double deletedValue, double reuploaded)
+        where TEntity : class, IV4TimeSeriesEntity
+    {
+        await using var verify = NewContext();
+
+        var tombstone = await verify.Set<TEntity>().IgnoreQueryFilters().AsNoTracking()
+            .SingleAsync(e => e.Id == tombstoneId);
+        tombstone.DeletedAt.Should().Be(DeletedOn, "the delete the member made still stands");
+        value(tombstone).Should().Be(deletedValue, "the re-upload must not be written into the tombstone");
+
+        var live = await verify.Set<TEntity>().AsNoTracking().SingleAsync();
+        live.Id.Should().NotBe(tombstoneId);
+        value(live).Should().Be(reuploaded, "a filtered read returns the re-uploaded record");
+    }
+
+    [Fact]
+    public async Task BulkCreate_WhenTheKeyIsHeldByASoftDeletedRow_InsertsPastTheTombstone()
+    {
+        var tombstoneId = SeedTombstone(new BolusEntity { Insulin = 5.0 });
+        var broadcaster = new RecordingBroadcaster<Bolus>();
+        var repo = new BolusRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<BolusRepository>.Instance,
+            broadcaster);
+
+        var result = await repo.BulkCreateAsync(
+            [new Bolus { Timestamp = T0, DataSource = DataSource, SyncIdentifier = SyncIdentifier, Insulin = 9.0 }],
+            WriteOrigin.Live);
+
+        result.Should().HaveCount(1);
+        broadcaster.Created.Should().HaveCount(1);
+        broadcaster.Updated.Should().BeEmpty("nothing was upserted in place");
+        await AssertInsertedPastTombstoneAsync<BolusEntity>(
+            tombstoneId, e => e.Insulin, deletedValue: 5.0, reuploaded: 9.0);
+    }
+
+    [Fact]
+    public async Task BulkCreate_WhenAGlucoseKeyIsHeldByASoftDeletedRow_InsertsPastTheTombstone()
+    {
+        var tombstoneId = SeedTombstone(new SensorGlucoseEntity { Mgdl = 120 });
+        var broadcaster = new RecordingBroadcaster<SensorGlucose>();
+        var repo = new SensorGlucoseRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<SensorGlucoseRepository>.Instance,
+            broadcaster);
+
+        var result = await repo.BulkCreateAsync(
+            [new SensorGlucose { Timestamp = T0, DataSource = DataSource, SyncIdentifier = SyncIdentifier, Mgdl = 180 }],
+            WriteOrigin.Live);
+
+        result.Should().HaveCount(1);
+        broadcaster.Created.Should().HaveCount(1);
+        broadcaster.Updated.Should().BeEmpty("nothing was upserted in place");
+        await AssertInsertedPastTombstoneAsync<SensorGlucoseEntity>(
+            tombstoneId, e => e.Mgdl, deletedValue: 120, reuploaded: 180);
+    }
+
+    private sealed class RecordingBroadcaster<TModel> : IV4RecordBroadcaster<TModel>
+        where TModel : class
+    {
+        public List<TModel> Created { get; } = [];
+        public List<TModel> Updated { get; } = [];
+
+        public Task BroadcastCreatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
+        {
+            Created.AddRange(items);
+            return Task.CompletedTask;
+        }
+
+        public Task BroadcastUpdatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
+        {
+            Updated.AddRange(items);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
@@ -2,7 +2,6 @@ using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Core.Contracts.Audit;
-using Nocturne.Core.Contracts.Events;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Models.V4;
@@ -62,7 +61,7 @@ public class SyncUpsertTombstoneTests : IDisposable
 
     private NocturneDbContext NewContext() => new(_options) { TenantId = Tenant };
 
-    private Guid SeedTombstone<TEntity>(TEntity entity)
+    private Guid SeedTombstone<TEntity>(TEntity entity, bool deletedByUser)
         where TEntity : class, IV4TimeSeriesEntity, ISyncDedupable
     {
         entity.Id = Guid.CreateVersion7();
@@ -73,10 +72,18 @@ public class SyncUpsertTombstoneTests : IDisposable
         entity.DeletedAt = DeletedOn;
 
         using var ctx = NewContext();
-        ctx.Set<TEntity>().Add(entity);
+        var entry = ctx.Set<TEntity>().Add(entity);
+        entry.Property("DeletedByUser").CurrentValue = deletedByUser;
         ctx.SaveChanges();
         return entity.Id;
     }
+
+    private BolusRepository NewBolusRepository(RecordingV4RecordBroadcaster<Bolus> broadcaster) =>
+        new(new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<BolusRepository>.Instance,
+            broadcaster);
 
     private async Task AssertInsertedPastTombstoneAsync<TEntity>(
         Guid tombstoneId, Func<TEntity, double> value, double deletedValue, double reuploaded)
@@ -86,7 +93,7 @@ public class SyncUpsertTombstoneTests : IDisposable
 
         var tombstone = await verify.Set<TEntity>().IgnoreQueryFilters().AsNoTracking()
             .SingleAsync(e => e.Id == tombstoneId);
-        tombstone.DeletedAt.Should().Be(DeletedOn, "the delete the member made still stands");
+        tombstone.DeletedAt.Should().Be(DeletedOn, "the tombstone row is left untouched");
         value(tombstone).Should().Be(deletedValue, "the re-upload must not be written into the tombstone");
 
         var live = await verify.Set<TEntity>().AsNoTracking().SingleAsync();
@@ -94,19 +101,29 @@ public class SyncUpsertTombstoneTests : IDisposable
         value(live).Should().Be(reuploaded, "a filtered read returns the re-uploaded record");
     }
 
-    [Fact]
-    public async Task BulkCreate_WhenTheKeyIsHeldByASoftDeletedRow_InsertsPastTheTombstone()
+    private async Task AssertTombstoneStillHoldsTheKeyAsync<TEntity>(
+        Guid tombstoneId, Func<TEntity, double> value, double deletedValue)
+        where TEntity : class, IV4TimeSeriesEntity
     {
-        var tombstoneId = SeedTombstone(new BolusEntity { Insulin = 5.0 });
-        var broadcaster = new RecordingV4RecordBroadcaster<Bolus>();
-        var repo = new BolusRepository(
-            new TestTenantDbContextFactory(_context),
-            new Mock<IDeduplicationService>().Object,
-            new Mock<IAuditContext>().Object,
-            NullLogger<BolusRepository>.Instance,
-            broadcaster);
+        await using var verify = NewContext();
 
-        var result = await repo.BulkCreateAsync(
+        var row = (await verify.Set<TEntity>().IgnoreQueryFilters().AsNoTracking().ToListAsync())
+            .Should().ContainSingle("the re-upload was dropped, not inserted beside the tombstone").Subject;
+        row.Id.Should().Be(tombstoneId);
+        row.DeletedAt.Should().Be(DeletedOn, "the tombstone row is left untouched");
+        value(row).Should().Be(deletedValue, "the re-upload must not be written into the tombstone");
+
+        (await verify.Set<TEntity>().AsNoTracking().ToListAsync())
+            .Should().BeEmpty("the record the user deleted stays deleted");
+    }
+
+    [Fact]
+    public async Task BulkCreate_WhenASystemSweptTombstoneHoldsTheKey_InsertsPastIt()
+    {
+        var tombstoneId = SeedTombstone(new BolusEntity { Insulin = 5.0 }, deletedByUser: false);
+        var broadcaster = new RecordingV4RecordBroadcaster<Bolus>();
+
+        var result = await NewBolusRepository(broadcaster).BulkCreateAsync(
             [new Bolus { Timestamp = T0, DataSource = DataSource, SyncIdentifier = SyncIdentifier, Insulin = 9.0 }],
             WriteOrigin.Live);
 
@@ -118,9 +135,9 @@ public class SyncUpsertTombstoneTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkCreate_WhenAGlucoseKeyIsHeldByASoftDeletedRow_InsertsPastTheTombstone()
+    public async Task BulkCreate_WhenASystemSweptGlucoseTombstoneHoldsTheKey_InsertsPastIt()
     {
-        var tombstoneId = SeedTombstone(new SensorGlucoseEntity { Mgdl = 120 });
+        var tombstoneId = SeedTombstone(new SensorGlucoseEntity { Mgdl = 120 }, deletedByUser: false);
         var broadcaster = new RecordingV4RecordBroadcaster<SensorGlucose>();
         var repo = new SensorGlucoseRepository(
             new TestTenantDbContextFactory(_context),
@@ -140,4 +157,49 @@ public class SyncUpsertTombstoneTests : IDisposable
             tombstoneId, e => e.Mgdl, deletedValue: 120, reuploaded: 180);
     }
 
+    [Fact]
+    public async Task BulkCreate_WhenAUserDeletedTombstoneHoldsTheKey_DropsTheReupload()
+    {
+        var tombstoneId = SeedTombstone(new BolusEntity { Insulin = 5.0 }, deletedByUser: true);
+        var broadcaster = new RecordingV4RecordBroadcaster<Bolus>();
+
+        var result = await NewBolusRepository(broadcaster).BulkCreateAsync(
+            [new Bolus { Timestamp = T0, DataSource = DataSource, SyncIdentifier = SyncIdentifier, Insulin = 9.0 }],
+            WriteOrigin.Live);
+
+        result.Should().BeEmpty();
+        broadcaster.Created.Should().BeEmpty();
+        broadcaster.Updated.Should().BeEmpty();
+        await AssertTombstoneStillHoldsTheKeyAsync<BolusEntity>(
+            tombstoneId, e => e.Insulin, deletedValue: 5.0);
+    }
+
+    /// <remarks>
+    /// The connectors that mint a sync identifier per record reuse it as the legacy id, so the
+    /// legacy-id guard covers this one too — pinned so the sync key alone remains sufficient.
+    /// </remarks>
+    [Fact]
+    public async Task BulkCreate_WhenAUserDeletedTombstoneHoldsTheKeyRepeatedAsLegacyId_DropsTheReupload()
+    {
+        var tombstoneId = SeedTombstone(
+            new BolusEntity { Insulin = 5.0, LegacyId = SyncIdentifier }, deletedByUser: true);
+        var broadcaster = new RecordingV4RecordBroadcaster<Bolus>();
+
+        var result = await NewBolusRepository(broadcaster).BulkCreateAsync(
+            [new Bolus
+            {
+                Timestamp = T0,
+                DataSource = DataSource,
+                SyncIdentifier = SyncIdentifier,
+                LegacyId = SyncIdentifier,
+                Insulin = 9.0,
+            }],
+            WriteOrigin.Live);
+
+        result.Should().BeEmpty();
+        broadcaster.Created.Should().BeEmpty();
+        broadcaster.Updated.Should().BeEmpty();
+        await AssertTombstoneStillHoldsTheKeyAsync<BolusEntity>(
+            tombstoneId, e => e.Insulin, deletedValue: 5.0);
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
@@ -175,8 +175,8 @@ public class SyncUpsertTombstoneTests : IDisposable
     }
 
     /// <remarks>
-    /// The connectors that mint a sync identifier per record reuse it as the legacy id, so the
-    /// legacy-id guard covers this one too — pinned so the sync key alone remains sufficient.
+    /// The connectors that mint a sync identifier per record reuse it as the legacy id, so both
+    /// guards see this one; pinned so they never disagree.
     /// </remarks>
     [Fact]
     public async Task BulkCreate_WhenAUserDeletedTombstoneHoldsTheKeyRepeatedAsLegacyId_DropsTheReupload()
@@ -201,5 +201,27 @@ public class SyncUpsertTombstoneTests : IDisposable
         broadcaster.Updated.Should().BeEmpty();
         await AssertTombstoneStillHoldsTheKeyAsync<BolusEntity>(
             tombstoneId, e => e.Insulin, deletedValue: 5.0);
+    }
+
+    [Fact]
+    public async Task BulkCreate_WhenALiveRowAndAUserTombstoneShareTheKey_UpdatesTheLiveRow()
+    {
+        var tombstoneId = SeedTombstone(new BolusEntity { Insulin = 5.0 }, deletedByUser: true);
+        var broadcaster = new RecordingV4RecordBroadcaster<Bolus>();
+        var repository = NewBolusRepository(broadcaster);
+        var live = await repository.CreateAsync(
+            new Bolus { Timestamp = T0, DataSource = DataSource, SyncIdentifier = SyncIdentifier, Insulin = 7.0 },
+            WriteOrigin.Live);
+
+        var result = await repository.BulkCreateAsync(
+            [new Bolus { Timestamp = T0, DataSource = DataSource, SyncIdentifier = SyncIdentifier, Insulin = 9.0 }],
+            WriteOrigin.Live);
+
+        result.Should().ContainSingle().Which.Id.Should().Be(live.Id);
+        broadcaster.Created.Should().ContainSingle(b => b.Id == live.Id, "the single create broadcast once");
+        await using var verify = NewContext();
+        var rows = await verify.Boluses.IgnoreQueryFilters().AsNoTracking().ToListAsync();
+        rows.Single(b => b.Id == live.Id).Insulin.Should().Be(9.0);
+        rows.Single(b => b.Id == tombstoneId).Insulin.Should().Be(5.0, "the tombstone row is left untouched");
     }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
@@ -9,20 +9,14 @@ using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Repositories.V4;
 using Nocturne.Tests.Shared.Infrastructure;
+using Nocturne.Tests.Shared.Mocks;
 
 namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 
-/// <summary>
-/// The soft-delete guard on <c>SyncUpsertRepositoryBase.SplitUpsertsAsync</c>. A connector replaying
-/// its catch-up window re-uploads records the member has since deleted; the split must not match the
-/// tombstone, or the re-upload lands in a row no read returns and the record is lost while the sync
-/// reports success. Matches the single-record <c>CreateAsync</c> path, which reads through the query
-/// filter and inserts afresh.
-/// </summary>
 /// <remarks>
-/// Deliberately a unit test on SQLite rather than the in-memory provider: <c>EnsureCreated</c> builds
-/// the partial unique index filtered to <c>deleted_at IS NULL</c>, so the insert past the tombstone
-/// is only proven legal against a store that enforces it.
+/// SQLite rather than the in-memory provider: <c>EnsureCreated</c> builds the partial unique index
+/// filtered to <c>deleted_at IS NULL</c>, so the insert past the tombstone is proven legal against a
+/// store that enforces it.
 /// </remarks>
 [Trait("Category", "Unit")]
 [Trait("Category", "Repository")]
@@ -68,7 +62,6 @@ public class SyncUpsertTombstoneTests : IDisposable
 
     private NocturneDbContext NewContext() => new(_options) { TenantId = Tenant };
 
-    /// <summary>Persists <paramref name="entity"/> already soft-deleted and returns its id.</summary>
     private Guid SeedTombstone<TEntity>(TEntity entity)
         where TEntity : class, IV4TimeSeriesEntity, ISyncDedupable
     {
@@ -85,10 +78,6 @@ public class SyncUpsertTombstoneTests : IDisposable
         return entity.Id;
     }
 
-    /// <summary>
-    /// Asserts the re-upload inserted a fresh live row carrying <paramref name="reuploaded"/> and left
-    /// the tombstone deleted and carrying <paramref name="deletedValue"/>.
-    /// </summary>
     private async Task AssertInsertedPastTombstoneAsync<TEntity>(
         Guid tombstoneId, Func<TEntity, double> value, double deletedValue, double reuploaded)
         where TEntity : class, IV4TimeSeriesEntity
@@ -109,7 +98,7 @@ public class SyncUpsertTombstoneTests : IDisposable
     public async Task BulkCreate_WhenTheKeyIsHeldByASoftDeletedRow_InsertsPastTheTombstone()
     {
         var tombstoneId = SeedTombstone(new BolusEntity { Insulin = 5.0 });
-        var broadcaster = new RecordingBroadcaster<Bolus>();
+        var broadcaster = new RecordingV4RecordBroadcaster<Bolus>();
         var repo = new BolusRepository(
             new TestTenantDbContextFactory(_context),
             new Mock<IDeduplicationService>().Object,
@@ -132,7 +121,7 @@ public class SyncUpsertTombstoneTests : IDisposable
     public async Task BulkCreate_WhenAGlucoseKeyIsHeldByASoftDeletedRow_InsertsPastTheTombstone()
     {
         var tombstoneId = SeedTombstone(new SensorGlucoseEntity { Mgdl = 120 });
-        var broadcaster = new RecordingBroadcaster<SensorGlucose>();
+        var broadcaster = new RecordingV4RecordBroadcaster<SensorGlucose>();
         var repo = new SensorGlucoseRepository(
             new TestTenantDbContextFactory(_context),
             new Mock<IDeduplicationService>().Object,
@@ -151,22 +140,4 @@ public class SyncUpsertTombstoneTests : IDisposable
             tombstoneId, e => e.Mgdl, deletedValue: 120, reuploaded: 180);
     }
 
-    private sealed class RecordingBroadcaster<TModel> : IV4RecordBroadcaster<TModel>
-        where TModel : class
-    {
-        public List<TModel> Created { get; } = [];
-        public List<TModel> Updated { get; } = [];
-
-        public Task BroadcastCreatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
-        {
-            Created.AddRange(items);
-            return Task.CompletedTask;
-        }
-
-        public Task BroadcastUpdatedAsync(IReadOnlyList<TModel> items, CancellationToken ct = default)
-        {
-            Updated.AddRange(items);
-            return Task.CompletedTask;
-        }
-    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
@@ -219,6 +219,7 @@ public class SyncUpsertTombstoneTests : IDisposable
 
         result.Should().ContainSingle().Which.Id.Should().Be(live.Id);
         broadcaster.Created.Should().ContainSingle(b => b.Id == live.Id, "the single create broadcast once");
+        broadcaster.Updated.Should().ContainSingle(b => b.Id == live.Id);
         await using var verify = NewContext();
         var rows = await verify.Boluses.IgnoreQueryFilters().AsNoTracking().ToListAsync();
         rows.Single(b => b.Id == live.Id).Insulin.Should().Be(9.0);


### PR DESCRIPTION
Closes #1065.

`SyncUpsertRepositoryBase.SplitUpsertsAsync` lifted the query filter to restore tenant scoping and matched soft-deleted rows by `(DataSource, SyncIdentifier)`, so a connector re-uploading a record in a batch wrote the new values into the tombstone. The sync reported an update and the record stayed invisible.

## What changes

The split now reads existing rows through `WhereBlocksRecreation`, the rule the legacy-id key already follows (`V4RepositoryBase.BulkWriteAsync` → `GetBlockingLegacyIdsAsync`):

| Key held by | Batch re-upload now |
|---|---|
| a live row | updated in place (unchanged) |
| a user-deleted tombstone | dropped from the batch: not updated, not inserted, not broadcast |
| a system-swept tombstone, or no row | inserted afresh; the tombstone stays for audit continuity |

Affects the four `SyncUpsertRepositoryBase` subclasses: Bolus, CarbIntake, BasalInjection, SensorGlucose. The snapshot repositories keep their own guarded splits and are unaffected.

The blanket "insert past every tombstone" option was considered and rejected: it would have resurrected records a member deleted, while the same record keyed by `LegacyId` stayed deleted. So for the issue's own scenario (a member deletes a mis-logged bolus and the connector re-sends it) the outcome is **stays deleted**, not "visible again"; the data loss the issue describes was the write into the tombstone, which no longer happens for any tombstone.

Known and unchanged: the single-record `CreateAsync` path reads through the query filter and inserts past a user tombstone, for both keys (the legacy-id path has the same split today). Recorded on #1066 rather than changed here.

## Tests

`SyncUpsertTombstoneTests` (SQLite, so `EnsureCreated` builds the real `deleted_at IS NULL` partial index): system-swept tombstone inserts past it (Bolus, SensorGlucose); user-deleted tombstone drops the re-upload, with and without `LegacyId == SyncIdentifier`; a live row sharing the key with a user tombstone is the one updated. Mutation-checked: reverting the guard to `DeletedAt == null` fails the user-tombstone test; reverting to the original unguarded query fails both insert-past tests; dropping the live-row preference fails the shared-key test.

Three private `RecordingBroadcaster` test doubles are replaced by one `RecordingV4RecordBroadcaster<TModel>` in `Nocturne.Tests.Shared`.

`Nocturne.Infrastructure.Data.Tests`: 731 passed, 0 failed.

https://claude.ai/code/session_01DoFQ3xHL2WEamV1WUSyGAK
