### PR TITLE
refactor(api): project legacy treatments from one per-type table on both paths

### DIFF
--- a/src/API/Nocturne.API/Services/V4/LegacyTreatmentTables.cs
+++ b/src/API/Nocturne.API/Services/V4/LegacyTreatmentTables.cs
@@ -1,0 +1,487 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Connectors.Core.Constants;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Mappers;
+using Nocturne.Infrastructure.Data.Mappers.V4;
+
+namespace Nocturne.API.Services.V4;
+
+/// <summary>The V4 repositories the time-range read of a <see cref="ILegacyTreatmentTable"/> goes through.</summary>
+internal sealed record LegacyTreatmentRepositories(
+    IBolusRepository Boluses,
+    ICarbIntakeRepository CarbIntakes,
+    IBGCheckRepository BGChecks,
+    INoteRepository Notes,
+    IDeviceEventRepository DeviceEvents,
+    ITempBasalRepository TempBasals,
+    IBolusCalculationRepository BolusCalculations
+);
+
+/// <summary>The time window, page size and provenance filter of one time-range projection read.</summary>
+/// <param name="NativeOnly">
+/// When <see langword="true"/>, records that mirror a legacy v1/v2/v3 write (<c>LegacyId</c> set) are
+/// dropped. Treatments have no legacy table left to double up against, so every caller passes
+/// <see langword="false"/>; the filter survives for callers that want V4-native records only.
+/// </param>
+internal readonly record struct LegacyTreatmentRange(
+    DateTime? From,
+    DateTime? To,
+    int Limit,
+    bool NativeOnly
+);
+
+/// <summary>
+/// One record fetched for projection, carrying the table that owns it and the <c>SysUpdatedAt</c> of
+/// the row it came from — the latter on the modified-since path only; the time-range path does not
+/// surface <see cref="Treatment.SrvModified"/>.
+/// </summary>
+internal readonly record struct FetchedRecord(
+    ILegacyTreatmentTable Table,
+    object Record,
+    DateTime? Modified
+);
+
+/// <summary>Food breakdown rows for the carb intakes of one projected page, keyed by carb intake.</summary>
+internal sealed class CarbFoodIndex
+{
+    internal static readonly CarbFoodIndex Empty = new([]);
+
+    private readonly Dictionary<Guid, List<TreatmentFood>> _byCarbIntakeId;
+
+    internal CarbFoodIndex(IEnumerable<TreatmentFood> foods) =>
+        _byCarbIntakeId = foods
+            .GroupBy(f => f.CarbIntakeId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+    internal List<TreatmentFood> For(Guid carbIntakeId) =>
+        _byCarbIntakeId.GetValueOrDefault(carbIntakeId, []);
+}
+
+/// <summary>
+/// One V4 record type behind the legacy treatment projection, in the terms both read surfaces need:
+/// a time-range read, a modified-since read, and the legacy <see cref="Treatment"/> a standalone
+/// record of that type projects into.
+/// </summary>
+/// <seealso cref="LegacyTreatmentTables"/>
+internal interface ILegacyTreatmentTable
+{
+    /// <summary>Record type name, reported when a per-type fetch fails.</summary>
+    string RecordType { get; }
+
+    /// <summary>
+    /// A page of records within the requested window, newest first.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="LegacyTreatmentRange.NativeOnly"/> is honoured after the page is taken, so for a
+    /// type whose repository cannot push the provenance filter down (TempBasal, BolusCalculation)
+    /// the page can come back short of <see cref="LegacyTreatmentRange.Limit"/>.
+    /// </remarks>
+    Task<IReadOnlyList<FetchedRecord>> InRangeAsync(
+        LegacyTreatmentRepositories repositories,
+        LegacyTreatmentRange range,
+        CancellationToken ct
+    );
+
+    /// <summary>
+    /// The oldest <paramref name="limit"/> records whose <c>SysUpdatedAt</c> is strictly after
+    /// <paramref name="threshold"/>, oldest first.
+    /// </summary>
+    Task<IReadOnlyList<FetchedRecord>> ModifiedSinceAsync(
+        NocturneDbContext context,
+        DateTime threshold,
+        int limit,
+        CancellationToken ct
+    );
+
+    /// <summary>Projects a record this table owns that is not part of a meal pairing.</summary>
+    Treatment Project(object record, CarbFoodIndex foods);
+}
+
+/// <inheritdoc cref="ILegacyTreatmentTable"/>
+internal sealed class LegacyTreatmentTable<TRecord, TEntity>(
+    Func<
+        LegacyTreatmentRepositories,
+        LegacyTreatmentRange,
+        CancellationToken,
+        Task<IEnumerable<TRecord>>
+    > inRange,
+    Func<TRecord, string?> legacyId,
+    Func<NocturneDbContext, IQueryable<TEntity>> table,
+    Func<TEntity, TRecord> toRecord,
+    Func<TRecord, CarbFoodIndex, Treatment> project
+) : ILegacyTreatmentTable
+    where TRecord : class
+    where TEntity : class, ISystemTimestamped
+{
+    private const string ModifiedProperty = nameof(ISystemTimestamped.SysUpdatedAt);
+
+    /// <inheritdoc />
+    public string RecordType { get; } = typeof(TRecord).Name;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FetchedRecord>> InRangeAsync(
+        LegacyTreatmentRepositories repositories,
+        LegacyTreatmentRange range,
+        CancellationToken ct
+    )
+    {
+        var records = await inRange(repositories, range, ct);
+
+        if (range.NativeOnly)
+            records = records.Where(r => legacyId(r) is null);
+
+        return records.Select(r => new FetchedRecord(this, r, null)).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<FetchedRecord>> ModifiedSinceAsync(
+        NocturneDbContext context,
+        DateTime threshold,
+        int limit,
+        CancellationToken ct
+    )
+    {
+        var entities = await table(context)
+            .AsNoTracking()
+            .Where(e => EF.Property<DateTime>(e, ModifiedProperty) > threshold)
+            .OrderBy(e => EF.Property<DateTime>(e, ModifiedProperty))
+            .Take(limit)
+            .ToListAsync(ct);
+
+        return entities.Select(e => new FetchedRecord(this, toRecord(e), e.SysUpdatedAt)).ToList();
+    }
+
+    /// <inheritdoc />
+    public Treatment Project(object record, CarbFoodIndex foods) => project((TRecord)record, foods);
+}
+
+/// <summary>
+/// Every V4 record type the legacy treatment projection covers, and the assembly of a fetched page
+/// into legacy <see cref="Treatment"/> shapes. Order is significant: it fixes the order equal-timestamp
+/// treatments appear in, which survives the stable sort each read surface finishes with.
+/// </summary>
+internal static class LegacyTreatmentTables
+{
+    // DeviceEventType → legacy Nightscout eventType string (reverse of TreatmentTypes.DeviceEventTypeMap)
+    private static readonly Dictionary<DeviceEventType, string> DeviceEventTypeToString =
+        new()
+        {
+            [DeviceEventType.SensorStart] = TreatmentTypes.SensorStart,
+            [DeviceEventType.SensorChange] = TreatmentTypes.SensorChange,
+            [DeviceEventType.SensorStop] = TreatmentTypes.SensorStop,
+            [DeviceEventType.SiteChange] = TreatmentTypes.SiteChange,
+            [DeviceEventType.InsulinChange] = TreatmentTypes.InsulinChange,
+            [DeviceEventType.PumpBatteryChange] = TreatmentTypes.PumpBatteryChange,
+            [DeviceEventType.PodChange] = TreatmentTypes.PodChange,
+            [DeviceEventType.ReservoirChange] = TreatmentTypes.ReservoirChange,
+            [DeviceEventType.CannulaChange] = TreatmentTypes.CannulaChange,
+            [DeviceEventType.TransmitterSensorInsert] = TreatmentTypes.TransmitterSensorInsert,
+        };
+
+    internal static readonly IReadOnlyList<ILegacyTreatmentTable> All =
+    [
+        new LegacyTreatmentTable<Bolus, BolusEntity>(
+            (repositories, range, ct) => repositories.Boluses.GetAsync(
+                from: range.From, to: range.To, device: null, source: null,
+                limit: range.Limit, offset: 0, descending: true, nativeOnly: range.NativeOnly, ct: ct),
+            r => r.LegacyId,
+            c => c.Boluses, BolusMapper.ToDomainModel,
+            (r, _) => ProjectCorrectionBolus(r)),
+        new LegacyTreatmentTable<CarbIntake, CarbIntakeEntity>(
+            (repositories, range, ct) => repositories.CarbIntakes.GetAsync(
+                from: range.From, to: range.To, device: null, source: null,
+                limit: range.Limit, offset: 0, descending: true, nativeOnly: range.NativeOnly, ct: ct),
+            r => r.LegacyId,
+            c => c.CarbIntakes, CarbIntakeMapper.ToDomainModel,
+            (r, foods) => ProjectCarbCorrection(r, foods.For(r.Id))),
+        new LegacyTreatmentTable<BGCheck, BGCheckEntity>(
+            (repositories, range, ct) => repositories.BGChecks.GetAsync(
+                from: range.From, to: range.To, device: null, source: null,
+                limit: range.Limit, offset: 0, descending: true, nativeOnly: range.NativeOnly, ct: ct),
+            r => r.LegacyId,
+            c => c.BGChecks, BGCheckMapper.ToDomainModel,
+            (r, _) => ProjectBgCheck(r)),
+        new LegacyTreatmentTable<Note, NoteEntity>(
+            (repositories, range, ct) => repositories.Notes.GetAsync(
+                from: range.From, to: range.To, device: null, source: null,
+                limit: range.Limit, offset: 0, descending: true, nativeOnly: range.NativeOnly, ct: ct),
+            r => r.LegacyId,
+            c => c.Notes, NoteMapper.ToDomainModel,
+            (r, _) => ProjectNote(r)),
+        new LegacyTreatmentTable<DeviceEvent, DeviceEventEntity>(
+            (repositories, range, ct) => repositories.DeviceEvents.GetAsync(
+                from: range.From, to: range.To, device: null, source: null,
+                limit: range.Limit, offset: 0, descending: true, nativeOnly: range.NativeOnly, ct: ct),
+            r => r.LegacyId,
+            c => c.DeviceEvents, DeviceEventMapper.ToDomainModel,
+            (r, _) => ProjectDeviceEvent(r)),
+        new LegacyTreatmentTable<TempBasal, TempBasalEntity>(
+            (repositories, range, ct) => repositories.TempBasals.GetAsync(
+                from: range.From, to: range.To, device: null, source: null,
+                limit: range.Limit, offset: 0, descending: true, ct: ct),
+            r => r.LegacyId,
+            c => c.TempBasals, TempBasalMapper.ToDomainModel,
+            (r, _) => TempBasalToTreatmentMapper.ToTreatment(r)),
+        new LegacyTreatmentTable<BolusCalculation, BolusCalculationEntity>(
+            (repositories, range, ct) => repositories.BolusCalculations.GetAsync(
+                from: range.From, to: range.To, device: null, source: null,
+                limit: range.Limit, offset: 0, descending: true, ct: ct),
+            r => r.LegacyId,
+            c => c.BolusCalculations, BolusCalculationMapper.ToDomainModel,
+            (r, _) => ProjectBolusCalculation(r)),
+    ];
+
+    /// <summary>
+    /// Turns a page of rows into legacy treatments: a bolus and a carb intake sharing a correlation
+    /// become one Meal Bolus, and everything else projects through its own table. Pairing only ever
+    /// sees the rows it is handed, so a page must be selected before it is assembled — see
+    /// <see cref="V4ToLegacyProjectionService.GetProjectedTreatmentsModifiedSinceAsync"/>.
+    /// </summary>
+    internal static List<Treatment> Assemble(IReadOnlyList<FetchedRecord> rows, CarbFoodIndex foods)
+    {
+        var treatments = new List<Treatment>();
+        var paired = PairMeals(rows, foods, treatments);
+
+        foreach (var row in rows)
+        {
+            if (paired.Contains(row.Record))
+                continue;
+
+            treatments.Add(Stamp(row.Table.Project(row.Record, foods), row.Modified));
+        }
+
+        return treatments;
+    }
+
+    /// <summary>
+    /// Pairs boluses and carb intakes by CorrelationId. Under N:M a single correlation may have
+    /// multiple boluses and/or multiple carb intakes: the dominant-dose bolus + carb are projected
+    /// as the primary Meal Bolus and returned as consumed, and any extras flow through as separate
+    /// Correction Bolus / Carb Correction treatments. Ordering by descending Insulin/Carbs picks the
+    /// record a human would recognise as the main one; ThenBy(Id) is a deterministic tiebreaker so
+    /// same-timestamp, same-dose records don't produce non-deterministic output across requests.
+    /// </summary>
+    private static HashSet<object> PairMeals(
+        IReadOnlyList<FetchedRecord> records,
+        CarbFoodIndex foods,
+        List<Treatment> treatments
+    )
+    {
+        var paired = new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        var boluses = Correlated<Bolus>(records);
+        var carbs = Correlated<CarbIntake>(records);
+
+        foreach (var correlationId in boluses.Select(g => g.Key).Union(carbs.Select(g => g.Key)))
+        {
+            var bolus = boluses[correlationId]
+                .OrderByDescending(b => b.Record.Insulin)
+                .ThenBy(b => b.Record.Id)
+                .FirstOrDefault();
+            var carb = carbs[correlationId]
+                .OrderByDescending(c => c.Record.Carbs)
+                .ThenBy(c => c.Record.Id)
+                .FirstOrDefault();
+
+            if (bolus.Record is null || carb.Record is null)
+                continue;
+
+            paired.Add(bolus.Record);
+            paired.Add(carb.Record);
+
+            // The meal carries the newer of the two stamps: stamping the older one leaves the other
+            // record above the cursor the consumer derives from this page, which re-serves the same
+            // meal on the next request without ever advancing.
+            treatments.Add(Stamp(
+                ProjectMealBolus(bolus.Record, carb.Record, foods.For(carb.Record.Id)),
+                Newest(bolus.Modified, carb.Modified)));
+        }
+
+        return paired;
+    }
+
+    private static ILookup<Guid, (T Record, DateTime? Modified)> Correlated<T>(
+        IReadOnlyList<FetchedRecord> records
+    )
+        where T : class, IV4Record =>
+        records
+            .Select(r => (Record: r.Record as T, r.Modified))
+            .Where(r => r.Record?.CorrelationId is not null)
+            .ToLookup(r => r.Record!.CorrelationId!.Value, r => (r.Record!, r.Modified));
+
+    private static DateTime? Newest(DateTime? left, DateTime? right) =>
+        left > right ? left : right ?? left;
+
+    private static Treatment Stamp(Treatment treatment, DateTime? modifiedAt)
+    {
+        if (modifiedAt.HasValue)
+            treatment.SrvModified = new DateTimeOffset(modifiedAt.Value, TimeSpan.Zero)
+                .ToUnixTimeMilliseconds();
+
+        return treatment;
+    }
+
+    private static Treatment ProjectMealBolus(Bolus bolus, CarbIntake carb, List<TreatmentFood> foods) =>
+        new()
+        {
+            Id = bolus.Id.ToString(),
+            EventType = TreatmentTypes.MealBolus,
+            Mills = bolus.Mills,
+            Insulin = bolus.Insulin,
+            Carbs = carb.Carbs,
+            FoodType = DeriveFoodType(foods),
+            Fat = DeriveTotalFat(foods),
+            Protein = DeriveTotalProtein(foods),
+            AbsorptionTime = carb.AbsorptionTime,
+            CarbTime = carb.CarbTime.HasValue ? (int?)((int)carb.CarbTime.Value) : null,
+            EnteredBy = bolus.Device,
+            DataSource = bolus.DataSource,
+            SyncIdentifier = bolus.SyncIdentifier,
+            InsulinType = bolus.InsulinType,
+            UtcOffset = bolus.UtcOffset,
+            Automatic = bolus.Automatic,
+        };
+
+    private static Treatment ProjectCorrectionBolus(Bolus bolus) =>
+        new()
+        {
+            Id = bolus.Id.ToString(),
+            EventType = TreatmentTypes.CorrectionBolus,
+            Mills = bolus.Mills,
+            Insulin = bolus.Insulin,
+            EnteredBy = bolus.Device,
+            DataSource = bolus.DataSource,
+            SyncIdentifier = bolus.SyncIdentifier,
+            InsulinType = bolus.InsulinType,
+            UtcOffset = bolus.UtcOffset,
+            // Preserve the algorithm/manual distinction (SMBs, auto-boluses): the v4 Bolus.Automatic
+            // flag (set alongside Kind=Algorithm during decomposition) maps onto the legacy Nightscout
+            // `automatic` field so v1/v3 clients (LoopFollow, Trio import) can tell an SMB from a
+            // user-initiated bolus.
+            Automatic = bolus.Automatic,
+        };
+
+    private static Treatment ProjectCarbCorrection(CarbIntake carb, List<TreatmentFood> foods) =>
+        new()
+        {
+            Id = carb.Id.ToString(),
+            EventType = TreatmentTypes.CarbCorrection,
+            Mills = carb.Mills,
+            Carbs = carb.Carbs,
+            FoodType = DeriveFoodType(foods),
+            Fat = DeriveTotalFat(foods),
+            Protein = DeriveTotalProtein(foods),
+            AbsorptionTime = carb.AbsorptionTime,
+            CarbTime = carb.CarbTime.HasValue ? (int?)((int)carb.CarbTime.Value) : null,
+            EnteredBy = carb.Device,
+            DataSource = carb.DataSource,
+            SyncIdentifier = carb.SyncIdentifier,
+            UtcOffset = carb.UtcOffset,
+        };
+
+    private static string? DeriveFoodType(List<TreatmentFood> foods)
+    {
+        if (foods.Count == 0) return null;
+
+        var names = foods
+            .Select(f => f.FoodName ?? f.Note)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .ToList();
+
+        return names.Count > 0 ? string.Join(", ", names) : null;
+    }
+
+    private static double? DeriveTotalFat(List<TreatmentFood> foods)
+    {
+        var sum = foods
+            .Where(f => f.FatPerPortion.HasValue && f.Portions > 0)
+            .Sum(f => (double)(f.FatPerPortion!.Value * f.Portions));
+        return sum > 0 ? sum : null;
+    }
+
+    private static double? DeriveTotalProtein(List<TreatmentFood> foods)
+    {
+        var sum = foods
+            .Where(f => f.ProteinPerPortion.HasValue && f.Portions > 0)
+            .Sum(f => (double)(f.ProteinPerPortion!.Value * f.Portions));
+        return sum > 0 ? sum : null;
+    }
+
+    private static Treatment ProjectBgCheck(BGCheck bgCheck) =>
+        new()
+        {
+            Id = bgCheck.Id.ToString(),
+            EventType = TreatmentTypes.BgCheck,
+            Mills = bgCheck.Mills,
+            Glucose = bgCheck.Glucose,
+            Mgdl = bgCheck.Mgdl,
+            Mmol = bgCheck.Mmol,
+            GlucoseType = bgCheck.GlucoseType?.ToString(),
+            Units = bgCheck.Units == GlucoseUnit.Mmol ? "mmol" : "mg/dl",
+            EnteredBy = bgCheck.Device,
+            DataSource = bgCheck.DataSource,
+            SyncIdentifier = bgCheck.SyncIdentifier,
+            UtcOffset = bgCheck.UtcOffset,
+        };
+
+    private static Treatment ProjectNote(Note note) =>
+        new()
+        {
+            Id = note.Id.ToString(),
+            EventType = note.EventType ?? "Note",
+            Mills = note.Mills,
+            Notes = note.Text,
+            IsAnnouncement = note.IsAnnouncement,
+            EnteredBy = note.Device,
+            DataSource = note.DataSource,
+            SyncIdentifier = note.SyncIdentifier,
+            UtcOffset = note.UtcOffset,
+        };
+
+    private static Treatment ProjectDeviceEvent(DeviceEvent deviceEvent)
+    {
+        DeviceEventTypeToString.TryGetValue(deviceEvent.EventType, out var eventTypeString);
+        return new Treatment
+        {
+            Id = deviceEvent.Id.ToString(),
+            EventType = eventTypeString ?? deviceEvent.EventType.ToString(),
+            Mills = deviceEvent.Mills,
+            Notes = deviceEvent.Notes,
+            EnteredBy = deviceEvent.Device,
+            DataSource = deviceEvent.DataSource,
+            SyncIdentifier = deviceEvent.SyncIdentifier,
+            UtcOffset = deviceEvent.UtcOffset,
+        };
+    }
+
+    private static Treatment ProjectBolusCalculation(BolusCalculation bc) =>
+        new()
+        {
+            Id = bc.Id.ToString(),
+            EventType = "Bolus Wizard",
+            Mills = bc.Mills,
+            BloodGlucoseInput = bc.BloodGlucoseInput,
+            BloodGlucoseInputSource = bc.BloodGlucoseInputSource,
+            Carbs = bc.CarbInput,
+            InsulinOnBoard = bc.InsulinOnBoard,
+            InsulinRecommendationForCorrection = bc.InsulinRecommendation,
+            CR = bc.CarbRatio,
+            CalculationType = bc.CalculationType.HasValue
+                ? (Nocturne.Core.Models.CalculationType)(int)bc.CalculationType.Value
+                : null,
+            InsulinRecommendationForCarbs = bc.InsulinRecommendationForCarbs,
+            InsulinProgrammed = bc.InsulinProgrammed,
+            EnteredInsulin = bc.EnteredInsulin,
+            SplitNow = bc.SplitNow,
+            SplitExt = bc.SplitExt,
+            PreBolus = bc.PreBolus,
+            EnteredBy = bc.Device,
+            DataSource = bc.DataSource,
+            UtcOffset = bc.UtcOffset,
+        };
+}

--- a/src/API/Nocturne.API/Services/V4/V4ToLegacyProjectionService.cs
+++ b/src/API/Nocturne.API/Services/V4/V4ToLegacyProjectionService.cs
@@ -1,24 +1,18 @@
-using Microsoft.EntityFrameworkCore;
 using Nocturne.API.Services.Entries;
 using Nocturne.API.Services.Glucose;
 using Nocturne.API.Services.Treatments;
-using Nocturne.Connectors.Core.Constants;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
-using Nocturne.Infrastructure.Data.Mappers;
-using Nocturne.Infrastructure.Data.Mappers.V4;
 
 namespace Nocturne.API.Services.V4;
 
 /// <summary>
 /// Projects V4 granular records back into the legacy <see cref="Entry"/> and <see cref="Treatment"/>
-/// shapes for v1/v2/v3 API compatibility. Only records written directly to V4 tables (those whose
-/// <c>LegacyId</c> is <see langword="null"/> — they have no corresponding row in the legacy
-/// entries/treatments tables) are projected.
+/// shapes for v1/v2/v3 API compatibility.
 /// </summary>
 /// <remarks>
 /// This service is the read side of the dual-path architecture.
@@ -26,38 +20,22 @@ namespace Nocturne.API.Services.V4;
 /// Projection covers: <see cref="SensorGlucose"/> → <see cref="Entry"/>,
 /// <see cref="Bolus"/> and <see cref="CarbIntake"/> → <see cref="Treatment"/>,
 /// <see cref="DeviceEvent"/> → <see cref="Treatment"/> using the legacy event-type map.
+/// <para>
+/// Entries are projected V4-native-only, supplementing the rows the legacy entries table still
+/// holds. Treatments have no legacy table left to supplement, so every treatment read projects
+/// records of both provenances — see <see cref="LegacyTreatmentRange.NativeOnly"/>.
+/// </para>
 /// </remarks>
 /// <seealso cref="IV4ToLegacyProjectionService"/>
+/// <seealso cref="LegacyTreatmentTables"/>
 /// <seealso cref="DecompositionPipeline"/>
 public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
 {
     private readonly ISensorGlucoseRepository _sensorGlucoseRepository;
-    private readonly IBolusRepository _bolusRepository;
-    private readonly ICarbIntakeRepository _carbIntakeRepository;
-    private readonly IBGCheckRepository _bgCheckRepository;
-    private readonly INoteRepository _noteRepository;
-    private readonly IDeviceEventRepository _deviceEventRepository;
-    private readonly ITempBasalRepository _tempBasalRepository;
-    private readonly IBolusCalculationRepository _bolusCalculationRepository;
+    private readonly LegacyTreatmentRepositories _repositories;
     private readonly ITreatmentFoodService _treatmentFoodService;
     private readonly NocturneDbContext _dbContext;
     private readonly ILogger<V4ToLegacyProjectionService> _logger;
-
-    // DeviceEventType → legacy Nightscout eventType string (reverse of TreatmentTypes.DeviceEventTypeMap)
-    private static readonly Dictionary<DeviceEventType, string> DeviceEventTypeToString =
-        new()
-        {
-            [DeviceEventType.SensorStart] = TreatmentTypes.SensorStart,
-            [DeviceEventType.SensorChange] = TreatmentTypes.SensorChange,
-            [DeviceEventType.SensorStop] = TreatmentTypes.SensorStop,
-            [DeviceEventType.SiteChange] = TreatmentTypes.SiteChange,
-            [DeviceEventType.InsulinChange] = TreatmentTypes.InsulinChange,
-            [DeviceEventType.PumpBatteryChange] = TreatmentTypes.PumpBatteryChange,
-            [DeviceEventType.PodChange] = TreatmentTypes.PodChange,
-            [DeviceEventType.ReservoirChange] = TreatmentTypes.ReservoirChange,
-            [DeviceEventType.CannulaChange] = TreatmentTypes.CannulaChange,
-            [DeviceEventType.TransmitterSensorInsert] = TreatmentTypes.TransmitterSensorInsert,
-        };
 
     public V4ToLegacyProjectionService(
         ISensorGlucoseRepository sensorGlucoseRepository,
@@ -74,13 +52,15 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
     )
     {
         _sensorGlucoseRepository = sensorGlucoseRepository;
-        _bolusRepository = bolusRepository;
-        _carbIntakeRepository = carbIntakeRepository;
-        _bgCheckRepository = bgCheckRepository;
-        _noteRepository = noteRepository;
-        _deviceEventRepository = deviceEventRepository;
-        _tempBasalRepository = tempBasalRepository;
-        _bolusCalculationRepository = bolusCalculationRepository;
+        _repositories = new LegacyTreatmentRepositories(
+            bolusRepository,
+            carbIntakeRepository,
+            bgCheckRepository,
+            noteRepository,
+            deviceEventRepository,
+            tempBasalRepository,
+            bolusCalculationRepository
+        );
         _treatmentFoodService = treatmentFoodService;
         _dbContext = dbContext;
         _logger = logger;
@@ -163,211 +143,11 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
         CancellationToken ct = default
     )
     {
-        // Fetch all V4 treatment record types sequentially.
-        // These repositories share a scoped DbContext which is not thread-safe,
-        // so they cannot be run concurrently via Task.WhenAll.
-        var boluses = (await FetchSafe(() =>
-            _bolusRepository.GetAsync(
-                from: MillsToDateTime(fromMills),
-                to: MillsToDateTime(toMills),
-                device: null,
-                source: null,
-                limit: limit,
-                offset: 0,
-                descending: true,
-                nativeOnly: nativeOnly,
-                ct: ct
-            )
-        )).ToList();
+        var range = new LegacyTreatmentRange(
+            MillsToDateTime(fromMills), MillsToDateTime(toMills), limit, nativeOnly);
 
-        var carbs = (await FetchSafe(() =>
-            _carbIntakeRepository.GetAsync(
-                from: MillsToDateTime(fromMills),
-                to: MillsToDateTime(toMills),
-                device: null,
-                source: null,
-                limit: limit,
-                offset: 0,
-                descending: true,
-                nativeOnly: nativeOnly,
-                ct: ct
-            )
-        )).ToList();
-
-        var bgChecks = (await FetchSafe(() =>
-            _bgCheckRepository.GetAsync(
-                from: MillsToDateTime(fromMills),
-                to: MillsToDateTime(toMills),
-                device: null,
-                source: null,
-                limit: limit,
-                offset: 0,
-                descending: true,
-                nativeOnly: nativeOnly,
-                ct: ct
-            )
-        )).ToList();
-
-        var notes = (await FetchSafe(() =>
-            _noteRepository.GetAsync(
-                from: MillsToDateTime(fromMills),
-                to: MillsToDateTime(toMills),
-                device: null,
-                source: null,
-                limit: limit,
-                offset: 0,
-                descending: true,
-                nativeOnly: nativeOnly,
-                ct: ct
-            )
-        )).ToList();
-
-        var deviceEvents = (await FetchSafe(() =>
-            _deviceEventRepository.GetAsync(
-                from: MillsToDateTime(fromMills),
-                to: MillsToDateTime(toMills),
-                device: null,
-                source: null,
-                limit: limit,
-                offset: 0,
-                descending: true,
-                nativeOnly: nativeOnly,
-                ct: ct
-            )
-        )).ToList();
-
-        var tempBasals = (await FetchSafe(() =>
-            _tempBasalRepository.GetAsync(
-                from: MillsToDateTime(fromMills),
-                to: MillsToDateTime(toMills),
-                device: null,
-                source: null,
-                limit: limit,
-                offset: 0,
-                descending: true,
-                ct: ct
-            )
-        )).ToList();
-        if (nativeOnly)
-            tempBasals = tempBasals.Where(r => r.LegacyId == null).ToList();
-
-        var bolusCalcs = (await FetchSafe(() =>
-            _bolusCalculationRepository.GetAsync(
-                from: MillsToDateTime(fromMills),
-                to: MillsToDateTime(toMills),
-                device: null,
-                source: null,
-                limit: limit,
-                offset: 0,
-                descending: true,
-                ct: ct
-            )
-        )).ToList();
-        if (nativeOnly)
-            bolusCalcs = bolusCalcs.Where(r => r.LegacyId == null).ToList();
-
-        // Load food breakdown entries for all carb intakes to populate legacy fields
-        var carbIds = carbs.Select(c => c.Id).ToList();
-        var allFoodEntries = carbIds.Count > 0
-            ? (await _treatmentFoodService.GetByCarbIntakeIdsAsync(carbIds, ct)).ToList()
-            : [];
-        var foodsByCarbId = allFoodEntries
-            .GroupBy(f => f.CarbIntakeId)
-            .ToDictionary(g => g.Key, g => g.ToList());
-
-        var treatments = new List<Treatment>();
-
-        // --- Bolus + CarbIntake pairing ---
-        // Pair by CorrelationId only. Under N:M a single correlation may have
-        // multiple boluses and/or multiple carb intakes: the first bolus + first
-        // carb in a correlation become the Meal Bolus projection, and any extras
-        // flow through as separate Correction Bolus / Carb Correction treatments.
-        var pairedCarbIds = new HashSet<Guid>();
-        var pairedBolusIds = new HashSet<Guid>();
-
-        var bolusesWithCorrelation = boluses
-            .Where(b => b.CorrelationId.HasValue)
-            .ToLookup(b => b.CorrelationId!.Value);
-        var bolusesWithoutCorrelation = boluses.Where(b => !b.CorrelationId.HasValue).ToList();
-
-        var carbsWithCorrelation = carbs
-            .Where(c => c.CorrelationId.HasValue)
-            .ToLookup(c => c.CorrelationId!.Value);
-        var carbsWithoutCorrelation = carbs.Where(c => !c.CorrelationId.HasValue).ToList();
-
-        var allCorrelationIds = bolusesWithCorrelation
-            .Select(g => g.Key)
-            .Union(carbsWithCorrelation.Select(g => g.Key))
-            .Distinct();
-
-        foreach (var correlationId in allCorrelationIds)
-        {
-            var correlatedBoluses = bolusesWithCorrelation[correlationId].ToList();
-            var correlatedCarbs = carbsWithCorrelation[correlationId].ToList();
-
-            if (correlatedBoluses.Count > 0 && correlatedCarbs.Count > 0)
-            {
-                // Under N:M a correlation may have multiple boluses and/or carbs.
-                // The dominant-dose bolus + carb are projected as the primary Meal
-                // Bolus; any extras fall through to the per-record handlers below
-                // as separate Correction Bolus / Carb Correction treatments.
-                // Ordering by descending Insulin/Carbs picks the "main" record a
-                // human would recognise; ThenBy(Id) is a deterministic tiebreaker
-                // so multiple same-timestamp, same-dose records don't produce
-                // non-deterministic output across requests.
-                var primaryBolus = correlatedBoluses
-                    .OrderByDescending(b => b.Insulin)
-                    .ThenBy(b => b.Id)
-                    .First();
-                var primaryCarb = correlatedCarbs
-                    .OrderByDescending(c => c.Carbs)
-                    .ThenBy(c => c.Id)
-                    .First();
-                pairedBolusIds.Add(primaryBolus.Id);
-                pairedCarbIds.Add(primaryCarb.Id);
-                treatments.Add(ProjectMealBolus(primaryBolus, primaryCarb, foodsByCarbId.GetValueOrDefault(primaryCarb.Id, [])));
-            }
-        }
-
-        // Remaining unpaired records: any bolus or carb that either has no
-        // correlation, or shares a correlation but wasn't the primary pair member.
-        foreach (var bolus in bolusesWithoutCorrelation)
-            treatments.Add(ProjectCorrectionBolus(bolus));
-
-        foreach (var group in bolusesWithCorrelation)
-        {
-            foreach (var bolus in group.Where(b => !pairedBolusIds.Contains(b.Id)))
-                treatments.Add(ProjectCorrectionBolus(bolus));
-        }
-
-        foreach (var carb in carbsWithoutCorrelation)
-            treatments.Add(ProjectCarbCorrection(carb, foodsByCarbId.GetValueOrDefault(carb.Id, [])));
-
-        foreach (var group in carbsWithCorrelation)
-        {
-            foreach (var carb in group.Where(c => !pairedCarbIds.Contains(c.Id)))
-                treatments.Add(ProjectCarbCorrection(carb, foodsByCarbId.GetValueOrDefault(carb.Id, [])));
-        }
-
-        // --- BGCheck → Treatment ---
-        foreach (var bgCheck in bgChecks)
-            treatments.Add(ProjectBgCheck(bgCheck));
-
-        // --- Note → Treatment ---
-        foreach (var note in notes)
-            treatments.Add(ProjectNote(note));
-
-        // --- DeviceEvent → Treatment ---
-        foreach (var deviceEvent in deviceEvents)
-            treatments.Add(ProjectDeviceEvent(deviceEvent));
-
-        // --- TempBasal → Treatment ---
-        foreach (var tempBasal in tempBasals)
-            treatments.Add(TempBasalToTreatmentMapper.ToTreatment(tempBasal));
-
-        // --- BolusCalculation → Treatment ---
-        foreach (var bolusCalc in bolusCalcs)
-            treatments.Add(ProjectBolusCalculation(bolusCalc));
+        var rows = await FetchAsync(table => table.InRangeAsync(_repositories, range, ct));
+        var treatments = await AssembleAsync(rows, ct);
 
         return treatments.OrderByDescending(t => t.Mills).Take(limit);
     }
@@ -376,255 +156,82 @@ public class V4ToLegacyProjectionService : IV4ToLegacyProjectionService
     public async Task<IEnumerable<Treatment>> GetProjectedTreatmentsModifiedSinceAsync(
         long lastModifiedMills, int limit, CancellationToken ct = default)
     {
-        var threshold = DateTimeOffset.FromUnixTimeMilliseconds(lastModifiedMills).UtcDateTime;
-        var treatments = new List<Treatment>();
-
         // Strictly-greater (not >=) so the cursor record AAPS already holds is not
         // re-returned; an inclusive bound makes AAPS re-request the same page in a loop.
+        var threshold = DateTimeOffset.FromUnixTimeMilliseconds(lastModifiedMills).UtcDateTime;
 
-        // Query each V4 entity table by ModifiedAt, map to domain, then project to Treatment.
-        // Sequential to avoid DbContext thread-safety issues.
-        var boluses = await _dbContext.Boluses.AsNoTracking()
-            .Where(e => e.SysUpdatedAt > threshold)
-            .OrderBy(static e => e.SysUpdatedAt)
-            .Take(limit)
-            .ToListAsync(ct);
-        foreach (var entity in boluses)
-            treatments.Add(WithSrvModified(ProjectCorrectionBolus(BolusMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
+        var rows = await FetchAsync(
+            table => table.ModifiedSinceAsync(_dbContext, threshold, limit, ct));
 
-        var carbIntakes = await _dbContext.CarbIntakes.AsNoTracking()
-            .Where(e => e.SysUpdatedAt > threshold)
-            .OrderBy(static e => e.SysUpdatedAt)
-            .Take(limit)
-            .ToListAsync(ct);
-        foreach (var entity in carbIntakes)
-            treatments.Add(WithSrvModified(ProjectCarbCorrection(CarbIntakeMapper.ToDomainModel(entity), []), entity.SysUpdatedAt));
+        // The page is cut on raw row stamps and only then paired. Each type contributes its own
+        // oldest `limit` rows, so this merge holds the globally-oldest `limit`, and every row left
+        // behind is strictly newer than every row returned. Pairing before the cut breaks that: a
+        // meal carries its newer constituent's stamp, so it can sort past the cut while the cursor
+        // — max(srvModified) over the page — still advances beyond the older constituent's own row,
+        // which is then never fetched again. Pairing after the cut can only merge rows that were
+        // both delivered, so a pair split by the cut simply arrives as two treatments.
+        var page = rows.OrderBy(r => r.Modified).Take(limit).ToList();
+        var treatments = await AssembleAsync(page, ct);
 
-        var bgChecks = await _dbContext.BGChecks.AsNoTracking()
-            .Where(e => e.SysUpdatedAt > threshold)
-            .OrderBy(static e => e.SysUpdatedAt)
-            .Take(limit)
-            .ToListAsync(ct);
-        foreach (var entity in bgChecks)
-            treatments.Add(WithSrvModified(ProjectBgCheck(BGCheckMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
-
-        var notes = await _dbContext.Notes.AsNoTracking()
-            .Where(e => e.SysUpdatedAt > threshold)
-            .OrderBy(static e => e.SysUpdatedAt)
-            .Take(limit)
-            .ToListAsync(ct);
-        foreach (var entity in notes)
-            treatments.Add(WithSrvModified(ProjectNote(NoteMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
-
-        var deviceEvents = await _dbContext.DeviceEvents.AsNoTracking()
-            .Where(e => e.SysUpdatedAt > threshold)
-            .OrderBy(static e => e.SysUpdatedAt)
-            .Take(limit)
-            .ToListAsync(ct);
-        foreach (var entity in deviceEvents)
-            treatments.Add(WithSrvModified(ProjectDeviceEvent(DeviceEventMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
-
-        var tempBasals = await _dbContext.TempBasals.AsNoTracking()
-            .Where(e => e.SysUpdatedAt > threshold)
-            .OrderBy(static e => e.SysUpdatedAt)
-            .Take(limit)
-            .ToListAsync(ct);
-        foreach (var entity in tempBasals)
-            treatments.Add(WithSrvModified(TempBasalToTreatmentMapper.ToTreatment(TempBasalMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
-
-        var bolusCalcs = await _dbContext.BolusCalculations.AsNoTracking()
-            .Where(e => e.SysUpdatedAt > threshold)
-            .OrderBy(static e => e.SysUpdatedAt)
-            .Take(limit)
-            .ToListAsync(ct);
-        foreach (var entity in bolusCalcs)
-            treatments.Add(WithSrvModified(ProjectBolusCalculation(BolusCalculationMapper.ToDomainModel(entity)), entity.SysUpdatedAt));
-
-        return treatments.OrderBy(t => t.SrvModified ?? t.Mills).Take(limit);
+        return treatments.OrderBy(t => t.SrvModified ?? t.Mills);
     }
 
-    // -------------------------------------------------------------------------
-    // Private projection helpers
-    // -------------------------------------------------------------------------
-
-    private static Entry ProjectSensorGlucoseToEntry(SensorGlucose sg) =>
-        SensorGlucoseToEntryMapper.ToEntry(sg);
-
-    private static Treatment ProjectMealBolus(Bolus bolus, CarbIntake carb, List<TreatmentFood> foods) =>
-        new()
-        {
-            Id = bolus.Id.ToString(),
-            EventType = TreatmentTypes.MealBolus,
-            Mills = bolus.Mills,
-            Insulin = bolus.Insulin,
-            Carbs = carb.Carbs,
-            FoodType = DeriveeFoodType(foods),
-            Fat = DeriveTotalFat(foods),
-            Protein = DeriveTotalProtein(foods),
-            AbsorptionTime = carb.AbsorptionTime,
-            CarbTime = carb.CarbTime.HasValue ? (int?)((int)carb.CarbTime.Value) : null,
-            EnteredBy = bolus.Device,
-            DataSource = bolus.DataSource,
-            SyncIdentifier = bolus.SyncIdentifier,
-            InsulinType = bolus.InsulinType,
-            UtcOffset = bolus.UtcOffset,
-            Automatic = bolus.Automatic,
-        };
-
-    private static Treatment ProjectCorrectionBolus(Bolus bolus) =>
-        new()
-        {
-            Id = bolus.Id.ToString(),
-            EventType = TreatmentTypes.CorrectionBolus,
-            Mills = bolus.Mills,
-            Insulin = bolus.Insulin,
-            EnteredBy = bolus.Device,
-            DataSource = bolus.DataSource,
-            SyncIdentifier = bolus.SyncIdentifier,
-            InsulinType = bolus.InsulinType,
-            UtcOffset = bolus.UtcOffset,
-            // Preserve the algorithm/manual distinction (SMBs, auto-boluses): the v4 Bolus.Automatic
-            // flag (set alongside Kind=Algorithm during decomposition) maps onto the legacy Nightscout
-            // `automatic` field so v1/v3 clients (LoopFollow, Trio import) can tell an SMB from a
-            // user-initiated bolus.
-            Automatic = bolus.Automatic,
-        };
-
-    private static Treatment ProjectCarbCorrection(CarbIntake carb, List<TreatmentFood> foods) =>
-        new()
-        {
-            Id = carb.Id.ToString(),
-            EventType = TreatmentTypes.CarbCorrection,
-            Mills = carb.Mills,
-            Carbs = carb.Carbs,
-            FoodType = DeriveeFoodType(foods),
-            Fat = DeriveTotalFat(foods),
-            Protein = DeriveTotalProtein(foods),
-            AbsorptionTime = carb.AbsorptionTime,
-            CarbTime = carb.CarbTime.HasValue ? (int?)((int)carb.CarbTime.Value) : null,
-            EnteredBy = carb.Device,
-            DataSource = carb.DataSource,
-            SyncIdentifier = carb.SyncIdentifier,
-            UtcOffset = carb.UtcOffset,
-        };
-
-    private static string? DeriveeFoodType(List<TreatmentFood> foods)
+    /// <summary>
+    /// Reads every record type through <paramref name="fetch"/>. Types are read sequentially: they
+    /// share a scoped DbContext, which is not thread-safe, so they cannot be run concurrently via
+    /// <see cref="Task.WhenAll(Task[])"/>. A type whose read fails contributes nothing rather than
+    /// failing the whole page.
+    /// </summary>
+    private async Task<List<FetchedRecord>> FetchAsync(
+        Func<ILegacyTreatmentTable, Task<IReadOnlyList<FetchedRecord>>> fetch
+    )
     {
-        if (foods.Count == 0) return null;
+        var rows = new List<FetchedRecord>();
+        foreach (var table in LegacyTreatmentTables.All)
+            rows.AddRange(await FetchSafe(table, fetch));
 
-        var names = foods
-            .Select(f => f.FoodName ?? f.Note)
-            .Where(n => !string.IsNullOrWhiteSpace(n))
+        return rows;
+    }
+
+    private async Task<List<Treatment>> AssembleAsync(
+        IReadOnlyList<FetchedRecord> rows, CancellationToken ct
+    ) => LegacyTreatmentTables.Assemble(rows, await LoadCarbFoodsAsync(rows, ct));
+
+    private async Task<CarbFoodIndex> LoadCarbFoodsAsync(
+        IReadOnlyList<FetchedRecord> rows,
+        CancellationToken ct
+    )
+    {
+        var carbIntakeIds = rows
+            .Select(r => r.Record)
+            .OfType<CarbIntake>()
+            .Select(c => c.Id)
             .ToList();
 
-        return names.Count > 0 ? string.Join(", ", names) : null;
+        return carbIntakeIds.Count == 0
+            ? CarbFoodIndex.Empty
+            : new CarbFoodIndex(await _treatmentFoodService.GetByCarbIntakeIdsAsync(carbIntakeIds, ct));
     }
 
-    private static double? DeriveTotalFat(List<TreatmentFood> foods)
-    {
-        var sum = foods
-            .Where(f => f.FatPerPortion.HasValue && f.Portions > 0)
-            .Sum(f => (double)(f.FatPerPortion!.Value * f.Portions));
-        return sum > 0 ? sum : null;
-    }
-
-    private static double? DeriveTotalProtein(List<TreatmentFood> foods)
-    {
-        var sum = foods
-            .Where(f => f.ProteinPerPortion.HasValue && f.Portions > 0)
-            .Sum(f => (double)(f.ProteinPerPortion!.Value * f.Portions));
-        return sum > 0 ? sum : null;
-    }
-
-    private static Treatment ProjectBgCheck(BGCheck bgCheck) =>
-        new()
-        {
-            Id = bgCheck.Id.ToString(),
-            EventType = TreatmentTypes.BgCheck,
-            Mills = bgCheck.Mills,
-            Glucose = bgCheck.Glucose,
-            Mgdl = bgCheck.Mgdl,
-            Mmol = bgCheck.Mmol,
-            GlucoseType = bgCheck.GlucoseType?.ToString(),
-            Units = bgCheck.Units == GlucoseUnit.Mmol ? "mmol" : "mg/dl",
-            EnteredBy = bgCheck.Device,
-            DataSource = bgCheck.DataSource,
-            SyncIdentifier = bgCheck.SyncIdentifier,
-            UtcOffset = bgCheck.UtcOffset,
-        };
-
-    private static Treatment ProjectNote(Note note) =>
-        new()
-        {
-            Id = note.Id.ToString(),
-            EventType = note.EventType ?? "Note",
-            Mills = note.Mills,
-            Notes = note.Text,
-            IsAnnouncement = note.IsAnnouncement,
-            EnteredBy = note.Device,
-            DataSource = note.DataSource,
-            SyncIdentifier = note.SyncIdentifier,
-            UtcOffset = note.UtcOffset,
-        };
-
-    private static Treatment ProjectDeviceEvent(DeviceEvent deviceEvent)
-    {
-        DeviceEventTypeToString.TryGetValue(deviceEvent.EventType, out var eventTypeString);
-        return new Treatment
-        {
-            Id = deviceEvent.Id.ToString(),
-            EventType = eventTypeString ?? deviceEvent.EventType.ToString(),
-            Mills = deviceEvent.Mills,
-            Notes = deviceEvent.Notes,
-            EnteredBy = deviceEvent.Device,
-            DataSource = deviceEvent.DataSource,
-            SyncIdentifier = deviceEvent.SyncIdentifier,
-            UtcOffset = deviceEvent.UtcOffset,
-        };
-    }
-
-    private static Treatment ProjectBolusCalculation(BolusCalculation bc) =>
-        new()
-        {
-            Id = bc.Id.ToString(),
-            EventType = "Bolus Wizard",
-            Mills = bc.Mills,
-            BloodGlucoseInput = bc.BloodGlucoseInput,
-            BloodGlucoseInputSource = bc.BloodGlucoseInputSource,
-            Carbs = bc.CarbInput,
-            InsulinOnBoard = bc.InsulinOnBoard,
-            InsulinRecommendationForCorrection = bc.InsulinRecommendation,
-            CR = bc.CarbRatio,
-            CalculationType = bc.CalculationType.HasValue
-                ? (Nocturne.Core.Models.CalculationType)(int)bc.CalculationType.Value
-                : null,
-            InsulinRecommendationForCarbs = bc.InsulinRecommendationForCarbs,
-            InsulinProgrammed = bc.InsulinProgrammed,
-            EnteredInsulin = bc.EnteredInsulin,
-            SplitNow = bc.SplitNow,
-            SplitExt = bc.SplitExt,
-            PreBolus = bc.PreBolus,
-            EnteredBy = bc.Device,
-            DataSource = bc.DataSource,
-            UtcOffset = bc.UtcOffset,
-        };
-
-    private static Treatment WithSrvModified(Treatment treatment, DateTime modifiedAt)
-    {
-        treatment.SrvModified = new DateTimeOffset(modifiedAt, TimeSpan.Zero).ToUnixTimeMilliseconds();
-        return treatment;
-    }
-
-    private async Task<IEnumerable<T>> FetchSafe<T>(Func<Task<IEnumerable<T>>> fetchFunc)
+    private async Task<IReadOnlyList<FetchedRecord>> FetchSafe(
+        ILegacyTreatmentTable table,
+        Func<ILegacyTreatmentTable, Task<IReadOnlyList<FetchedRecord>>> fetch
+    )
     {
         try
         {
-            return await fetchFunc();
+            return await fetch(table);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to fetch V4 records of type {Type} for legacy projection", typeof(T).Name);
-            return Enumerable.Empty<T>();
+            _logger.LogError(
+                ex,
+                "Failed to fetch V4 records of type {Type} for legacy projection",
+                table.RecordType);
+            return [];
         }
     }
+
+    private static Entry ProjectSensorGlucoseToEntry(SensorGlucose sg) =>
+        SensorGlucoseToEntryMapper.ToEntry(sg);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/IV4ToLegacyProjectionService.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/IV4ToLegacyProjectionService.cs
@@ -46,8 +46,10 @@ public interface IV4ToLegacyProjectionService
     );
 
     /// <summary>
-    /// Returns legacy <see cref="Treatment"/> objects synthesised from V4 records
-    /// whose <c>ModifiedAt</c> is at or after the given threshold. Used for v3 incremental sync.
+    /// Returns legacy <see cref="Treatment"/> objects synthesised from V4 records whose system
+    /// update stamp is strictly after the given threshold, oldest first. Used for v3 incremental
+    /// sync, and shaped exactly as <see cref="GetProjectedTreatmentsAsync"/> shapes a time range:
+    /// records of both provenances, meals paired into one treatment, carb foods populated.
     /// </summary>
     Task<IEnumerable<Treatment>> GetProjectedTreatmentsModifiedSinceAsync(
         long lastModifiedMills,

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/V4ToLegacyProjectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/V4ToLegacyProjectionServiceTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.V4;
@@ -9,6 +10,7 @@ using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Entities.V4;
 using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
@@ -91,20 +93,9 @@ public class V4ToLegacyProjectionServiceTests
             .ReturnsAsync(Enumerable.Empty<BolusCalculation>());
 
         _dbContext = TestDbContextFactory.CreateInMemoryContext();
+        _dbContext.TenantId = TenantId; // satisfy the tenant query filter
 
-        _service = new V4ToLegacyProjectionService(
-            _sensorGlucoseRepo.Object,
-            _bolusRepo.Object,
-            _carbIntakeRepo.Object,
-            _bgCheckRepo.Object,
-            _noteRepo.Object,
-            _deviceEventRepo.Object,
-            _tempBasalRepo.Object,
-            _bolusCalcRepo.Object,
-            _treatmentFoodService.Object,
-            _dbContext,
-            NullLogger<V4ToLegacyProjectionService>.Instance
-        );
+        _service = CreateService(_dbContext);
     }
 
     private void SetupBoluses(IEnumerable<Bolus> boluses) =>
@@ -358,39 +349,390 @@ public class V4ToLegacyProjectionServiceTests
         // AAPS passes the timestamp of the newest record it already holds as the cursor.
         // The history query must be strictly-greater (>), so the record AT the cursor is
         // not re-returned; an inclusive bound loops AAPS re-requesting the same page.
-        var cursor = new DateTime(2025, 01, 01, 12, 0, 0, DateTimeKind.Utc);
-        var tenantId = Guid.CreateVersion7();
-        _dbContext.TenantId = tenantId; // satisfy the tenant query filter
-
         var atCursor = new BolusEntity
         {
             Id = Guid.CreateVersion7(),
-            TenantId = tenantId,
-            Timestamp = cursor,
+            TenantId = TenantId,
+            Timestamp = Cursor,
             Insulin = 1.0,
         };
         var newer = Guid.CreateVersion7();
         var afterCursor = new BolusEntity
         {
             Id = newer,
-            TenantId = tenantId,
-            Timestamp = cursor.AddMinutes(1),
+            TenantId = TenantId,
+            Timestamp = Cursor.AddMinutes(1),
             Insulin = 2.0,
         };
-        _dbContext.Boluses.Add(atCursor);
-        _dbContext.Boluses.Add(afterCursor);
-        await _dbContext.SaveChangesAsync();
 
-        // SaveChanges stamps SysUpdatedAt = UtcNow on insert; a second save that touches only
-        // SysUpdatedAt keeps the assigned value, letting us pin the two rows either side of the cursor.
-        atCursor.SysUpdatedAt = cursor; // exactly at the cursor -> must be excluded
-        afterCursor.SysUpdatedAt = cursor.AddMilliseconds(1); // strictly newer -> must be returned
-        await _dbContext.SaveChangesAsync();
+        await AddModifiedAsync(
+            (atCursor, Cursor), // exactly at the cursor -> must be excluded
+            (afterCursor, Cursor.AddMilliseconds(1))); // strictly newer -> must be returned
 
-        var cursorMills = new DateTimeOffset(cursor).ToUnixTimeMilliseconds();
-        var result = (await _service.GetProjectedTreatmentsModifiedSinceAsync(cursorMills, 100)).ToList();
+        var result = (await _service.GetProjectedTreatmentsModifiedSinceAsync(CursorMills, 100)).ToList();
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(newer.ToString());
     }
+
+    [Fact]
+    public async Task GetProjectedTreatmentsModifiedSince_CorrelatedBolusAndCarb_ProjectOneMealBolusWithFoods()
+    {
+        // The range path pairs a correlated bolus + carb intake into a single Meal Bolus carrying
+        // the food breakdown. The modified-since surface must agree, or a v3 sync client sees two
+        // treatments (and no foods) for a meal the range read shows as one.
+        var correlationId = Guid.CreateVersion7();
+        var bolusId = Guid.CreateVersion7();
+        var carbId = Guid.CreateVersion7();
+
+        var bolus = new BolusEntity
+        {
+            Id = bolusId,
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Insulin = 3.5,
+            CorrelationId = correlationId,
+        };
+        var carb = new CarbIntakeEntity
+        {
+            Id = carbId,
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Carbs = 42.0,
+            CorrelationId = correlationId,
+        };
+        await AddModifiedAsync((bolus, Cursor.AddMinutes(1)), (carb, Cursor.AddMinutes(1)));
+
+        _treatmentFoodService
+            .Setup(s => s.GetByCarbIntakeIdsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new TreatmentFood
+                {
+                    CarbIntakeId = carbId,
+                    FoodName = "Pizza",
+                    Portions = 2m,
+                    FatPerPortion = 6m,
+                    ProteinPerPortion = 4m,
+                },
+            });
+
+        var result = (await _service.GetProjectedTreatmentsModifiedSinceAsync(CursorMills, 100)).ToList();
+
+        result.Should().ContainSingle();
+        result[0].EventType.Should().Be(TreatmentTypes.MealBolus);
+        result[0].Id.Should().Be(bolusId.ToString());
+        result[0].Insulin.Should().Be(3.5);
+        result[0].Carbs.Should().Be(42.0);
+        result[0].FoodType.Should().Be("Pizza");
+        result[0].Fat.Should().Be(12.0);
+        result[0].Protein.Should().Be(8.0);
+    }
+
+    [Fact]
+    public async Task GetProjectedTreatmentsModifiedSince_MealPair_StampsTheNewerOfTheTwoModifications()
+    {
+        // The consumer advances its cursor to max(srvModified) over the page. Stamping the meal with
+        // the older of the pair leaves the other record above that cursor, so the next request
+        // re-serves the same meal with the same stamp and the cursor never moves.
+        var correlationId = Guid.CreateVersion7();
+        var bolus = new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Insulin = 1.0,
+            CorrelationId = correlationId,
+        };
+        var carb = new CarbIntakeEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Carbs = 10.0,
+            CorrelationId = correlationId,
+        };
+        var newest = Cursor.AddMinutes(5);
+        await AddModifiedAsync((bolus, Cursor.AddMinutes(1)), (carb, newest));
+
+        var result = (await _service.GetProjectedTreatmentsModifiedSinceAsync(CursorMills, 100)).ToList();
+
+        result.Should().ContainSingle();
+        result[0].SrvModified.Should().Be(new DateTimeOffset(newest, TimeSpan.Zero).ToUnixTimeMilliseconds());
+    }
+
+    [Fact]
+    public async Task GetProjectedTreatmentsModifiedSince_LegacyOriginatedRecord_IsProjected()
+    {
+        // A treatment uploaded through v1/v2/v3 is stored as a V4 record with LegacyId set, and
+        // there is no legacy treatments table for it to duplicate. Filtering those out would hide
+        // every client-uploaded treatment from the v3 history sync.
+        var legacyOriginated = new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Insulin = 2.0,
+            LegacyId = "65f0c0ffee0000000000cafe",
+        };
+        await AddModifiedAsync((legacyOriginated, Cursor.AddMinutes(1)));
+
+        var result = (await _service.GetProjectedTreatmentsModifiedSinceAsync(CursorMills, 100)).ToList();
+
+        result.Should().ContainSingle();
+        result[0].Id.Should().Be(legacyOriginated.Id.ToString());
+    }
+
+    [Fact]
+    public async Task GetProjectedTreatmentsModifiedSince_FailingType_StillProjectsTheOthers()
+    {
+        // One type's read blowing up must degrade that type only, exactly as the range path does.
+        var bolus = new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Insulin = 1.0,
+        };
+        var note = new NoteEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Text = "survivor",
+        };
+        await AddModifiedAsync((bolus, Cursor.AddMinutes(1)), (note, Cursor.AddMinutes(1)));
+
+        // A set whose own context is gone throws when read, leaving the other six types intact.
+        using var abandoned = TestDbContextFactory.CreateInMemoryContext();
+        var abandonedSet = abandoned.Set<BolusEntity>();
+        await abandoned.DisposeAsync();
+        _dbContext.Boluses = abandonedSet;
+
+        var result = (await _service.GetProjectedTreatmentsModifiedSinceAsync(CursorMills, 100)).ToList();
+
+        result.Should().ContainSingle();
+        result[0].Id.Should().Be(note.Id.ToString());
+    }
+
+    [Fact]
+    public async Task GetProjectedTreatments_FailingType_StillProjectsTheOthers()
+    {
+        SetupBoluses(Enumerable.Empty<Bolus>());
+        _bolusRepo
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(),
+                It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<BolusKind?>(),
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("bolus read failed"));
+
+        var note = new Note { Id = Guid.CreateVersion7(), Timestamp = Cursor, Text = "survivor" };
+        _noteRepo
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(),
+                It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { note });
+
+        var result = (await _service.GetProjectedTreatmentsAsync(null, null, 100)).ToList();
+
+        result.Should().ContainSingle();
+        result[0].Id.Should().Be(note.Id.ToString());
+    }
+
+    [Fact]
+    public async Task GetProjectedTreatmentsModifiedSince_OverLimit_ReturnsTheGloballyOldestPage()
+    {
+        // Each type contributes its own oldest `limit` rows and the merge is then cut to `limit`, so
+        // the page is the globally-oldest window and never a multiple of the requested limit.
+        var notes = Enumerable.Range(1, 3)
+            .Select(i => (Entity: (object)new NoteEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = TenantId,
+                Timestamp = Cursor,
+                Text = $"note-{i}",
+            }, Modified: Cursor.AddMinutes(i * 2)))
+            .ToList();
+        var bgChecks = Enumerable.Range(1, 3)
+            .Select(i => (Entity: (object)new BGCheckEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = TenantId,
+                Timestamp = Cursor,
+                Glucose = 100 + i,
+            }, Modified: Cursor.AddMinutes(i * 2 - 1)))
+            .ToList();
+
+        await AddModifiedAsync([.. notes, .. bgChecks]);
+
+        var result = (await _service.GetProjectedTreatmentsModifiedSinceAsync(CursorMills, 2)).ToList();
+
+        result.Should().HaveCount(2);
+        result.Select(t => t.Id).Should().Equal(
+            ((BGCheckEntity)bgChecks[0].Entity).Id.ToString(),
+            ((NoteEntity)notes[0].Entity).Id.ToString());
+    }
+
+    [Fact]
+    public async Task GetProjectedTreatmentsModifiedSince_PairStraddlingThePageCut_LosesNeitherConstituent()
+    {
+        // The page is cut on raw row stamps before pairing. Cutting after pairing let the meal carry
+        // the carb's far-newer stamp past the cut while the cursor still advanced past the bolus's
+        // own row, so the insulin record was never fetched again.
+        var correlationId = Guid.CreateVersion7();
+        var bolus = new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Insulin = 4.0,
+            CorrelationId = correlationId,
+        };
+        var carb = new CarbIntakeEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Carbs = 30.0,
+            CorrelationId = correlationId,
+        };
+        var notes = SeedNotes(3);
+
+        await AddModifiedAsync(
+            (bolus, Cursor.AddMinutes(1)),
+            (carb, Cursor.AddMinutes(100)),
+            (notes[0], Cursor.AddMinutes(2)),
+            (notes[1], Cursor.AddMinutes(3)),
+            (notes[2], Cursor.AddMinutes(4)));
+
+        var delivered = await WalkHistoryAsync(limit: 3, mealCarbIntakeId: carb.Id);
+
+        delivered.Should().BeEquivalentTo(new[]
+        {
+            bolus.Id, carb.Id, notes[0].Id, notes[1].Id, notes[2].Id,
+        });
+    }
+
+    [Fact]
+    public async Task GetProjectedTreatmentsModifiedSince_PairInsideThePage_MergesAndAdvancesPastBoth()
+    {
+        var correlationId = Guid.CreateVersion7();
+        var bolus = new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Insulin = 4.0,
+            CorrelationId = correlationId,
+        };
+        var carb = new CarbIntakeEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = TenantId,
+            Timestamp = Cursor,
+            Carbs = 30.0,
+            CorrelationId = correlationId,
+        };
+        var notes = SeedNotes(1);
+
+        await AddModifiedAsync(
+            (bolus, Cursor.AddMinutes(1)),
+            (carb, Cursor.AddMinutes(2)),
+            (notes[0], Cursor.AddMinutes(3)));
+
+        var firstPage = (await _service.GetProjectedTreatmentsModifiedSinceAsync(CursorMills, 3)).ToList();
+
+        firstPage.Should().HaveCount(2);
+        firstPage.Should().ContainSingle(t => t.EventType == TreatmentTypes.MealBolus)
+            .Which.Id.Should().Be(bolus.Id.ToString());
+
+        var delivered = await WalkHistoryAsync(limit: 3, mealCarbIntakeId: carb.Id);
+
+        delivered.Should().BeEquivalentTo(new[] { bolus.Id, carb.Id, notes[0].Id });
+    }
+
+    /// <summary>
+    /// Walks the history surface the way a v3 sync client does — advancing the cursor to
+    /// <c>max(srvModified)</c> over each page — and returns every record id it was handed, counting
+    /// a Meal Bolus as delivering both of its constituents. Duplicates and omissions both survive
+    /// into the result, so one equivalence assertion covers re-sends, loops and skipped rows.
+    /// </summary>
+    private async Task<List<Guid>> WalkHistoryAsync(int limit, Guid? mealCarbIntakeId = null)
+    {
+        var delivered = new List<Guid>();
+        var cursor = CursorMills;
+
+        for (var page = 0; page < 10; page++)
+        {
+            var treatments = (await _service.GetProjectedTreatmentsModifiedSinceAsync(cursor, limit)).ToList();
+            if (treatments.Count == 0)
+                break;
+
+            foreach (var treatment in treatments)
+            {
+                delivered.Add(Guid.Parse(treatment.Id!));
+                if (treatment.EventType == TreatmentTypes.MealBolus && mealCarbIntakeId.HasValue)
+                    delivered.Add(mealCarbIntakeId.Value);
+            }
+
+            cursor = treatments.Max(t => t.SrvModified ?? t.Mills);
+        }
+
+        return delivered;
+    }
+
+    private static List<NoteEntity> SeedNotes(int count) =>
+        Enumerable.Range(1, count)
+            .Select(i => new NoteEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = TenantId,
+                Timestamp = Cursor,
+                Text = $"note-{i}",
+            })
+            .ToList();
+
+    private static readonly DateTime Cursor = new(2025, 01, 01, 12, 0, 0, DateTimeKind.Utc);
+
+    private static readonly Guid TenantId = Guid.CreateVersion7();
+
+    private static long CursorMills => new DateTimeOffset(Cursor, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+    /// <summary>
+    /// Persists entities and then pins their <c>SysUpdatedAt</c>: <c>SaveChanges</c> stamps
+    /// <c>UtcNow</c> on insert, and a second save that touches only that column keeps the assigned
+    /// value, letting a test place rows either side of the cursor.
+    /// </summary>
+    private async Task AddModifiedAsync(params (object Entity, DateTime Modified)[] rows)
+    {
+        foreach (var (entity, _) in rows)
+            _dbContext.Add(entity);
+        await _dbContext.SaveChangesAsync();
+
+        foreach (var (entity, modified) in rows)
+            ((ISystemTimestamped)entity).SysUpdatedAt = modified;
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private V4ToLegacyProjectionService CreateService(NocturneDbContext dbContext) =>
+        new(
+            _sensorGlucoseRepo.Object,
+            _bolusRepo.Object,
+            _carbIntakeRepo.Object,
+            _bgCheckRepo.Object,
+            _noteRepo.Object,
+            _deviceEventRepo.Object,
+            _tempBasalRepo.Object,
+            _bolusCalcRepo.Object,
+            _treatmentFoodService.Object,
+            dbContext,
+            NullLogger<V4ToLegacyProjectionService>.Instance
+        );
 }


### PR DESCRIPTION
Part of #1084 — the range path's tempBasal/bolusCalc under-fill wrinkle stays open on the issue (unreachable in production; fixing it means widening two repository interfaces).

## What changes

- **One `LegacyTreatmentTables.All`** (shape follows `DataOverviewTables.All`): seven per-type entries (repository range read, LegacyId accessor, DbSet accessor, mapper, projector) plus the shared meal pairing and `srvModified` stamping, consumed by both `GetProjectedTreatmentsAsync` and the v3 sync's `GetProjectedTreatmentsModifiedSinceAsync`. The service's two public methods collapse onto shared fetch/assemble stages; modified-since reads use one generic `EF.Property<DateTime>(e, nameof(ISystemTimestamped.SysUpdatedAt))` query.

## Declared behavioural fixes (modified-since path only; the range path's output is byte-identical)

1. **A correlated bolus + carb pair is one Meal Bolus** (was two treatments — the real cause of the duplicate-treatment symptom the issue attributed to provenance filtering).
2. **The meal carries the newer of the pair's `SysUpdatedAt`** — required for cursor correctness, since the consumer advances to `max(srvModified)` over the page.
3. **Carb foods are populated** (were always null on this path).
4. **Per-type `FetchSafe` degradation** (one failing type no longer fails the whole call).
5. **Page assembly is cut-then-pair**: the page is selected on raw row stamps (per-type oldest-`limit` fetches, merged, global `Take(limit)`), and pairing runs only within the page. Hostile review proved the first draft's pair-then-cut ordering could permanently drop a meal's older constituent (an insulin record lost from a follower sync feed) when the pair-max stamp pulled the meal past the cut; with cut-then-pair, every page row is delivered exactly once — a pair straddling the cut arrives as two independent treatments across pages, exactly main's behaviour. Pinned by an exhaustion-walk regression test (the reviewer's probe: union of all pages equals every seeded record exactly once; fails on omissions, duplicates, and loops).

## Issue claims refuted (recorded on #1084)

The proposed native-only filter would have hidden every v1/v2/v3-uploaded treatment from its own `/api/v3/treatments/history` — there is no legacy treatments table, every live caller passes `nativeOnly: false`, and the decomposer stamps `LegacyId` on all legacy uploads. Not applied; a test pins that those records are returned. The "7× limit" claim was also false (main already merged and cut).

## Tests

Projection filter 30 → 38, full `Nocturne.API.Tests` 6323 passed / 0 failed. All eight new/changed behaviours mutation-checked with one-test-reddens isolation, including hostile review's own probes (older-stamp mutant, descending-order mutant, and pair-before-cut restoration reddening exactly the exhaustion test).

## Known residuals, flagged by hostile review (recorded on issues, not this PR)

- Equal-`SysUpdatedAt` rows cut mid-tie-group are skipped by the strict `>` cursor — pre-existing on main, filed as #1117.
- Editing one constituent of an already-delivered meal re-serves it standalone, degrading a history-only consumer's merged meal until the sibling is next touched — intrinsic to serving merged meals on history at all (main showed the same shape for consumers mixing the two read paths); the possible remedy (partner-lookup by CorrelationId, stamped with the in-page row's stamp) is a spec decision recorded on #1084.