### PR TITLE
refactor(api): drive the legacy-API migration pulls through one paged loop

### DIFF
--- a/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
+++ b/src/API/Nocturne.API/Services/Migration/MigrationJobService.cs
@@ -727,15 +727,15 @@ internal class MigrationJob
         var dbContext = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
 
         // Build the list of collections to migrate
-        var allCollections = new (string name, Func<HttpClient, NocturneDbContext, CancellationToken, Task> migrate)[]
+        var allCollections = new (string name, Func<HttpClient, CancellationToken, Task> migrate)[]
         {
-            ("subjects", MigrateSubjectsViaApiAsync),
-            ("entries", MigrateEntriesViaApiAsync),
-            ("treatments", MigrateTreatmentsViaApiAsync),
-            ("devicestatus", MigrateDeviceStatusViaApiAsync),
+            ("subjects", (client, token) => MigrateSubjectsViaApiAsync(client, dbContext, token)),
+            ("entries", (client, token) => MigratePagedCollectionAsync(client, s_entriesCollection, token)),
+            ("treatments", (client, token) => MigratePagedCollectionAsync(client, s_treatmentsCollection, token)),
+            ("devicestatus", (client, token) => MigratePagedCollectionAsync(client, s_deviceStatusCollection, token)),
             ("profile", MigrateProfilesViaApiAsync),
-            ("food", MigrateFoodViaApiAsync),
-            ("activity", MigrateActivityViaApiAsync),
+            ("food", (client, token) => MigrateFoodViaApiAsync(client, dbContext, token)),
+            ("activity", (client, token) => MigratePagedCollectionAsync(client, s_activityCollection, token)),
         };
 
         var collectionsToMigrate = allCollections
@@ -760,9 +760,9 @@ internal class MigrationJob
             _totalDocumentsAllCollections += count;
         }
 
-        foreach (var (name, migrate) in collectionsToMigrate)
+        foreach (var (_, migrate) in collectionsToMigrate)
         {
-            await migrate(httpClient, dbContext, ct);
+            await migrate(httpClient, ct);
         }
     }
 
@@ -842,231 +842,160 @@ internal class MigrationJob
     /// </summary>
     private static DateTime FirstPageAnchor => DateTime.UtcNow;
 
-    private async Task MigrateEntriesViaApiAsync(
+    /// <summary>
+    ///     Page size for every legacy-API pull. The merged v1 reads (devicestatus, activity) clamp
+    ///     to <see cref="LegacyReadLimits.MaxMergedCount"/>, and the loops terminate on a short
+    ///     page, so a larger value here would silently end those pulls after one page.
+    /// </summary>
+    private const int ApiPageSize = LegacyReadLimits.MaxMergedCount;
+
+    /// <summary>
+    ///     How a paged pull bounds and advances its time cursor: <paramref name="Filter"/> is the
+    ///     query-string fragment restricting a page to records at or before the cursor, and
+    ///     <paramref name="Oldest"/> reads the page's oldest record, answering <c>null</c> when the
+    ///     page carries no usable timestamp to page back from.
+    /// </summary>
+    private sealed record PageCursor(
+        Func<DateTime, string> Filter,
+        Func<IReadOnlyList<ProcessableDocumentBase>, DateTime?> Oldest
+    );
+
+    /// <summary>Entries page on the numeric <c>date</c> field, which mirrors mills exactly.</summary>
+    private static readonly PageCursor s_dateCursor = new(
+        to => $"&find[date][$lte]={new DateTimeOffset(to, TimeSpan.Zero).ToUnixTimeMilliseconds()}",
+        page =>
+        {
+            var oldestMs = page.Min(d => d.Mills);
+            return oldestMs <= 0
+                ? null
+                : DateTimeOffset.FromUnixTimeMilliseconds(oldestMs).UtcDateTime;
+        });
+
+    /// <summary>Every other collection pages on the ISO-8601 <c>created_at</c> string.</summary>
+    private static readonly PageCursor s_createdAtCursor = new(
+        to => $"&find[created_at][$lte]={to.ToUniversalTime():o}",
+        page => page
+            .Select(d => DateTimeOffset.TryParse(d.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
+            .Where(dt => dt.HasValue)
+            .Min());
+
+    /// <summary>
+    ///     A legacy collection pulled page by page over a time cursor. <paramref name="Name"/> is
+    ///     both the v1 route segment and the progress key; <paramref name="Label"/> names the
+    ///     records in operation and log text; <paramref name="Decompose"/> resolves the
+    ///     collection's decomposer from the migration's tenant scope once per pull.
+    /// </summary>
+    private sealed record PagedCollection<T>(
+        string Name,
+        string Label,
+        PageCursor Cursor,
+        Func<IServiceProvider, Func<T[], CancellationToken, Task>> Decompose
+    ) where T : ProcessableDocumentBase;
+
+    private static readonly PagedCollection<Entry> s_entriesCollection = new(
+        "entries", "entries", s_dateCursor,
+        sp =>
+        {
+            var decomposer = sp.GetRequiredService<IEntryDecomposer>();
+            return (page, ct) => decomposer.DecomposeBatchAsync(page, WriteOrigin.Backfill, ct);
+        });
+
+    private static readonly PagedCollection<Treatment> s_treatmentsCollection = new(
+        "treatments", "treatments", s_createdAtCursor,
+        sp =>
+        {
+            var decomposer = sp.GetRequiredService<ITreatmentDecomposer>();
+            return (page, ct) => decomposer.DecomposeBatchAsync(page, WriteOrigin.Backfill, ct);
+        });
+
+    private static readonly PagedCollection<DeviceStatus> s_deviceStatusCollection = new(
+        "devicestatus", "device statuses", s_createdAtCursor,
+        sp =>
+        {
+            var decomposer = sp.GetRequiredService<IDeviceStatusDecomposer>();
+            return (page, ct) => decomposer.DecomposeBatchAsync(page, source: null, WriteOrigin.Backfill, ct);
+        });
+
+    private static readonly PagedCollection<Activity> s_activityCollection = new(
+        "activity", "activities", s_createdAtCursor,
+        sp =>
+        {
+            var decomposer = sp.GetRequiredService<IActivityDecomposer>();
+            return (page, ct) => decomposer.DecomposeBatchAsync(page, WriteOrigin.Backfill, ct);
+        });
+
+    private async Task MigratePagedCollectionAsync<T>(
         HttpClient httpClient,
-        NocturneDbContext dbContext,
+        PagedCollection<T> collection,
         CancellationToken ct
-    )
+    ) where T : ProcessableDocumentBase
     {
-        _currentOperation = "Migrating entries";
-        const string collectionName = "entries";
-        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing)
+        _currentOperation = $"Migrating {collection.Label}";
+        var knownTotal = _collectionProgress.TryGetValue(collection.Name, out var existing)
             ? existing.TotalDocuments : 0;
 
         var totalMigrated = 0L;
         var totalFailed = 0L;
         DateTime? currentTo = FirstPageAnchor;
-        const int pageSize = 10000;
 
         using var scope = CreateTenantScope();
-        var decomposer = scope.ServiceProvider.GetRequiredService<IEntryDecomposer>();
+        var decompose = collection.Decompose(scope.ServiceProvider);
 
         while (true)
         {
             ct.ThrowIfCancellationRequested();
 
-            var url = $"/api/v1/entries.json?count={pageSize}";
+            var url = $"/api/v1/{collection.Name}.json?count={ApiPageSize}";
             if (currentTo.HasValue)
-            {
-                var toMs = new DateTimeOffset(currentTo.Value, TimeSpan.Zero).ToUnixTimeMilliseconds();
-                url += $"&find[date][$lte]={toMs}";
-            }
+                url += collection.Cursor.Filter(currentTo.Value);
 
             var response = await httpClient.GetAsync(url, ct);
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogError("Failed to fetch entries: {StatusCode}", response.StatusCode);
+                _logger.LogError(
+                    "Failed to fetch {Collection}: {StatusCode}", collection.Label, response.StatusCode);
                 break;
             }
 
             var content = await response.Content.ReadAsStringAsync(ct);
-            var entries = System.Text.Json.JsonSerializer.Deserialize<Entry[]>(content) ?? [];
+            var page = System.Text.Json.JsonSerializer.Deserialize<T[]>(content) ?? [];
 
-            if (entries.Length == 0) break;
+            if (page.Length == 0) break;
 
             try
             {
-                await decomposer.DecomposeBatchAsync(entries, WriteOrigin.Backfill, ct);
-                totalMigrated += entries.Length;
+                await decompose(page, ct);
+                totalMigrated += page.Length;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to decompose entries page");
-                totalFailed += entries.Length;
+                _logger.LogError(ex, "Failed to decompose {Collection} page", collection.Label);
+                totalFailed += page.Length;
             }
 
-            UpdateCollectionProgress(collectionName,
+            UpdateCollectionProgress(collection.Name,
                 Math.Max(knownTotal, totalMigrated + totalFailed),
                 totalMigrated, totalFailed, false);
             UpdateOverallProgress();
 
-            if (entries.Length < pageSize) break;
+            if (page.Length < ApiPageSize) break;
 
-            var oldestMs = entries.Min(e => e.Mills);
-            if (oldestMs <= 0) break;
-
-            var oldestDate = DateTimeOffset.FromUnixTimeMilliseconds(oldestMs).UtcDateTime;
-            if (currentTo.HasValue && oldestDate >= currentTo.Value) break;
-            currentTo = oldestDate.AddMilliseconds(-1);
-        }
-
-        UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
-            totalMigrated, totalFailed, true);
-        UpdateOverallProgress();
-        _logger.LogInformation("Migrated {Count} entries via API", totalMigrated);
-    }
-
-    private async Task MigrateTreatmentsViaApiAsync(
-        HttpClient httpClient,
-        NocturneDbContext dbContext,
-        CancellationToken ct
-    )
-    {
-        _currentOperation = "Migrating treatments";
-        const string collectionName = "treatments";
-        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing)
-            ? existing.TotalDocuments : 0;
-
-        var totalMigrated = 0L;
-        var totalFailed = 0L;
-        DateTime? currentTo = FirstPageAnchor;
-        const int pageSize = 10000;
-
-        using var scope = CreateTenantScope();
-        var decomposer = scope.ServiceProvider.GetRequiredService<ITreatmentDecomposer>();
-
-        while (true)
-        {
-            ct.ThrowIfCancellationRequested();
-
-            var url = $"/api/v1/treatments.json?count={pageSize}";
-            if (currentTo.HasValue)
-                url += $"&find[created_at][$lte]={currentTo.Value.ToUniversalTime():o}";
-
-            var response = await httpClient.GetAsync(url, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogError("Failed to fetch treatments: {StatusCode}", response.StatusCode);
-                break;
-            }
-
-            var content = await response.Content.ReadAsStringAsync(ct);
-            var treatments = System.Text.Json.JsonSerializer.Deserialize<Treatment[]>(content) ?? [];
-
-            if (treatments.Length == 0) break;
-
-            try
-            {
-                await decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Backfill, ct);
-                totalMigrated += treatments.Length;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to decompose treatments page");
-                totalFailed += treatments.Length;
-            }
-
-            UpdateCollectionProgress(collectionName,
-                Math.Max(knownTotal, totalMigrated + totalFailed),
-                totalMigrated, totalFailed, false);
-            UpdateOverallProgress();
-
-            if (treatments.Length < pageSize) break;
-
-            var oldestDate = treatments
-                .Select(t => DateTimeOffset.TryParse(t.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
-                .Where(dt => dt.HasValue)
-                .Min();
+            var oldestDate = collection.Cursor.Oldest(page);
 
             if (!oldestDate.HasValue) break;
             if (currentTo.HasValue && oldestDate.Value >= currentTo.Value) break;
             currentTo = oldestDate.Value.AddMilliseconds(-1);
         }
 
-        UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
+        UpdateCollectionProgress(collection.Name, Math.Max(knownTotal, totalMigrated + totalFailed),
             totalMigrated, totalFailed, true);
         UpdateOverallProgress();
-        _logger.LogInformation("Migrated {Count} treatments via API", totalMigrated);
-    }
-
-    private async Task MigrateDeviceStatusViaApiAsync(
-        HttpClient httpClient,
-        NocturneDbContext dbContext,
-        CancellationToken ct
-    )
-    {
-        _currentOperation = "Migrating device statuses";
-        const string collectionName = "devicestatus";
-        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing)
-            ? existing.TotalDocuments : 0;
-
-        var totalMigrated = 0L;
-        var totalFailed = 0L;
-        DateTime? currentTo = FirstPageAnchor;
-        // The v1 read clamps to this, and the loop below terminates on a short page, so a larger
-        // page size here would silently end the pull after one page.
-        const int pageSize = LegacyReadLimits.MaxMergedCount;
-
-        using var scope = CreateTenantScope();
-        var decomposer = scope.ServiceProvider.GetRequiredService<IDeviceStatusDecomposer>();
-
-        while (true)
-        {
-            ct.ThrowIfCancellationRequested();
-
-            var url = $"/api/v1/devicestatus.json?count={pageSize}";
-            if (currentTo.HasValue)
-                url += $"&find[created_at][$lte]={currentTo.Value.ToUniversalTime():o}";
-
-            var response = await httpClient.GetAsync(url, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogError("Failed to fetch device statuses: {StatusCode}", response.StatusCode);
-                break;
-            }
-
-            var content = await response.Content.ReadAsStringAsync(ct);
-            var statuses = System.Text.Json.JsonSerializer.Deserialize<DeviceStatus[]>(content) ?? [];
-
-            if (statuses.Length == 0) break;
-
-            try
-            {
-                await decomposer.DecomposeBatchAsync(statuses, source: null, WriteOrigin.Backfill, ct);
-                totalMigrated += statuses.Length;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to decompose device status page");
-                totalFailed += statuses.Length;
-            }
-
-            UpdateCollectionProgress(collectionName,
-                Math.Max(knownTotal, totalMigrated + totalFailed),
-                totalMigrated, totalFailed, false);
-            UpdateOverallProgress();
-
-            if (statuses.Length < pageSize) break;
-
-            var oldestDate = statuses
-                .Select(d => DateTimeOffset.TryParse(d.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
-                .Where(dt => dt.HasValue)
-                .Min();
-
-            if (!oldestDate.HasValue) break;
-            if (currentTo.HasValue && oldestDate.Value >= currentTo.Value) break;
-            currentTo = oldestDate.Value.AddMilliseconds(-1);
-        }
-
-        UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
-            totalMigrated, totalFailed, true);
-        UpdateOverallProgress();
-        _logger.LogInformation("Migrated {Count} device statuses via API", totalMigrated);
+        _logger.LogInformation(
+            "Migrated {Count} {Collection} via API", totalMigrated, collection.Label);
     }
 
     private async Task MigrateProfilesViaApiAsync(
         HttpClient httpClient,
-        NocturneDbContext dbContext,
         CancellationToken ct
     )
     {
@@ -1141,7 +1070,6 @@ internal class MigrationJob
         var totalMigrated = 0L;
         var totalFailed = 0L;
         var totalSkipped = 0;
-        const int pageSize = 10000;
 
         try
         {
@@ -1149,7 +1077,7 @@ internal class MigrationJob
             {
                 ct.ThrowIfCancellationRequested();
 
-                var url = $"/api/v1/food.json?count={pageSize}&skip={totalSkipped}";
+                var url = $"/api/v1/food.json?count={ApiPageSize}&skip={totalSkipped}";
 
                 var response = await httpClient.GetAsync(url, ct);
                 if (!response.IsSuccessStatusCode)
@@ -1212,7 +1140,7 @@ internal class MigrationJob
                     totalMigrated, totalFailed, false);
                 UpdateOverallProgress();
 
-                if (foods.Length < pageSize) break;
+                if (foods.Length < ApiPageSize) break;
             }
 
             UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
@@ -1225,81 +1153,6 @@ internal class MigrationJob
         }
 
         _logger.LogInformation("Migrated {Count} food items via API", totalMigrated);
-    }
-
-    private async Task MigrateActivityViaApiAsync(
-        HttpClient httpClient,
-        NocturneDbContext dbContext,
-        CancellationToken ct
-    )
-    {
-        _currentOperation = "Migrating activities";
-        const string collectionName = "activity";
-        var knownTotal = _collectionProgress.TryGetValue(collectionName, out var existing)
-            ? existing.TotalDocuments : 0;
-
-        var totalMigrated = 0L;
-        var totalFailed = 0L;
-        DateTime? currentTo = FirstPageAnchor;
-        // The v1 read clamps to this, and the loop below terminates on a short page, so a larger
-        // page size here would silently end the pull after one page.
-        const int pageSize = LegacyReadLimits.MaxMergedCount;
-
-        using var scope = CreateTenantScope();
-        var decomposer = scope.ServiceProvider.GetRequiredService<IActivityDecomposer>();
-
-        while (true)
-        {
-            ct.ThrowIfCancellationRequested();
-
-            var url = $"/api/v1/activity.json?count={pageSize}";
-            if (currentTo.HasValue)
-                url += $"&find[created_at][$lte]={currentTo.Value.ToUniversalTime():o}";
-
-            var response = await httpClient.GetAsync(url, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogError("Failed to fetch activities: {StatusCode}", response.StatusCode);
-                break;
-            }
-
-            var content = await response.Content.ReadAsStringAsync(ct);
-            var activities = System.Text.Json.JsonSerializer.Deserialize<Activity[]>(content) ?? [];
-
-            if (activities.Length == 0) break;
-
-            try
-            {
-                await decomposer.DecomposeBatchAsync(activities, WriteOrigin.Backfill, ct);
-                totalMigrated += activities.Length;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to decompose activity page");
-                totalFailed += activities.Length;
-            }
-
-            UpdateCollectionProgress(collectionName,
-                Math.Max(knownTotal, totalMigrated + totalFailed),
-                totalMigrated, totalFailed, false);
-            UpdateOverallProgress();
-
-            if (activities.Length < pageSize) break;
-
-            var oldestDate = activities
-                .Select(a => DateTimeOffset.TryParse(a.CreatedAt, out var dto) ? dto.UtcDateTime : (DateTime?)null)
-                .Where(dt => dt.HasValue)
-                .Min();
-
-            if (!oldestDate.HasValue) break;
-            if (currentTo.HasValue && oldestDate.Value >= currentTo.Value) break;
-            currentTo = oldestDate.Value.AddMilliseconds(-1);
-        }
-
-        UpdateCollectionProgress(collectionName, Math.Max(knownTotal, totalMigrated + totalFailed),
-            totalMigrated, totalFailed, true);
-        UpdateOverallProgress();
-        _logger.LogInformation("Migrated {Count} activities via API", totalMigrated);
     }
 
     private async Task ExecuteMongoMigrationAsync(CancellationToken ct)

--- a/tests/Unit/Nocturne.API.Tests/Migration/MigrationPagedPullTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Migration/MigrationPagedPullTests.cs
@@ -1,0 +1,216 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Helpers;
+using Nocturne.API.Services.Audit;
+using Nocturne.API.Services.Migration;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Tests.Migration;
+
+/// <summary>
+/// The request sequence an API-mode migration issues while pulling a collection page by page.
+/// Every page is explicitly dated and asks for <see cref="LegacyReadLimits.MaxMergedCount"/>
+/// records: a larger page is clamped by the merged v1 reads, and since a short page ends the pull,
+/// a clamped first page would import one page and report the collection complete. The cursor field
+/// differs per collection (entries carry a numeric <c>date</c>, everything else an ISO
+/// <c>created_at</c>), so each has to page back on its own field or the second request repeats the
+/// first page.
+/// </summary>
+public class MigrationPagedPullTests
+{
+    /// <summary>
+    /// Stands in for the source Nightscout instance, serving one queued response per request to a
+    /// single collection route and recording the URLs asked for. Everything else — including the
+    /// count endpoint the migration probes first — answers 404.
+    /// </summary>
+    private sealed class NightscoutPager(string route, Queue<(HttpStatusCode Status, string Body)> pages)
+        : HttpMessageHandler
+    {
+        public List<string> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri!;
+            if (uri.AbsolutePath != route)
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+            Requests.Add(Uri.UnescapeDataString(uri.PathAndQuery));
+
+            var (status, body) = pages.Count > 0 ? pages.Dequeue() : (HttpStatusCode.OK, "[]");
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private sealed class FixedTenantAccessor : ITenantAccessor
+    {
+        public TenantContext? Context { get; private set; }
+
+        public bool IsResolved => Context is not null;
+
+        public Guid TenantId => Context?.TenantId ?? Guid.Empty;
+
+        public void SetTenant(TenantContext? tenant) => Context = tenant;
+    }
+
+    private static ServiceProvider BuildProvider(HttpMessageHandler handler)
+    {
+        var database = $"migration-paged-{Guid.NewGuid():N}";
+
+        var entries = new Mock<IEntryDecomposer>();
+        entries
+            .Setup(d => d.DecomposeBatchAsync(It.IsAny<IReadOnlyList<Entry>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DecompositionResult());
+
+        var treatments = new Mock<ITreatmentDecomposer>();
+        treatments
+            .Setup(d => d.DecomposeBatchAsync(It.IsAny<IReadOnlyList<Treatment>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DecompositionResult());
+
+        var deviceStatuses = new Mock<IDeviceStatusDecomposer>();
+        deviceStatuses
+            .Setup(d => d.DecomposeBatchAsync(It.IsAny<IReadOnlyList<DeviceStatus>>(), It.IsAny<string?>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DecompositionResult());
+
+        var activities = new Mock<IActivityDecomposer>();
+        activities
+            .Setup(d => d.DecomposeBatchAsync(It.IsAny<IReadOnlyList<Activity>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DecompositionResult());
+
+        return new ServiceCollection()
+            .AddDbContext<NocturneDbContext>(o => o.UseInMemoryDatabase(database))
+            .AddScoped<ITenantAccessor, FixedTenantAccessor>()
+            .AddScoped<IAuditContext, AuditContext>()
+            .AddSingleton<IHttpClientFactory>(new StubHttpClientFactory(handler))
+            .AddSingleton(entries.Object)
+            .AddSingleton(treatments.Object)
+            .AddSingleton(deviceStatuses.Object)
+            .AddSingleton(activities.Object)
+            .BuildServiceProvider();
+    }
+
+    private static async Task<MigrationJobStatus> RunAsync(IServiceProvider provider, string collection)
+    {
+        var tenant = new TenantContext(
+            Guid.CreateVersion7(), "migrated", "Migrated Tenant", true, IsDemo: false);
+
+        var job = new MigrationJob(
+            Guid.CreateVersion7(),
+            tenant.TenantId,
+            new StartMigrationRequest
+            {
+                Mode = MigrationMode.Api,
+                NightscoutUrl = "https://example-nightscout.invalid",
+                Collections = [collection],
+            },
+            new MigrationJobInfo
+            {
+                Id = Guid.CreateVersion7(),
+                Mode = MigrationMode.Api,
+                CreatedAt = DateTime.UtcNow,
+            },
+            tenant,
+            NullLogger.Instance,
+            provider);
+
+        await job.ExecuteAsync(CancellationToken.None);
+
+        return job.GetStatus();
+    }
+
+    private static string FullPage(Func<int, string> record) =>
+        "[" + string.Join(",", Enumerable.Range(0, LegacyReadLimits.MaxMergedCount).Select(record)) + "]";
+
+    [Theory]
+    [InlineData("entries", "find[date][$lte]=")]
+    [InlineData("treatments", "find[created_at][$lte]=")]
+    [InlineData("devicestatus", "find[created_at][$lte]=")]
+    [InlineData("activity", "find[created_at][$lte]=")]
+    public async Task A_pull_asks_for_a_full_page_and_dates_it_on_the_collections_own_cursor_field(
+        string collection, string cursorField)
+    {
+        var handler = new NightscoutPager(
+            $"/api/v1/{collection}.json",
+            new Queue<(HttpStatusCode, string)>([(HttpStatusCode.OK, """[{ }]""")]));
+
+        await using var provider = BuildProvider(handler);
+        await RunAsync(provider, collection);
+
+        handler.Requests.Should().ContainSingle()
+            .Which.Should().Contain($"count={LegacyReadLimits.MaxMergedCount}&")
+            .And.Contain(cursorField);
+    }
+
+    [Fact]
+    public async Task Entries_page_back_from_the_oldest_date_on_the_page()
+    {
+        var oldestMs = DateTimeOffset.Parse("2026-02-01T00:00:00Z").ToUnixTimeMilliseconds();
+        var handler = new NightscoutPager(
+            "/api/v1/entries.json",
+            new Queue<(HttpStatusCode, string)>([
+                (HttpStatusCode.OK, FullPage(i => $$"""{"date":{{oldestMs + i}}}""")),
+                (HttpStatusCode.OK, """[{ }]"""),
+            ]));
+
+        await using var provider = BuildProvider(handler);
+        await RunAsync(provider, "entries");
+
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[1].Should().Contain($"find[date][$lte]={oldestMs - 1}");
+    }
+
+    [Fact]
+    public async Task Created_at_collections_page_back_from_the_oldest_timestamp_on_the_page()
+    {
+        var oldest = DateTimeOffset.Parse("2026-02-01T00:00:00Z");
+        var handler = new NightscoutPager(
+            "/api/v1/treatments.json",
+            new Queue<(HttpStatusCode, string)>([
+                (HttpStatusCode.OK, FullPage(i =>
+                    $$"""{"created_at":"{{oldest.AddMinutes(i):yyyy-MM-ddTHH:mm:ss.fffZ}}"}""")),
+                (HttpStatusCode.OK, """[{ }]"""),
+            ]));
+
+        await using var provider = BuildProvider(handler);
+        await RunAsync(provider, "treatments");
+
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[1].Should().Contain(
+            $"find[created_at][$lte]={oldest.UtcDateTime.AddMilliseconds(-1):o}");
+    }
+
+    [Fact]
+    public async Task A_failed_fetch_ends_the_pull_after_one_request()
+    {
+        var handler = new NightscoutPager(
+            "/api/v1/entries.json",
+            new Queue<(HttpStatusCode, string)>([(HttpStatusCode.InternalServerError, "")]));
+
+        await using var provider = BuildProvider(handler);
+        var status = await RunAsync(provider, "entries");
+
+        handler.Requests.Should().ContainSingle();
+
+        // Asserted deliberately: an aborted pull reporting the collection complete is the job's
+        // current contract for every collection.
+        status.CollectionProgress["entries"].IsComplete.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Closes #1093.

The four legacy-API paging pulls (entries, treatments, devicestatus, activity) were one loop copied four times, three of them hardcoding the page size the other two took from `LegacyReadLimits`. Net **−147 lines** in the service, plus the loop's first real tests.

## What changes

- **One `MigratePagedCollectionAsync<T>`** driven by `PagedCollection<T>` descriptors (name, label, cursor, decomposer factory) and two `PageCursor`s: entries page on numeric `find[date][$lte]` advancing from `Min(Mills)`; treatments/devicestatus/activity share one `created_at` cursor (all four DTOs extend `ProcessableDocumentBase`, so no per-type field plumbing was needed). URL construction, first-page anchor, `-1 ms` cursor step, equal-timestamp guard, short-page/non-2xx/no-cursor termination, per-pull tenant scope, progress-update ordering and rendered operation strings are byte-identical per type.
- **`ApiPageSize = LegacyReadLimits.MaxMergedCount`** in one place, carrying the "a larger value would silently end the pull after one page" constraint; the three `10000` hardcodes (entries, treatments, food) are gone. `MaxMergedCount` is 10,000, so nothing observable changes today — but lowering the clamp can no longer truncate three collections to a single page.
- **Dead delegate parameter dropped**: the collection delegate is now `Func<HttpClient, CancellationToken, Task>`; food and subjects capture the outer `dbContext` at their call sites, and `MigrateProfilesViaApiAsync` loses the parameter it never used.
- **Food keeps its own loop** — it genuinely differs (offset paging, no time cursor, inline `FoodEntity` inserts, per-page saves); only its page size was unified.

## Declared behavioural deltas

1. Two error-log texts pluralize via the collection label: "Failed to decompose device status page" → "device statuses page", "activity page" → "activities page"; the fetch/decompose/summary log templates now carry a `{Collection}` parameter (affects structured-log queries, not behavior).
2. Deliberately **not** fixed: #1092's completed-while-aborted semantics are preserved exactly, and `A_failed_fetch_ends_the_pull_after_one_request` pins that current contract on purpose — #1092 becomes a one-place change once merged.

## Tests

`Nocturne.API.Tests`: 6322 passed, 0 failed, 5 skipped (+7 new in `MigrationPagedPullTests`: a recording `HttpMessageHandler` asserting page-size value, per-collection cursor field, exact back-cursor values for both cursor kinds, and abort-after-one-request).

Mutation-checked: `ApiPageSize + 1` and a cursor-field rename fail 6/7; removing the `-1 ms` step fails both cursor-advance tests; `break`→`continue` on non-2xx fails the abort test; hostile review's cursor-object swap between entries and treatments failed 2. The page-size assertion was tightened to `count=10000&` so a magnitude change cannot hide in a substring match.