### PR TITLE
refactor(web): give the inspection dialogs one APS-prediction and navigation core

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/DeliveryInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/DeliveryInspectionDialog.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
   import * as Dialog from "$lib/components/ui/dialog";
   import { Badge } from "$lib/components/ui/badge";
-  import { Button } from "$lib/components/ui/button";
-  import { Activity, Syringe, Utensils, AlertTriangle } from "lucide-svelte";
-  import { BasalDeliveryOrigin, type ApsSnapshot } from "$lib/api";
+  import { Activity, Syringe, AlertTriangle } from "lucide-svelte";
+  import { BasalDeliveryOrigin } from "$lib/api";
   import { bg, bgLabel, formatLocale, time } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
-  import type { PredictionData } from "$api/predictions.remote";
-  import { getAll as getApsSnapshots } from "$lib/api/generated/apsSnapshots.generated.remote";
-  import { apsSnapshotToPrediction } from "$lib/utils/aps-snapshot-to-prediction";
-  import GlucoseResponseChart from "./GlucoseResponseChart.svelte";
+  import { useApsPrediction } from "./aps-prediction.svelte";
+  import InspectionChart from "./InspectionChart.svelte";
+  import InspectionFooter from "./InspectionFooter.svelte";
 
   interface Props {
     open: boolean;
@@ -63,8 +61,11 @@
 
   const sourceDisplayName = $derived(getDataSourceDisplayName(dataSource));
 
-  let snapshot: ApsSnapshot | null = $state(null);
-  let predictionData: PredictionData | null = $state(null);
+  const aps = useApsPrediction(
+    () => open,
+    () => timestamp,
+  );
+  const snapshot = $derived(aps.snapshot);
 
   // Derive delivery mode badge from basalOrigin
   const deliveryMode = $derived.by(() => {
@@ -107,20 +108,6 @@
     return `${prefix} (${label})`;
   }
 
-  // Filter glucose data for the prediction chart window (+-30 min)
-  const chartGlucoseData = $derived.by(() => {
-    const centerMs = timestamp.getTime();
-    const minMs = centerMs - 30 * 60 * 1000;
-    const predictionHorizonMs = predictionData?.curves.main.length
-      ? Math.max(...predictionData.curves.main.map((p) => p.timestamp))
-      : centerMs + 30 * 60 * 1000;
-    const maxMs = Math.max(centerMs + 30 * 60 * 1000, predictionHorizonMs);
-    return glucoseData.filter((d) => {
-      const t = d.time.getTime();
-      return t >= minMs && t <= maxMs;
-    });
-  });
-
   // Whether we have active modifiers to show
   const hasActiveModifiers = $derived(
     !!overrideState ||
@@ -128,29 +115,6 @@
       tempBasalRate != null ||
       (activityStates != null && activityStates.length > 0),
   );
-
-  // Fetch nearest APS snapshot on open
-  $effect(() => {
-    if (!open) return;
-    snapshot = null;
-    predictionData = null;
-    let cancelled = false;
-    const from = new Date(timestamp.getTime() - 5 * 60 * 1000);
-    const to = new Date(timestamp.getTime() + 5 * 60 * 1000);
-    getApsSnapshots({ from, to, limit: 1, sort: "timestamp_desc" })
-      .then((result) => {
-        if (!cancelled && result?.data?.length) {
-          snapshot = result.data[0];
-          predictionData = apsSnapshotToPrediction(result.data[0]);
-        }
-      })
-      .catch(() => {
-        /* APS data is optional */
-      });
-    return () => {
-      cancelled = true;
-    };
-  });
 </script>
 
 <Dialog.Root bind:open>
@@ -274,19 +238,15 @@
       </div>
     {/if}
 
-    <!-- Glucose response chart (shows glucose trace, with prediction overlay when available) -->
-    {#if chartGlucoseData.length > 0}
-      <div class="py-2">
-        <p class="text-xs text-muted-foreground mb-1">Glucose Response</p>
-        <GlucoseResponseChart
-          glucoseData={chartGlucoseData}
-          centerTime={timestamp}
-          {predictionData}
-          {highThreshold}
-          {lowThreshold}
-        />
-      </div>
-    {/if}
+    <InspectionChart
+      {glucoseData}
+      centerTime={timestamp}
+      predictionData={aps.predictionData}
+      {highThreshold}
+      {lowThreshold}
+      beforeMs={30 * 60 * 1000}
+      afterMs={30 * 60 * 1000}
+    />
 
     <!-- Active modifiers -->
     {#if hasActiveModifiers}
@@ -349,22 +309,10 @@
       </div>
     {/if}
 
-    <Dialog.Footer class="flex gap-2">
-      {#if hasGlucoseContext && onNavigateGlucose}
-        <Button variant="outline" size="sm" onclick={onNavigateGlucose}>
-          <Activity class="mr-1.5 h-4 w-4" />
-          Glucose
-        </Button>
-      {/if}
-      {#if hasTreatmentContext && onNavigateTreatment}
-        <Button variant="outline" size="sm" onclick={onNavigateTreatment}>
-          <Utensils class="mr-1.5 h-4 w-4" />
-          Treatments
-        </Button>
-      {/if}
-      <Button variant="secondary" size="sm" onclick={onClose}>
-        Close
-      </Button>
-    </Dialog.Footer>
+    <InspectionFooter
+      onNavigateGlucose={hasGlucoseContext ? onNavigateGlucose : undefined}
+      onNavigateTreatment={hasTreatmentContext ? onNavigateTreatment : undefined}
+      {onClose}
+    />
   </Dialog.Content>
 </Dialog.Root>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/GlucoseInspectionDialog.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
   import * as Dialog from "$lib/components/ui/dialog";
   import { Badge } from "$lib/components/ui/badge";
-  import { Button } from "$lib/components/ui/button";
-  import { Syringe, Utensils } from "lucide-svelte";
   import { BasalDeliveryOrigin } from "$lib/api";
   import { bg, bgDelta, bgLabel, formatLocale, time } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
-  import type { PredictionData } from "$api/predictions.remote";
-  import { getAll as getApsSnapshots } from "$lib/api/generated/apsSnapshots.generated.remote";
-  import { apsSnapshotToPrediction } from "$lib/utils/aps-snapshot-to-prediction";
-  import GlucoseResponseChart from "./GlucoseResponseChart.svelte";
+  import { useApsPrediction } from "./aps-prediction.svelte";
+  import InspectionChart from "./InspectionChart.svelte";
+  import InspectionFooter from "./InspectionFooter.svelte";
 
   interface Props {
     open: boolean;
@@ -67,7 +64,10 @@
 
   const sourceDisplayName = $derived(getDataSourceDisplayName(dataSource));
 
-  let predictionData: PredictionData | null = $state(null);
+  const aps = useApsPrediction(
+    () => open,
+    () => timestamp,
+  );
 
   // Determine range status (at-threshold is "In Range", matching getGlucoseColor)
   const rangeStatus = $derived.by(() => {
@@ -95,43 +95,6 @@
       text += ` (sched: ${scheduledBasalRate.toFixed(2)})`;
     }
     return text;
-  });
-
-  // Filter glucose data for the chart window (-15 min to +3 hours, extended by predictions)
-  const chartGlucoseData = $derived.by(() => {
-    const centerMs = timestamp.getTime();
-    const minMs = centerMs - 15 * 60 * 1000;
-    const threeHoursMs = centerMs + 3 * 60 * 60 * 1000;
-    // If we have prediction data, extend the window to cover predictions
-    const predictionHorizonMs = predictionData?.curves.main.length
-      ? Math.max(...predictionData.curves.main.map((p) => p.timestamp))
-      : threeHoursMs;
-    const maxMs = Math.max(threeHoursMs, predictionHorizonMs);
-    return glucoseData.filter((d) => {
-      const t = d.time.getTime();
-      return t >= minMs && t <= maxMs;
-    });
-  });
-
-  // Fetch nearest APS snapshot on open
-  $effect(() => {
-    if (!open) return;
-    predictionData = null;
-    let cancelled = false;
-    const from = new Date(timestamp.getTime() - 5 * 60 * 1000);
-    const to = new Date(timestamp.getTime() + 5 * 60 * 1000);
-    getApsSnapshots({ from, to, limit: 1, sort: "timestamp_desc" })
-      .then((result) => {
-        if (!cancelled && result?.data?.length) {
-          predictionData = apsSnapshotToPrediction(result.data[0]);
-        }
-      })
-      .catch(() => {
-        /* APS data is optional */
-      });
-    return () => {
-      cancelled = true;
-    };
   });
 </script>
 
@@ -208,36 +171,20 @@
       {/if}
     </div>
 
-    <!-- Glucose response chart (shows glucose trace, with prediction overlay when available) -->
-    {#if chartGlucoseData.length > 0}
-      <div class="py-2">
-        <p class="text-xs text-muted-foreground mb-1">Glucose Response</p>
-        <GlucoseResponseChart
-          glucoseData={chartGlucoseData}
-          centerTime={timestamp}
-          {predictionData}
-          {highThreshold}
-          {lowThreshold}
-        />
-      </div>
-    {/if}
+    <InspectionChart
+      {glucoseData}
+      centerTime={timestamp}
+      predictionData={aps.predictionData}
+      {highThreshold}
+      {lowThreshold}
+      beforeMs={15 * 60 * 1000}
+      afterMs={3 * 60 * 60 * 1000}
+    />
 
-    <Dialog.Footer class="flex gap-2">
-      {#if hasDeliveryContext && onNavigateDelivery}
-        <Button variant="outline" size="sm" onclick={onNavigateDelivery}>
-          <Syringe class="mr-1.5 h-4 w-4" />
-          Delivery
-        </Button>
-      {/if}
-      {#if hasTreatmentContext && onNavigateTreatment}
-        <Button variant="outline" size="sm" onclick={onNavigateTreatment}>
-          <Utensils class="mr-1.5 h-4 w-4" />
-          Treatments
-        </Button>
-      {/if}
-      <Button variant="secondary" size="sm" onclick={onClose}>
-        Close
-      </Button>
-    </Dialog.Footer>
+    <InspectionFooter
+      onNavigateDelivery={hasDeliveryContext ? onNavigateDelivery : undefined}
+      onNavigateTreatment={hasTreatmentContext ? onNavigateTreatment : undefined}
+      {onClose}
+    />
   </Dialog.Content>
 </Dialog.Root>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/InspectionChart.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/InspectionChart.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import type { PredictionData } from "$api/predictions.remote";
+  import GlucoseResponseChart from "./GlucoseResponseChart.svelte";
+
+  interface Props {
+    glucoseData: { time: Date; sgv: number; color: string }[];
+    centerTime: Date;
+    predictionData: PredictionData | null;
+    highThreshold: number;
+    lowThreshold: number;
+    beforeMs: number;
+    afterMs: number;
+    label?: string;
+  }
+
+  let {
+    glucoseData,
+    centerTime,
+    predictionData,
+    highThreshold,
+    lowThreshold,
+    beforeMs,
+    afterMs,
+    label,
+  }: Props = $props();
+
+  // Predictions can reach past afterMs, so the window stretches to cover them.
+  const windowedGlucoseData = $derived.by(() => {
+    const centerMs = centerTime.getTime();
+    const minMs = centerMs - beforeMs;
+    const horizonMs = centerMs + afterMs;
+    const predictionHorizonMs = predictionData?.curves.main.length
+      ? Math.max(...predictionData.curves.main.map((p) => p.timestamp))
+      : horizonMs;
+    const maxMs = Math.max(horizonMs, predictionHorizonMs);
+    return glucoseData.filter((d) => {
+      const t = d.time.getTime();
+      return t >= minMs && t <= maxMs;
+    });
+  });
+</script>
+
+{#if windowedGlucoseData.length > 0}
+  <div class="py-2">
+    <p class="text-xs text-muted-foreground mb-1">Glucose Response</p>
+    <GlucoseResponseChart
+      glucoseData={windowedGlucoseData}
+      {centerTime}
+      {predictionData}
+      {highThreshold}
+      {lowThreshold}
+      {label}
+    />
+  </div>
+{/if}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/InspectionFooter.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/InspectionFooter.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import * as Dialog from "$lib/components/ui/dialog";
+  import { Button } from "$lib/components/ui/button";
+  import { Activity, Pencil, Syringe, Utensils } from "lucide-svelte";
+
+  interface Props {
+    onNavigateGlucose?: () => void;
+    onNavigateDelivery?: () => void;
+    onNavigateTreatment?: () => void;
+    onEditEntry?: () => void;
+    onClose: () => void;
+  }
+
+  let {
+    onNavigateGlucose,
+    onNavigateDelivery,
+    onNavigateTreatment,
+    onEditEntry,
+    onClose,
+  }: Props = $props();
+</script>
+
+<Dialog.Footer class="flex gap-2">
+  {#if onNavigateGlucose}
+    <Button variant="outline" size="sm" onclick={onNavigateGlucose}>
+      <Activity class="mr-1.5 h-4 w-4" />
+      Glucose
+    </Button>
+  {/if}
+  {#if onNavigateDelivery}
+    <Button variant="outline" size="sm" onclick={onNavigateDelivery}>
+      <Syringe class="mr-1.5 h-4 w-4" />
+      Delivery
+    </Button>
+  {/if}
+  {#if onNavigateTreatment}
+    <Button variant="outline" size="sm" onclick={onNavigateTreatment}>
+      <Utensils class="mr-1.5 h-4 w-4" />
+      Treatments
+    </Button>
+  {/if}
+  {#if onEditEntry}
+    <Button variant="outline" size="sm" onclick={onEditEntry}>
+      <Pencil class="mr-1.5 h-4 w-4" />
+      Edit
+    </Button>
+  {/if}
+  <Button variant="secondary" size="sm" onclick={onClose}>
+    Close
+  </Button>
+</Dialog.Footer>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentInspectionDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/TreatmentInspectionDialog.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
   import * as Dialog from "$lib/components/ui/dialog";
   import { Badge } from "$lib/components/ui/badge";
-  import { Button } from "$lib/components/ui/button";
-  import { Activity, Syringe, Pencil } from "lucide-svelte";
+  import { Syringe } from "lucide-svelte";
   import { bg, bgLabel, formatLocale, time } from "$lib/utils/formatting";
   import { getDataSourceDisplayName } from "$lib/utils/data-source-display";
-  import type { PredictionData } from "$api/predictions.remote";
   import type { BolusCalculation } from "$lib/api";
   import { CalculationType } from "$lib/api";
   import type { EntryRecord } from "$lib/constants/entry-categories";
   import { ENTRY_CATEGORIES } from "$lib/constants/entry-categories";
   import { getAll as getBolusCalculations } from "$lib/api/generated/bolusCalculations.generated.remote";
-  import { getAll as getApsSnapshots } from "$lib/api/generated/apsSnapshots.generated.remote";
-  import { apsSnapshotToPrediction } from "$lib/utils/aps-snapshot-to-prediction";
-  import GlucoseResponseChart from "./GlucoseResponseChart.svelte";
+  import { useApsPrediction } from "./aps-prediction.svelte";
+  import { inspectionSearchWindow } from "./inspection-window";
+  import InspectionChart from "./InspectionChart.svelte";
+  import InspectionFooter from "./InspectionFooter.svelte";
 
   interface Props {
     open: boolean;
@@ -75,7 +74,11 @@
   );
 
   let bolusCalc: BolusCalculation | null = $state(null);
-  let predictionData: PredictionData | null = $state(null);
+
+  const aps = useApsPrediction(
+    () => open,
+    () => timestamp,
+  );
 
   // Build the treatment header summary
   const treatmentSummary = $derived.by(() => {
@@ -119,20 +122,6 @@
     }
   });
 
-  // Filter glucose data for the response chart window (-15 min to +3 hours)
-  const chartGlucoseData = $derived.by(() => {
-    const centerMs = timestamp.getTime();
-    const minMs = centerMs - 15 * 60 * 1000;
-    const predictionHorizonMs = predictionData?.curves.main.length
-      ? Math.max(...predictionData.curves.main.map((p) => p.timestamp))
-      : centerMs + 3 * 60 * 60 * 1000;
-    const maxMs = Math.max(centerMs + 3 * 60 * 60 * 1000, predictionHorizonMs);
-    return glucoseData.filter((d) => {
-      const t = d.time.getTime();
-      return t >= minMs && t <= maxMs;
-    });
-  });
-
   // Format entry summary for correlated records (matches TreatmentDisambiguationDialog)
   function formatEntrySummary(record: EntryRecord): string {
     const parts: string[] = [];
@@ -157,23 +146,13 @@
     return parts.join(" · ") || ENTRY_CATEGORIES[record.kind].name;
   }
 
-  // Fetch bolus calculation and APS snapshot in parallel on open
+  // Fetch the bolus calculation behind the treatment on open
   $effect(() => {
     if (!open) return;
     bolusCalc = null;
-    predictionData = null;
     let cancelled = false;
-
-    const from = new Date(timestamp.getTime() - 5 * 60 * 1000);
-    const to = new Date(timestamp.getTime() + 5 * 60 * 1000);
-
-    // Fetch both in parallel
-    const bolusCalcPromise = getBolusCalculations({
-      from,
-      to,
-      limit: 1,
-      sort: "timestamp_desc",
-    })
+    const { from, to } = inspectionSearchWindow(timestamp);
+    getBolusCalculations({ from, to, limit: 1, sort: "timestamp_desc" })
       .then((result) => {
         if (!cancelled && result?.data?.length) {
           bolusCalc = result.data[0];
@@ -182,25 +161,6 @@
       .catch(() => {
         /* Bolus calculation data is optional */
       });
-
-    const apsPromise = getApsSnapshots({
-      from,
-      to,
-      limit: 1,
-      sort: "timestamp_desc",
-    })
-      .then((result) => {
-        if (!cancelled && result?.data?.length) {
-          predictionData = apsSnapshotToPrediction(result.data[0]);
-        }
-      })
-      .catch(() => {
-        /* APS data is optional */
-      });
-
-    // Await both (fire-and-forget pattern — cleanup on cancelled)
-    void Promise.all([bolusCalcPromise, apsPromise]);
-
     return () => {
       cancelled = true;
     };
@@ -342,20 +302,16 @@
       </div>
     {/if}
 
-    <!-- Glucose response chart -->
-    {#if chartGlucoseData.length > 0}
-      <div class="py-2">
-        <p class="text-xs text-muted-foreground mb-1">Glucose Response</p>
-        <GlucoseResponseChart
-          glucoseData={chartGlucoseData}
-          centerTime={timestamp}
-          {predictionData}
-          {highThreshold}
-          {lowThreshold}
-          label={chartLabel}
-        />
-      </div>
-    {/if}
+    <InspectionChart
+      {glucoseData}
+      centerTime={timestamp}
+      predictionData={aps.predictionData}
+      {highThreshold}
+      {lowThreshold}
+      beforeMs={15 * 60 * 1000}
+      afterMs={3 * 60 * 60 * 1000}
+      label={chartLabel}
+    />
 
     <!-- Related entries (conditional) -->
     {#if correlatedRecords && correlatedRecords.length > 0}
@@ -392,28 +348,11 @@
       </div>
     {/if}
 
-    <Dialog.Footer class="flex gap-2">
-      {#if hasGlucoseContext && onNavigateGlucose}
-        <Button variant="outline" size="sm" onclick={onNavigateGlucose}>
-          <Activity class="mr-1.5 h-4 w-4" />
-          Glucose
-        </Button>
-      {/if}
-      {#if hasDeliveryContext && onNavigateDelivery}
-        <Button variant="outline" size="sm" onclick={onNavigateDelivery}>
-          <Syringe class="mr-1.5 h-4 w-4" />
-          Delivery
-        </Button>
-      {/if}
-      {#if onEditEntry}
-        <Button variant="outline" size="sm" onclick={onEditEntry}>
-          <Pencil class="mr-1.5 h-4 w-4" />
-          Edit
-        </Button>
-      {/if}
-      <Button variant="secondary" size="sm" onclick={onClose}>
-        Close
-      </Button>
-    </Dialog.Footer>
+    <InspectionFooter
+      onNavigateGlucose={hasGlucoseContext ? onNavigateGlucose : undefined}
+      onNavigateDelivery={hasDeliveryContext ? onNavigateDelivery : undefined}
+      {onEditEntry}
+      {onClose}
+    />
   </Dialog.Content>
 </Dialog.Root>

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/aps-prediction.svelte.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/aps-prediction.svelte.ts
@@ -1,0 +1,57 @@
+import type { ApsSnapshot } from "$lib/api";
+import type { PredictionData } from "$api/predictions.remote";
+import { getAll as getApsSnapshots } from "$lib/api/generated/apsSnapshots.generated.remote";
+import { apsSnapshotToPrediction } from "$lib/utils/aps-snapshot-to-prediction";
+import { inspectionSearchWindow } from "./inspection-window";
+
+export interface ApsPrediction {
+  readonly snapshot: ApsSnapshot | null;
+  readonly predictionData: PredictionData | null;
+}
+
+/**
+ * Resolves the APS snapshot nearest an inspected instant, and the prediction curves derived from
+ * it, for as long as the dialog reading them is open.
+ *
+ * Call during component initialization: the fetch is owned by an `$effect` that re-runs when the
+ * dialog opens or the instant moves, and a superseded fetch is dropped rather than allowed to
+ * overwrite the newer one. A tenant with no APS integration has no snapshots, so a failure leaves
+ * both values null instead of surfacing an error.
+ */
+export function useApsPrediction(
+  open: () => boolean,
+  timestamp: () => Date,
+): ApsPrediction {
+  let snapshot = $state<ApsSnapshot | null>(null);
+  let predictionData = $state<PredictionData | null>(null);
+
+  $effect(() => {
+    if (!open()) return;
+    snapshot = null;
+    predictionData = null;
+    let cancelled = false;
+    const { from, to } = inspectionSearchWindow(timestamp());
+    getApsSnapshots({ from, to, limit: 1, sort: "timestamp_desc" })
+      .then((result) => {
+        if (!cancelled && result?.data?.length) {
+          snapshot = result.data[0];
+          predictionData = apsSnapshotToPrediction(result.data[0]);
+        }
+      })
+      .catch(() => {
+        /* APS data is optional */
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  return {
+    get snapshot() {
+      return snapshot;
+    },
+    get predictionData() {
+      return predictionData;
+    },
+  };
+}

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/inspection-window.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/inspection-window.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+
+import { inspectionSearchWindow } from "./inspection-window";
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+describe("inspectionSearchWindow", () => {
+  it("spans five minutes either side of the inspected instant", () => {
+    const timestamp = new Date("2026-09-02T12:00:00.000Z");
+
+    const { from, to } = inspectionSearchWindow(timestamp);
+
+    expect(from.toISOString()).toBe("2026-09-02T11:55:00.000Z");
+    expect(to.toISOString()).toBe("2026-09-02T12:05:00.000Z");
+  });
+
+  it("stays symmetrical across a DST boundary", () => {
+    // 2026-10-25T00:58Z sits either side of the UK autumn change, so a window built by
+    // calendar arithmetic rather than epoch milliseconds would come out lopsided.
+    const timestamp = new Date("2026-10-25T00:58:00.000Z");
+
+    const { from, to } = inspectionSearchWindow(timestamp);
+
+    expect(timestamp.getTime() - from.getTime()).toBe(FIVE_MINUTES);
+    expect(to.getTime() - timestamp.getTime()).toBe(FIVE_MINUTES);
+  });
+
+  it("leaves the inspected instant untouched", () => {
+    const timestamp = new Date("2026-09-02T12:00:00.000Z");
+
+    inspectionSearchWindow(timestamp);
+
+    expect(timestamp.toISOString()).toBe("2026-09-02T12:00:00.000Z");
+  });
+});

--- a/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/inspection-window.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/glucose-chart/dialogs/inspection-window.ts
@@ -1,0 +1,18 @@
+/**
+ * Half-width of the window an inspection dialog searches for the record describing the instant it
+ * was opened on. A loop cycle runs every five minutes, so this reaches at most one cycle either
+ * side.
+ */
+const SEARCH_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * Bounds of the window an inspection dialog searches. Paired with `limit: 1` and
+ * `sort: "timestamp_desc"`, this keeps the latest record at or before the far edge of the window.
+ */
+export function inspectionSearchWindow(timestamp: Date): { from: Date; to: Date } {
+  const centerMs = timestamp.getTime();
+  return {
+    from: new Date(centerMs - SEARCH_WINDOW_MS),
+    to: new Date(centerMs + SEARCH_WINDOW_MS),
+  };
+}


### PR DESCRIPTION
Closes #1062.

The three glucose-chart inspection dialogs each carried their own copy of the APS-prediction fetch, the chart-window filter, and the cross-navigation footer. The dialogs shrink by 316 lines; the shared pieces live once (net +50 with the new focused tests).

## What changes

- `aps-prediction.svelte.ts` — `useApsPrediction(() => open, () => timestamp)`: per-call `$state` (no module state, no SSR leak), live getters (never spread by consumers), effect-owned fetch with the same cancellation flag, keep-first mapping and swallow-on-error as before. Delivery also consumes the raw snapshot through it.
- `inspection-window.ts` — the ±5-minute search window, now also used by Treatment's bolus-calculation fetch, so the policy has one owner across all four fetches.
- `InspectionChart.svelte` — the chart wrapper plus the window filter all three dialogs computed separately (including the prediction-horizon extension), parameterised by each dialog's offsets (Glucose −15m/+3h, Delivery ±30m, Treatment −15m/+3h).
- `InspectionFooter.svelte` — one canonical button set. Labels deliberately stay as markup text: wuchale extracts translations from Svelte markup only, so the issue's proposed `{icon, label}` target list would have silently dropped Glucose/Delivery/Treatments/Edit/Close from all 11 locales (verified empirically against `en.po`).
- Treatment's `void Promise.all([...])` removed as dead code: both constituent promises end in `.catch` and the combined promise had no continuation — verified against main independently by reviewer and hostile review. The survey's claim that Treatment "races" the fetches was wrong.

## Discrepancies with the issue text

Treatment's footer has three buttons plus Edit (gated only on `onEditEntry`), not two; its chart also passes `label`; Delivery binds the raw `ApsSnapshot` (~15 references), not just the prediction; and the chart-window `$derived` was a fourth, unlisted duplication — folding it into `InspectionChart` is most of the line saving.

## Tests

`test:unit`: 1 failed / 1026 passed — the single failure is the known `appearance-store.ssr` baseline on main; the +3 passes are the new `inspection-window` tests (including a DST case). `svelte-check`: 51 errors, identical to the pristine baseline, none in touched files. Hostile-review coverage note, accepted: the helper's cancellation guard has no test — the three original copies were equally untested, and the guard's semantics are unchanged.