### PR TITLE
refactor(data): drive DeduplicateAllAsync from one per-type table and delete the dead merge island

### DIFF
--- a/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/DataOverviewService.cs
@@ -547,7 +547,7 @@ public class DataOverviewService : IDataOverviewService
         RecordType recordType
     )
     {
-        var key = recordType.ToString().ToLowerInvariant();
+        var key = RecordTypeKeys.Key(recordType);
         return context
             .LinkedRecords.Where(lr => lr.RecordType == key && !lr.IsPrimary)
             .Select(lr => lr.RecordId);

--- a/src/Core/Nocturne.Core.Models/DeduplicationModels.cs
+++ b/src/Core/Nocturne.Core.Models/DeduplicationModels.cs
@@ -198,18 +198,6 @@ public record DeduplicationResult
     public TimeSpan Duration { get; init; }
 
     /// <summary>
-    /// Number of entries processed
-    /// </summary>
-    [JsonPropertyName("entriesProcessed")]
-    public int EntriesProcessed { get; init; }
-
-    /// <summary>
-    /// Number of treatments processed
-    /// </summary>
-    [JsonPropertyName("treatmentsProcessed")]
-    public int TreatmentsProcessed { get; init; }
-
-    /// <summary>
     /// Number of state spans processed
     /// </summary>
     [JsonPropertyName("stateSpansProcessed")]

--- a/src/Core/Nocturne.Core.Models/LinkedRecord.cs
+++ b/src/Core/Nocturne.Core.Models/LinkedRecord.cs
@@ -125,3 +125,49 @@ public enum RecordType
     /// </summary>
     TempBasal
 }
+
+/// <summary>
+/// The <c>linked_records.record_type</c> key of every <see cref="RecordType"/>. The per-type
+/// constants exist alongside <see cref="Key"/> because EF Core cannot translate a method call
+/// inside an expression tree; <c>RecordTypeKeysTests</c> holds the two forms equal.
+/// </summary>
+public static class RecordTypeKeys
+{
+    /// <summary><see cref="RecordType.Entry"/></summary>
+    public const string Entry = "entry";
+
+    /// <summary><see cref="RecordType.Treatment"/></summary>
+    public const string Treatment = "treatment";
+
+    /// <summary><see cref="RecordType.StateSpan"/></summary>
+    public const string StateSpan = "statespan";
+
+    /// <summary><see cref="RecordType.SensorGlucose"/></summary>
+    public const string SensorGlucose = "sensorglucose";
+
+    /// <summary><see cref="RecordType.Bolus"/></summary>
+    public const string Bolus = "bolus";
+
+    /// <summary><see cref="RecordType.CarbIntake"/></summary>
+    public const string CarbIntake = "carbintake";
+
+    /// <summary><see cref="RecordType.BGCheck"/></summary>
+    public const string BGCheck = "bgcheck";
+
+    /// <summary><see cref="RecordType.DeviceEvent"/></summary>
+    public const string DeviceEvent = "deviceevent";
+
+    /// <summary><see cref="RecordType.Note"/></summary>
+    public const string Note = "note";
+
+    /// <summary><see cref="RecordType.BolusCalculation"/></summary>
+    public const string BolusCalculation = "boluscalculation";
+
+    /// <summary><see cref="RecordType.TempBasal"/></summary>
+    public const string TempBasal = "tempbasal";
+
+    /// <summary>
+    /// The stored key for <paramref name="recordType"/>.
+    /// </summary>
+    public static string Key(RecordType recordType) => recordType.ToString().ToLowerInvariant();
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
@@ -150,7 +150,7 @@ public class StateSpanRepository : IStateSpanRepository
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(s => !_context.LinkedRecords
-            .Any(lr => lr.RecordType == "statespan" && !lr.IsPrimary && lr.RecordId == s.Id));
+            .Any(lr => lr.RecordType == RecordTypeKeys.StateSpan && !lr.IsPrimary && lr.RecordId == s.Id));
 
         return query;
     }
@@ -412,7 +412,7 @@ public class StateSpanRepository : IStateSpanRepository
         var latest = await _context.StateSpans.AsNoTracking()
             .Where(s => s.Category == pumpModeCategory && s.EndTimestamp == null)
             .Where(s => !_context.LinkedRecords
-                .Any(lr => lr.RecordType == "statespan" && !lr.IsPrimary && lr.RecordId == s.Id))
+                .Any(lr => lr.RecordType == RecordTypeKeys.StateSpan && !lr.IsPrimary && lr.RecordId == s.Id))
             .OrderByDescending(s => s.StartTimestamp)
             .ThenByDescending(s => s.Id)
             .Select(s => s.State)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -60,7 +60,7 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
     /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
     /// </summary>
     protected override IQueryable<BGCheckEntity> ApplyReadVisibility(IQueryable<BGCheckEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "bgcheck" && !lr.IsPrimary && lr.RecordId == b.Id));
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.BGCheck && !lr.IsPrimary && lr.RecordId == b.Id));
 
     /// <summary>
     /// Routes the base 7-arg form through the extended BG-check query (non-primary LinkedRecords
@@ -113,7 +113,7 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == "bgcheck" && !lr.IsPrimary && lr.RecordId == b.Id));
+            .Any(lr => lr.RecordType == RecordTypeKeys.BGCheck && !lr.IsPrimary && lr.RecordId == b.Id));
 
         query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
         var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -61,7 +61,7 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
     /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
     /// </summary>
     protected override IQueryable<BolusCalculationEntity> ApplyReadVisibility(IQueryable<BolusCalculationEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "boluscalculation" && !lr.IsPrimary && lr.RecordId == b.Id));
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.BolusCalculation && !lr.IsPrimary && lr.RecordId == b.Id));
 
     /// <summary>
     /// Gets bolus calculation records based on filter criteria.
@@ -101,7 +101,7 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == "boluscalculation" && !lr.IsPrimary && lr.RecordId == b.Id));
+            .Any(lr => lr.RecordType == RecordTypeKeys.BolusCalculation && !lr.IsPrimary && lr.RecordId == b.Id));
 
         query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
         var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -59,7 +59,7 @@ public class BolusRepository : SyncUpsertRepositoryBase<Bolus, BolusEntity>, IBo
     /// <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
     /// </summary>
     protected override IQueryable<BolusEntity> ApplyReadVisibility(IQueryable<BolusEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "bolus" && !lr.IsPrimary && lr.RecordId == b.Id));
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.Bolus && !lr.IsPrimary && lr.RecordId == b.Id));
 
     /// <summary>
     /// Routes the base 7-arg form through the extended bolus query (non-primary LinkedRecords
@@ -121,7 +121,7 @@ public class BolusRepository : SyncUpsertRepositoryBase<Bolus, BolusEntity>, IBo
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == "bolus" && !lr.IsPrimary && lr.RecordId == b.Id));
+            .Any(lr => lr.RecordType == RecordTypeKeys.Bolus && !lr.IsPrimary && lr.RecordId == b.Id));
 
         // Keyset cursor — when provided, replaces OFFSET with a WHERE clause
         // that seeks directly to the cursor position. O(limit) vs O(offset + limit).

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -61,7 +61,7 @@ public class CarbIntakeRepository : SyncUpsertRepositoryBase<CarbIntake, CarbInt
     /// meals imported from multiple connectors). Mirrors the inline filter in the extended <c>GetAsync</c>.
     /// </summary>
     protected override IQueryable<CarbIntakeEntity> ApplyReadVisibility(IQueryable<CarbIntakeEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "carbintake" && !lr.IsPrimary && lr.RecordId == b.Id));
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.CarbIntake && !lr.IsPrimary && lr.RecordId == b.Id));
 
     /// <summary>
     /// Routes the base 7-arg form through the extended carb-intake query (non-primary LinkedRecords
@@ -119,7 +119,7 @@ public class CarbIntakeRepository : SyncUpsertRepositoryBase<CarbIntake, CarbInt
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == "carbintake" && !lr.IsPrimary && lr.RecordId == b.Id));
+            .Any(lr => lr.RecordType == RecordTypeKeys.CarbIntake && !lr.IsPrimary && lr.RecordId == b.Id));
 
         // Keyset cursor — when provided, replaces OFFSET with a WHERE clause
         // that seeks directly to the cursor position. O(limit) vs O(offset + limit).

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -59,7 +59,7 @@ public class DeviceEventRepository : SyncKeyedRepositoryBase<DeviceEvent, Device
     /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
     /// </summary>
     protected override IQueryable<DeviceEventEntity> ApplyReadVisibility(IQueryable<DeviceEventEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "deviceevent" && !lr.IsPrimary && lr.RecordId == b.Id));
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.DeviceEvent && !lr.IsPrimary && lr.RecordId == b.Id));
 
     /// <summary>
     /// Routes the base 7-arg form through the extended device-event query (non-primary LinkedRecords
@@ -116,7 +116,7 @@ public class DeviceEventRepository : SyncKeyedRepositoryBase<DeviceEvent, Device
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == "deviceevent" && !lr.IsPrimary && lr.RecordId == b.Id));
+            .Any(lr => lr.RecordType == RecordTypeKeys.DeviceEvent && !lr.IsPrimary && lr.RecordId == b.Id));
 
         query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
         var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -58,7 +58,7 @@ public class NoteRepository : SyncKeyedRepositoryBase<Note, NoteEntity>, INoteRe
     /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
     /// </summary>
     protected override IQueryable<NoteEntity> ApplyReadVisibility(IQueryable<NoteEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "note" && !lr.IsPrimary && lr.RecordId == b.Id));
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.Note && !lr.IsPrimary && lr.RecordId == b.Id));
 
     /// <summary>
     /// Routes the base 7-arg form through the extended note query (non-primary LinkedRecords
@@ -111,7 +111,7 @@ public class NoteRepository : SyncKeyedRepositoryBase<Note, NoteEntity>, INoteRe
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == "note" && !lr.IsPrimary && lr.RecordId == b.Id));
+            .Any(lr => lr.RecordType == RecordTypeKeys.Note && !lr.IsPrimary && lr.RecordId == b.Id));
 
         query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
         var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -126,7 +126,7 @@ public class SensorGlucoseRepository : SyncUpsertRepositoryBase<SensorGlucose, S
     /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
     /// </summary>
     protected override IQueryable<SensorGlucoseEntity> ApplyReadVisibility(IQueryable<SensorGlucoseEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == "sensorglucose" && !lr.IsPrimary && lr.RecordId == b.Id));
+        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.SensorGlucose && !lr.IsPrimary && lr.RecordId == b.Id));
 
     /// <summary>
     /// Routes the base 7-arg form through the extended sensor-glucose query (non-primary LinkedRecords
@@ -187,7 +187,7 @@ public class SensorGlucoseRepository : SyncUpsertRepositoryBase<SensorGlucose, S
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == "sensorglucose" && !lr.IsPrimary && lr.RecordId == b.Id));
+            .Any(lr => lr.RecordType == RecordTypeKeys.SensorGlucose && !lr.IsPrimary && lr.RecordId == b.Id));
 
         // Keyset cursor — when provided, replaces OFFSET with a WHERE clause
         // that seeks directly to the cursor position. O(limit) vs O(offset + limit).

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -98,7 +98,7 @@ public class TempBasalRepository : ITempBasalRepository
 
         // Exclude non-primary duplicates from cross-connector deduplication
         query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == "tempbasal" && !lr.IsPrimary && lr.RecordId == b.Id));
+            .Any(lr => lr.RecordType == RecordTypeKeys.TempBasal && !lr.IsPrimary && lr.RecordId == b.Id));
 
         query = descending
             ? query.OrderByDescending(e => e.StartTimestamp)
@@ -444,7 +444,7 @@ public class TempBasalRepository : ITempBasalRepository
             .AsNoTracking()
             .Where(t => t.StartTimestamp <= at && (t.EndTimestamp == null || t.EndTimestamp > at))
             .Where(t => !ctx.LinkedRecords
-                .Any(lr => lr.RecordType == "tempbasal" && !lr.IsPrimary && lr.RecordId == t.Id))
+                .Any(lr => lr.RecordType == RecordTypeKeys.TempBasal && !lr.IsPrimary && lr.RecordId == t.Id))
             .OrderByDescending(t => t.StartTimestamp)
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : TempBasalMapper.ToDomainModel(entity);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -154,27 +155,6 @@ public class DeduplicationService : IDeduplicationService
     /// tenant in the process, so status and cancellation are matched against this before answering.
     /// </summary>
     private static readonly ConcurrentDictionary<Guid, Guid> _jobTenants = new();
-
-    /// <summary>
-    /// Event types that should be grouped together for deduplication.
-    /// When a Basal and Temp Basal occur at the same time, they represent
-    /// the same underlying event and should be deduplicated together.
-    /// </summary>
-    private static readonly HashSet<string> BasalRelatedTypes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "Basal",
-        "Temp Basal"
-    };
-
-    /// <summary>
-    /// Priority order for basal-related types. Higher priority types
-    /// are preferred when merging duplicates.
-    /// </summary>
-    private static readonly Dictionary<string, int> BasalTypePriority = new(StringComparer.OrdinalIgnoreCase)
-    {
-        { "Temp Basal", 1 },  // Highest priority - most specific
-        { "Basal", 0 }       // Lower priority - generic
-    };
 
     /// <inheritdoc cref="IDeduplicationService" />
     public DeduplicationService(
@@ -373,7 +353,7 @@ public class DeduplicationService : IDeduplicationService
         if (records.Count == 0)
             return new DeduplicationBatchResult(0, 0, 0, 0);
 
-        var recordTypeStr = recordType.ToString().ToLowerInvariant();
+        var recordTypeStr = RecordTypeKeys.Key(recordType);
         var wideEligible = WideMatchableTypes.Contains(recordType);
 
         // 1. Compute union time window. Wide-eligible types load the wider window so the wide
@@ -699,7 +679,7 @@ public class DeduplicationService : IDeduplicationService
         IReadOnlySet<Guid>? candidateCanonicalIds,
         CancellationToken ct)
     {
-        var recordTypeStr = recordType.ToString().ToLowerInvariant();
+        var recordTypeStr = RecordTypeKeys.Key(recordType);
         var wideEligible = WideMatchableTypes.Contains(recordType);
 
         // The span the candidate-bounded path actually loaded. Groups whose extent reaches within a
@@ -1353,7 +1333,7 @@ public class DeduplicationService : IDeduplicationService
         Guid recordId,
         CancellationToken cancellationToken = default)
     {
-        var recordTypeStr = recordType.ToString().ToLowerInvariant();
+        var recordTypeStr = RecordTypeKeys.Key(recordType);
 
         var entity = await _context.LinkedRecords
             .FirstOrDefaultAsync(lr =>
@@ -1382,7 +1362,7 @@ public class DeduplicationService : IDeduplicationService
         CancellationToken cancellationToken = default)
     {
         var linkedRecords = await _context.LinkedRecords
-            .Where(lr => lr.CanonicalId == canonicalId && lr.RecordType == "statespan")
+            .Where(lr => lr.CanonicalId == canonicalId && lr.RecordType == RecordTypeKeys.StateSpan)
             .OrderBy(static lr => lr.SourceTimestamp)
             .ToListAsync(cancellationToken);
 
@@ -1406,6 +1386,91 @@ public class DeduplicationService : IDeduplicationService
         return MergeStateSpans(sortedStateSpans, canonicalId);
     }
 
+    private delegate Task<(int processed, int groups, int linked, int duplicates)> PhaseRunner(
+        DeduplicationService service,
+        int totalRecords,
+        int startOffset,
+        IProgress<DeduplicationProgress>? progress,
+        CancellationToken ct);
+
+    /// <summary>
+    /// One record type's <see cref="DeduplicateAllAsync"/> phase. <see cref="Name"/> is reported as
+    /// <see cref="DeduplicationProgress.CurrentPhase"/>, so callers observe it.
+    /// </summary>
+    private sealed record TypePhase(
+        RecordType RecordType,
+        string Name,
+        Func<NocturneDbContext, CancellationToken, Task<int>> CountAsync,
+        PhaseRunner RunAsync);
+
+    /// <summary>
+    /// Builds one <see cref="TypePhase"/>. <paramref name="timestamp"/> both orders the query and
+    /// supplies the event time, so a type whose event time is not <c>Timestamp</c> states it once.
+    /// </summary>
+    private static TypePhase Phase<TEntity>(
+        RecordType recordType,
+        string name,
+        Func<NocturneDbContext, IQueryable<TEntity>> set,
+        Expression<Func<TEntity, DateTime>> timestamp,
+        Func<TEntity, Guid> id,
+        Func<TEntity, string?> dataSource,
+        Func<TEntity, MatchCriteria> criteria) where TEntity : class
+    {
+        var eventTime = timestamp.Compile();
+
+        return new TypePhase(
+            recordType,
+            name,
+            (context, ct) => set(context).CountAsync(ct),
+            (service, totalRecords, startOffset, progress, ct) => service.DeduplicateTypeAsync(
+                recordType,
+                set(service._context).OrderBy(timestamp),
+                e => new DeduplicationInput(
+                    id(e),
+                    new DateTimeOffset(eventTime(e), TimeSpan.Zero).ToUnixTimeMilliseconds(),
+                    dataSource(e) ?? DeduplicationInput.UnknownDataSource,
+                    criteria(e)),
+                name, totalRecords, startOffset, progress, ct));
+    }
+
+    /// <summary>
+    /// Every record type <see cref="DeduplicateAllAsync"/> passes over, in processing order.
+    /// MeterGlucose was previously processed via DeduplicateEntriesAsync alongside SensorGlucose,
+    /// but there is no <see cref="RecordType"/> value for it, and the old code also double-processed
+    /// SensorGlucose (once in Entries, once standalone). MeterGlucose dedup is intentionally
+    /// dropped; add a <see cref="RecordType"/> if it is needed in the future.
+    /// </summary>
+    private static readonly TypePhase[] TypePhases =
+    [
+        Phase(RecordType.SensorGlucose, "SensorGlucose",
+            static c => c.SensorGlucose, static e => e.Timestamp,
+            static e => e.Id, static e => e.DataSource, MatchCriteriaMapper.From),
+        Phase(RecordType.Bolus, "Boluses",
+            static c => c.Boluses, static b => b.Timestamp,
+            static b => b.Id, static b => b.DataSource, MatchCriteriaMapper.From),
+        Phase(RecordType.CarbIntake, "CarbIntakes",
+            static c => c.CarbIntakes, static c => c.Timestamp,
+            static c => c.Id, static c => c.DataSource, MatchCriteriaMapper.From),
+        Phase(RecordType.BGCheck, "BGChecks",
+            static c => c.BGChecks, static bg => bg.Timestamp,
+            static bg => bg.Id, static bg => bg.DataSource, MatchCriteriaMapper.From),
+        Phase(RecordType.DeviceEvent, "DeviceEvents",
+            static c => c.DeviceEvents, static d => d.Timestamp,
+            static d => d.Id, static d => d.DataSource, MatchCriteriaMapper.From),
+        Phase(RecordType.Note, "Notes",
+            static c => c.Notes, static n => n.Timestamp,
+            static n => n.Id, static n => n.DataSource, static _ => MatchCriteriaMapper.ForNote()),
+        Phase(RecordType.BolusCalculation, "BolusCalculations",
+            static c => c.BolusCalculations, static bc => bc.Timestamp,
+            static bc => bc.Id, static bc => bc.DataSource, MatchCriteriaMapper.From),
+        Phase(RecordType.TempBasal, "TempBasals",
+            static c => c.TempBasals, static t => t.StartTimestamp,
+            static t => t.Id, static t => t.DataSource, MatchCriteriaMapper.From),
+        Phase(RecordType.StateSpan, "StateSpans",
+            static c => c.StateSpans, static s => s.StartTimestamp,
+            static s => s.Id, static s => s.Source, MatchCriteriaMapper.From)
+    ];
+
     /// <inheritdoc />
     public async Task<DeduplicationResult> DeduplicateAllAsync(
         IProgress<DeduplicationProgress>? progress = null,
@@ -1415,161 +1480,27 @@ public class DeduplicationService : IDeduplicationService
 
         try
         {
-            var stateSpanCount = await _context.StateSpans.CountAsync(cancellationToken);
-            var sensorGlucoseCount = await _context.SensorGlucose.CountAsync(cancellationToken);
-            var bolusCount = await _context.Boluses.CountAsync(cancellationToken);
-            var carbIntakeCount = await _context.CarbIntakes.CountAsync(cancellationToken);
-            var bgCheckCount = await _context.BGChecks.CountAsync(cancellationToken);
-            var deviceEventCount = await _context.DeviceEvents.CountAsync(cancellationToken);
-            var noteCount = await _context.Notes.CountAsync(cancellationToken);
-            var bolusCalcCount = await _context.BolusCalculations.CountAsync(cancellationToken);
-            var tempBasalCount = await _context.TempBasals.CountAsync(cancellationToken);
-            // NOTE: MeterGlucose was previously processed via DeduplicateEntriesAsync alongside
-            // SensorGlucose, but there is no RecordType.MeterGlucose enum value. The old code also
-            // double-processed SensorGlucose (once in Entries, once standalone). MeterGlucose dedup
-            // is intentionally dropped; add a RecordType if it's needed in the future.
-            var totalRecords = stateSpanCount + sensorGlucoseCount + bolusCount + carbIntakeCount
-                + bgCheckCount + deviceEventCount + noteCount + bolusCalcCount + tempBasalCount;
+            var totalRecords = 0;
+            foreach (var phase in TypePhases)
+            {
+                totalRecords += await phase.CountAsync(_context, cancellationToken);
+            }
 
             var processed = 0;
             var groupsCreated = 0;
             var recordsLinked = 0;
             var duplicateGroups = 0;
+            var processedByType = new Dictionary<RecordType, int>();
 
-            // --- SensorGlucose ---
-            var sensorGlucoseResult = await DeduplicateTypeAsync(
-                RecordType.SensorGlucose,
-                _context.SensorGlucose.OrderBy(e => e.Timestamp),
-                e => new DeduplicationInput(
-                    e.Id,
-                    new DateTimeOffset(e.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    e.DataSource ?? DeduplicationInput.UnknownDataSource,
-                    MatchCriteriaMapper.From(e)),
-                "SensorGlucose", totalRecords, processed, progress, cancellationToken);
-            processed += sensorGlucoseResult.processed;
-            groupsCreated += sensorGlucoseResult.groups;
-            recordsLinked += sensorGlucoseResult.linked;
-            duplicateGroups += sensorGlucoseResult.duplicates;
-
-            // --- Boluses ---
-            var bolusResult = await DeduplicateTypeAsync(
-                RecordType.Bolus,
-                _context.Boluses.OrderBy(b => b.Timestamp),
-                b => new DeduplicationInput(
-                    b.Id,
-                    new DateTimeOffset(b.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    b.DataSource ?? DeduplicationInput.UnknownDataSource,
-                    MatchCriteriaMapper.From(b)),
-                "Boluses", totalRecords, processed, progress, cancellationToken);
-            processed += bolusResult.processed;
-            groupsCreated += bolusResult.groups;
-            recordsLinked += bolusResult.linked;
-            duplicateGroups += bolusResult.duplicates;
-
-            // --- CarbIntakes ---
-            var carbIntakeResult = await DeduplicateTypeAsync(
-                RecordType.CarbIntake,
-                _context.CarbIntakes.OrderBy(c => c.Timestamp),
-                c => new DeduplicationInput(
-                    c.Id,
-                    new DateTimeOffset(c.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    c.DataSource ?? DeduplicationInput.UnknownDataSource,
-                    MatchCriteriaMapper.From(c)),
-                "CarbIntakes", totalRecords, processed, progress, cancellationToken);
-            processed += carbIntakeResult.processed;
-            groupsCreated += carbIntakeResult.groups;
-            recordsLinked += carbIntakeResult.linked;
-            duplicateGroups += carbIntakeResult.duplicates;
-
-            // --- BGChecks ---
-            var bgCheckResult = await DeduplicateTypeAsync(
-                RecordType.BGCheck,
-                _context.BGChecks.OrderBy(bg => bg.Timestamp),
-                bg => new DeduplicationInput(
-                    bg.Id,
-                    new DateTimeOffset(bg.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    bg.DataSource ?? DeduplicationInput.UnknownDataSource,
-                    MatchCriteriaMapper.From(bg)),
-                "BGChecks", totalRecords, processed, progress, cancellationToken);
-            processed += bgCheckResult.processed;
-            groupsCreated += bgCheckResult.groups;
-            recordsLinked += bgCheckResult.linked;
-            duplicateGroups += bgCheckResult.duplicates;
-
-            // --- DeviceEvents ---
-            var deviceEventResult = await DeduplicateTypeAsync(
-                RecordType.DeviceEvent,
-                _context.DeviceEvents.OrderBy(d => d.Timestamp),
-                d => new DeduplicationInput(
-                    d.Id,
-                    new DateTimeOffset(d.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    d.DataSource ?? DeduplicationInput.UnknownDataSource,
-                    MatchCriteriaMapper.From(d)),
-                "DeviceEvents", totalRecords, processed, progress, cancellationToken);
-            processed += deviceEventResult.processed;
-            groupsCreated += deviceEventResult.groups;
-            recordsLinked += deviceEventResult.linked;
-            duplicateGroups += deviceEventResult.duplicates;
-
-            // --- Notes ---
-            var noteResult = await DeduplicateTypeAsync(
-                RecordType.Note,
-                _context.Notes.OrderBy(n => n.Timestamp),
-                n => new DeduplicationInput(
-                    n.Id,
-                    new DateTimeOffset(n.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    n.DataSource ?? DeduplicationInput.UnknownDataSource,
-                    MatchCriteriaMapper.ForNote()),
-                "Notes", totalRecords, processed, progress, cancellationToken);
-            processed += noteResult.processed;
-            groupsCreated += noteResult.groups;
-            recordsLinked += noteResult.linked;
-            duplicateGroups += noteResult.duplicates;
-
-            // --- BolusCalculations ---
-            var bolusCalcResult = await DeduplicateTypeAsync(
-                RecordType.BolusCalculation,
-                _context.BolusCalculations.OrderBy(bc => bc.Timestamp),
-                bc => new DeduplicationInput(
-                    bc.Id,
-                    new DateTimeOffset(bc.Timestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    bc.DataSource ?? DeduplicationInput.UnknownDataSource,
-                    MatchCriteriaMapper.From(bc)),
-                "BolusCalculations", totalRecords, processed, progress, cancellationToken);
-            processed += bolusCalcResult.processed;
-            groupsCreated += bolusCalcResult.groups;
-            recordsLinked += bolusCalcResult.linked;
-            duplicateGroups += bolusCalcResult.duplicates;
-
-            // --- TempBasals ---
-            var tempBasalResult = await DeduplicateTypeAsync(
-                RecordType.TempBasal,
-                _context.TempBasals.OrderBy(t => t.StartTimestamp),
-                t => new DeduplicationInput(
-                    t.Id,
-                    new DateTimeOffset(t.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    t.DataSource ?? DeduplicationInput.UnknownDataSource,
-                    MatchCriteriaMapper.From(t)),
-                "TempBasals", totalRecords, processed, progress, cancellationToken);
-            processed += tempBasalResult.processed;
-            groupsCreated += tempBasalResult.groups;
-            recordsLinked += tempBasalResult.linked;
-            duplicateGroups += tempBasalResult.duplicates;
-
-            // --- StateSpans ---
-            var stateSpanResult = await DeduplicateTypeAsync(
-                RecordType.StateSpan,
-                _context.StateSpans.OrderBy(s => s.StartTimestamp),
-                s => new DeduplicationInput(
-                    s.Id,
-                    new DateTimeOffset(s.StartTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds(),
-                    s.Source ?? DeduplicationInput.UnknownDataSource,
-                    MatchCriteriaMapper.From(s)),
-                "StateSpans", totalRecords, processed, progress, cancellationToken);
-            processed += stateSpanResult.processed;
-            groupsCreated += stateSpanResult.groups;
-            recordsLinked += stateSpanResult.linked;
-            duplicateGroups += stateSpanResult.duplicates;
+            foreach (var phase in TypePhases)
+            {
+                var result = await phase.RunAsync(this, totalRecords, processed, progress, cancellationToken);
+                processedByType[phase.RecordType] = result.processed;
+                processed += result.processed;
+                groupsCreated += result.groups;
+                recordsLinked += result.linked;
+                duplicateGroups += result.duplicates;
+            }
 
             stopwatch.Stop();
 
@@ -1584,17 +1515,15 @@ public class DeduplicationService : IDeduplicationService
                 RecordsLinked = recordsLinked,
                 DuplicateGroupsFound = duplicateGroups,
                 Duration = stopwatch.Elapsed,
-                EntriesProcessed = sensorGlucoseResult.processed,
-                TreatmentsProcessed = 0,
-                StateSpansProcessed = stateSpanResult.processed,
-                SensorGlucoseProcessed = sensorGlucoseResult.processed,
-                BolusesProcessed = bolusResult.processed,
-                CarbIntakesProcessed = carbIntakeResult.processed,
-                BGChecksProcessed = bgCheckResult.processed,
-                DeviceEventsProcessed = deviceEventResult.processed,
-                NotesProcessed = noteResult.processed,
-                BolusCalculationsProcessed = bolusCalcResult.processed,
-                TempBasalsProcessed = tempBasalResult.processed,
+                StateSpansProcessed = processedByType[RecordType.StateSpan],
+                SensorGlucoseProcessed = processedByType[RecordType.SensorGlucose],
+                BolusesProcessed = processedByType[RecordType.Bolus],
+                CarbIntakesProcessed = processedByType[RecordType.CarbIntake],
+                BGChecksProcessed = processedByType[RecordType.BGCheck],
+                DeviceEventsProcessed = processedByType[RecordType.DeviceEvent],
+                NotesProcessed = processedByType[RecordType.Note],
+                BolusCalculationsProcessed = processedByType[RecordType.BolusCalculation],
+                TempBasalsProcessed = processedByType[RecordType.TempBasal],
                 Success = true
             };
         }
@@ -1801,82 +1730,6 @@ public class DeduplicationService : IDeduplicationService
         return (totalProcessed, totalGroups, totalLinked, totalDuplicates);
     }
 
-    private static Treatment MergeTreatments(List<Treatment> treatments, Guid canonicalId)
-    {
-        if (treatments.Count == 0)
-            throw new ArgumentException("Cannot merge empty list of treatments");
-
-        // For basal-related treatments, prefer the highest priority type (e.g., Temp Basal over Basal)
-        var primary = treatments[0];
-        var preferredEventType = GetPreferredEventType(treatments);
-
-        // When the preferred event type differs from the primary (e.g., Temp Basal preferred but
-        // Basal is first by timestamp), use basal-related fields from the preferred-type treatment
-        // so Duration/Percent/Rate come from the correct source.
-        var basalSource = primary;
-        if (preferredEventType != null && preferredEventType != primary.EventType)
-        {
-            basalSource = treatments.FirstOrDefault(t => t.EventType == preferredEventType) ?? primary;
-        }
-
-        var merged = new Treatment
-        {
-            Id = primary.Id,
-            Mills = primary.Mills,
-            Created_at = primary.Created_at,
-            EventType = preferredEventType,
-            Insulin = primary.Insulin,
-            Carbs = primary.Carbs,
-            Protein = primary.Protein,
-            Fat = primary.Fat,
-            Duration = basalSource.Duration,
-            EnteredBy = primary.EnteredBy,
-            Notes = primary.Notes,
-            Reason = primary.Reason,
-            Glucose = primary.Glucose,
-            GlucoseType = primary.GlucoseType,
-            Profile = primary.Profile,
-            Percent = basalSource.Percent,
-            Rate = basalSource.Rate,
-            DataSource = primary.DataSource,
-            AdditionalProperties = primary.AdditionalProperties != null
-                ? new Dictionary<string, object>(primary.AdditionalProperties)
-                : new(),
-            CanonicalId = canonicalId,
-            Sources = treatments.Select(t => t.DataSource).Where(s => s != null).Distinct().ToArray()!
-        };
-
-        // Enrich with data from other sources
-        foreach (var treatment in treatments.Skip(1))
-        {
-            merged.Notes ??= treatment.Notes;
-            merged.Reason ??= treatment.Reason;
-            merged.Glucose ??= treatment.Glucose;
-            merged.GlucoseType ??= treatment.GlucoseType;
-            merged.Profile ??= treatment.Profile;
-            merged.Protein ??= treatment.Protein;
-            merged.Fat ??= treatment.Fat;
-
-            // Enrich basal-related fields
-            merged.Duration ??= treatment.Duration;
-            merged.Percent ??= treatment.Percent;
-            merged.Rate ??= treatment.Rate;
-            merged.Carbs ??= treatment.Carbs;
-            merged.Insulin ??= treatment.Insulin;
-
-            // Merge additional properties
-            if (treatment.AdditionalProperties != null)
-            {
-                foreach (var kvp in treatment.AdditionalProperties)
-                {
-                    merged.AdditionalProperties.TryAdd(kvp.Key, kvp.Value);
-                }
-            }
-        }
-
-        return merged;
-    }
-
     private static StateSpan MergeStateSpans(List<StateSpan> stateSpans, Guid canonicalId)
     {
         if (stateSpans.Count == 0)
@@ -1919,49 +1772,6 @@ public class DeduplicationService : IDeduplicationService
         }
 
         return merged;
-    }
-
-    /// <summary>
-    /// Gets the priority for a basal-related type.
-    /// Higher values indicate higher priority (preferred when deduplicating).
-    /// </summary>
-    private static int GetBasalTypePriority(string? eventType)
-    {
-        if (string.IsNullOrEmpty(eventType))
-            return -1;
-
-        return BasalTypePriority.TryGetValue(eventType, out var priority) ? priority : -1;
-    }
-
-    /// <summary>
-    /// Gets the preferred event type when merging treatments.
-    /// For basal-related types, returns the highest priority type among all treatments.
-    /// For other types, returns the primary treatment's event type.
-    /// </summary>
-    private static string? GetPreferredEventType(List<Treatment> treatments)
-    {
-        if (treatments.Count == 0)
-            return null;
-
-        var primary = treatments[0];
-
-        // Check if any treatment is a basal-related type
-        var basalTypes = treatments
-            .Where(t => !string.IsNullOrEmpty(t.EventType) && BasalRelatedTypes.Contains(t.EventType))
-            .Select(t => t.EventType!)
-            .Distinct()
-            .ToList();
-
-        if (basalTypes.Count == 0)
-        {
-            // No basal-related types, use primary's event type
-            return primary.EventType;
-        }
-
-        // Return the highest priority basal type
-        return basalTypes
-            .OrderByDescending(GetBasalTypePriority)
-            .First();
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.Core.Models.Tests/RecordTypeKeysTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/RecordTypeKeysTests.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using FluentAssertions;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests;
+
+[Trait("Category", "Unit")]
+public class RecordTypeKeysTests
+{
+    private static readonly Dictionary<string, string> Constants = typeof(RecordTypeKeys)
+        .GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Where(f => f is { IsLiteral: true, IsInitOnly: false } && f.FieldType == typeof(string))
+        .ToDictionary(f => f.Name, f => (string)f.GetRawConstantValue()!);
+
+    [Fact]
+    public void Every_record_type_has_a_constant_and_no_constant_is_orphaned()
+    {
+        Constants.Keys.Should().BeEquivalentTo(Enum.GetNames<RecordType>());
+    }
+
+    [Theory]
+    [MemberData(nameof(RecordTypes))]
+    public void Constant_equals_the_computed_key(RecordType recordType)
+    {
+        Constants[recordType.ToString()].Should().Be(RecordTypeKeys.Key(recordType));
+    }
+
+    public static TheoryData<RecordType> RecordTypes()
+    {
+        var data = new TheoryData<RecordType>();
+        foreach (var recordType in Enum.GetValues<RecordType>())
+        {
+            data.Add(recordType);
+        }
+
+        return data;
+    }
+}


### PR DESCRIPTION
Closes #1094.

`DeduplicateAllAsync` wrote the same 14-line block nine times behind nine hand-written count queries, `MergeTreatments` and its four exclusive dependents were unreachable, two result counters were a hardcoded zero and an alias, and the `linked_records.record_type` key string was derived in four places and matched against 19 independent literals. Net **−202 production lines**.

## What changes

- **`TypePhases` registry**: nine rows of (record type, phase name, DbSet, event-time expression, id/data-source accessors, criteria mapper) drive both the count pass and the dedup pass. The event-time expression both orders the query and supplies the mills, so `StartTimestamp` for TempBasal/StateSpan is stated once; StateSpan's `s.Source` and Note's `ForNote()` are per-row. Processing order, phase-name strings (they surface as `DeduplicationProgress.CurrentPhase`), `DeduplicationInput` construction and count semantics are byte-identical; the pre-existing MeterGlucose rationale comment moved onto the table.
- **Dead island deleted**: `MergeTreatments`, `GetPreferredEventType`, `GetBasalTypePriority`, `BasalRelatedTypes`, `BasalTypePriority` (zero callers; the live `MergeStateSpans` untouched).
- **`DeduplicationResult.EntriesProcessed`/`TreatmentsProcessed` deleted** — always 0 and an alias of `SensorGlucoseProcessed` respectively, with no reader anywhere (the type never crosses the wire from `src/API` at all; the dedup dialog reads other fields).
- **`RecordTypeKeys`** (next to the `RecordType` enum): eleven consts plus `Key()`. `Key()` replaces the four `ToString().ToLowerInvariant()` writer sites (three in `DeduplicationService`, one in `DataOverviewService`); the consts replace all 19 predicate literals across the nine repositories and `GetUnifiedStateSpanAsync` — consts because EF must inline them into expression trees, so SQL translation is unchanged. Hostile review diffed every substitution hunk for transposition: none.

## Declared behavioural deltas

None at runtime. The only wire-adjacent change is the two deleted dead counters, and `DeduplicationResult` is not referenced by any controller. The nine count queries now run in phase order (statespan last instead of first); only their sum is observable.

## Discrepancy with the issue text

"~18 repository literals" was 19 — the nineteenth sits inside `DeduplicationService.GetUnifiedStateSpanAsync` itself. All 19 replaced.

## Tests

`Nocturne.Core.Models.Tests` 841 passed (+12: `RecordTypeKeysTests`), `Nocturne.Infrastructure.Data.Tests` 835 passed, `Nocturne.API.Tests` 6315 passed; 0 failures throughout.

`RecordTypeKeysTests` reflects over the consts and pins name-set == enum-name-set and each value == `Key()`, so the mapping cannot drift silently in either direction. Mutations: a const value change and an added enum member both redden it; transposing `RecordType.Bolus`→`CarbIntake` in a registry row reddens 8 existing dedup tests. A repository-side const transposition (`BGCheck`→`Bolus` in `ApplyReadVisibility`) escapes the local unit suites and is caught only by the CI integration goldens' independent literals — a pre-existing exposure the old string literals shared, noted here rather than papered over; the 15-copy read-visibility predicate is filed as #1105.