### PR TITLE
refactor(api): give the V4 read-visibility predicate one owner

### DIFF
--- a/src/Core/Nocturne.Core.Models/LinkedRecord.cs
+++ b/src/Core/Nocturne.Core.Models/LinkedRecord.cs
@@ -115,39 +115,10 @@ public enum RecordType
 }
 
 /// <summary>
-/// The <c>linked_records.record_type</c> key of every <see cref="RecordType"/>. The per-type
-/// constants exist alongside <see cref="Key"/> because EF Core cannot translate a method call
-/// inside an expression tree; <c>RecordTypeKeysTests</c> holds the two forms equal.
+/// Owns the <c>linked_records.record_type</c> key of every <see cref="RecordType"/>.
 /// </summary>
 public static class RecordTypeKeys
 {
-    /// <summary><see cref="RecordType.StateSpan"/></summary>
-    public const string StateSpan = "statespan";
-
-    /// <summary><see cref="RecordType.SensorGlucose"/></summary>
-    public const string SensorGlucose = "sensorglucose";
-
-    /// <summary><see cref="RecordType.Bolus"/></summary>
-    public const string Bolus = "bolus";
-
-    /// <summary><see cref="RecordType.CarbIntake"/></summary>
-    public const string CarbIntake = "carbintake";
-
-    /// <summary><see cref="RecordType.BGCheck"/></summary>
-    public const string BGCheck = "bgcheck";
-
-    /// <summary><see cref="RecordType.DeviceEvent"/></summary>
-    public const string DeviceEvent = "deviceevent";
-
-    /// <summary><see cref="RecordType.Note"/></summary>
-    public const string Note = "note";
-
-    /// <summary><see cref="RecordType.BolusCalculation"/></summary>
-    public const string BolusCalculation = "boluscalculation";
-
-    /// <summary><see cref="RecordType.TempBasal"/></summary>
-    public const string TempBasal = "tempbasal";
-
     /// <summary>
     /// The stored key for <paramref name="recordType"/>.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IIdentified.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IIdentified.cs
@@ -1,0 +1,18 @@
+namespace Nocturne.Infrastructure.Data.Entities;
+
+/// <summary>
+/// A row addressable by its own primary key.
+/// </summary>
+/// <remarks>
+/// Implementers MUST map every member of this interface and its derivatives as an ordinary EF column
+/// (a plain auto-property with a <c>[Column]</c> mapping) — not an explicit-interface
+/// implementation, backing-field-only, or <c>[NotMapped]</c> — so generic queries over an
+/// <c>IQueryable&lt;TEntity&gt;</c> constrained to the interface translate the interface-member
+/// access to SQL, the same way they already do for <see cref="ITenantScoped.TenantId"/> and
+/// <see cref="ISoftDeletable.DeletedAt"/>.
+/// </remarks>
+public interface IIdentified
+{
+    /// <summary>Primary key.</summary>
+    Guid Id { get; set; }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IOriginalIdentified.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IOriginalIdentified.cs
@@ -5,18 +5,8 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// migration, so an id minted against the legacy database still resolves. The V4 clinical entities
 /// spell the same idea as <see cref="IV4Entity.LegacyId"/>.
 /// </summary>
-/// <remarks>
-/// Implementers MUST map every member as an ordinary EF column (a plain auto-property with a
-/// <c>[Column]</c> mapping) — not an explicit-interface implementation, backing-field-only, or
-/// <c>[NotMapped]</c> — so generic <c>Set&lt;TEntity&gt;()</c> queries translate the
-/// interface-member access to SQL, the same way they already do for
-/// <see cref="ITenantScoped.TenantId"/> and <see cref="ISoftDeletable.DeletedAt"/>.
-/// </remarks>
-public interface IOriginalIdentified
+public interface IOriginalIdentified : IIdentified
 {
-    /// <summary>Primary key.</summary>
-    Guid Id { get; set; }
-
     /// <summary>The MongoDB ObjectId this row carried before migration, when it had one.</summary>
     string? OriginalId { get; set; }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4Entity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4Entity.cs
@@ -2,13 +2,12 @@ namespace Nocturne.Infrastructure.Data.Entities;
 
 /// <summary>
 /// Marker for V4 clinical entities that participate in tenant-scoped soft-delete
-/// dedup. Implementations expose <see cref="Id"/>, <see cref="LegacyId"/>,
+/// dedup. Implementations expose <see cref="IIdentified.Id"/>, <see cref="LegacyId"/>,
 /// <see cref="CorrelationId"/>, <see cref="ITenantScoped.TenantId"/>, and
 /// <see cref="ISoftDeletable.DeletedAt"/>.
 /// </summary>
-public interface IV4Entity : ITenantScoped, ISoftDeletable
+public interface IV4Entity : ITenantScoped, ISoftDeletable, IIdentified
 {
-    Guid Id { get; set; }
     string? LegacyId { get; set; }
 
     /// <summary>Links records decomposed from the same legacy Treatment or DeviceStatus.</summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StateSpanEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/StateSpanEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// Maps to Nocturne.Core.Models.StateSpan
 /// </summary>
 [Table("state_spans")]
-public class StateSpanEntity : ITenantScoped, IAuditable, IEntityTimestamped, ISoftDeletable
+public class StateSpanEntity : ITenantScoped, IAuditable, IEntityTimestamped, ISoftDeletable, IIdentified
 {
     /// <summary>
     /// Identifier of the tenant this state span belongs to

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ReadVisibilityFilter.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ReadVisibilityFilter.cs
@@ -1,0 +1,26 @@
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// The one predicate for "the rows a read shows once deduplication has run".
+/// </summary>
+/// <remarks>
+/// A count has to apply the same predicate as the read it paginates, or totals are inflated by
+/// duplicates.
+/// </remarks>
+public static class ReadVisibilityFilter
+{
+    /// <summary>Drops the rows <paramref name="recordType"/>'s links mark non-primary.</summary>
+    public static IQueryable<TEntity> ExcludeNonPrimary<TEntity>(
+        this IQueryable<TEntity> query,
+        NocturneDbContext ctx,
+        RecordType recordType)
+        where TEntity : IIdentified
+    {
+        var key = RecordTypeKeys.Key(recordType);
+        return query.Where(e =>
+            !ctx.LinkedRecords.Any(lr => lr.RecordType == key && !lr.IsPrimary && lr.RecordId == e.Id));
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
@@ -148,9 +148,7 @@ public class StateSpanRepository : IStateSpanRepository
                 query = query.Where(s => s.EndTimestamp != null);
         }
 
-        // Exclude non-primary duplicates from cross-connector deduplication
-        query = query.Where(s => !_context.LinkedRecords
-            .Any(lr => lr.RecordType == RecordTypeKeys.StateSpan && !lr.IsPrimary && lr.RecordId == s.Id));
+        query = query.ExcludeNonPrimary(_context, RecordType.StateSpan);
 
         return query;
     }
@@ -411,8 +409,7 @@ public class StateSpanRepository : IStateSpanRepository
 
         var latest = await _context.StateSpans.AsNoTracking()
             .Where(s => s.Category == pumpModeCategory && s.EndTimestamp == null)
-            .Where(s => !_context.LinkedRecords
-                .Any(lr => lr.RecordType == RecordTypeKeys.StateSpan && !lr.IsPrimary && lr.RecordId == s.Id))
+            .ExcludeNonPrimary(_context, RecordType.StateSpan)
             .OrderByDescending(s => s.StartTimestamp)
             .ThenByDescending(s => s.Id)
             .Select(s => s.State)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BGCheckRepository.cs
@@ -55,12 +55,8 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
     /// <inheritdoc />
     protected override void ApplyUpdate(BGCheckEntity target, BGCheck source) => BGCheckMapper.UpdateEntity(target, source);
 
-    /// <summary>
-    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
-    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
-    /// </summary>
-    protected override IQueryable<BGCheckEntity> ApplyReadVisibility(IQueryable<BGCheckEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.BGCheck && !lr.IsPrimary && lr.RecordId == b.Id));
+    /// <inheritdoc />
+    protected internal override RecordType? DedupRecordType => RecordType.BGCheck;
 
     /// <summary>
     /// Routes the base 7-arg form through the extended BG-check query (non-primary LinkedRecords
@@ -111,9 +107,7 @@ public class BGCheckRepository : V4RepositoryBase<BGCheck, BGCheckEntity>, IBGCh
         if (nativeOnly)
             query = query.Where(e => e.LegacyId == null);
 
-        // Exclude non-primary duplicates from cross-connector deduplication
-        query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == RecordTypeKeys.BGCheck && !lr.IsPrimary && lr.RecordId == b.Id));
+        query = ApplyReadVisibility(query, ctx);
 
         query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
         var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusCalculationRepository.cs
@@ -56,12 +56,8 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
     /// <inheritdoc />
     protected override void ApplyUpdate(BolusCalculationEntity target, BolusCalculation source) => BolusCalculationMapper.UpdateEntity(target, source);
 
-    /// <summary>
-    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
-    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
-    /// </summary>
-    protected override IQueryable<BolusCalculationEntity> ApplyReadVisibility(IQueryable<BolusCalculationEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.BolusCalculation && !lr.IsPrimary && lr.RecordId == b.Id));
+    /// <inheritdoc />
+    protected internal override RecordType? DedupRecordType => RecordType.BolusCalculation;
 
     /// <summary>
     /// Gets bolus calculation records based on filter criteria.
@@ -99,9 +95,7 @@ public class BolusCalculationRepository : V4RepositoryBase<BolusCalculation, Bol
         if (source != null)
             query = query.Where(e => e.DataSource == source);
 
-        // Exclude non-primary duplicates from cross-connector deduplication
-        query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == RecordTypeKeys.BolusCalculation && !lr.IsPrimary && lr.RecordId == b.Id));
+        query = ApplyReadVisibility(query, ctx);
 
         query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
         var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/BolusRepository.cs
@@ -54,12 +54,8 @@ public class BolusRepository : SyncUpsertRepositoryBase<Bolus, BolusEntity>, IBo
     /// <inheritdoc />
     protected override void ApplyUpdate(BolusEntity target, Bolus source) => BolusMapper.UpdateEntity(target, source);
 
-    /// <summary>
-    /// Excludes non-primary cross-connector duplicates so <see cref="CountAsync"/> matches the rows
-    /// <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
-    /// </summary>
-    protected override IQueryable<BolusEntity> ApplyReadVisibility(IQueryable<BolusEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.Bolus && !lr.IsPrimary && lr.RecordId == b.Id));
+    /// <inheritdoc />
+    protected internal override RecordType? DedupRecordType => RecordType.Bolus;
 
     /// <summary>
     /// Routes the base 7-arg form through the extended bolus query (non-primary LinkedRecords
@@ -119,9 +115,7 @@ public class BolusRepository : SyncUpsertRepositoryBase<Bolus, BolusEntity>, IBo
         if (kind.HasValue)
             query = query.Where(e => e.BolusKind == kind.Value.ToString());
 
-        // Exclude non-primary duplicates from cross-connector deduplication
-        query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == RecordTypeKeys.Bolus && !lr.IsPrimary && lr.RecordId == b.Id));
+        query = ApplyReadVisibility(query, ctx);
 
         // Keyset cursor — when provided, replaces OFFSET with a WHERE clause
         // that seeks directly to the cursor position. O(limit) vs O(offset + limit).

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/CarbIntakeRepository.cs
@@ -55,13 +55,8 @@ public class CarbIntakeRepository : SyncUpsertRepositoryBase<CarbIntake, CarbInt
     /// <inheritdoc />
     protected override void ApplyUpdate(CarbIntakeEntity target, CarbIntake source) => CarbIntakeMapper.UpdateEntity(target, source);
 
-    /// <summary>
-    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
-    /// matches the rows <c>GetAsync</c> returns (otherwise pagination totals are inflated by duplicate
-    /// meals imported from multiple connectors). Mirrors the inline filter in the extended <c>GetAsync</c>.
-    /// </summary>
-    protected override IQueryable<CarbIntakeEntity> ApplyReadVisibility(IQueryable<CarbIntakeEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.CarbIntake && !lr.IsPrimary && lr.RecordId == b.Id));
+    /// <inheritdoc />
+    protected internal override RecordType? DedupRecordType => RecordType.CarbIntake;
 
     /// <summary>
     /// Routes the base 7-arg form through the extended carb-intake query (non-primary LinkedRecords
@@ -117,9 +112,7 @@ public class CarbIntakeRepository : SyncUpsertRepositoryBase<CarbIntake, CarbInt
         if (nativeOnly)
             query = query.Where(e => e.LegacyId == null);
 
-        // Exclude non-primary duplicates from cross-connector deduplication
-        query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == RecordTypeKeys.CarbIntake && !lr.IsPrimary && lr.RecordId == b.Id));
+        query = ApplyReadVisibility(query, ctx);
 
         // Keyset cursor — when provided, replaces OFFSET with a WHERE clause
         // that seeks directly to the cursor position. O(limit) vs O(offset + limit).

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/DeviceEventRepository.cs
@@ -54,12 +54,8 @@ public class DeviceEventRepository : SyncKeyedRepositoryBase<DeviceEvent, Device
     /// <inheritdoc />
     protected override void ApplyUpdate(DeviceEventEntity target, DeviceEvent source) => DeviceEventMapper.UpdateEntity(target, source);
 
-    /// <summary>
-    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
-    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
-    /// </summary>
-    protected override IQueryable<DeviceEventEntity> ApplyReadVisibility(IQueryable<DeviceEventEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.DeviceEvent && !lr.IsPrimary && lr.RecordId == b.Id));
+    /// <inheritdoc />
+    protected internal override RecordType? DedupRecordType => RecordType.DeviceEvent;
 
     /// <summary>
     /// Routes the base 7-arg form through the extended device-event query (non-primary LinkedRecords
@@ -114,9 +110,7 @@ public class DeviceEventRepository : SyncKeyedRepositoryBase<DeviceEvent, Device
         if (patientDeviceId.HasValue)
             query = query.Where(e => e.PatientDeviceId == patientDeviceId.Value);
 
-        // Exclude non-primary duplicates from cross-connector deduplication
-        query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == RecordTypeKeys.DeviceEvent && !lr.IsPrimary && lr.RecordId == b.Id));
+        query = ApplyReadVisibility(query, ctx);
 
         query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
         var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/NoteRepository.cs
@@ -53,12 +53,8 @@ public class NoteRepository : SyncKeyedRepositoryBase<Note, NoteEntity>, INoteRe
     /// <inheritdoc />
     protected override void ApplyUpdate(NoteEntity target, Note source) => NoteMapper.UpdateEntity(target, source);
 
-    /// <summary>
-    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
-    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
-    /// </summary>
-    protected override IQueryable<NoteEntity> ApplyReadVisibility(IQueryable<NoteEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.Note && !lr.IsPrimary && lr.RecordId == b.Id));
+    /// <inheritdoc />
+    protected internal override RecordType? DedupRecordType => RecordType.Note;
 
     /// <summary>
     /// Routes the base 7-arg form through the extended note query (non-primary LinkedRecords
@@ -109,9 +105,7 @@ public class NoteRepository : SyncKeyedRepositoryBase<Note, NoteEntity>, INoteRe
         if (nativeOnly)
             query = query.Where(e => e.LegacyId == null);
 
-        // Exclude non-primary duplicates from cross-connector deduplication
-        query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == RecordTypeKeys.Note && !lr.IsPrimary && lr.RecordId == b.Id));
+        query = ApplyReadVisibility(query, ctx);
 
         query = descending ? query.OrderByDescending(e => e.Timestamp) : query.OrderBy(e => e.Timestamp);
         var entities = await query.Skip(offset).Take(limit).ToListAsync(ct);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/SensorGlucoseRepository.cs
@@ -121,12 +121,8 @@ public class SensorGlucoseRepository : SyncUpsertRepositoryBase<SensorGlucose, S
     /// <inheritdoc />
     protected override void ApplyUpdate(SensorGlucoseEntity target, SensorGlucose source) => SensorGlucoseMapper.UpdateEntity(target, source);
 
-    /// <summary>
-    /// Excludes non-primary cross-connector duplicates so <see cref="V4RepositoryBase{TModel,TEntity}.CountAsync"/>
-    /// matches the rows <c>GetAsync</c> returns. Mirrors the inline filter in the extended <c>GetAsync</c>.
-    /// </summary>
-    protected override IQueryable<SensorGlucoseEntity> ApplyReadVisibility(IQueryable<SensorGlucoseEntity> query, NocturneDbContext ctx) =>
-        query.Where(b => !ctx.LinkedRecords.Any(lr => lr.RecordType == RecordTypeKeys.SensorGlucose && !lr.IsPrimary && lr.RecordId == b.Id));
+    /// <inheritdoc />
+    protected internal override RecordType? DedupRecordType => RecordType.SensorGlucose;
 
     /// <summary>
     /// Routes the base 7-arg form through the extended sensor-glucose query (non-primary LinkedRecords
@@ -185,9 +181,7 @@ public class SensorGlucoseRepository : SyncUpsertRepositoryBase<SensorGlucose, S
         if (nativeOnly)
             query = query.Where(e => e.LegacyId == null);
 
-        // Exclude non-primary duplicates from cross-connector deduplication
-        query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == RecordTypeKeys.SensorGlucose && !lr.IsPrimary && lr.RecordId == b.Id));
+        query = ApplyReadVisibility(query, ctx);
 
         // Keyset cursor — when provided, replaces OFFSET with a WHERE clause
         // that seeks directly to the cursor position. O(limit) vs O(offset + limit).

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/TempBasalRepository.cs
@@ -96,9 +96,7 @@ public class TempBasalRepository : ITempBasalRepository
         if (source != null)
             query = query.Where(e => e.DataSource == source);
 
-        // Exclude non-primary duplicates from cross-connector deduplication
-        query = query.Where(b => !ctx.LinkedRecords
-            .Any(lr => lr.RecordType == RecordTypeKeys.TempBasal && !lr.IsPrimary && lr.RecordId == b.Id));
+        query = query.ExcludeNonPrimary(ctx, RecordType.TempBasal);
 
         query = descending
             ? query.OrderByDescending(e => e.StartTimestamp)
@@ -443,8 +441,7 @@ public class TempBasalRepository : ITempBasalRepository
         var entity = await ctx.TempBasals
             .AsNoTracking()
             .Where(t => t.StartTimestamp <= at && (t.EndTimestamp == null || t.EndTimestamp > at))
-            .Where(t => !ctx.LinkedRecords
-                .Any(lr => lr.RecordType == RecordTypeKeys.TempBasal && !lr.IsPrimary && lr.RecordId == t.Id))
+            .ExcludeNonPrimary(ctx, RecordType.TempBasal)
             .OrderByDescending(t => t.StartTimestamp)
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : TempBasalMapper.ToDomainModel(entity);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -297,12 +297,18 @@ public abstract class V4RepositoryBase<TModel, TEntity>
     }
 
     /// <summary>
-    /// Read-visibility hook applied by <see cref="CountAsync"/> (and reusable by future read paths) so
-    /// counts match the rows reads return. The base is identity; dedup participants override it to
-    /// exclude non-primary LinkedRecords for their RecordType — replacing the per-type CountAsync
-    /// overrides that each carried the same exclusion.
+    /// The <see cref="RecordType"/> this repository's rows are linked under, or null for a type that
+    /// does not participate in deduplication.
     /// </summary>
-    protected virtual IQueryable<TEntity> ApplyReadVisibility(IQueryable<TEntity> query, NocturneDbContext ctx) => query;
+    protected internal virtual RecordType? DedupRecordType => null;
+
+    /// <summary>
+    /// Applies <see cref="ReadVisibilityFilter.ExcludeNonPrimary{TEntity}"/> for
+    /// <see cref="DedupRecordType"/>. Every read path of a dedup participant routes through this so
+    /// its counts and its rows agree.
+    /// </summary>
+    protected IQueryable<TEntity> ApplyReadVisibility(IQueryable<TEntity> query, NocturneDbContext ctx) =>
+        DedupRecordType is { } recordType ? query.ExcludeNonPrimary(ctx, recordType) : query;
 
     /// <inheritdoc cref="Core.Contracts.V4.Repositories.IV4Repository{T}.CountAsync" />
     public virtual async Task<int> CountAsync(DateTime? from, DateTime? to, CancellationToken ct = default)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -1376,8 +1376,9 @@ public class DeduplicationService : IDeduplicationService
         Guid canonicalId,
         CancellationToken cancellationToken = default)
     {
+        var key = RecordTypeKeys.Key(RecordType.StateSpan);
         var linkedRecords = await _context.LinkedRecords
-            .Where(lr => lr.CanonicalId == canonicalId && lr.RecordType == RecordTypeKeys.StateSpan)
+            .Where(lr => lr.CanonicalId == canonicalId && lr.RecordType == key)
             .OrderBy(static lr => lr.SourceTimestamp)
             .ToListAsync(cancellationToken);
 

--- a/tests/Unit/Nocturne.Core.Models.Tests/RecordTypeKeysTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/RecordTypeKeysTests.cs
@@ -1,39 +1,50 @@
-using System.Reflection;
 using FluentAssertions;
 using Nocturne.Core.Models;
 using Xunit;
 
 namespace Nocturne.Core.Models.Tests;
 
+/// <summary>
+/// Pins each <see cref="RecordType"/> to the key already stored in <c>linked_records.record_type</c>,
+/// so renaming a member orphans no rows and adding one cannot skip the pin.
+/// </summary>
 [Trait("Category", "Unit")]
 public class RecordTypeKeysTests
 {
-    private static readonly Dictionary<string, string> Constants = typeof(RecordTypeKeys)
-        .GetFields(BindingFlags.Public | BindingFlags.Static)
-        .Where(f => f is { IsLiteral: true, IsInitOnly: false } && f.FieldType == typeof(string))
-        .ToDictionary(f => f.Name, f => (string)f.GetRawConstantValue()!);
-
-    [Fact]
-    public void Every_record_type_has_a_constant_and_no_constant_is_orphaned()
+    private static readonly Dictionary<RecordType, string> StoredKeys = new()
     {
-        Constants.Keys.Should().BeEquivalentTo(Enum.GetNames<RecordType>());
-    }
+        [RecordType.StateSpan] = "statespan",
+        [RecordType.SensorGlucose] = "sensorglucose",
+        [RecordType.Bolus] = "bolus",
+        [RecordType.CarbIntake] = "carbintake",
+        [RecordType.BGCheck] = "bgcheck",
+        [RecordType.DeviceEvent] = "deviceevent",
+        [RecordType.Note] = "note",
+        [RecordType.BolusCalculation] = "boluscalculation",
+        [RecordType.TempBasal] = "tempbasal",
+    };
 
-    [Theory]
-    [MemberData(nameof(RecordTypes))]
-    public void Constant_equals_the_computed_key(RecordType recordType)
+    public static TheoryData<RecordType, string> Pins()
     {
-        Constants[recordType.ToString()].Should().Be(RecordTypeKeys.Key(recordType));
-    }
-
-    public static TheoryData<RecordType> RecordTypes()
-    {
-        var data = new TheoryData<RecordType>();
-        foreach (var recordType in Enum.GetValues<RecordType>())
+        var data = new TheoryData<RecordType, string>();
+        foreach (var (recordType, stored) in StoredKeys)
         {
-            data.Add(recordType);
+            data.Add(recordType, stored);
         }
 
         return data;
+    }
+
+    [Fact]
+    public void Every_record_type_is_pinned()
+    {
+        StoredKeys.Keys.Should().BeEquivalentTo(Enum.GetValues<RecordType>());
+    }
+
+    [Theory]
+    [MemberData(nameof(Pins))]
+    public void Key_is_the_stored_key(RecordType recordType, string stored)
+    {
+        RecordTypeKeys.Key(recordType).Should().Be(stored);
     }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/StateSpanRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/StateSpanRepositoryTests.cs
@@ -377,23 +377,48 @@ public class StateSpanRepositoryTests : IDisposable
         duplicateEntity.Source = "duplicate";
 
         _context.StateSpans.AddRange(primaryEntity, duplicateEntity);
-        _context.LinkedRecords.Add(new LinkedRecordEntity
-        {
-            Id = Guid.NewGuid(),
-            CanonicalId = Guid.NewGuid(),
-            RecordType = "statespan",
-            RecordId = duplicateEntity.Id,
-            SourceTimestamp = 0,
-            DataSource = "duplicate",
-            IsPrimary = false,
-            SysCreatedAt = DateTime.UtcNow,
-        });
+        _context.LinkedRecords.Add(Link(Guid.NewGuid(), duplicateEntity.Id, isPrimary: false));
         await _context.SaveChangesAsync();
 
         var current = await _repository.GetCurrentPumpModeAsync();
 
         current.Should().Be(PumpModeState.Automatic);
     }
+
+    [Fact]
+    public async Task GetStateSpansAsync_ExcludesNonPrimaryDeduplicatedSpans()
+    {
+        var start = new DateTime(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc);
+        var state = PumpModeState.Automatic.ToString();
+
+        var primaryEntity = SpanEntity(_context.TenantId, StateSpanCategory.PumpMode, state, start, null);
+        primaryEntity.Source = "primary";
+        var duplicateEntity = SpanEntity(_context.TenantId, StateSpanCategory.PumpMode, state, start, null);
+        duplicateEntity.Source = "duplicate";
+
+        _context.StateSpans.AddRange(primaryEntity, duplicateEntity);
+        var canonicalId = Guid.NewGuid();
+        _context.LinkedRecords.AddRange(
+            Link(canonicalId, primaryEntity.Id, isPrimary: true),
+            Link(canonicalId, duplicateEntity.Id, isPrimary: false));
+        await _context.SaveChangesAsync();
+
+        var spans = (await _repository.GetStateSpansAsync()).ToList();
+
+        spans.Should().ContainSingle().Which.Source.Should().Be("primary");
+    }
+
+    private static LinkedRecordEntity Link(Guid canonicalId, Guid recordId, bool isPrimary) => new()
+    {
+        Id = Guid.NewGuid(),
+        CanonicalId = canonicalId,
+        RecordType = "statespan",
+        RecordId = recordId,
+        SourceTimestamp = 0,
+        DataSource = isPrimary ? "primary" : "duplicate",
+        IsPrimary = isPrimary,
+        SysCreatedAt = DateTime.UtcNow,
+    };
 
     // --- GetActiveAtAsync ---
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DedupRecordTypeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/DedupRecordTypeTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Models;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>
+/// Holds each dedup participant's read-visibility record type equal to the one it hands
+/// <c>DeduplicateBatchAsync</c>; a mismatch hides another type's duplicates and shows its own.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+public class DedupRecordTypeTests : IDisposable
+{
+    private readonly NocturneDbContext _context;
+    private readonly TestTenantDbContextFactory _factory;
+    private readonly IDeduplicationService _dedup = new Mock<IDeduplicationService>().Object;
+    private readonly IAuditContext _audit = new Mock<IAuditContext>().Object;
+
+    public DedupRecordTypeTests()
+    {
+        _context = TestDbContextFactory.CreateInMemoryContext();
+        _context.TenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        _factory = new TestTenantDbContextFactory(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Theory]
+    [InlineData(RecordType.SensorGlucose)]
+    [InlineData(RecordType.Bolus)]
+    [InlineData(RecordType.BolusCalculation)]
+    [InlineData(RecordType.CarbIntake)]
+    [InlineData(RecordType.BGCheck)]
+    [InlineData(RecordType.DeviceEvent)]
+    [InlineData(RecordType.Note)]
+    public void Participant_declares_the_record_type_it_deduplicates(RecordType recordType)
+    {
+        Declared(recordType).Should().Be(recordType);
+    }
+
+    private RecordType? Declared(RecordType recordType) => recordType switch
+    {
+        RecordType.SensorGlucose => new SensorGlucoseRepository(
+            _factory, _dedup, _audit, NullLogger<SensorGlucoseRepository>.Instance).DedupRecordType,
+        RecordType.Bolus => new BolusRepository(
+            _factory, _dedup, _audit, NullLogger<BolusRepository>.Instance).DedupRecordType,
+        RecordType.BolusCalculation => new BolusCalculationRepository(
+            _factory, _dedup, _audit, NullLogger<BolusCalculationRepository>.Instance).DedupRecordType,
+        RecordType.CarbIntake => new CarbIntakeRepository(
+            _factory, _dedup, _audit, NullLogger<CarbIntakeRepository>.Instance).DedupRecordType,
+        RecordType.BGCheck => new BGCheckRepository(
+            _factory, _dedup, _audit, NullLogger<BGCheckRepository>.Instance).DedupRecordType,
+        RecordType.DeviceEvent => new DeviceEventRepository(
+            _factory, _dedup, _audit, NullLogger<DeviceEventRepository>.Instance).DedupRecordType,
+        RecordType.Note => new NoteRepository(
+            _factory, _dedup, _audit, NullLogger<NoteRepository>.Instance).DedupRecordType,
+        _ => throw new ArgumentOutOfRangeException(nameof(recordType)),
+    };
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalReadVisibilityTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalReadVisibilityTests.cs
@@ -1,0 +1,117 @@
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Core.Contracts.Infrastructure;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
+
+/// <summary>Holds the shared read-visibility predicate translatable by a real relational provider.</summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "Repository")]
+[Trait("Category", "TempBasal")]
+public class TempBasalReadVisibilityTests : IDisposable
+{
+    private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private readonly DbConnection _connection;
+    private readonly NocturneDbContext _context;
+    private readonly TempBasalRepository _repo;
+
+    public TempBasalReadVisibilityTests()
+    {
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        var contextOptions = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(_connection)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        using (var seedContext = new NocturneDbContext(contextOptions))
+        {
+            seedContext.TenantId = TestTenantId;
+            seedContext.Database.EnsureCreated();
+            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
+            seedContext.SaveChanges();
+        }
+
+        _context = new NocturneDbContext(contextOptions);
+        _context.TenantId = TestTenantId;
+
+        _repo = new TempBasalRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IDeduplicationService>().Object,
+            new Mock<IAuditContext>().Object,
+            NullLogger<TempBasalRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task GetAsync_ExcludesNonPrimaryButKeepsPrimary()
+    {
+        var start = new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var primary = await _repo.CreateAsync(new TempBasal
+        {
+            StartTimestamp = start,
+            EndTimestamp = start.AddMinutes(30),
+            DataSource = "mylife-connector",
+            Rate = 0.5,
+        }, WriteOrigin.Live);
+        var duplicate = await _repo.CreateAsync(new TempBasal
+        {
+            StartTimestamp = start,
+            EndTimestamp = start.AddMinutes(30),
+            DataSource = "glooko-connector",
+            Rate = 0.5,
+        }, WriteOrigin.Live);
+
+        var canonicalId = Guid.CreateVersion7();
+        var mills = new DateTimeOffset(start, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        _context.LinkedRecords.AddRange(
+            new LinkedRecordEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = TestTenantId,
+                CanonicalId = canonicalId,
+                RecordType = "tempbasal",
+                RecordId = primary.Id,
+                SourceTimestamp = mills,
+                DataSource = "mylife-connector",
+                IsPrimary = true,
+            },
+            new LinkedRecordEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = TestTenantId,
+                CanonicalId = canonicalId,
+                RecordType = "tempbasal",
+                RecordId = duplicate.Id,
+                SourceTimestamp = mills,
+                DataSource = "glooko-connector",
+                IsPrimary = false,
+            });
+        await _context.SaveChangesAsync();
+
+        var fetched = (await _repo.GetAsync(
+            from: null, to: null, device: null, source: null)).ToList();
+
+        fetched.Should().ContainSingle().Which.Id.Should().Be(primary.Id);
+    }
+}


### PR DESCRIPTION
Fixes #1105

The predicate that hides deduplication's non-primary rows, `!ctx.LinkedRecords.Any(lr => lr.RecordType == <key> && !lr.IsPrimary && lr.RecordId == x.Id)`, was written 18 times (the issue says 15; its own list adds to 18): seven `ApplyReadVisibility` overrides on `V4RepositoryBase` subclasses, the same filter inline in each of their extended `GetAsync`, and two copies each in `TempBasalRepository` and `StateSpanRepository`. A drifted copy silently reintroduces duplicate display, and nothing held the copies against each other.

## Design

`ReadVisibilityFilter.ExcludeNonPrimary<TEntity>(this IQueryable<TEntity>, NocturneDbContext, RecordType)` is the one owner, constrained on a new `IIdentified` (`Guid Id`). `IV4Entity` and `IOriginalIdentified` inherit `IIdentified` instead of redeclaring `Id`, so every V4 time-series entity and `TempBasalEntity` satisfy it for free; `StateSpanEntity` (which had no Id-bearing interface) declares it.

`V4RepositoryBase` gains `protected virtual RecordType? DedupRecordType => null` and `ApplyReadVisibility` becomes a non-virtual base method that applies the filter when that is set. The seven overrides collapse to one line each (`protected override RecordType? DedupRecordType => RecordType.Bolus;`) and the inline copies become `query = ApplyReadVisibility(query, ctx)`, so each repository names its record type once on the read path. TempBasal/StateSpan call `ExcludeNonPrimary` directly. The predicate string now occurs exactly once in `src/`.

The helper takes the enum and computes `RecordTypeKeys.Key(recordType)` before building the expression, so the eleven per-type `RecordTypeKeys` constants (which existed only because EF cannot translate a method call inside a tree) are dead and deleted; `Key(RecordType)` is the owner. `RecordTypeKeysTests` now drives from one `StoredKeys` dictionary of the eleven literals: a fact holds its keys equivalent to `Enum.GetValues<RecordType>()` (catches an added or removed member) and a `MemberData` theory holds `Key(x)` to each literal (catches a rename, which would orphan stored `linked_records` rows).

## Behavioural deltas

None in rows returned. The SQL shape is the same correlated `NOT EXISTS`; the record-type key moves from an inlined literal to a query parameter (the shape `DataOverviewService.NonPrimaryRecordIds` already uses). `ApplyReadVisibility` went from virtual to non-virtual and nothing outside the seven repositories overrode it (whole-solution build).

## Tests

Translation proof against SQLite (the real relational provider): the pre-existing `CarbIntakeRepositoryTests.CountAsync_ExcludesNonPrimaryDuplicates` now runs through the shared helper, and new `TempBasalReadVisibilityTests.GetAsync_ExcludesNonPrimaryButKeepsPrimary` covers the non-`V4RepositoryBase` path. Mutation-proven: dropping `!lr.IsPrimary` from the helper fails both. (The existing TempBasal/StateSpan repository tests use EF InMemory and cannot prove translation; noted on #1035.)

`DedupRecordType` is `protected internal` (the Data project already exposes internals to its test project) and `DedupRecordTypeTests` holds each of the seven participants' declared type equal to the one it deduplicates, since one token now flips a whole type's read visibility. Mutation-proven: `BGCheckRepository.DedupRecordType => RecordType.Note` fails that row; adding a `RecordType.Profile` member fails the exhaustiveness fact. The two hand-written TempBasal and StateSpan sites are each held too (`StateSpanRepositoryTests.GetStateSpansAsync_ExcludesNonPrimaryDeduplicatedSpans` is new; mutating only that site's token fails it), so every record-type token in the refactor fails a test if it drifts.

Rebased onto main after #1126 merged (which deleted `RecordType.Entry`/`Treatment`): `Nocturne.Infrastructure.Data.Tests` 867/0, `Nocturne.Core.Models.Tests` 839/0, `Nocturne.API.Tests` (unit filter) 6394/0.

Diff: prod −38 net (17 files), tests +223 net.
