### PR TITLE
fix(web): lint the runes modules eslint could not parse

### DIFF
--- a/src/Web/packages/app/eslint.config.js
+++ b/src/Web/packages/app/eslint.config.js
@@ -24,7 +24,7 @@ export default ts.config(
 	}
   },
   {
-    files: ["**/*.svelte"],
+    files: ["**/*.svelte", "**/*.svelte.ts"],
 
     languageOptions: {
 	  parserOptions: {

--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -675,7 +675,7 @@ export class RealtimeStore {
         break;
 
       case "update":
-      case "ack":
+      case "ack": {
         // Update existing instance
         const updateIndex = this.trackerInstances.findIndex((i) => i.id === instance.id);
         if (updateIndex !== -1) {
@@ -689,6 +689,7 @@ export class RealtimeStore {
           ];
         }
         break;
+      }
 
       case "complete":
       case "delete":


### PR DESCRIPTION
Closes #1050.

Every `*.svelte.ts` runes module (30 files) failed eslint with a parse error, which both silenced all real findings in them and inflated the lint total by exactly one opaque "problem" per file.

## What changes

One glob: the parser block's `files: ["**/*.svelte"]` gains `"**/*.svelte.ts"`. The custom-rule block already listed the pattern; only the block wiring `parserOptions.parser` (typescript-eslint) into `svelte-eslint-parser` did not. This works *with* eslint-plugin-svelte 3.17's intended flat-config wiring — overriding the top-level parser with `ts.parser` instead would have silenced the svelte rules on runes modules (`svelte/prefer-svelte-reactivity` et al., which account for a third of what surfaced).

Plus one mechanical fix the newly-working lint demanded in a touched file: `realtime-store.svelte.ts:680` `no-case-declarations`, wrapped in a block — the binding is referenced only inside its own case (hostile review verified the whole switch for TDZ/sibling-case hazards).

## What surfaced, deliberately left

29 parse errors → 0; **153 real findings now visible** (54 `svelte/prefer-svelte-reactivity`, 51 `consistent-type-assertions`, 23 `no-explicit-any`, 17 object-injection warnings, 3 `nocturne/no-imperative-remote-query`, 3 `svelte/no-navigation-without-resolve`, 2 singletons). No `eslint-disable` added, no rule weakened; the big classes need real reactivity/type work, not drive-by fixes. Repo-wide: 1685 problems → 1809 (−29 parse, +153 findings, −1 fixed).

Non-runes files' lint output is proven unchanged: a keyed diff of the full JSON reports (file|line|column|rule|message) shows 1656 = 1656 with zero keys added or removed.

## Tests

vitest: 1 failed / 1023 passed — the single failure is the known `appearance-store.ssr` baseline on main, count unchanged. Lint-infrastructure gaps found along the way (generated client not in eslint ignores → 5,238-problem wall when present; no workflow runs eslint at all; 9 of 10 workspace packages unlinted) are recorded on #1064.