### PR TITLE
refactor(api): give single and batch decomposition one per-item core

### DIFF
--- a/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
+++ b/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
@@ -1,3 +1,5 @@
+using Nocturne.API.Services.Audit;
+using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
@@ -59,6 +61,11 @@ public abstract class DecomposerBase
     /// stamps whatever is still unattributed. A re-resolution that has since become ambiguous
     /// therefore cannot displace a stored link.
     /// </summary>
+    /// <remarks>
+    /// The source argument is the fallback for records carrying no
+    /// <see cref="IDeviceAttributed.DataSource"/> of their own, so passing the model's own source
+    /// here matches what a batch stamp resolves for the same record with no batch source at all.
+    /// </remarks>
     protected static Task StampAttributionAsync(
         IPatientDeviceStamper stamper,
         IDeviceAttributed model,
@@ -69,6 +76,25 @@ public abstract class DecomposerBase
         model.PatientDeviceId ??= existing?.PatientDeviceId;
         return stamper.StampAsync([model], categories, model.DataSource, ct);
     }
+
+    /// <summary>
+    /// System-attributes the writes made inside the scope, keeping the mutation audit log a human
+    /// mutation trail.
+    /// </summary>
+    /// <remarks>
+    /// Every legacy create reaches a decomposer's batch path — v1 and v3 normalize a lone record
+    /// into a one-element array — so that path carries uploader ingestion (Loop, AAPS, xDrip,
+    /// connectors, the demo seeder) at CGM sample rate. The audit interceptor drops
+    /// system-attributed saves, and provenance for those rows lives on their own
+    /// <see cref="IV4Record.DataSource"/>. The single-record path deliberately keeps caller
+    /// attribution: it is reached from a genuine per-record edit, and since a legacy record
+    /// persists only as its decomposed v4 rows, their audit rows are the whole trail of that edit.
+    /// Connector re-syncs of the single path are system-attributed by the sync scope's own audit
+    /// context rather than here. <see cref="ProfileDecomposer"/> has no batch path at all, so it
+    /// takes no scope.
+    /// </remarks>
+    protected static IDisposable SystemAttributedBatchWrites(IAuditContext auditContext)
+        => SystemAuditScope.Push(auditContext);
 
     protected static async Task BulkCreateAsync<TRecord>(
         IBulkCreateRepository<TRecord> repository,

--- a/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/DeviceStatusDecomposer.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using Nocturne.API.Services.Audit;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.Glucose;
@@ -82,9 +81,7 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
             CorrelationId = Guid.CreateVersion7()
         };
 
-        // AAPS sends "date" instead of "mills" — normalize before decomposition
-        if (ds.Mills == 0 && ds.Date is > 0)
-            ds.Mills = ds.Date.Value;
+        NormalizeMills(ds);
 
         var legacyId = ds.Id;
 
@@ -100,13 +97,9 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
             await RegisterCgmDeviceAsync(ds, origin, ct);
         }
 
-        if (ds.OpenAps != null)
+        if (MapToApsSnapshot(ds, legacyId, source, result.CorrelationId) is { } apsModel)
         {
-            await DecomposeApsFromOpenApsAsync(ds, legacyId, source, result, pumpDeviceId, origin, ct);
-        }
-        else if (ds.Loop != null)
-        {
-            await DecomposeApsFromLoopAsync(ds, legacyId, source, result, pumpDeviceId, origin, ct);
+            await UpsertApsSnapshotAsync(ds, legacyId, apsModel, pumpDeviceId, result, origin, ct);
         }
 
         if (ds.Uploader != null || ds.UploaderBattery.HasValue)
@@ -124,19 +117,14 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
         return result;
     }
 
+    /// <summary>AAPS sends <c>date</c> instead of <c>mills</c>; normalize before decomposition.</summary>
+    private static void NormalizeMills(DeviceStatus ds)
+    {
+        if (ds.Mills == 0 && ds.Date is > 0)
+            ds.Mills = ds.Date.Value;
+    }
+
     #region APS Decomposition
-
-    private Task DecomposeApsFromOpenApsAsync(
-        DeviceStatus ds, string? legacyId, string? source, V4Models.DecompositionResult result, Guid? pumpDeviceId, WriteOrigin origin, CancellationToken ct)
-        => UpsertApsSnapshotAsync(
-            ds, legacyId, MapToApsSnapshotFromOpenAps(ds, legacyId, source, result.CorrelationId),
-            pumpDeviceId, result, origin, ct);
-
-    private Task DecomposeApsFromLoopAsync(
-        DeviceStatus ds, string? legacyId, string? source, V4Models.DecompositionResult result, Guid? pumpDeviceId, WriteOrigin origin, CancellationToken ct)
-        => UpsertApsSnapshotAsync(
-            ds, legacyId, MapToApsSnapshotFromLoop(ds, legacyId, source, result.CorrelationId),
-            pumpDeviceId, result, origin, ct);
 
     private async Task UpsertApsSnapshotAsync(
         DeviceStatus ds, string? legacyId, V4Models.ApsSnapshot model, Guid? pumpDeviceId,
@@ -169,16 +157,28 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
             ? ds.Pump?.Serial ?? ds.Pump?.Model
             : ds.Pump?.Model;
 
-    private async Task<Guid?> DecomposePumpAsync(
-        DeviceStatus ds, string? legacyId, string? source, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    /// <summary>
+    /// The patient-device link is left to the caller: only the single path has a stored
+    /// attribution to fall back to when the re-resolution comes back null.
+    /// </summary>
+    private async Task<V4Models.PumpSnapshot> BuildPumpSnapshotAsync(
+        DeviceStatus ds, string? legacyId, string? source, Guid? correlationId, CancellationToken ct)
     {
-        var model = MapToPumpSnapshot(ds, legacyId, source, result.CorrelationId);
+        var model = MapToPumpSnapshot(ds, legacyId, source, correlationId);
 
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump,
             ds.Pump?.Manufacturer,
             PumpDeviceKey(ds),
             ds.Mills, ct);
+
+        return model;
+    }
+
+    private async Task<Guid?> DecomposePumpAsync(
+        DeviceStatus ds, string? legacyId, string? source, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    {
+        var model = await BuildPumpSnapshotAsync(ds, legacyId, source, result.CorrelationId, ct);
 
         var (persisted, _) = await UpsertByLegacyIdAsync(
             _pumpRepo, legacyId, model, result, origin, ct,
@@ -452,16 +452,24 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
 
     #region Uploader Decomposition
 
-    private async Task DecomposeUploaderAsync(
-        DeviceStatus ds, string? legacyId, string? source, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    private async Task<V4Models.UploaderSnapshot> BuildUploaderSnapshotAsync(
+        DeviceStatus ds, string? legacyId, string? source, Guid? correlationId, CancellationToken ct)
     {
-        var model = MapToUploaderSnapshot(ds, legacyId, source, result.CorrelationId);
+        var model = MapToUploaderSnapshot(ds, legacyId, source, correlationId);
 
         model.DeviceId = await _deviceService.ResolveAsync(
             V4Models.DeviceCategory.Uploader,
             ds.Uploader?.Name,
             ds.Uploader?.Type ?? "unknown",
             ds.Mills, ct);
+
+        return model;
+    }
+
+    private async Task DecomposeUploaderAsync(
+        DeviceStatus ds, string? legacyId, string? source, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    {
+        var model = await BuildUploaderSnapshotAsync(ds, legacyId, source, result.CorrelationId, ct);
 
         await UpsertByLegacyIdAsync(_uploaderRepo, legacyId, model, result, origin, ct);
     }
@@ -470,11 +478,10 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
 
     #region Override Decomposition
 
-    private async Task DecomposeOverrideAsync(
-        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    private static StateSpan BuildOverrideSpan(DeviceStatus ds, string? legacyId)
     {
         var timestamp = ResolveTimestamp(ds);
-        var stateSpan = new StateSpan
+        return new StateSpan
         {
             Category = StateSpanCategory.Override,
             State = OverrideState.Custom.ToString(),
@@ -486,8 +493,12 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
             OriginalId = legacyId,
             Metadata = BuildOverrideMetadata(ds.Override),
         };
+    }
 
-        var upserted = await _stateSpanService.UpsertStateSpanAsync(stateSpan, ct);
+    private async Task DecomposeOverrideAsync(
+        DeviceStatus ds, string? legacyId, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    {
+        var upserted = await _stateSpanService.UpsertStateSpanAsync(BuildOverrideSpan(ds, legacyId), ct);
         result.CreatedRecords.Add(upserted);
         Logger.LogDebug("Delegated Override from device status {LegacyId} to IStateSpanService", legacyId);
     }
@@ -496,8 +507,11 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
 
     #region Extras Decomposition
 
-    private async Task DecomposeExtrasAsync(
-        DeviceStatus ds, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    /// <summary>
+    /// The sub-objects and unknown top-level keys with no typed snapshot of their own, or
+    /// <see langword="null"/> when the device status carries none.
+    /// </summary>
+    private static V4Models.DeviceStatusExtras? BuildExtras(DeviceStatus ds, Guid correlationId)
     {
         var extras = new Dictionary<string, object?>();
 
@@ -525,20 +539,27 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
                 extras[kvp.Key] = kvp.Value;
         }
 
-        if (extras.Count == 0 || result.CorrelationId is not { } correlationId)
-            return;
+        if (extras.Count == 0)
+            return null;
 
-        var model = new V4Models.DeviceStatusExtras
+        return new V4Models.DeviceStatusExtras
         {
             CorrelationId = correlationId,
             Timestamp = ResolveTimestamp(ds),
             Extras = extras,
         };
+    }
+
+    private async Task DecomposeExtrasAsync(
+        DeviceStatus ds, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    {
+        if (result.CorrelationId is not { } correlationId || BuildExtras(ds, correlationId) is not { } model)
+            return;
 
         var created = await _extrasRepo.CreateAsync(model, origin, ct);
         result.CreatedRecords.Add(created);
         Logger.LogDebug("Created DeviceStatusExtras with {Count} keys for correlation {CorrelationId}",
-            extras.Count, result.CorrelationId);
+            model.Extras!.Count, correlationId);
     }
 
     #endregion
@@ -566,9 +587,7 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
 
         foreach (var ds in statuses)
         {
-            // AAPS sends "date" instead of "mills" — normalize before decomposition
-            if (ds.Mills == 0 && ds.Date is > 0)
-                ds.Mills = ds.Date.Value;
+            NormalizeMills(ds);
 
             var legacyId = ds.Id;
 
@@ -576,13 +595,7 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
 
             if (ds.Pump != null)
             {
-                var pumpModel = MapToPumpSnapshot(ds, legacyId, source, correlationId);
-
-                pumpModel.DeviceId = await _deviceService.ResolveAsync(
-                    V4Models.DeviceCategory.InsulinPump,
-                    ds.Pump.Manufacturer,
-                    PumpDeviceKey(ds),
-                    ds.Mills, ct);
+                var pumpModel = await BuildPumpSnapshotAsync(ds, legacyId, source, correlationId, ct);
                 pumpModel.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpModel.DeviceId, ds.Mills, ct);
 
                 pumpDeviceId = pumpModel.DeviceId;
@@ -594,16 +607,8 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
                 await RegisterCgmDeviceAsync(ds, origin, ct);
             }
 
-            if (ds.OpenAps != null)
+            if (MapToApsSnapshot(ds, legacyId, source, correlationId) is { } apsModel)
             {
-                var apsModel = MapToApsSnapshotFromOpenAps(ds, legacyId, source, correlationId);
-                apsModel.DeviceId = pumpDeviceId;
-                apsModel.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
-                apsList.Add(apsModel);
-            }
-            else if (ds.Loop != null)
-            {
-                var apsModel = MapToApsSnapshotFromLoop(ds, legacyId, source, correlationId);
                 apsModel.DeviceId = pumpDeviceId;
                 apsModel.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(pumpDeviceId, ds.Mills, ct);
                 apsList.Add(apsModel);
@@ -611,37 +616,21 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
 
             if (ds.Uploader != null || ds.UploaderBattery.HasValue)
             {
-                var uploaderModel = MapToUploaderSnapshot(ds, legacyId, source, correlationId);
-                uploaderModel.DeviceId = await _deviceService.ResolveAsync(
-                    V4Models.DeviceCategory.Uploader,
-                    ds.Uploader?.Name,
-                    ds.Uploader?.Type ?? "unknown",
-                    ds.Mills, ct);
-                uploaderList.Add(uploaderModel);
+                uploaderList.Add(await BuildUploaderSnapshotAsync(ds, legacyId, source, correlationId, ct));
             }
 
             if (ds.Override is { Active: true })
             {
-                var timestamp = ResolveTimestamp(ds);
-                var stateSpan = new StateSpan
-                {
-                    Category = StateSpanCategory.Override,
-                    State = OverrideState.Custom.ToString(),
-                    StartTimestamp = timestamp,
-                    EndTimestamp = ds.Override.Duration is > 0
-                        ? timestamp.AddMinutes(ds.Override.Duration.Value)
-                        : null,
-                    Source = ds.Device,
-                    OriginalId = legacyId,
-                    Metadata = BuildOverrideMetadata(ds.Override),
-                };
-                overrideSpans.Add(stateSpan);
+                overrideSpans.Add(BuildOverrideSpan(ds, legacyId));
             }
 
-            CollectExtras(ds, correlationId, extrasList);
+            if (BuildExtras(ds, correlationId) is { } extrasModel)
+            {
+                extrasList.Add(extrasModel);
+            }
         }
 
-        using (SystemAuditScope.Push(_auditContext))
+        using (SystemAttributedBatchWrites(_auditContext))
         {
             await BulkCreateAsync(_apsRepo, apsList, result, origin, ct);
             await BulkCreateAsync(_pumpRepo, pumpList, result, origin, ct);
@@ -681,49 +670,22 @@ public class DeviceStatusDecomposer : DecomposerBase, IDeviceStatusDecomposer, I
         return result;
     }
 
-    /// <summary>
-    /// Collects extras from a DeviceStatus into the provided list without persisting.
-    /// </summary>
-    private static void CollectExtras(
-        DeviceStatus ds, Guid correlationId, List<V4Models.DeviceStatusExtras> extrasList)
-    {
-        var extras = new Dictionary<string, object?>();
-
-        if (ds.XDripJs != null)
-            extras["xdripjs"] = ds.XDripJs;
-        if (ds.RadioAdapter != null)
-            extras["radioAdapter"] = ds.RadioAdapter;
-        if (ds.Connect != null)
-            extras["connect"] = ds.Connect;
-        if (ds.Cgm != null)
-            extras["cgm"] = ds.Cgm;
-        if (ds.Meter != null)
-            extras["meter"] = ds.Meter;
-        if (ds.InsulinPen != null)
-            extras["insulinPen"] = ds.InsulinPen;
-        if (ds.MmTune != null)
-            extras["mmtune"] = ds.MmTune;
-
-        if (ds.ExtensionData != null)
-        {
-            foreach (var kvp in ds.ExtensionData)
-                extras[kvp.Key] = kvp.Value;
-        }
-
-        if (extras.Count == 0)
-            return;
-
-        extrasList.Add(new V4Models.DeviceStatusExtras
-        {
-            CorrelationId = correlationId,
-            Timestamp = ResolveTimestamp(ds),
-            Extras = extras,
-        });
-    }
-
     #endregion
 
     #region Mapping Helpers
+
+    /// <summary>
+    /// An OpenAPS/AAPS/Trio payload wins over a Loop one; <see langword="null"/> when the device
+    /// status carries neither.
+    /// </summary>
+    private static V4Models.ApsSnapshot? MapToApsSnapshot(
+        DeviceStatus ds, string? legacyId, string? source, Guid? correlationId)
+    {
+        if (ds.OpenAps != null)
+            return MapToApsSnapshotFromOpenAps(ds, legacyId, source, correlationId);
+
+        return ds.Loop != null ? MapToApsSnapshotFromLoop(ds, legacyId, source, correlationId) : null;
+    }
 
     private static V4Models.ApsSnapshot MapToApsSnapshotFromOpenAps(
         DeviceStatus ds, string? legacyId, string? source, Guid? correlationId)

--- a/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/EntryDecomposer.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Nocturne.API.Services.Audit;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4;
@@ -88,11 +87,14 @@ public class EntryDecomposer : DecomposerBase, IEntryDecomposer, IDecomposer<Ent
         return result;
     }
 
-    private async Task DecomposeSgvAsync(Entry entry, DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    /// <summary>
+    /// Glucose processing type and smoothed/unsmoothed values are resolved from the hints a v1/v3
+    /// entry carries in its additional properties.
+    /// </summary>
+    private async Task<SensorGlucose> BuildSensorGlucoseAsync(Entry entry, Guid? correlationId, CancellationToken ct)
     {
-        var model = MapToSensorGlucose(entry, result.CorrelationId);
+        var model = MapToSensorGlucose(entry, correlationId);
 
-        // Extract glucose processing hints from v1/v3 additional properties
         string? gpHint = null;
         double? smoothedHint = null;
         double? unsmoothedHint = null;
@@ -108,6 +110,12 @@ public class EntryDecomposer : DecomposerBase, IEntryDecomposer, IDecomposer<Ent
         }
 
         await _glucoseResolver.ResolveAsync(model, gpHint, smoothedHint, unsmoothedHint, ct);
+        return model;
+    }
+
+    private async Task DecomposeSgvAsync(Entry entry, DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    {
+        var model = await BuildSensorGlucoseAsync(entry, result.CorrelationId, ct);
 
         await UpsertByLegacyIdAsync(
             _sensorGlucoseRepository, entry.Id, model, result, origin, ct,
@@ -148,27 +156,8 @@ public class EntryDecomposer : DecomposerBase, IEntryDecomposer, IDecomposer<Ent
             switch (entry.Type?.ToLowerInvariant())
             {
                 case "sgv":
-                {
-                    var model = MapToSensorGlucose(entry, correlationId);
-
-                    string? gpHint = null;
-                    double? smoothedHint = null;
-                    double? unsmoothedHint = null;
-
-                    if (entry.AdditionalProperties is { } props)
-                    {
-                        if (TryGetString(props, "glucoseProcessing", out var gpStr))
-                            gpHint = gpStr;
-                        if (TryGetDouble(props, "smoothedMgdl", out var sm))
-                            smoothedHint = sm;
-                        if (TryGetDouble(props, "unsmoothedMgdl", out var um))
-                            unsmoothedHint = um;
-                    }
-
-                    await _glucoseResolver.ResolveAsync(model, gpHint, smoothedHint, unsmoothedHint, ct);
-                    sgvList.Add(model);
+                    sgvList.Add(await BuildSensorGlucoseAsync(entry, correlationId, ct));
                     break;
-                }
                 case "mbg":
                     mbgList.Add(MapToMeterGlucose(entry, correlationId));
                     break;
@@ -186,7 +175,7 @@ public class EntryDecomposer : DecomposerBase, IEntryDecomposer, IDecomposer<Ent
         if (mbgList.Count > 0)
             await _patientDeviceStamper.StampAsync(mbgList, DeviceAttributionCategories.MeterGlucose, batchSource: null, ct);
 
-        using (SystemAuditScope.Push(_auditContext))
+        using (SystemAttributedBatchWrites(_auditContext))
         {
             await BulkCreateAsync(_sensorGlucoseRepository, sgvList, result, origin, ct);
             await BulkCreateAsync(_meterGlucoseRepository, mbgList, result, origin, ct);

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -64,11 +64,10 @@ public class ProfileDecomposer : DecomposerBase, IProfileDecomposer, IDecomposer
             return result;
         }
 
-        // No SystemAuditScope here: profiles persist ONLY as these five granular records,
-        // so on the HTTP path (v1/v3 profile create/update) their audit rows are the entire
-        // mutation trail for a user's profile edit. Connector re-syncs are suppressed by the
-        // sync scope's system audit context instead, and byte-identical re-upserts diff to
-        // empty (bookkeeping columns are [AuditIgnored]) and are skipped.
+        // No system attribution here — there is no batch path to take it on (see
+        // DecomposerBase.SystemAttributedBatchWrites): a profile write is a user's profile edit,
+        // and byte-identical re-upserts diff to empty (bookkeeping columns are [AuditIgnored])
+        // and are skipped.
         foreach (var (storeName, profileData) in profile.Store)
         {
             var legacyId = $"{profile.Id}:{storeName}";

--- a/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/TreatmentDecomposer.cs
@@ -15,7 +15,6 @@ using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Infrastructure.Data.Extensions;
-using Nocturne.API.Services.Audit;
 
 using V4Models = Nocturne.Core.Models.V4;
 
@@ -342,10 +341,19 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
             produceNote = true;
         }
 
-        return new TreatmentClassification(
+        var classification = new TreatmentClassification(
             produceBolus, produceCarbIntake, produceBGCheck, produceNote, produceBolusCalc,
             produceDeviceEvent, delegateToStateSpan, isProfileSwitch, isOverride, isTemporaryTarget,
             isAnnouncement, parsedDeviceEventType);
+
+        if (classification.ProducesNothing)
+        {
+            Logger.LogWarning(
+                "Unknown event type '{EventType}' for treatment {Id} with no insulin/carbs, skipping decomposition",
+                treatment.EventType, treatment.Id);
+        }
+
+        return classification;
     }
 
     /// <inheritdoc />
@@ -430,14 +438,6 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
             await _bolusRepository.UpdateAsync(bolus.Id, bolus, origin, ct);
         }
 
-        // If nothing was produced and there's no delegation, log a warning
-        if (c.ProducesNothing)
-        {
-            Logger.LogWarning(
-                "Unknown event type '{EventType}' for treatment {Id} with no insulin/carbs, skipping decomposition",
-                treatment.EventType, treatment.Id);
-        }
-
         return result;
     }
 
@@ -459,9 +459,9 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
         _deviceService.ResolveAsync(
             V4Models.DeviceCategory.InsulinPump, treatment.PumpType, treatment.PumpSerial, treatment.Mills, ct);
 
-    private async Task DecomposeBolusAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    private async Task<V4Models.Bolus> BuildBolusAsync(Treatment treatment, Guid? correlationId, CancellationToken ct)
     {
-        var model = MapToBolus(treatment, result.CorrelationId);
+        var model = MapToBolus(treatment, correlationId);
 
         if (IsAlgorithmBolus(treatment))
         {
@@ -472,10 +472,52 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
         model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
 
+        return model;
+    }
+
+    private async Task DecomposeBolusAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
+    {
+        var model = await BuildBolusAsync(treatment, result.CorrelationId, ct);
+
         await UpsertByLegacyIdAsync(
             _bolusRepository, treatment.Id, model, result, origin, ct,
             beforeWrite: existing => StampAttributionAsync(
                 _patientDeviceStamper, model, existing, V4Models.DeviceAttributionCategories.Bolus, ct));
+    }
+
+    /// <summary>
+    /// Preserves a legacy <see cref="Treatment.FoodType"/> as the carb intake's one
+    /// <see cref="TreatmentFood"/> line. No-op unless the treatment names a food and carries carbs,
+    /// and no-op when the carb intake already has any food line.
+    /// </summary>
+    /// <remarks>
+    /// These rows are also the user-editable food-breakdown surface
+    /// (<see cref="ITreatmentFoodService"/>, <c>/carbs/{id}/foods</c>), so re-decomposing a
+    /// treatment must neither duplicate the line nor overwrite what a user has since attributed to
+    /// it. Reaching a stored carb intake is routine rather than exceptional: a create that matches
+    /// on the sync key upserts the stored row in place and still reports as created, so a connector
+    /// replaying its catch-up overlap window arrives here on every poll. The existence check is
+    /// what makes this write idempotent — the "created" signal cannot carry it, and there is no
+    /// unique index to lean on because a carb intake legitimately holds many lines once a user has
+    /// attributed several foods to it.
+    /// </remarks>
+    private async Task WriteLegacyFoodLineAsync(Guid carbIntakeId, Treatment treatment, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(treatment.FoodType) || treatment.Carbs is not > 0)
+            return;
+
+        var existingLines = await _treatmentFoodService.GetByCarbIntakeIdsAsync([carbIntakeId], ct);
+        if (existingLines.Any())
+            return;
+
+        await _treatmentFoodService.AddAsync(new TreatmentFood
+        {
+            CarbIntakeId = carbIntakeId,
+            Portions = 0m,
+            Carbs = (decimal)treatment.Carbs.Value,
+            TimeOffsetMinutes = 0,
+            Note = treatment.FoodType,
+        }, ct);
     }
 
     private async Task DecomposeCarbIntakeAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
@@ -483,18 +525,8 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
         var (carbIntake, created) = await UpsertByLegacyIdAsync(
             _carbIntakeRepository, treatment.Id, MapToCarbIntake(treatment, result.CorrelationId), result, origin, ct);
 
-        // Preserve legacy FoodType as a TreatmentFood entry (log without saving)
-        if (created && !string.IsNullOrWhiteSpace(treatment.FoodType) && treatment.Carbs is > 0)
-        {
-            await _treatmentFoodService.AddAsync(new TreatmentFood
-            {
-                CarbIntakeId = carbIntake.Id,
-                Portions = 0m,
-                Carbs = (decimal)treatment.Carbs.Value,
-                TimeOffsetMinutes = 0,
-                Note = treatment.FoodType,
-            }, ct);
-        }
+        if (created)
+            await WriteLegacyFoodLineAsync(carbIntake.Id, treatment, ct);
     }
 
     private async Task DecomposeBGCheckAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
@@ -505,11 +537,19 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
         => await UpsertByLegacyIdAsync(
             _noteRepository, treatment.Id, MapToNote(treatment, result.CorrelationId, isAnnouncement), result, origin, ct);
 
-    private async Task DecomposeDeviceEventAsync(Treatment treatment, V4Models.DecompositionResult result, DeviceEventType deviceEventType, WriteOrigin origin, CancellationToken ct)
+    private async Task<V4Models.DeviceEvent> BuildDeviceEventAsync(
+        Treatment treatment, Guid? correlationId, DeviceEventType deviceEventType, CancellationToken ct)
     {
-        var model = MapToDeviceEvent(treatment, result.CorrelationId, deviceEventType);
+        var model = MapToDeviceEvent(treatment, correlationId, deviceEventType);
         model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
         model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+
+        return model;
+    }
+
+    private async Task DecomposeDeviceEventAsync(Treatment treatment, V4Models.DecompositionResult result, DeviceEventType deviceEventType, WriteOrigin origin, CancellationToken ct)
+    {
+        var model = await BuildDeviceEventAsync(treatment, result.CorrelationId, deviceEventType, ct);
 
         await UpsertByLegacyIdAsync(
             _deviceEventRepository, treatment.Id, model, result, origin, ct,
@@ -581,36 +621,46 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
         => await UpsertByLegacyIdAsync(
             _bolusCalculationRepository, treatment.Id, MapToBolusCalculation(treatment, result.CorrelationId), result, origin, ct);
 
+    /// <summary>
+    /// The insulin context is left to the caller: the batch path resolves it against a
+    /// batch-local profile-switch timeline the single path cannot see.
+    /// </summary>
+    private async Task<V4Models.TempBasal> BuildTempBasalAsync(
+        Treatment treatment, Guid? correlationId, CancellationToken ct)
+    {
+        var model = MapToTempBasal(treatment, correlationId);
+        model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
+        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+
+        return model;
+    }
+
+    private static V4Models.TreatmentInsulinContext? ToInsulinContext(V4Models.PatientInsulin? insulin)
+        => insulin is null
+            ? null
+            : new V4Models.TreatmentInsulinContext
+            {
+                PatientInsulinId = insulin.Id,
+                InsulinName = insulin.Name,
+                Dia = insulin.Dia,
+                Peak = insulin.Peak,
+                Curve = insulin.Curve,
+                Concentration = insulin.Concentration,
+            };
+
     private async Task DecomposeTempBasalAsync(Treatment treatment, V4Models.DecompositionResult result, WriteOrigin origin, CancellationToken ct)
     {
         var existing = treatment.Id != null
             ? await _tempBasalRepository.GetByLegacyIdAsync(treatment.Id, ct)
             : null;
 
-        var model = MapToTempBasal(treatment, result.CorrelationId);
-        model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
-        model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
+        var model = await BuildTempBasalAsync(treatment, result.CorrelationId, ct);
         await StampAttributionAsync(
             _patientDeviceStamper, model, existing, V4Models.DeviceAttributionCategories.TempBasal, ct);
 
         // Resolve insulin context: active profile switch → primary insulin → null
-        model.InsulinContext = await _activeProfileResolver.GetActiveInsulinContextAsync(treatment.Mills, ct);
-        if (model.InsulinContext is null)
-        {
-            var primaryInsulin = await _insulinRepo.GetPrimaryBolusInsulinAsync(ct);
-            if (primaryInsulin is not null)
-            {
-                model.InsulinContext = new V4Models.TreatmentInsulinContext
-                {
-                    PatientInsulinId = primaryInsulin.Id,
-                    InsulinName = primaryInsulin.Name,
-                    Dia = primaryInsulin.Dia,
-                    Peak = primaryInsulin.Peak,
-                    Curve = primaryInsulin.Curve,
-                    Concentration = primaryInsulin.Concentration,
-                };
-            }
-        }
+        model.InsulinContext = await _activeProfileResolver.GetActiveInsulinContextAsync(treatment.Mills, ct)
+            ?? ToInsulinContext(await _insulinRepo.GetPrimaryBolusInsulinAsync(ct));
 
         if (existing != null)
         {
@@ -1132,6 +1182,9 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
         // Track treatments that produce both bolus AND bolusCalculation for post-insert linking
         var bolusCalcLinkTreatmentIds = new HashSet<string>();
 
+        // Carb-producing treatments by legacy id, for the post-insert TreatmentFood pass
+        var foodLineTreatments = new Dictionary<string, Treatment>();
+
         var pumpSuspendResumeTreatments = new List<(Treatment Treatment, DeviceEventType EventType)>();
 
         foreach (var treatment in treatments)
@@ -1146,10 +1199,7 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
                 // TempBasal treatments can also be bulk-inserted
                 if (!c.IsProfileSwitch && !c.IsOverride && !c.IsTemporaryTarget)
                 {
-                    var tempBasal = MapToTempBasal(treatment, correlationId);
-                    tempBasal.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
-                    tempBasal.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(tempBasal.DeviceId, treatment.Mills, ct);
-                    tempBasalList.Add(tempBasal);
+                    tempBasalList.Add(await BuildTempBasalAsync(treatment, correlationId, ct));
                 }
                 else
                 {
@@ -1158,22 +1208,16 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
             }
 
             if (c.ProduceBolus)
-            {
-                var model = MapToBolus(treatment, correlationId);
-
-                if (IsAlgorithmBolus(treatment))
-                {
-                    model.Kind = V4Models.BolusKind.Algorithm;
-                    model.Automatic = true;
-                }
-
-                model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
-                model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
-                bolusList.Add(model);
-            }
+                bolusList.Add(await BuildBolusAsync(treatment, correlationId, ct));
 
             if (c.ProduceCarbIntake)
+            {
                 carbList.Add(MapToCarbIntake(treatment, correlationId));
+                // First-wins, matching the bulk write's own keep-first dedup by legacy id, so the
+                // line describes the carb intake that was actually inserted.
+                if (treatment.Id is { } carbLegacyId)
+                    foodLineTreatments.TryAdd(carbLegacyId, treatment);
+            }
 
             if (c.ProduceBGCheck)
                 bgCheckList.Add(MapToBGCheck(treatment, correlationId));
@@ -1186,10 +1230,8 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
 
             if (c.ProduceDeviceEvent)
             {
-                var model = MapToDeviceEvent(treatment, correlationId, c.ParsedDeviceEventType);
-                model.DeviceId = await ResolvePumpDeviceAsync(treatment, ct);
-                model.PatientDeviceId = await _deviceService.ResolvePatientDeviceAsync(model.DeviceId, treatment.Mills, ct);
-                deviceEventList.Add(model);
+                deviceEventList.Add(
+                    await BuildDeviceEventAsync(treatment, correlationId, c.ParsedDeviceEventType, ct));
 
                 if (c.ParsedDeviceEventType is DeviceEventType.PumpSuspend or DeviceEventType.PumpResume)
                 {
@@ -1200,14 +1242,6 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
             // Track for post-insert linking
             if (c.ProduceBolus && c.ProduceBolusCalc && treatment.Id != null)
                 bolusCalcLinkTreatmentIds.Add(treatment.Id);
-
-            // Log unrecognized treatments
-            if (c.ProducesNothing)
-            {
-                Logger.LogWarning(
-                    "Unknown event type '{EventType}' for treatment {Id} with no insulin/carbs, skipping decomposition",
-                    treatment.EventType, treatment.Id);
-            }
         }
 
         // Fallback attribution for records the serial-based DeviceId resolution left unattributed.
@@ -1259,24 +1293,13 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
                     primaryInsulin = await _insulinRepo.GetPrimaryBolusInsulinAsync(ct);
                     primaryInsulinFetched = true;
                 }
-                if (primaryInsulin is not null)
-                {
-                    icfg = new V4Models.TreatmentInsulinContext
-                    {
-                        PatientInsulinId = primaryInsulin.Id,
-                        InsulinName = primaryInsulin.Name,
-                        Dia = primaryInsulin.Dia,
-                        Peak = primaryInsulin.Peak,
-                        Curve = primaryInsulin.Curve,
-                        Concentration = primaryInsulin.Concentration,
-                    };
-                }
+                icfg = ToInsulinContext(primaryInsulin);
             }
 
             tb.InsulinContext = icfg;
         }
 
-        using (SystemAuditScope.Push(_auditContext))
+        using (SystemAttributedBatchWrites(_auditContext))
         {
             await BulkCreateAsync(_bolusRepository, bolusList, result, origin, ct);
             await BulkCreateAsync(_carbIntakeRepository, carbList, result, origin, ct);
@@ -1285,6 +1308,15 @@ public class TreatmentDecomposer : DecomposerBase, ITreatmentDecomposer, IDecomp
             await BulkCreateAsync(_bolusCalculationRepository, bolusCalcList, result, origin, ct);
             await BulkCreateAsync(_deviceEventRepository, deviceEventList, result, origin, ct);
             await BulkCreateAsync(_tempBasalRepository, tempBasalList, result, origin, ct);
+        }
+
+        // Post-insert food pass: the carb intake's id is only known once it is persisted. This set
+        // is not create-only — a sync-key upsert of a stored carb intake lands in it too — so the
+        // writer, not this loop, is what keeps the line idempotent.
+        foreach (var carbIntake in result.CreatedRecords.OfType<V4Models.CarbIntake>())
+        {
+            if (carbIntake.LegacyId is { } legacyId && foodLineTreatments.TryGetValue(legacyId, out var treatment))
+                await WriteLegacyFoodLineAsync(carbIntake.Id, treatment, ct);
         }
 
         // Post-insert pump suspend/resume pass: sequential, order-dependent

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/EntryDecomposerBatchTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.Audit;
 using Nocturne.API.Services.V4;
+using Nocturne.Core.Constants;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4;
@@ -22,6 +23,7 @@ public class EntryDecomposerBatchTests : IDisposable
     private readonly Mock<IMeterGlucoseRepository> _mgRepoMock;
     private readonly Mock<ICalibrationRepository> _calRepoMock;
     private readonly IGlucoseProcessingResolver _glucoseResolver;
+    private readonly Mock<IPatientDeviceStamper> _stamperMock = new();
     private readonly EntryDecomposer _decomposer;
 
     public EntryDecomposerBatchTests()
@@ -61,7 +63,7 @@ public class EntryDecomposerBatchTests : IDisposable
             _mgRepoMock.Object,
             _calRepoMock.Object,
             _glucoseResolver,
-            Mock.Of<IPatientDeviceStamper>(),
+            _stamperMock.Object,
             auditContext,
             NullLogger<EntryDecomposer>.Instance);
 
@@ -198,6 +200,41 @@ public class EntryDecomposerBatchTests : IDisposable
 
         auditContext.IsSystem.Should().BeFalse();
         auditContext.SubjectName.Should().Be("uploader");
+    }
+
+    /// <summary>
+    /// Device attribution matches on each record's own <see cref="IDeviceAttributed.DataSource"/> —
+    /// the batch source argument is only the fallback for records that carry none — so a batch
+    /// mixing sources must reach the stamper with every record's source intact.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeBatchAsync_StampsRecordsCarryingTheirOwnDataSource()
+    {
+        // Arrange
+        var stamped = new List<IDeviceAttributed>();
+        _stamperMock
+            .Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+                It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((IReadOnlyList<IDeviceAttributed> records, IReadOnlyList<DeviceCategory> _, string? _, CancellationToken _) =>
+                stamped.AddRange(records))
+            .Returns(Task.CompletedTask);
+
+        var entries = new List<Entry>
+        {
+            new() { Id = "sgv1", Type = "sgv", Mills = 1700000000000, Sgv = 120.0, DataSource = DataSources.DexcomConnector },
+            new() { Id = "sgv2", Type = "sgv", Mills = 1700000001000, Sgv = 130.0, DataSource = DataSources.LibreConnector },
+            new() { Id = "mbg1", Type = "mbg", Mills = 1700000002000, Mbg = 140.0, DataSource = DataSources.GlookoConnector },
+        };
+
+        // Act
+        await _decomposer.DecomposeBatchAsync(entries, WriteOrigin.Live);
+
+        // Assert
+        stamped.Select(r => r.DataSource).Should().BeEquivalentTo(
+            [DataSources.DexcomConnector, DataSources.LibreConnector, DataSources.GlookoConnector]);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerBatchTests.cs
@@ -336,6 +336,143 @@ public class TreatmentDecomposerBatchTests : IDisposable
         result.CreatedRecords.Should().HaveCount(2);
     }
 
+    /// <summary>
+    /// A bulk-uploaded meal treatment's <c>foodType</c> is preserved as its carb intake's
+    /// <see cref="TreatmentFood"/> line, as on the single-record path — the carb intake's id is
+    /// only known once the bulk write has persisted it, so the line is written afterwards.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeBatchAsync_MealWithFoodType_WritesTreatmentFoodLine()
+    {
+        // Arrange — the persisted carb intakes carry repository-assigned ids
+        var mealCarbIntakeId = Guid.CreateVersion7();
+        _carbRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.CarbIntake> records, WriteOrigin _, CancellationToken _) =>
+            {
+                var persisted = records.ToList();
+                foreach (var record in persisted)
+                    record.Id = record.LegacyId == "meal-1" ? mealCarbIntakeId : Guid.CreateVersion7();
+                return persisted;
+            });
+
+        var treatments = new List<Treatment>
+        {
+            new() { Id = "meal-1", EventType = "Meal Bolus", Mills = 1700000000000, Insulin = 5.0, Carbs = 45, FoodType = "Sandwich" },
+            new() { Id = "carb-1", EventType = "Carb Correction", Mills = 1700000001000, Carbs = 15 },
+        };
+
+        // Act
+        await _decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Live);
+
+        // Assert — one line, on the meal's carb intake, carrying the legacy food type
+        _treatmentFoodServiceMock.Verify(
+            x => x.AddAsync(
+                It.Is<TreatmentFood>(f =>
+                    f.CarbIntakeId == mealCarbIntakeId && f.Note == "Sandwich" && f.Carbs == 45m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // The carb correction names no food, so it gets no line
+        _treatmentFoodServiceMock.Verify(
+            x => x.AddAsync(It.IsAny<TreatmentFood>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// A connector replaying its catch-up overlap window re-sends a carb intake the bulk write
+    /// upserts in place on its sync key — which still comes back in the created set — so the food
+    /// line must not be written a second time. Those rows are the user-editable food breakdown and
+    /// feed the legacy projection, so a duplicate per replay compounds.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeBatchAsync_SyncUpsertedCarbIntakeAlreadyHasFoodLine_WritesNoSecondLine()
+    {
+        // Arrange — the bulk write returns the stored row it upserted in place, which already
+        // carries the line written on first ingest
+        var storedCarbIntakeId = Guid.CreateVersion7();
+        _carbRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.CarbIntake> records, WriteOrigin _, CancellationToken _) =>
+            {
+                var upserted = records.ToList();
+                foreach (var record in upserted)
+                    record.Id = storedCarbIntakeId;
+                return upserted;
+            });
+
+        _treatmentFoodServiceMock
+            .Setup(x => x.GetByCarbIntakeIdsAsync(
+                It.Is<IEnumerable<Guid>>(ids => ids.Contains(storedCarbIntakeId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TreatmentFood>
+            {
+                new() { CarbIntakeId = storedCarbIntakeId, Note = "Sandwich", Carbs = 45m },
+            });
+
+        var treatments = new List<Treatment>
+        {
+            new()
+            {
+                Id = "meal-1",
+                EventType = "Meal Bolus",
+                Mills = 1700000000000,
+                Insulin = 5.0,
+                Carbs = 45,
+                FoodType = "Sandwich",
+                SyncIdentifier = "sync-1",
+                DataSource = "dexcom-connector",
+            },
+        };
+
+        // Act
+        await _decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Live);
+
+        // Assert
+        _treatmentFoodServiceMock.Verify(
+            x => x.AddAsync(It.IsAny<TreatmentFood>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// The bulk write dedups its insert set by legacy id keeping the first, so the food line must
+    /// describe that same first treatment rather than a later duplicate's food type.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeBatchAsync_DuplicateLegacyId_FoodLineFollowsTheInsertedTreatment()
+    {
+        // Arrange — emulate the bulk write's keep-first dedup by legacy id
+        var carbIntakeId = Guid.CreateVersion7();
+        _carbRepoMock
+            .Setup(x => x.BulkCreateAsync(It.IsAny<IEnumerable<V4Models.CarbIntake>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<V4Models.CarbIntake> records, WriteOrigin _, CancellationToken _) =>
+            {
+                var inserted = records.GroupBy(r => r.LegacyId!).Select(g => g.First()).ToList();
+                foreach (var record in inserted)
+                    record.Id = carbIntakeId;
+                return inserted;
+            });
+
+        var treatments = new List<Treatment>
+        {
+            new() { Id = "dupe-1", EventType = "Carb Correction", Mills = 1700000000000, Carbs = 45, FoodType = "Sandwich" },
+            new() { Id = "dupe-1", EventType = "Carb Correction", Mills = 1700000000000, Carbs = 45, FoodType = "Pizza" },
+        };
+
+        // Act
+        await _decomposer.DecomposeBatchAsync(treatments, WriteOrigin.Live);
+
+        // Assert
+        _treatmentFoodServiceMock.Verify(
+            x => x.AddAsync(
+                It.Is<TreatmentFood>(f => f.CarbIntakeId == carbIntakeId && f.Note == "Sandwich"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _treatmentFoodServiceMock.Verify(
+            x => x.AddAsync(It.IsAny<TreatmentFood>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task DecomposeBatchAsync_ProfileSwitch_DelegatesToStateSpanService()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/TreatmentDecomposerTests.cs
@@ -130,6 +130,39 @@ public class TreatmentDecomposerTests : IDisposable
         bolus.CorrelationId.Should().Be(carbIntake.CorrelationId);
     }
 
+    /// <summary>
+    /// The legacy <c>foodType</c> is preserved as the carb intake's <see cref="TreatmentFood"/>
+    /// line. Create-only: those rows are also the user-editable food breakdown.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeAsync_MealWithFoodType_WritesTreatmentFoodLine()
+    {
+        // Arrange
+        var treatment = new Treatment
+        {
+            Id = "meal-food-1",
+            EventType = "Meal Bolus",
+            Mills = 1700000000000,
+            Insulin = 5.0,
+            Carbs = 45,
+            FoodType = "Sandwich",
+        };
+
+        // Act
+        var result = await _decomposer.DecomposeAsync(treatment, WriteOrigin.Live);
+
+        // Assert
+        var carbIntake = result.CreatedRecords.OfType<V4Models.CarbIntake>().Single();
+        carbIntake.Id.Should().NotBeEmpty();
+
+        _treatmentFoodServiceMock.Verify(
+            x => x.AddAsync(
+                It.Is<TreatmentFood>(f =>
+                    f.CarbIntakeId == carbIntake.Id && f.Note == "Sandwich" && f.Carbs == 45m),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task DecomposeAsync_SnackBolus_CreatesBolusAndCarbIntake()
     {


### PR DESCRIPTION
Part of #1083 — the shared core and three of the four drifts; drift 1 (batch create-or-skip vs single create-or-update) deliberately stays open on the issue, untouched here to keep clear of #1103's `V4RepositoryBase` surface.

## What changes

- **One per-item core.** The ~10 builders duplicated between the single and batch paths of `EntryDecomposer`/`TreatmentDecomposer`/`DeviceStatusDecomposer` (glucose-hint extraction, override `StateSpan`, extras collection, insulin context, bolus/device-event/temp-basal/pump/uploader builders, the OpenAPS-over-Loop snapshot selection, AAPS mills normalization) now exist once each; where the paths genuinely differ (TempBasal's batch-local profile-switch timeline, pump `PatientDeviceId`), the difference stays at the call sites. Net −4 production lines; the dedup is ~−60, offset by the new policy documentation.
- **Behavioural fix, declared: batch meal treatments write their `TreatmentFood` line** — bulk-uploaded meals silently lost foodType/fat/protein. The shared `WriteLegacyFoodLineAsync` is **idempotent** (skips when the carb intake already has any line): hostile review proved the naive create-gate leaks on connector catch-up replays, because the bulk write's returned set includes sync-upserted rows (`UpdatedInPlace.Concat(toInsert)`), which would have written a duplicate user-visible food row on every re-poll. The skip is also the correct create semantics: a fresh carb intake has zero lines so the seed always lands, and once a user has attributed foods via `/carbs/{id}/foods`, re-seeding would double-count in the projection. The single path's update branch still writes nothing, with the reason stated at the writer.
- **Two issue claims refuted, documented instead of "fixed"**: the stamp-source drift is a no-op (`PatientDeviceStamper` resolves `record.DataSource ?? batchSource`, so `batchSource: null` loses nothing — now regression-tested), and the audit-scope asymmetry is load-bearing (`MutationAuditInterceptor` *suppresses* system-attributed rows; batch = uploader-rate ingestion, single = the only audit trail a per-record edit has). The policy lives once on `DecomposerBase.SystemAttributedBatchWrites`.
- Duplicate legacy ids within one batch now resolve first-wins in the food pass, matching the bulk write's own insert dedup.

## Tests

Decomposer filter 365 → 370, full `Nocturne.API.Tests` 6320 passed / 0 failed. New: TreatmentFood on batch and on single create; per-record stamp sources; the sync-upsert replay writes no second line (arranged with an `UpdatedInPlace`-style bulk return — the case the naive mock could not see); duplicate-legacy-id first-wins. Every fix mutation-checked (each mutant reddens exactly its pinning test), and hostile review re-ran its original replay trace plus its own mutation against the final shape.

## Known residual, flagged by hostile review (recorded on #1083, not fixed here)

"Zero lines means seed" can re-write the seed line if a user deletes it while the record is still inside a connector's replay window — bounded to one line, no compounding, but it overrides a user deletion. A true fix needs a create signal from the bulk write (the #1103 surface this PR deliberately avoids) or a tombstone.