### PR TITLE
refactor(api): delete the dead statistics surface and share the risk-index core

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -681,46 +681,6 @@ public class StatisticsController : ControllerBase
     }
 
     /// <summary>
-    /// Format insulin value for display
-    /// </summary>
-    /// <param name="value">Insulin value</param>
-    /// <returns>Formatted insulin string</returns>
-    [HttpGet("format/insulin/{value:double}")]
-    [RequireScope(Scope.ReportsRead)]
-    public ActionResult<string> FormatInsulinDisplay(double value)
-    {
-        try
-        {
-            var result = _statisticsService.FormatInsulinDisplay(value);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
-    }
-
-    /// <summary>
-    /// Format carb value for display
-    /// </summary>
-    /// <param name="value">Carb value</param>
-    /// <returns>Formatted carb string</returns>
-    [HttpGet("format/carb/{value:double}")]
-    [RequireScope(Scope.ReportsRead)]
-    public ActionResult<string> FormatCarbDisplay(double value)
-    {
-        try
-        {
-            var result = _statisticsService.FormatCarbDisplay(value);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
-    }
-
-    /// <summary>
     /// Validate treatment data for completeness and consistency
     /// </summary>
     /// <param name="treatment">Treatment to validate</param>

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Nocturne.API.Services.Profiles.Resolvers;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Analytics;
@@ -18,6 +17,12 @@ namespace Nocturne.API.Services.Analytics;
 /// <seealso cref="Treatment"/>
 public class StatisticsService : IStatisticsService
 {
+    /// <summary>
+    /// The divisor the Kovatchev risk transform is published with. It is 18 exactly, not the
+    /// mg/dL-per-mmol/L conversion factor in <see cref="GlucoseConstants.MgdlPerMmol"/>.
+    /// </summary>
+    private const double KovatchevMgdlPerMmol = 18.0;
+
     private static readonly string[] BolusTreatmentTypes = new[]
     {
         "Meal Bolus",
@@ -945,7 +950,7 @@ public class StatisticsService : IStatisticsService
     /// <param name="values">Collection of glucose values</param>
     /// <param name="hours">Number of hours for the window</param>
     /// <returns>CONGA value, or 0 if insufficient data</returns>
-    public double CalculateCONGA(IEnumerable<double> values, int hours = 2)
+    private double CalculateCONGA(IEnumerable<double> values, int hours = 2)
     {
         var valuesList = values.ToList();
         const int interval = 5; // 5-minute intervals
@@ -986,7 +991,7 @@ public class StatisticsService : IStatisticsService
     /// </summary>
     /// <param name="entries">Collection of glucose entries with timestamps</param>
     /// <returns>Lability Index value</returns>
-    public double CalculateLabilityIndex(IEnumerable<SensorGlucose> entries)
+    private double CalculateLabilityIndex(IEnumerable<SensorGlucose> entries)
     {
         var entriesList = entries.ToList();
         if (entriesList.Count < 2)
@@ -1029,28 +1034,8 @@ public class StatisticsService : IStatisticsService
     /// </summary>
     /// <param name="values">Collection of glucose values</param>
     /// <returns>HBGI value</returns>
-    public double CalculateHBGI(IEnumerable<double> values)
-    {
-        var valuesList = values.ToList();
-        if (!valuesList.Any())
-            throw new ArgumentException(
-                "Not enough data points to calculate HBGI.",
-                nameof(values)
-            );
-
-        var riskSum = valuesList.Sum(glucose =>
-        {
-            // Kovatchev formula: f(BG) = 1.084 * (ln(BG/18)^1.084 - 1.928)
-            var bgInMmol = glucose / 18;
-            var logBG = Math.Log(bgInMmol);
-            var fBG = 1.084 * (Math.Pow(logBG, 1.084) - 1.928);
-
-            var risk = fBG > 0 ? 10 * Math.Pow(fBG, 2) : 0;
-            return risk;
-        });
-
-        return riskSum / valuesList.Count;
-    }
+    public double CalculateHBGI(IEnumerable<double> values) =>
+        KovatchevRisk(values, keepPositive: true, "HBGI");
 
     /// <summary>
     /// Calculate LBGI (Low Blood Glucose Index)
@@ -1059,24 +1044,37 @@ public class StatisticsService : IStatisticsService
     /// </summary>
     /// <param name="values">Collection of glucose values</param>
     /// <returns>LBGI value</returns>
-    public double CalculateLBGI(IEnumerable<double> values)
+    public double CalculateLBGI(IEnumerable<double> values) =>
+        KovatchevRisk(values, keepPositive: false, "LBGI");
+
+    /// <summary>
+    /// Mean of the Kovatchev risk transform <c>f(BG) = 1.084 * (ln(BG/18)^1.084 - 1.928)</c> over
+    /// <paramref name="values"/>, counting only the readings whose <c>f(BG)</c> falls on one side
+    /// of zero: the hyperglycaemic side when <paramref name="keepPositive"/>, the hypoglycaemic
+    /// side otherwise. <paramref name="indexName"/> names the index in the empty-input message.
+    /// </summary>
+    /// <seealso cref="KovatchevMgdlPerMmol"/>
+    private static double KovatchevRisk(
+        IEnumerable<double> values,
+        bool keepPositive,
+        string indexName
+    )
     {
         var valuesList = values.ToList();
         if (!valuesList.Any())
             throw new ArgumentException(
-                "Not enough data points to calculate LBGI.",
+                $"Not enough data points to calculate {indexName}.",
                 nameof(values)
             );
 
         var riskSum = valuesList.Sum(glucose =>
         {
-            // Kovatchev formula: f(BG) = 1.084 * (ln(BG/18)^1.084 - 1.928)
-            var bgInMmol = glucose / 18;
+            var bgInMmol = glucose / KovatchevMgdlPerMmol;
             var logBG = Math.Log(bgInMmol);
             var fBG = 1.084 * (Math.Pow(logBG, 1.084) - 1.928);
 
-            var risk = fBG < 0 ? 10 * Math.Pow(fBG, 2) : 0;
-            return risk;
+            var onSide = keepPositive ? fBG > 0 : fBG < 0;
+            return onSide ? 10 * Math.Pow(fBG, 2) : 0;
         });
 
         return riskSum / valuesList.Count;
@@ -1090,7 +1088,7 @@ public class StatisticsService : IStatisticsService
     /// <param name="values">Collection of glucose values</param>
     /// <param name="entries">Collection of glucose entries with timestamps</param>
     /// <returns>GVI value</returns>
-    public double CalculateGVI(IEnumerable<double> values, IEnumerable<SensorGlucose> entries)
+    private double CalculateGVI(IEnumerable<double> values, IEnumerable<SensorGlucose> entries)
     {
         var valuesList = values.ToList();
         var entriesList = entries.ToList();
@@ -1246,17 +1244,6 @@ public class StatisticsService : IStatisticsService
         thresholds ??= new GlycemicThresholds();
 
         var entriesList = entries.Where(e => e.Mgdl > 0).OrderBy(e => e.Mills).ToList();
-
-        if (!entriesList.Any())
-        {
-            return new TimeInRangeMetrics
-            {
-                Percentages = new TimeInRangePercentages(),
-                Durations = new TimeInRangeDurations(),
-                Episodes = new TimeInRangeEpisodes(),
-                RangeStats = new TimeInRangeDetailedStats(),
-            };
-        }
 
         var glucoseValues = ExtractGlucoseValues(entriesList).ToList();
         var totalReadings = glucoseValues.Count;
@@ -1485,7 +1472,7 @@ public class StatisticsService : IStatisticsService
     /// <param name="glucoseValues">Collection of glucose values</param>
     /// <param name="bins">Distribution bins (optional, uses defaults if not provided)</param>
     /// <returns>Collection of distribution data points</returns>
-    public IEnumerable<DistributionDataPoint> CalculateGlucoseDistributionFromValues(
+    private IEnumerable<DistributionDataPoint> CalculateGlucoseDistributionFromValues(
         IEnumerable<double> glucoseValues,
         IEnumerable<DistributionBin>? bins = null
     )
@@ -2083,18 +2070,20 @@ public class StatisticsService : IStatisticsService
         var bolusList = boluses.ToList();
         var dailyData = new Dictionary<string, (double Basal, double Bolus)>();
 
+        void Accumulate(long mills, double basal, double bolus)
+        {
+            var dateKey = MillsToLocalDateString(mills, tz);
+            dailyData.TryGetValue(dateKey, out var current);
+            dailyData[dateKey] = (current.Basal + basal, current.Bolus + bolus);
+        }
+
         // Process boluses (all Bolus records are bolus insulin)
         foreach (var bolus in bolusList)
         {
             if (bolus.Insulin <= 0 || bolus.Mills <= 0)
                 continue;
 
-            var dateKey = MillsToLocalDateString(bolus.Mills, tz);
-            if (!dailyData.ContainsKey(dateKey))
-                dailyData[dateKey] = (0, 0);
-
-            var (currentBasal, currentBolus) = dailyData[dateKey];
-            dailyData[dateKey] = (currentBasal, currentBolus + bolus.Insulin);
+            Accumulate(bolus.Mills, 0, bolus.Insulin);
         }
 
         // Process TempBasals — clip overlapping records (loop systems write every ~5 min with longer declared duration)
@@ -2104,12 +2093,7 @@ public class StatisticsService : IStatisticsService
             if (basalInsulin <= 0)
                 continue;
 
-            var dateKey = MillsToLocalDateString(tb.StartMills, tz);
-            if (!dailyData.ContainsKey(dateKey))
-                dailyData[dateKey] = (0, 0);
-
-            var (currentBasal, currentBolus) = dailyData[dateKey];
-            dailyData[dateKey] = (currentBasal + basalInsulin, currentBolus);
+            Accumulate(tb.StartMills, basalInsulin, 0);
         }
 
         // Process algorithm boluses (basal side)
@@ -2118,12 +2102,7 @@ public class StatisticsService : IStatisticsService
             if (ab.Insulin <= 0 || ab.Mills <= 0)
                 continue;
 
-            var dateKey = MillsToLocalDateString(ab.Mills, tz);
-            if (!dailyData.ContainsKey(dateKey))
-                dailyData[dateKey] = (0, 0);
-
-            var (currentBasal, currentBolus) = dailyData[dateKey];
-            dailyData[dateKey] = (currentBasal + ab.Insulin, currentBolus);
+            Accumulate(ab.Mills, ab.Insulin, 0);
         }
 
         // Process basal injections (MDI long-acting insulin — treated as basal)
@@ -2134,12 +2113,7 @@ public class StatisticsService : IStatisticsService
                 if (bi.Units <= 0)
                     continue;
 
-                var dateKey = MillsToLocalDateString(bi.Mills, tz);
-                if (!dailyData.ContainsKey(dateKey))
-                    dailyData[dateKey] = (0, 0);
-
-                var (currentBasal, currentBolus) = dailyData[dateKey];
-                dailyData[dateKey] = (currentBasal + bi.Units, currentBolus);
+                Accumulate(bi.Mills, bi.Units, 0);
             }
         }
 
@@ -2514,54 +2488,6 @@ public class StatisticsService : IStatisticsService
     #endregion
 
     #region Formatting Utilities
-
-    /// <summary>
-    /// Format insulin values for display with appropriate precision
-    /// Uses "shifted" display format where values like 0.05 display as ".05"
-    /// </summary>
-    /// <param name="value">Insulin value</param>
-    /// <returns>Formatted insulin string</returns>
-    public string FormatInsulinDisplay(double value)
-    {
-        if (value == 0)
-        {
-            return "0";
-        }
-
-        var formattedValue = value.ToString("F2");
-
-        // Apply shift formatting - remove leading zero for values less than 1
-        if (value < 1 && value > 0)
-        {
-            formattedValue = Regex.Replace(formattedValue, "^0", "");
-        }
-
-        return formattedValue;
-    }
-
-    /// <summary>
-    /// Format carb values for display with appropriate precision
-    /// Uses "shifted" display format where values like 0.5 display as ".5"
-    /// </summary>
-    /// <param name="value">Carb value</param>
-    /// <returns>Formatted carb string</returns>
-    public string FormatCarbDisplay(double value)
-    {
-        if (value == 0)
-        {
-            return "0";
-        }
-
-        var formattedValue = value.ToString("F1");
-
-        // Apply shift formatting - remove leading zero for values less than 1
-        if (value < 1 && value > 0)
-        {
-            formattedValue = Regex.Replace(formattedValue, "^0", "");
-        }
-
-        return formattedValue;
-    }
 
     /// <summary>
     /// Format percentage values for display
@@ -2997,11 +2923,6 @@ public class StatisticsService : IStatisticsService
         result.HasSufficientData =
             dataPoints.Count >= 10 && beforeValues.Count >= 50 && afterValues.Count >= 50;
 
-        if (!result.HasSufficientData)
-        {
-            // Insufficient data flag already set
-        }
-
         // Calculate summary statistics
         if (beforeValues.Count > 0 && afterValues.Count > 0)
         {
@@ -3015,11 +2936,15 @@ public class StatisticsService : IStatisticsService
                 (double)afterValues.Count(v => v >= GlucoseConstants.TargetBottomMgdl && v <= GlucoseConstants.TargetTopMgdl) / afterValues.Count * 100;
 
             // Calculate CV (coefficient of variation)
-            var stdDevBefore = Math.Sqrt(
-                beforeValues.Sum(v => Math.Pow(v - avgBefore, 2)) / beforeValues.Count
+            var stdDevBefore = GlucoseStatistics.StandardDeviation(
+                beforeValues,
+                avgBefore,
+                VarianceMode.Population
             );
-            var stdDevAfter = Math.Sqrt(
-                afterValues.Sum(v => Math.Pow(v - avgAfter, 2)) / afterValues.Count
+            var stdDevAfter = GlucoseStatistics.StandardDeviation(
+                afterValues,
+                avgAfter,
+                VarianceMode.Population
             );
             var cvBefore = avgBefore > 0 ? (stdDevBefore / avgBefore) * 100 : 0;
             var cvAfter = avgAfter > 0 ? (stdDevAfter / avgAfter) * 100 : 0;

--- a/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
@@ -127,27 +127,11 @@ public interface IStatisticsService
     double CalculateMAGE(IEnumerable<double> values);
 
     /// <summary>
-    /// Calculate Continuous Overall Net Glycemic Action (CONGA).
-    /// </summary>
-    /// <param name="values">Glucose values in mg/dL at regular intervals.</param>
-    /// <param name="hours">CONGA window in hours (default 2).</param>
-    /// <returns>CONGA value.</returns>
-    double CalculateCONGA(IEnumerable<double> values, int hours = 2);
-
-    /// <summary>
     /// Calculate Average Daily Risk Range (ADRR).
     /// </summary>
     /// <param name="values">Glucose values in mg/dL.</param>
     /// <returns>ADRR value.</returns>
     double CalculateADRR(IEnumerable<double> values);
-
-    /// <summary>
-    /// Calculate the Lability Index from timestamped glucose entries.
-    /// </summary>
-    /// <param name="entries"><see cref="SensorGlucose"/> entries.</param>
-    /// <returns>Lability Index value.</returns>
-    /// <exception cref="ArgumentException">Thrown when there are fewer than 2 entries.</exception>
-    double CalculateLabilityIndex(IEnumerable<SensorGlucose> entries);
 
     /// <summary>
     /// Calculate the J-Index (combines mean and variability).
@@ -172,15 +156,6 @@ public interface IStatisticsService
     /// <returns>LBGI value.</returns>
     /// <exception cref="ArgumentException">Thrown when the values collection is empty.</exception>
     double CalculateLBGI(IEnumerable<double> values);
-
-    /// <summary>
-    /// Calculate Glycemic Variability Index (GVI).
-    /// </summary>
-    /// <param name="values">Glucose values in mg/dL.</param>
-    /// <param name="entries"><see cref="SensorGlucose"/> entries with timestamps.</param>
-    /// <returns>GVI value (1.0 = perfectly stable).</returns>
-    /// <exception cref="ArgumentException">Thrown when there are fewer than 2 values or entries.</exception>
-    double CalculateGVI(IEnumerable<double> values, IEnumerable<SensorGlucose> entries);
 
     /// <summary>
     /// Calculate Patient Glycemic Status (PGS) composite score.
@@ -233,24 +208,6 @@ public interface IStatisticsService
     );
 
     /// <summary>
-    /// Calculate glucose distribution across bins from raw glucose values.
-    /// </summary>
-    /// <param name="glucoseValues">Glucose values in mg/dL.</param>
-    /// <param name="bins">Optional custom distribution bins. Uses default bins if <c>null</c>.</param>
-    /// <returns>Distribution data points for histogram rendering.</returns>
-    IEnumerable<DistributionDataPoint> CalculateGlucoseDistributionFromValues(
-        IEnumerable<double> glucoseValues,
-        IEnumerable<DistributionBin>? bins = null
-    );
-
-    /// <summary>
-    /// Calculate estimated HbA1c as a formatted string from glucose values.
-    /// </summary>
-    /// <param name="values">Glucose values in mg/dL.</param>
-    /// <returns>Formatted estimated HbA1c string (e.g., "6.5%").</returns>
-    string CalculateEstimatedHbA1C(IEnumerable<double> values);
-
-    /// <summary>
     /// Calculate averaged statistics bucketed by time of day from <see cref="SensorGlucose"/> entries.
     /// </summary>
     /// <param name="entries"><see cref="SensorGlucose"/> entries.</param>
@@ -290,13 +247,6 @@ public interface IStatisticsService
     double GetBolusPercentage(TreatmentSummary treatmentSummary);
 
     /// <summary>
-    /// Get basal insulin as a percentage of total daily insulin.
-    /// </summary>
-    /// <param name="treatmentSummary">Treatment summary to read from.</param>
-    /// <returns>Basal percentage (0-100).</returns>
-    double GetBasalPercentage(TreatmentSummary treatmentSummary);
-
-    /// <summary>
     /// Calculate comprehensive insulin delivery statistics.
     /// Basal data comes from TempBasals, algorithmBoluses, and basalInjections (MDI); pass empty collections if none are available.
     /// </summary>
@@ -309,29 +259,6 @@ public interface IStatisticsService
         DateTime endDate,
         IEnumerable<BasalInjection>? basalInjections = null
     );
-
-    // Formatting Utilities
-
-    /// <summary>Format an insulin value for display (e.g., "1.25U").</summary>
-    /// <param name="value">Insulin value in units.</param>
-    /// <returns>Formatted display string.</returns>
-    string FormatInsulinDisplay(double value);
-
-    /// <summary>Format a carb value for display (e.g., "45g").</summary>
-    /// <param name="value">Carb value in grams.</param>
-    /// <returns>Formatted display string.</returns>
-    string FormatCarbDisplay(double value);
-
-    /// <summary>Format a percentage value for display.</summary>
-    /// <param name="value">Percentage value (0-100).</param>
-    /// <returns>Formatted display string.</returns>
-    string FormatPercentageDisplay(double value);
-
-    /// <summary>Round an insulin value to pump delivery precision.</summary>
-    /// <param name="value">Insulin value in units.</param>
-    /// <param name="step">Pump step size in units (default 0.05).</param>
-    /// <returns>Rounded insulin value.</returns>
-    double RoundInsulinToPumpPrecision(double value, double step = 0.05);
 
     // Validation
 
@@ -356,11 +283,6 @@ public interface IStatisticsService
     /// <param name="mmol">Glucose value in mmol/L.</param>
     /// <returns>Glucose value in mg/dL.</returns>
     double MmolToMGDL(double mmol);
-
-    /// <summary>Convert a glucose value from mg/dL to a formatted mmol/L string.</summary>
-    /// <param name="mgdl">Glucose value in mg/dL.</param>
-    /// <returns>Formatted mmol/L string.</returns>
-    string MgdlToMMOLString(double mgdl);
 
     // Comprehensive Analytics
     GlucoseAnalytics AnalyzeGlucoseData(

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models.V4;
 
@@ -436,17 +435,6 @@ public class DistributionBin
     /// Maximum value for this bin
     /// </summary>
     public double Max { get; set; }
-}
-
-/// <summary>
-/// Averaged statistics for a specific hour
-/// </summary>
-public class HourlyAveragedStats : BasicGlucoseStats
-{
-    /// <summary>
-    /// Hour of the day (0-23)
-    /// </summary>
-    public int Hour { get; set; }
 }
 
 /// <summary>
@@ -1167,192 +1155,6 @@ public class PeriodMetrics
 }
 
 /// <summary>
-/// Analysis of glucose patterns by time of day
-/// </summary>
-public class TimeOfDayAnalysis
-{
-    /// <summary>Overnight period metrics (12:00 AM - 6:00 AM)</summary>
-    public PeriodMetrics Overnight { get; set; } =
-        new()
-        {
-            PeriodName = "Overnight",
-            StartHour = 0,
-            EndHour = 6,
-        };
-
-    /// <summary>Morning period metrics (6:00 AM - 12:00 PM)</summary>
-    public PeriodMetrics Morning { get; set; } =
-        new()
-        {
-            PeriodName = "Morning",
-            StartHour = 6,
-            EndHour = 12,
-        };
-
-    /// <summary>Afternoon period metrics (12:00 PM - 6:00 PM)</summary>
-    public PeriodMetrics Afternoon { get; set; } =
-        new()
-        {
-            PeriodName = "Afternoon",
-            StartHour = 12,
-            EndHour = 18,
-        };
-
-    /// <summary>Evening period metrics (6:00 PM - 12:00 AM)</summary>
-    public PeriodMetrics Evening { get; set; } =
-        new()
-        {
-            PeriodName = "Evening",
-            StartHour = 18,
-            EndHour = 24,
-        };
-
-    /// <summary>Dawn phenomenon detected (rising glucose 3-6 AM)</summary>
-    public bool DawnPhenomenonDetected { get; set; }
-
-    /// <summary>Magnitude of dawn phenomenon rise (mg/dL)</summary>
-    public double DawnPhenomenonMagnitude { get; set; }
-
-    /// <summary>Period with highest variability</summary>
-    public string HighestVariabilityPeriod { get; set; } = string.Empty;
-
-    /// <summary>Period with lowest time in range</summary>
-    public string LowestTIRPeriod { get; set; } = string.Empty;
-
-    /// <summary>Period with most hypoglycemia events</summary>
-    public string MostHypoglycemiaPeriod { get; set; } = string.Empty;
-}
-
-/// <summary>
-/// Day-specific metrics for day-of-week analysis
-/// </summary>
-public class DayMetrics : PeriodMetrics
-{
-    /// <summary>Day of week (0 = Sunday, 6 = Saturday)</summary>
-    public DayOfWeek DayOfWeek { get; set; }
-}
-
-/// <summary>
-/// Analysis of glucose patterns by day of week
-/// </summary>
-public class DayOfWeekAnalysis
-{
-    /// <summary>Metrics for each day of the week</summary>
-    public Dictionary<DayOfWeek, DayMetrics> DayMetrics { get; set; } = new();
-
-    /// <summary>Average weekday metrics (Monday-Friday)</summary>
-    public PeriodMetrics WeekdayAverage { get; set; } = new() { PeriodName = "Weekday Average" };
-
-    /// <summary>Average weekend metrics (Saturday-Sunday)</summary>
-    public PeriodMetrics WeekendAverage { get; set; } = new() { PeriodName = "Weekend Average" };
-
-    /// <summary>Day with highest variability</summary>
-    public DayOfWeek? HighestVariabilityDay { get; set; }
-
-    /// <summary>Day with lowest time in range</summary>
-    public DayOfWeek? LowestTIRDay { get; set; }
-
-    /// <summary>Significant difference between weekday and weekend patterns</summary>
-    public bool WeekdayWeekendDifference { get; set; }
-
-    /// <summary>Description of weekday vs weekend pattern</summary>
-    public string PatternDescription { get; set; } = string.Empty;
-}
-
-/// <summary>
-/// Individual hypoglycemia episode details
-/// </summary>
-public class HypoglycemiaEpisode
-{
-    /// <summary>Start time of the episode (Unix milliseconds)</summary>
-    public long StartTime { get; set; }
-
-    /// <summary>End time of the episode (Unix milliseconds)</summary>
-    public long EndTime { get; set; }
-
-    /// <summary>Duration of the episode in minutes</summary>
-    public double DurationMinutes { get; set; }
-
-    /// <summary>Lowest glucose value during the episode (mg/dL)</summary>
-    public double NadirValue { get; set; }
-
-    /// <summary>Time of nadir (Unix milliseconds)</summary>
-    public long NadirTime { get; set; }
-
-    /// <summary>Whether this was a severe episode (&lt;54 mg/dL)</summary>
-    public bool IsSevere { get; set; }
-
-    /// <summary>Hour of day when episode started (0-23)</summary>
-    public int HourOfDay { get; set; }
-
-    /// <summary>Day of week when episode occurred</summary>
-    public DayOfWeek DayOfWeek { get; set; }
-
-    /// <summary>Time to recover to >70 mg/dL in minutes</summary>
-    public double RecoveryTimeMinutes { get; set; }
-
-    /// <summary>Glucose value before the episode (mg/dL, if available)</summary>
-    public double? PreEpisodeGlucose { get; set; }
-}
-
-/// <summary>
-/// Comprehensive hypoglycemia analysis
-/// </summary>
-public class HypoglycemiaAnalysis
-{
-    /// <summary>Total number of hypoglycemia episodes (&lt;70 mg/dL)</summary>
-    public int TotalEpisodes { get; set; }
-
-    /// <summary>Number of severe hypoglycemia episodes (&lt;54 mg/dL)</summary>
-    public int SevereEpisodes { get; set; }
-
-    /// <summary>Average episodes per day</summary>
-    public double EpisodesPerDay { get; set; }
-
-    /// <summary>Average duration of episodes in minutes</summary>
-    public double AverageDurationMinutes { get; set; }
-
-    /// <summary>Average nadir (lowest) glucose during episodes</summary>
-    public double AverageNadir { get; set; }
-
-    /// <summary>Lowest glucose recorded</summary>
-    public double LowestGlucose { get; set; }
-
-    /// <summary>Average time to recover above 70 mg/dL</summary>
-    public double AverageRecoveryTimeMinutes { get; set; }
-
-    /// <summary>Time of day distribution of episodes (hour -> count)</summary>
-    public Dictionary<int, int> HourlyDistribution { get; set; } = new();
-
-    /// <summary>Day of week distribution of episodes</summary>
-    public Dictionary<DayOfWeek, int> DayOfWeekDistribution { get; set; } = new();
-
-    /// <summary>Most common hour for hypoglycemia</summary>
-    public int? PeakHour { get; set; }
-
-    /// <summary>Most common day for hypoglycemia</summary>
-    public DayOfWeek? PeakDay { get; set; }
-
-    /// <summary>Whether there's a recurring pattern</summary>
-    public bool HasRecurringPattern { get; set; }
-
-    /// <summary>Description of the recurring pattern if detected</summary>
-    public string PatternDescription { get; set; } = string.Empty;
-
-    /// <summary>List of individual episodes</summary>
-    public List<HypoglycemiaEpisode> Episodes { get; set; } = new();
-
-    /// <summary>Nocturnal hypoglycemia episodes (12 AM - 6 AM)</summary>
-    public int NocturnalEpisodes { get; set; }
-
-    /// <summary>Percentage of total hypos that are nocturnal</summary>
-    public double NocturnalPercentage { get; set; }
-
-    /// <summary>Clinical risk assessment</summary>
-    public string RiskAssessment { get; set; } = string.Empty;
-}
-
-/// <summary>
 /// Individual hyperglycemia episode details
 /// </summary>
 public class HyperglycemiaEpisode
@@ -1449,27 +1251,6 @@ public class HyperglycemiaAnalysis
 }
 
 /// <summary>
-/// Trend direction indicator
-/// </summary>
-public enum TrendDirection
-{
-    /// <summary>Significant improvement</summary>
-    Improving,
-
-    /// <summary>Slight improvement</summary>
-    SlightlyImproving,
-
-    /// <summary>No significant change</summary>
-    Stable,
-
-    /// <summary>Slight decline</summary>
-    SlightlyDeclining,
-
-    /// <summary>Significant decline</summary>
-    Declining,
-}
-
-/// <summary>
 /// Reliability metadata for a statistics analysis block.
 /// Provides raw facts so the frontend can compose a plain-English message
 /// when the data doesn't meet clinical reliability criteria.
@@ -1487,60 +1268,6 @@ public class StatisticReliability
 
     /// <summary>Number of glucose readings used in this analysis</summary>
     public int ReadingCount { get; set; }
-}
-
-/// <summary>
-/// Comparison between two time periods
-/// </summary>
-public class TrendComparison
-{
-    /// <summary>Current period analytics</summary>
-    public GlucoseAnalytics CurrentPeriod { get; set; } = new();
-
-    /// <summary>Previous period analytics</summary>
-    public GlucoseAnalytics PreviousPeriod { get; set; } = new();
-
-    /// <summary>Change in GMI (current - previous)</summary>
-    public double GMIDelta { get; set; }
-
-    /// <summary>Change in time in range (current - previous)</summary>
-    public double TIRDelta { get; set; }
-
-    /// <summary>Change in time below range (current - previous)</summary>
-    public double TBRDelta { get; set; }
-
-    /// <summary>Change in time above range (current - previous)</summary>
-    public double TARDelta { get; set; }
-
-    /// <summary>Change in coefficient of variation (current - previous)</summary>
-    public double CVDelta { get; set; }
-
-    /// <summary>Change in GRI score (current - previous)</summary>
-    public double GRIDelta { get; set; }
-
-    /// <summary>Overall trend direction for GMI</summary>
-    public TrendDirection GMITrend { get; set; }
-
-    /// <summary>Overall trend direction for TIR</summary>
-    public TrendDirection TIRTrend { get; set; }
-
-    /// <summary>Overall trend direction for TBR (improvement = decreasing)</summary>
-    public TrendDirection TBRTrend { get; set; }
-
-    /// <summary>Overall trend direction for CV</summary>
-    public TrendDirection CVTrend { get; set; }
-
-    /// <summary>Overall trend direction for GRI (improvement = decreasing)</summary>
-    public TrendDirection GRITrend { get; set; }
-
-    /// <summary>Number of days in current period with TIR >70%</summary>
-    public int DaysInRangeCurrent { get; set; }
-
-    /// <summary>Number of days in previous period with TIR >70%</summary>
-    public int DaysInRangePrevious { get; set; }
-
-    /// <summary>Summary interpretation of overall trend</summary>
-    public string TrendSummary { get; set; } = string.Empty;
 }
 
 /// <summary>
@@ -1698,15 +1425,6 @@ public class ExtendedGlucoseAnalytics : GlucoseAnalytics
     /// <summary>Glycemic Risk Index (composite risk score)</summary>
     public GlycemicRiskIndex GRI { get; set; } = new();
 
-    /// <summary>Time-of-day pattern analysis</summary>
-    public TimeOfDayAnalysis TimeOfDayPatterns { get; set; } = new();
-
-    /// <summary>Day-of-week pattern analysis</summary>
-    public DayOfWeekAnalysis DayOfWeekPatterns { get; set; } = new();
-
-    /// <summary>Hypoglycemia event analysis</summary>
-    public HypoglycemiaAnalysis HypoglycemiaAnalysis { get; set; } = new();
-
     /// <summary>Hyperglycemia event analysis</summary>
     public HyperglycemiaAnalysis HyperglycemiaAnalysis { get; set; } = new();
 
@@ -1735,7 +1453,6 @@ public class ReportAnalysisResult
     public IEnumerable<AveragedStats> AveragedStats { get; set; } = [];
 
     /// <summary>Registered devices that contributed readings within the requested window, for device-picker UIs.</summary>
-    [JsonPropertyName("contributingDevices")]
     public List<ContributingDevice> ContributingDevices { get; set; } = new();
 
     /// <summary>
@@ -1777,15 +1494,12 @@ public class PersonalRangeTimeInRange
 public sealed class ContributingDevice
 {
     /// <summary>The registered <see cref="PatientDevice"/> id, or <c>null</c> for the unattributed bucket.</summary>
-    [JsonPropertyName("patientDeviceId")]
     public Guid? PatientDeviceId { get; set; }
 
     /// <summary>Display name of the device, or "Unattributed" for readings with no <see cref="PatientDeviceId"/>.</summary>
-    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>Number of readings attributed to this device within the requested window.</summary>
-    [JsonPropertyName("readingCount")]
     public int ReadingCount { get; set; }
 }
 
@@ -1796,39 +1510,30 @@ public sealed class ContributingDevice
 public class SiteChangeImpactDataPoint
 {
     /// <summary>Minutes from site change (negative = before, positive = after)</summary>
-    [JsonPropertyName("minutesFromChange")]
     public int MinutesFromChange { get; set; }
 
     /// <summary>Average glucose at this time offset (mg/dL)</summary>
-    [JsonPropertyName("averageGlucose")]
     public double AverageGlucose { get; set; }
 
     /// <summary>Median glucose at this time offset (mg/dL)</summary>
-    [JsonPropertyName("medianGlucose")]
     public double MedianGlucose { get; set; }
 
     /// <summary>Standard deviation of glucose values</summary>
-    [JsonPropertyName("stdDev")]
     public double StdDev { get; set; }
 
     /// <summary>Number of readings contributing to this data point</summary>
-    [JsonPropertyName("count")]
     public int Count { get; set; }
 
     /// <summary>10th percentile glucose value (mg/dL)</summary>
-    [JsonPropertyName("percentile10")]
     public double Percentile10 { get; set; }
 
     /// <summary>25th percentile glucose value (mg/dL)</summary>
-    [JsonPropertyName("percentile25")]
     public double Percentile25 { get; set; }
 
     /// <summary>75th percentile glucose value (mg/dL)</summary>
-    [JsonPropertyName("percentile75")]
     public double Percentile75 { get; set; }
 
     /// <summary>90th percentile glucose value (mg/dL)</summary>
-    [JsonPropertyName("percentile90")]
     public double Percentile90 { get; set; }
 }
 
@@ -1838,31 +1543,24 @@ public class SiteChangeImpactDataPoint
 public class SiteChangeImpactSummary
 {
     /// <summary>Average glucose before site change (mg/dL)</summary>
-    [JsonPropertyName("avgGlucoseBeforeChange")]
     public double AvgGlucoseBeforeChange { get; set; }
 
     /// <summary>Average glucose after site change (mg/dL)</summary>
-    [JsonPropertyName("avgGlucoseAfterChange")]
     public double AvgGlucoseAfterChange { get; set; }
 
     /// <summary>Percent improvement in glucose after site change</summary>
-    [JsonPropertyName("percentImprovement")]
     public double PercentImprovement { get; set; }
 
     /// <summary>Time in range before site change (%)</summary>
-    [JsonPropertyName("timeInRangeBeforeChange")]
     public double TimeInRangeBeforeChange { get; set; }
 
     /// <summary>Time in range after site change (%)</summary>
-    [JsonPropertyName("timeInRangeAfterChange")]
     public double TimeInRangeAfterChange { get; set; }
 
     /// <summary>Coefficient of variation before site change (%)</summary>
-    [JsonPropertyName("cvBeforeChange")]
     public double CvBeforeChange { get; set; }
 
     /// <summary>Coefficient of variation after site change (%)</summary>
-    [JsonPropertyName("cvAfterChange")]
     public double CvAfterChange { get; set; }
 }
 
@@ -2290,35 +1988,27 @@ public class HourlyInsulinDeliveryResponse
 public class SiteChangeImpactAnalysis
 {
     /// <summary>Number of site changes analyzed</summary>
-    [JsonPropertyName("siteChangeCount")]
     public int SiteChangeCount { get; set; }
 
     /// <summary>Average number of days between site changes</summary>
-    [JsonPropertyName("averageDaysBetweenChanges")]
     public double? AverageDaysBetweenChanges { get; set; }
 
     /// <summary>Time points with averaged glucose data</summary>
-    [JsonPropertyName("dataPoints")]
     public List<SiteChangeImpactDataPoint> DataPoints { get; set; } = new();
 
     /// <summary>Summary statistics comparing before vs after</summary>
-    [JsonPropertyName("summary")]
     public SiteChangeImpactSummary Summary { get; set; } = new();
 
     /// <summary>Hours analyzed before site change</summary>
-    [JsonPropertyName("hoursBeforeChange")]
     public int HoursBeforeChange { get; set; }
 
     /// <summary>Hours analyzed after site change</summary>
-    [JsonPropertyName("hoursAfterChange")]
     public int HoursAfterChange { get; set; }
 
     /// <summary>Bucket size in minutes for averaging</summary>
-    [JsonPropertyName("bucketSizeMinutes")]
     public int BucketSizeMinutes { get; set; }
 
     /// <summary>Whether sufficient data exists for meaningful analysis</summary>
-    [JsonPropertyName("hasSufficientData")]
     public bool HasSufficientData { get; set; }
 }
 
@@ -2329,39 +2019,30 @@ public class SiteChangeImpactAnalysis
 public class AidSystemMetrics
 {
     /// <summary>Comma-separated current CGM device names from catalog</summary>
-    [JsonPropertyName("cgmDeviceNames")]
     public string? CgmDeviceNames { get; set; }
 
     /// <summary>Comma-separated current pump device names from catalog</summary>
-    [JsonPropertyName("pumpDeviceNames")]
     public string? PumpDeviceNames { get; set; }
 
     /// <summary>Time-weighted pump use percentage across segments</summary>
-    [JsonPropertyName("pumpUsePercent")]
     public double? PumpUsePercent { get; set; }
 
     /// <summary>Time-weighted AID active percentage across segments</summary>
-    [JsonPropertyName("aidActivePercent")]
     public double? AidActivePercent { get; set; }
 
     /// <summary>CGM data completeness percentage</summary>
-    [JsonPropertyName("cgmActivePercent")]
     public double? CgmActivePercent { get; set; }
 
     /// <summary>Lower target bound in mg/dL</summary>
-    [JsonPropertyName("targetLow")]
     public double? TargetLow { get; set; }
 
     /// <summary>Upper target bound in mg/dL</summary>
-    [JsonPropertyName("targetHigh")]
     public double? TargetHigh { get; set; }
 
     /// <summary>Number of DeviceEvent SiteChange events in the period</summary>
-    [JsonPropertyName("siteChangeCount")]
     public int? SiteChangeCount { get; set; }
 
     /// <summary>Per-device time segments with individual metrics</summary>
-    [JsonPropertyName("segments")]
     public List<AidTimeSegment> Segments { get; set; } = new();
 }
 
@@ -2372,23 +2053,18 @@ public class AidSystemMetrics
 public class AidTimeSegment
 {
     /// <summary>Which AID algorithm was active during this segment</summary>
-    [JsonPropertyName("algorithm")]
     public AidAlgorithm Algorithm { get; set; }
 
     /// <summary>Start of the segment</summary>
-    [JsonPropertyName("startDate")]
     public DateTime StartDate { get; set; }
 
     /// <summary>End of the segment</summary>
-    [JsonPropertyName("endDate")]
     public DateTime EndDate { get; set; }
 
     /// <summary>Duration of the segment in hours</summary>
-    [JsonPropertyName("durationHours")]
     public double DurationHours { get; set; }
 
     /// <summary>Computed metrics for this segment</summary>
-    [JsonPropertyName("metrics")]
     public AidSegmentMetrics Metrics { get; set; } = new();
 }
 
@@ -2398,19 +2074,15 @@ public class AidTimeSegment
 public class AidSegmentMetrics
 {
     /// <summary>Percentage of time AID was active in this segment</summary>
-    [JsonPropertyName("aidActivePercent")]
     public double? AidActivePercent { get; set; }
 
     /// <summary>Percentage of time pump was in use in this segment</summary>
-    [JsonPropertyName("pumpUsePercent")]
     public double? PumpUsePercent { get; set; }
 
     /// <summary>Number of loop iterations (applicable to open-source AIDs)</summary>
-    [JsonPropertyName("loopCycleCount")]
     public int? LoopCycleCount { get; set; }
 
     /// <summary>Number of enacted suggestions</summary>
-    [JsonPropertyName("enactedCount")]
     public int? EnactedCount { get; set; }
 }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceClinicalAccuracyTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceClinicalAccuracyTests.cs
@@ -486,6 +486,23 @@ public class StatisticsServiceClinicalAccuracyTests
         result.Should().BeGreaterThan(9.0, "HBGI > 9.0 indicates high hyperglycemia risk");
     }
 
+    /// <summary>
+    /// Pins the published Kovatchev magnitudes exactly: the risk transform divides by 18 (not the
+    /// 18.0182 unit-conversion factor), and a drifted divisor or coefficient moves these values
+    /// well past the tolerance.
+    /// </summary>
+    [Fact]
+    public void CalculateHBGI_KnownSeries_MatchesPublishedFormula()
+    {
+        _sut.CalculateHBGI([180.0, 250.0, 300.0]).Should().BeApproximately(9.6041173, 0.001);
+    }
+
+    [Fact]
+    public void CalculateLBGI_KnownSeries_MatchesPublishedFormula()
+    {
+        _sut.CalculateLBGI([40.0, 54.0, 65.0]).Should().BeApproximately(9.2579505, 0.001);
+    }
+
     [Fact]
     public void CalculateLBGI_AllInRange_ShouldBeMinimal()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTDDTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTDDTests.cs
@@ -598,15 +598,6 @@ public class StatisticsServiceTDDTests
     }
 
     [Fact]
-    public void FormatInsulinDisplay_ShouldFormatCorrectly()
-    {
-        _sut.FormatInsulinDisplay(1.0).Should().Be("1.00");
-        // Values < 1 use "shifted" format (no leading zero)
-        _sut.FormatInsulinDisplay(0.05).Should().Be(".05");
-        _sut.FormatInsulinDisplay(10.567).Should().Be("10.57");
-    }
-
-    [Fact]
     public void GetBolusPercentage_WithZeroTotal_ShouldReturnZero()
     {
         var summary = new TreatmentSummary

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
@@ -517,27 +517,6 @@ public class StatisticsServiceTests
     #region Formatting Tests
 
     [Fact]
-    public void FormatInsulinDisplay_WithVariousValues_ShouldFormatCorrectly()
-    {
-        // Arrange & Act & Assert
-        _statisticsService.FormatInsulinDisplay(0).Should().Be("0");
-        _statisticsService.FormatInsulinDisplay(0.05).Should().Be(".05");
-        _statisticsService.FormatInsulinDisplay(0.5).Should().Be(".50");
-        _statisticsService.FormatInsulinDisplay(1.0).Should().Be("1.00");
-        _statisticsService.FormatInsulinDisplay(5.25).Should().Be("5.25");
-    }
-
-    [Fact]
-    public void FormatCarbDisplay_WithVariousValues_ShouldFormatCorrectly()
-    {
-        // Arrange & Act & Assert
-        _statisticsService.FormatCarbDisplay(0).Should().Be("0");
-        _statisticsService.FormatCarbDisplay(0.5).Should().Be(".5");
-        _statisticsService.FormatCarbDisplay(1.0).Should().Be("1.0");
-        _statisticsService.FormatCarbDisplay(15.5).Should().Be("15.5");
-    }
-
-    [Fact]
     public void FormatPercentageDisplay_WithValidValue_ShouldFormatToOneDecimal()
     {
         // Arrange & Act & Assert


### PR DESCRIPTION
Closes #1099.

The statistics stack carried ~370 lines of response models nothing populates, nine interface members with no external caller, a backend copy of the display formatters the web never calls, 46 `[JsonPropertyName]` attributes restating the serializer default, and several duplicated bodies inside `StatisticsService`. Net **−551 lines**, all deletion or consolidation.

## What changes

- **Dead model tree deleted**: `TimeOfDayPatterns`, `DayOfWeekPatterns`, `HypoglycemiaAnalysis` and their type sets (`HourlyAveragedStats`, `TrendComparison`+`TrendDirection`, `TimeOfDayAnalysis`, `DayMetrics`, `DayOfWeekAnalysis`, `HypoglycemiaEpisode`) — `AnalyzeGlucoseDataExtended` never set any of them, so `/range-analytics` and `/extended-analytics` emitted always-empty objects.
- **Interface slimmed**: `CalculateCONGA`, `CalculateLabilityIndex`, `CalculateGVI`, `CalculateGlucoseDistributionFromValues` become private; `RoundInsulinToPumpPrecision`, `FormatPercentageDisplay`, `MgdlToMMOLString`, `GetBasalPercentage`, `CalculateEstimatedHbA1C` stay public on the class (their tests hold the concrete type) but leave `IStatisticsService`.
- **Backend formatters deleted**: `FormatInsulinDisplay`/`FormatCarbDisplay`, their `GET format/insulin/{value}` / `format/carb/{value}` endpoints and their three tests — every component imports the frontend copy in `formatting.ts`, and the two implementations disagreed anyway.
- **46 `[JsonPropertyName]` attributes removed** — each verified equal to `JsonNamingPolicy.CamelCase` output for its property (including `StdDev`→`stdDev` and the acronym cases); the API serializes these models only through the MVC pipeline, which already applies that policy.
- **`KovatchevRisk` shared core** replaces the token-identical `CalculateHBGI`/`CalculateLBGI` bodies, with `KovatchevMgdlPerMmol = 18.0` named to state that the published formula divides by 18 exactly, not `GlucoseConstants.MgdlPerMmol` (18.0182).
- Smaller dedups: one `Accumulate` local for the four-copy dictionary fold in `CalculateDailyBasalBolusRatios`; the two inline stddevs now call `GlucoseStatistics.StandardDeviation(..., Population)`; a redundant empty-input early return in `CalculateTimeInRange` collapsed onto the equivalent `totalReadings == 0` return; an empty `if` deleted.

## Declared behavioural deltas (wire only; every numeric result is byte-identical)

1. `analysis.timeOfDayPatterns`, `analysis.dayOfWeekPatterns` and `analysis.hypoglycemiaAnalysis` disappear from `/range-analytics` and `/extended-analytics` responses (they were always empty objects). The corresponding schema types leave the OpenAPI document and generated clients.
2. `GET /api/v4/statistics/format/insulin/{value}` and `format/carb/{value}` now 404.

## Discrepancy with the issue text

The issue claimed all four pattern trees were caller-free. **`hyperglycemiaAnalysis` has a web caller** — the reports comparison page reads `averageDurationMinutes`/`totalEpisodes` — so `ExtendedGlucoseAnalytics.HyperglycemiaAnalysis`, its class and `HyperglycemiaEpisode` are retained. It is still never populated, which means that page renders hard zeros as measured values; filed as #1104. The `/18.0` copies in `DirectionService` and `PebbleController` the issue mentions in passing are untouched (unit conversion for display, a different constant semantically).

## Tests

`Nocturne.API.Tests`: 6314 passed, 0 failed, 5 skipped (−3 deleted formatter tests, +2 new). All eight statistics fixtures already held the concrete `StatisticsService`, so the interface slimming needed no test changes.

New `CalculateHBGI_KnownSeries_MatchesPublishedFormula` / `CalculateLBGI_KnownSeries_MatchesPublishedFormula` pin the exact Kovatchev magnitudes: hostile review found that mutating the divisor to 18.016 survived the entire pre-existing suite (thresholds were pinned, magnitudes were not); these fail on that mutant. A `keepPositive` polarity mutant was caught by two existing clinical-accuracy tests.