### PR TITLE
refactor(cache): drop stats:/cob: invalidation and dead constants

### DIFF
--- a/src/Core/Nocturne.Core.Constants/DataSources.cs
+++ b/src/Core/Nocturne.Core.Constants/DataSources.cs
@@ -234,44 +234,4 @@ public static class DataSources
         LibreConnector or MyLifeConnector => 1,
         _ => 5,
     };
-
-    /// <summary>
-    /// Gets all known data source identifier values.
-    /// </summary>
-    /// <value>A read-only list of every data source constant defined in this class.</value>
-    public static IReadOnlyList<string> All { get; } =
-        new[]
-        {
-            DemoService,
-            Testing,
-            DexcomConnector,
-            LibreConnector,
-            MiniMedConnector,
-            CareLinkConnector,
-            GlookoConnector,
-            NightscoutConnector,
-            GlurooConnector,
-            TidepoolConnector,
-            TConnectSyncConnector,
-            HomeAssistantConnector,
-            EversenseConnector,
-            NocturneRemoteConnector,
-            TwiistConnector,
-            XDrip,
-            Spike,
-            ManualEntry,
-            Careportal,
-            ApiClient,
-            MongoDbImport,
-            CsvImport,
-            TidepoolImport,
-            Unknown,
-            System,
-            WebSocket,
-            Loop,
-            OpenAps,
-            AndroidAps,
-            IAps,
-            Trio,
-        };
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Constants/CacheConstants.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Constants/CacheConstants.cs
@@ -21,70 +21,17 @@ public static class CacheConstants
     /// </summary>
     public static class Defaults
     {
-        public const int DefaultExpirationSeconds = 300; // 5 minutes
         public const int CurrentEntryExpirationSeconds = 60; // 1 minute
         public const int RecentEntriesExpirationSeconds = 120; // 2 minutes
         public const int RecentTreatmentsExpirationSeconds = 300; // 5 minutes
-        public const int ProfileTimestampExpirationSeconds = 1800; // 30 minutes
-        public const int IobCalculationExpirationSeconds = 900; // 15 minutes
-        public const int CobCalculationExpirationSeconds = 900; // 15 minutes
-        public const int ProfileCalculationExpirationSeconds = 3600; // 1 hour
-        public const int StatisticsExpirationSeconds = 1800; // 30 minutes
-        public const string KeyPrefix = "nocturne";
-        public const bool EnableBackgroundCacheRefresh = false;
-        public const bool EnableCalculationCacheCompression = false;
     }
 
     /// <summary>
-    /// Cache key prefixes and patterns
+    /// Cache key prefixes
     /// </summary>
     public static class KeyPrefixes
     {
-        public const string Entries = "entries";
-        public const string Treatments = "treatments";
-        public const string DeviceStatus = "devicestatus";
-        public const string Profiles = "profiles";
-        public const string Food = "food";
-        public const string Settings = "settings";
-        public const string Status = "status";
-        public const string Version = "version";
-        public const string Loop = "loop";
-        public const string Iob = "iob";
-        public const string Cob = "cob";
-        public const string Current = "current";
-        public const string Recent = "recent";
-        public const string Calculations = "calculations";
-        public const string Stats = "stats";
         public const string System = "system";
-        public const string Response = "response";
-        public const string ProcessingStatus = "processing:status";
-    }
-
-    /// <summary>
-    /// Cache invalidation patterns
-    /// </summary>
-    public static class InvalidationPatterns
-    {
-        public const string AllPattern = "*";
-        public const string GlucosePattern = "glucose:*";
-        public const string TirPattern = "tir:*";
-        public const string HbA1cPattern = "hba1c:*";
-    }
-
-    /// <summary>
-    /// Response cache route patterns
-    /// </summary>
-    public static class CacheableRoutes
-    {
-        public const string EntriesCurrent = "/api/v1/entries/current";
-        public const string Entries = "/api/v1/entries";
-        public const string Treatments = "/api/v1/treatments";
-        public const string Profile = "/api/v1/profile";
-        public const string Status = "/api/v1/status";
-        public const string EntriesCurrentV2 = "/api/v2/entries/current";
-        public const string EntriesV2 = "/api/v2/entries";
-        public const string TreatmentsV2 = "/api/v2/treatments";
-        public const string ProfileV2 = "/api/v2/profile";
     }
 
     /// <summary>
@@ -93,18 +40,6 @@ public static class CacheConstants
     public static class EntryTypes
     {
         public const string Sgv = "sgv";
-        public const string Mbg = "mbg";
-        public const string Cal = "cal";
-    }
-
-    /// <summary>
-    /// Statistics periods
-    /// </summary>
-    public static class StatsPeriods
-    {
-        public const string TwentyFourHours = "24h";
-        public const string SevenDays = "7d";
-        public const string ThirtyDays = "30d";
     }
 
     /// <summary>
@@ -113,7 +48,6 @@ public static class CacheConstants
     public static class CleanupIntervals
     {
         public static readonly TimeSpan StatusCleanup = TimeSpan.FromMinutes(5);
-        public static readonly TimeSpan CacheCleanup = TimeSpan.FromMinutes(5);
     }
 
     /// <summary>
@@ -124,6 +58,5 @@ public static class CacheConstants
         public static readonly TimeSpan ProcessingStatus = TimeSpan.FromHours(1);
         public static readonly TimeSpan SystemLookups = TimeSpan.FromHours(4);
         public static readonly TimeSpan SystemStatus = TimeSpan.FromMinutes(5);
-        public static readonly TimeSpan StatusResponse = TimeSpan.FromMinutes(2);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Keys/CacheKeyBuilder.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Keys/CacheKeyBuilder.cs
@@ -145,14 +145,6 @@ public static class CacheKeyBuilder
         BuildKey("calculations", "iob", userId, timestamp.ToString());
 
     /// <summary>
-    /// Builds a cache key for COB calculation results
-    /// </summary>
-    /// <param name="userId">User ID</param>
-    /// <param name="timestamp">Timestamp for calculation</param>
-    public static string BuildCobCalculationKey(string userId, long timestamp) =>
-        BuildKey("calculations", "cob", userId, timestamp.ToString());
-
-    /// <summary>
     /// Builds a cache key for profile calculations at timestamp
     /// </summary>
     /// <param name="profileId">Profile ID</param>
@@ -166,20 +158,6 @@ public static class CacheKeyBuilder
     /// <param name="userId">User ID</param>
     public static string BuildIobCalculationPattern(string userId) =>
         $"calculations{KeySeparator}iob{KeySeparator}{userId}{KeySeparator}*";
-
-    /// <summary>
-    /// Creates a pattern for invalidating all COB calculation cache for a user
-    /// </summary>
-    /// <param name="userId">User ID</param>
-    public static string BuildCobCalculationPattern(string userId) =>
-        $"calculations{KeySeparator}cob{KeySeparator}{userId}{KeySeparator}*";
-
-    /// <summary>
-    /// Creates a pattern for invalidating all statistics cache for a user
-    /// </summary>
-    /// <param name="userId">User ID</param>
-    public static string BuildStatsPattern(string userId) =>
-        $"stats{KeySeparator}*{KeySeparator}{userId}{KeySeparator}*";
 
     /// <summary>
     /// Creates a pattern for invalidating all profile calculated cache for a profile

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/README.md
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/README.md
@@ -140,7 +140,6 @@ public class TreatmentService
         // Automatically invalidates:
         // - treatments:recent:*
         // - calculations:iob:*
-        // - stats:*
         await _invalidation.InvalidateForNewInsulinTreatmentAsync(treatment.UserId);
     }
 }
@@ -151,18 +150,14 @@ public class TreatmentService
 The system uses consistent, hierarchical cache keys for diabetes data:
 
 ```
-glucose:{userId}:recent           # Last 24 hours glucose readings
-glucose:{userId}:trends          # Calculated trends and statistics
-user:{userId}:profile            # User profile information
-user:{userId}:settings           # User preferences and settings
-system:lookups                   # System-wide lookup data
-entries:current                  # Current entry cache
-entries:recent:{userId}:{count}  # Recent entries with filters
-treatments:recent:{userId}:{hours} # Recent treatments by time
-calculations:iob:{userId}:{timestamp} # IOB calculation results
-calculations:cob:{userId}:{timestamp} # COB calculation results
-stats:glucose:{userId}:{period}  # Glucose statistics
-profiles:at:{userId}:{timestamp} # Profile at specific time
+entries:current:{tenantId}                  # Current entry cache
+entries:recent:{tenantId}:{count}           # Recent entries with filters
+treatments:recent:{tenantId}:{hours}h       # Recent treatments by time
+calculations:iob:{tenantId}:{timestamp}     # IOB calculation results
+profiles:current:{tenantId}                 # Active profile
+profiles:calculated:{profileId}:{timestamp} # Profile calculated at a timestamp
+system:lookups                              # System-wide lookup data
+system:status                               # System status
 ```
 
 ## Cache Policies & TTL
@@ -261,7 +256,7 @@ The memory cache now supports advanced features:
 ```csharp
 // Pattern-based cache invalidation now works in memory cache
 await cacheService.RemoveByPatternAsync("entries:recent:*");
-await cacheService.RemoveByPatternAsync("user:123:*");
+await cacheService.RemoveByPatternAsync("calculations:iob:*");
 
 // Get enhanced statistics
 var stats = await cacheService.GetStatisticsAsync();
@@ -290,7 +285,7 @@ Enhanced health check system with better diagnostics:
 
 ### 🔧 Constants and Maintainability
 
-- **Centralized Constants**: All magic strings moved to `CacheConstants` class
+- **Shared Constants**: Processing statuses, default TTLs, and cleanup intervals live in `CacheConstants`; most keys come from `CacheKeyBuilder`, though some callers still assemble their own
 - **Consistent Naming**: Standardized health check names and tags
 - **Better Service Lifetimes**: Optimized singleton/scoped registrations
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/CacheInvalidationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/CacheInvalidationService.cs
@@ -6,14 +6,13 @@ using Nocturne.Infrastructure.Cache.Services;
 namespace Nocturne.Infrastructure.Cache.Services;
 
 /// <summary>
-/// Service for managing complex cache invalidation chains for Phase 3 calculations
-/// Implements the invalidation patterns specified in the issue requirements
+/// Removes the cache entries invalidated by a new treatment, entry, or profile change.
 /// </summary>
 public interface ICacheInvalidationService
 {
     /// <summary>
     /// Invalidate cache when new insulin treatment is added
-    /// Invalidates: treatments:recent:*, calculations:iob:*, stats:*
+    /// Invalidates: treatments:recent:*, calculations:iob:*
     /// </summary>
     Task InvalidateForNewInsulinTreatmentAsync(
         string userId,
@@ -22,7 +21,7 @@ public interface ICacheInvalidationService
 
     /// <summary>
     /// Invalidate cache when new carb treatment is added
-    /// Invalidates: treatments:recent:*, calculations:cob:*, stats:*
+    /// Invalidates: treatments:recent:*
     /// </summary>
     Task InvalidateForNewCarbTreatmentAsync(
         string userId,
@@ -31,7 +30,7 @@ public interface ICacheInvalidationService
 
     /// <summary>
     /// Invalidate cache when new glucose entry is added
-    /// Invalidates: entries:current, entries:recent:*, stats:glucose:*, stats:tir:*, stats:hba1c:*
+    /// Invalidates: entries:current, entries:recent:*
     /// </summary>
     Task InvalidateForNewGlucoseEntryAsync(
         string userId,
@@ -40,7 +39,7 @@ public interface ICacheInvalidationService
 
     /// <summary>
     /// Invalidate cache when profile changes
-    /// Invalidates: profiles:*, calculations:iob:*, calculations:cob:*
+    /// Invalidates: profiles:*, calculations:iob:*
     /// </summary>
     Task InvalidateForProfileChangeAsync(
         string userId,
@@ -57,9 +56,6 @@ public interface ICacheInvalidationService
     );
 }
 
-/// <summary>
-/// Implementation of cache invalidation service for Phase 3 calculation chains
-/// </summary>
 public class CacheInvalidationService : ICacheInvalidationService
 {
     private readonly ICacheService _cacheService;
@@ -90,7 +86,6 @@ public class CacheInvalidationService : ICacheInvalidationService
             // Invalidation chain for new insulin treatment:
             // - treatments:recent:* (recent treatments cache)
             // - calculations:iob:* (all IOB calculations)
-            // - stats:* (potentially affected statistics)
 
             var invalidationTasks = new List<Task>
             {
@@ -100,10 +95,6 @@ public class CacheInvalidationService : ICacheInvalidationService
                 ),
                 _cacheService.RemoveByPatternAsync(
                     CacheKeyBuilder.BuildIobCalculationPattern(userId),
-                    cancellationToken
-                ),
-                _cacheService.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildStatsPattern(userId),
                     cancellationToken
                 ),
             };
@@ -141,21 +132,11 @@ public class CacheInvalidationService : ICacheInvalidationService
 
             // Invalidation chain for new carb treatment:
             // - treatments:recent:* (recent treatments cache)
-            // - calculations:cob:* (all COB calculations)
-            // - stats:* (potentially affected statistics)
 
             var invalidationTasks = new List<Task>
             {
                 _cacheService.RemoveByPatternAsync(
                     CacheKeyBuilder.BuildRecentTreatmentsPattern(userId),
-                    cancellationToken
-                ),
-                _cacheService.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildCobCalculationPattern(userId),
-                    cancellationToken
-                ),
-                _cacheService.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildStatsPattern(userId),
                     cancellationToken
                 ),
             };
@@ -194,9 +175,6 @@ public class CacheInvalidationService : ICacheInvalidationService
             // Invalidation chain for new glucose entry:
             // - entries:current (current entries cache)
             // - entries:recent:* (recent entries cache)
-            // - stats:glucose:* (glucose statistics)
-            // - stats:tir:* (time in range statistics)
-            // - stats:hba1c:* (HbA1c estimates)
 
             var invalidationTasks = new List<Task>
             {
@@ -206,18 +184,6 @@ public class CacheInvalidationService : ICacheInvalidationService
                 ),
                 _cacheService.RemoveByPatternAsync(
                     CacheKeyBuilder.BuildRecentEntriesPattern(userId),
-                    cancellationToken
-                ),
-                _cacheService.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildPattern("stats", userId, "glucose:*"),
-                    cancellationToken
-                ),
-                _cacheService.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildPattern("stats", userId, "tir:*"),
-                    cancellationToken
-                ),
-                _cacheService.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildPattern("stats", userId, "hba1c:*"),
                     cancellationToken
                 ),
             };
@@ -258,7 +224,6 @@ public class CacheInvalidationService : ICacheInvalidationService
             // Invalidation chain for profile change:
             // - profiles:* (all profile caches)
             // - calculations:iob:* (basal rates affect IOB)
-            // - calculations:cob:* (carb ratios affect COB)
 
             var invalidationTasks = new List<Task>
             {
@@ -268,10 +233,6 @@ public class CacheInvalidationService : ICacheInvalidationService
                 ),
                 _cacheService.RemoveByPatternAsync(
                     CacheKeyBuilder.BuildIobCalculationPattern(userId),
-                    cancellationToken
-                ),
-                _cacheService.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildCobCalculationPattern(userId),
                     cancellationToken
                 ),
             };
@@ -344,15 +305,6 @@ public class CacheInvalidationService : ICacheInvalidationService
                 // Calculations
                 _cacheService.RemoveByPatternAsync(
                     CacheKeyBuilder.BuildIobCalculationPattern(userId),
-                    cancellationToken
-                ),
-                _cacheService.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildCobCalculationPattern(userId),
-                    cancellationToken
-                ),
-                // Statistics
-                _cacheService.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildStatsPattern(userId),
                     cancellationToken
                 ),
             };

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/CachedCalculationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/CachedCalculationService.cs
@@ -22,19 +22,9 @@ public class CalculationCacheConfiguration
     public int IobCalculationExpirationSeconds { get; set; } = 900; // 15 minutes
 
     /// <summary>
-    /// COB calculation cache expiration in seconds (default: 15 minutes)
-    /// </summary>
-    public int CobCalculationExpirationSeconds { get; set; } = 900; // 15 minutes
-
-    /// <summary>
     /// Profile calculation cache expiration in seconds (default: 1 hour)
     /// </summary>
     public int ProfileCalculationExpirationSeconds { get; set; } = 3600; // 1 hour
-
-    /// <summary>
-    /// Statistics cache expiration in seconds (default: 30 minutes)
-    /// </summary>
-    public int StatisticsExpirationSeconds { get; set; } = 1800; // 30 minutes
 }
 
 /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Services/CalculationCacheTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/CalculationCacheTests.cs
@@ -52,9 +52,7 @@ public class Phase3CalculationCacheTests
             new CalculationCacheConfiguration
             {
                 IobCalculationExpirationSeconds = 900,
-                CobCalculationExpirationSeconds = 900,
                 ProfileCalculationExpirationSeconds = 3600,
-                StatisticsExpirationSeconds = 1800,
             }
         );
     }
@@ -278,14 +276,35 @@ public class Phase3CalculationCacheTests
                 ),
             Times.Once
         );
+        _mockCacheService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    [Trait("Category", "Cache")]
+    [Trait("Category", "Invalidation")]
+    public async Task CacheInvalidationService_InvalidateForNewCarbTreatment_InvalidatesCorrectPatterns()
+    {
+        // Arrange
+        var userId = "test-user";
+        var invalidationService = new CacheInvalidationService(
+            _mockCacheService.Object,
+            _mockInvalidationLogger.Object
+        );
+
+        // Act
+        await invalidationService.InvalidateForNewCarbTreatmentAsync(userId, CancellationToken.None);
+
+        // Assert
         _mockCacheService.Verify(
             x =>
                 x.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildStatsPattern(userId),
+                    CacheKeyBuilder.BuildRecentTreatmentsPattern(userId),
                     It.IsAny<CancellationToken>()
                 ),
             Times.Once
         );
+        _mockCacheService.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -321,30 +340,7 @@ public class Phase3CalculationCacheTests
                 ),
             Times.Once
         );
-        _mockCacheService.Verify(
-            x =>
-                x.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildPattern("stats", userId, "glucose:*"),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Once
-        );
-        _mockCacheService.Verify(
-            x =>
-                x.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildPattern("stats", userId, "tir:*"),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Once
-        );
-        _mockCacheService.Verify(
-            x =>
-                x.RemoveByPatternAsync(
-                    CacheKeyBuilder.BuildPattern("stats", userId, "hba1c:*"),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Once
-        );
+        _mockCacheService.VerifyNoOtherCalls();
     }
 
     #endregion
@@ -366,24 +362,6 @@ public class Phase3CalculationCacheTests
 
         // Assert
         var expected = $"calculations:iob:{userId}:{timestamp}";
-        Assert.Equal(expected, key);
-    }
-
-    [Theory]
-    [InlineData("user123", 1640995200000L)] // 2022-01-01 00:00:00 UTC
-    [InlineData("user456", 1641081600000L)] // 2022-01-02 00:00:00 UTC
-    [Trait("Category", "Unit")]
-    [Trait("Category", "CacheKeys")]
-    public void CacheKeyBuilder_BuildCobCalculationKey_GeneratesCorrectKey(
-        string userId,
-        long timestamp
-    )
-    {
-        // Act
-        var key = CacheKeyBuilder.BuildCobCalculationKey(userId, timestamp);
-
-        // Assert
-        var expected = $"calculations:cob:{userId}:{timestamp}";
         Assert.Equal(expected, key);
     }
 


### PR DESCRIPTION
Fixes #1109

Deletion only. Every member removed was proven reader-free (or, for the invalidation sweeps, writer-free) with `git grep` over `src/ tests/ tools/ crates/ sdk/`; the whole solution builds afterwards.

## The `stats:` sweeps

`CacheKeyBuilder.BuildKey` has zero call sites outside `CacheKeyBuilder.cs`, so no caller can construct a `stats`-category key; `git grep` for `"stats"`, `stats:` and `$"stats` finds only the declaration, the three `BuildPattern("stats", …)` sites and unrelated web UI labels. The six sweeps in `CacheInvalidationService` (3× `BuildStatsPattern`, 3× literal `BuildPattern("stats", userId, …)`) were scanning for keys nothing ever wrote. `BuildStatsPattern`, the six sweeps, the six `// - stats:…` chain comments and the `stats:*` clauses in the interface docs are gone; the four `Verify` blocks in `CalculationCacheTests` that pinned those sweeps go with them (both tests keep their remaining live assertions).

## `calculations:cob:*`

The same shape one namespace over: `BuildCobCalculationKey` has no production caller, so no `calculations:cob:` key is ever written, yet three invalidation sweeps, the interface docs and the README advertised it (there is no `CachedCobService`; only IOB and profile calculations are cached). The key/pattern builders, the three sweeps and their mentions are deleted under the same no-writer proof.

## `DataSources.All`, `CacheConstants`

`DataSources.All` and `CacheConstants.KeyPrefixes.Stats` had zero readers. Widened to finish `CacheConstants.cs`: with no `using static CacheConstants` anywhere, every reference must be spelled `CacheConstants.<Group>.<Member>`, so enumerating those is a complete reader set. Declared vs referenced is now an exact bijection of 13 members; 29 dead members were removed (`InvalidationPatterns`, `CacheableRoutes` and `StatsPeriods` whole; 9 `Defaults`, 16 `KeyPrefixes`, `EntryTypes.Mbg/Cal`, `CleanupIntervals.CacheCleanup`, `DefaultTtl.StatusResponse`). `InvalidationPatterns.GlucosePattern/TirPattern/HbA1cPattern` were byte-identical to the literals the deleted sweeps hardcoded and were never referenced by them. The write-only `CalculationCacheConfiguration.StatisticsExpirationSeconds` and `CobCalculationExpirationSeconds` (there is no `CachedCobService` for the latter to configure) are deleted with their test assignments.

The `ICacheInvalidationService` summary no longer refers to "Phase 3" or "the issue requirements"; the `Phase3*` file/type names are untouched. The Cache project's README loses its `stats:*` and `calculations:cob:*` lines, its key-pattern rows that nothing emits (`glucose:*`, `user:*`, `profiles:at:*`), and the false claim that all magic strings live in `CacheConstants`; the surviving rows are corrected to the shapes the builders and `CacheWarmingService` actually write, and the three real keys it omitted are added. `StatisticsController` does cache `GET periods` under a `statistics:multi-period:` key with a hard-coded TTL; that prefix never matched `stats:*`, so it is unaffected (and nothing invalidates it, which is #1097's territory).

## Behavioural deltas

- The invalidation entry points no longer issue `RemoveByPatternAsync` for `stats:*` or `calculations:cob:*` patterns: one to three fewer pattern scans per insulin treatment, carb treatment, glucose entry and nuclear invalidation. Cache correctness is unchanged because no matching key was ever written.
- The constant deletions are inert at runtime (zero readers). `CacheConstants` and `CacheKeyBuilder` are public in a non-packaged project, so an out-of-tree consumer would see a source break; nothing in this repo does.

## Tests

Diff: prod −192 net (6 files incl. README), tests −22. The two surviving invalidation tests gain `VerifyNoOtherCalls()`, so a reintroduced sweep fails them (mutation-proven by re-adding one). `InvalidateForNewCarbTreatmentAsync` had no test at all (re-adding its cob sweep survived 10/10), so it gains one with the same shape; `InvalidateForProfileChangeAsync` and `InvalidateAllCalculationsAsync` remain untested (noted on #1124 with the profile-namespace findings). `Nocturne.Core.Constants.Tests` 29/0, `Nocturne.Infrastructure.Cache.Tests` 2/0, `Nocturne.API.Tests` (unit filter) 6352/0 (−2 deleted cob rows, +1 carb fact).
