### PR TITLE
refactor(api): give statistics one error policy at each layer

### DIFF
--- a/src/API/Nocturne.API/Attributes/BadRequestOnInvalidInputAttribute.cs
+++ b/src/API/Nocturne.API/Attributes/BadRequestOnInvalidInputAttribute.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Nocturne.API.Attributes;
+
+/// <summary>
+/// Answers an <see cref="ArgumentException"/> or <see cref="InvalidOperationException"/> from a
+/// decorated action with the same 400 <c>ProblemDetails</c> that
+/// <c>Problem(detail:, statusCode: 400, title: "Bad Request")</c> produces elsewhere, the message
+/// in <c>detail</c>.
+/// </summary>
+/// <remarks>
+/// Every other exception — <see cref="OperationCanceledException"/> included — is left unhandled,
+/// so a server fault is reported as a 5xx by the global handler rather than as a client error.
+/// </remarks>
+/// <seealso cref="Middleware.ApiErrorEnvelopeHandler"/>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class BadRequestOnInvalidInputAttribute : Attribute, IExceptionFilter
+{
+    public void OnException(ExceptionContext context)
+    {
+        if (context.Exception is not (ArgumentException or InvalidOperationException))
+            return;
+
+        var problemDetails = context
+            .HttpContext.RequestServices.GetRequiredService<ProblemDetailsFactory>()
+            .CreateProblemDetails(
+                context.HttpContext,
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Bad Request",
+                detail: context.Exception.Message
+            );
+
+        context.Result = new ObjectResult(problemDetails) { StatusCode = problemDetails.Status };
+        context.ExceptionHandled = true;
+    }
+}

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -44,6 +44,7 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 [Tags("Analytics")]
 [Route("api/v4/[controller]")]
 [Produces("application/json")]
+[BadRequestOnInvalidInput]
 public class StatisticsController : ControllerBase
 {
     /// <summary>
@@ -130,22 +131,15 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     public ActionResult<BasicGlucoseStats> CalculateBasicStats([FromBody] double[] values)
     {
-        try
-        {
-            var result = _statisticsService.CalculateBasicStats(values);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateBasicStats(values);
+        return Ok(result);
     }
 
     /// <summary>
     /// Calculate comprehensive glycemic variability metrics
     /// </summary>
     /// <param name="request">Request containing glucose values and entries</param>
-    /// <returns>Comprehensive glycemic variability metrics</returns>
+    /// <returns>Comprehensive glycemic variability metrics, or no content for fewer than two values</returns>
     [HttpPost("glycemic-variability")]
     [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(Scope.ReportsRead)]
@@ -153,18 +147,15 @@ public class StatisticsController : ControllerBase
         [FromBody] GlycemicVariabilityRequest request
     )
     {
-        try
+        var result = _statisticsService.CalculateGlycemicVariability(
+            request.Values,
+            request.Entries
+        );
+        if (result == null)
         {
-            var result = _statisticsService.CalculateGlycemicVariability(
-                request.Values,
-                request.Entries
-            );
-            return Ok(result);
+            return NoContent();
         }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        return Ok(result);
     }
 
     /// <summary>
@@ -181,18 +172,11 @@ public class StatisticsController : ControllerBase
         [FromBody] TimeInRangeRequest request
     )
     {
-        try
-        {
-            var result = _statisticsService.CalculateTimeInRange(
-                request.Entries,
-                request.Thresholds
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateTimeInRange(
+            request.Entries,
+            request.Thresholds
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -208,18 +192,11 @@ public class StatisticsController : ControllerBase
         [FromBody] GlucoseDistributionRequest request
     )
     {
-        try
-        {
-            var result = _statisticsService.CalculateGlucoseDistribution(
-                request.Entries,
-                request.Bins
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateGlucoseDistribution(
+            request.Entries,
+            request.Bins
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -236,15 +213,8 @@ public class StatisticsController : ControllerBase
         [FromBody] SensorGlucose[] entries
     )
     {
-        try
-        {
-            var result = _statisticsService.CalculateAveragedStats(entries);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateAveragedStats(entries);
+        return Ok(result);
     }
 
     /// <summary>
@@ -259,18 +229,11 @@ public class StatisticsController : ControllerBase
         [FromBody] TreatmentSummaryRequest request
     )
     {
-        try
-        {
-            var result = _statisticsService.CalculateTreatmentSummary(
-                request.Boluses ?? Enumerable.Empty<Bolus>(),
-                request.CarbIntakes ?? Enumerable.Empty<CarbIntake>()
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateTreatmentSummary(
+            request.Boluses ?? Enumerable.Empty<Bolus>(),
+            request.CarbIntakes ?? Enumerable.Empty<CarbIntake>()
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -285,19 +248,12 @@ public class StatisticsController : ControllerBase
         [FromBody] DayData[] dailyDataPoints
     )
     {
-        try
+        var result = _statisticsService.CalculateOverallAverages(dailyDataPoints);
+        if (result == null)
         {
-            var result = _statisticsService.CalculateOverallAverages(dailyDataPoints);
-            if (result == null)
-            {
-                return NoContent();
-            }
-            return Ok(result);
+            return NoContent();
         }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        return Ok(result);
     }
 
     /// <summary>
@@ -313,20 +269,13 @@ public class StatisticsController : ControllerBase
         [FromBody] GlucoseAnalyticsRequest request
     )
     {
-        try
-        {
-            var result = _statisticsService.AnalyzeGlucoseData(
-                request.Entries,
-                request.Boluses ?? Enumerable.Empty<Bolus>(),
-                request.CarbIntakes ?? Enumerable.Empty<CarbIntake>(),
-                request.Config
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.AnalyzeGlucoseData(
+            request.Entries,
+            request.Boluses ?? Enumerable.Empty<Bolus>(),
+            request.CarbIntakes ?? Enumerable.Empty<CarbIntake>(),
+            request.Config
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -342,21 +291,14 @@ public class StatisticsController : ControllerBase
         [FromBody] ExtendedGlucoseAnalyticsRequest request
     )
     {
-        try
-        {
-            var result = _statisticsService.AnalyzeGlucoseDataExtended(
-                request.Entries,
-                request.Boluses ?? Enumerable.Empty<Bolus>(),
-                request.CarbIntakes ?? Enumerable.Empty<CarbIntake>(),
-                request.Population,
-                request.Config
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.AnalyzeGlucoseDataExtended(
+            request.Entries,
+            request.Boluses ?? Enumerable.Empty<Bolus>(),
+            request.CarbIntakes ?? Enumerable.Empty<CarbIntake>(),
+            request.Population,
+            request.Config
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -382,81 +324,74 @@ public class StatisticsController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        try
+        var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+        var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+
+        // int.MaxValue limit mirrors ActogramReportService so dense tenants are never
+        // silently truncated (the cause of skewed report stats on high-frequency uploads).
+        var glucoseTask = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, patientDeviceId: patientDeviceId, ct: cancellationToken);
+        var bolusTask   = _bolusRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
+        var carbTask    = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, ct: cancellationToken);
+        var devicesTask = _patientDeviceRepository.GetByDateRangeAsync(startDt, endDt, ct: cancellationToken);
+
+        await Task.WhenAll(glucoseTask, bolusTask, carbTask, devicesTask);
+
+        var rawGlucose = (await glucoseTask).ToList();
+
+        // Unfiltered statistics compute over the canonical stream, never blended CGMs.
+        // A patientDeviceId filter already restricts the fetch to one device raw, so there
+        // is nothing left to canonicalize/blend.
+        var entries = patientDeviceId is null
+            ? (await _canonicalGlucose.SelectAsync(rawGlucose, cancellationToken)).ToList()
+            : rawGlucose;
+        var boluses = await bolusTask;
+        var carbs   = await carbTask;
+        var devices = await devicesTask;
+
+        // Registered devices that contributed readings, for the UI's device picker. Count in a
+        // single pass over the raw readings rather than re-scanning per device. The unattributed
+        // bucket is tracked separately — a null key can't live in a Dictionary.
+        var countByDevice = new Dictionary<Guid, int>();
+        var unattributedCount = 0;
+        foreach (var r in rawGlucose)
         {
-            var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
-            var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
-
-            // int.MaxValue limit mirrors ActogramReportService so dense tenants are never
-            // silently truncated (the cause of skewed report stats on high-frequency uploads).
-            var glucoseTask = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, patientDeviceId: patientDeviceId, ct: cancellationToken);
-            var bolusTask   = _bolusRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
-            var carbTask    = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, int.MaxValue, descending: false, ct: cancellationToken);
-            var devicesTask = _patientDeviceRepository.GetByDateRangeAsync(startDt, endDt, ct: cancellationToken);
-
-            await Task.WhenAll(glucoseTask, bolusTask, carbTask, devicesTask);
-
-            var rawGlucose = (await glucoseTask).ToList();
-
-            // Unfiltered statistics compute over the canonical stream, never blended CGMs.
-            // A patientDeviceId filter already restricts the fetch to one device raw, so there
-            // is nothing left to canonicalize/blend.
-            var entries = patientDeviceId is null
-                ? (await _canonicalGlucose.SelectAsync(rawGlucose, cancellationToken)).ToList()
-                : rawGlucose;
-            var boluses = await bolusTask;
-            var carbs   = await carbTask;
-            var devices = await devicesTask;
-
-            // Registered devices that contributed readings, for the UI's device picker. Count in a
-            // single pass over the raw readings rather than re-scanning per device. The unattributed
-            // bucket is tracked separately — a null key can't live in a Dictionary.
-            var countByDevice = new Dictionary<Guid, int>();
-            var unattributedCount = 0;
-            foreach (var r in rawGlucose)
-            {
-                if (r.PatientDeviceId is { } id)
-                    countByDevice[id] = countByDevice.GetValueOrDefault(id) + 1;
-                else
-                    unattributedCount++;
-            }
-
-            var contributingDevices = new List<ContributingDevice>();
-            foreach (var d in devices.Where(d => d.DeviceCategory == DeviceCategory.CGM))
-            {
-                if (!countByDevice.TryGetValue(d.Id, out var readingCount) || readingCount == 0) continue;
-
-                contributingDevices.Add(new ContributingDevice
-                {
-                    PatientDeviceId = d.Id,
-                    Name = d.DisplayName(),
-                    ReadingCount = readingCount,
-                });
-            }
-
-            if (unattributedCount > 0)
-            {
-                contributingDevices.Add(new ContributingDevice
-                {
-                    PatientDeviceId = null,
-                    Name = "Unattributed",
-                    ReadingCount = unattributedCount,
-                });
-            }
-
-            var result = new ReportAnalysisResult
-            {
-                Analysis = _statisticsService.AnalyzeGlucoseDataExtended(entries, boluses, carbs, population),
-                AveragedStats = _statisticsService.CalculateAveragedStats(entries).ToList(),
-                ContributingDevices = contributingDevices,
-                PersonalRange = await CalculatePersonalRangeAsync(entries, cancellationToken),
-            };
-            return Ok(result);
+            if (r.PatientDeviceId is { } id)
+                countByDevice[id] = countByDevice.GetValueOrDefault(id) + 1;
+            else
+                unattributedCount++;
         }
-        catch (Exception ex)
+
+        var contributingDevices = new List<ContributingDevice>();
+        foreach (var d in devices.Where(d => d.DeviceCategory == DeviceCategory.CGM))
         {
-            return BadRequest(new { error = ex.Message });
+            if (!countByDevice.TryGetValue(d.Id, out var readingCount) || readingCount == 0) continue;
+
+            contributingDevices.Add(new ContributingDevice
+            {
+                PatientDeviceId = d.Id,
+                Name = d.DisplayName(),
+                ReadingCount = readingCount,
+            });
         }
+
+        if (unattributedCount > 0)
+        {
+            contributingDevices.Add(new ContributingDevice
+            {
+                PatientDeviceId = null,
+                Name = "Unattributed",
+                ReadingCount = unattributedCount,
+            });
+        }
+
+        var result = new ReportAnalysisResult
+        {
+            Analysis = _statisticsService.AnalyzeGlucoseDataExtended(entries, boluses, carbs, population),
+            AveragedStats = _statisticsService.CalculateAveragedStats(entries).ToList(),
+            ContributingDevices = contributingDevices,
+            PersonalRange = await CalculatePersonalRangeAsync(entries, cancellationToken),
+        };
+        return Ok(result);
     }
 
     /// <summary>
@@ -515,15 +450,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     public ActionResult<GlucoseManagementIndicator> CalculateGMI(double meanGlucose)
     {
-        try
-        {
-            var result = _statisticsService.CalculateGMI(meanGlucose);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateGMI(meanGlucose);
+        return Ok(result);
     }
 
     /// <summary>
@@ -536,15 +464,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     public ActionResult<GlycemicRiskIndex> CalculateGRI([FromBody] TimeInRangeMetrics timeInRange)
     {
-        try
-        {
-            var result = _statisticsService.CalculateGRI(timeInRange);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateGRI(timeInRange);
+        return Ok(result);
     }
 
     /// <summary>
@@ -559,18 +480,11 @@ public class StatisticsController : ControllerBase
         [FromBody] ClinicalAssessmentRequest request
     )
     {
-        try
-        {
-            var result = _statisticsService.AssessAgainstTargets(
-                request.Analytics,
-                request.Population
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.AssessAgainstTargets(
+            request.Analytics,
+            request.Population
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -585,19 +499,12 @@ public class StatisticsController : ControllerBase
         [FromBody] DataSufficiencyRequest request
     )
     {
-        try
-        {
-            var result = _statisticsService.AssessDataSufficiency(
-                request.Entries,
-                request.Days,
-                request.ExpectedReadingsPerDay
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.AssessDataSufficiency(
+            request.Entries,
+            request.Days,
+            request.ExpectedReadingsPerDay
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -609,15 +516,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     public ActionResult<ClinicalTargets> GetClinicalTargets(DiabetesPopulation population)
     {
-        try
-        {
-            var result = ClinicalTargets.ForPopulation(population);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = ClinicalTargets.ForPopulation(population);
+        return Ok(result);
     }
 
     /// <summary>
@@ -629,15 +529,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     public ActionResult<double> CalculateEstimatedA1C(double averageGlucose)
     {
-        try
-        {
-            var result = _statisticsService.CalculateEstimatedA1C(averageGlucose);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateEstimatedA1C(averageGlucose);
+        return Ok(result);
     }
 
     /// <summary>
@@ -649,15 +542,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     public ActionResult<double> MgdlToMMOL(double mgdl)
     {
-        try
-        {
-            var result = _statisticsService.MgdlToMMOL(mgdl);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.MgdlToMMOL(mgdl);
+        return Ok(result);
     }
 
     /// <summary>
@@ -669,15 +555,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     public ActionResult<double> MmolToMGDL(double mmol)
     {
-        try
-        {
-            var result = _statisticsService.MmolToMGDL(mmol);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.MmolToMGDL(mmol);
+        return Ok(result);
     }
 
     /// <summary>
@@ -690,15 +569,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     public ActionResult<bool> ValidateTreatmentData([FromBody] Treatment treatment)
     {
-        try
-        {
-            var result = _statisticsService.ValidateTreatmentData(treatment);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.ValidateTreatmentData(treatment);
+        return Ok(result);
     }
 
     /// <summary>
@@ -713,15 +585,8 @@ public class StatisticsController : ControllerBase
         [FromBody] Treatment[] treatments
     )
     {
-        try
-        {
-            var result = _statisticsService.CleanTreatmentData(treatments);
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CleanTreatmentData(treatments);
+        return Ok(result);
     }
 
     /// <summary>
@@ -746,213 +611,206 @@ public class StatisticsController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        try
+        var cacheKey = $"statistics:multi-period:{TenantCacheId}";
+
+        // Try to get from cache first
+        var cachedResult = await _cacheService.GetAsync<MultiPeriodStatistics>(
+            cacheKey,
+            cancellationToken
+        );
+        if (cachedResult != null)
         {
-            var cacheKey = $"statistics:multi-period:{TenantCacheId}";
+            return Ok(cachedResult);
+        }
 
-            // Try to get from cache first
-            var cachedResult = await _cacheService.GetAsync<MultiPeriodStatistics>(
-                cacheKey,
-                cancellationToken
-            );
-            if (cachedResult != null)
+        // Check if profile data exists for scheduled basal calculation
+        var hasProfileData = await _therapySettingsResolver.HasDataAsync(cancellationToken);
+
+        // Calculate statistics for each period
+        var periods = new[] { 1, 3, 7, 30, 90 };
+        var now = DateTime.UtcNow;
+        var result = new MultiPeriodStatistics { LastUpdated = now };
+
+        var periodResults = new List<(int Days, PeriodStatistics Statistics)>();
+
+        foreach (var days in periods)
+        {
+            var startDate = now.AddDays(-days);
+            var endDate = now;
+
+            var startTimestamp = startDate;
+            var endTimestamp = endDate;
+
+            var glucoseTask = _sensorGlucoseRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
+            var bolusTask   = _bolusRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
+            var carbTask    = _carbIntakeRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
+
+            await Task.WhenAll(glucoseTask, bolusTask, carbTask);
+
+            var filteredEntries = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
+            var filteredBoluses = (await bolusTask).ToList();
+            var filteredCarbs   = (await carbTask).ToList();
+
+            // Calculate analytics if we have sufficient data
+            GlucoseAnalytics? analytics = null;
+            TreatmentSummary? treatmentSummary = null;
+            InsulinDeliveryStatistics? insulinDelivery = null;
+            bool hasSufficientData = filteredEntries.Count >= 10; // Minimum 10 readings
+
+            if (hasSufficientData)
             {
-                return Ok(cachedResult);
-            }
-
-            // Check if profile data exists for scheduled basal calculation
-            var hasProfileData = await _therapySettingsResolver.HasDataAsync(cancellationToken);
-
-            // Calculate statistics for each period
-            var periods = new[] { 1, 3, 7, 30, 90 };
-            var now = DateTime.UtcNow;
-            var result = new MultiPeriodStatistics { LastUpdated = now };
-
-            var periodResults = new List<(int Days, PeriodStatistics Statistics)>();
-
-            foreach (var days in periods)
-            {
-                var startDate = now.AddDays(-days);
-                var endDate = now;
-
-                var startTimestamp = startDate;
-                var endTimestamp = endDate;
-
-                var glucoseTask = _sensorGlucoseRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
-                var bolusTask   = _bolusRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
-                var carbTask    = _carbIntakeRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
-
-                await Task.WhenAll(glucoseTask, bolusTask, carbTask);
-
-                var filteredEntries = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
-                var filteredBoluses = (await bolusTask).ToList();
-                var filteredCarbs   = (await carbTask).ToList();
-
-                // Calculate analytics if we have sufficient data
-                GlucoseAnalytics? analytics = null;
-                TreatmentSummary? treatmentSummary = null;
-                InsulinDeliveryStatistics? insulinDelivery = null;
-                bool hasSufficientData = filteredEntries.Count >= 10; // Minimum 10 readings
-
-                if (hasSufficientData)
-                {
-                    analytics = _statisticsService.AnalyzeGlucoseData(
-                        filteredEntries,
-                        filteredBoluses,
-                        filteredCarbs
-                    );
-
-                    treatmentSummary = _statisticsService.CalculateTreatmentSummary(
-                        filteredBoluses,
-                        filteredCarbs
-                    );
-
-                    // Fetch TempBasals and algorithm boluses for basal data
-                    // Deduplicate by 30s window + rate to eliminate duplicates from multiple connectors
-                    // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
-                    // which does not support concurrent operations.
-                    var tempBasals       = (await _tempBasalRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken)).ToList();
-                    var algorithmBoluses = (await _bolusRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken)).ToList();
-                    var basalInjections  = (await _basalInjectionRepository.GetAsync(startTimestamp, endTimestamp, null, null, int.MaxValue, 0, false, cancellationToken)).ToList();
-
-                    insulinDelivery = _statisticsService.CalculateInsulinDeliveryStatistics(
-                        filteredBoluses,
-                        algorithmBoluses,
-                        tempBasals,
-                        filteredCarbs,
-                        startDate,
-                        endDate,
-                        basalInjections
-                    );
-
-                    // If no TempBasals/algorithm boluses/basal injections but we have profile data, augment with scheduled basal
-                    if (
-                        tempBasals.Count == 0
-                        && algorithmBoluses.Count == 0
-                        && basalInjections.Count == 0
-                        && hasProfileData
-                    )
-                    {
-                        var fromMs = new DateTimeOffset(startTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-                        var toMs = new DateTimeOffset(endTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-                        var profileBasal = Math.Round(
-                            await _basalSegments.GetSegmentsAsync(fromMs, toMs, cancellationToken).SumUnitsAsync(cancellationToken)
-                            * 100) / 100;
-                        var totalWithProfile = insulinDelivery.TotalBolus + profileBasal;
-                        insulinDelivery.TotalBasal = Math.Round(profileBasal * 100) / 100;
-                        insulinDelivery.ScheduledBasal = Math.Round(profileBasal * 100) / 100;
-                        insulinDelivery.AdditionalBasal = 0;
-                        insulinDelivery.TotalInsulin = Math.Round(totalWithProfile * 100) / 100;
-                        insulinDelivery.Tdd =
-                            Math.Round(
-                                totalWithProfile / Math.Max(1, insulinDelivery.DayCount) * 10
-                            ) / 10;
-                        insulinDelivery.BasalPercent =
-                            totalWithProfile > 0
-                                ? Math.Round(profileBasal / totalWithProfile * 100 * 10) / 10
-                                : 0;
-                        insulinDelivery.BolusPercent =
-                            totalWithProfile > 0
-                                ? Math.Round(
-                                    insulinDelivery.TotalBolus / totalWithProfile * 100 * 10
-                                ) / 10
-                                : 0;
-                    }
-
-                    // Keep treatment summary basal consistent
-                    treatmentSummary.Totals.Insulin.Basal = insulinDelivery.TotalBasal;
-                    treatmentSummary.Totals.Insulin.ScheduledBasal = insulinDelivery.ScheduledBasal;
-                    treatmentSummary.Totals.Insulin.AdditionalBasal =
-                        insulinDelivery.AdditionalBasal;
-                }
-
-                // Compute GMI and reliability for this period
-                GlucoseManagementIndicator? periodGmi = null;
-                StatisticReliability? periodReliability = null;
-
-                if (hasSufficientData && analytics != null)
-                {
-                    periodGmi = _statisticsService.CalculateGMI(analytics.BasicStats.Mean);
-
-                    var actualDaysWithData = filteredEntries
-                        .Where(e => e.Mills > 0)
-                        .Select(e => DateTimeOffset.FromUnixTimeMilliseconds(e.Mills).Date)
-                        .Distinct()
-                        .Count();
-
-                    // Context-appropriate recommended minimums:
-                    // Short periods can't reasonably need 14 days
-                    var recommendedDays = days switch
-                    {
-                        <= 3 => days,
-                        <= 7 => 7,
-                        _ => 14, // clinical standard for 30/90 day periods
-                    };
-
-                    periodReliability = _statisticsService.AssessReliability(
-                        actualDaysWithData,
-                        filteredEntries.Count,
-                        recommendedDays
-                    );
-
-                    periodGmi.Reliability = periodReliability;
-                }
-
-                periodResults.Add(
-                    (
-                        days,
-                        new PeriodStatistics
-                        {
-                            PeriodDays = days,
-                            StartDate = startDate,
-                            EndDate = endDate,
-                            Analytics = analytics,
-                            TreatmentSummary = treatmentSummary,
-                            InsulinDelivery = insulinDelivery,
-                            HasSufficientData = hasSufficientData,
-                            Gmi = periodGmi,
-                            Reliability = periodReliability,
-                            EntryCount = filteredEntries.Count,
-                            TreatmentCount = filteredBoluses.Count + filteredCarbs.Count,
-                        }
-                    )
+                analytics = _statisticsService.AnalyzeGlucoseData(
+                    filteredEntries,
+                    filteredBoluses,
+                    filteredCarbs
                 );
-            }
 
-            // Map results to the response object
-            foreach (var periodResult in periodResults)
-            {
-                switch (periodResult.Days)
+                treatmentSummary = _statisticsService.CalculateTreatmentSummary(
+                    filteredBoluses,
+                    filteredCarbs
+                );
+
+                // Fetch TempBasals and algorithm boluses for basal data
+                // Deduplicate by 30s window + rate to eliminate duplicates from multiple connectors
+                // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
+                // which does not support concurrent operations.
+                var tempBasals       = (await _tempBasalRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken)).ToList();
+                var algorithmBoluses = (await _bolusRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken)).ToList();
+                var basalInjections  = (await _basalInjectionRepository.GetAsync(startTimestamp, endTimestamp, null, null, int.MaxValue, 0, false, cancellationToken)).ToList();
+
+                insulinDelivery = _statisticsService.CalculateInsulinDeliveryStatistics(
+                    filteredBoluses,
+                    algorithmBoluses,
+                    tempBasals,
+                    filteredCarbs,
+                    startDate,
+                    endDate,
+                    basalInjections
+                );
+
+                // If no TempBasals/algorithm boluses/basal injections but we have profile data, augment with scheduled basal
+                if (
+                    tempBasals.Count == 0
+                    && algorithmBoluses.Count == 0
+                    && basalInjections.Count == 0
+                    && hasProfileData
+                )
                 {
-                    case 1:
-                        result.LastDay = periodResult.Statistics;
-                        break;
-                    case 3:
-                        result.Last3Days = periodResult.Statistics;
-                        break;
-                    case 7:
-                        result.LastWeek = periodResult.Statistics;
-                        break;
-                    case 30:
-                        result.LastMonth = periodResult.Statistics;
-                        break;
-                    case 90:
-                        result.Last90Days = periodResult.Statistics;
-                        break;
+                    var fromMs = new DateTimeOffset(startTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
+                    var toMs = new DateTimeOffset(endTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
+                    var profileBasal = Math.Round(
+                        await _basalSegments.GetSegmentsAsync(fromMs, toMs, cancellationToken).SumUnitsAsync(cancellationToken)
+                        * 100) / 100;
+                    var totalWithProfile = insulinDelivery.TotalBolus + profileBasal;
+                    insulinDelivery.TotalBasal = Math.Round(profileBasal * 100) / 100;
+                    insulinDelivery.ScheduledBasal = Math.Round(profileBasal * 100) / 100;
+                    insulinDelivery.AdditionalBasal = 0;
+                    insulinDelivery.TotalInsulin = Math.Round(totalWithProfile * 100) / 100;
+                    insulinDelivery.Tdd =
+                        Math.Round(
+                            totalWithProfile / Math.Max(1, insulinDelivery.DayCount) * 10
+                        ) / 10;
+                    insulinDelivery.BasalPercent =
+                        totalWithProfile > 0
+                            ? Math.Round(profileBasal / totalWithProfile * 100 * 10) / 10
+                            : 0;
+                    insulinDelivery.BolusPercent =
+                        totalWithProfile > 0
+                            ? Math.Round(
+                                insulinDelivery.TotalBolus / totalWithProfile * 100 * 10
+                            ) / 10
+                            : 0;
                 }
+
+                // Keep treatment summary basal consistent
+                treatmentSummary.Totals.Insulin.Basal = insulinDelivery.TotalBasal;
+                treatmentSummary.Totals.Insulin.ScheduledBasal = insulinDelivery.ScheduledBasal;
+                treatmentSummary.Totals.Insulin.AdditionalBasal =
+                    insulinDelivery.AdditionalBasal;
             }
 
-            // Cache for 5 minutes — long enough to absorb rapid dashboard refreshes,
-            // short enough that newly-imported connector data (basal StateSpans, etc.) appears promptly.
-            var expiry = DateTime.UtcNow.AddMinutes(5);
-            await _cacheService.SetAsync(cacheKey, result, expiry, cancellationToken);
+            // Compute GMI and reliability for this period
+            GlucoseManagementIndicator? periodGmi = null;
+            StatisticReliability? periodReliability = null;
 
-            return Ok(result);
+            if (hasSufficientData && analytics != null)
+            {
+                periodGmi = _statisticsService.CalculateGMI(analytics.BasicStats.Mean);
+
+                var actualDaysWithData = filteredEntries
+                    .Where(e => e.Mills > 0)
+                    .Select(e => DateTimeOffset.FromUnixTimeMilliseconds(e.Mills).Date)
+                    .Distinct()
+                    .Count();
+
+                // Context-appropriate recommended minimums:
+                // Short periods can't reasonably need 14 days
+                var recommendedDays = days switch
+                {
+                    <= 3 => days,
+                    <= 7 => 7,
+                    _ => 14, // clinical standard for 30/90 day periods
+                };
+
+                periodReliability = _statisticsService.AssessReliability(
+                    actualDaysWithData,
+                    filteredEntries.Count,
+                    recommendedDays
+                );
+
+                periodGmi.Reliability = periodReliability;
+            }
+
+            periodResults.Add(
+                (
+                    days,
+                    new PeriodStatistics
+                    {
+                        PeriodDays = days,
+                        StartDate = startDate,
+                        EndDate = endDate,
+                        Analytics = analytics,
+                        TreatmentSummary = treatmentSummary,
+                        InsulinDelivery = insulinDelivery,
+                        HasSufficientData = hasSufficientData,
+                        Gmi = periodGmi,
+                        Reliability = periodReliability,
+                        EntryCount = filteredEntries.Count,
+                        TreatmentCount = filteredBoluses.Count + filteredCarbs.Count,
+                    }
+                )
+            );
         }
-        catch (Exception ex)
+
+        // Map results to the response object
+        foreach (var periodResult in periodResults)
         {
-            return BadRequest(new { error = ex.Message });
+            switch (periodResult.Days)
+            {
+                case 1:
+                    result.LastDay = periodResult.Statistics;
+                    break;
+                case 3:
+                    result.Last3Days = periodResult.Statistics;
+                    break;
+                case 7:
+                    result.LastWeek = periodResult.Statistics;
+                    break;
+                case 30:
+                    result.LastMonth = periodResult.Statistics;
+                    break;
+                case 90:
+                    result.Last90Days = periodResult.Statistics;
+                    break;
+            }
         }
+
+        // Cache for 5 minutes — long enough to absorb rapid dashboard refreshes,
+        // short enough that newly-imported connector data (basal StateSpans, etc.) appears promptly.
+        var expiry = DateTime.UtcNow.AddMinutes(5);
+        await _cacheService.SetAsync(cacheKey, result, expiry, cancellationToken);
+
+        return Ok(result);
     }
 
     /// <summary>
@@ -968,21 +826,14 @@ public class StatisticsController : ControllerBase
         [FromBody] SiteChangeImpactRequest request
     )
     {
-        try
-        {
-            var result = _statisticsService.CalculateSiteChangeImpact(
-                request.Entries,
-                request.DeviceEvents,
-                request.HoursBeforeChange,
-                request.HoursAfterChange,
-                request.BucketSizeMinutes
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateSiteChangeImpact(
+            request.Entries,
+            request.DeviceEvents,
+            request.HoursBeforeChange,
+            request.HoursAfterChange,
+            request.BucketSizeMinutes
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -999,36 +850,29 @@ public class StatisticsController : ControllerBase
         [FromQuery] DateTime endDate
     )
     {
-        try
-        {
-            var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
-            var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+        var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+        var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
 
-            // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
-            // which does not support concurrent operations.
-            var boluses          = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
-            var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false)).ToList();
-            var algorithmBoluses = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
-            var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10000, 0, false)).ToList();
+        // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
+        // which does not support concurrent operations.
+        var boluses          = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
+        var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false)).ToList();
+        var algorithmBoluses = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
+        var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10000, 0, false)).ToList();
 
-            var tzId = await _therapySettingsResolver.GetTimezoneAsync();
-            var tz = !string.IsNullOrEmpty(tzId)
-                ? TimeZoneHelper.GetTimeZoneInfoFromId(tzId)
-                : TimeZoneInfo.Utc;
+        var tzId = await _therapySettingsResolver.GetTimezoneAsync();
+        var tz = !string.IsNullOrEmpty(tzId)
+            ? TimeZoneHelper.GetTimeZoneInfoFromId(tzId)
+            : TimeZoneInfo.Utc;
 
-            var result = _statisticsService.CalculateDailyBasalBolusRatios(
-                boluses,
-                algorithmBoluses,
-                tempBasals,
-                tz,
-                basalInjections
-            );
-            return Ok(result);
-        }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateDailyBasalBolusRatios(
+            boluses,
+            algorithmBoluses,
+            tempBasals,
+            tz,
+            basalInjections
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -1049,197 +893,186 @@ public class StatisticsController : ControllerBase
         CancellationToken cancellationToken = default
     )
     {
-        try
+        var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: cancellationToken);
+        var tz = !string.IsNullOrEmpty(tzId)
+            ? TimeZoneHelper.GetTimeZoneInfoFromId(tzId)
+            : TimeZoneInfo.Utc;
+
+        var startLocalDate = DateTime.SpecifyKind(startDate.Date, DateTimeKind.Unspecified);
+        var endLocalDate = DateTime.SpecifyKind(endDate.Date, DateTimeKind.Unspecified);
+        var startDt = TimeZoneInfo.ConvertTimeToUtc(startLocalDate, tz);
+        var endDt = TimeZoneInfo.ConvertTimeToUtc(endLocalDate.AddDays(1).AddTicks(-1), tz);
+
+        // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
+        // which does not support concurrent operations.
+        var rawGlucose       = (await _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, 100_000, descending: false, ct: cancellationToken)).ToList();
+        var glucoseData      = (await _canonicalGlucose.SelectAsync(rawGlucose, cancellationToken)).ToList();
+        var manualBoluses    = (await _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Manual, ct: cancellationToken)).ToList();
+        var carbs            = (await _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken)).ToList();
+        var algorithmBoluses = (await _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken)).ToList();
+        var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken)).ToList();
+        var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10_000, 0, false, ct: cancellationToken)).ToList();
+
+        // Daily basal totals come from the existing service path so the calendar's "totalBasal"
+        // matches what /daily-basal-bolus-ratios would return for the same window.
+        var dailyBasalBolus = _statisticsService.CalculateDailyBasalBolusRatios(
+            manualBoluses, algorithmBoluses, tempBasals, tz, basalInjections);
+        var dailyBasalMap = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (var d in dailyBasalBolus.DailyData)
         {
-            var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: cancellationToken);
-            var tz = !string.IsNullOrEmpty(tzId)
-                ? TimeZoneHelper.GetTimeZoneInfoFromId(tzId)
-                : TimeZoneInfo.Utc;
+            if (!string.IsNullOrEmpty(d.Date)) dailyBasalMap[d.Date] = d.Basal;
+        }
 
-            var startLocalDate = DateTime.SpecifyKind(startDate.Date, DateTimeKind.Unspecified);
-            var endLocalDate = DateTime.SpecifyKind(endDate.Date, DateTimeKind.Unspecified);
-            var startDt = TimeZoneInfo.ConvertTimeToUtc(startLocalDate, tz);
-            var endDt = TimeZoneInfo.ConvertTimeToUtc(endLocalDate.AddDays(1).AddTicks(-1), tz);
+        // Build the per-month/per-day shape.
+        var monthsMap = new Dictionary<string, PunchCardMonth>(StringComparer.Ordinal);
+        string[] monthNames =
+        [
+            "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December"
+        ];
 
-            // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
-            // which does not support concurrent operations.
-            var rawGlucose       = (await _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, 100_000, descending: false, ct: cancellationToken)).ToList();
-            var glucoseData      = (await _canonicalGlucose.SelectAsync(rawGlucose, cancellationToken)).ToList();
-            var manualBoluses    = (await _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Manual, ct: cancellationToken)).ToList();
-            var carbs            = (await _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken)).ToList();
-            var algorithmBoluses = (await _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken)).ToList();
-            var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken)).ToList();
-            var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10_000, 0, false, ct: cancellationToken)).ToList();
+        for (var day = startLocalDate.Date; day <= endLocalDate.Date; day = day.AddDays(1))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
 
-            // Daily basal totals come from the existing service path so the calendar's "totalBasal"
-            // matches what /daily-basal-bolus-ratios would return for the same window.
-            var dailyBasalBolus = _statisticsService.CalculateDailyBasalBolusRatios(
-                manualBoluses, algorithmBoluses, tempBasals, tz, basalInjections);
-            var dailyBasalMap = new Dictionary<string, double>(StringComparer.Ordinal);
-            foreach (var d in dailyBasalBolus.DailyData)
+            var monthKey = $"{day.Year}-{day.Month - 1}";
+            if (!monthsMap.TryGetValue(monthKey, out var monthBucket))
             {
-                if (!string.IsNullOrEmpty(d.Date)) dailyBasalMap[d.Date] = d.Basal;
-            }
-
-            // Build the per-month/per-day shape.
-            var monthsMap = new Dictionary<string, PunchCardMonth>(StringComparer.Ordinal);
-            string[] monthNames =
-            [
-                "January", "February", "March", "April", "May", "June",
-                "July", "August", "September", "October", "November", "December"
-            ];
-
-            for (var day = startLocalDate.Date; day <= endLocalDate.Date; day = day.AddDays(1))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var monthKey = $"{day.Year}-{day.Month - 1}";
-                if (!monthsMap.TryGetValue(monthKey, out var monthBucket))
+                monthBucket = new PunchCardMonth
                 {
-                    monthBucket = new PunchCardMonth
-                    {
-                        Year = day.Year,
-                        Month = day.Month - 1,
-                        MonthName = monthNames[day.Month - 1],
-                    };
-                    monthsMap[monthKey] = monthBucket;
-                }
-
-                var dayStartLocal = DateTime.SpecifyKind(day, DateTimeKind.Unspecified);
-                var dayEndLocal = dayStartLocal.AddDays(1).AddTicks(-1);
-                var dayStartUtc = TimeZoneInfo.ConvertTimeToUtc(dayStartLocal, tz);
-                var dayEndUtc = TimeZoneInfo.ConvertTimeToUtc(dayEndLocal, tz);
-                var dayStartMs = new DateTimeOffset(dayStartUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-                var dayEndMs = new DateTimeOffset(dayEndUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-                var dayEntries = glucoseData
-                    .Where(e => e.Mills >= dayStartMs && e.Mills <= dayEndMs)
-                    .ToList();
-                var dayBoluses = manualBoluses
-                    .Where(b => b.Mills >= dayStartMs && b.Mills <= dayEndMs)
-                    .ToList();
-                var dayCarbs = carbs
-                    .Where(c => c.Mills >= dayStartMs && c.Mills <= dayEndMs)
-                    .ToList();
-
-                TimeInRangeMetrics? tir = dayEntries.Count > 0
-                    ? _statisticsService.CalculateTimeInRange(dayEntries)
-                    : null;
-                TreatmentSummary? treatment = dayBoluses.Count > 0 || dayCarbs.Count > 0
-                    ? _statisticsService.CalculateTreatmentSummary(dayBoluses, dayCarbs)
-                    : null;
-
-                var pct = tir?.Percentages;
-                var inRangePct = pct?.Target ?? 0;
-                var lowPct = (pct?.VeryLow ?? 0) + (pct?.Low ?? 0);
-                var highPct = (pct?.VeryHigh ?? 0) + (pct?.High ?? 0);
-
-                var dur = tir?.Durations;
-                var totalMinutes = (dur?.VeryLow ?? 0) + (dur?.Low ?? 0)
-                    + (dur?.Target ?? 0) + (dur?.High ?? 0) + (dur?.VeryHigh ?? 0);
-                var totalReadings = (int)Math.Round(totalMinutes / 5.0);
-                var inRangeCount = (int)Math.Round(inRangePct / 100.0 * totalReadings);
-                var lowCount = (int)Math.Round(lowPct / 100.0 * totalReadings);
-                var highCount = (int)Math.Round(highPct / 100.0 * totalReadings);
-
-                var rangeStats = tir?.RangeStats;
-                var avgGlucose = rangeStats?.Target?.Mean ?? rangeStats?.Low?.Mean ?? 0;
-
-                var dateStr = day.ToString("yyyy-MM-dd");
-                var totals = treatment?.Totals;
-                var totalCarbs = totals?.Food?.Carbs ?? 0;
-                var totalBolus = totals?.Insulin?.Bolus ?? 0;
-                var totalBasal = dailyBasalMap.GetValueOrDefault(dateStr, 0.0);
-                var totalInsulin = totalBolus + totalBasal;
-                var carbToInsulinRatio = treatment?.CarbToInsulinRatio ?? 0;
-
-                var entries = dayEntries
-                    .Where(e => e.Mgdl > 0)
-                    .OrderBy(e => e.Mills)
-                    .Select(e => new PunchCardEntry { Mills = e.Mills, Mgdl = e.Mgdl })
-                    .ToList();
-
-                var dayStats = new PunchCardDay
-                {
-                    Date = dateStr,
-                    Timestamp = dayStartMs,
-                    TotalReadings = totalReadings,
-                    InRangeCount = inRangeCount,
-                    LowCount = lowCount,
-                    HighCount = highCount,
-                    InRangePercent = inRangePct,
-                    LowPercent = lowPct,
-                    HighPercent = highPct,
-                    AverageGlucose = avgGlucose,
-                    TotalCarbs = totalCarbs,
-                    TotalInsulin = totalInsulin,
-                    TotalBolus = totalBolus,
-                    TotalBasal = totalBasal,
-                    CarbToInsulinRatio = carbToInsulinRatio,
-                    Entries = entries,
+                    Year = day.Year,
+                    Month = day.Month - 1,
+                    MonthName = monthNames[day.Month - 1],
                 };
-
-                monthBucket.Days.Add(dayStats);
-                monthBucket.MaxCarbs = Math.Max(monthBucket.MaxCarbs, dayStats.TotalCarbs);
-                monthBucket.MaxInsulin = Math.Max(monthBucket.MaxInsulin, dayStats.TotalInsulin);
-                monthBucket.MaxCarbInsulinDiff = Math.Max(
-                    monthBucket.MaxCarbInsulinDiff, Math.Abs(dayStats.CarbToInsulinRatio));
-                monthBucket.TotalReadings += dayStats.TotalReadings;
+                monthsMap[monthKey] = monthBucket;
             }
 
-            // Per-month summaries from days that actually had data.
-            foreach (var month in monthsMap.Values)
-            {
-                var daysWithData = month.Days.Where(d => d.TotalReadings > 0).ToList();
-                if (daysWithData.Count == 0)
-                {
-                    month.Summary = null;
-                    continue;
-                }
+            var dayStartLocal = DateTime.SpecifyKind(day, DateTimeKind.Unspecified);
+            var dayEndLocal = dayStartLocal.AddDays(1).AddTicks(-1);
+            var dayStartUtc = TimeZoneInfo.ConvertTimeToUtc(dayStartLocal, tz);
+            var dayEndUtc = TimeZoneInfo.ConvertTimeToUtc(dayEndLocal, tz);
+            var dayStartMs = new DateTimeOffset(dayStartUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+            var dayEndMs = new DateTimeOffset(dayEndUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
 
-                var totalIR = daysWithData.Sum(d => d.InRangeCount);
-                var totalLow = daysWithData.Sum(d => d.LowCount);
-                var totalHigh = daysWithData.Sum(d => d.HighCount);
-                var totalReadings = daysWithData.Sum(d => d.TotalReadings);
-                var glucoseDays = daysWithData.Where(d => d.AverageGlucose > 0).ToList();
-
-                month.Summary = new PunchCardMonthSummary
-                {
-                    DayCount = daysWithData.Count,
-                    TotalReadings = totalReadings,
-                    InRangePercent = totalReadings > 0 ? (double)totalIR / totalReadings * 100 : 0,
-                    LowPercent = totalReadings > 0 ? (double)totalLow / totalReadings * 100 : 0,
-                    HighPercent = totalReadings > 0 ? (double)totalHigh / totalReadings * 100 : 0,
-                    AvgGlucose = glucoseDays.Count > 0
-                        ? glucoseDays.Average(d => d.AverageGlucose) : 0,
-                };
-            }
-
-            var months = monthsMap.Values
-                .OrderBy(m => m.Year).ThenBy(m => m.Month)
+            var dayEntries = glucoseData
+                .Where(e => e.Mills >= dayStartMs && e.Mills <= dayEndMs)
+                .ToList();
+            var dayBoluses = manualBoluses
+                .Where(b => b.Mills >= dayStartMs && b.Mills <= dayEndMs)
+                .ToList();
+            var dayCarbs = carbs
+                .Where(c => c.Mills >= dayStartMs && c.Mills <= dayEndMs)
                 .ToList();
 
-            return Ok(new PunchCardResponse
+            TimeInRangeMetrics? tir = dayEntries.Count > 0
+                ? _statisticsService.CalculateTimeInRange(dayEntries)
+                : null;
+            TreatmentSummary? treatment = dayBoluses.Count > 0 || dayCarbs.Count > 0
+                ? _statisticsService.CalculateTreatmentSummary(dayBoluses, dayCarbs)
+                : null;
+
+            var pct = tir?.Percentages;
+            var inRangePct = pct?.Target ?? 0;
+            var lowPct = (pct?.VeryLow ?? 0) + (pct?.Low ?? 0);
+            var highPct = (pct?.VeryHigh ?? 0) + (pct?.High ?? 0);
+
+            var dur = tir?.Durations;
+            var totalMinutes = (dur?.VeryLow ?? 0) + (dur?.Low ?? 0)
+                + (dur?.Target ?? 0) + (dur?.High ?? 0) + (dur?.VeryHigh ?? 0);
+            var totalReadings = (int)Math.Round(totalMinutes / 5.0);
+            var inRangeCount = (int)Math.Round(inRangePct / 100.0 * totalReadings);
+            var lowCount = (int)Math.Round(lowPct / 100.0 * totalReadings);
+            var highCount = (int)Math.Round(highPct / 100.0 * totalReadings);
+
+            var rangeStats = tir?.RangeStats;
+            var avgGlucose = rangeStats?.Target?.Mean ?? rangeStats?.Low?.Mean ?? 0;
+
+            var dateStr = day.ToString("yyyy-MM-dd");
+            var totals = treatment?.Totals;
+            var totalCarbs = totals?.Food?.Carbs ?? 0;
+            var totalBolus = totals?.Insulin?.Bolus ?? 0;
+            var totalBasal = dailyBasalMap.GetValueOrDefault(dateStr, 0.0);
+            var totalInsulin = totalBolus + totalBasal;
+            var carbToInsulinRatio = treatment?.CarbToInsulinRatio ?? 0;
+
+            var entries = dayEntries
+                .Where(e => e.Mgdl > 0)
+                .OrderBy(e => e.Mills)
+                .Select(e => new PunchCardEntry { Mills = e.Mills, Mgdl = e.Mgdl })
+                .ToList();
+
+            var dayStats = new PunchCardDay
             {
-                Months = months,
-                DateRange = new PunchCardDateRange
-                {
-                    From = startDt.ToString("o"),
-                    To = endDt.ToString("o"),
-                },
-                GlobalMaxCarbs = months.Count > 0 ? months.Max(m => m.MaxCarbs) : 0,
-                GlobalMaxInsulin = months.Count > 0 ? months.Max(m => m.MaxInsulin) : 0,
-                GlobalMaxCarbInsulinDiff = months.Count > 0 ? months.Max(m => m.MaxCarbInsulinDiff) : 0,
-            });
+                Date = dateStr,
+                Timestamp = dayStartMs,
+                TotalReadings = totalReadings,
+                InRangeCount = inRangeCount,
+                LowCount = lowCount,
+                HighCount = highCount,
+                InRangePercent = inRangePct,
+                LowPercent = lowPct,
+                HighPercent = highPct,
+                AverageGlucose = avgGlucose,
+                TotalCarbs = totalCarbs,
+                TotalInsulin = totalInsulin,
+                TotalBolus = totalBolus,
+                TotalBasal = totalBasal,
+                CarbToInsulinRatio = carbToInsulinRatio,
+                Entries = entries,
+            };
+
+            monthBucket.Days.Add(dayStats);
+            monthBucket.MaxCarbs = Math.Max(monthBucket.MaxCarbs, dayStats.TotalCarbs);
+            monthBucket.MaxInsulin = Math.Max(monthBucket.MaxInsulin, dayStats.TotalInsulin);
+            monthBucket.MaxCarbInsulinDiff = Math.Max(
+                monthBucket.MaxCarbInsulinDiff, Math.Abs(dayStats.CarbToInsulinRatio));
+            monthBucket.TotalReadings += dayStats.TotalReadings;
         }
-        catch (OperationCanceledException)
+
+        // Per-month summaries from days that actually had data.
+        foreach (var month in monthsMap.Values)
         {
-            throw;
+            var daysWithData = month.Days.Where(d => d.TotalReadings > 0).ToList();
+            if (daysWithData.Count == 0)
+            {
+                month.Summary = null;
+                continue;
+            }
+
+            var totalIR = daysWithData.Sum(d => d.InRangeCount);
+            var totalLow = daysWithData.Sum(d => d.LowCount);
+            var totalHigh = daysWithData.Sum(d => d.HighCount);
+            var totalReadings = daysWithData.Sum(d => d.TotalReadings);
+            var glucoseDays = daysWithData.Where(d => d.AverageGlucose > 0).ToList();
+
+            month.Summary = new PunchCardMonthSummary
+            {
+                DayCount = daysWithData.Count,
+                TotalReadings = totalReadings,
+                InRangePercent = totalReadings > 0 ? (double)totalIR / totalReadings * 100 : 0,
+                LowPercent = totalReadings > 0 ? (double)totalLow / totalReadings * 100 : 0,
+                HighPercent = totalReadings > 0 ? (double)totalHigh / totalReadings * 100 : 0,
+                AvgGlucose = glucoseDays.Count > 0
+                    ? glucoseDays.Average(d => d.AverageGlucose) : 0,
+            };
         }
-        catch (Exception ex)
+
+        var months = monthsMap.Values
+            .OrderBy(m => m.Year).ThenBy(m => m.Month)
+            .ToList();
+
+        return Ok(new PunchCardResponse
         {
-            return BadRequest(new { error = ex.Message });
-        }
+            Months = months,
+            DateRange = new PunchCardDateRange
+            {
+                From = startDt.ToString("o"),
+                To = endDt.ToString("o"),
+            },
+            GlobalMaxCarbs = months.Count > 0 ? months.Max(m => m.MaxCarbs) : 0,
+            GlobalMaxInsulin = months.Count > 0 ? months.Max(m => m.MaxInsulin) : 0,
+            GlobalMaxCarbInsulinDiff = months.Count > 0 ? months.Max(m => m.MaxCarbInsulinDiff) : 0,
+        });
     }
 
     /// <summary>
@@ -1256,44 +1089,37 @@ public class StatisticsController : ControllerBase
         [FromQuery] DateTime endDate
     )
     {
-        try
+        var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+        var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+
+        var startMs = new DateTimeOffset(startDt, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var endMs   = new DateTimeOffset(endDt,   TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+        // These reads share the request-scoped NocturneDbContext, which is not safe for
+        // concurrent operations, so they are awaited sequentially rather than via Task.WhenAll.
+        var boluses          = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
+        var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false)).ToList();
+        var algorithmBoluses = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
+        var carbs            = await _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
+        var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10000, 0, false)).ToList();
+        var rateAt           = await _basalRateResolver.BuildResolverAsync(startMs, endMs);
+
+        foreach (var tb in tempBasals)
         {
-            var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
-            var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
-
-            var startMs = new DateTimeOffset(startDt, TimeSpan.Zero).ToUnixTimeMilliseconds();
-            var endMs   = new DateTimeOffset(endDt,   TimeSpan.Zero).ToUnixTimeMilliseconds();
-
-            // These reads share the request-scoped NocturneDbContext, which is not safe for
-            // concurrent operations, so they are awaited sequentially rather than via Task.WhenAll.
-            var boluses          = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
-            var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false)).ToList();
-            var algorithmBoluses = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
-            var carbs            = await _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
-            var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10000, 0, false)).ToList();
-            var rateAt           = await _basalRateResolver.BuildResolverAsync(startMs, endMs);
-
-            foreach (var tb in tempBasals)
-            {
-                if (!tb.ScheduledRate.HasValue && tb.Origin != TempBasalOrigin.Scheduled)
-                    tb.ScheduledRate = rateAt(tb.StartMills);
-            }
-
-            var result = _statisticsService.CalculateInsulinDeliveryStatistics(
-                boluses,
-                algorithmBoluses,
-                tempBasals,
-                carbs,
-                startDate,
-                endDate,
-                basalInjections
-            );
-            return Ok(result);
+            if (!tb.ScheduledRate.HasValue && tb.Origin != TempBasalOrigin.Scheduled)
+                tb.ScheduledRate = rateAt(tb.StartMills);
         }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+
+        var result = _statisticsService.CalculateInsulinDeliveryStatistics(
+            boluses,
+            algorithmBoluses,
+            tempBasals,
+            carbs,
+            startDate,
+            endDate,
+            basalInjections
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -1310,64 +1136,57 @@ public class StatisticsController : ControllerBase
         [FromQuery] DateTime? endDate = null
     )
     {
-        try
+        if (startDate is null || endDate is null)
+            return Problem(detail: "startDate and endDate are required.", statusCode: 400, title: "Bad Request");
+
+        // Force UTC kind to avoid DateTimeOffset throwing when the server's local
+        // timezone offset would push DateTime.MinValue/MaxValue out of the valid range.
+        var startUtc = DateTime.SpecifyKind(startDate.Value, DateTimeKind.Utc);
+        var endUtc = DateTime.SpecifyKind(endDate.Value, DateTimeKind.Utc);
+
+        // Fetch TempBasals and algorithm boluses
+        // Deduplicate by 30s window + rate to eliminate duplicates from multiple connectors
+        // No practical fetch cap — see GetHourlyInsulinDelivery: a 10k cap
+        // silently truncates ~5-minute AID records past ~35 days.
+        var tempBasalTask = _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false);
+        var algoTask      = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
+
+        await Task.WhenAll(tempBasalTask, algoTask);
+
+        var tempBasals       = (await tempBasalTask).ToList();
+        var algorithmBoluses = await algoTask;
+
+        // Fall back to profile-based scheduled rates when no TempBasals exist.
+        // Each segment becomes one synthetic TempBasal; CalculateBasalAnalysis distributes
+        // each across the user-local hour-of-day buckets it overlaps, weighted by duration.
+        var hasTherapyData = await _therapySettingsResolver.HasDataAsync(HttpContext.RequestAborted);
+        if (tempBasals.Count == 0 && hasTherapyData)
         {
-            if (startDate is null || endDate is null)
-                return BadRequest(new { error = "startDate and endDate are required." });
-
-            // Force UTC kind to avoid DateTimeOffset throwing when the server's local
-            // timezone offset would push DateTime.MinValue/MaxValue out of the valid range.
-            var startUtc = DateTime.SpecifyKind(startDate.Value, DateTimeKind.Utc);
-            var endUtc = DateTime.SpecifyKind(endDate.Value, DateTimeKind.Utc);
-
-            // Fetch TempBasals and algorithm boluses
-            // Deduplicate by 30s window + rate to eliminate duplicates from multiple connectors
-            // No practical fetch cap — see GetHourlyInsulinDelivery: a 10k cap
-            // silently truncates ~5-minute AID records past ~35 days.
-            var tempBasalTask = _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false);
-            var algoTask      = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
-
-            await Task.WhenAll(tempBasalTask, algoTask);
-
-            var tempBasals       = (await tempBasalTask).ToList();
-            var algorithmBoluses = await algoTask;
-
-            // Fall back to profile-based scheduled rates when no TempBasals exist.
-            // Each segment becomes one synthetic TempBasal; CalculateBasalAnalysis distributes
-            // each across the user-local hour-of-day buckets it overlaps, weighted by duration.
-            var hasTherapyData = await _therapySettingsResolver.HasDataAsync(HttpContext.RequestAborted);
-            if (tempBasals.Count == 0 && hasTherapyData)
+            var fromMs = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+            var toMs = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+            await foreach (var seg in _basalSegments.GetSegmentsAsync(fromMs, toMs, HttpContext.RequestAborted))
             {
-                var fromMs = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-                var toMs = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-                await foreach (var seg in _basalSegments.GetSegmentsAsync(fromMs, toMs, HttpContext.RequestAborted))
+                tempBasals.Add(new TempBasal
                 {
-                    tempBasals.Add(new TempBasal
-                    {
-                        StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.StartMills).UtcDateTime,
-                        EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.EndMills).UtcDateTime,
-                        Rate = seg.UnitsPerHour,
-                        Origin = TempBasalOrigin.Scheduled,
-                    });
-                }
+                    StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.StartMills).UtcDateTime,
+                    EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.EndMills).UtcDateTime,
+                    Rate = seg.UnitsPerHour,
+                    Origin = TempBasalOrigin.Scheduled,
+                });
             }
-
-            var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: HttpContext.RequestAborted);
-            var userTz = string.IsNullOrEmpty(tzId) ? null : TimeZoneHelper.GetTimeZoneInfoFromId(tzId);
-
-            var result = _statisticsService.CalculateBasalAnalysis(
-                tempBasals,
-                algorithmBoluses,
-                startUtc,
-                endUtc,
-                userTz
-            );
-            return Ok(result);
         }
-        catch (Exception ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+
+        var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: HttpContext.RequestAborted);
+        var userTz = string.IsNullOrEmpty(tzId) ? null : TimeZoneHelper.GetTimeZoneInfoFromId(tzId);
+
+        var result = _statisticsService.CalculateBasalAnalysis(
+            tempBasals,
+            algorithmBoluses,
+            startUtc,
+            endUtc,
+            userTz
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -1388,72 +1207,59 @@ public class StatisticsController : ControllerBase
         [FromQuery] DateTime? endDate = null
     )
     {
-        try
+        if (startDate is null || endDate is null)
+            return Problem(detail: "startDate and endDate are required.", statusCode: 400, title: "Bad Request");
+
+        var startUtc = DateTime.SpecifyKind(startDate.Value, DateTimeKind.Utc);
+        var endUtc = DateTime.SpecifyKind(endDate.Value, DateTimeKind.Utc);
+
+        // No practical fetch cap: AID pumps write a TempBasal (and often an
+        // SMB) every ~5 minutes, so 90 days is ~26k records per type — a
+        // 10k cap would silently truncate to the oldest ~35 days and
+        // understate every average.
+        // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
+        // which does not support concurrent operations.
+        var tempBasals       = (await _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false)).ToList();
+        var boluses          = await _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual);
+        var algorithmBoluses = await _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
+        var basalInjections  = (await _basalInjectionRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, 0, false)).ToList();
+
+        // Fall back to profile-based scheduled rates when no TempBasals exist,
+        // mirroring GetBasalAnalysis: each segment becomes one synthetic
+        // TempBasal that gets duration-weighted across the hours it overlaps.
+        // Skip the profile fallback when basal injections exist: MDI injections are the
+        // actual basal source, so synthesizing scheduled rates from the profile on top of
+        // them would double-count the day's baseline coverage.
+        var hasTherapyData = await _therapySettingsResolver.HasDataAsync(HttpContext.RequestAborted);
+        if (tempBasals.Count == 0 && basalInjections.Count == 0 && hasTherapyData)
         {
-            if (startDate is null || endDate is null)
-                return BadRequest(new { error = "startDate and endDate are required." });
-
-            var startUtc = DateTime.SpecifyKind(startDate.Value, DateTimeKind.Utc);
-            var endUtc = DateTime.SpecifyKind(endDate.Value, DateTimeKind.Utc);
-
-            // No practical fetch cap: AID pumps write a TempBasal (and often an
-            // SMB) every ~5 minutes, so 90 days is ~26k records per type — a
-            // 10k cap would silently truncate to the oldest ~35 days and
-            // understate every average.
-            // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
-            // which does not support concurrent operations.
-            var tempBasals       = (await _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false)).ToList();
-            var boluses          = await _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual);
-            var algorithmBoluses = await _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
-            var basalInjections  = (await _basalInjectionRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, 0, false)).ToList();
-
-            // Fall back to profile-based scheduled rates when no TempBasals exist,
-            // mirroring GetBasalAnalysis: each segment becomes one synthetic
-            // TempBasal that gets duration-weighted across the hours it overlaps.
-            // Skip the profile fallback when basal injections exist: MDI injections are the
-            // actual basal source, so synthesizing scheduled rates from the profile on top of
-            // them would double-count the day's baseline coverage.
-            var hasTherapyData = await _therapySettingsResolver.HasDataAsync(HttpContext.RequestAborted);
-            if (tempBasals.Count == 0 && basalInjections.Count == 0 && hasTherapyData)
+            var fromMs = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+            var toMs = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+            await foreach (var seg in _basalSegments.GetSegmentsAsync(fromMs, toMs, HttpContext.RequestAborted))
             {
-                var fromMs = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-                var toMs = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-                await foreach (var seg in _basalSegments.GetSegmentsAsync(fromMs, toMs, HttpContext.RequestAborted))
+                tempBasals.Add(new TempBasal
                 {
-                    tempBasals.Add(new TempBasal
-                    {
-                        StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.StartMills).UtcDateTime,
-                        EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.EndMills).UtcDateTime,
-                        Rate = seg.UnitsPerHour,
-                        Origin = TempBasalOrigin.Scheduled,
-                    });
-                }
+                    StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.StartMills).UtcDateTime,
+                    EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.EndMills).UtcDateTime,
+                    Rate = seg.UnitsPerHour,
+                    Origin = TempBasalOrigin.Scheduled,
+                });
             }
+        }
 
-            var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: HttpContext.RequestAborted);
-            var userTz = string.IsNullOrEmpty(tzId) ? null : TimeZoneHelper.GetTimeZoneInfoFromId(tzId);
+        var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: HttpContext.RequestAborted);
+        var userTz = string.IsNullOrEmpty(tzId) ? null : TimeZoneHelper.GetTimeZoneInfoFromId(tzId);
 
-            var result = _statisticsService.CalculateHourlyInsulinDelivery(
-                tempBasals,
-                boluses,
-                algorithmBoluses,
-                startUtc,
-                endUtc,
-                userTz,
-                basalInjections
-            );
-            return Ok(result);
-        }
-        // Input-shaped failures only; anything else propagates to the global
-        // handler as a 5xx instead of masquerading as a client error.
-        catch (ArgumentException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
-        catch (InvalidOperationException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = _statisticsService.CalculateHourlyInsulinDelivery(
+            tempBasals,
+            boluses,
+            algorithmBoluses,
+            startUtc,
+            endUtc,
+            userTz,
+            basalInjections
+        );
+        return Ok(result);
     }
 
     /// <summary>
@@ -1478,156 +1284,149 @@ public class StatisticsController : ControllerBase
         [FromQuery] DateTime endDate
     )
     {
+        var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+        var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
+
+        // Fetch patient devices overlapping the date range
+        var devices = await _patientDeviceRepository.GetByDateRangeAsync(startDt, endDt);
+
+        // Map patient devices to segment inputs
+        var deviceSegments = devices
+            .Where(d =>
+                d.DeviceCategory == DeviceCategory.InsulinPump && d.AidAlgorithm.HasValue
+            )
+            .Select(d => new DeviceSegmentInput
+            {
+                Algorithm = d.AidAlgorithm!.Value,
+                StartDate = d.StartDate.HasValue
+                    ? d.StartDate.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)
+                    : startDt,
+                EndDate = d.EndDate.HasValue
+                    ? d.EndDate.Value.ToDateTime(new TimeOnly(23, 59, 59), DateTimeKind.Utc)
+                    : endDt,
+            })
+            .ToList();
+
+        var apsTask     = _apsSnapshotRepository.GetAsync(startDt, endDt, null, null, 50000, descending: false);
+        var basalTask   = _tempBasalRepository.GetAsync(startDt, endDt, null, null, 50000, descending: false);
+        var eventTask   = _deviceEventRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
+        var glucoseTask = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, 50000, descending: false);
+
+        await Task.WhenAll(apsTask, basalTask, eventTask, glucoseTask);
+
+        var apsSnapshots = (await apsTask).ToList();
+        var tempBasals   = (await basalTask).ToList();
+        var deviceEvents = (await eventTask).ToList();
+        var glucose      = (await glucoseTask).ToList();
+
+        // Count site changes
+        var siteChangeCount = deviceEvents.Count(e =>
+            e.EventType == DeviceEventType.SiteChange
+        );
+
+        // Resolve CGM device names
+        var cgmDevices = devices.Where(d => d.DeviceCategory == DeviceCategory.CGM).ToList();
+        var cgmDeviceNames = cgmDevices.Count > 0
+            ? string.Join(", ", cgmDevices
+                .Select(d => d.CatalogId != null ? DeviceCatalog.GetById(d.CatalogId)?.Name : null)
+                .Where(n => n != null)
+                .DefaultIfEmpty(cgmDevices.First().Model ?? cgmDevices.First().Manufacturer))
+            : null;
+
+        // Resolve pump device names
+        var pumpDeviceNames = deviceSegments.Count > 0
+            ? string.Join(", ", devices
+                .Where(d => d.DeviceCategory == DeviceCategory.InsulinPump)
+                .Select(d => d.CatalogId != null ? DeviceCatalog.GetById(d.CatalogId)?.Name : null)
+                .Where(n => n != null)
+                .Distinct())
+            : null;
+
+        // Calculate per-device CGM active time
+        double? cgmActivePercent = null;
+        if (glucose.Count > 0)
+        {
+            if (cgmDevices.Count > 0)
+            {
+                double totalExpected = 0;
+                double totalActual = 0;
+
+                foreach (var cgm in cgmDevices)
+                {
+                    var catalogEntry = cgm.CatalogId != null ? DeviceCatalog.GetById(cgm.CatalogId) : null;
+                    var interval = catalogEntry?.Cgm?.UpdateIntervalMinutes ?? 5;
+                    var deviceStart = cgm.StartDate.HasValue
+                        ? DateTime.SpecifyKind(cgm.StartDate.Value.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc)
+                        : startDt;
+                    var deviceEnd = cgm.EndDate.HasValue
+                        ? DateTime.SpecifyKind(cgm.EndDate.Value.ToDateTime(new TimeOnly(23, 59, 59)), DateTimeKind.Utc)
+                        : endDt;
+                    var windowStart = deviceStart > startDt ? deviceStart : startDt;
+                    var windowEnd = deviceEnd < endDt ? deviceEnd : endDt;
+                    var windowMinutes = (windowEnd - windowStart).TotalMinutes;
+
+                    if (windowMinutes <= 0) continue;
+
+                    totalExpected += windowMinutes / interval;
+                    totalActual += glucose.Count(r => r.PatientDeviceId == cgm.Id);
+                }
+
+                // Count unattributed readings with fallback interval
+                var unattributed = glucose.Count(r => r.PatientDeviceId == null);
+                if (unattributed > 0 && cgmDevices.Count == 0)
+                {
+                    var fallbackSource = glucose.FirstOrDefault(r => r.PatientDeviceId == null)?.DataSource;
+                    var fallbackInterval = DataSources.GetDefaultUpdateIntervalMinutes(fallbackSource);
+                    totalExpected += (endDt - startDt).TotalMinutes / fallbackInterval;
+                    totalActual += unattributed;
+                }
+
+                cgmActivePercent = totalExpected > 0
+                    ? Math.Min(Math.Round(totalActual / totalExpected * 100.0, 1), 100.0)
+                    : null;
+            }
+            else
+            {
+                // No device registered — use AnalyzeGlucoseData with defaults
+                var analytics = _statisticsService.AnalyzeGlucoseData(
+                    glucose, Enumerable.Empty<Bolus>(), Enumerable.Empty<CarbIntake>(),
+                    startDate: startDt, endDate: endDt);
+                cgmActivePercent = analytics.DataQuality.CgmActivePercent;
+            }
+        }
+
+        // Get target range from target range schedule repository
+        double? targetLow = null;
+        double? targetHigh = null;
         try
         {
-            var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
-            var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
-
-            // Fetch patient devices overlapping the date range
-            var devices = await _patientDeviceRepository.GetByDateRangeAsync(startDt, endDt);
-
-            // Map patient devices to segment inputs
-            var deviceSegments = devices
-                .Where(d =>
-                    d.DeviceCategory == DeviceCategory.InsulinPump && d.AidAlgorithm.HasValue
-                )
-                .Select(d => new DeviceSegmentInput
-                {
-                    Algorithm = d.AidAlgorithm!.Value,
-                    StartDate = d.StartDate.HasValue
-                        ? d.StartDate.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)
-                        : startDt,
-                    EndDate = d.EndDate.HasValue
-                        ? d.EndDate.Value.ToDateTime(new TimeOnly(23, 59, 59), DateTimeKind.Utc)
-                        : endDt,
-                })
-                .ToList();
-
-            var apsTask     = _apsSnapshotRepository.GetAsync(startDt, endDt, null, null, 50000, descending: false);
-            var basalTask   = _tempBasalRepository.GetAsync(startDt, endDt, null, null, 50000, descending: false);
-            var eventTask   = _deviceEventRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
-            var glucoseTask = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, 50000, descending: false);
-
-            await Task.WhenAll(apsTask, basalTask, eventTask, glucoseTask);
-
-            var apsSnapshots = (await apsTask).ToList();
-            var tempBasals   = (await basalTask).ToList();
-            var deviceEvents = (await eventTask).ToList();
-            var glucose      = (await glucoseTask).ToList();
-
-            // Count site changes
-            var siteChangeCount = deviceEvents.Count(e =>
-                e.EventType == DeviceEventType.SiteChange
-            );
-
-            // Resolve CGM device names
-            var cgmDevices = devices.Where(d => d.DeviceCategory == DeviceCategory.CGM).ToList();
-            var cgmDeviceNames = cgmDevices.Count > 0
-                ? string.Join(", ", cgmDevices
-                    .Select(d => d.CatalogId != null ? DeviceCatalog.GetById(d.CatalogId)?.Name : null)
-                    .Where(n => n != null)
-                    .DefaultIfEmpty(cgmDevices.First().Model ?? cgmDevices.First().Manufacturer))
-                : null;
-
-            // Resolve pump device names
-            var pumpDeviceNames = deviceSegments.Count > 0
-                ? string.Join(", ", devices
-                    .Where(d => d.DeviceCategory == DeviceCategory.InsulinPump)
-                    .Select(d => d.CatalogId != null ? DeviceCatalog.GetById(d.CatalogId)?.Name : null)
-                    .Where(n => n != null)
-                    .Distinct())
-                : null;
-
-            // Calculate per-device CGM active time
-            double? cgmActivePercent = null;
-            if (glucose.Count > 0)
+            var activeSchedule = await GetActiveTargetRangeScheduleAsync(HttpContext.RequestAborted);
+            if (activeSchedule?.Entries.Count > 0)
             {
-                if (cgmDevices.Count > 0)
-                {
-                    double totalExpected = 0;
-                    double totalActual = 0;
-
-                    foreach (var cgm in cgmDevices)
-                    {
-                        var catalogEntry = cgm.CatalogId != null ? DeviceCatalog.GetById(cgm.CatalogId) : null;
-                        var interval = catalogEntry?.Cgm?.UpdateIntervalMinutes ?? 5;
-                        var deviceStart = cgm.StartDate.HasValue
-                            ? DateTime.SpecifyKind(cgm.StartDate.Value.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc)
-                            : startDt;
-                        var deviceEnd = cgm.EndDate.HasValue
-                            ? DateTime.SpecifyKind(cgm.EndDate.Value.ToDateTime(new TimeOnly(23, 59, 59)), DateTimeKind.Utc)
-                            : endDt;
-                        var windowStart = deviceStart > startDt ? deviceStart : startDt;
-                        var windowEnd = deviceEnd < endDt ? deviceEnd : endDt;
-                        var windowMinutes = (windowEnd - windowStart).TotalMinutes;
-
-                        if (windowMinutes <= 0) continue;
-
-                        totalExpected += windowMinutes / interval;
-                        totalActual += glucose.Count(r => r.PatientDeviceId == cgm.Id);
-                    }
-
-                    // Count unattributed readings with fallback interval
-                    var unattributed = glucose.Count(r => r.PatientDeviceId == null);
-                    if (unattributed > 0 && cgmDevices.Count == 0)
-                    {
-                        var fallbackSource = glucose.FirstOrDefault(r => r.PatientDeviceId == null)?.DataSource;
-                        var fallbackInterval = DataSources.GetDefaultUpdateIntervalMinutes(fallbackSource);
-                        totalExpected += (endDt - startDt).TotalMinutes / fallbackInterval;
-                        totalActual += unattributed;
-                    }
-
-                    cgmActivePercent = totalExpected > 0
-                        ? Math.Min(Math.Round(totalActual / totalExpected * 100.0, 1), 100.0)
-                        : null;
-                }
-                else
-                {
-                    // No device registered — use AnalyzeGlucoseData with defaults
-                    var analytics = _statisticsService.AnalyzeGlucoseData(
-                        glucose, Enumerable.Empty<Bolus>(), Enumerable.Empty<CarbIntake>(),
-                        startDate: startDt, endDate: endDt);
-                    cgmActivePercent = analytics.DataQuality.CgmActivePercent;
-                }
+                targetLow = activeSchedule.Entries.Min(e => e.Low);
+                targetHigh = activeSchedule.Entries.Max(e => e.High);
             }
-
-            // Get target range from target range schedule repository
-            double? targetLow = null;
-            double? targetHigh = null;
-            try
-            {
-                var activeSchedule = await GetActiveTargetRangeScheduleAsync(HttpContext.RequestAborted);
-                if (activeSchedule?.Entries.Count > 0)
-                {
-                    targetLow = activeSchedule.Entries.Min(e => e.Low);
-                    targetHigh = activeSchedule.Entries.Max(e => e.High);
-                }
-            }
-            catch
-            {
-                // Target range is optional — continue without it
-            }
-
-            var result = _aidMetricsService.Calculate(
-                deviceSegments,
-                apsSnapshots,
-                tempBasals,
-                siteChangeCount,
-                cgmDeviceNames,
-                pumpDeviceNames,
-                cgmActivePercent,
-                targetLow,
-                targetHigh,
-                startDt,
-                endDt
-            );
-
-            return Ok(result);
         }
-        catch (Exception ex)
+        catch
         {
-            return BadRequest(new { error = ex.Message });
+            // Target range is optional — continue without it
         }
+
+        var result = _aidMetricsService.Calculate(
+            deviceSegments,
+            apsSnapshots,
+            tempBasals,
+            siteChangeCount,
+            cgmDeviceNames,
+            pumpDeviceNames,
+            cgmActivePercent,
+            targetLow,
+            targetHigh,
+            startDt,
+            endDt
+        );
+
+        return Ok(result);
     }
 }
 

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -236,7 +236,7 @@ public class StatisticsService : IStatisticsService
     {
         var targets = ClinicalTargets.ForPopulation(population);
         var tir = analytics.TimeInRange.Percentages;
-        var cv = analytics.GlycemicVariability.CoefficientOfVariation;
+        var cv = analytics.GlycemicVariability?.CoefficientOfVariation ?? 0;
 
         var assessment = new ClinicalTargetAssessment
         {
@@ -782,8 +782,11 @@ public class StatisticsService : IStatisticsService
     /// </summary>
     /// <param name="values">Collection of glucose values</param>
     /// <param name="entries">Collection of glucose entries with timestamps</param>
-    /// <returns>Comprehensive glycemic variability metrics</returns>
-    public GlycemicVariability CalculateGlycemicVariability(
+    /// <returns>
+    /// Comprehensive glycemic variability metrics, or null for fewer than two readings. The
+    /// individual metrics have differing data floors; this one governs all of them.
+    /// </returns>
+    public GlycemicVariability? CalculateGlycemicVariability(
         IEnumerable<double> values,
         IEnumerable<SensorGlucose> entries
     )
@@ -792,11 +795,7 @@ public class StatisticsService : IStatisticsService
         var entriesList = entries.ToList();
 
         if (valuesList.Count < 2)
-        {
-            throw new ArgumentException(
-                "Not enough data points to calculate glycemic variability metrics"
-            );
-        }
+            return null;
 
         var mean = valuesList.Average();
         var standardDeviation = GlucoseStatistics.StandardDeviation(
@@ -810,7 +809,7 @@ public class StatisticsService : IStatisticsService
         var jIndex = CalculateJIndex(valuesList, mean);
         var hbgi = CalculateHBGI(valuesList);
         var lbgi = CalculateLBGI(valuesList);
-        var gvi = CalculateGVI(valuesList, entriesList);
+        var gvi = CalculateGVI(entriesList);
         var pgs = CalculatePGS(valuesList, gvi, mean);
 
         // Calculate Mean Total Daily Change and Time in Fluctuation
@@ -958,10 +957,7 @@ public class StatisticsService : IStatisticsService
         var windowSize = hours * pointsPerHour;
 
         if (valuesList.Count < windowSize)
-        {
-            // Return 0 instead of throwing exception when insufficient data
             return 0;
-        }
 
         var differences = new List<double>();
         for (int i = 0; i <= valuesList.Count - windowSize; i++)
@@ -978,10 +974,12 @@ public class StatisticsService : IStatisticsService
     /// Calculate ADRR (Average Daily Risk Range)
     /// </summary>
     /// <param name="values">Collection of glucose values</param>
-    /// <returns>ADRR value</returns>
+    /// <returns>ADRR value, or 0 if no data</returns>
     public double CalculateADRR(IEnumerable<double> values)
     {
         var logTransformed = values.Select(val => Math.Log(val)).ToList();
+        if (logTransformed.Count == 0)
+            return 0;
 
         return GlucoseStatistics.StandardDeviation(logTransformed, VarianceMode.Population) * 100;
     }
@@ -990,15 +988,12 @@ public class StatisticsService : IStatisticsService
     /// Calculate Lability Index
     /// </summary>
     /// <param name="entries">Collection of glucose entries with timestamps</param>
-    /// <returns>Lability Index value</returns>
+    /// <returns>Lability Index value, or 0 for fewer than two entries</returns>
     private double CalculateLabilityIndex(IEnumerable<SensorGlucose> entries)
     {
         var entriesList = entries.ToList();
         if (entriesList.Count < 2)
-            throw new ArgumentException(
-                "Not enough data points to calculate Lability Index (requires at least 2).",
-                nameof(entries)
-            );
+            return 0;
 
         double totalChange = 0;
         for (int i = 1; i < entriesList.Count; i++)
@@ -1016,12 +1011,16 @@ public class StatisticsService : IStatisticsService
     /// </summary>
     /// <param name="values">Collection of glucose values</param>
     /// <param name="mean">Mean glucose value</param>
-    /// <returns>J-Index value</returns>
+    /// <returns>J-Index value, or 0 if no data</returns>
     public double CalculateJIndex(IEnumerable<double> values, double mean)
     {
+        var valuesList = values.ToList();
+        if (valuesList.Count == 0)
+            return 0;
+
         const double targetMean = 112; // Target glucose level in mg/dL
         var meanComponent = 0.324 * Math.Pow(mean - targetMean, 2);
-        var variance = GlucoseStatistics.Variance(values.ToList(), mean, VarianceMode.Population);
+        var variance = GlucoseStatistics.Variance(valuesList, mean, VarianceMode.Population);
         var variabilityComponent = 0.0018 * variance;
 
         return meanComponent + variabilityComponent;
@@ -1035,7 +1034,7 @@ public class StatisticsService : IStatisticsService
     /// <param name="values">Collection of glucose values</param>
     /// <returns>HBGI value</returns>
     public double CalculateHBGI(IEnumerable<double> values) =>
-        KovatchevRisk(values, keepPositive: true, "HBGI");
+        KovatchevRisk(values, keepPositive: true);
 
     /// <summary>
     /// Calculate LBGI (Low Blood Glucose Index)
@@ -1045,27 +1044,20 @@ public class StatisticsService : IStatisticsService
     /// <param name="values">Collection of glucose values</param>
     /// <returns>LBGI value</returns>
     public double CalculateLBGI(IEnumerable<double> values) =>
-        KovatchevRisk(values, keepPositive: false, "LBGI");
+        KovatchevRisk(values, keepPositive: false);
 
     /// <summary>
     /// Mean of the Kovatchev risk transform <c>f(BG) = 1.084 * (ln(BG/18)^1.084 - 1.928)</c> over
     /// <paramref name="values"/>, counting only the readings whose <c>f(BG)</c> falls on one side
     /// of zero: the hyperglycaemic side when <paramref name="keepPositive"/>, the hypoglycaemic
-    /// side otherwise. <paramref name="indexName"/> names the index in the empty-input message.
+    /// side otherwise. Zero for an empty series.
     /// </summary>
     /// <seealso cref="KovatchevMgdlPerMmol"/>
-    private static double KovatchevRisk(
-        IEnumerable<double> values,
-        bool keepPositive,
-        string indexName
-    )
+    private static double KovatchevRisk(IEnumerable<double> values, bool keepPositive)
     {
         var valuesList = values.ToList();
-        if (!valuesList.Any())
-            throw new ArgumentException(
-                $"Not enough data points to calculate {indexName}.",
-                nameof(values)
-            );
+        if (valuesList.Count == 0)
+            return 0;
 
         var riskSum = valuesList.Sum(glucose =>
         {
@@ -1085,19 +1077,11 @@ public class StatisticsService : IStatisticsService
     /// Measures the distance traveled by the glucose line if stretched out
     /// GVI = 1.0-1.2: low variability (non-diabetic), GVI = 1.2-1.5: modest variability, GVI > 1.5: high glycemic variability
     /// </summary>
-    /// <param name="values">Collection of glucose values</param>
     /// <param name="entries">Collection of glucose entries with timestamps</param>
-    /// <returns>GVI value</returns>
-    private double CalculateGVI(IEnumerable<double> values, IEnumerable<SensorGlucose> entries)
+    /// <returns>GVI value, or 1.0 when no pair of entries is close enough together to measure</returns>
+    private double CalculateGVI(IEnumerable<SensorGlucose> entries)
     {
-        var valuesList = values.ToList();
         var entriesList = entries.ToList();
-
-        if (valuesList.Count < 2 || entriesList.Count < 2)
-            throw new ArgumentException(
-                "Not enough data points to calculate GVI (requires at least 2).",
-                nameof(values)
-            );
 
         double actualDistance = 0;
         double idealTime = 0;
@@ -1146,11 +1130,8 @@ public class StatisticsService : IStatisticsService
     public double CalculatePGS(IEnumerable<double> values, double gvi, double meanGlucose)
     {
         var valuesList = values.ToList();
-        if (!valuesList.Any())
-        {
-            // Return 0 instead of throwing exception when no data
+        if (valuesList.Count == 0)
             return 0;
-        }
 
         const double targetLow = GlucoseConstants.TargetBottomMgdl;
         const double targetHigh = GlucoseConstants.TargetTopMgdl;
@@ -2642,7 +2623,6 @@ public class StatisticsService : IStatisticsService
                 },
                 BasicStats = new BasicGlucoseStats(),
                 TimeInRange = new TimeInRangeMetrics(),
-                GlycemicVariability = new GlycemicVariability(),
                 DataQuality = new DataQuality(),
             };
         }

--- a/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
@@ -105,9 +105,11 @@ public interface IStatisticsService
     /// </summary>
     /// <param name="values">Glucose values in mg/dL.</param>
     /// <param name="entries"><see cref="SensorGlucose"/> entries with timestamps for time-dependent metrics.</param>
-    /// <returns>A <see cref="GlycemicVariability"/> containing all variability metrics.</returns>
-    /// <exception cref="ArgumentException">Thrown when there are fewer than 2 data points.</exception>
-    GlycemicVariability CalculateGlycemicVariability(
+    /// <returns>
+    /// A <see cref="GlycemicVariability"/> containing all variability metrics, or null for fewer
+    /// than two values.
+    /// </returns>
+    GlycemicVariability? CalculateGlycemicVariability(
         IEnumerable<double> values,
         IEnumerable<SensorGlucose> entries
     );

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -733,9 +733,11 @@ public class GlucoseAnalytics
     public TimeInRangeMetrics TimeInRange { get; set; } = new();
 
     /// <summary>
-    /// Glycemic variability metrics
+    /// Glycemic variability metrics, or null when the window held fewer than two readings. Every
+    /// metric has a clinical band whose best end is at or near zero, so a defaulted instance reads
+    /// as excellent control rather than as absent data.
     /// </summary>
-    public GlycemicVariability GlycemicVariability { get; set; } = new();
+    public GlycemicVariability? GlycemicVariability { get; set; }
 
     /// <summary>
     /// Data quality assessment

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/day-in-review/+page.svelte
@@ -348,7 +348,8 @@
           <div>
             <div class="text-muted-foreground">CV</div>
             <div class="font-medium tabular-nums">
-              {(analysis?.glycemicVariability?.coefficientOfVariation ?? 0).toFixed(1)}%
+              {analysis?.glycemicVariability?.coefficientOfVariation?.toFixed(1) ??
+                "–"}%
             </div>
           </div>
           <div>

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/glucose-distribution/+page.svelte
@@ -75,10 +75,10 @@
       stdDev: basicStats?.standardDeviation ?? 0,
       // The A1c estimate is computed by the backend; there is no frontend fallback.
       a1cDCCT: analysis?.gmi?.value ?? glycemicVariability?.estimatedA1c ?? null,
-      gvi: glycemicVariability?.glycemicVariabilityIndex ?? 0,
-      pgs: glycemicVariability?.patientGlycemicStatus ?? 0,
-      meanTotalDailyChange: glycemicVariability?.meanTotalDailyChange ?? 0,
-      timeInFluctuation: glycemicVariability?.timeInFluctuation ?? 0,
+      gvi: glycemicVariability?.glycemicVariabilityIndex ?? null,
+      pgs: glycemicVariability?.patientGlycemicStatus ?? null,
+      meanTotalDailyChange: glycemicVariability?.meanTotalDailyChange ?? null,
+      timeInFluctuation: glycemicVariability?.timeInFluctuation ?? null,
     };
   });
 
@@ -252,13 +252,17 @@
               <div class="flex justify-between">
                 <span class="text-muted-foreground">GVI</span>
                 <span class="text-2xl font-bold">
-                  {overallStats.gvi.toFixed(2)}
+                  {overallStats.gvi != null
+                    ? overallStats.gvi.toFixed(2)
+                    : "No estimate"}
                 </span>
               </div>
               <div class="flex justify-between">
                 <span class="text-muted-foreground">PGS</span>
                 <span class="text-2xl font-bold">
-                  {overallStats.pgs.toFixed(1)}
+                  {overallStats.pgs != null
+                    ? overallStats.pgs.toFixed(1)
+                    : "No estimate"}
                 </span>
               </div>
             </div>
@@ -275,13 +279,17 @@
               <div class="flex justify-between">
                 <span class="text-muted-foreground">Mean Total Daily Change</span>
                 <span class="text-2xl font-bold">
-                  {bg(overallStats.meanTotalDailyChange)} {bgLabel()}
+                  {overallStats.meanTotalDailyChange != null
+                    ? `${bg(overallStats.meanTotalDailyChange)} ${bgLabel()}`
+                    : "No estimate"}
                 </span>
               </div>
               <div class="flex justify-between">
                 <span class="text-muted-foreground">Time in Fluctuation</span>
                 <span class="text-2xl font-bold">
-                  {overallStats.timeInFluctuation.toFixed(1)}%
+                  {overallStats.timeInFluctuation != null
+                    ? `${overallStats.timeInFluctuation.toFixed(1)}%`
+                    : "No estimate"}
                 </span>
               </div>
             </div>

--- a/src/Widgets/Nocturne.Widget.Windows11/WidgetProvider.cs
+++ b/src/Widgets/Nocturne.Widget.Windows11/WidgetProvider.cs
@@ -946,7 +946,7 @@ public sealed class NocturneWidgetProvider : IWidgetProvider, IWidgetProvider2
         {
             data["statAvg"] = GlucoseFormatHelper.FormatValue(analytics!.BasicStats.Mean, settings.Unit);
             data["statGmi"] = day!.Gmi is { } gmi ? $"{gmi.Value:0.0}%" : "--";
-            data["statCv"] = $"{analytics.GlycemicVariability.CoefficientOfVariation:0}%";
+            data["statCv"] = analytics.GlycemicVariability is { } gv ? $"{gv.CoefficientOfVariation:0}%" : "--";
         }
 
         return (GetTemplate("StatsTemplate.json"), data);

--- a/tests/Unit/Nocturne.API.Tests/Filters/BadRequestOnInvalidInputAttributeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Filters/BadRequestOnInvalidInputAttributeTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.API.Attributes;
+using Nocturne.API.Controllers.V4.Analytics;
+
+namespace Nocturne.API.Tests.Filters;
+
+[Trait("Category", "Unit")]
+public class BadRequestOnInvalidInputAttributeTests
+{
+    private static readonly IServiceProvider Services = new ServiceCollection()
+        .AddControllers()
+        .Services.BuildServiceProvider();
+
+    private static ExceptionContext Run(Exception exception)
+    {
+        var httpContext = new DefaultHttpContext { RequestServices = Services };
+        var context = new ExceptionContext(
+            new ActionContext(httpContext, new RouteData(), new ActionDescriptor()),
+            new List<IFilterMetadata>()
+        )
+        {
+            Exception = exception,
+        };
+
+        new BadRequestOnInvalidInputAttribute().OnException(context);
+        return context;
+    }
+
+    [Theory]
+    [MemberData(nameof(InputFaults))]
+    public void AnInputFaultBecomesA400ProblemDetailsCarryingTheMessageInDetail(Exception exception)
+    {
+        var context = Run(exception);
+
+        context.ExceptionHandled.Should().BeTrue();
+        var result = context.Result.Should().BeOfType<ObjectResult>().Subject;
+        result.StatusCode.Should().Be(400);
+        var problem = result.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Status.Should().Be(400);
+        problem.Title.Should().Be("Bad Request");
+        problem.Detail.Should().Be(exception.Message);
+    }
+
+    /// <summary>
+    /// <see cref="ObjectDisposedException"/> derives from <see cref="InvalidOperationException"/>,
+    /// so a context used after disposal is answered as a client error. That is what the one action
+    /// already catching the two types by name did, and it is kept rather than special-cased.
+    /// </summary>
+    public static TheoryData<Exception> InputFaults =>
+        [
+            new ArgumentException("bad values"),
+            new ArgumentNullException("entries"),
+            new InvalidOperationException("no profile loaded"),
+            new ObjectDisposedException("NocturneDbContext"),
+        ];
+
+    /// <summary>
+    /// A cancelled request and a server fault both have to reach the global handler; answering
+    /// either with a 400 reports a server-side failure as the caller's fault.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(PropagatedExceptions))]
+    public void EveryOtherExceptionIsLeftUnhandled(Exception exception)
+    {
+        var context = Run(exception);
+
+        context.ExceptionHandled.Should().BeFalse();
+        context.Result.Should().BeNull();
+    }
+
+    public static TheoryData<Exception> PropagatedExceptions =>
+        [
+            new OperationCanceledException(),
+            new TaskCanceledException(),
+            new TimeoutException(),
+            new DbUpdateException("the update failed"),
+            new Exception("connection reset"),
+        ];
+
+    /// <summary>
+    /// The filter changes nothing unless it is applied, so the controller the statistics stack
+    /// answers from has to carry it.
+    /// </summary>
+    [Fact]
+    public void StatisticsControllerCarriesTheAttribute()
+    {
+        typeof(StatisticsController)
+            .GetCustomAttributes(typeof(BadRequestOnInvalidInputAttribute), inherit: false)
+            .Should()
+            .HaveCount(1);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Filters/BadRequestOnInvalidInputPipelineTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Filters/BadRequestOnInvalidInputPipelineTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Nocturne.API.Tests.GoldenFiles.Infrastructure;
+using Nocturne.Core.Contracts.Analytics;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Basal;
+using Nocturne.Core.Models.V4;
+
+namespace Nocturne.API.Tests.Filters;
+
+/// <summary>
+/// Runs the filter through the real pipeline rather than against a hand-built
+/// <c>ExceptionContext</c>: a bare <c>Attribute : IExceptionFilter</c> on the controller class has
+/// to be discovered as filter metadata, run for an async action, and answer before
+/// <c>UseExceptionHandler</c> turns the exception into a 500.
+/// </summary>
+[Trait("Category", "Unit")]
+public class BadRequestOnInvalidInputPipelineTests : IClassFixture<GoldenFileWebAppFactory>
+{
+    private const string Message = "Not enough data points to calculate daily ratios";
+
+    private readonly HttpClient _client;
+
+    public BadRequestOnInvalidInputPipelineTests(GoldenFileWebAppFactory factory)
+    {
+        var statistics = new Mock<IStatisticsService>();
+        statistics
+            .Setup(s =>
+                s.CalculateDailyBasalBolusRatios(
+                    It.IsAny<IEnumerable<Bolus>>(),
+                    It.IsAny<IEnumerable<Bolus>>(),
+                    It.IsAny<IEnumerable<TempBasal>>(),
+                    It.IsAny<TimeZoneInfo?>(),
+                    It.IsAny<IEnumerable<BasalInjection>?>()
+                )
+            )
+            .Throws(new ArgumentException(Message));
+
+        _client = factory
+            .WithWebHostBuilder(builder =>
+                builder.ConfigureServices(services => services.AddScoped(_ => statistics.Object))
+            )
+            .CreateClient();
+    }
+
+    [Fact]
+    public async Task AnArgumentExceptionFromAnAsyncAction_Is400ProblemDetailsWithTheMessageInDetail()
+    {
+        var response = await _client.GetAsync(
+            "/api/v4/statistics/daily-basal-bolus-ratios"
+                + "?startDate=2026-01-01T00:00:00Z&endDate=2026-01-08T00:00:00Z"
+        );
+
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, "the body was: {0}", body);
+
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem.Should().NotBeNull();
+        problem!.Status.Should().Be(400);
+        problem.Title.Should().Be("Bad Request");
+        problem.Detail.Should().Be(Message);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/GlucoseStatisticsCharacterisationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/GlucoseStatisticsCharacterisationTests.cs
@@ -88,7 +88,7 @@ public class GlucoseStatisticsCharacterisationTests
     [Fact]
     public void CalculateGlycemicVariability_PinsSampleStandardDeviationAndDerivedMetrics()
     {
-        var result = _service.CalculateGlycemicVariability(DayCurve, EntriesEveryFiveMinutes(DayCurve));
+        var result = _service.CalculateGlycemicVariability(DayCurve, EntriesEveryFiveMinutes(DayCurve))!;
 
         // Unlike CalculateBasicStats this centres on the unrounded mean 114.375, giving
         // sqrt(sum((v - 114.375)^2) / 23) = 44.19109933990741.
@@ -102,13 +102,54 @@ public class GlucoseStatisticsCharacterisationTests
         result.EstimatedA1c.Should().BeApproximately(5.612369337979094, 1e-12);
     }
 
-    [Fact]
-    public void CalculateGlycemicVariability_ThrowsBelowTwoReadings()
+    /// <summary>
+    /// Every metric's clinical band has its best end at or near zero, so absent data is reported
+    /// as absent rather than as a defaulted instance a consumer would band as excellent control.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void CalculateGlycemicVariability_PinsNullBelowTwoReadings(int readingCount)
     {
-        var act = () => _service.CalculateGlycemicVariability([100d], EntriesEveryFiveMinutes([100d]));
+        var values = DayCurve.Take(readingCount).ToArray();
 
-        act.Should().Throw<ArgumentException>();
+        _service.CalculateGlycemicVariability(values, EntriesEveryFiveMinutes(values))
+            .Should().BeNull();
     }
+
+    /// <summary>
+    /// The timestamped entries are counted separately from the values, so a series that clears the
+    /// aggregate's floor can still leave a timestamp-driven metric under its own.
+    /// </summary>
+    [Fact]
+    public void CalculateGlycemicVariability_PinsTheTimestampedMetricsWithoutEntries()
+    {
+        var result = _service.CalculateGlycemicVariability([100d, 120d], []);
+
+        result.Should().NotBeNull();
+        Metrics(result!).Should().HaveCount(MetricCount)
+            .And.NotContain(metric => double.IsNaN(metric.Value));
+        result!.LabilityIndex.Should().Be(0);
+        result.MeanTotalDailyChange.Should().Be(0);
+        result.TimeInFluctuation.Should().Be(0);
+
+        // No pair of entries survives the 15-minute gap test, so the ideal distance is zero and
+        // GVI reports its floor rather than dividing by it.
+        result.GlycemicVariabilityIndex.Should().Be(1.0);
+    }
+
+    /// <summary>
+    /// Guards <see cref="Metrics"/> against reflecting over nothing, which would make every
+    /// assertion over the set pass vacuously.
+    /// </summary>
+    private const int MetricCount = 14;
+
+    private static IEnumerable<KeyValuePair<string, double>> Metrics(GlycemicVariability variability) =>
+        typeof(GlycemicVariability)
+            .GetProperties()
+            .Where(property => property.PropertyType == typeof(double))
+            .Select(property =>
+                KeyValuePair.Create(property.Name, (double)property.GetValue(variability)!));
 
     #endregion
 
@@ -146,6 +187,16 @@ public class GlucoseStatisticsCharacterisationTests
         _service.CalculateADRR([100d, 100d, 100d]).Should().BeApproximately(0, 1e-12);
     }
 
+    /// <summary>
+    /// An unguarded ADRR reaches <see cref="GlucoseStatistics.StandardDeviation(IReadOnlyCollection{double}, VarianceMode)"/>,
+    /// whose mean of an empty series throws.
+    /// </summary>
+    [Fact]
+    public void CalculateAdrr_PinsZeroForAnEmptySeries()
+    {
+        _service.CalculateADRR([]).Should().Be(0);
+    }
+
     [Fact]
     public void CalculateJIndex_PinsThePopulationVarianceComponent()
     {
@@ -153,6 +204,16 @@ public class GlucoseStatisticsCharacterisationTests
 
         // 0.324 * (114.375 - 112)^2 + 0.0018 * (sum(dev^2) / 24)
         _service.CalculateJIndex(DayCurve, mean).Should().BeApproximately(5.1962343749999995, 1e-12);
+    }
+
+    /// <summary>
+    /// The population variance divides by the reading count, so an unguarded J-Index over an empty
+    /// series would report <see cref="double.NaN"/> from <c>0 / 0</c>.
+    /// </summary>
+    [Fact]
+    public void CalculateJIndex_PinsZeroForAnEmptySeries()
+    {
+        _service.CalculateJIndex([], 0).Should().Be(0);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceClinicalAccuracyTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceClinicalAccuracyTests.cs
@@ -1023,7 +1023,7 @@ public class StatisticsServiceClinicalAccuracyTests
             Timestamp = DateTimeOffset.UtcNow.AddMinutes(i * 5).UtcDateTime,
         });
 
-        var result = _sut.CalculateGlycemicVariability(values, entries);
+        var result = _sut.CalculateGlycemicVariability(values, entries)!;
 
         // CV < 36% is the clinical target
         result.CoefficientOfVariation.Should().BeLessThan(36);
@@ -1041,7 +1041,7 @@ public class StatisticsServiceClinicalAccuracyTests
             Timestamp = DateTimeOffset.UtcNow.AddMinutes(i * 5).UtcDateTime,
         });
 
-        var result = _sut.CalculateGlycemicVariability(values, entries);
+        var result = _sut.CalculateGlycemicVariability(values, entries)!;
 
         result.CoefficientOfVariation.Should().BeGreaterThan(50);
     }
@@ -1169,7 +1169,7 @@ public class StatisticsServiceClinicalAccuracyTests
         }).ToArray();
 
         var basicStats = _sut.CalculateBasicStats(values);
-        var gv = _sut.CalculateGlycemicVariability(values, entries);
+        var gv = _sut.CalculateGlycemicVariability(values, entries)!;
 
         // Both use sample SD (N-1): sqrt(Σ(x-mean)²/4) = sqrt(4000/4) = sqrt(1000) ≈ 31.6
         basicStats.StandardDeviation.Should().Be(

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
@@ -146,34 +146,13 @@ public class StatisticsServiceTests
         );
 
         // Act
-        var result = _statisticsService.CalculateGlycemicVariability(values, entries);
+        var result = _statisticsService.CalculateGlycemicVariability(values, entries)!;
 
         // Assert
         result.Should().NotBeNull();
         result.CoefficientOfVariation.Should().BeGreaterThan(0);
         result.StandardDeviation.Should().BeGreaterThan(0);
         result.EstimatedA1c.Should().BeGreaterThan(0);
-    }
-
-    [Fact]
-    public void CalculateGlycemicVariability_WithInsufficientData_ShouldThrowException()
-    {
-        // Arrange
-        var values = new double[] { 100 };
-        var entries = new[]
-        {
-            new SensorGlucose
-            {
-                Mgdl = 100,
-                Timestamp = DateTimeOffset.UtcNow.UtcDateTime,
-            },
-        };
-
-        // Act & Assert
-        Action act = () => _statisticsService.CalculateGlycemicVariability(values, entries);
-        act.Should()
-            .Throw<ArgumentException>()
-            .WithMessage("Not enough data points to calculate glycemic variability metrics");
     }
 
     [Fact]
@@ -714,7 +693,7 @@ public class StatisticsServiceTests
         );
 
         // Act
-        var result = _statisticsService.CalculateGlycemicVariability(values, entries);
+        var result = _statisticsService.CalculateGlycemicVariability(values, entries)!;
 
         // Assert
         result.Should().NotBeNull();


### PR DESCRIPTION
Fixes #1098

## 1. One error policy on the controller

`StatisticsController` hand-rolled its error policy 28 times: a catch-all returning `BadRequest(new { error = ex.Message })` on 26 actions, an `OperationCanceledException` rethrow on one, and one `ArgumentException`/`InvalidOperationException` pair. A database timeout was answered as a 400 carrying the raw exception message, in an anonymous `{ error }` body that no web error arm reads (`error-body.ts` and the generated catch chain extract only ProblemDetails `detail`/`title`/`message`), so the caller saw NSwag's "An unexpected server error occurred." boilerplate instead of the server's sentence.

All 28 are replaced by one `[BadRequestOnInvalidInput]` exception filter on the controller. It maps `ArgumentException` and `InvalidOperationException` to the same 400 ProblemDetails the rest of V4 returns (built through the MVC `ProblemDetailsFactory`, so the body equals `Problem(detail:, statusCode: 400, title: "Bad Request")`), and leaves everything else, cancellation included, to the global handler. It is an attribute rather than a global filter registration so no other controller's status codes move; `ApiErrorEnvelopeHandler` was not extended because it is hardcoded to 500 and shapes bodies per Nightscout API version. The two literal-message validation 400s move to `Problem(...)` for the same body shape.

The controller diff is mechanical apart from that: `git diff -w` shows 7 insertions / 208 deletions — the class attribute, the two `Problem(...)` conversions, the `NoContent()` branch and one `<returns>` line; everything deleted is try/catch scaffolding. Attribute counts (`RequireScope`, `EnableRateLimiting`, `RemoteQuery`, `RequestSizeLimit`) and all 28 action signatures are unchanged.

## 2. One sparse-data policy in `CalculateGlycemicVariability`

The aggregate ran nine metric helpers under four policies: four throw sites (`ArgumentException`), three zero floors, and two unguarded paths (`CalculateADRR` → `values.Average()` on empty; `CalculateJIndex` → `0/0` NaN). The aggregate's own `Count < 2` throw ran first, so the real drift was `values.Count >= 2` with `entries.Count < 2`: LabilityIndex/GVI threw (400) while MAGE/CONGA returned 0.

Insufficient data is now a discriminator, not zeros: an all-zero `GlycemicVariability` would emit values outside the metrics' domains (GVI cannot be below 1.0 by construction; PGS ≤ 35 is banded "excellent"; an A1c of 0), and the report pages colour-band on them. So `CalculateGlycemicVariability` returns `GlycemicVariability?` (null below two readings), `GlucoseAnalytics.GlycemicVariability` is nullable with no `= new()` initialiser (`AnalyzeGlucoseData`'s zero-reading path, which already had this defect, nulls it too), and `POST glycemic-variability` returns `NoContent()` on null exactly as `CalculateOverallAverages` already does. Every remaining helper floor returns 0 for direct callers; ADRR and J-Index gain empty guards; `CalculateGVI`'s guard is deleted because it already had a defined degenerate answer (`idealTime == 0 → 1.0`), which also made its `values` parameter dead.

Consumers walked: all 12 web reads of `glycemicVariability` already use `?.`/`?? {}`/`!= null` and now render the no-data glyph (`"–"`, "No data", blanked diff row) instead of `0.0`; the IDP page's CV banding falls to its `?? 50` default (orange, not green). Two sites that coerced `?? 0` (`glucose-distribution`'s GVI/PGS/MTDC/TIF card, `day-in-review`'s CV) now render each page's existing no-data text; `pnpm check` error set is identical before and after (51 pre-existing), and both files were already prettier-non-conforming (not reformatted). `WidgetProvider.cs` (Windows widget) and `AssessAgainstTargets` gained null handling; the latter still assesses CV 0 as "met" for a null variability, byte-identical to before (noted on #1100).

## Behavioural deltas

Body shape on every 400 from this controller: `{ error }` → ProblemDetails (`detail` carries the message).

Status codes on the 27 formerly catch-all actions:

| Fault | Before | After |
|---|---|---|
| `ArgumentException`, `InvalidOperationException` | 400 `{error}` | 400 ProblemDetails |
| `OperationCanceledException` | 400 | propagates |
| everything else (`DbUpdateException`, `NpgsqlException`, `TimeoutException`, …) | 400 with the raw exception message | 500, no exception text |

`ObjectDisposedException : InvalidOperationException` is still answered as 400, as it was on `GetHourlyInsulinDelivery` before.

Wire: `glycemicVariability` becomes nullable on `GlucoseAnalytics`/`ExtendedGlucoseAnalytics` and is serialised as an explicit `null` (V4 uses the default JSON options; `NightscoutJsonFilter`'s default-dropping applies to V1–V3 only) on `POST comprehensive-analytics`, `POST extended-analytics`, `GET range-analytics` and the `GET periods` per-period analytics when the window held fewer than two readings; previously a zero-filled object. The generated TS client types it `glycemicVariability?: GlycemicVariability | undefined`. `POST glycemic-variability`'s 204 is not in the OpenAPI doc (no action on this controller declares `ProducesResponseType`); the NSwag template resolves 204 to `null`, as it already does for `calculateOverallAverages`. `POST glycemic-variability` with fewer than two values: 400 → 204. `values ≥ 2, entries < 2`: 400 → 200 with `LabilityIndex: 0`, `GlycemicVariabilityIndex: 1.0`. Direct `IStatisticsService` calls: `CalculateHBGI/LBGI([])` 400-class exception → 0, `CalculateADRR([])` exception → 0, `CalculateJIndex([])` NaN → 0. `IStatisticsService.CalculateGlycemicVariability`'s return type changes.

## Tests

`BadRequestOnInvalidInputAttributeTests`: `ArgumentException`/`ArgumentNullException`/`InvalidOperationException`/`ObjectDisposedException` → 400 ProblemDetails; `OperationCanceledException`/`TaskCanceledException`/`TimeoutException`/`DbUpdateException`/`Exception` left unhandled; the controller carries the attribute. `BadRequestOnInvalidInputPipelineTests` drives `GET daily-basal-bolus-ratios` through the full `Program.cs` pipeline (`GoldenFileWebAppFactory`, `IStatisticsService` mocked to throw) and asserts 400 ProblemDetails, proving MVC discovers the bare `IExceptionFilter` attribute on the class, that it fires for an async action, and that it precedes `UseExceptionHandler` (deleting the attribute fails it). Characterisation: 0 and 1 readings → null; `values ≥ 2 / entries < 2` → 14 metrics, none NaN, `GlycemicVariabilityIndex == 1.0`; `CalculateAdrr_PinsZeroForAnEmptySeries`; `CalculateJIndex_PinsZeroForAnEmptySeries`.

Mutation-proven: ADRR `return 0 → NaN` fails 1; GVI floor `1.0 → 0.0` fails 1; aggregate `null → new()` fails 2; one divergent helper throw fails 1; attribute removed fails 2; filter widened to catch-all fails 2.

`Nocturne.API.Tests` (CI filter) 6367/0. Diff: prod −170 net (8 files incl. 2 web), tests +206.
