### PR TITLE
refactor(desktop): drive the taskbar mod's settings defaults from a data file

### DIFF
--- a/src/Taskbar/README.md
+++ b/src/Taskbar/README.md
@@ -37,6 +37,12 @@ current `mod.wh.cpp` each time it changes and recompile.
 
 The mod exposes these settings in Windhawk (open the mod → **Settings**):
 
+The unit, range and colour defaults are held in
+[`settings-defaults.json`](settings-defaults.json), which is where they are
+edited. The settings block Windhawk reads and the `==SettingsDefaults==` block
+`mod.wh.cpp` falls back on both have to match that file, and `GlucoseMirrorTests`
+fails if they drift from it or if it drifts from the server's own constants.
+
 ### Data
 
 - **Summary JSON path** — set this to force a single source. Blank (default) auto-
@@ -51,7 +57,6 @@ The mod exposes these settings in Windhawk (open the mod → **Settings**):
   1 dp, mg/dL to a whole number).
 - **Target range low / high** — the target-range band and in-range colouring,
   expressed in the display unit (the summary has no range of its own).
-  Defaults `3.9` / `10.0`.
 
 ### Style
 

--- a/src/Taskbar/mod.wh.cpp
+++ b/src/Taskbar/mod.wh.cpp
@@ -50,9 +50,8 @@ two coexist. Windows 11 only.
 */
 // ==/WindhawkModReadme==
 
-// The range and palette defaults in this block must equal GlucoseConstants.TargetBottomMgdl /
-// TargetTopMgdl, converted to the display unit selected here, and GlucoseConstants.StatusPalette;
-// GlucoseMirrorTests fails if any of them drift.
+// The unit, range and colour defaults in this block are the ones in settings-defaults.json, which
+// GlucoseMirrorTests holds against GlucoseConstants; edit the two together.
 // ==WindhawkModSettings==
 /*
 - dataPath: ""
@@ -163,17 +162,38 @@ using winrt::Windows::Foundation::Point;
 // ---------------------------------------------------------------------------
 // Settings
 // ---------------------------------------------------------------------------
+// Windhawk hands out the ==WindhawkModSettings== default when a setting is unset, so these apply
+// only to a value it cannot supply or the mod cannot parse — an absent key, or a colour a user
+// typed as something other than RRGGBB. The block is generated from settings-defaults.json and
+// GlucoseMirrorTests fails if it stops matching that file line for line.
+// ==SettingsDefaults==
+constexpr PCWSTR kDefaultUnit = L"mmol";
+constexpr double kDefaultRangeLow = 3.9;
+constexpr double kDefaultRangeHigh = 10.0;
+constexpr COLORREF kDefaultColorInRange = RGB(0x36, 0xC7, 0x6A);
+constexpr COLORREF kDefaultColorHigh = RGB(0xE6, 0xB8, 0x00);
+constexpr COLORREF kDefaultColorLow = RGB(0xE0, 0x53, 0x3D);
+constexpr COLORREF kDefaultColorPredicted = RGB(0x8A, 0xA0, 0xB4);
+constexpr COLORREF kDefaultTextColor = RGB(0xFF, 0xFF, 0xFF);
+// ==/SettingsDefaults==
+
+// The display-unit setting is an $options key ("mmol" or "mgdl"); this is the label it renders as.
+static PCWSTR UnitLabel(PCWSTR key) {
+    return (key && wcscmp(key, L"mgdl") == 0) ? L"mg/dL" : L"mmol/L";
+}
+
 struct Settings {
     std::vector<std::wstring> dataPaths;  // candidate summary JSON paths, tried freshest-wins
     int pollSeconds = 15;
     int staleAfterSeconds = 600;
-    std::wstring unit = L"mmol/L";  // display unit: "mmol/L" or "mg/dL"
-    double rangeLow = 3.9, rangeHigh = 10.0;  // target range, in the display unit
-    COLORREF colorInRange = 0, colorHigh = 0, colorLow = 0, colorPredicted = 0;
+    std::wstring unit = UnitLabel(kDefaultUnit);
+    double rangeLow = kDefaultRangeLow, rangeHigh = kDefaultRangeHigh;  // in the display unit
+    COLORREF colorInRange = kDefaultColorInRange, colorHigh = kDefaultColorHigh,
+             colorLow = kDefaultColorLow, colorPredicted = kDefaultColorPredicted;
     bool showBand = true, showCurrentValue = true, showTrendArrow = true, showIobCob = true;
     int sparkWidth = 120, sparkHeight = 26, lineThickness = 2, fontSize = 13;
     bool autoTextColor = true;
-    COLORREF textColor = 0;
+    COLORREF textColor = kDefaultTextColor;
     bool pulseOutOfRange = true;
     int borderThickness = 2;
     int rank = 20;  // left-to-right order among tiles in the shared host (lower = leftmost)
@@ -1222,9 +1242,8 @@ void LoadSettings() {
     int stale = Wh_GetIntSetting(L"staleAfterSeconds");
     g_settings.staleAfterSeconds = stale < 1 ? 1 : stale;
 
-    // Display unit: the $options key is "mmol" or "mgdl"; map to the format string.
     PCWSTR unit = Wh_GetStringSetting(L"unit");
-    g_settings.unit = (unit && wcscmp(unit, L"mgdl") == 0) ? L"mg/dL" : L"mmol/L";
+    g_settings.unit = UnitLabel(unit && *unit ? unit : kDefaultUnit);
     Wh_FreeStringSetting(unit);
 
     // Target range, expressed in the display unit (the summary carries no range).
@@ -1235,10 +1254,8 @@ void LoadSettings() {
         Wh_FreeStringSetting(s);
         return v;
     };
-    // Applied only when a setting is absent. Each duplicates a default from the settings block, and
-    // nothing enforces that the two still agree.
-    g_settings.rangeLow = getDouble(L"rangeLow", 3.9);
-    g_settings.rangeHigh = getDouble(L"rangeHigh", 10.0);
+    g_settings.rangeLow = getDouble(L"rangeLow", kDefaultRangeLow);
+    g_settings.rangeHigh = getDouble(L"rangeHigh", kDefaultRangeHigh);
 
     auto color = [](PCWSTR key, COLORREF def) {
         PCWSTR s = Wh_GetStringSetting(key);
@@ -1246,10 +1263,10 @@ void LoadSettings() {
         Wh_FreeStringSetting(s);
         return c;
     };
-    g_settings.colorInRange = color(L"style.colorInRange", RGB(0x36, 0xC7, 0x6A));
-    g_settings.colorHigh = color(L"style.colorHigh", RGB(0xE6, 0xB8, 0x00));
-    g_settings.colorLow = color(L"style.colorLow", RGB(0xE0, 0x53, 0x3D));
-    g_settings.colorPredicted = color(L"style.colorPredicted", RGB(0x8A, 0xA0, 0xB4));
+    g_settings.colorInRange = color(L"style.colorInRange", kDefaultColorInRange);
+    g_settings.colorHigh = color(L"style.colorHigh", kDefaultColorHigh);
+    g_settings.colorLow = color(L"style.colorLow", kDefaultColorLow);
+    g_settings.colorPredicted = color(L"style.colorPredicted", kDefaultColorPredicted);
     g_settings.showBand = Wh_GetIntSetting(L"style.showBand");
     g_settings.showCurrentValue = Wh_GetIntSetting(L"style.showCurrentValue");
     g_settings.showTrendArrow = Wh_GetIntSetting(L"style.showTrendArrow");
@@ -1259,7 +1276,7 @@ void LoadSettings() {
     g_settings.lineThickness = Wh_GetIntSetting(L"style.lineThickness");
     g_settings.fontSize = Wh_GetIntSetting(L"style.fontSize");
     g_settings.autoTextColor = Wh_GetIntSetting(L"style.autoTextColor");
-    g_settings.textColor = color(L"style.textColor", RGB(0xFF, 0xFF, 0xFF));
+    g_settings.textColor = color(L"style.textColor", kDefaultTextColor);
 
     g_settings.pulseOutOfRange = Wh_GetIntSetting(L"alert.pulseOutOfRange");
     g_settings.borderThickness = Wh_GetIntSetting(L"alert.borderThickness");

--- a/src/Taskbar/settings-defaults.json
+++ b/src/Taskbar/settings-defaults.json
@@ -1,0 +1,10 @@
+{
+  "unit": "mmol",
+  "rangeLow": "3.9",
+  "rangeHigh": "10.0",
+  "colorInRange": "36C76A",
+  "colorHigh": "E6B800",
+  "colorLow": "E0533D",
+  "colorPredicted": "8AA0B4",
+  "textColor": "FFFFFF"
+}

--- a/tests/Unit/Nocturne.Core.Constants.Tests/GlucoseMirrorTests.cs
+++ b/tests/Unit/Nocturne.Core.Constants.Tests/GlucoseMirrorTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using Xunit;
@@ -14,20 +15,27 @@ namespace Nocturne.Core.Constants.Tests;
 /// mmol reading, and a range or colour off by any amount means two surfaces describe the same
 /// reading differently.
 /// <para>
-/// Caught, for the declarations the rows below name: a value edited on one surface and not the
-/// others; a declaration renamed, deleted, or duplicated, each of which fails rather than passing on
-/// nothing; and a superseded copy left behind in a comment, which is blanked before matching so it
-/// cannot answer for the live line.
+/// TypeScript and Rust are read by regex, with comments blanked so a superseded copy left behind in
+/// one cannot answer for the live line. The mod is read as data: <c>src/Taskbar/settings-defaults.json</c>
+/// holds its unit, range and colour defaults, and both surfaces that ship those values — the
+/// <c>==WindhawkModSettings==</c> block Windhawk hands to a user who has overridden nothing, and the
+/// <c>==SettingsDefaults==</c> block of <c>constexpr</c>s the mod falls back on for a value Windhawk
+/// cannot supply or the mod cannot parse — are held against that file line for line. Nothing here
+/// lexes C++.
 /// </para>
 /// <para>
-/// Not caught: the mod's compiled-in C++ fallbacks — the <c>Settings</c> struct initialisers and the
-/// defaults passed at the <c>LoadSettings</c> read sites — are not guarded. Those apply only when a
-/// Windhawk setting is absent, and enforcing them means parsing C++ rather than reading it; three
-/// attempts to bound them by region left paths where this passed while the value had moved, which is
-/// worse than an unguarded copy. What the mod ships to a user who has not overridden anything is the
-/// settings block, and that is guarded. Beyond that: this reads text, not programs, so a value
-/// assembled at runtime is invisible, and declarations that agree are not proof a surface uses the
-/// one it declares.
+/// Caught, for the declarations the rows below name: a value edited on one surface and not the
+/// others; a declaration renamed, deleted, or duplicated, each of which fails rather than passing on
+/// nothing; and a mod default that ships in one of the mod's two blocks but not the other.
+/// </para>
+/// <para>
+/// Not caught: the mod's compiled-in constants that are not settings defaults, which
+/// <c>settings-defaults.json</c> does not cover — its own copy of the factor
+/// (<c>mod.wh.cpp</c>'s <c>kMgdlPerMmol</c>) and the theme-derived text colours. Beyond that: this
+/// reads text, not programs, so a value assembled at runtime is invisible, and declarations that
+/// agree are not proof a surface uses the one it declares —
+/// <see cref="ModReferencesEveryCompiledDefault"/> only establishes that each <c>constexpr</c> is
+/// named somewhere besides its own declaration, not that it is named at the read site it belongs to.
 /// </para>
 /// </summary>
 public class GlucoseMirrorTests
@@ -35,30 +43,44 @@ public class GlucoseMirrorTests
     private const string UiGlucose = "@nocturne/ui glucose.ts";
     private const string TrayIcon = "desktop tray.rs";
     private const string GlucosePoll = "desktop glucose_poll.rs";
-    private const string ModSettings = "mod.wh.cpp settings block";
 
-    private enum Syntax
+    private static readonly Dictionary<string, string> Sources = new()
     {
-        Code,
-        Yaml,
+        [UiGlucose] = Path.Combine("src", "Web", "packages", "ui", "src", "lib", "glucose.ts"),
+        [TrayIcon] = Path.Combine("src", "Web", "packages", "desktop", "src-tauri", "src", "tray.rs"),
+        [GlucosePoll] =
+            Path.Combine("src", "Web", "packages", "desktop", "src-tauri", "src", "glucose_poll.rs"),
+    };
+
+    private static readonly string ModDefaultsPath = Path.Combine("src", "Taskbar", "settings-defaults.json");
+    private static readonly string ModSourcePath = Path.Combine("src", "Taskbar", "mod.wh.cpp");
+
+    private const string SettingsOpen = "// ==WindhawkModSettings==";
+    private const string SettingsClose = "// ==/WindhawkModSettings==";
+    private const string DefaultsOpen = "// ==SettingsDefaults==";
+    private const string DefaultsClose = "// ==/SettingsDefaults==";
+
+    /// <summary>How a default is written on each of the mod's two surfaces.</summary>
+    private enum Shape
+    {
+        Option,
+        Number,
+        Color,
     }
 
-    private sealed record Source(string RelativePath, Syntax Syntax, string? Open = null, string? Close = null);
+    private sealed record ModDefault(string Key, Shape Shape, string Constant);
 
-    private static readonly Dictionary<string, Source> Sources = new()
-    {
-        [UiGlucose] = new(
-            Path.Combine("src", "Web", "packages", "ui", "src", "lib", "glucose.ts"), Syntax.Code),
-        [TrayIcon] = new(
-            Path.Combine("src", "Web", "packages", "desktop", "src-tauri", "src", "tray.rs"), Syntax.Code),
-        [GlucosePoll] = new(
-            Path.Combine("src", "Web", "packages", "desktop", "src-tauri", "src", "glucose_poll.rs"), Syntax.Code),
-        [ModSettings] = new(
-            Path.Combine("src", "Taskbar", "mod.wh.cpp"),
-            Syntax.Yaml,
-            "// ==WindhawkModSettings==",
-            "// ==/WindhawkModSettings=="),
-    };
+    private static readonly ModDefault[] ModDefaults =
+    [
+        new("unit", Shape.Option, "kDefaultUnit"),
+        new("rangeLow", Shape.Number, "kDefaultRangeLow"),
+        new("rangeHigh", Shape.Number, "kDefaultRangeHigh"),
+        new("colorInRange", Shape.Color, "kDefaultColorInRange"),
+        new("colorHigh", Shape.Color, "kDefaultColorHigh"),
+        new("colorLow", Shape.Color, "kDefaultColorLow"),
+        new("colorPredicted", Shape.Color, "kDefaultColorPredicted"),
+        new("textColor", Shape.Color, "kDefaultTextColor"),
+    ];
 
     public static TheoryData<string, string> FactorDeclarations() => new()
     {
@@ -73,17 +95,10 @@ public class GlucoseMirrorTests
         ReadNumber(source, pattern).Should().Be(GlucoseConstants.MgdlPerMmol);
     }
 
-    /// <summary>
-    /// The mod's range settings are in the user's display unit — mmol/L by default — at the one
-    /// decimal place it renders, so <see cref="ToMmolSetting"/> is as tight as the guard can be
-    /// there.
-    /// </summary>
     public static TheoryData<string, string, double> TargetRangeDeclarations() => new()
     {
         { TrayIcon, @"const LOW_THRESHOLD_MGDL: f64 = ([0-9.]+);", GlucoseConstants.TargetBottomMgdl },
         { TrayIcon, @"const HIGH_THRESHOLD_MGDL: f64 = ([0-9.]+);", GlucoseConstants.TargetTopMgdl },
-        { ModSettings, @"- rangeLow: ([0-9.]+)", ToMmolSetting(GlucoseConstants.TargetBottomMgdl) },
-        { ModSettings, @"- rangeHigh: ([0-9.]+)", ToMmolSetting(GlucoseConstants.TargetTopMgdl) },
     };
 
     [Theory]
@@ -93,31 +108,11 @@ public class GlucoseMirrorTests
         ReadNumber(source, pattern).Should().BeApproximately(expected, 1e-9);
     }
 
-    /// <summary>
-    /// <see cref="ToMmolSetting"/> describes the mod's range defaults only while the mod itself
-    /// defaults to mmol/L. Switching that default to mg/dL leaves both range rows above green while
-    /// the mod reads 3.9 as a low bound in mg/dL, so the premise is pinned rather than assumed.
-    /// </summary>
-    public static TheoryData<string, string, string> DisplayUnitDefaults() => new()
-    {
-        { ModSettings, @"- unit: (\w+)", "mmol" },
-    };
-
-    [Theory]
-    [MemberData(nameof(DisplayUnitDefaults))]
-    public void ModRangeDefaultsAreDeclaredInMmol(string source, string pattern, string expected)
-    {
-        Capture(source, pattern)[0].Should().Be(expected);
-    }
-
     public static TheoryData<string, string, string> PaletteDeclarations() => new()
     {
         { TrayIcon, RustColor("COLOR_IN_RANGE"), GlucoseConstants.StatusPalette.InRange },
         { TrayIcon, RustColor("COLOR_HIGH"), GlucoseConstants.StatusPalette.High },
         { TrayIcon, RustColor("COLOR_LOW"), GlucoseConstants.StatusPalette.Low },
-        { ModSettings, ModColorSetting("colorInRange"), GlucoseConstants.StatusPalette.InRange },
-        { ModSettings, ModColorSetting("colorHigh"), GlucoseConstants.StatusPalette.High },
-        { ModSettings, ModColorSetting("colorLow"), GlucoseConstants.StatusPalette.Low },
     };
 
     [Theory]
@@ -127,61 +122,179 @@ public class GlucoseMirrorTests
         ReadHex(source, pattern).Should().Be(expected.ToUpperInvariant());
     }
 
+    /// <summary>
+    /// The mod's range defaults are in the user's display unit — mmol/L by default — at the one
+    /// decimal place it renders, so <see cref="ToMmolSetting"/> is as tight as the guard can be
+    /// there.
+    /// </summary>
+    public static TheoryData<string, double> ModTargetRangeDefaults() => new()
+    {
+        { "rangeLow", ToMmolSetting(GlucoseConstants.TargetBottomMgdl) },
+        { "rangeHigh", ToMmolSetting(GlucoseConstants.TargetTopMgdl) },
+    };
+
+    [Theory]
+    [MemberData(nameof(ModTargetRangeDefaults))]
+    public void ModTargetRangeDefaultMatchesTheBackend(string key, double expected)
+    {
+        double.Parse(ModDefaultValue(key), CultureInfo.InvariantCulture)
+            .Should().BeApproximately(expected, 1e-9);
+    }
+
+    /// <summary>
+    /// <see cref="ToMmolSetting"/> describes the mod's range defaults only while the mod itself
+    /// defaults to mmol/L. Switching that default to mg/dL leaves both range rows above green while
+    /// the mod reads 3.9 as a low bound in mg/dL, so the premise is pinned rather than assumed.
+    /// </summary>
+    [Fact]
+    public void ModRangeDefaultsAreDeclaredInMmol()
+    {
+        ModDefaultValue("unit").Should().Be("mmol");
+    }
+
+    public static TheoryData<string, string> ModPaletteDefaults() => new()
+    {
+        { "colorInRange", GlucoseConstants.StatusPalette.InRange },
+        { "colorHigh", GlucoseConstants.StatusPalette.High },
+        { "colorLow", GlucoseConstants.StatusPalette.Low },
+    };
+
+    [Theory]
+    [MemberData(nameof(ModPaletteDefaults))]
+    public void ModPaletteDefaultMatchesTheBackend(string key, string expected)
+    {
+        ModDefaultValue(key).Should().Be(expected.ToUpperInvariant());
+    }
+
+    /// <summary>
+    /// What Windhawk hands out for a setting the user has not overridden, and therefore what the mod
+    /// ships with.
+    /// </summary>
+    [Fact]
+    public void ModSettingsBlockDeclaresTheDataFileDefaults()
+    {
+        var block = Region(ModSource(), SettingsOpen, SettingsClose);
+        var declared = DeclaredModDefaults();
+
+        foreach (var mod in ModDefaults)
+            SettingsRow(block, mod.Key).Should()
+                .Be(SettingsValue(mod, declared[mod.Key]), $"{mod.Key} is declared in {ModDefaultsPath}");
+    }
+
+    /// <summary>
+    /// The mod is distributed as one file pasted into Windhawk's editor, so it cannot include a
+    /// generated header: the constants have to live in <c>mod.wh.cpp</c>, and the block that carries
+    /// them is rendered from the data file here so drift is a failure rather than a compile that
+    /// silently ships another value. A red run prints the block to paste.
+    /// </summary>
+    [Fact]
+    public void ModCompiledDefaultsMatchTheDataFile()
+    {
+        var declared = DeclaredModDefaults();
+
+        Lines(Region(ModSource(), DefaultsOpen, DefaultsClose))
+            .Should().Equal(ModDefaults.Select(mod => Declaration(mod, declared[mod.Key])));
+    }
+
+    /// <summary>
+    /// A constant named only by its own declaration is text the mod does not read, which is how a
+    /// generated block goes stale while every row above stays green. This says each is named
+    /// somewhere else in the file; it does not say where.
+    /// </summary>
+    [Fact]
+    public void ModReferencesEveryCompiledDefault()
+    {
+        var source = ModSource();
+
+        foreach (var mod in ModDefaults)
+            Regex.Matches(source, $@"\b{Regex.Escape(mod.Constant)}\b").Count
+                .Should().BeGreaterThan(1, $"{mod.Constant} is declared but never read");
+    }
+
     private static string RustColor(string name) =>
         $@"const {name}: \(u8, u8, u8\) = \(0x([0-9A-Fa-f]{{2}}), 0x([0-9A-Fa-f]{{2}}), 0x([0-9A-Fa-f]{{2}})\);";
 
-    /// <summary>
-    /// A leading <c>#</c> is admitted so that writing one is reported as the wrong value it is: the
-    /// mod parses these with <c>swscanf(L"%2x%2x%2x")</c>, which rejects <c>#RRGGBB</c> outright and
-    /// silently keeps its own default.
-    /// </summary>
-    private static string ModColorSetting(string key) => $@"- {key}: ""(#?[0-9A-Fa-f]{{6}})""";
-
     private static double ToMmolSetting(double mgdl) => Math.Round(mgdl / GlucoseConstants.MgdlPerMmol, 1);
 
-    private static double ReadNumber(string source, string pattern) =>
-        double.Parse(Capture(source, pattern)[0], CultureInfo.InvariantCulture);
+    private static string ModDefaultValue(string key) => DeclaredModDefaults()[key];
 
     /// <summary>
-    /// The declared colour as upper-case RRGGBB, whether the source writes it as one hex string or as
-    /// three byte components.
+    /// The mod's settings defaults, keyed by setting name. Every value is the literal text that
+    /// ships on both of the mod's surfaces, so the file states what each of them must read rather
+    /// than a number a formatter has to render back the same way twice.
     /// </summary>
-    private static string ReadHex(string source, string pattern) =>
-        string.Concat(Capture(source, pattern)).ToUpperInvariant();
-
-    private static string[] Capture(string source, string pattern)
+    private static Dictionary<string, string> DeclaredModDefaults()
     {
-        var declaration = Sources[source];
-        var path = Path.Combine(RepositoryRoot(), declaration.RelativePath);
-        var matches = Regex.Matches(LiveText(File.ReadAllText(path), declaration), pattern);
+        var path = Path.Combine(RepositoryRoot(), ModDefaultsPath);
+        using var document = JsonDocument.Parse(File.ReadAllBytes(path));
+        var declared = document.RootElement.EnumerateObject().ToDictionary(
+            property => property.Name,
+            property => property.Value.GetString()
+                        ?? throw new InvalidOperationException($"{property.Name} in {path} is not a string."));
+
+        if (!declared.Keys.Order().SequenceEqual(ModDefaults.Select(mod => mod.Key).Order()))
+            throw new InvalidOperationException(
+                $"{path} declares [{string.Join(", ", declared.Keys)}]; expected "
+                + $"[{string.Join(", ", ModDefaults.Select(mod => mod.Key))}].");
+
+        foreach (var mod in ModDefaults.Where(mod => mod.Shape == Shape.Color))
+            if (!Regex.IsMatch(declared[mod.Key], "^[0-9A-F]{6}$"))
+                throw new InvalidOperationException(
+                    $"{mod.Key} in {path} reads '{declared[mod.Key]}', which is not upper-case RRGGBB.");
+
+        return declared;
+    }
+
+    private static string ModSource() => File.ReadAllText(Path.Combine(RepositoryRoot(), ModSourcePath));
+
+    /// <summary>
+    /// The value text of a <c>- key: value</c> row, at whatever nesting the setting sits at. A row
+    /// commented out with a leading <c>#</c> is not a row, so a superseded copy cannot answer for the
+    /// live one, and a trailing comment is part of the value and reported as the wrong text it is.
+    /// </summary>
+    private static string SettingsRow(string block, string key)
+    {
+        var matches = Regex.Matches(block, $@"(?m)^[ \t]*- {Regex.Escape(key)}: (.*)$");
 
         if (matches.Count != 1)
             throw new InvalidOperationException(
-                $"Expected one live declaration matching /{pattern}/ in {source} ({path}), found {matches.Count}.");
+                $"Expected one '- {key}:' row in the mod's settings block, found {matches.Count}.");
 
-        return matches[0].Groups.Cast<Group>().Skip(1).Select(group => group.Value).ToArray();
+        return matches[0].Groups[1].Value.TrimEnd();
     }
 
-    private static string LiveText(string text, Source source) => source.Syntax switch
+    /// <summary>
+    /// A colour is quoted so YAML keeps it a string; an all-digit hex would otherwise parse as a
+    /// number, which the mod's <c>swscanf(L"%2x%2x%2x")</c> read cannot recover.
+    /// </summary>
+    private static string SettingsValue(ModDefault mod, string value) =>
+        mod.Shape == Shape.Color ? $"\"{value}\"" : value;
+
+    private static string Declaration(ModDefault mod, string value) => mod.Shape switch
     {
-        Syntax.Yaml => BlankYamlComments(SettingsBlock(text, source)),
-        _ => BlankCodeComments(text),
+        Shape.Option => $"constexpr PCWSTR {mod.Constant} = L\"{value}\";",
+        Shape.Number => $"constexpr double {mod.Constant} = {value};",
+        _ => $"constexpr COLORREF {mod.Constant} = "
+             + $"RGB(0x{value[..2]}, 0x{value[2..4]}, 0x{value[4..]});",
     };
 
+    private static string[] Lines(string text) =>
+        text.Split('\n').Select(line => line.Trim()).Where(line => line.Length > 0).ToArray();
+
     /// <summary>
-    /// The mod's settings block, located by its delimiter lines rather than by the first mention of
-    /// one: the README above it is prose that may quote a delimiter, and a region that quietly starts
-    /// somewhere else would guard the wrong text.
+    /// The text between two delimiter lines, each located as a whole line rather than by its first
+    /// mention: the mod's README above them is prose that may quote a delimiter, and a region that
+    /// quietly starts somewhere else would guard the wrong text.
     /// </summary>
-    private static string SettingsBlock(string text, Source source)
+    private static string Region(string text, string open, string close)
     {
-        var open = SoleDelimiterLine(text, source.Open!);
-        var close = SoleDelimiterLine(text, source.Close!);
+        var start = SoleDelimiterLine(text, open);
+        var end = SoleDelimiterLine(text, close);
 
-        if (close <= open)
-            throw new InvalidOperationException($"'{source.Close}' precedes '{source.Open}'.");
+        if (end <= start)
+            throw new InvalidOperationException($"'{close}' precedes '{open}'.");
 
-        return text[(open + source.Open!.Length)..close];
+        return text[(start + open.Length)..end];
     }
 
     private static int SoleDelimiterLine(string text, string delimiter)
@@ -195,35 +308,26 @@ public class GlucoseMirrorTests
         return matches[0].Index;
     }
 
+    private static double ReadNumber(string source, string pattern) =>
+        double.Parse(Capture(source, pattern)[0], CultureInfo.InvariantCulture);
+
     /// <summary>
-    /// The same text with YAML comments blanked. A <c>#</c> inside a quoted value is part of the
-    /// value, so the row is still read and reported as malformed rather than missing.
+    /// The declared colour as upper-case RRGGBB, whether the source writes it as one hex string or as
+    /// three byte components.
     /// </summary>
-    private static string BlankYamlComments(string text)
+    private static string ReadHex(string source, string pattern) =>
+        string.Concat(Capture(source, pattern)).ToUpperInvariant();
+
+    private static string[] Capture(string source, string pattern)
     {
-        var characters = text.ToCharArray();
-        var quoted = false;
-        var commented = false;
+        var path = Path.Combine(RepositoryRoot(), Sources[source]);
+        var matches = Regex.Matches(BlankCodeComments(File.ReadAllText(path)), pattern);
 
-        for (var index = 0; index < characters.Length; index++)
-        {
-            if (characters[index] == '\n')
-            {
-                quoted = false;
-                commented = false;
-                continue;
-            }
+        if (matches.Count != 1)
+            throw new InvalidOperationException(
+                $"Expected one live declaration matching /{pattern}/ in {source} ({path}), found {matches.Count}.");
 
-            if (!commented && characters[index] == '"')
-                quoted = !quoted;
-            else if (!quoted && characters[index] == '#')
-                commented = true;
-
-            if (commented)
-                characters[index] = ' ';
-        }
-
-        return new string(characters);
+        return matches[0].Groups.Cast<Group>().Skip(1).Select(group => group.Value).ToArray();
     }
 
     private static string BlankCodeComments(string text)


### PR DESCRIPTION
Closes #931.

The cross-language drift guard could not safely read the taskbar mod's compiled-in defaults — three hostile-review rounds each closed one C++-regex-lexing hole and opened another, so #820 left the fallbacks deliberately unguarded. This closes that gap by making the guard read structured data instead of parsing a program.

## Design (constrained by how the mod ships)

Nothing builds `mod.wh.cpp` — Windhawk compiles whatever a user pastes, so the single `.cpp` file *is* the artifact and no generated header can exist. Shape chosen:

- `src/Taskbar/settings-defaults.json` — the source of truth, 8 keys, values as the literal text both surfaces ship (no formatter has to render a number identically twice).
- A fenced `// ==SettingsDefaults==` block in `mod.wh.cpp`: one `constexpr` per line, **rendered from the data file by the test and compared as an exact ordered line sequence** — the verifier is the generator (a red run prints the paste-ready block). Hostile review confirmed a reordered line or a smuggled extra `constexpr` inside the fence both redden.
- The `==WindhawkModSettings==` YAML block (what Windhawk actually reads) is byte-untouched — verified by extraction diff — and now guarded against the same data file, so each mod-side copy has exactly one source: settings block ⇄ data file ⇄ `GlucoseConstants`.
- The C++ fallbacks must stay: Windhawk supplies YAML defaults for unset settings, but the colour fallbacks fire whenever `ParseHexColor` rejects a user-typed value — deleting them means falling back to black.

`GlucoseMirrorTests` drops the struct-region scanner, YAML comment blanker and per-setting regexes for the mod (the TS/Rust comment blanker stays); gains an 8-row schema table and three consistency facts, including one that fails if a compiled default stops being referenced. Widened by two keys (`colorPredicted`, `textColor`) that had the identical duplicate-pair gap.

## Behaviour

All guarded values byte-identical (3.9 / 10.0 / 36C76A / E6B800 / E0533D / 8AA0B4 / FFFFFF / mmol). Hostile review traced every switched read site for value and parse/fallback parity, including the unit label for "mgdl"/"mmol"/garbage/null inputs (identical outcomes), and confirmed no path reads `g_settings` colours before `Wh_ModInit`'s first-statement `LoadSettings()` — the struct initialisers naming the constants instead of `0` is unobservable. The shared-host protocol block is untouched.

## Tests

`GlucoseMirrorTests` 13 → 16, all green. Mutations (each caught, then reverted): a drifted fence value (prints the paste-ready block), a drifted YAML value, data-file value changes (redden against both mod surfaces *and* the backend rows), an orphaned constant, a fence reorder, a smuggled constant, and a unit flip to "mgdl" (reddens three facts — the mmol premise is pinned via the `GlucoseConstants` conversion in the range rows). Known residual, documented in the test: a read site using the *wrong* named constant is not machine-caught; review owns that. Follow-up filed: #1114 (the mod's `kMgdlPerMmol` copy sits outside every guard row).