### PR TITLE
fix(api): run the per-item validators on V4 bulk bodies

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Base/V4BulkValidation.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4BulkValidation.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Models.Requests.V4;
 
@@ -22,20 +23,28 @@ public static class V4BulkValidation
     /// Rejects a payload that is empty, longer than <see cref="MaxItems"/>, carries an unset
     /// timestamp, or supplies a <c>SyncIdentifier</c> with no <c>DataSource</c> — which would
     /// leave the row outside the (DataSource, SyncIdentifier) key the upsert matches on, so a
-    /// re-upload of the same record would insert a duplicate instead of updating it.
+    /// re-upload of the same record would insert a duplicate instead of updating it. Then runs
+    /// the registered <see cref="IValidator{T}"/> over each item.
     /// </summary>
+    /// <remarks>
+    /// FluentValidation's auto-validation filter does not descend into a root-array body, so the
+    /// per-item rules only run for a bulk payload because this chokepoint invokes them. The
+    /// validator is optional: a request type with none registered is not newly rejected.
+    /// </remarks>
     /// <param name="controller">The controller answering the request.</param>
     /// <param name="requests">The payload as bound from the body.</param>
     /// <param name="subject">The payload's name, as it opens the empty-payload message ("Bolus").</param>
     /// <param name="singular">One item ("bolus").</param>
     /// <param name="plural">Many items ("boluses").</param>
+    /// <param name="ct">Cancels the per-item validation.</param>
     /// <returns>The error response to return, or <c>null</c> when the payload is usable.</returns>
-    public static ObjectResult? ValidateBulk<TRequest>(
+    public static async Task<ObjectResult?> ValidateBulkAsync<TRequest>(
         this ControllerBase controller,
         TRequest[]? requests,
         string subject,
         string singular,
-        string plural)
+        string plural,
+        CancellationToken ct = default)
         where TRequest : IBulkUpsertRequest
     {
         if (requests is not { Length: > 0 })
@@ -49,6 +58,22 @@ public static class V4BulkValidation
 
         if (requests.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
             return controller.Problem(detail: "DataSource is required when SyncIdentifier is supplied", statusCode: 400, title: "Bad Request");
+
+        if (controller.HttpContext?.RequestServices?.GetService(typeof(IValidator<TRequest>)) is not IValidator<TRequest> validator)
+            return null;
+
+        for (var index = 0; index < requests.Length; index++)
+        {
+            var result = await validator.ValidateAsync(requests[index], ct);
+            if (result.IsValid)
+                continue;
+
+            var failure = result.Errors[0];
+            return controller.Problem(
+                detail: $"{subject} at index {index} is invalid: {failure.PropertyName}: {failure.ErrorMessage}",
+                statusCode: 400,
+                title: "Bad Request");
+        }
 
         return null;
     }

--- a/src/API/Nocturne.API/Controllers/V4/Devices/ApsSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/ApsSnapshotController.cs
@@ -51,7 +51,7 @@ public class ApsSnapshotController(IApsSnapshotRepository repo)
         [FromBody] UpsertApsSnapshotRequest[] requests,
         CancellationToken ct = default)
     {
-        if (this.ValidateBulk(requests, "APS snapshot", "snapshot", "snapshots") is { } invalid)
+        if (await this.ValidateBulkAsync(requests, "APS snapshot", "snapshot", "snapshots", ct) is { } invalid)
             return invalid;
 
         var models = requests.Select(MapToModel).ToList();

--- a/src/API/Nocturne.API/Controllers/V4/Devices/PumpSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/PumpSnapshotController.cs
@@ -51,7 +51,7 @@ public class PumpSnapshotController(IPumpSnapshotRepository repo)
         [FromBody] UpsertPumpSnapshotRequest[] requests,
         CancellationToken ct = default)
     {
-        if (this.ValidateBulk(requests, "Pump snapshot", "snapshot", "snapshots") is { } invalid)
+        if (await this.ValidateBulkAsync(requests, "Pump snapshot", "snapshot", "snapshots", ct) is { } invalid)
             return invalid;
 
         var models = requests.Select(MapToModel).ToList();

--- a/src/API/Nocturne.API/Controllers/V4/Devices/UploaderSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/UploaderSnapshotController.cs
@@ -51,7 +51,7 @@ public class UploaderSnapshotController(IUploaderSnapshotRepository repo)
         [FromBody] UpsertUploaderSnapshotRequest[] requests,
         CancellationToken ct = default)
     {
-        if (this.ValidateBulk(requests, "Uploader snapshot", "snapshot", "snapshots") is { } invalid)
+        if (await this.ValidateBulkAsync(requests, "Uploader snapshot", "snapshot", "snapshots", ct) is { } invalid)
             return invalid;
 
         var models = requests.Select(MapToModel).ToList();

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -178,7 +178,7 @@ public class SensorGlucoseController(
         [FromBody] UpsertSensorGlucoseRequest[] requests,
         CancellationToken ct = default)
     {
-        if (this.ValidateBulk(requests, "Sensor glucose", "reading", "readings") is { } invalid)
+        if (await this.ValidateBulkAsync(requests, "Sensor glucose", "reading", "readings", ct) is { } invalid)
             return invalid;
 
         var models = requests.Select(MapCreateToModel).ToList();

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -162,7 +162,7 @@ public class BasalInjectionController(
         [FromBody] CreateBasalInjectionRequest[] requests,
         CancellationToken ct = default)
     {
-        if (this.ValidateBulk(requests, "Basal injection", "injection", "injections") is { } invalid)
+        if (await this.ValidateBulkAsync(requests, "Basal injection", "injection", "injections", ct) is { } invalid)
             return invalid;
 
         var models = new List<BasalInjection>(requests.Length);

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -181,7 +181,7 @@ public class BolusController(
         [FromBody] CreateBolusRequest[] requests,
         CancellationToken ct = default)
     {
-        if (this.ValidateBulk(requests, "Bolus", "bolus", "boluses") is { } invalid)
+        if (await this.ValidateBulkAsync(requests, "Bolus", "bolus", "boluses", ct) is { } invalid)
             return invalid;
 
         var models = new List<Bolus>(requests.Length);

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/NutritionController.cs
@@ -154,7 +154,7 @@ public class NutritionController : ControllerBase, IWriteScopedController
         [FromBody] CreateCarbIntakeRequest[] requests,
         CancellationToken ct = default)
     {
-        if (this.ValidateBulk(requests, "Carb intake", "intake", "intakes") is { } invalid)
+        if (await this.ValidateBulkAsync(requests, "Carb intake", "intake", "intakes", ct) is { } invalid)
             return invalid;
 
         var models = requests.Select(MapCreateToModel).ToList();

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/TempBasalController.cs
@@ -100,7 +100,7 @@ public class TempBasalController(
         [FromBody] CreateTempBasalRequest[] requests,
         CancellationToken ct = default)
     {
-        if (this.ValidateBulk(requests, "Temp basal", "temp basal", "temp basals") is { } invalid)
+        if (await this.ValidateBulkAsync(requests, "Temp basal", "temp basal", "temp basals", ct) is { } invalid)
             return invalid;
 
         if (requests.Any(r => !r.IsCancel && (r.Rate < 0 || r.DurationMinutes < 0)))

--- a/src/API/Nocturne.API/Models/Requests/V4/IBulkUpsertRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/IBulkUpsertRequest.cs
@@ -5,7 +5,7 @@ namespace Nocturne.API.Models.Requests.V4;
 /// event time, and the (<see cref="DataSource"/>, <see cref="SyncIdentifier"/>) pair the upsert
 /// keys on.
 /// </summary>
-/// <seealso cref="Controllers.V4.Base.V4BulkValidation.ValidateBulk{TRequest}"/>
+/// <seealso cref="Controllers.V4.Base.V4BulkValidation.ValidateBulkAsync{TRequest}"/>
 public interface IBulkUpsertRequest
 {
     /// <summary>When the event this record describes happened.</summary>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
@@ -1,6 +1,9 @@
 using FluentAssertions;
+using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Controllers.V4.Devices;
@@ -9,6 +12,7 @@ using Nocturne.API.Controllers.V4.Treatments;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.API.Services.Platform;
 using Nocturne.API.Services.V4;
+using Nocturne.API.Validators.V4;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Treatments;
@@ -199,7 +203,100 @@ public class V4BulkValidationTests
             Times.Never);
     }
 
+    // ── The per-item validators auto-validation cannot reach ────────
+
+    [Fact]
+    public async Task SensorGlucoseBulk_RejectsAReadingOutsideTheMgdlRange()
+    {
+        var repo = new Mock<ISensorGlucoseRepository>();
+
+        var result = await WithValidators(SensorGlucose(repo)).CreateSensorGlucoseBulk(
+            [new UpsertSensorGlucoseRequest { Timestamp = T0, Mgdl = -1 }]);
+
+        Rejected(result.Result, "Sensor glucose at index 0 is invalid: Mgdl: Mgdl must be between 0 and 10000");
+        repo.Verify(
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<Core.Models.V4.SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SensorGlucoseBulk_NamesTheIndexOfTheOffendingReading()
+    {
+        var result = await WithValidators(SensorGlucose()).CreateSensorGlucoseBulk(
+        [
+            new UpsertSensorGlucoseRequest { Timestamp = T0, Mgdl = 120 },
+            new UpsertSensorGlucoseRequest { Timestamp = T0.AddMinutes(5), Mgdl = 115 },
+            new UpsertSensorGlucoseRequest { Timestamp = T0.AddMinutes(10), Mgdl = 1_000_000 },
+        ]);
+
+        Rejected(result.Result, "Sensor glucose at index 2 is invalid: Mgdl: Mgdl must be between 0 and 10000");
+    }
+
+    [Fact]
+    public async Task SensorGlucoseBulk_AcceptsReadingsEveryRulePasses()
+    {
+        var repo = new Mock<ISensorGlucoseRepository>();
+        repo.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<Core.Models.V4.SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<Core.Models.V4.SensorGlucose> models, WriteOrigin _, CancellationToken _) => [.. models]);
+
+        var result = await WithValidators(SensorGlucose(repo)).CreateSensorGlucoseBulk(
+        [
+            new UpsertSensorGlucoseRequest
+            {
+                Timestamp = T0,
+                Mgdl = 120,
+                Direction = GlucoseDirection.Flat,
+                Device = "dexcom-g7",
+                App = "xdrip",
+                DataSource = "xdrip",
+                GlucoseProcessing = "Smoothed",
+            },
+            new UpsertSensorGlucoseRequest { Timestamp = T0.AddMinutes(5), Mgdl = 0 },
+        ]);
+
+        result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(201);
+    }
+
+    [Fact]
+    public async Task ApsSnapshotBulk_HasNoValidator_SoNothingNewRejectsIt()
+    {
+        Validators.GetService<IValidator<UpsertApsSnapshotRequest>>().Should().BeNull();
+        _aps.Setup(r => r.BulkUpsertAsync(It.IsAny<IEnumerable<ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<ApsSnapshot> models, WriteOrigin _, CancellationToken _) => [.. models]);
+
+        var result = await WithValidators(ApsController()).CreateApsSnapshots(Snapshots(3));
+
+        result.Result.Should().BeOfType<ObjectResult>().Which.StatusCode.Should().Be(201);
+    }
+
     // ── Controllers ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// The validators as <c>Program</c> registers them: scanned off the API assembly, so a request
+    /// type nobody wrote a validator for resolves to nothing here too. MVC comes with them because
+    /// a request-services-bearing controller resolves its <see cref="ProblemDetailsFactory"/> from
+    /// there rather than falling back to the built-in one.
+    /// </summary>
+    private static readonly IServiceProvider Validators = BuildValidatorProvider();
+
+    private static IServiceProvider BuildValidatorProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMvcCore();
+        services.AddValidatorsFromAssemblyContaining<UpsertSensorGlucoseRequestValidator>();
+        return services.BuildServiceProvider();
+    }
+
+    private static TController WithValidators<TController>(TController controller)
+        where TController : ControllerBase
+    {
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { RequestServices = Validators },
+        };
+        return controller;
+    }
 
     private static TRequest[] Fill<TRequest>(int count, Func<TRequest> item) =>
         [.. Enumerable.Range(0, count).Select(_ => item())];


### PR DESCRIPTION
Closes #1087.

FluentValidation's auto-validation never descends into a root-array body, so every V4 bulk endpoint's per-item rules were dead: a bulk CGM upload could persist a negative or million-mg/dL reading the single endpoint refuses. Proven empirically in #1087; this wires the rules into the one chokepoint all bulk upserts share.

## What changes

- `ValidateBulk` becomes `async ValidateBulkAsync`: after the four existing generic guards (which run first, so no existing 400 message changes), it optionally resolves `IValidator<TRequest>` (`GetService` — a request type with no validator is not newly rejected) and validates per item, returning the same ProblemDetails shape the guards use with the failing index in `detail` ("Sensor glucose at index 2 is invalid: Mgdl: …") so a 5,000-item upload is debuggable.
- All 8 `IBulkUpsertRequest` endpoints updated (one `await` + `ct` each). Async chosen deliberately: no current validator has async rules, but a future `MustAsync` under a sync `Validate` call throws at runtime as a 500 for uploaders.
- The five bulk-ish endpoints *off* the chokepoint (Activity, HeartRate, StepCount, Sleep, ConnectorFood) are untouched — none has a validator, so routing them through would change nothing today; their missing caps and shape defects are #1115.

## Declared behavioural deltas (bulk paths only; the single-record paths already enforced all of this)

Three validators come alive on bulk: sensor glucose (Mgdl family ∈ [0,10000] — inclusive, so legacy `0` sentinels still pass; 500-char caps), bolus (`Insulin ≥ 0`, `Duration ≥ 0`, `CorrelationId ≠ empty`), carb intake (`Carbs ≥ 0`, `AbsorptionTime ≥ 0`). One invalid item rejects the batch atomically before any persist, first failure only — consistent with the existing guards.

**The one silent-ignore → 400:** `GlucoseProcessing` is a string the resolver previously ignored when unparsable; a bulk client sending e.g. `"raw"` or `""` now gets a 400 (`.When(supplied)`, case-insensitive). Hostile review traced the blast radius: AAPS/Loop/xDrip upload via v1/v3 (never these routes), NocturneRemote writes via repositories, and the demo seeder's payloads pass every rule — the only known consumers are unaffected. An out-of-tree v4 bulk client sending garbage in that field is the residual risk, and it was already rejected on the single path.

## Tests

`V4BulkValidationTests` +4: Mgdl range rejects on bulk (nothing persisted), the offending index is named (bad item at index 2 of 3), a fully-valid batch still succeeds end-to-end, and a no-validator control that first proves the DI container (same assembly scan as `Program.cs`) has no validator for that type. Full `Nocturne.API.Tests`: 6319 passed / 0 failed. Mutations: disabling the new block reddened exactly the 2 rejection tests; hostile review's `index + 1` and validate-only-`requests[0]` mutants were each caught.