### PR TITLE
refactor(connectors): collapse the tenant-URL installer trio onto a shared base

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
@@ -99,8 +99,7 @@ public static class ConnectorServiceCollectionExtensions
         /// <typeparam name="TTokenProvider">Token provider type</typeparam>
         /// <param name="configuration">Configuration</param>
         /// <param name="options">Connector options</param>
-        /// <returns>The configuration if enabled, null otherwise</returns>
-        public TConfig? AddConnector<TConfig, TService, TTokenProvider>(IConfiguration configuration,
+        public void AddConnector<TConfig, TService, TTokenProvider>(IConfiguration configuration,
             ConnectorOptions options)
             where TConfig : BaseConnectorConfiguration, new()
             where TService : class, IConnectorService<TConfig>
@@ -114,7 +113,7 @@ public static class ConnectorServiceCollectionExtensions
 
             // Skip registration if disabled
             if (!config.Enabled)
-                return null;
+                return;
 
             // Register server resolver
             services.AddSingleton<IConnectorServerResolver<TConfig>>(
@@ -153,8 +152,6 @@ public static class ConnectorServiceCollectionExtensions
 
             services.AddConnectorTokenProvider<TTokenProvider>();
             services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TService, TConfig>>();
-
-            return config;
         }
 
         /// <summary>

--- a/src/Connectors/Nocturne.Connectors.Core/Interfaces/IConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Interfaces/IConnectorInstaller.cs
@@ -10,11 +10,6 @@ namespace Nocturne.Connectors.Core.Interfaces;
 public interface IConnectorInstaller
 {
     /// <summary>
-    ///     The connector name (e.g., "Dexcom", "LibreLinkUp").
-    /// </summary>
-    string ConnectorName { get; }
-
-    /// <summary>
     ///     Registers all services required by this connector.
     /// </summary>
     void Install(IServiceCollection services, IConfiguration configuration);

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorInstaller.cs
@@ -9,9 +9,11 @@ namespace Nocturne.Connectors.Core.Services;
 /// <summary>
 ///     Installs a connector whose registration is entirely standard — configuration, service,
 ///     token provider and the generic sync executor — so that all it has to state is
-///     <paramref name="options"/> and its three types. A connector that needs anything else
-///     (a hand-rolled client, extra services, no token provider) implements
-///     <see cref="IConnectorInstaller"/> directly and calls the pieces itself.
+///     <paramref name="options"/> and its three types. A connector that has no token provider and
+///     takes its base URL from per-tenant configuration derives from
+///     <see cref="TenantUrlConnectorInstaller{TConfig,TService}"/>; one that needs anything else
+///     again (a hand-rolled client, extra services) implements <see cref="IConnectorInstaller"/>
+///     directly and calls the pieces itself.
 /// </summary>
 /// <typeparam name="TConfig">Configuration type</typeparam>
 /// <typeparam name="TService">Connector service type</typeparam>
@@ -23,9 +25,6 @@ public abstract class ConnectorInstaller<TConfig, TService, TTokenProvider>(Conn
     where TService : class, IConnectorService<TConfig>
     where TTokenProvider : class
 {
-    /// <inheritdoc />
-    public string ConnectorName => options.ConnectorName;
-
     /// <inheritdoc />
     public void Install(IServiceCollection services, IConfiguration configuration) =>
         services.AddConnector<TConfig, TService, TTokenProvider>(configuration, options);

--- a/src/Connectors/Nocturne.Connectors.Core/Services/TenantUrlConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/TenantUrlConnectorInstaller.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
+
+namespace Nocturne.Connectors.Core.Services;
+
+/// <summary>
+///     Installs a connector that reaches a base URL supplied per tenant rather than a server chosen
+///     by region, and that authenticates without a token provider — configuration, an unmapped
+///     <see cref="ConnectorServerResolver{TConfig}"/>, the configuration loader, the shared token
+///     cache and the generic sync executor. The server-mapping members of
+///     <paramref name="options"/> have no effect here; a connector that resolves a server by region
+///     or holds a token provider derives from
+///     <see cref="ConnectorInstaller{TConfig,TService,TTokenProvider}"/> instead.
+/// </summary>
+/// <typeparam name="TConfig">Configuration type</typeparam>
+/// <typeparam name="TService">Connector service type</typeparam>
+/// <param name="options">Connector options</param>
+/// <param name="configuredUrl">Reads the connector's base URL off its configuration</param>
+public abstract class TenantUrlConnectorInstaller<TConfig, TService>(
+    ConnectorOptions options,
+    Func<TConfig, string?> configuredUrl)
+    : IConnectorInstaller
+    where TConfig : BaseConnectorConfiguration, new()
+    where TService : class, IConnectorService<TConfig>
+{
+    /// <inheritdoc />
+    public void Install(IServiceCollection services, IConfiguration configuration)
+    {
+        var config = services.AddConnectorConfiguration<TConfig>(
+            configuration,
+            options.ConnectorName);
+
+        InstallUnconditional(services, config);
+
+        if (!config.Enabled)
+            return;
+
+        services.AddSingleton<IConnectorServerResolver<TConfig>>(
+            new ConnectorServerResolver<TConfig>(null, null, null));
+        services.AddScoped<IConnectorConfigurationLoader<TConfig>, ConnectorConfigurationLoader<TConfig>>();
+        services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
+        services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());
+
+        ConfigureClient(services.AddHttpClient<TService>(), config);
+
+        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<TService, TConfig>>();
+
+        InstallAdditional(services, config);
+    }
+
+    /// <summary>
+    ///     Applies the connector's client configuration to <paramref name="builder"/>, baking in the
+    ///     base URL when one is already known at startup.
+    /// </summary>
+    /// <remarks>
+    ///     Every client goes through <c>ConfigureConnectorClient</c> whether or not there is a base
+    ///     address to set, because that is what installs <see cref="LinkLocalGuardHandler"/> and
+    ///     turns transport-level redirects off. The URL normally arrives from per-tenant
+    ///     configuration at runtime, so at startup it is usually empty — the no-URL case is the one
+    ///     that runs in production, and a bare <c>AddHttpClient</c> there left the guard absent for
+    ///     exactly the connectors whose base URL a member supplies.
+    /// </remarks>
+    protected IHttpClientBuilder ConfigureClient(IHttpClientBuilder builder, TConfig config) =>
+        builder.ConfigureConnectorClient(
+            configuredUrl(config) is { Length: > 0 } url ? url : null,
+            options.AdditionalHeaders,
+            options.UserAgent,
+            options.Timeout,
+            options.ConnectTimeout,
+            options.AddResilience);
+
+    /// <summary>
+    ///     Registrations a disabled connector still needs, made ahead of the enablement check.
+    /// </summary>
+    protected virtual void InstallUnconditional(IServiceCollection services, TConfig config)
+    {
+    }
+
+    /// <summary>
+    ///     Registrations beyond the standard set, made only for an enabled connector.
+    /// </summary>
+    protected virtual void InstallAdditional(IServiceCollection services, TConfig config)
+    {
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Gluroo/GlurooConnectorInstaller.cs
@@ -1,42 +1,11 @@
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Gluroo.Configurations;
 using Nocturne.Connectors.Gluroo.Services;
 
 namespace Nocturne.Connectors.Gluroo;
 
-public class GlurooConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "Gluroo";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var glurooConfig = services.AddConnectorConfiguration<GlurooConnectorConfiguration>(
-            configuration,
-            "Gluroo");
-
-        if (!glurooConfig.Enabled)
-            return;
-
-        // Server resolver — Gluroo URLs come from per-tenant config, not a server mapping
-        services.AddSingleton<IConnectorServerResolver<GlurooConnectorConfiguration>>(
-            new ConnectorServerResolver<GlurooConnectorConfiguration>(null, null, null));
-        services.AddScoped<IConnectorConfigurationLoader<GlurooConnectorConfiguration>,
-            ConnectorConfigurationLoader<GlurooConnectorConfiguration>>();
-        services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
-        services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());
-
-        // Always through ConfigureConnectorClient — the branch only decides whether there is a
-        // BaseAddress to set. The bare else-branch previously skipped LinkLocalGuardHandler and
-        // left transport redirects on for any deployment that had not configured a URL.
-        services.AddHttpClient<GlurooConnectorService>()
-            .ConfigureConnectorClient(
-                string.IsNullOrEmpty(glurooConfig.Url) ? null : glurooConfig.Url);
-
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<GlurooConnectorService, GlurooConnectorConfiguration>>();
-    }
-}
+public class GlurooConnectorInstaller()
+    : TenantUrlConnectorInstaller<GlurooConnectorConfiguration, GlurooConnectorService>(
+        new ConnectorOptions { ConnectorName = "Gluroo" },
+        config => config.Url);

--- a/src/Connectors/Nocturne.Connectors.HomeAssistant/HomeAssistantConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.HomeAssistant/HomeAssistantConnectorInstaller.cs
@@ -8,8 +8,6 @@ namespace Nocturne.Connectors.HomeAssistant;
 
 public class HomeAssistantConnectorInstaller : IConnectorInstaller
 {
-    public string ConnectorName => "HomeAssistant";
-
     public void Install(IServiceCollection services, IConfiguration configuration)
     {
         services.AddConnectorConfiguration<HomeAssistantConnectorConfiguration>(

--- a/src/Connectors/Nocturne.Connectors.MyLife/MyLifeConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/MyLifeConnectorInstaller.cs
@@ -12,8 +12,6 @@ namespace Nocturne.Connectors.MyLife;
 
 public class MyLifeConnectorInstaller : IConnectorInstaller
 {
-    public string ConnectorName => "MyLife";
-
     public void Install(IServiceCollection services, IConfiguration configuration)
     {
         var config = services.AddConnectorConfiguration<MyLifeConnectorConfiguration>(

--- a/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/NightscoutConnectorInstaller.cs
@@ -1,6 +1,4 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
@@ -10,59 +8,33 @@ using Nocturne.Connectors.Nightscout.Services.WriteBack;
 
 namespace Nocturne.Connectors.Nightscout;
 
-public class NightscoutConnectorInstaller : IConnectorInstaller
+public class NightscoutConnectorInstaller()
+    : TenantUrlConnectorInstaller<NightscoutConnectorConfiguration, NightscoutConnectorService>(
+        new ConnectorOptions { ConnectorName = "Nightscout" },
+        config => config.Url)
 {
-    public string ConnectorName => "Nightscout";
+    /// <summary>
+    ///     A direct singleton of the startup config. The connector service and write-back sinks go
+    ///     through <see cref="IConnectorRegistration{TConfig}"/> /
+    ///     <see cref="IConnectorConfigurationLoader{TConfig}"/>, but the compatibility proxy stack —
+    ///     RequestForwardingService, NightscoutTransitionController, CompatibilityController,
+    ///     CompatibilityProxyHealthCheck — still injects
+    ///     <see cref="NightscoutConnectorConfiguration"/> directly. Migrating those to the loader
+    ///     pattern is what would let this registration go.
+    /// </summary>
+    protected override void InstallUnconditional(
+        IServiceCollection services,
+        NightscoutConnectorConfiguration config) =>
+        services.AddSingleton(config);
 
-    public void Install(IServiceCollection services, IConfiguration configuration)
+    protected override void InstallAdditional(
+        IServiceCollection services,
+        NightscoutConnectorConfiguration config)
     {
-        var nightscoutConfig = services.AddConnectorConfiguration<NightscoutConnectorConfiguration>(
-            configuration,
-            "Nightscout");
-
-        // Direct singleton of the startup config. The connector service and write-back
-        // sinks no longer take this dependency (they go through IConnectorRegistration /
-        // IConnectorConfigurationLoader), but the compatibility proxy stack —
-        // RequestForwardingService, NightscoutTransitionController, CompatibilityController,
-        // CompatibilityProxyHealthCheck — still injects NightscoutConnectorConfiguration
-        // directly. Those should be migrated to the loader pattern as a followup, at which
-        // point this registration can be removed.
-        services.AddSingleton(nightscoutConfig);
-
-        if (!nightscoutConfig.Enabled)
-            return;
-
-        // Server resolver — Nightscout URLs come from per-tenant config, not a server mapping
-        services.AddSingleton<IConnectorServerResolver<NightscoutConnectorConfiguration>>(
-            new ConnectorServerResolver<NightscoutConnectorConfiguration>(null, null, null));
-        services.AddScoped<IConnectorConfigurationLoader<NightscoutConnectorConfiguration>,
-            ConnectorConfigurationLoader<NightscoutConnectorConfiguration>>();
-        services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
-        services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());
-
-        // URL comes from user config (possibly loaded from DB at runtime),
-        // so configure it at registration time only if already available.
-        // ConfigureConnectorClient unconditionally — the URL only decides whether there is a
-        // BaseAddress to set. The comment above is the whole point: the URL normally arrives from
-        // per-tenant configuration at runtime, so at startup it is empty and the bare branch is the
-        // one that actually runs in production. That branch skipped LinkLocalGuardHandler and left
-        // transport redirects on, which meant the guard was absent for exactly the connectors whose
-        // base URL a member supplies.
-        services.AddHttpClient<NightscoutConnectorService>()
-            .ConfigureConnectorClient(
-                string.IsNullOrEmpty(nightscoutConfig.Url) ? null : nightscoutConfig.Url);
-
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<NightscoutConnectorService, NightscoutConnectorConfiguration>>();
-
-        // Write-back sinks (circuit breaker is shared singleton, sinks are scoped)
         services.AddSingleton<NightscoutCircuitBreaker>();
 
-        void RegisterWriteBackClient<TSink>() where TSink : class
-        {
-            services.AddHttpClient<TSink>()
-                .ConfigureConnectorClient(
-                    string.IsNullOrEmpty(nightscoutConfig.Url) ? null : nightscoutConfig.Url);
-        }
+        void RegisterWriteBackClient<TSink>() where TSink : class =>
+            ConfigureClient(services.AddHttpClient<TSink>(), config);
 
         RegisterWriteBackClient<NightscoutEntryWriteBackSink>();
         RegisterWriteBackClient<NightscoutTreatmentWriteBackSink>();

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/NocturneRemoteConnectorInstaller.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/NocturneRemoteConnectorInstaller.cs
@@ -1,46 +1,11 @@
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nocturne.Connectors.Core.Extensions;
-using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.NocturneRemote.Configurations;
 using Nocturne.Connectors.NocturneRemote.Services;
 
 namespace Nocturne.Connectors.NocturneRemote;
 
-public class NocturneRemoteConnectorInstaller : IConnectorInstaller
-{
-    public string ConnectorName => "NocturneRemote";
-
-    public void Install(IServiceCollection services, IConfiguration configuration)
-    {
-        var config = services.AddConnectorConfiguration<NocturneRemoteConnectorConfiguration>(
-            configuration,
-            "NocturneRemote");
-
-        if (!config.Enabled)
-            return;
-
-        // Server resolver — URLs come from per-tenant config, not a server mapping
-        services.AddSingleton<IConnectorServerResolver<NocturneRemoteConnectorConfiguration>>(
-            new ConnectorServerResolver<NocturneRemoteConnectorConfiguration>(null, null, null));
-        services.AddScoped<IConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>,
-            ConnectorConfigurationLoader<NocturneRemoteConnectorConfiguration>>();
-        services.TryAddSingleton<IConnectorTokenCache, ConnectorTokenCache>();
-        services.TryAddSingleton<IConnectorCacheInvalidator>(sp => sp.GetRequiredService<IConnectorTokenCache>());
-
-        // URL comes from user config (possibly loaded from DB at runtime),
-        // so configure it at registration time only if already available.
-        // ConfigureConnectorClient unconditionally — the URL only decides whether there is a
-        // BaseAddress to set. The comment above is the whole point: the URL normally arrives from
-        // per-tenant configuration at runtime, so at startup it is empty and the bare branch is the
-        // one that actually runs in production. That branch skipped LinkLocalGuardHandler and left
-        // transport redirects on, which meant the guard was absent for exactly the connectors whose
-        // base URL a member supplies.
-        services.AddHttpClient<NocturneRemoteConnectorService>()
-            .ConfigureConnectorClient(string.IsNullOrEmpty(config.Url) ? null : config.Url);
-
-        services.AddConnectorSyncExecutor<ConnectorSyncExecutor<NocturneRemoteConnectorService, NocturneRemoteConnectorConfiguration>>();
-    }
-}
+public class NocturneRemoteConnectorInstaller()
+    : TenantUrlConnectorInstaller<NocturneRemoteConnectorConfiguration, NocturneRemoteConnectorService>(
+        new ConnectorOptions { ConnectorName = "NocturneRemote" },
+        config => config.Url);

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorClientGuardCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorClientGuardCoverageTests.cs
@@ -36,7 +36,7 @@ public class ConnectorClientGuardCoverageTests
     {
         var data = new TheoryData<string>();
         foreach (var installer in ConnectorInstallers.Discover())
-            data.Add(installer.ConnectorName);
+            data.Add(ConnectorInstallers.NameOf(installer));
         return data;
     }
 
@@ -69,7 +69,8 @@ public class ConnectorClientGuardCoverageTests
     public void EveryClientAConnectorRegisters_CarriesTheGuardAndNoTransportRedirects(
         string connectorName)
     {
-        var installer = ConnectorInstallers.Discover().Single(i => i.ConnectorName == connectorName);
+        var installer = ConnectorInstallers.Discover()
+            .Single(i => ConnectorInstallers.NameOf(i) == connectorName);
 
         var services = new ServiceCollection();
         services.AddLogging();

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorInstallers.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorInstallers.cs
@@ -1,5 +1,9 @@
+using System.Collections.Concurrent;
 using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Models;
 
 namespace Nocturne.API.Tests.Connectors;
 
@@ -10,6 +14,8 @@ namespace Nocturne.API.Tests.Connectors;
 /// </summary>
 internal static class ConnectorInstallers
 {
+    private static readonly ConcurrentDictionary<Type, string> NameCache = new();
+
     /// <summary>
     /// One installer per connector, discovered rather than listed so a new connector project is
     /// covered without editing a test.
@@ -19,9 +25,46 @@ internal static class ConnectorInstallers
             .Where(t => typeof(IConnectorInstaller).IsAssignableFrom(t)
                         && t is { IsAbstract: false, IsInterface: false }
                         && t.GetConstructor(Type.EmptyTypes) is not null)
-            .Select(t => (IConnectorInstaller)Activator.CreateInstance(t)!)
-            .GroupBy(i => i.ConnectorName)
-            .Select(g => g.First())];
+            .DistinctBy(t => t.FullName)
+            .Select(t => (IConnectorInstaller)Activator.CreateInstance(t)!)];
+
+    /// <summary>
+    /// The connector name an installer keys its configuration by, taken from the frozen startup
+    /// registration every installer makes through <c>AddConnectorConfiguration</c>. That is the same
+    /// name <see cref="IConnectorConfigurationLoader{TConfig}"/> reads per-tenant configuration and
+    /// secrets under, so it cannot drift from what the connector actually runs as.
+    /// </summary>
+    /// <remarks>
+    /// Read by installing into a throwaway collection, because an installer does not state its own
+    /// name — nothing in production asks one for it. Covariance on
+    /// <see cref="IConnectorRegistration{TConfig}"/> is what lets the closed registration be read
+    /// without knowing the configuration type.
+    /// </remarks>
+    internal static string NameOf(IConnectorInstaller installer) =>
+        NameCache.GetOrAdd(installer.GetType(), _ =>
+        {
+            var services = new ServiceCollection();
+            installer.Install(services, new ConfigurationBuilder().Build());
+
+            return services
+                .Select(descriptor => descriptor.ImplementationInstance)
+                .OfType<IConnectorRegistration<BaseConnectorConfiguration>>()
+                .Select(registration => registration.ConnectorName)
+                .Single();
+        });
+
+    /// <summary>
+    /// The closed <paramref name="openBase"/> in <paramref name="installer"/>'s inheritance chain,
+    /// or <c>null</c> when it derives from no such thing.
+    /// </summary>
+    internal static Type? ClosedBaseOf(Type installer, Type openBase)
+    {
+        for (var current = installer; current is not null; current = current.BaseType)
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == openBase)
+                return current;
+
+        return null;
+    }
 
     /// <summary>
     /// Every type across the connector assemblies.

--- a/tests/Unit/Nocturne.API.Tests/Connectors/PatternConnectorInstallerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/PatternConnectorInstallerTests.cs
@@ -28,7 +28,7 @@ public class PatternConnectorInstallerTests
     {
         // Also guards the theories: a connector that stops deriving from the base drops out of
         // every case below rather than failing one.
-        PatternInstallers().Select(installer => installer.ConnectorName)
+        PatternInstallers().Select(ConnectorInstallers.NameOf)
             .Should().BeEquivalentTo(Pattern);
     }
 
@@ -44,7 +44,7 @@ public class PatternConnectorInstallerTests
     [MemberData(nameof(PatternConnectors))]
     public void AnEnabledConnector_RegistersItsTokenProviderScoped(string connectorName)
     {
-        var installer = PatternInstallers().Single(i => i.ConnectorName == connectorName);
+        var installer = PatternInstallers().Single(i => ConnectorInstallers.NameOf(i) == connectorName);
 
         var services = new ServiceCollection();
         installer.Install(services, Configuration(connectorName, enabled: true));
@@ -77,7 +77,7 @@ public class PatternConnectorInstallerTests
     [MemberData(nameof(PatternConnectors))]
     public void ADisabledConnector_RegistersOnlyItsFrozenConfiguration(string connectorName)
     {
-        var installer = PatternInstallers().Single(i => i.ConnectorName == connectorName);
+        var installer = PatternInstallers().Single(i => ConnectorInstallers.NameOf(i) == connectorName);
 
         var services = new ServiceCollection();
         installer.Install(services, Configuration(connectorName, enabled: false));
@@ -107,13 +107,6 @@ public class PatternConnectorInstallerTests
     private static Type TypeArgument(IConnectorInstaller installer, int index) =>
         SharedBaseOf(installer.GetType())!.GetGenericArguments()[index];
 
-    private static Type? SharedBaseOf(Type installer)
-    {
-        for (var current = installer; current is not null; current = current.BaseType)
-            if (current.IsGenericType
-                && current.GetGenericTypeDefinition() == typeof(ConnectorInstaller<,,>))
-                return current;
-
-        return null;
-    }
+    private static Type? SharedBaseOf(Type installer) =>
+        ConnectorInstallers.ClosedBaseOf(installer, typeof(ConnectorInstaller<,,>));
 }

--- a/tests/Unit/Nocturne.API.Tests/Connectors/TenantUrlConnectorInstallerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/TenantUrlConnectorInstallerTests.cs
@@ -1,0 +1,199 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Nightscout.Configurations;
+using Xunit;
+
+namespace Nocturne.API.Tests.Connectors;
+
+/// <summary>
+/// Pins what <see cref="TenantUrlConnectorInstaller{TConfig,TService}"/> registers for the
+/// connectors whose base URL is supplied per tenant. One body serves all three, so a single edit
+/// there arms or disarms every one of them at once, and neither outcome shows up until a sync runs.
+/// </summary>
+public class TenantUrlConnectorInstallerTests
+{
+    private const string ConfiguredUrl = "https://ns.example.invalid/";
+
+    private static readonly string[] TenantUrl = ["Gluroo", "Nightscout", "NocturneRemote"];
+
+    public static TheoryData<string> TenantUrlConnectors() => [.. TenantUrl];
+
+    [Fact]
+    public void TheTenantUrlConnectors_InstallThroughTheSharedBase()
+    {
+        // Also guards the theories: a connector that stops deriving from the base drops out of
+        // every case below rather than failing one.
+        TenantUrlInstallers().Select(ConnectorInstallers.NameOf)
+            .Should().BeEquivalentTo(TenantUrl);
+    }
+
+    /// <summary>
+    /// The whole registration set an enabled connector gets from the base, by service type,
+    /// lifetime and implementation. A sync resolves every one of these, and a lifetime or
+    /// implementation that quietly changes fails at request time rather than at build time.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TenantUrlConnectors))]
+    public void AnEnabledConnector_RegistersTheSharedSet(string connectorName)
+    {
+        var installer = InstallerNamed(connectorName);
+        var config = TypeArgument(installer, 0);
+        var service = TypeArgument(installer, 1);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        installer.Install(services, Configuration(connectorName, enabled: true));
+
+        (Type Service, ServiceLifetime Lifetime, Type? Implementation)[] expected =
+        [
+            (typeof(IConnectorRegistration<>).MakeGenericType(config), ServiceLifetime.Singleton,
+                typeof(ConnectorRegistration<>).MakeGenericType(config)),
+            (typeof(IConnectorServerResolver<>).MakeGenericType(config), ServiceLifetime.Singleton,
+                typeof(ConnectorServerResolver<>).MakeGenericType(config)),
+            (typeof(IConnectorConfigurationLoader<>).MakeGenericType(config), ServiceLifetime.Scoped,
+                typeof(ConnectorConfigurationLoader<>).MakeGenericType(config)),
+            (typeof(IConnectorTokenCache), ServiceLifetime.Singleton, typeof(ConnectorTokenCache)),
+            (typeof(IConnectorCacheInvalidator), ServiceLifetime.Singleton, null),
+            (typeof(IConnectorSyncExecutor), ServiceLifetime.Scoped,
+                typeof(ConnectorSyncExecutor<,>).MakeGenericType(service, config)),
+            (service, ServiceLifetime.Transient, null),
+        ];
+
+        foreach (var (serviceType, lifetime, implementation) in expected)
+        {
+            var descriptor = services.Should()
+                .ContainSingle(d => d.ServiceType == serviceType,
+                    "{0} registers exactly one {1}", connectorName, serviceType.Name)
+                .Subject;
+
+            descriptor.Lifetime.Should().Be(lifetime,
+                "{0}'s {1} resolves from that scope", connectorName, serviceType.Name);
+
+            if (implementation is null)
+                continue;
+
+            (descriptor.ImplementationType ?? descriptor.ImplementationInstance?.GetType())
+                .Should().Be(implementation,
+                    "{0}'s {1} is served by that type", connectorName, serviceType.Name);
+        }
+    }
+
+    /// <summary>
+    /// A connector nobody turned on must register nothing a sync could reach. The frozen startup
+    /// defaults are the exception — the configuration surface reads them to show what could be
+    /// enabled — as is anything a subclass registers unconditionally.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TenantUrlConnectors))]
+    public void ADisabledConnector_RegistersNothingASyncCouldReach(string connectorName)
+    {
+        var installer = InstallerNamed(connectorName);
+        var config = TypeArgument(installer, 0);
+
+        var services = new ServiceCollection();
+        installer.Install(services, Configuration(connectorName, enabled: false));
+
+        services.Should().NotContain(d => d.ServiceType == typeof(IConnectorSyncExecutor),
+            "a disabled {0} must not answer a manual sync trigger", connectorName);
+        services.Should().NotContain(
+            d => d.ServiceType == typeof(IConnectorConfigurationLoader<>).MakeGenericType(config),
+            "a disabled {0} loads no per-tenant configuration", connectorName);
+        services.Should().NotContain(d => d.ServiceType == typeof(IConnectorTokenCache),
+            "a disabled {0} needs no token cache", connectorName);
+        services.Should().Contain(
+            d => d.ServiceType == typeof(IConnectorRegistration<>).MakeGenericType(config),
+            "a disabled {0} still records its frozen startup defaults", connectorName);
+    }
+
+    /// <summary>
+    /// Nightscout is the one subclass with a registration ahead of the enablement check: its
+    /// compatibility proxy stack injects the startup configuration directly rather than through
+    /// <see cref="IConnectorRegistration{TConfig}"/>, so that singleton has to be there whether or
+    /// not anyone turned the connector on.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Nightscout_RegistersItsStartupConfigurationDirectly(bool enabled)
+    {
+        var installer = InstallerNamed("Nightscout");
+
+        var services = new ServiceCollection();
+        installer.Install(services, Configuration("Nightscout", enabled));
+
+        services.Should().ContainSingle(
+            d => d.ServiceType == typeof(NightscoutConnectorConfiguration),
+            "the compatibility proxy stack resolves it directly, enabled or not");
+    }
+
+    /// <summary>
+    /// A URL already in the startup configuration is baked into the typed client's base address.
+    /// The per-connector service reads relative paths off it, so losing it turns every request into
+    /// an invalid-URI throw at call time.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TenantUrlConnectors))]
+    public void AConfiguredUrl_BecomesTheClientsBaseAddress(string connectorName)
+    {
+        BaseAddressOf(connectorName, ConfiguredUrl).Should().Be(new Uri(ConfiguredUrl));
+    }
+
+    /// <summary>
+    /// The case that actually runs in production: the URL arrives from per-tenant configuration
+    /// after startup, so the client is registered without a base address and the connector supplies
+    /// absolute URIs itself.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(TenantUrlConnectors))]
+    public void AnUnconfiguredUrl_LeavesTheClientWithoutABaseAddress(string connectorName)
+    {
+        BaseAddressOf(connectorName, url: null).Should().BeNull();
+    }
+
+    private static Uri? BaseAddressOf(string connectorName, string? url)
+    {
+        var installer = InstallerNamed(connectorName);
+        var service = TypeArgument(installer, 1);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        installer.Install(services, Configuration(connectorName, enabled: true, url));
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IHttpClientFactory>()
+            .CreateClient(service.Name)
+            .BaseAddress;
+    }
+
+    private static IConfiguration Configuration(string connectorName, bool enabled, string? url = null)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            [$"Parameters:Connectors:{connectorName}:Enabled"] = enabled.ToString(),
+            [$"Connectors:{connectorName}:Enabled"] = enabled.ToString(),
+        };
+
+        if (url is not null)
+            values[$"Parameters:Connectors:{connectorName}:Url"] = url;
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    private static IConnectorInstaller InstallerNamed(string connectorName) =>
+        TenantUrlInstallers().Single(i => ConnectorInstallers.NameOf(i) == connectorName);
+
+    private static List<IConnectorInstaller> TenantUrlInstallers() =>
+        [.. ConnectorInstallers.Discover().Where(i => SharedBaseOf(i.GetType()) is not null)];
+
+    /// <summary>
+    /// The installer's shared-base type arguments: configuration at 0, service at 1.
+    /// </summary>
+    private static Type TypeArgument(IConnectorInstaller installer, int index) =>
+        SharedBaseOf(installer.GetType())!.GetGenericArguments()[index];
+
+    private static Type? SharedBaseOf(Type installer) =>
+        ConnectorInstallers.ClosedBaseOf(installer, typeof(TenantUrlConnectorInstaller<,>));
+}


### PR DESCRIPTION
Closes #1075. The three loose ends #1048/PR #1073 ring-fenced out.

## What changes

- **New `TenantUrlConnectorInstaller<TConfig, TService>`** beside `ConnectorInstaller<,,>`: the five standard registrations (configuration, null-mapping server resolver, configuration loader, shared token cache pair, `ConfigureConnectorClient`-routed HTTP client, sync executor) plus `InstallUnconditional`/`InstallAdditional` hooks. The LinkLocalGuard/bare-branch rationale — previously two near-verbatim 8-line copies and a Gluroo variant — now lives once, on the base's `ConfigureClient`.
- **Gluroo and NocturneRemote** collapse to 3-line primary-constructor subclasses (42→11 and 47→11 lines). **Nightscout** (75→46) keeps its genuine divergences: the startup-config singleton for the compatibility-proxy stack via `InstallUnconditional` (still registered before the enablement gate, as on main), and the circuit breaker + write-back clients via `InstallAdditional` reusing the base's `ConfigureClient`.
- **`AddConnector<,,>` returns `void`** — its `TConfig?` return had no reader after #1073, and returning it invited the pre-#1073 `if (config == null) return;` pattern back.
- **`IConnectorInstaller.ConnectorName` removed** — test-only member; the test helper now reads the name off the frozen `IConnectorRegistration<TConfig>` (covariant), and its `Discover()` dedup keys on `Type.FullName`, which widens rather than narrows coverage. The `ConnectorName` *option* (keys per-tenant DB config and secrets) is untouched.

Net: installer/production code −18 lines (the base carries the consolidated rationale); tests +236 (`TenantUrlConnectorInstallerTests`, 15 cases, mirroring `PatternConnectorInstallerTests`).

## Declared behavioural deltas

None. Proven, not asserted: a registration snapshot — every `ServiceDescriptor` in order, HTTP client names, `BaseAddress`, timeouts, headers, full handler chains, `SocketsHttpHandler` properties, for enabled/enabled-with-URL/disabled — is **byte-identical** before/after across all 14 installers, and a hostile reviewer reproduced the same result with an independent harness (including the disabled-Nightscout set). The base's option pass-through equals `ConfigureConnectorClient`'s parameter defaults exactly, and the `is { Length: > 0 }` URL guard is equivalent to the old `IsNullOrEmpty` ternary.

## Discrepancies with the issue text

- `ConnectorName` was also read by the test discovery helper and `PatternConnectorInstallerTests`, not just `ConnectorClientGuardCoverageTests` — all reworked.
- There are 14 installers, not twelve; the parity proof covers all 14.
- Gluroo's guard comment was a 3-line variant, not a copy; all three collapsed to the one home.
- No shared `Url` member exists to constrain on (`Nightscout` and `NocturneRemote` declare it independently; Gluroo inherits Nightscout's), hence the `Func<TConfig, string?>` accessor.

## Follow-up left out

`MyLifeConnectorInstaller` still carries the last copy of the five-registration block (it needs a token provider and session cache, so it belongs on `ConnectorInstaller<,,>` or a widened base, not this one).

## Tests

12× `Nocturne.Connectors.*.Tests` 708/708; `Nocturne.API.Tests` full unit 6330 passed / 0 failed; `CompatibilityProxy.Tests` 22/22. Mutations caught: forced-null base address (3 failures), loader lifetime flip (3), deleted `InstallUnconditional` call (2), inverted enablement gate (12).