### PR TITLE
refactor(api): fold the snapshot upserts onto the sync-upsert base

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Devices/ApsSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/ApsSnapshotController.cs
@@ -55,7 +55,7 @@ public class ApsSnapshotController(IApsSnapshotRepository repo)
             return invalid;
 
         var models = requests.Select(MapToModel).ToList();
-        var persisted = await Repository.BulkUpsertAsync(models, WriteOrigin.Live, ct);
+        var persisted = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         return StatusCode(201, persisted.ToArray());
     }
 

--- a/src/API/Nocturne.API/Controllers/V4/Devices/PumpSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/PumpSnapshotController.cs
@@ -55,7 +55,7 @@ public class PumpSnapshotController(IPumpSnapshotRepository repo)
             return invalid;
 
         var models = requests.Select(MapToModel).ToList();
-        var persisted = await Repository.BulkUpsertAsync(models, WriteOrigin.Live, ct);
+        var persisted = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         return StatusCode(201, persisted.ToArray());
     }
 

--- a/src/API/Nocturne.API/Controllers/V4/Devices/UploaderSnapshotController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/UploaderSnapshotController.cs
@@ -55,7 +55,7 @@ public class UploaderSnapshotController(IUploaderSnapshotRepository repo)
             return invalid;
 
         var models = requests.Select(MapToModel).ToList();
-        var persisted = await Repository.BulkUpsertAsync(models, WriteOrigin.Live, ct);
+        var persisted = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
         return StatusCode(201, persisted.ToArray());
     }
 

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IApsSnapshotRepository.cs
@@ -1,5 +1,4 @@
 using Nocturne.Core.Models.V4;
-using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -95,16 +94,4 @@ public interface IApsSnapshotRepository : ILegacyKeyedRepository<ApsSnapshot>
     /// <param name="asOf">When non-null, restricts to snapshots with <c>Timestamp &lt;= asOf</c>.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<decimal?> GetLatestSensitivityRatioAsync(DateTime? asOf, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk create-or-update by (DataSource, SyncIdentifier): rows matched by that key are updated
-    /// in place, so uploader retries of the same loop cycle stay idempotent. Everything else inserts
-    /// through the LegacyId-dedup path of <see cref="BulkCreateAsync"/>.
-    /// </summary>
-    /// <param name="records">Records to upsert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>All persisted records: updated rows first, then inserted rows.</returns>
-    Task<IEnumerable<ApsSnapshot>> BulkUpsertAsync(
-        IEnumerable<ApsSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IPumpSnapshotRepository.cs
@@ -1,5 +1,4 @@
 using Nocturne.Core.Models.V4;
-using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -68,16 +67,4 @@ public interface IPumpSnapshotRepository : ILegacyKeyedRepository<PumpSnapshot>
     /// <param name="source">Optional connector data source filter.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<DateTime?> GetLatestTimestampAsync(string? source = null, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk create-or-update by (DataSource, SyncIdentifier): rows matched by that key are updated
-    /// in place, so uploader retries of the same loop cycle stay idempotent. Everything else inserts
-    /// through the LegacyId-dedup path of <see cref="BulkCreateAsync"/>.
-    /// </summary>
-    /// <param name="records">Records to upsert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>All persisted records: updated rows first, then inserted rows.</returns>
-    Task<IEnumerable<PumpSnapshot>> BulkUpsertAsync(
-        IEnumerable<PumpSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IUploaderSnapshotRepository.cs
@@ -1,5 +1,4 @@
 using Nocturne.Core.Models.V4;
-using Nocturne.Core.Contracts.V4;
 
 namespace Nocturne.Core.Contracts.V4.Repositories;
 
@@ -57,16 +56,4 @@ public interface IUploaderSnapshotRepository : ILegacyKeyedRepository<UploaderSn
     /// when <c>null</c>, returns the absolute latest snapshot per the lowest-battery rule.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<UploaderSnapshot?> GetLatestAsync(DateTime? asOf, CancellationToken ct = default);
-
-    /// <summary>
-    /// Bulk create-or-update by (DataSource, SyncIdentifier): rows matched by that key are updated
-    /// in place, so uploader retries of the same loop cycle stay idempotent. Everything else inserts
-    /// through the LegacyId-dedup path of <see cref="BulkCreateAsync"/>.
-    /// </summary>
-    /// <param name="records">Records to upsert.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>All persisted records: updated rows first, then inserted rows.</returns>
-    Task<IEnumerable<UploaderSnapshot>> BulkUpsertAsync(
-        IEnumerable<UploaderSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default);
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/ApsSnapshotEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.ApsSnapshot
 /// </summary>
 [Table("aps_snapshots")]
-public class ApsSnapshotEntity : V4TimeSeriesEntityBase
+public class ApsSnapshotEntity : V4TimeSeriesEntityBase, ISyncDedupable
 {
     /// <summary>
     /// Stable per-source identifier for synchronization. Unlike <see cref="V4TimeSeriesEntityBase.LegacyId"/> (insert-only),

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/PumpSnapshotEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.PumpSnapshot
 /// </summary>
 [Table("pump_snapshots")]
-public class PumpSnapshotEntity : V4TimeSeriesEntityBase
+public class PumpSnapshotEntity : V4TimeSeriesEntityBase, ISyncDedupable
 {
     /// <summary>
     /// Stable per-source identifier for synchronization. Unlike <see cref="V4TimeSeriesEntityBase.LegacyId"/> (insert-only),

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/V4/UploaderSnapshotEntity.cs
@@ -8,7 +8,7 @@ namespace Nocturne.Infrastructure.Data.Entities.V4;
 /// Maps to Nocturne.Core.Models.V4.UploaderSnapshot
 /// </summary>
 [Table("uploader_snapshots")]
-public class UploaderSnapshotEntity : V4TimeSeriesEntityBase
+public class UploaderSnapshotEntity : V4TimeSeriesEntityBase, ISyncDedupable
 {
     /// <summary>
     /// Stable per-source identifier for synchronization. Unlike <see cref="V4TimeSeriesEntityBase.LegacyId"/> (insert-only),

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/ApsSnapshotRepository.cs
@@ -12,11 +12,11 @@ using Nocturne.Core.Contracts.V4;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing APS snapshots in the database. Inherits the shared CRUD, soft-delete and
-/// LegacyId-deduplicated bulk-insert surface from <see cref="V4RepositoryBase{TModel,TEntity}"/> and
-/// keeps only the APS-specific queries and the (DataSource, SyncIdentifier) upsert below.
+/// Repository for managing APS snapshots in the database. Takes the sync-key upsert and keyed delete
+/// of <see cref="SyncUpsertRepositoryBase{TModel,TEntity}"/>, so it keeps only the APS-specific
+/// queries.
 /// </summary>
-public class ApsSnapshotRepository : V4RepositoryBase<ApsSnapshot, ApsSnapshotEntity>, IApsSnapshotRepository
+public class ApsSnapshotRepository : SyncUpsertRepositoryBase<ApsSnapshot, ApsSnapshotEntity>, IApsSnapshotRepository
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ApsSnapshotRepository"/> class.
@@ -145,77 +145,5 @@ public class ApsSnapshotRepository : V4RepositoryBase<ApsSnapshot, ApsSnapshotEn
             .Select(e => e.SensitivityRatio)
             .FirstOrDefaultAsync(ct);
         return value is double v && double.IsFinite(v) ? (decimal)v : null;
-    }
-
-    /// <inheritdoc />
-    public Task<IEnumerable<ApsSnapshot>> BulkUpsertAsync(
-        IEnumerable<ApsSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default)
-        => BulkWriteAsync(records, SplitBySyncKeyAsync, origin, ct);
-
-    /// <summary>
-    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
-    /// rows in the DB by that key and update them in place. Soft-deleted rows are excluded: the partial
-    /// unique index ignores them, so a re-upload after a delete inserts a fresh row instead of writing
-    /// into the deleted one.
-    /// </summary>
-    private static async Task<UpsertSplit> SplitBySyncKeyAsync(
-        NocturneDbContext ctx, List<ApsSnapshotEntity> entities, CancellationToken ct)
-    {
-        // Records without both keys keep a unique grouping key so they're not collapsed.
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                : $"id|{e.Id}")
-            .Select(g => g.Last())
-            .ToList();
-
-        var syncKeyed = entities
-            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-            .ToList();
-
-        var updatedEntities = new List<ApsSnapshotEntity>();
-        var materiallyChanged = new List<ApsSnapshotEntity>();
-        if (syncKeyed.Count == 0)
-            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
-
-        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-        var existingRows = await ctx.ApsSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
-            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-            .ToListAsync(ct);
-
-        var existingByKey = existingRows
-            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-            .ToDictionary(g => g.Key, g => g.First());
-
-        var toInsert = new List<ApsSnapshotEntity>();
-        foreach (var entity in entities)
-        {
-            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                && !string.IsNullOrEmpty(entity.SyncIdentifier);
-            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-            {
-                ApsSnapshotMapper.UpdateEntity(existing, ApsSnapshotMapper.ToDomainModel(entity));
-                updatedEntities.Add(existing);
-                // Capture material changes now, before SaveChanges clears the modified flags.
-                if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
-                    materiallyChanged.Add(existing);
-            }
-            else
-            {
-                toInsert.Add(entity);
-            }
-        }
-
-        if (updatedEntities.Count > 0)
-        {
-            // Persist updates before the insert-chunking loop clears the tracker.
-            await ctx.SaveChangesAsync(ct);
-        }
-
-        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/PumpSnapshotRepository.cs
@@ -12,12 +12,11 @@ using Nocturne.Core.Contracts.V4;
 namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
-/// Repository for managing pump snapshot records (point-in-time pump state) in the database. Inherits
-/// the shared CRUD, soft-delete and LegacyId-deduplicated bulk-insert surface from
-/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the pump-specific queries and the
-/// (DataSource, SyncIdentifier) upsert below.
+/// Repository for managing pump snapshot records (point-in-time pump state) in the database. Takes the
+/// sync-key upsert and keyed delete of <see cref="SyncUpsertRepositoryBase{TModel,TEntity}"/>, so it
+/// keeps only the pump-specific queries.
 /// </summary>
-public class PumpSnapshotRepository : V4RepositoryBase<PumpSnapshot, PumpSnapshotEntity>, IPumpSnapshotRepository
+public class PumpSnapshotRepository : SyncUpsertRepositoryBase<PumpSnapshot, PumpSnapshotEntity>, IPumpSnapshotRepository
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="PumpSnapshotRepository"/> class.
@@ -89,77 +88,5 @@ public class PumpSnapshotRepository : V4RepositoryBase<PumpSnapshot, PumpSnapsho
             .ToListAsync(ct);
 
         return entities.Select(PumpSnapshotMapper.ToDomainModel);
-    }
-
-    /// <inheritdoc />
-    public Task<IEnumerable<PumpSnapshot>> BulkUpsertAsync(
-        IEnumerable<PumpSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default)
-        => BulkWriteAsync(records, SplitBySyncKeyAsync, origin, ct);
-
-    /// <summary>
-    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
-    /// rows in the DB by that key and update them in place. Soft-deleted rows are excluded: the partial
-    /// unique index ignores them, so a re-upload after a delete inserts a fresh row instead of writing
-    /// into the deleted one.
-    /// </summary>
-    private static async Task<UpsertSplit> SplitBySyncKeyAsync(
-        NocturneDbContext ctx, List<PumpSnapshotEntity> entities, CancellationToken ct)
-    {
-        // Records without both keys keep a unique grouping key so they're not collapsed.
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                : $"id|{e.Id}")
-            .Select(g => g.Last())
-            .ToList();
-
-        var syncKeyed = entities
-            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-            .ToList();
-
-        var updatedEntities = new List<PumpSnapshotEntity>();
-        var materiallyChanged = new List<PumpSnapshotEntity>();
-        if (syncKeyed.Count == 0)
-            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
-
-        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-        var existingRows = await ctx.PumpSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
-            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-            .ToListAsync(ct);
-
-        var existingByKey = existingRows
-            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-            .ToDictionary(g => g.Key, g => g.First());
-
-        var toInsert = new List<PumpSnapshotEntity>();
-        foreach (var entity in entities)
-        {
-            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                && !string.IsNullOrEmpty(entity.SyncIdentifier);
-            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-            {
-                PumpSnapshotMapper.UpdateEntity(existing, PumpSnapshotMapper.ToDomainModel(entity));
-                updatedEntities.Add(existing);
-                // Capture material changes now, before SaveChanges clears the modified flags.
-                if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
-                    materiallyChanged.Add(existing);
-            }
-            else
-            {
-                toInsert.Add(entity);
-            }
-        }
-
-        if (updatedEntities.Count > 0)
-        {
-            // Persist updates before the insert-chunking loop clears the tracker.
-            await ctx.SaveChangesAsync(ct);
-        }
-
-        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/UploaderSnapshotRepository.cs
@@ -13,11 +13,10 @@ namespace Nocturne.Infrastructure.Data.Repositories.V4;
 
 /// <summary>
 /// Repository for managing uploader snapshot records (point-in-time uploader state) in the database.
-/// Inherits the shared CRUD, soft-delete and LegacyId-deduplicated bulk-insert surface from
-/// <see cref="V4RepositoryBase{TModel,TEntity}"/> and keeps only the uploader-specific queries and the
-/// (DataSource, SyncIdentifier) upsert below.
+/// Takes the sync-key upsert and keyed delete of <see cref="SyncUpsertRepositoryBase{TModel,TEntity}"/>,
+/// so it keeps only the uploader-specific queries.
 /// </summary>
-public class UploaderSnapshotRepository : V4RepositoryBase<UploaderSnapshot, UploaderSnapshotEntity>, IUploaderSnapshotRepository
+public class UploaderSnapshotRepository : SyncUpsertRepositoryBase<UploaderSnapshot, UploaderSnapshotEntity>, IUploaderSnapshotRepository
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="UploaderSnapshotRepository"/> class.
@@ -79,77 +78,5 @@ public class UploaderSnapshotRepository : V4RepositoryBase<UploaderSnapshot, Upl
             .ThenByDescending(e => e.Timestamp)     // tie-break: most recent
             .FirstOrDefaultAsync(ct);
         return entity is null ? null : UploaderSnapshotMapper.ToDomainModel(entity);
-    }
-
-    /// <inheritdoc />
-    public Task<IEnumerable<UploaderSnapshot>> BulkUpsertAsync(
-        IEnumerable<UploaderSnapshot> records,
-        WriteOrigin origin, CancellationToken ct = default)
-        => BulkWriteAsync(records, SplitBySyncKeyAsync, origin, ct);
-
-    /// <summary>
-    /// SyncId-upsert split: intra-batch keep-last per (DataSource, SyncIdentifier), then match existing
-    /// rows in the DB by that key and update them in place. Soft-deleted rows are excluded: the partial
-    /// unique index ignores them, so a re-upload after a delete inserts a fresh row instead of writing
-    /// into the deleted one.
-    /// </summary>
-    private static async Task<UpsertSplit> SplitBySyncKeyAsync(
-        NocturneDbContext ctx, List<UploaderSnapshotEntity> entities, CancellationToken ct)
-    {
-        // Records without both keys keep a unique grouping key so they're not collapsed.
-        entities = entities
-            .GroupBy(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier)
-                ? $"sync|{e.DataSource}|{e.SyncIdentifier}"
-                : $"id|{e.Id}")
-            .Select(g => g.Last())
-            .ToList();
-
-        var syncKeyed = entities
-            .Where(e => !string.IsNullOrEmpty(e.DataSource) && !string.IsNullOrEmpty(e.SyncIdentifier))
-            .ToList();
-
-        var updatedEntities = new List<UploaderSnapshotEntity>();
-        var materiallyChanged = new List<UploaderSnapshotEntity>();
-        if (syncKeyed.Count == 0)
-            return new UpsertSplit(updatedEntities, materiallyChanged, entities);
-
-        var sources = syncKeyed.Select(e => e.DataSource!).Distinct().ToList();
-        var syncIds = syncKeyed.Select(e => e.SyncIdentifier!).Distinct().ToList();
-
-        var existingRows = await ctx.UploaderSnapshots.IgnoreQueryFilters()
-            .Where(e => e.TenantId == ctx.TenantId && e.DeletedAt == null)
-            .Where(e => sources.Contains(e.DataSource!) && syncIds.Contains(e.SyncIdentifier!))
-            .ToListAsync(ct);
-
-        var existingByKey = existingRows
-            .GroupBy(e => $"{e.DataSource}|{e.SyncIdentifier}")
-            .ToDictionary(g => g.Key, g => g.First());
-
-        var toInsert = new List<UploaderSnapshotEntity>();
-        foreach (var entity in entities)
-        {
-            var hasKey = !string.IsNullOrEmpty(entity.DataSource)
-                && !string.IsNullOrEmpty(entity.SyncIdentifier);
-            if (hasKey && existingByKey.TryGetValue($"{entity.DataSource}|{entity.SyncIdentifier}", out var existing))
-            {
-                UploaderSnapshotMapper.UpdateEntity(existing, UploaderSnapshotMapper.ToDomainModel(entity));
-                updatedEntities.Add(existing);
-                // Capture material changes now, before SaveChanges clears the modified flags.
-                if (V4MaterialChange.HasMaterialChange(ctx.Entry(existing)))
-                    materiallyChanged.Add(existing);
-            }
-            else
-            {
-                toInsert.Add(entity);
-            }
-        }
-
-        if (updatedEntities.Count > 0)
-        {
-            // Persist updates before the insert-chunking loop clears the tracker.
-            await ctx.SaveChangesAsync(ct);
-        }
-
-        return new UpsertSplit(updatedEntities, materiallyChanged, toInsert);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/V4/V4RepositoryBase.cs
@@ -387,27 +387,15 @@ public abstract class V4RepositoryBase<TModel, TEntity>
         => Task.CompletedTask;
 
     /// <summary>
-    /// Bulk-inserts records with batch-level and DB-level deduplication by LegacyId. The base
-    /// implements the LegacyId-only path; SyncId-upsert / DeduplicationService participants override
-    /// the <see cref="SplitUpsertsAsync"/> / <see cref="PostCommitDedupAsync"/> hooks rather than the
-    /// whole method.
+    /// Bulk write in one transaction: <see cref="SplitUpsertsAsync"/> separates the rows upserted in
+    /// place from the rows still to insert, the insert set is deduplicated by LegacyId (batch- then
+    /// DB-level) and inserted in chunks, and the commit is followed by dedup linking and the
+    /// broadcast. The base implements the LegacyId-only path; SyncId-upsert / DeduplicationService
+    /// participants override the <see cref="SplitUpsertsAsync"/> / <see cref="PostCommitDedupAsync"/>
+    /// hooks rather than the whole method.
     /// </summary>
-    public virtual Task<IEnumerable<TModel>> BulkCreateAsync(
+    public virtual async Task<IEnumerable<TModel>> BulkCreateAsync(
         IEnumerable<TModel> recordsParam, WriteOrigin origin, CancellationToken ct = default)
-        => BulkWriteAsync(recordsParam, SplitUpsertsAsync, origin, ct);
-
-    /// <summary>
-    /// The transaction every bulk write shares: <paramref name="splitter"/> separates the rows upserted
-    /// in place from the rows still to insert, the insert set is deduplicated by LegacyId (batch- then
-    /// DB-level) and inserted in chunks, and the commit is followed by dedup linking and the broadcast.
-    /// Types that expose a second bulk entry point alongside the insert-only
-    /// <see cref="BulkCreateAsync"/> (an explicit <c>BulkUpsertAsync</c>) pass their own splitter.
-    /// </summary>
-    protected async Task<IEnumerable<TModel>> BulkWriteAsync(
-        IEnumerable<TModel> recordsParam,
-        Func<NocturneDbContext, List<TEntity>, CancellationToken, Task<UpsertSplit>> splitter,
-        WriteOrigin origin,
-        CancellationToken ct)
     {
         var records = recordsParam.ToList();
         if (records.Count == 0) return [];
@@ -418,7 +406,7 @@ public abstract class V4RepositoryBase<TModel, TEntity>
             await using var tx = await ctx.Database.BeginTransactionAsync(ct);
             var entities = records.Select(ToEntity).ToList();
 
-            var split = await splitter(ctx, entities, ct);
+            var split = await SplitUpsertsAsync(ctx, entities, ct);
             var toInsert = split.ToInsert;
 
             // Batch-level LegacyId dedup

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
@@ -55,7 +55,7 @@ public class V4BulkValidationTests
     }
 
     private void NothingPersisted() => _aps.Verify(
-        r => r.BulkUpsertAsync(It.IsAny<IEnumerable<ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+        r => r.BulkCreateAsync(It.IsAny<IEnumerable<ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
         Times.Never);
 
     private static UpsertApsSnapshotRequest[] Snapshots(int count) =>
@@ -80,7 +80,7 @@ public class V4BulkValidationTests
     [Fact]
     public async Task PayloadAtTheCap_IsAccepted()
     {
-        _aps.Setup(r => r.BulkUpsertAsync(It.IsAny<IEnumerable<ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+        _aps.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<ApsSnapshot> models, WriteOrigin _, CancellationToken _) => [.. models]);
 
         var result = await ApsController().CreateApsSnapshots(Snapshots(1000));
@@ -120,7 +120,7 @@ public class V4BulkValidationTests
     [Fact]
     public async Task SyncIdentifierWithDataSource_IsAccepted()
     {
-        _aps.Setup(r => r.BulkUpsertAsync(It.IsAny<IEnumerable<ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+        _aps.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<ApsSnapshot> models, WriteOrigin _, CancellationToken _) => [.. models]);
 
         var requests = Snapshots(1);
@@ -261,7 +261,7 @@ public class V4BulkValidationTests
     public async Task ApsSnapshotBulk_HasNoValidator_SoNothingNewRejectsIt()
     {
         Validators.GetService<IValidator<UpsertApsSnapshotRequest>>().Should().BeNull();
-        _aps.Setup(r => r.BulkUpsertAsync(It.IsAny<IEnumerable<ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+        _aps.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<ApsSnapshot>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<ApsSnapshot> models, WriteOrigin _, CancellationToken _) => [.. models]);
 
         var result = await WithValidators(ApsController()).CreateApsSnapshots(Snapshots(3));

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/ApsSnapshotRepositoryBulkUpsertTests.cs
@@ -52,7 +52,7 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_InsertsNewRecords()
+    public async Task BulkCreateAsync_InsertsNewRecords()
     {
         var snapshots = new[]
         {
@@ -60,19 +60,19 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
             CreateSnapshot("sync-2", timestamp: new DateTime(2026, 5, 1, 11, 0, 0, DateTimeKind.Utc)),
         };
 
-        var result = (await _repository.BulkUpsertAsync(snapshots, WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(2);
         _context.ApsSnapshots.Count().Should().Be(2);
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_UpdatesExistingRecordInPlace()
+    public async Task BulkCreateAsync_UpdatesExistingRecordInPlace()
     {
-        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
+        await _repository.BulkCreateAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
 
         var retry = CreateSnapshot("sync-1", iob: 2.5);
-        var result = (await _repository.BulkUpsertAsync([retry], WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync([retry], WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         _context.ApsSnapshots.Count().Should().Be(1);
@@ -80,7 +80,7 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_KeepsLastOccurrenceWithinBatch()
+    public async Task BulkCreateAsync_KeepsLastOccurrenceWithinBatch()
     {
         var snapshots = new[]
         {
@@ -88,7 +88,7 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
             CreateSnapshot("sync-dup", iob: 3.0),
         };
 
-        var result = (await _repository.BulkUpsertAsync(snapshots, WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         _context.ApsSnapshots.Count().Should().Be(1);
@@ -96,9 +96,9 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_MixedBatch_UpdatesMatchedAndInsertsRest()
+    public async Task BulkCreateAsync_MixedBatch_UpdatesMatchedAndInsertsRest()
     {
-        await _repository.BulkUpsertAsync([CreateSnapshot("sync-existing", iob: 1.0)], WriteOrigin.Live);
+        await _repository.BulkCreateAsync([CreateSnapshot("sync-existing", iob: 1.0)], WriteOrigin.Live);
 
         var snapshots = new[]
         {
@@ -106,7 +106,7 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
             CreateSnapshot("sync-new"),
         };
 
-        var result = (await _repository.BulkUpsertAsync(snapshots, WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(2);
         _context.ApsSnapshots.Count().Should().Be(2);
@@ -114,7 +114,7 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_RecordsWithoutSyncKeyAlwaysInsert()
+    public async Task BulkCreateAsync_RecordsWithoutSyncKeyAlwaysInsert()
     {
         var unkeyed = new[]
         {
@@ -122,14 +122,14 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
             CreateSnapshot(syncIdentifier: null, timestamp: new DateTime(2026, 5, 1, 10, 0, 0, DateTimeKind.Utc)),
         };
 
-        await _repository.BulkUpsertAsync(unkeyed, WriteOrigin.Live);
-        await _repository.BulkUpsertAsync(unkeyed, WriteOrigin.Live);
+        await _repository.BulkCreateAsync(unkeyed, WriteOrigin.Live);
+        await _repository.BulkCreateAsync(unkeyed, WriteOrigin.Live);
 
         _context.ApsSnapshots.Count().Should().Be(4);
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_SameSyncIdDifferentSource_DoesNotCollide()
+    public async Task BulkCreateAsync_SameSyncIdDifferentSource_DoesNotCollide()
     {
         var snapshots = new[]
         {
@@ -137,37 +137,37 @@ public class ApsSnapshotRepositoryBulkUpsertTests : IDisposable
             CreateSnapshot("sync-1", dataSource: "loop"),
         };
 
-        var result = (await _repository.BulkUpsertAsync(snapshots, WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync(snapshots, WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(2);
         _context.ApsSnapshots.Count().Should().Be(2);
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_EmptyInput_ReturnsEmpty()
+    public async Task BulkCreateAsync_EmptyInput_ReturnsEmpty()
     {
-        var result = (await _repository.BulkUpsertAsync([], WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync([], WriteOrigin.Live)).ToList();
 
         result.Should().BeEmpty();
         _context.ApsSnapshots.Count().Should().Be(0);
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_ByteIdenticalRetry_DoesNotBroadcastUpdates()
+    public async Task BulkCreateAsync_ByteIdenticalRetry_DoesNotBroadcastUpdates()
     {
         var broadcaster = new RecordingV4RecordBroadcaster<ApsSnapshot>();
         var repository = new ApsSnapshotRepository(
             new TestTenantDbContextFactory(_context), new SystemAuditContext(), NullLogger<ApsSnapshotRepository>.Instance, broadcaster);
 
-        await repository.BulkUpsertAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
+        await repository.BulkCreateAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
         broadcaster.Created.Should().HaveCount(1);
 
         // Byte-identical retry: matched in place, but nothing materially changed.
-        await repository.BulkUpsertAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
+        await repository.BulkCreateAsync([CreateSnapshot("sync-1", iob: 1.0)], WriteOrigin.Live);
         broadcaster.Updated.Should().BeEmpty();
 
         // A real change does broadcast as an update.
-        await repository.BulkUpsertAsync([CreateSnapshot("sync-1", iob: 2.0)], WriteOrigin.Live);
+        await repository.BulkCreateAsync([CreateSnapshot("sync-1", iob: 2.0)], WriteOrigin.Live);
         broadcaster.Updated.Should().HaveCount(1);
     }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/PumpSnapshotRepositoryBulkUpsertTests.cs
@@ -45,11 +45,11 @@ public class PumpSnapshotRepositoryBulkUpsertTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_UpdatesExistingRecordInPlace()
+    public async Task BulkCreateAsync_UpdatesExistingRecordInPlace()
     {
-        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", reservoir: 100)], WriteOrigin.Live);
+        await _repository.BulkCreateAsync([CreateSnapshot("sync-1", reservoir: 100)], WriteOrigin.Live);
 
-        var result = (await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", reservoir: 80)], WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync([CreateSnapshot("sync-1", reservoir: 80)], WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         _context.PumpSnapshots.Count().Should().Be(1);
@@ -57,11 +57,11 @@ public class PumpSnapshotRepositoryBulkUpsertTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_InsertsWhenNoKeyMatch()
+    public async Task BulkCreateAsync_InsertsWhenNoKeyMatch()
     {
-        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1")], WriteOrigin.Live);
+        await _repository.BulkCreateAsync([CreateSnapshot("sync-1")], WriteOrigin.Live);
 
-        var result = (await _repository.BulkUpsertAsync([CreateSnapshot("sync-2")], WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync([CreateSnapshot("sync-2")], WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         _context.PumpSnapshots.Count().Should().Be(2);

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/SyncUpsertTombstoneTests.cs
@@ -23,6 +23,7 @@ public class SyncUpsertTombstoneTests : IDisposable
 {
     private const string DataSource = "aaps";
     private const string SyncIdentifier = "sync-1";
+    private const string LiveSyncIdentifier = "sync-2";
 
     private static readonly Guid Tenant = Guid.Parse("00000000-0000-0000-0000-00000000000a");
     private static readonly DateTime T0 = new(2026, 6, 1, 8, 0, 0, DateTimeKind.Utc);
@@ -83,6 +84,13 @@ public class SyncUpsertTombstoneTests : IDisposable
             new Mock<IDeduplicationService>().Object,
             new Mock<IAuditContext>().Object,
             NullLogger<BolusRepository>.Instance,
+            broadcaster);
+
+    private ApsSnapshotRepository NewApsSnapshotRepository(
+        RecordingV4RecordBroadcaster<ApsSnapshot> broadcaster) =>
+        new(new TestTenantDbContextFactory(_context),
+            new Mock<IAuditContext>().Object,
+            NullLogger<ApsSnapshotRepository>.Instance,
             broadcaster);
 
     private async Task AssertInsertedPastTombstoneAsync<TEntity>(
@@ -224,5 +232,139 @@ public class SyncUpsertTombstoneTests : IDisposable
         var rows = await verify.Boluses.IgnoreQueryFilters().AsNoTracking().ToListAsync();
         rows.Single(b => b.Id == live.Id).Insulin.Should().Be(9.0);
         rows.Single(b => b.Id == tombstoneId).Insulin.Should().Be(5.0, "the tombstone row is left untouched");
+    }
+
+    /// <remarks>
+    /// One batch spanning both halves of the rule for the device snapshots, whose bulk upsert is the
+    /// wire path an uploader retries on: <see cref="SyncIdentifier"/> is held by a user tombstone and
+    /// <see cref="LiveSyncIdentifier"/> by a live row.
+    /// </remarks>
+    private async Task AssertSnapshotUpsertFollowsTombstonePolicyAsync<TModel, TEntity>(
+        TEntity deleted,
+        Func<string, double, TModel> build,
+        Func<TModel, Task<TModel>> createAsync,
+        Func<TModel[], Task<IEnumerable<TModel>>> bulkCreateAsync,
+        RecordingV4RecordBroadcaster<TModel> broadcaster,
+        Func<TEntity, double?> value)
+        where TModel : V4RecordBase
+        where TEntity : class, IV4TimeSeriesEntity, ISyncDedupable
+    {
+        var tombstoneId = SeedTombstone(deleted, deletedByUser: true);
+        var live = await createAsync(build(LiveSyncIdentifier, 7.0));
+
+        var result = await bulkCreateAsync([build(SyncIdentifier, 9.0), build(LiveSyncIdentifier, 8.0)]);
+
+        result.Should().ContainSingle().Which.Id.Should().Be(live.Id);
+        broadcaster.Created.Should().ContainSingle("the batch inserted nothing").Which.Id.Should().Be(live.Id);
+        broadcaster.Updated.Should().ContainSingle().Which.Id.Should().Be(live.Id);
+
+        await using var verify = NewContext();
+        var rows = await verify.Set<TEntity>().IgnoreQueryFilters().AsNoTracking().ToListAsync();
+        rows.Should().HaveCount(2, "the re-upload neither lands past the tombstone nor duplicates the live row");
+        value(rows.Single(e => e.Id == tombstoneId)).Should().Be(5.0, "the tombstone row is left untouched");
+        value(rows.Single(e => e.Id == live.Id)).Should().Be(8.0);
+    }
+
+    [Fact]
+    public async Task BulkCreate_WhenAUserDeletedApsTombstoneHoldsTheKey_DropsItAndUpdatesTheLiveRow()
+    {
+        var broadcaster = new RecordingV4RecordBroadcaster<ApsSnapshot>();
+        var repository = NewApsSnapshotRepository(broadcaster);
+
+        await AssertSnapshotUpsertFollowsTombstonePolicyAsync(
+            new ApsSnapshotEntity { AidAlgorithm = nameof(AidAlgorithm.Trio), Iob = 5.0 },
+            (sync, iob) => new ApsSnapshot
+            {
+                Timestamp = T0,
+                DataSource = DataSource,
+                SyncIdentifier = sync,
+                AidAlgorithm = AidAlgorithm.Trio,
+                Iob = iob,
+            },
+            model => repository.CreateAsync(model, WriteOrigin.Live),
+            models => repository.BulkCreateAsync(models, WriteOrigin.Live),
+            broadcaster,
+            e => e.Iob);
+    }
+
+    [Fact]
+    public async Task BulkCreate_WhenAUserDeletedPumpTombstoneHoldsTheKey_DropsItAndUpdatesTheLiveRow()
+    {
+        var broadcaster = new RecordingV4RecordBroadcaster<PumpSnapshot>();
+        var repository = new PumpSnapshotRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IAuditContext>().Object,
+            NullLogger<PumpSnapshotRepository>.Instance,
+            broadcaster);
+
+        await AssertSnapshotUpsertFollowsTombstonePolicyAsync(
+            new PumpSnapshotEntity { Reservoir = 5.0 },
+            (sync, reservoir) => new PumpSnapshot
+            {
+                Timestamp = T0,
+                DataSource = DataSource,
+                SyncIdentifier = sync,
+                Reservoir = reservoir,
+            },
+            model => repository.CreateAsync(model, WriteOrigin.Live),
+            models => repository.BulkCreateAsync(models, WriteOrigin.Live),
+            broadcaster,
+            e => e.Reservoir);
+    }
+
+    [Fact]
+    public async Task BulkCreate_WhenAUserDeletedUploaderTombstoneHoldsTheKey_DropsItAndUpdatesTheLiveRow()
+    {
+        var broadcaster = new RecordingV4RecordBroadcaster<UploaderSnapshot>();
+        var repository = new UploaderSnapshotRepository(
+            new TestTenantDbContextFactory(_context),
+            new Mock<IAuditContext>().Object,
+            NullLogger<UploaderSnapshotRepository>.Instance,
+            broadcaster);
+
+        await AssertSnapshotUpsertFollowsTombstonePolicyAsync(
+            new UploaderSnapshotEntity { BatteryVoltage = 5.0 },
+            (sync, voltage) => new UploaderSnapshot
+            {
+                Timestamp = T0,
+                DataSource = DataSource,
+                SyncIdentifier = sync,
+                BatteryVoltage = voltage,
+            },
+            model => repository.CreateAsync(model, WriteOrigin.Live),
+            models => repository.BulkCreateAsync(models, WriteOrigin.Live),
+            broadcaster,
+            e => e.BatteryVoltage);
+    }
+
+    /// <remarks>
+    /// One snapshot type pins the system-swept half: the branch is the base's and carries no per-type
+    /// code, and the mapper each type contributes is exercised by the user-tombstone tests above. APS
+    /// snapshots are the highest-volume of the three — one per loop cycle from every AID uploader.
+    /// </remarks>
+    [Fact]
+    public async Task BulkCreate_WhenASystemSweptApsTombstoneHoldsTheKey_InsertsPastIt()
+    {
+        var tombstoneId = SeedTombstone(
+            new ApsSnapshotEntity { AidAlgorithm = nameof(AidAlgorithm.Trio), Iob = 5.0 },
+            deletedByUser: false);
+        var broadcaster = new RecordingV4RecordBroadcaster<ApsSnapshot>();
+
+        var result = await NewApsSnapshotRepository(broadcaster).BulkCreateAsync(
+            [new ApsSnapshot
+            {
+                Timestamp = T0,
+                DataSource = DataSource,
+                SyncIdentifier = SyncIdentifier,
+                AidAlgorithm = AidAlgorithm.Trio,
+                Iob = 9.0,
+            }],
+            WriteOrigin.Live);
+
+        result.Should().HaveCount(1);
+        broadcaster.Created.Should().HaveCount(1);
+        broadcaster.Updated.Should().BeEmpty("nothing was upserted in place");
+        await AssertInsertedPastTombstoneAsync<ApsSnapshotEntity>(
+            tombstoneId, e => e.Iob!.Value, deletedValue: 5.0, reuploaded: 9.0);
     }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkUpsertTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/UploaderSnapshotRepositoryBulkUpsertTests.cs
@@ -45,11 +45,11 @@ public class UploaderSnapshotRepositoryBulkUpsertTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_UpdatesExistingRecordInPlace()
+    public async Task BulkCreateAsync_UpdatesExistingRecordInPlace()
     {
-        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", battery: 90)], WriteOrigin.Live);
+        await _repository.BulkCreateAsync([CreateSnapshot("sync-1", battery: 90)], WriteOrigin.Live);
 
-        var result = (await _repository.BulkUpsertAsync([CreateSnapshot("sync-1", battery: 85)], WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync([CreateSnapshot("sync-1", battery: 85)], WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         _context.UploaderSnapshots.Count().Should().Be(1);
@@ -57,11 +57,11 @@ public class UploaderSnapshotRepositoryBulkUpsertTests : IDisposable
     }
 
     [Fact]
-    public async Task BulkUpsertAsync_InsertsWhenNoKeyMatch()
+    public async Task BulkCreateAsync_InsertsWhenNoKeyMatch()
     {
-        await _repository.BulkUpsertAsync([CreateSnapshot("sync-1")], WriteOrigin.Live);
+        await _repository.BulkCreateAsync([CreateSnapshot("sync-1")], WriteOrigin.Live);
 
-        var result = (await _repository.BulkUpsertAsync([CreateSnapshot("sync-2")], WriteOrigin.Live)).ToList();
+        var result = (await _repository.BulkCreateAsync([CreateSnapshot("sync-2")], WriteOrigin.Live)).ToList();
 
         result.Should().HaveCount(1);
         _context.UploaderSnapshots.Count().Should().Be(2);


### PR DESCRIPTION
Part of #1066 (item 5)

`ApsSnapshotRepository`, `PumpSnapshotRepository` and `UploaderSnapshotRepository` each carried a private `SplitBySyncKeyAsync` that was the body of `SyncUpsertRepositoryBase.SplitUpsertsAsync`, differing only in the typed `DbSet`, the mapper pair and `V4MaterialChange.HasMaterialChange(ctx.Entry(…))` versus the base's hook. All three derived from `V4RepositoryBase` directly, so the #1047 consolidation had stopped at four of seven sync-keyed writers.

## Fold

The three repositories now derive from `SyncUpsertRepositoryBase`; the three splits are deleted. Their entities declare `ISyncDedupable` (they already had `SyncIdentifier` and were already in `NocturneDbContext.SyncDedupedEntities`, so the partial unique index the base relies on already existed). Every difference between the private splits and the base was absorbed by an existing hook (`ToDomain`/`ApplyUpdate` bridges the repositories already overrode; `V4RepositoryBase.HasMaterialChange` is literally the expression the splits inlined), except the tombstone filter, declared below.

`BulkUpsertAsync` on the three snapshot interfaces became a one-line alias of the inherited `BulkCreateAsync`, so it is deleted from the interfaces, repositories and the three `*SnapshotController` bulk actions (wire shape unchanged). With that alias gone `V4RepositoryBase.BulkWriteAsync` had one caller, so it is inlined into `BulkCreateAsync` and its `splitter` parameter dropped.

## Behavioural deltas

1. **Tombstone policy.** The private splits fetched `DeletedAt == null` only; the base uses `WhereBlocksRecreation`. A device snapshot whose `(DataSource, SyncIdentifier)` is held by a user-deleted tombstone is now dropped from a bulk write instead of re-inserted, so a user delete survives a connector replay. A system-swept tombstone still does not block; a live row sharing the key still wins the upsert.
2. Single-record `CreateAsync` on the three repositories now upserts on the sync key (base behaviour) instead of always inserting. Its one production caller is `ReservoirReportsController` (manual reservoir report → `IPumpSnapshotRepository.CreateAsync`, `DataSources.ManualEntry`, no `SyncIdentifier`), which takes the unkeyed insert branch, so it is unchanged. It still reads through the query filter, so item 6's single-vs-batch divergence now applies to snapshots too (recorded on the issue).
3. `BulkCreateAsync` runs the upsert split; its one production caller (`DeviceStatusDecomposer`) mints no `SyncIdentifier`, so every record takes the unkeyed branch and the legacy devicestatus path is unchanged.
4. `DeleteBySyncIdentifierAsync`/`FindBySyncIdentifierAsync` exist on the concrete classes but not on the snapshot interfaces, so nothing resolving via DI can reach them (recorded on the issue next to item 2).

## Tests

One new test per repository in the existing `SyncUpsertTombstoneTests` SQLite fixture: a mixed batch where one key is held by a user-deleted tombstone and the other by a live row asserts the re-upload is dropped (tombstone untouched, no third row), the live row is updated in place, `broadcaster.Updated` holds exactly the live row and `Created` only the earlier single create. A fourth test pins the other half of the rule for a snapshot type: a system-swept tombstone does not block, the bulk write inserts a fresh row. Mutation-proven: `WhereBlocksRecreation` → `DeletedAt == null` fails the three user-tombstone tests; `WhereBlocksRecreation` → block-everything fails the system-swept one; `HasMaterialChange => false` fails all three; breaking the `existingByKey` lookup fails all three plus the existing `UpdatesExistingRecordInPlace` tests.

`Nocturne.Infrastructure.Data.Tests` 845/0 (+4), `Nocturne.API.Tests` (unit filter) 6353/0 (includes `DeviceStatusDecomposerTests`, which constructs all three repositories directly). The `BulkUpsertAsync_*` test methods in the three `*SnapshotRepositoryBulkUpsertTests` classes are renamed to `BulkCreateAsync_*`.

Diff: prod −269 net (13 files), tests +142 net.
