### PR TITLE
fix(connectors): keep partly-loadable assemblies and one global switch

### DIFF
--- a/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorConfigurationService.cs
@@ -374,7 +374,7 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
         }
 
         // Find the configuration class type
-        var configType = FindConfigurationType(connectorName);
+        var configType = FindConfigurationType(connectorName, _logger);
         if (configType == null)
         {
             _logger.LogWarning("Could not find configuration type for connector {ConnectorName}", connectorName);
@@ -547,7 +547,7 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
         string connectorName,
         CancellationToken ct = default)
     {
-        var configType = FindConfigurationType(connectorName);
+        var configType = FindConfigurationType(connectorName, _logger);
         if (configType == null)
         {
             _logger.LogWarning("Unknown connector {ConnectorName} for effective config", connectorName);
@@ -574,7 +574,7 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
     /// <summary>
     /// Finds the configuration class Type for a given connector name.
     /// </summary>
-    private static Type? FindConfigurationType(string connectorName)
+    private static Type? FindConfigurationType(string connectorName, ILogger logger)
     {
         var assemblies = AppDomain.CurrentDomain.GetAssemblies()
             .Where(a => a.FullName?.Contains("Nocturne.Connectors") == true)
@@ -582,21 +582,13 @@ public class ConnectorConfigurationService : IConnectorConfigurationService
 
         foreach (var assembly in assemblies)
         {
-            try
+            foreach (var type in assembly.LoadableTypes(logger))
             {
-                var types = assembly.GetTypes();
-                foreach (var type in types)
+                var attr = type.GetCustomAttribute<ConnectorRegistrationAttribute>();
+                if (attr != null && attr.ConnectorName.Equals(connectorName, StringComparison.OrdinalIgnoreCase))
                 {
-                    var attr = type.GetCustomAttribute<ConnectorRegistrationAttribute>();
-                    if (attr != null && attr.ConnectorName.Equals(connectorName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return type;
-                    }
+                    return type;
                 }
-            }
-            catch (ReflectionTypeLoadException)
-            {
-                // Some types may not be loadable, skip them
             }
         }
 

--- a/src/API/Nocturne.API/Services/Connectors/ConnectorHealthService.cs
+++ b/src/API/Nocturne.API/Services/Connectors/ConnectorHealthService.cs
@@ -1,4 +1,5 @@
 using Nocturne.API.Models;
+using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Models.Configuration;
@@ -79,9 +80,7 @@ public class ConnectorHealthService(
         );
 
         // Determine enabled state (check environment config first)
-        var envEnabled = configuration.GetValue<bool?>(
-            $"Parameters:Connectors:{connector.ConfigKey}:Enabled"
-        );
+        var envEnabled = configuration.ConnectorEnabled(connector.ConfigKey);
         var enabledConfig = envEnabled == false ? false : (dbConfig?.IsActive ?? envEnabled);
 
         var hasDatabaseConfig = configStatus?.HasDatabaseConfig ?? dbConfig != null;

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/AssemblyExtensions.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+
+namespace Nocturne.Connectors.Core.Extensions;
+
+public static class AssemblyExtensions
+{
+    extension(Assembly assembly)
+    {
+        /// <summary>
+        ///     The assembly's types, less any that cannot be loaded — a missing transitive
+        ///     dependency, a version mismatch after an image bump. One such type fails
+        ///     <see cref="Assembly.GetTypes"/> for every type in the assembly, so a scan that treats
+        ///     the failure as "no types here" loses every connector the assembly ships.
+        /// </summary>
+        public IEnumerable<Type> LoadableTypes(ILogger? logger = null)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.LoadableTypes(assembly.GetName().Name, logger);
+            }
+        }
+    }
+
+    extension(ReflectionTypeLoadException exception)
+    {
+        /// <summary>
+        ///     The types a failed <see cref="Assembly.GetTypes"/> did load, with the loader failures
+        ///     reported against <paramref name="assemblyName"/>.
+        /// </summary>
+        public IEnumerable<Type> LoadableTypes(string? assemblyName, ILogger? logger = null)
+        {
+            logger?.LogWarning(
+                "Types in {ConnectorAssembly} failed to load; only the loadable types are scanned: "
+                + "{LoaderErrors}",
+                assemblyName,
+                string.Join("; ", exception.LoaderExceptions.Select(loaderError => loaderError?.Message)));
+
+            return exception.Types.OfType<Type>();
+        }
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConfigurationExtensions.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConfigurationExtensions.cs
@@ -149,10 +149,36 @@ public static class ConfigurationExtensions
     extension(IConfiguration configuration)
     {
         /// <summary>
-        ///     Binds connector configuration from multiple sources in order of precedence:
-        ///     1. Environment variables (highest priority)
-        ///     2. Parameters:Connectors:{ConnectorName} section
-        ///     3. Connectors:{ConnectorName} section (fallback)
+        ///     The <c>Connectors:{<paramref name="name"/>}</c> section, preferring the
+        ///     <c>Parameters:</c>-prefixed copy Aspire writes.
+        /// </summary>
+        /// <param name="name">A connector name, or <c>Settings</c> for the shared defaults</param>
+        public IConfigurationSection ConnectorSection(string name)
+        {
+            var parameterised = configuration.GetSection($"Parameters:Connectors:{name}");
+            return parameterised.Exists()
+                ? parameterised
+                : configuration.GetSection($"Connectors:{name}");
+        }
+
+        /// <summary>
+        ///     The defaults every connector inherits before its own section is applied.
+        /// </summary>
+        public IConfigurationSection GlobalConnectorSettings => configuration.ConnectorSection("Settings");
+
+        /// <summary>
+        ///     Whether configuration enables the named connector, or <c>null</c> when neither its own
+        ///     section nor the shared defaults say. Callers own the default: installation and polling
+        ///     treat silence as enabled, the health surface reports it as unconfigured.
+        /// </summary>
+        public bool? ConnectorEnabled(string name) =>
+            configuration.ConnectorSection(name).GetValue<bool?>("Enabled")
+            ?? configuration.GlobalConnectorSettings.GetValue<bool?>("Enabled");
+
+        /// <summary>
+        ///     Binds connector configuration in increasing order of precedence: the defaults every
+        ///     connector shares (<c>Connectors:Settings</c>), the connector's own section, then
+        ///     environment variables.
         /// </summary>
         /// <typeparam name="T">The configuration type</typeparam>
         /// <param name="config">The configuration object to bind to</param>
@@ -160,33 +186,17 @@ public static class ConfigurationExtensions
         public void BindConnectorConfiguration<T>(T config, string connectorName)
             where T : BaseConnectorConfiguration
         {
-            // 1. Bind Global Settings (Parameters:Connectors:Settings)
-            var globalSection = configuration.GetSection("Parameters:Connectors:Settings");
+            var globalSection = configuration.GlobalConnectorSettings;
             if (globalSection.Exists()) globalSection.Bind(config);
 
-            // 2. Bind Specific Connector Settings
-            // Try primary configuration path
-            var section = configuration.GetSection($"Parameters:Connectors:{connectorName}");
+            var section = configuration.ConnectorSection(connectorName);
 
-            // Fallback to alternate path if not found
-            if (!section.Exists()) section = configuration.GetSection($"Connectors:{connectorName}");
-
-            // Bind the section if it exists
             // First use standard Bind for properties with matching names
             if (section.Exists()) section.Bind(config);
 
             // Then use [ConnectorProperty] or [AspireParameter] attributes for properties
             // with different names (e.g., JSON "Username" → C# property "LibreUsername")
             BindFromAttributes(section, config);
-
-            // Override with environment variables (these take precedence)
-            // Common base configuration properties
-            if (bool.TryParse(configuration["Enabled"], out var enabled)) config.Enabled = enabled;
-
-            if (int.TryParse(configuration["BatchSize"], out var batchSize)) config.BatchSize = batchSize;
-
-            if (int.TryParse(configuration["SyncIntervalMinutes"], out var syncIntervalMinutes))
-                config.SyncIntervalMinutes = syncIntervalMinutes;
 
             // Bind TimezoneOffset from environment variable (set by Aspire)
             if (double.TryParse(configuration["TimezoneOffset"], out var timezoneOffset))

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/ConnectorServiceCollectionExtensions.cs
@@ -243,44 +243,26 @@ public static class ConnectorServiceCollectionExtensions
 
             // Discover and invoke all IConnectorInstaller implementations
             foreach (var assembly in connectorAssemblies)
-            {
-                try
+                foreach (var type in assembly.LoadableTypes())
                 {
-                    foreach (var type in assembly.GetTypes())
-                    {
-                        if (type.IsAbstract || type.IsInterface)
-                            continue;
+                    if (type.IsAbstract || type.IsInterface)
+                        continue;
 
-                        if (!typeof(IConnectorInstaller).IsAssignableFrom(type))
-                            continue;
+                    if (!typeof(IConnectorInstaller).IsAssignableFrom(type))
+                        continue;
 
-                        var installer = (IConnectorInstaller)Activator.CreateInstance(type)!;
-                        installer.Install(services, configuration);
-                    }
+                    var installer = (IConnectorInstaller)Activator.CreateInstance(type)!;
+                    installer.Install(services, configuration);
                 }
-                catch (ReflectionTypeLoadException)
-                {
-                    // Some types may not be loadable, skip them
-                }
-            }
 
             if (pollingService is null)
                 return services;
 
             void AddPollerIfEnabled(Type hostedService, Type configType)
             {
-                // Per-connector section, then the global Settings section, then on by default.
                 var connectorName = ConnectorRegistrationAttribute.DeclaredOn(configType).ConnectorName;
-                var section = configuration.GetSection($"Parameters:Connectors:{connectorName}");
-                if (!section.Exists())
-                    section = configuration.GetSection($"Connectors:{connectorName}");
 
-                var isEnabled = section.GetValue<bool?>("Enabled")
-                    ?? configuration.GetValue<bool?>("Parameters:Connectors:Settings:Enabled")
-                    ?? configuration.GetValue<bool?>("Connectors:Settings:Enabled")
-                    ?? true;
-
-                if (isEnabled)
+                if (configuration.ConnectorEnabled(connectorName) ?? true)
                     services.TryAddEnumerable(
                         ServiceDescriptor.Singleton(typeof(IHostedService), hostedService));
             }

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorMetadataService.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorMetadataService.cs
@@ -109,34 +109,27 @@ public static class ConnectorMetadataService
                 .ToList();
 
             foreach (var assembly in assemblies)
-                try
+                foreach (var type in assembly.LoadableTypes())
                 {
-                    foreach (var type in assembly.GetTypes())
+                    var attr = type.GetCustomAttribute<ConnectorRegistrationAttribute>();
+                    if (attr == null || string.IsNullOrEmpty(attr.DataSourceId)) continue;
+                    var info = new ConnectorDisplayInfo
                     {
-                        var attr = type.GetCustomAttribute<ConnectorRegistrationAttribute>();
-                        if (attr == null || string.IsNullOrEmpty(attr.DataSourceId)) continue;
-                        var info = new ConnectorDisplayInfo
-                        {
-                            ConnectorName = attr.ConnectorName,
-                            ConnectorId = attr.ConnectorId,
-                            DisplayName = attr.DisplayName,
-                            DataSourceId = attr.DataSourceId,
-                            Icon = attr.Icon,
-                            Category = attr.Category,
-                            Description = attr.Description,
-                            ServiceName = attr.ServiceName,
-                            DefaultActiveThresholdMinutes = attr.DefaultActiveThresholdMinutes,
-                            DefaultStaleThresholdMinutes = attr.DefaultStaleThresholdMinutes
-                        };
+                        ConnectorName = attr.ConnectorName,
+                        ConnectorId = attr.ConnectorId,
+                        DisplayName = attr.DisplayName,
+                        DataSourceId = attr.DataSourceId,
+                        Icon = attr.Icon,
+                        Category = attr.Category,
+                        Description = attr.Description,
+                        ServiceName = attr.ServiceName,
+                        DefaultActiveThresholdMinutes = attr.DefaultActiveThresholdMinutes,
+                        DefaultStaleThresholdMinutes = attr.DefaultStaleThresholdMinutes
+                    };
 
-                        ConnectorsByDataSourceId[attr.DataSourceId] = info;
+                    ConnectorsByDataSourceId[attr.DataSourceId] = info;
 
-                        RegistrationsByConnectorId[attr.ConnectorId] = attr;
-                    }
-                }
-                catch (ReflectionTypeLoadException)
-                {
-                    // Some types may not be loadable, skip them
+                    RegistrationsByConnectorId[attr.ConnectorId] = attr;
                 }
 
             _initialized = true;

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorHealthEnabledStateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/ConnectorHealthEnabledStateTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Connectors;
+using Nocturne.Core.Contracts.Connectors;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Connectors;
+
+/// <summary>
+/// The health surface is where an operator checks whether a connector is running. It reads the same
+/// <c>Enabled</c> configuration that decides installation and polling, so a switch the other two
+/// honour and this one does not reports a connector as live while nothing syncs it.
+/// </summary>
+public class ConnectorHealthEnabledStateTests
+{
+    [Theory]
+    [InlineData("Parameters:Connectors:Settings:Enabled")]
+    [InlineData("Connectors:Settings:Enabled")]
+    public async Task DisablingConnectorsGlobally_ReportsEveryConnectorDisabled(string key)
+    {
+        var statuses = await Service((key, "false")).GetConnectorStatusesAsync();
+
+        statuses.Should().NotBeEmpty();
+        statuses.Should().OnlyContain(status => status.IsEnabled == false && status.State == "Disabled");
+    }
+
+    /// <summary>
+    /// The chain enables as well as disables. A connector the configuration switches on is
+    /// installed and polled on that alone, with no database row, so the health surface reports it
+    /// enabled on the same evidence rather than as unconfigured.
+    /// </summary>
+    [Theory]
+    [InlineData("Parameters:Connectors:Settings:Enabled")]
+    [InlineData("Connectors:Settings:Enabled")]
+    public async Task EnablingConnectorsGlobally_ReportsThemEnabledWithNoDatabaseRow(string key)
+    {
+        var statuses = await Service((key, "true")).GetConnectorStatusesAsync();
+
+        statuses.Should().NotBeEmpty();
+        statuses.Should().OnlyContain(status => status.IsEnabled && !status.HasDatabaseConfig);
+    }
+
+    /// <summary>
+    /// Silence is neither a yes nor a no. A connector with no configuration row and no configured
+    /// switch is unconfigured, and the aggregate drops an unconfigured connector that holds no data
+    /// — so defaulting the missing switch either way would put every connector on the dashboard.
+    /// </summary>
+    [Fact]
+    public async Task WithNoEnabledSettingAnywhere_NoConnectorIsReportedAtAll()
+    {
+        (await Service().GetConnectorStatusesAsync()).Should().BeEmpty();
+    }
+
+    private static ConnectorHealthService Service(params (string Key, string Value)[] settings)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.Select(s => new KeyValuePair<string, string?>(s.Key, s.Value)))
+            .Build();
+
+        var dataSources = new Mock<IDataSourceService>();
+        dataSources
+            .Setup(s => s.GetDataSourceStatsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string dataSource, CancellationToken _) => new DataSourceStats(
+                dataSource, 0, 0, null, null, 0, 0, null, null, 0, 0, null, null, [], []));
+
+        var connectorConfig = new Mock<IConnectorConfigurationService>();
+        connectorConfig
+            .Setup(s => s.GetAllConnectorStatusAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        connectorConfig
+            .Setup(s => s.GetConfigurationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConnectorConfigurationResponse?)null);
+
+        return new ConnectorHealthService(
+            configuration,
+            dataSources.Object,
+            connectorConfig.Object,
+            NullLogger<ConnectorHealthService>.Instance);
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorAssemblyScanTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorAssemblyScanTests.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Extensions;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Extensions;
+
+/// <summary>
+///     A connector installs, and shows in the UI, only if a scan reaches its types. One type that
+///     cannot be loaded fails <see cref="Assembly.GetTypes"/> for its whole assembly, so a scan that
+///     reads the failure as "no types here" drops every connector the assembly ships.
+/// </summary>
+public class ConnectorAssemblyScanTests
+{
+    [Fact]
+    public void AnAssemblyThatLoadsInPart_StillContributesItsLoadableTypes()
+    {
+        var partialLoad = new ReflectionTypeLoadException(
+            [typeof(string), null, typeof(int)],
+            [null, new TypeLoadException("Nocturne.Missing, Version=2.0.0 not found"), null]);
+
+        partialLoad.LoadableTypes("Nocturne.Connectors.Broken")
+            .Should().Equal(typeof(string), typeof(int));
+    }
+
+    [Fact]
+    public void AnAssemblyThatLoadsInPart_ReportsTheLoaderFailures()
+    {
+        var logger = new RecordingLogger();
+        var partialLoad = new ReflectionTypeLoadException(
+            [null],
+            [new TypeLoadException("Nocturne.Missing, Version=2.0.0 not found")]);
+
+        _ = partialLoad.LoadableTypes("Nocturne.Connectors.Broken", logger).ToList();
+
+        var entry = logger.Entries.Should().ContainSingle().Subject;
+        entry.Level.Should().Be(LogLevel.Warning);
+        entry.Message.Should().Contain("Nocturne.Connectors.Broken")
+            .And.Contain("Nocturne.Missing, Version=2.0.0 not found");
+    }
+
+    [Fact]
+    public void AnAssemblyThatLoadsWhole_IsScannedWithoutComment()
+    {
+        var logger = new RecordingLogger();
+
+        typeof(ConnectorAssemblyScanTests).Assembly.LoadableTypes(logger)
+            .Should().Contain(typeof(ConnectorAssemblyScanTests));
+
+        logger.Entries.Should().BeEmpty();
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/GlobalConnectorSettingsTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/GlobalConnectorSettingsTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Nocturne.Connectors.Core.Extensions;
+using Nocturne.Connectors.Core.Models;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Extensions;
+
+/// <summary>
+///     <c>Enabled</c> decides both whether a connector installs and whether it is polled, from two
+///     readers. A global switch honoured by one and not the other leaves the connector installed
+///     with a working manual sync and a live executor while every poller stands down.
+/// </summary>
+public class GlobalConnectorSettingsTests
+{
+    [Theory]
+    [InlineData("Parameters:Connectors:Settings:Enabled")]
+    [InlineData("Connectors:Settings:Enabled")]
+    public void DisablingConnectorsGlobally_DisablesTheBoundConfiguration(string key)
+    {
+        Bound((key, "false")).Enabled.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Parameters:Connectors:Settings", "Parameters:Connectors:Test")]
+    [InlineData("Connectors:Settings", "Connectors:Test")]
+    public void AConnectorEnabledInItsOwnSection_OutranksAGlobalFalse(string global, string connector)
+    {
+        Bound(($"{global}:Enabled", "false"), ($"{connector}:Enabled", "true"))
+            .Enabled.Should().BeTrue();
+    }
+
+    /// <summary>
+    ///     <c>Enabled</c>, <c>BatchSize</c> and <c>SyncIntervalMinutes</c> at the configuration root
+    ///     name no connector, so an unrelated setting of that name reached every connector.
+    /// </summary>
+    [Fact]
+    public void RootLevelSettings_ReachNoConnector()
+    {
+        var config = Bound(
+            ("Enabled", "false"),
+            ("BatchSize", "17"),
+            ("SyncIntervalMinutes", "23"));
+
+        config.Enabled.Should().BeTrue();
+        config.BatchSize.Should().Be(new TestConnectorConfiguration().BatchSize);
+        config.SyncIntervalMinutes.Should().Be(new TestConnectorConfiguration().SyncIntervalMinutes);
+    }
+
+    [Theory]
+    [InlineData("Parameters:Connectors:Settings")]
+    [InlineData("Connectors:Settings")]
+    public void GlobalDefaults_ApplyToConnectorsThatDoNotOverrideThem(string global)
+    {
+        Bound(($"{global}:BatchSize", "17")).BatchSize.Should().Be(17);
+    }
+
+    /// <summary>
+    ///     Aspire writes the <c>Parameters:</c>-prefixed copy, so where both are present that one
+    ///     is the operator's live setting and the bare section is what it was layered over.
+    /// </summary>
+    [Fact]
+    public void WithBothCopiesOfTheGlobalSection_TheParametersPrefixedOneWins()
+    {
+        Bound(
+            ("Parameters:Connectors:Settings:Enabled", "true"),
+            ("Connectors:Settings:Enabled", "false")).Enabled.Should().BeTrue();
+    }
+
+    /// <summary>
+    ///     <c>TimezoneOffset</c> is the one root key with a producer: the Aspire generator emits
+    ///     <c>connector.WithEnvironment("TimezoneOffset", …)</c> per connector resource, where the
+    ///     unprefixed name addresses that connector alone.
+    /// </summary>
+    [Fact]
+    public void RootLevelTimezoneOffset_StillReachesTheConnector()
+    {
+        Bound(("TimezoneOffset", "-5.5")).TimezoneOffset.Should().Be(-5.5);
+    }
+
+    private static TestConnectorConfiguration Bound(params (string Key, string Value)[] settings)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.Select(s => new KeyValuePair<string, string?>(s.Key, s.Value)))
+            .Build();
+
+        var config = new TestConnectorConfiguration();
+        configuration.BindConnectorConfiguration(config, "Test");
+        return config;
+    }
+
+    private sealed class TestConnectorConfiguration : BaseConnectorConfiguration
+    {
+        protected override void ValidateSourceSpecificConfiguration() { }
+    }
+}


### PR DESCRIPTION
Fixes #1049

## One unloadable type dropped a whole connector assembly

Three sites wrapped `assembly.GetTypes()` in `catch (ReflectionTypeLoadException) { }` — `AddConnectors` (installers), `ConnectorMetadataService` (display metadata) and `ConnectorConfigurationService` (config-type lookup) — so one type that fails to load (a missing transitive dependency after an image bump) made the connector vanish from the deployment silently. `Assembly.LoadableTypes(ILogger?)` is the one owner: it returns the loadable types from `ex.Types` and logs the loader exceptions at Warning against the assembly name. `AddConnectors` runs pre-`Build()` with no logger and `ConnectorMetadataService` is a static class, so both pass null; `ConnectorConfigurationService` passes its logger, so a partly-loadable assembly is logged when the connector configuration schema or effective configuration is read (the config UI endpoints); the install and metadata scans themselves still cannot log because they run before a logger exists.

## The global `Enabled` switch was read by one half of registration

The poller chain read `Parameters:Connectors:{name}:Enabled` → `Connectors:{name}:Enabled` → `Parameters:Connectors:Settings:Enabled` → `Connectors:Settings:Enabled`; `BindConnectorConfiguration` bound globals from `Parameters:Connectors:Settings` only, and `ConnectorHealthService` read only `Parameters:Connectors:{key}:Enabled`. `IConfiguration.ConnectorSection(name)` (the `Parameters:`-prefixed copy if it exists, else the bare one), `GlobalConnectorSettings` and `ConnectorEnabled(name)` (`bool?`, no default: the poller treats silence as enabled, the health surface keeps its tri-state "Not Configured") are the one fallback, used by the binder, the poller chain and the health service.

The "environment variable override" step read the unprefixed root keys `Enabled`, `BatchSize`, `SyncIntervalMinutes` and applied them to every connector. Nothing in the repo sets a root-level key of those names (no `appsettings*.json`, compose/helm/Aspire env var, or doc); all three carry `[ConnectorProperty]`, so the prefixed `CONNECT_{NAME}_*` variables and the section binds already cover every route. Those three root reads are deleted. The root `TimezoneOffset` read stays: the Aspire source generator emits `WithEnvironment("TimezoneOffset", …)` per connector resource, and a test now pins it.

## Behavioural deltas

- `Connectors:Settings:*` now applies to installation as well as polling: `Connectors:Settings:Enabled=false` installs nothing; other `BaseConnectorConfiguration` defaults under that section apply globally (previously only the `Parameters:`-prefixed copy did). `ConnectorConfigurationService`'s startup-defaults reader sees it too.
- The global lookup is section-existence based (matching the per-connector fallback): if `Parameters:Connectors:Settings` exists without an `Enabled` key while `Connectors:Settings:Enabled=false`, the poller previously stood down and now runs. No repo configuration produces this.
- Root-level `Enabled`/`BatchSize`/`SyncIntervalMinutes` no longer affect any connector (`TimezoneOffset` unchanged).
- The health surface follows the same chain as installation in both directions: a connector disabled by the global or bare-section switch is reported disabled, and one enabled only by the global or bare-section switch (no database row) is now listed as enabled instead of hidden as "Not Configured". With nothing set anywhere it stays unconfigured (tri-state preserved).
- A partly-loadable connector assembly contributes its loadable installers, metadata and config type, and logs a Warning naming the assembly and loader errors.

## Tests

`ConnectorAssemblyScanTests` (partial load keeps loadable types; loader failures logged), `GlobalConnectorSettingsTests` (both global keys disable; per-connector overrides global; root keys reach no connector; root `TimezoneOffset` still does), and health-service facts (global disable reported; global enable listed; no setting anywhere → unconfigured; `Parameters:` preferred over the bare section when both are set). Mutation-proven: swallow-all, unreachable warning, `Parameters:`-only global bind, restored root override, deleted `TimezoneOffset` read, `Parameters:`-only health read, and collapsed tri-state each fail exactly their tests. The one-line `Assembly.LoadableTypes` wrapper's catch is exercised only via the exception overload (fabricating a partly-loadable assembly would load a fixture into the test process).

`Nocturne.Connectors.Core.Tests` 167/0, `Nocturne.API.Tests` (unit filter) 6358/0. Diff: prod +22 net (6 files), tests +249.
