### PR TITLE
refactor(api): one size policy for every V4 bulk write

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Base/V4BulkValidation.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4BulkValidation.cs
@@ -14,10 +14,32 @@ public static class V4BulkValidation
     /// Maximum records one bulk create-or-update request may carry.
     /// </summary>
     /// <remarks>
-    /// Flat-record bulks share this ceiling; a shape whose items nest collections carries its own
-    /// lower one (<c>SleepController.CreateSessionsBulk</c>).
+    /// Flat-record bulks share this ceiling; a shape whose items nest collections passes its own
+    /// lower one to <see cref="ValidateBulkSize{TRequest}"/>.
     /// </remarks>
     public const int MaxItems = 1000;
+
+    /// <summary>
+    /// Rejects a payload that is absent, empty, or longer than <paramref name="maxItems"/>.
+    /// </summary>
+    /// <param name="subject">The payload's name, as it opens the empty-payload message ("Bolus").</param>
+    /// <param name="plural">Many items ("boluses").</param>
+    /// <returns>The error response to return, or <c>null</c> when the payload is usable.</returns>
+    public static ObjectResult? ValidateBulkSize<TRequest>(
+        this ControllerBase controller,
+        IReadOnlyList<TRequest>? requests,
+        string subject,
+        string plural,
+        int maxItems = MaxItems)
+    {
+        if (requests is not { Count: > 0 })
+            return controller.Problem(detail: $"{subject} data is required", statusCode: 400, title: "Bad Request");
+
+        if (requests.Count > maxItems)
+            return controller.Problem(detail: $"Bulk operations are limited to {maxItems} {plural} per request", statusCode: 400, title: "Bad Request");
+
+        return null;
+    }
 
     /// <summary>
     /// Rejects a payload that is empty, longer than <see cref="MaxItems"/>, carries an unset
@@ -47,24 +69,23 @@ public static class V4BulkValidation
         CancellationToken ct = default)
         where TRequest : IBulkUpsertRequest
     {
-        if (requests is not { Length: > 0 })
-            return controller.Problem(detail: $"{subject} data is required", statusCode: 400, title: "Bad Request");
+        if (controller.ValidateBulkSize(requests, subject, plural) is { } invalid)
+            return invalid;
 
-        if (requests.Length > MaxItems)
-            return controller.Problem(detail: $"Bulk operations are limited to {MaxItems} {plural} per request", statusCode: 400, title: "Bad Request");
+        var items = requests!;
 
-        if (requests.Any(r => r.Timestamp == default))
+        if (items.Any(r => r.Timestamp == default))
             return controller.Problem(detail: $"Timestamp must be set on every {singular}", statusCode: 400, title: "Bad Request");
 
-        if (requests.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
+        if (items.Any(r => !string.IsNullOrEmpty(r.SyncIdentifier) && string.IsNullOrEmpty(r.DataSource)))
             return controller.Problem(detail: "DataSource is required when SyncIdentifier is supplied", statusCode: 400, title: "Bad Request");
 
         if (controller.HttpContext?.RequestServices?.GetService(typeof(IValidator<TRequest>)) is not IValidator<TRequest> validator)
             return null;
 
-        for (var index = 0; index < requests.Length; index++)
+        for (var index = 0; index < items.Length; index++)
         {
-            var result = await validator.ValidateAsync(requests[index], ct);
+            var result = await validator.ValidateAsync(items[index], ct);
             if (result.IsValid)
                 continue;
 

--- a/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
@@ -127,8 +127,8 @@ public class ActivityController : ControllerBase
         [FromBody] UpsertActivityRequest[] requests,
         CancellationToken cancellationToken = default)
     {
-        if (requests.Length == 0)
-            return BadRequest("At least one activity record is required");
+        if (this.ValidateBulkSize(requests, "Activity", "activity records") is { } invalid)
+            return invalid;
 
         var activityList = requests.Select(MapToActivity).ToList();
 

--- a/src/API/Nocturne.API/Controllers/V4/Health/HealthRecordControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/HealthRecordControllerBase.cs
@@ -25,6 +25,9 @@ public abstract class HealthRecordControllerBase<TModel> : ControllerBase
     /// </summary>
     protected abstract string RecordTypeName { get; }
 
+    /// <summary>The record type as it reads mid-sentence — "heart rate".</summary>
+    protected string RecordTypeNoun => char.ToLowerInvariant(RecordTypeName[0]) + RecordTypeName[1..];
+
     protected abstract Task<IEnumerable<TModel>> ReadPageAsync(int count, int skip, CancellationToken ct);
 
     protected abstract Task<TModel?> ReadAsync(string id, CancellationToken ct);
@@ -43,11 +46,8 @@ public abstract class HealthRecordControllerBase<TModel> : ControllerBase
 
     protected async Task<ActionResult<IEnumerable<TModel>>> CreateResponseAsync(
         IReadOnlyList<TModel> models, CancellationToken ct) =>
-        models.Count == 0
-            ? Problem(
-                detail: $"At least one {char.ToLowerInvariant(RecordTypeName[0]) + RecordTypeName[1..]} record is required",
-                statusCode: 400,
-                title: "Bad Request")
+        this.ValidateBulkSize(models, RecordTypeName, $"{RecordTypeNoun} records") is { } invalid
+            ? invalid
             : Ok(await WriteManyAsync(models, ct));
 
     protected async Task<ActionResult<TModel>> UpdateResponseAsync(string id, TModel model, CancellationToken ct) =>

--- a/src/API/Nocturne.API/Controllers/V4/Health/HealthSeriesControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/HealthSeriesControllerBase.cs
@@ -31,7 +31,12 @@ public abstract class HealthSeriesControllerBase<TModel, TUpsertRequest> : Healt
             : await ReadPageAsync(V4ReadLimits.ClampLimit(count ?? DefaultCount), skip, ct));
     }
 
-    protected Task<ActionResult<IEnumerable<TModel>>> CreateResponseAsync(
+    /// <remarks>
+    /// The payload is sized before it is mapped, so an oversized one is not projected first.
+    /// </remarks>
+    protected async Task<ActionResult<IEnumerable<TModel>>> CreateResponseAsync(
         TUpsertRequest[] requests, CancellationToken ct) =>
-        CreateResponseAsync([.. requests.Select(ToModel)], ct);
+        this.ValidateBulkSize(requests, RecordTypeName, $"{RecordTypeNoun} records") is { } invalid
+            ? invalid
+            : await CreateResponseAsync([.. requests.Select(ToModel)], ct);
 }

--- a/src/API/Nocturne.API/Controllers/V4/SleepController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SleepController.cs
@@ -119,13 +119,10 @@ public class SleepController : ControllerBase
         [FromBody] SleepSession[] sessions,
         CancellationToken cancellationToken = default)
     {
-        if (sessions is not { Length: > 0 })
-            return Problem(detail: "Sleep session data is required", statusCode: 400, title: "Bad Request");
-
         // Sessions embed stage intervals and biometric samples, so the cap is lower than the
-        // 1000-item flat-record bulks.
-        if (sessions.Length > 100)
-            return Problem(detail: "Bulk operations are limited to 100 sessions per request", statusCode: 400, title: "Bad Request");
+        // flat-record bulks' V4BulkValidation.MaxItems.
+        if (this.ValidateBulkSize(sessions, "Sleep session", "sessions", maxItems: 100) is { } invalid)
+            return invalid;
 
         var results = new List<SleepSession>(sessions.Length);
         try

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
@@ -6,8 +7,10 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Nocturne.API.Controllers.V4;
 using Nocturne.API.Controllers.V4.Devices;
 using Nocturne.API.Controllers.V4.Glucose;
+using Nocturne.API.Controllers.V4.Health;
 using Nocturne.API.Controllers.V4.Treatments;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.API.Services.Platform;
@@ -15,9 +18,12 @@ using Nocturne.API.Services.V4;
 using Nocturne.API.Validators.V4;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.Sleep;
 using Nocturne.Core.Contracts.Treatments;
 using Nocturne.Core.Contracts.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Xunit;
 
@@ -203,6 +209,125 @@ public class V4BulkValidationTests
             Times.Never);
     }
 
+    [Fact]
+    public async Task ActivityBulk_OverTheCap_IsRejected()
+    {
+        var service = new Mock<IActivityService>();
+
+        var result = await Activities(service).CreateActivities(Fill(1001, () => new UpsertActivityRequest()));
+
+        Rejected(result.Result, "Bulk operations are limited to 1000 activity records per request");
+        service.Verify(
+            s => s.CreateActivitiesAsync(It.IsAny<IEnumerable<Activity>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ActivityBulk_NullPayload_IsRejected()
+    {
+        var service = new Mock<IActivityService>();
+
+        var result = await Activities(service).CreateActivities(null!);
+
+        Rejected(result.Result, "Activity data is required");
+        service.Verify(
+            s => s.CreateActivitiesAsync(It.IsAny<IEnumerable<Activity>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HeartRateBulk_OverTheCap_IsRejected()
+    {
+        var service = new Mock<IHeartRateService>();
+
+        var result = await HeartRates(service).CreateHeartRates(Fill(1001, () => new UpsertHeartRateRequest()));
+
+        Rejected(result.Result, "Bulk operations are limited to 1000 heart rate records per request");
+        service.Verify(
+            s => s.CreateHeartRatesAsync(It.IsAny<IEnumerable<HeartRate>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HeartRateBulk_NullPayload_IsRejected()
+    {
+        var service = new Mock<IHeartRateService>();
+
+        var result = await HeartRates(service).CreateHeartRates(null!);
+
+        Rejected(result.Result, "Heart rate data is required");
+        service.Verify(
+            s => s.CreateHeartRatesAsync(It.IsAny<IEnumerable<HeartRate>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task StepCountBulk_OverTheCap_IsRejected()
+    {
+        var service = new Mock<IStepCountService>();
+
+        var result = await StepCounts(service).CreateStepCounts(Fill(1001, () => new UpsertStepCountRequest()));
+
+        Rejected(result.Result, "Bulk operations are limited to 1000 step count records per request");
+        service.Verify(
+            s => s.CreateStepCountsAsync(It.IsAny<IEnumerable<StepCount>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task StepCountBulk_NullPayload_IsRejected()
+    {
+        var service = new Mock<IStepCountService>();
+
+        var result = await StepCounts(service).CreateStepCounts(null!);
+
+        Rejected(result.Result, "Step count data is required");
+        service.Verify(
+            s => s.CreateStepCountsAsync(It.IsAny<IEnumerable<StepCount>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task BodyWeightBatch_OverTheCap_IsRejected()
+    {
+        var service = new Mock<IBodyWeightService>();
+        var body = JsonSerializer.SerializeToElement(Fill(1001, () => new BodyWeight()));
+
+        var result = await BodyWeights(service).CreateBodyWeights(body);
+
+        Rejected(result.Result, "Bulk operations are limited to 1000 body weight records per request");
+        service.Verify(
+            s => s.CreateBodyWeightsAsync(It.IsAny<IEnumerable<BodyWeight>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task BodyWeightBatch_EmptyPayload_IsRejected()
+    {
+        var service = new Mock<IBodyWeightService>();
+        var body = JsonSerializer.SerializeToElement(Array.Empty<BodyWeight>());
+
+        var result = await BodyWeights(service).CreateBodyWeights(body);
+
+        Rejected(result.Result, "Body weight data is required");
+        service.Verify(
+            s => s.CreateBodyWeightsAsync(It.IsAny<IEnumerable<BodyWeight>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SleepBulk_OverItsOwnLowerCap_IsRejected()
+    {
+        var service = new Mock<ISleepService>();
+
+        var result = await Sleep(service).CreateSessionsBulk(Fill(101, () => new SleepSession()));
+
+        Rejected(result.Result, "Bulk operations are limited to 100 sessions per request");
+        service.Verify(
+            s => s.UpsertSessionAsync(It.IsAny<SleepSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     // ── The per-item validators auto-validation cannot reach ────────
 
     [Fact]
@@ -329,6 +454,21 @@ public class V4BulkValidationTests
 
     private static TempBasalController TempBasals() =>
         WithContext(new TempBasalController(Mock.Of<ITempBasalRepository>(), Mock.Of<IPatientDeviceStamper>()));
+
+    private static ActivityController Activities(Mock<IActivityService> service) =>
+        WithContext(new ActivityController(service.Object, Mock.Of<IActivityDecomposer>()));
+
+    private static HeartRateController HeartRates(Mock<IHeartRateService> service) =>
+        WithContext(new HeartRateController(service.Object));
+
+    private static StepCountController StepCounts(Mock<IStepCountService> service) =>
+        WithContext(new StepCountController(service.Object));
+
+    private static BodyWeightController BodyWeights(Mock<IBodyWeightService> service) =>
+        WithContext(new BodyWeightController(service.Object));
+
+    private static SleepController Sleep(Mock<ISleepService> service) =>
+        WithContext(new SleepController(service.Object));
 
     private static SensorGlucoseController SensorGlucose(Mock<ISensorGlucoseRepository>? repo = null) =>
         WithContext(new SensorGlucoseController(

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/HealthRecordResponseContractTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/HealthRecordResponseContractTests.cs
@@ -170,7 +170,7 @@ public class HealthRecordResponseContractTests
     {
         var result = await StepCount().CreateStepCounts([]);
 
-        Problem(result.Result, 400).Detail.Should().Be("At least one step count record is required");
+        Problem(result.Result, 400).Detail.Should().Be("Step count data is required");
         _stepCounts.Verify(
             s => s.CreateStepCountsAsync(It.IsAny<IEnumerable<StepCount>>(), It.IsAny<CancellationToken>()),
             Times.Never);


### PR DESCRIPTION
Fixes #1115
Part of #1091 (item 2)

V4 had three bulk-size policies: `V4BulkValidation.MaxItems` (1,000) on the eight `IBulkUpsertRequest` bulks, an inline cap of 100 with its own guards on `SleepController.CreateSessionsBulk`, and no cap at all on the health bulk creates (`Activity`, `HeartRate`, `StepCount`). Activity's empty-payload 400 was a bare string rather than ProblemDetails, and its `requests.Length == 0` check threw on a null body.

## Design

`V4BulkValidation.ValidateBulkSize<TRequest>(this ControllerBase, IReadOnlyList<TRequest>?, subject, plural, maxItems = MaxItems)` holds the absent/empty/over-cap guards for any item type, taking the ceiling as a parameter. `ValidateBulkAsync` now calls it instead of repeating them, so the eight existing call sites keep one implementation and one wording. Activity and Sleep call it directly (Sleep with `maxItems: 100`, which keeps its stated reason: sessions embed stage intervals and biometric samples). `HealthSeriesControllerBase.CreateResponseAsync` calls it before mapping, covering HeartRate and StepCount in one place, and `HealthRecordControllerBase.CreateResponseAsync`'s own empty check folds into the same call, which also covers `BodyWeight`'s `batch` route.

None of the four request types has a FluentValidation validator, so this is caps and shape only.

## Behavioural deltas

- `POST /api/v4/heartrate`, `/stepcount`, `/activity`, `/bodyweight/batch`: payloads over 1,000 now 400 (`Bulk operations are limited to 1000 <noun> records per request`); previously unbounded. `bodyweight/batch` is not named in either issue; it inherits the guard from the shared base.
- Empty-array 400 wording on those four routes becomes `<Noun> data is required` (status and shape unchanged for HeartRate/StepCount/BodyWeight; Activity's changes from a bare string to ProblemDetails, the point of the issue).
- Null body on Activity/HeartRate/StepCount: `NullReferenceException` (Activity) or `ArgumentNullException` from `Enumerable.Select` (HeartRate/StepCount) at the controller contract → 400 ProblemDetails. Over HTTP this is unreachable: `Nullable` is enabled, all four controllers carry `[ApiController]`, and nothing in `src/API` sets `SuppressImplicitRequiredAttributeForNonNullableReferenceTypes`, so a JSON `null` body is already answered 400 `ValidationProblemDetails` before the action. The guard gives contract parity with the eight siblings, which all pin `NullPayload_IsRejected`.
- Sleep: zero wire delta (cap 100, same two messages).
- No route, verb, request shape, success shape or status code changed; no NSwag-visible signature changed.

## Tests

Nine new facts in `V4BulkValidationTests` using that file's existing helpers: over-cap on Activity/HeartRate/StepCount/BodyWeight-batch, empty payload on BodyWeight-batch (pins the post-map guard in `HealthRecordControllerBase`, whose only unique consumer is that route), null payload on Activity/HeartRate/StepCount, over-its-own-cap on Sleep; each asserts 400 + ProblemDetails + detail and that the service was never called. The HeartRate/StepCount null tests pin the pre-map guard in `HealthSeriesControllerBase` (reverting it to map-first NREs). `HealthRecordResponseContractTests`' pinned empty-payload wording for step count is updated to the new text. Mutation-proven: deleting the `Count > maxItems` branch fails all four over-cap tests; changing Sleep's cap to the default fails its test; changing the empty-payload message fails five.

`Nocturne.API.Tests` (unit filter) 6362/0. Diff: prod +23 net (the new method's signature and doc; executable lines went down), tests +140.

Not done here: `V3/EntriesController.cs:311` and `V3/TreatmentsController.cs:299` hard-code their own `> 1000` and message text (V3 answers its own envelope, but the number could come from `MaxItems`).
