### PR TITLE
refactor: delete the dead cache-key builders and data-source predicates

### DIFF
--- a/src/Core/Nocturne.Core.Constants/DataSources.cs
+++ b/src/Core/Nocturne.Core.Constants/DataSources.cs
@@ -226,65 +226,6 @@ public static class DataSources
     }
 
     /// <summary>
-    /// Returns <see langword="true"/> if the data source represents data fetched by a CGM or
-    /// device connector service.
-    /// </summary>
-    /// <param name="dataSource">The data source identifier to check, or <see langword="null"/>.</param>
-    /// <returns><see langword="true"/> if <paramref name="dataSource"/> is a connector source; otherwise <see langword="false"/>.</returns>
-    /// <seealso cref="ConnectorEnvironmentVariables"/>
-    public static bool IsConnector(string? dataSource)
-    {
-        return dataSource
-            is DexcomConnector
-                or LibreConnector
-                or MiniMedConnector
-                or CareLinkConnector
-                or GlookoConnector
-                or NightscoutConnector
-                or GlurooConnector
-                or TidepoolConnector
-                or TConnectSyncConnector
-                or HomeAssistantConnector
-                or EversenseConnector
-                or NocturneRemoteConnector
-                or TwiistConnector;
-    }
-
-    /// <summary>
-    /// Returns <see langword="true"/> if the data source represents manually entered data
-    /// from the web UI, Careportal, or an API client.
-    /// </summary>
-    /// <param name="dataSource">The data source identifier to check, or <see langword="null"/>.</param>
-    /// <returns><see langword="true"/> if <paramref name="dataSource"/> is a manual entry source; otherwise <see langword="false"/>.</returns>
-    public static bool IsManualEntry(string? dataSource)
-    {
-        return dataSource is ManualEntry or Careportal or ApiClient;
-    }
-
-    /// <summary>
-    /// Returns <see langword="true"/> if the data source represents data imported or migrated
-    /// from an external system (MongoDB, CSV, Tidepool export).
-    /// </summary>
-    /// <param name="dataSource">The data source identifier to check, or <see langword="null"/>.</param>
-    /// <returns><see langword="true"/> if <paramref name="dataSource"/> is an import source; otherwise <see langword="false"/>.</returns>
-    public static bool IsImported(string? dataSource)
-    {
-        return dataSource is MongoDbImport or CsvImport or TidepoolImport;
-    }
-
-    /// <summary>
-    /// Returns <see langword="true"/> if the data source represents data from an automated insulin delivery
-    /// (AID) or closed-loop system such as <see cref="Loop"/>, <see cref="OpenAps"/>,
-    /// <see cref="AndroidAps"/>, <see cref="IAps"/>, or <see cref="Trio"/>.
-    /// </summary>
-    /// <param name="dataSource">The data source identifier to check, or <see langword="null"/>.</param>
-    /// <returns><see langword="true"/> if <paramref name="dataSource"/> is an AID system source; otherwise <see langword="false"/>.</returns>
-    public static bool IsAidSystem(string? dataSource)
-    {
-        return dataSource is Loop or OpenAps or AndroidAps or IAps or Trio;
-    }
-
-    /// <summary>
     /// Returns the default CGM update interval in minutes for a given data source.
     /// Used as fallback when no PatientDevice is registered.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Keys/CacheKeyBuilder.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Keys/CacheKeyBuilder.cs
@@ -8,106 +8,6 @@ public static class CacheKeyBuilder
     private const string KeySeparator = ":";
 
     /// <summary>
-    /// Builds a cache key for glucose entries
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildEntriesKey(string tenantId, string? suffix = null) =>
-        BuildKey("entries", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for treatments
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildTreatmentsKey(string tenantId, string? suffix = null) =>
-        BuildKey("treatments", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for device status
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildDeviceStatusKey(string tenantId, string? suffix = null) =>
-        BuildKey("devicestatus", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for profiles
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildProfilesKey(string tenantId, string? suffix = null) =>
-        BuildKey("profiles", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for food entries
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildFoodKey(string tenantId, string? suffix = null) =>
-        BuildKey("food", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for settings
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildSettingsKey(string tenantId, string? suffix = null) =>
-        BuildKey("settings", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for API status
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildStatusKey(string tenantId, string? suffix = null) =>
-        BuildKey("status", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for version information
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildVersionKey(string tenantId, string? suffix = null) =>
-        BuildKey("version", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for Loop integration data
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildLoopKey(string tenantId, string? suffix = null) =>
-        BuildKey("loop", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for IOB calculations
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildIobKey(string tenantId, string? suffix = null) =>
-        BuildKey("iob", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for COB calculations
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildCobKey(string tenantId, string? suffix = null) =>
-        BuildKey("cob", tenantId, suffix);
-
-    /// <summary>
-    /// Builds a cache key for profile calculations
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="timestamp">Timestamp for time-based calculations</param>
-    /// <param name="suffix">Optional suffix</param>
-    public static string BuildProfileCalculationKey(
-        string tenantId,
-        long timestamp,
-        string? suffix = null
-    ) => BuildKey("profile-calc", tenantId, timestamp.ToString(), suffix);
-
-    /// <summary>
     /// Builds a cache key for current entries
     /// </summary>
     /// <param name="tenantId">Tenant ID</param>
@@ -179,14 +79,6 @@ public static class CacheKeyBuilder
 
         return string.Join(KeySeparator, keyParts);
     }
-
-    /// <summary>
-    /// Builds a cache key for profile at specific timestamp
-    /// </summary>
-    /// <param name="tenantId">Tenant ID</param>
-    /// <param name="timestamp">Unix timestamp for profile lookup</param>
-    public static string BuildProfileAtTimestampKey(string tenantId, long timestamp) =>
-        BuildKey("profiles", "at", tenantId, timestamp.ToString());
 
     /// <summary>
     /// Builds a generic cache key
@@ -267,30 +159,6 @@ public static class CacheKeyBuilder
     /// <param name="timestamp">Timestamp for calculation</param>
     public static string BuildProfileCalculatedKey(string profileId, long timestamp) =>
         BuildKey("profiles", "calculated", profileId, timestamp.ToString());
-
-    /// <summary>
-    /// Builds a cache key for time-in-range statistics
-    /// </summary>
-    /// <param name="userId">User ID</param>
-    /// <param name="period">Time period (e.g., "24h", "7d", "30d")</param>
-    public static string BuildTirStatsKey(string userId, string period) =>
-        BuildKey("stats", "tir", userId, period);
-
-    /// <summary>
-    /// Builds a cache key for HbA1c estimate statistics
-    /// </summary>
-    /// <param name="userId">User ID</param>
-    /// <param name="period">Time period (e.g., "24h", "7d", "30d")</param>
-    public static string BuildHbA1cStatsKey(string userId, string period) =>
-        BuildKey("stats", "hba1c", userId, period);
-
-    /// <summary>
-    /// Builds a cache key for glucose statistics
-    /// </summary>
-    /// <param name="userId">User ID</param>
-    /// <param name="period">Time period (e.g., "24h", "7d", "30d")</param>
-    public static string BuildGlucoseStatsKey(string userId, string period) =>
-        BuildKey("stats", "glucose", userId, period);
 
     /// <summary>
     /// Creates a pattern for invalidating all IOB calculation cache for a user


### PR DESCRIPTION
Closes #1061.

Deletion-only: **−191 lines, zero insertions** (`git diff -U0 | grep '^+[^+]'` is empty).

## What changes

- `CacheKeyBuilder`: all **16** caller-free typed builders deleted (`BuildEntriesKey`, `BuildTreatmentsKey`, `BuildDeviceStatusKey`, `BuildProfilesKey`, `BuildFoodKey`, `BuildSettingsKey`, `BuildStatusKey`, `BuildVersionKey`, `BuildLoopKey`, `BuildIobKey`, `BuildCobKey`, `BuildProfileCalculationKey`, `BuildProfileAtTimestampKey`, `BuildTirStatsKey`, `BuildHbA1cStatsKey`, `BuildGlucoseStatsKey`) — the issue title said 15; the grep says 16. `BuildKey`/`BuildPattern` and every live builder stay.
- `DataSources`: the four dead classification predicates deleted (`IsConnector`, `IsManualEntry`, `IsImported`, `IsAidSystem`); the live `IsEphemeral` kept.

Every name was re-proven caller-free on this base with word-boundary greps over the whole tracked tree (src incl. Web, tools, sdk, docs), plus checks for reflection (`typeof`/`GetMethod`), `nameof`, and XML `cref` hooks. The only extra `IsConnector` hits are node labels in an unrelated mermaid diagram.

## Declared behavioural deltas

None — pure deletion. No test referenced any deleted member, so no test changed.

## Follow-up (filed, not in this PR)

Deleting the stats builders makes it visible that the `stats:` cache namespace now has no writer at all while six invalidation call sites still sweep it, and that `DataSources.All` / `CacheConstants.Stats` are themselves reader-free — #1109.

## Tests

Full solution build clean; `Nocturne.Infrastructure.Cache.Tests` 2/2, `Nocturne.Core.Constants.Tests` 29/29, cache-related `Nocturne.API.Tests` 15/15.