### PR TITLE
fix(api): close four loose ends from the dedup PRs

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OAuthController.cs
@@ -799,9 +799,7 @@ public class OAuthController : ControllerBase
             return subjectError;
         }
 
-        // Verify ownership: load all grants for the subject and check if grantId is among them
-        var grants = await _grantService.GetGrantsForSubjectAsync(subjectId);
-        if (grants.All(g => g.Id != grantId))
+        if (await _grantService.GetGrantForSubjectAsync(grantId, subjectId) is null)
         {
             return NotFound(new OAuthError
             {

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StateSpansController.cs
@@ -406,7 +406,7 @@ public class StateSpansController : ControllerBase
     /// </summary>
     [HttpDelete("{id}")]
     [RemoteCommand(Invalidates = [
-        nameof(GetStateSpans),
+        nameof(GetStateSpans), nameof(GetStateSpan),
         nameof(GetPumpModes), nameof(GetConnectivity), nameof(GetOverrides), nameof(GetTemporaryTargets),
         nameof(GetProfiles), nameof(GetExercise), nameof(GetIllness), nameof(GetTravel)])]
     [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/src/API/Nocturne.API/Controllers/V4/Identity/ConnectedAppsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ConnectedAppsController.cs
@@ -95,12 +95,8 @@ public class ConnectedAppsController : ControllerBase
             return Unauthorized();
         }
 
-        // Verify ownership: the grant must belong to this subject on this tenant.
-        var grants = await _grantService.GetGrantsForSubjectAsync(subjectId.Value, ct);
-        var grant = grants.FirstOrDefault(g =>
-            g.Id == grantId && g.GrantType == OAuthGrantTypes.App && !g.IsRevoked);
-
-        if (grant is null)
+        var grant = await _grantService.GetGrantForSubjectAsync(grantId, subjectId.Value, ct);
+        if (grant is null || grant.GrantType != OAuthGrantTypes.App)
         {
             return NotFound();
         }

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -16,10 +16,10 @@ namespace Nocturne.API.Controllers.V4.Treatments;
 /// </summary>
 /// <remarks>
 /// Both create and update enforce the same rules: <see cref="BasalInjection.Units"/> must be in (0, 500],
-/// <see cref="BasalInjection.Timestamp"/> may not be more than five minutes in the future, and — when the
-/// request carries a <c>PatientInsulinId</c> — the referenced <see cref="PatientInsulin"/> must exist with
-/// role <see cref="InsulinRole.Basal"/> or <see cref="InsulinRole.Both"/> and be active at the injection
-/// time. The server resolves <see cref="PatientInsulin"/> fresh on every write to populate the
+/// <see cref="BasalInjection.Timestamp"/> must be set and no more than five minutes in the future, and —
+/// when the request carries a <c>PatientInsulinId</c> — the referenced <see cref="PatientInsulin"/> must
+/// exist with role <see cref="InsulinRole.Basal"/> or <see cref="InsulinRole.Both"/> and be active at the
+/// injection time. The server resolves <see cref="PatientInsulin"/> fresh on every write to populate the
 /// <see cref="TreatmentInsulinContext"/> snapshot.
 ///
 /// The insulin reference is optional, matching <see cref="BolusController"/>: uploader-style clients that
@@ -211,6 +211,9 @@ public class BasalInjectionController(
     {
         if (units <= 0 || units > UnitsHardCeiling)
             return Problem(detail: "Units must be > 0 and <= 500.", statusCode: 400, title: "Bad Request");
+
+        if (timestamp == default)
+            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
         if (timestamp > DateTimeOffset.UtcNow.AddMinutes(FutureToleranceMinutes))
             return Problem(detail: "Timestamp cannot be more than 5 minutes in the future.", statusCode: 400, title: "Bad Request");

--- a/src/API/Nocturne.API/Models/Requests/V4/CreateBasalInjectionRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/CreateBasalInjectionRequest.cs
@@ -5,7 +5,6 @@ namespace Nocturne.API.Models.Requests.V4;
 /// <summary>
 /// Request body for creating a new basal insulin injection record via the V4 API.
 /// </summary>
-/// <seealso cref="Validators.V4.CreateBasalInjectionRequestValidator"/>
 /// <seealso cref="Nocturne.API.Controllers.V4.Treatments.BasalInjectionController"/>
 public class CreateBasalInjectionRequest : IBulkUpsertRequest
 {

--- a/src/API/Nocturne.API/Models/Requests/V4/UpdateBasalInjectionRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpdateBasalInjectionRequest.cs
@@ -6,7 +6,6 @@ namespace Nocturne.API.Models.Requests.V4;
 /// Request body for updating an existing basal insulin injection record via the V4 API.
 /// The injection is identified by the route-level ID parameter.
 /// </summary>
-/// <seealso cref="Validators.V4.UpdateBasalInjectionRequestValidator"/>
 /// <seealso cref="Nocturne.API.Controllers.V4.Treatments.BasalInjectionController"/>
 public class UpdateBasalInjectionRequest
 {

--- a/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OAuthGrantService.cs
@@ -148,6 +148,28 @@ public class OAuthGrantService : IOAuthGrantService
     }
 
     /// <inheritdoc />
+    public async Task<OAuthGrantInfo?> GetGrantForSubjectAsync(
+        Guid grantId,
+        Guid ownerSubjectId,
+        CancellationToken ct = default)
+    {
+        var entity = await _dbContext.OAuthGrants
+            .AsNoTracking()
+            .Include(g => g.Client)
+            .Where(g => g.Id == grantId
+                     && g.SubjectId == ownerSubjectId
+                     && g.RevokedAt == null)
+            .FirstOrDefaultAsync(ct);
+
+        if (entity == null)
+        {
+            return null;
+        }
+
+        return MapToInfo(entity);
+    }
+
+    /// <inheritdoc />
     public async Task RevokeGrantAsync(Guid grantId, CancellationToken ct = default)
     {
         var grant = await _dbContext.OAuthGrants
@@ -266,11 +288,10 @@ public class OAuthGrantService : IOAuthGrantService
     {
         var grant = await _dbContext.OAuthGrants
             .Include(g => g.Client)
-            .Where(g => g.Id == grantId)
+            .Where(g => g.Id == grantId && g.SubjectId == ownerSubjectId)
             .FirstOrDefaultAsync(ct);
 
-        // Grant not found or not owned by the specified subject
-        if (grant == null || grant.SubjectId != ownerSubjectId)
+        if (grant == null)
             return null;
 
         // Validated before anything is assigned, so a rejected update leaves the tracked entity

--- a/src/Core/Nocturne.Core.Contracts/Auth/IOAuthGrantService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IOAuthGrantService.cs
@@ -46,6 +46,20 @@ public interface IOAuthGrantService
     );
 
     /// <summary>
+    /// Get the active (non-revoked) grant with this id that this subject owns. A grant that is
+    /// revoked, absent, or owned by another subject all come back <c>null</c>, so a caller
+    /// authorizing against one cannot tell the three apart.
+    /// </summary>
+    /// <param name="grantId">The grant ID to look up</param>
+    /// <param name="ownerSubjectId">The owner subject ID (for authorization check)</param>
+    /// <param name="ct">Cancellation token</param>
+    Task<OAuthGrantInfo?> GetGrantForSubjectAsync(
+        Guid grantId,
+        Guid ownerSubjectId,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
     /// Revoke a grant (soft delete). Invalidates all associated refresh tokens, and — because
     /// access tokens carry their grant id — every outstanding access token minted from the grant.
     /// </summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/FoodMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/FoodMapper.cs
@@ -58,9 +58,7 @@ public static class FoodMapper
             Energy = entity.Energy,
             Gi = (int)entity.Gi,
             Unit = entity.Unit,
-            Foods = !string.IsNullOrEmpty(entity.Foods)
-                ? JsonSerializer.Deserialize<List<QuickPickFood>>(entity.Foods)
-                : null,
+            Foods = MapperHelpers.DeserializeJson<List<QuickPickFood>>(entity.Foods),
             HideAfterUse = entity.HideAfterUse,
             Hidden = entity.Hidden,
             Position = entity.Position,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalInjectionMapper.cs
@@ -42,9 +42,9 @@ public static class BasalInjectionMapper
             PatientDeviceId = entity.PatientDeviceId,
             Units = entity.Units,
             Notes = entity.Notes,
-            InsulinContext = !string.IsNullOrEmpty(entity.InsulinContextJson)
-                ? JsonSerializer.Deserialize<TreatmentInsulinContext>(entity.InsulinContextJson)
-                : null,
+            InsulinContext = MapperHelpers.DeserializeJson<TreatmentInsulinContext>(
+                entity.InsulinContextJson
+            ),
         }.WithHeaderFrom(entity);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BasalScheduleMapper.cs
@@ -33,7 +33,7 @@ public static class BasalScheduleMapper
         return new BasalSchedule
         {
             ProfileName = entity.ProfileName,
-            Entries = JsonSerializer.Deserialize<List<ScheduleEntry>>(entity.EntriesJson) ?? [],
+            Entries = MapperHelpers.DeserializeJson<List<ScheduleEntry>>(entity.EntriesJson) ?? [],
         }.WithHeaderFrom(entity);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/BolusMapper.cs
@@ -57,9 +57,9 @@ public static class BolusMapper
             Duration = entity.Duration,
             SyncIdentifier = entity.SyncIdentifier,
             InsulinType = entity.InsulinType,
-            InsulinContext = !string.IsNullOrEmpty(entity.InsulinContextJson)
-                ? JsonSerializer.Deserialize<TreatmentInsulinContext>(entity.InsulinContextJson)
-                : null,
+            InsulinContext = MapperHelpers.DeserializeJson<TreatmentInsulinContext>(
+                entity.InsulinContextJson
+            ),
             Unabsorbed = entity.Unabsorbed,
             DeviceId = entity.DeviceId,
             PatientDeviceId = entity.PatientDeviceId,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbRatioScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/CarbRatioScheduleMapper.cs
@@ -33,7 +33,7 @@ public static class CarbRatioScheduleMapper
         return new CarbRatioSchedule
         {
             ProfileName = entity.ProfileName,
-            Entries = JsonSerializer.Deserialize<List<ScheduleEntry>>(entity.EntriesJson) ?? [],
+            Entries = MapperHelpers.DeserializeJson<List<ScheduleEntry>>(entity.EntriesJson) ?? [],
         }.WithHeaderFrom(entity);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceMapper.cs
@@ -47,9 +47,9 @@ public static class DeviceMapper
             Serial = entity.Serial,
             FirstSeenTimestamp = entity.FirstSeenTimestamp,
             LastSeenTimestamp = entity.LastSeenTimestamp,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
+            AdditionalProperties = MapperHelpers.DeserializeJson<Dictionary<string, object?>>(
+                entity.AdditionalPropertiesJson
+            ),
         };
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceStatusExtrasMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/DeviceStatusExtrasMapper.cs
@@ -43,9 +43,9 @@ public static class DeviceStatusExtrasMapper
             TenantId = entity.TenantId,
             CorrelationId = entity.CorrelationId,
             Timestamp = entity.Timestamp,
-            Extras = !string.IsNullOrEmpty(entity.ExtrasJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.ExtrasJson)
-                : null,
+            Extras = MapperHelpers.DeserializeJson<Dictionary<string, object?>>(
+                entity.ExtrasJson
+            ),
             CreatedAt = entity.SysCreatedAt,
             ModifiedAt = entity.SysUpdatedAt,
         };

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensitivityScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/SensitivityScheduleMapper.cs
@@ -33,7 +33,7 @@ public static class SensitivityScheduleMapper
         return new SensitivitySchedule
         {
             ProfileName = entity.ProfileName,
-            Entries = JsonSerializer.Deserialize<List<ScheduleEntry>>(entity.EntriesJson) ?? [],
+            Entries = MapperHelpers.DeserializeJson<List<ScheduleEntry>>(entity.EntriesJson) ?? [],
         }.WithHeaderFrom(entity);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TargetRangeScheduleMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TargetRangeScheduleMapper.cs
@@ -33,7 +33,7 @@ public static class TargetRangeScheduleMapper
         return new TargetRangeSchedule
         {
             ProfileName = entity.ProfileName,
-            Entries = JsonSerializer.Deserialize<List<TargetRangeEntry>>(entity.EntriesJson) ?? [],
+            Entries = MapperHelpers.DeserializeJson<List<TargetRangeEntry>>(entity.EntriesJson) ?? [],
         }.WithHeaderFrom(entity);
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TempBasalMapper.cs
@@ -76,12 +76,12 @@ public static class TempBasalMapper
             PumpRecordId = entity.PumpRecordId,
             SyncIdentifier = entity.SyncIdentifier,
             ApsSnapshotId = entity.ApsSnapshotId,
-            InsulinContext = !string.IsNullOrEmpty(entity.InsulinContextJson)
-                ? JsonSerializer.Deserialize<TreatmentInsulinContext>(entity.InsulinContextJson)
-                : null,
-            AdditionalProperties = !string.IsNullOrEmpty(entity.AdditionalPropertiesJson)
-                ? JsonSerializer.Deserialize<Dictionary<string, object?>>(entity.AdditionalPropertiesJson)
-                : null,
+            InsulinContext = MapperHelpers.DeserializeJson<TreatmentInsulinContext>(
+                entity.InsulinContextJson
+            ),
+            AdditionalProperties = MapperHelpers.DeserializeJson<Dictionary<string, object?>>(
+                entity.AdditionalPropertiesJson
+            ),
         };
     }
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TherapySettingsMapper.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Mappers/V4/TherapySettingsMapper.cs
@@ -64,9 +64,9 @@ public static class TherapySettingsMapper
             DelayHigh = entity.DelayHigh,
             DelayMedium = entity.DelayMedium,
             DelayLow = entity.DelayLow,
-            LoopSettings = !string.IsNullOrEmpty(entity.LoopSettingsJson)
-                ? JsonSerializer.Deserialize<LoopProfileSettings>(entity.LoopSettingsJson)
-                : null,
+            LoopSettings = MapperHelpers.DeserializeJson<LoopProfileSettings>(
+                entity.LoopSettingsJson
+            ),
             IsDefault = entity.IsDefault,
             EnteredBy = entity.EnteredBy,
             IsExternallyManaged = entity.IsExternallyManaged,

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerGrantOwnershipTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthControllerGrantOwnershipTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.Authentication;
+using Nocturne.API.Models.OAuth;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Authorization;
+
+/// <summary>
+/// <c>DELETE /api/oauth/grants/{id}</c> authorizes against the grant's owner. A grant owned by
+/// another subject is answered the same way as one that does not exist, so the refusal never
+/// confirms an id the caller may not touch.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Category", "OAuth")]
+public class OAuthControllerGrantOwnershipTests
+{
+    private readonly Mock<IOAuthGrantService> _grantService = new();
+    private readonly Guid _callerSubjectId = Guid.CreateVersion7();
+
+    [Fact]
+    public async Task A_grant_the_caller_does_not_own_is_not_found_and_is_not_revoked()
+    {
+        var grantId = Guid.CreateVersion7();
+        GrantFor(grantId, grant: null);
+
+        var result = await CreateController().DeleteGrant(grantId);
+
+        var refusal = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        refusal.Value.Should().BeOfType<OAuthError>().Which.Error.Should().Be("not_found");
+        _grantService.Verify(
+            s => s.RevokeGrantAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task The_callers_own_grant_is_revoked()
+    {
+        var grantId = Guid.CreateVersion7();
+        GrantFor(grantId, new OAuthGrantInfo { Id = grantId, SubjectId = _callerSubjectId });
+
+        var result = await CreateController().DeleteGrant(grantId);
+
+        result.Should().BeOfType<NoContentResult>();
+        _grantService.Verify(
+            s => s.RevokeGrantAsync(grantId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private void GrantFor(Guid grantId, OAuthGrantInfo? grant) => _grantService
+        .Setup(s => s.GetGrantForSubjectAsync(
+            grantId, _callerSubjectId, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(grant);
+
+    private OAuthController CreateController()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.SessionCookie,
+            SubjectId = _callerSubjectId,
+        };
+
+        return new OAuthController(
+            Mock.Of<IOAuthClientService>(),
+            _grantService.Object,
+            Mock.Of<IOAuthTokenService>(),
+            Mock.Of<IOAuthDeviceCodeService>(),
+            Mock.Of<ISubjectService>(),
+            Mock.Of<IJwtService>(),
+            Mock.Of<IOAuthTokenRevocationCache>(),
+            NullLogger<OAuthController>.Instance
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthGrantServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthGrantServiceTests.cs
@@ -181,6 +181,54 @@ public class OAuthGrantServiceTests : IDisposable
     }
 
     // ---------------------------------------------------------------
+    // GetGrantForSubjectAsync
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public async Task GetGrantForSubjectAsync_ReturnsTheSubjectsActiveGrant()
+    {
+        using var db = CreateDbContext();
+        await SeedClientAsync(db);
+        await SeedSubjectAsync(db, _ownerSubjectId, "Owner");
+        var grantId = await SeedGrantAsync(db, subjectId: _ownerSubjectId);
+
+        var service = CreateService(db);
+        var grant = await service.GetGrantForSubjectAsync(grantId, _ownerSubjectId);
+
+        grant.Should().NotBeNull();
+        grant!.Id.Should().Be(grantId);
+        grant.ClientId.Should().Be(TestClientId, "the caller audits the revocation by client id");
+    }
+
+    [Fact]
+    public async Task GetGrantForSubjectAsync_ReturnsNullForAnotherSubjectsGrant()
+    {
+        using var db = CreateDbContext();
+        await SeedClientAsync(db);
+        var otherSubjectId = Guid.CreateVersion7();
+        await SeedSubjectAsync(db, otherSubjectId, "Other");
+        var grantId = await SeedGrantAsync(db, subjectId: otherSubjectId);
+
+        var service = CreateService(db);
+
+        (await service.GetGrantForSubjectAsync(grantId, _ownerSubjectId)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetGrantForSubjectAsync_ReturnsNullForARevokedGrant()
+    {
+        using var db = CreateDbContext();
+        await SeedClientAsync(db);
+        await SeedSubjectAsync(db, _ownerSubjectId, "Owner");
+        var grantId = await SeedGrantAsync(
+            db, subjectId: _ownerSubjectId, revokedAt: DateTime.UtcNow);
+
+        var service = CreateService(db);
+
+        (await service.GetGrantForSubjectAsync(grantId, _ownerSubjectId)).Should().BeNull();
+    }
+
+    // ---------------------------------------------------------------
     // RevokeGrantAsync
     // ---------------------------------------------------------------
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StateSpanInvalidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StateSpanInvalidationTests.cs
@@ -32,11 +32,22 @@ public class StateSpanInvalidationTests
     [InlineData(nameof(StateSpansController.DeleteStateSpan))]
     public void EveryWrite_RefreshesTheGenericListAndEveryCategoryRead(string write)
     {
-        var invalidates = typeof(StateSpansController).GetMethod(write)!
-            .GetCustomAttribute<RemoteCommandAttribute>()!.Invalidates;
+        var invalidates = Command(write).Invalidates;
 
         invalidates.Should().Contain(nameof(StateSpansController.GetStateSpans));
         invalidates.Should().Contain(CategoryReads);
+    }
+
+    /// <summary>
+    /// A write to a span that already exists can stale the by-id read the detail view holds; a
+    /// create cannot, because nothing is holding the minted id yet.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(StateSpansController.UpdateStateSpan))]
+    [InlineData(nameof(StateSpansController.DeleteStateSpan))]
+    public void AWriteToAnExistingSpan_RefreshesTheByIdRead(string write)
+    {
+        Command(write).Invalidates.Should().Contain(nameof(StateSpansController.GetStateSpan));
     }
 
     [Theory]
@@ -53,4 +64,8 @@ public class StateSpanInvalidationTests
         typeof(StateSpansController).GetMethod(read)!
             .GetCustomAttribute<RemoteQueryAttribute>().Should().NotBeNull();
     }
+
+    private static RemoteCommandAttribute Command(string write) =>
+        typeof(StateSpansController).GetMethod(write)!
+            .GetCustomAttribute<RemoteCommandAttribute>()!;
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ConnectedAppsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ConnectedAppsControllerTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.Core.Contracts.Auth;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Identity;
+
+/// <summary>
+/// <c>DELETE /api/v4/account/connected-apps/{grantId}</c> authorizes against the grant's owner,
+/// through the same ownership-scoped lookup as the OAuth grants API.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ConnectedAppsControllerTests
+{
+    private readonly Mock<IOAuthGrantService> _grantService = new();
+    private readonly Guid _callerSubjectId = Guid.CreateVersion7();
+
+    [Fact]
+    public async Task Revoke_a_grant_the_caller_does_not_own_is_not_found_and_is_not_revoked()
+    {
+        var grantId = Guid.CreateVersion7();
+        GrantFor(grantId, grant: null);
+
+        var result = await CreateController().Revoke(grantId, CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+        _grantService.Verify(
+            s => s.RevokeGrantAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Revoke_the_callers_own_app_grant_is_revoked()
+    {
+        var grantId = Guid.CreateVersion7();
+        GrantFor(grantId, new OAuthGrantInfo
+        {
+            Id = grantId,
+            SubjectId = _callerSubjectId,
+            GrantType = OAuthGrantTypes.App,
+        });
+
+        var result = await CreateController().Revoke(grantId, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        _grantService.Verify(
+            s => s.RevokeGrantAsync(grantId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// A guest link records the data owner's subject id, so the owner reaches their own guest
+    /// grant through this route; only app grants are connected apps.
+    /// </summary>
+    [Fact]
+    public async Task Revoke_a_guest_grant_is_not_found_and_is_not_revoked()
+    {
+        var grantId = Guid.CreateVersion7();
+        GrantFor(grantId, new OAuthGrantInfo
+        {
+            Id = grantId,
+            SubjectId = _callerSubjectId,
+            GrantType = OAuthGrantTypes.Guest,
+        });
+
+        var result = await CreateController().Revoke(grantId, CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+        _grantService.Verify(
+            s => s.RevokeGrantAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private void GrantFor(Guid grantId, OAuthGrantInfo? grant) => _grantService
+        .Setup(s => s.GetGrantForSubjectAsync(
+            grantId, _callerSubjectId, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(grant);
+
+    private ConnectedAppsController CreateController()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.SessionCookie,
+            SubjectId = _callerSubjectId,
+        };
+
+        return new ConnectedAppsController(
+            _grantService.Object,
+            Mock.Of<IOAuthTokenService>(),
+            NullLogger<ConnectedAppsController>.Instance
+        )
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
@@ -117,6 +117,31 @@ public class BasalInjectionControllerTests
         _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    /// <summary>
+    /// The bulk endpoint rejects an unset timestamp through <c>V4BulkValidation</c>; the single
+    /// create carries the same guard, in the same wording, or it persists 0001-01-01 injections
+    /// the bulk path refuses.
+    /// </summary>
+    [Fact]
+    public async Task Create_returns_400_when_timestamp_is_unset()
+    {
+        var controller = CreateController();
+        var request = new CreateBasalInjectionRequest
+        {
+            Timestamp = default,
+            PatientInsulinId = Guid.NewGuid(),
+            Units = 12,
+        };
+
+        var result = await controller.Create(request);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        objectResult.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Be("Timestamp must be set");
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     [Fact]
     public async Task Create_returns_400_when_PatientInsulin_not_found()
     {

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/FoodMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/FoodMapperTests.cs
@@ -1,0 +1,24 @@
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Mappers;
+
+namespace Nocturne.Infrastructure.Data.Tests.Mappers;
+
+public class FoodMapperTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ToDomainModel_MalformedFoodsJson_YieldsNoFoods()
+    {
+        var entity = new FoodEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Name = "Quick pick",
+            Foods = """[{"name":""",
+        };
+
+        var model = FoodMapper.ToDomainModel(entity);
+
+        model.Foods.Should().BeNull(
+            "one unparseable jsonb row must not fail the read of every record around it");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/BasalInjectionMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/BasalInjectionMapperTests.cs
@@ -1,0 +1,25 @@
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Mappers.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.Mappers.V4;
+
+public class BasalInjectionMapperTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ToDomainModel_MalformedInsulinContextJson_YieldsNoInsulinContext()
+    {
+        var entity = new BasalInjectionEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            Units = 12,
+            InsulinContextJson = """{"insulinName":""",
+        };
+
+        var model = BasalInjectionMapper.ToDomainModel(entity);
+
+        model.InsulinContext.Should().BeNull(
+            "one unparseable jsonb row must not fail the read of every record around it");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/BolusMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/BolusMapperTests.cs
@@ -554,4 +554,22 @@ public class BolusMapperTests
         entity.InsulinContextJson.Should().NotBeNullOrEmpty();
         entity.InsulinContextJson.Should().Contain("Lantus");
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ToDomainModel_MalformedInsulinContextJson_YieldsNoInsulinContext()
+    {
+        var entity = new BolusEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            Insulin = 2.5,
+            InsulinContextJson = """{"insulinName":""",
+        };
+
+        var model = BolusMapper.ToDomainModel(entity);
+
+        model.InsulinContext.Should().BeNull(
+            "one unparseable jsonb row must not fail the read of every record around it");
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/DeviceMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/DeviceMapperTests.cs
@@ -200,4 +200,25 @@ public class DeviceMapperTests
         roundTripped.FirstSeenMills.Should().Be(original.FirstSeenMills);
         roundTripped.LastSeenMills.Should().Be(original.LastSeenMills);
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ToDomainModel_MalformedAdditionalPropertiesJson_YieldsNoAdditionalProperties()
+    {
+        var entity = new DeviceEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Category = "InsulinPump",
+            Type = "Omnipod DASH",
+            Serial = "SN-12345",
+            FirstSeenTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            LastSeenTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            AdditionalPropertiesJson = """{"unterminated":""",
+        };
+
+        var model = DeviceMapper.ToDomainModel(entity);
+
+        model.AdditionalProperties.Should().BeNull(
+            "one unparseable jsonb row must not fail the read of every record around it");
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/DeviceStatusExtrasMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/DeviceStatusExtrasMapperTests.cs
@@ -1,0 +1,24 @@
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Mappers.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.Mappers.V4;
+
+public class DeviceStatusExtrasMapperTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ToDomainModel_MalformedExtrasJson_YieldsNoExtras()
+    {
+        var entity = new DeviceStatusExtrasEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            ExtrasJson = """{"unterminated":""",
+        };
+
+        var model = DeviceStatusExtrasMapper.ToDomainModel(entity);
+
+        model.Extras.Should().BeNull(
+            "one unparseable jsonb row must not fail the read of every record around it");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/ScheduleMapperEntriesTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/ScheduleMapperEntriesTests.cs
@@ -1,0 +1,47 @@
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Mappers.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.Mappers.V4;
+
+/// <summary>
+/// The four schedule mappers each project one <c>entries_json</c> column into a non-nullable
+/// list, so they share one contract: an unreadable column reads as an empty schedule.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ScheduleMapperEntriesTests
+{
+    public static TheoryData<string, Func<string?, int>> EntryCounts => new()
+    {
+        {
+            nameof(BasalScheduleMapper),
+            json => BasalScheduleMapper.ToDomainModel(
+                new BasalScheduleEntity { EntriesJson = json! }).Entries.Count
+        },
+        {
+            nameof(CarbRatioScheduleMapper),
+            json => CarbRatioScheduleMapper.ToDomainModel(
+                new CarbRatioScheduleEntity { EntriesJson = json! }).Entries.Count
+        },
+        {
+            nameof(SensitivityScheduleMapper),
+            json => SensitivityScheduleMapper.ToDomainModel(
+                new SensitivityScheduleEntity { EntriesJson = json! }).Entries.Count
+        },
+        {
+            nameof(TargetRangeScheduleMapper),
+            json => TargetRangeScheduleMapper.ToDomainModel(
+                new TargetRangeScheduleEntity { EntriesJson = json! }).Entries.Count
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(EntryCounts))]
+    public void ToDomainModel_UnreadableEntriesJson_YieldsNoEntries(
+        string mapper, Func<string?, int> entryCount)
+    {
+        entryCount("""[{"start":""").Should().Be(0,
+            "{0}: one unparseable jsonb row must not fail the read of every record around it",
+            mapper);
+        entryCount(null).Should().Be(0, "{0}: a null column is not a parse failure either", mapper);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/TempBasalMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/TempBasalMapperTests.cs
@@ -430,4 +430,42 @@ public class TempBasalMapperTests
                 because: $"TempBasalOrigin.{origin} should survive a round trip");
         }
     }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ToDomainModel_MalformedAdditionalPropertiesJson_YieldsNoAdditionalProperties()
+    {
+        var entity = new TempBasalEntity
+        {
+            Id = Guid.CreateVersion7(),
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            Rate = 1.0,
+            Origin = "Algorithm",
+            AdditionalPropertiesJson = """{"unterminated":""",
+        };
+
+        var model = TempBasalMapper.ToDomainModel(entity);
+
+        model.AdditionalProperties.Should().BeNull(
+            "one unparseable jsonb row must not fail the read of every record around it");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ToDomainModel_MalformedInsulinContextJson_YieldsNoInsulinContext()
+    {
+        var entity = new TempBasalEntity
+        {
+            Id = Guid.CreateVersion7(),
+            StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            Rate = 1.0,
+            Origin = "Algorithm",
+            InsulinContextJson = """{"insulinName":""",
+        };
+
+        var model = TempBasalMapper.ToDomainModel(entity);
+
+        model.InsulinContext.Should().BeNull(
+            "one unparseable jsonb row must not fail the read of every record around it");
+    }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/TherapySettingsMapperTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Mappers/V4/TherapySettingsMapperTests.cs
@@ -1,0 +1,24 @@
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Mappers.V4;
+
+namespace Nocturne.Infrastructure.Data.Tests.Mappers.V4;
+
+public class TherapySettingsMapperTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ToDomainModel_MalformedLoopSettingsJson_YieldsNoLoopSettings()
+    {
+        var entity = new TherapySettingsEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000).UtcDateTime,
+            LoopSettingsJson = """{"dia":""",
+        };
+
+        var model = TherapySettingsMapper.ToDomainModel(entity);
+
+        model.LoopSettings.Should().BeNull(
+            "one unparseable jsonb row must not fail the read of every record around it");
+    }
+}


### PR DESCRIPTION
Part of #1091 (items 1, 3, 4, 5; item 2 landed with #1115)

## 1. BasalInjection single create/update accepted an unset Timestamp

`BasalInjectionController.Create`/`Update` route through `ValidateUnitsAndTimestamp`, which checked units and the five-minute future tolerance only, so a default timestamp persisted a `0001-01-01` injection while the bulk path (after #1089) rejected it. The check now lives in that helper with the base's wording (`Timestamp must be set`). Both `CreateBasalInjectionRequest` and `UpdateBasalInjectionRequest` carried a `<seealso>` to a validator type that does not exist; the references are deleted (no validator is written: the sibling `CreateBolusRequestValidator` is a 13-rule class, not a 5-line copy).

## 3. StateSpans delete did not invalidate the by-id query

`DeleteStateSpan`'s `Invalidates` gains `nameof(GetStateSpan)`, matching `UpdateStateSpan`.

## 4. OAuth grant lookups loaded every grant to test one

`OAuthController.DeleteGrant` fetched all of the subject's grants and ran `All(g => g.Id != grantId)`; `ConnectedAppsController.Revoke` did the same with a `FirstOrDefault`. `IOAuthGrantService.GetGrantForSubjectAsync(grantId, ownerSubjectId)` is one ownership-scoped row (subject and `RevokedAt == null` in the WHERE, `Include(Client)` for the connected-apps audit log) and both sites use it; `ConnectedAppsController` keeps its `GrantType == App` check on the returned row. `UpdateGrantAsync`'s in-memory `SubjectId` comparison moves into its WHERE too (no `RevokedAt` term added there: a revoked grant was PATCH-able before and still is). Status codes and bodies are unchanged: another subject's grant, a revoked grant, a non-app grant and an unknown id all still 404 identically.

## 5. Legacy mappers threw on malformed jsonb

`DeviceMapper`/`TempBasalMapper` raw-deserialised `additional_properties_json` where the 18 `IV4Record` mappers use the tolerant `MapperHelpers.DeserializeJson`; the other raw sites over nullable jsonb columns (`InsulinContextJson` in three mappers, `ExtrasJson`, `LoopSettingsJson`, `Foods`, and the four schedule mappers' `EntriesJson`) are switched the same way, keeping each site's existing fallback so only the throw goes away (the schedules keep `?? []`; their old code also threw `ArgumentNullException` on a NULL column). `SettingsMapper` is left alone: its own `try/catch` already falls back to the raw string, which is better than null. One malformed row no longer fails the whole read.

## Behavioural deltas

- `POST/PUT basal-injections` with an absent or default timestamp: persisted → 400 `Timestamp must be set` (units are still checked first).
- `DELETE state-spans/{id}` refreshes the by-id remote query (client cache only).
- `DELETE oauth/grants/{id}` and connected-apps revoke issue one row lookup instead of loading the subject's grants; `IOAuthGrantService` gains a member (no out-of-tree implementers).
- Reads of rows with unparseable jsonb yield the mapper's fallback instead of a `JsonException`.

## Tests

Per item: 400 on unset timestamp; `StateSpanInvalidationTests` extended to Update+Delete; `OAuthControllerGrantOwnershipTests` and `ConnectedAppsControllerTests` (not-owned → 404 with nothing revoked; own app grant → 204; own non-app grant → 404); `OAuthGrantServiceTests` (SQLite) for owned/other-subject/revoked; one malformed-JSON fact per mapper plus a theory over the four schedule mappers (malformed and NULL). Mutation-proven: removing the timestamp check, dropping the subject from either WHERE, ignoring the null in `Revoke`, reverting the `nameof`, and restoring all twelve mapper bodies from `origin/main` (exactly the twelve pinning facts fail, 841 others green) each fail only the tests that pin them.

`Nocturne.API.Tests` (unit filter) 6364/0, `Nocturne.Infrastructure.Data.Tests` 853/0. Diff: prod +28 net (19 files), tests +494.
