### PR TITLE
refactor(connectors): delete the dead in-memory connector health state

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/BaseConnectorService.cs
@@ -1357,59 +1357,21 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
         // HttpClient is managed by IHttpClientFactory - do not dispose
     }
 
-    #region Health Tracking
+    #region Failure Tracking
 
-    /// <summary>
-    ///     Tracks consecutive failed requests for health monitoring.
-    ///     Automatically incremented on failures and reset on success.
-    /// </summary>
     private int _failedRequestCount;
 
-    /// <summary>
-    ///     Maximum failed requests before connector is considered unhealthy.
-    ///     Override in derived classes to customize threshold.
-    /// </summary>
-    protected virtual int MaxFailedRequestsBeforeUnhealthy => 5;
-
-    /// <summary>
-    ///     Gets whether the connector is in a healthy state based on recent request failures.
-    ///     Returns false if consecutive failures exceed MaxFailedRequestsBeforeUnhealthy.
-    /// </summary>
-    public virtual bool IsHealthy =>
-        Volatile.Read(ref _failedRequestCount) < MaxFailedRequestsBeforeUnhealthy;
-
-    /// <summary>
-    ///     Gets the number of consecutive failed requests.
-    /// </summary>
-    public int FailedRequestCount => Volatile.Read(ref _failedRequestCount);
-
-    /// <summary>
-    ///     Resets the failed request counter. Call this after successful recovery.
-    /// </summary>
-    public virtual void ResetFailedRequestCount()
-    {
-        Interlocked.Exchange(ref _failedRequestCount, 0);
-        _logger.LogInformation("[{ConnectorSource}] Failed request count reset", ConnectorSource);
-    }
-
-    /// <summary>
-    ///     Increments the failed request count and logs the failure.
-    /// </summary>
     protected void TrackFailedRequest(string? reason = null)
     {
         var newCount = Interlocked.Increment(ref _failedRequestCount);
         _logger.LogWarning(
-            "[{ConnectorSource}] Request failed (count: {FailedCount}/{MaxAllowed}){Reason}",
+            "[{ConnectorSource}] Request failed (consecutive: {FailedCount}){Reason}",
             ConnectorSource,
             newCount,
-            MaxFailedRequestsBeforeUnhealthy,
             reason != null ? $": {reason}" : ""
         );
     }
 
-    /// <summary>
-    ///     Resets the failed request count on success.
-    /// </summary>
     protected void TrackSuccessfulRequest()
     {
         var previousCount = Volatile.Read(ref _failedRequestCount);
@@ -1430,8 +1392,8 @@ public abstract class BaseConnectorService<TConfig> : IConnectorService<TConfig>
 
     /// <summary>
     ///     Executes an async operation under the shared connector retry loop, tracking success and
-    ///     failure for health monitoring. See <see cref="ConnectorRetryLoop.RunAsync{T}"/> for the
-    ///     attempt-budget and delay contract.
+    ///     failure. See <see cref="ConnectorRetryLoop.RunAsync{T}"/> for the attempt-budget and
+    ///     delay contract.
     /// </summary>
     /// <typeparam name="T">The return type of the operation</typeparam>
     /// <param name="operation">The async operation to execute</param>

--- a/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.FreeStyle/Services/LibreLinkUpConnectorService.cs
@@ -72,8 +72,6 @@ public class LibreConnectorService(
     public override string ServiceName => "LibreLinkUp";
     protected override string ConnectorSource => DataSources.LibreConnector;
 
-    public override bool IsHealthy => base.IsHealthy && !_tokenProvider.IsTokenExpired;
-
     private async Task<bool> AuthenticateWithConfigAsync(LibreLinkUpConnectorConfiguration config)
     {
         var token = await _tokenProvider.GetValidTokenAsync(config);

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeConnectorService.cs
@@ -35,10 +35,6 @@ public class MyLifeConnectorService(
     public override string ServiceName => "MyLife";
     protected override string ConnectorSource => DataSources.MyLifeConnector;
 
-
-    public override bool IsHealthy =>
-        FailedRequestCount < MaxFailedRequestsBeforeUnhealthy && !tokenProvider.IsTokenExpired;
-
     /// <summary>
     /// Fetches pump settings readouts from MyLife. Returns an empty list when no valid session
     /// is established.

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/BaseConnectorServiceTests.cs
@@ -178,7 +178,6 @@ public class BaseConnectorServiceTests
         reAuthentications.Should().Be(3);
         delays.DelayedAttempts.Should().BeEmpty(
             "fresh credentials replace the backoff rather than waiting one out");
-        service.FailedRequestCount.Should().Be(1, "the exhausted run tracks exactly one failure");
     }
 
     [Fact]
@@ -203,7 +202,6 @@ public class BaseConnectorServiceTests
         result.Should().BeNull();
         attempts.Should().Be(1, "there is nothing to retry with once re-authentication fails");
         delays.DelayedAttempts.Should().BeEmpty();
-        service.FailedRequestCount.Should().Be(1);
     }
 
     private static (TestConnectorService service, Mock<IConnectorPublisher> publisher,

--- a/tests/Unit/Nocturne.Connectors.Eversense.Tests/Services/EversenseConnectorServiceTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Eversense.Tests/Services/EversenseConnectorServiceTests.cs
@@ -117,7 +117,6 @@ public class EversenseConnectorServiceTests
 
         // Assert
         result.Should().BeTrue();
-        fixture.Service.FailedRequestCount.Should().Be(0);
     }
 
     #endregion

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceStateIsolationTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceStateIsolationTests.cs
@@ -101,10 +101,10 @@ public class GlookoConnectorServiceStateIsolationTests
     /// <see cref="GlookoConnectorService"/> declares no mutable field of its own, instance or static.
     /// It does not (and cannot cheaply) prove a readonly field holds nothing mutable, and
     /// <c>DeclaredOnly</c> excludes <c>BaseConnectorService</c>, which does declare mutable per-run
-    /// fields (<c>_glucosePublishOrigin</c>, <c>_treatmentPublishOrigin</c>, <c>_devicePublishOrigin</c>,
-    /// <c>_failedRequestCount</c>) whose own comment says they are safe *because* the connector is
-    /// resolved fresh per run. That base-class reliance on the registration lifetime is out of this
-    /// issue's scope and is not covered here.
+    /// fields (<c>_glucosePublishOrigin</c>, <c>_treatmentPublishOrigin</c>, <c>_devicePublishOrigin</c>)
+    /// whose own comment says they are safe *because* the connector is resolved fresh per run. That
+    /// base-class reliance on the registration lifetime is out of this issue's scope and is not
+    /// covered here.
     /// </summary>
     [Fact]
     public void GlookoConnectorService_DeclaresNoMutableFields()


### PR DESCRIPTION
Fixes #1043

`BaseConnectorService` kept an in-memory health verdict (`IsHealthy => failures < MaxFailedRequestsBeforeUnhealthy`, plus `FailedRequestCount` and `ResetFailedRequestCount()`), and `LibreLinkUpConnectorService`/`MyLifeConnectorService` overrode it to fold in token expiry. Nothing read it.

## Verification

- `IsHealthy` was never on `IConnectorService` or any other connector interface. Every non-migration `IsHealthy` hit in `src/`, `tests/`, `tools/` resolves to the persisted `ConnectorConfiguration.IsHealthy` row and its DTOs (`ConnectorHealthService`, `ServicesController`, `ConnectorCursorResetService`, Aspire `TenantCommandExtensions`), to `DataSourceInfo.IsHealthy => Status == "active"`, or to `DemoServiceHealthCheck`. The Web's `isHealthy` reads all come off `ConnectorStatusDto`. `ResetFailedRequestCount()` had no callers at all.
- The overrides were once load-bearing: `git log -S'connectorService.IsHealthy'` shows six per-connector `*HealthCheck` classes reading it, all deleted in 11de2ac47 ("chore: connector refactor", 2026-02-01, 637 deletions). Nothing has read the property since.

## Change

Deleted `IsHealthy`, `MaxFailedRequestsBeforeUnhealthy`, `FailedRequestCount`, `ResetFailedRequestCount()` and the two vendor overrides. `_failedRequestCount` and `TrackFailedRequest`/`TrackSuccessfulRequest` stay: the consecutive-failure number feeds the failure warning at 27 call sites. That log line reads `Request failed (consecutive: {n})` instead of `(count: {n}/{max})`. Three `FailedRequestCount` assertions on retry-budget tests are removed (the tests' subject is the attempt budget; no test is deleted). They were the counter's only observability, so the reset in `TrackSuccessfulRequest` is now pinned by nothing but the log line's wording.

## Behavioural deltas

None at runtime beyond the log template. The whole solution builds with the members gone, which is the proof no other project referenced them. No interface changes.

## Tests

`Nocturne.Connectors.Core.Tests` 155/0, `Eversense` 24/0, `Glooko` 126/0, `MyLife` 39/0. Diff: prod −44 net (3 files), tests −3.

Noted, not done here: the surviving counter is per-sync-run (the service is resolved fresh per run), so nothing should build backoff on it without changing the registration lifetime; `Nocturne.Connectors.FreeStyle` has no test project at all.
