### PR TITLE
fix(connectors): give every connector one instance-URL resolution

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Connectors/ConfigurationController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nocturne.API.Attributes;
 using Nocturne.API.Authorization;
+using Nocturne.Connectors.Core.Utilities;
 using OpenApi.Remote.Attributes;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Models.Authorization;
@@ -315,8 +316,8 @@ public class ConfigurationController : ControllerBase
     /// </summary>
     /// <remarks>
     /// The scheme-less allowance mirrors the connectors' own normalisation
-    /// (<c>NightscoutConnectorService.ResolveBaseUrl</c> and <c>ConfigureConnectorClient</c> prepend
-    /// <c>https://</c> to any stored value that does not already begin with <c>http</c>), so
+    /// (<c>ConnectorUrl.ResolveBase</c> and <c>ConfigureConnectorClient</c> prepend
+    /// <c>https://</c> to any stored value that is not already an absolute http/https URI), so
     /// validating here does not reject a value the connector would have accepted — an existing
     /// tenant re-saving <c>mysite.example</c> or <c>mysite.example:1337</c> must not start failing.
     /// <para>
@@ -324,8 +325,9 @@ public class ConfigurationController : ControllerBase
     /// parse alone: <c>Uri.TryCreate("mysite.example:1337", UriKind.Absolute, …)</c> succeeds with
     /// <c>Scheme == "mysite.example"</c> and an empty host, and <c>"localhost:1337"</c> the same way
     /// — 1337 is Nightscout's default self-hosted port, so that form is common. So once http/https
-    /// has been accepted above, what is left has to look like a host: no leading slash, and no
-    /// colon except the one introducing a port.
+    /// has been accepted, what is left has to look like a host: no leading slash, and no colon
+    /// except the one introducing a port. Both readings are
+    /// <c>ConnectorUrl.TryResolveBase</c>, which the connectors resolve their base URL through.
     /// </para>
     /// <para>
     /// Embedded credentials are refused because this value is stored in the connector's runtime
@@ -337,52 +339,9 @@ public class ConfigurationController : ControllerBase
     /// </remarks>
     private static bool IsAcceptableUri(string? candidate)
     {
-        if (string.IsNullOrWhiteSpace(candidate))
-            return false;
-
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out var absolute)
-            && (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps))
-        {
-            return string.IsNullOrEmpty(absolute.UserInfo);
-        }
-
-        // Any other explicit scheme is out. Tested before the scheme-less fallback, because
-        // prepending https:// to "file:/etc/passwd" produces something that still parses.
-        if (candidate.StartsWith('/') || !ColonIntroducesOnlyAPort(candidate))
-            return false;
-
-        // No scheme of its own: a host, optionally with a port, which the connectors read as https.
-        return Uri.TryCreate($"https://{candidate}", UriKind.Absolute, out var implied)
-            && string.IsNullOrEmpty(implied.UserInfo);
-    }
-
-    /// <summary>
-    /// A scheme and a <c>host:port</c> cannot be told apart by charset — a scheme may contain the
-    /// dots and dashes a hostname does — so what follows the first colon decides: digits to the end
-    /// of the value or to the first path separator, and it is a port.
-    /// </summary>
-    private static bool ColonIntroducesOnlyAPort(string candidate)
-    {
-        var authority = candidate.AsSpan();
-
-        if (authority[0] == '[')
-        {
-            var close = authority.IndexOf(']');
-            if (close < 0)
-                return false;
-
-            authority = authority[(close + 1)..];
-        }
-
-        var colon = authority.IndexOf(':');
-        if (colon < 0)
-            return true;
-
-        var afterColon = authority[(colon + 1)..];
-        var slash = afterColon.IndexOf('/');
-        var port = slash < 0 ? afterColon : afterColon[..slash];
-
-        return port.Length > 0 && !port.ContainsAnyExcept("0123456789");
+        return ConnectorUrl.TryResolveBase(candidate, out var resolved)
+            && Uri.TryCreate(resolved, UriKind.Absolute, out var absolute)
+            && string.IsNullOrEmpty(absolute.UserInfo);
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/ConnectorBackgroundService.cs
@@ -6,6 +6,7 @@ using Nocturne.API.Services.Audit;
 using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Contracts.Connectors;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
@@ -191,6 +192,28 @@ public abstract class ConnectorBackgroundService<TConfig> : BackgroundService
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// The tenant's configured instance URL as an absolute origin, or null when the stored value
+    /// cannot be read as one. A listener cannot reach an unresolvable URL and the tenant's polling
+    /// path rejects it in the same words, so this reports it against the listener and leaves the
+    /// caller to fall back to polling rather than raising it as an unexpected failure.
+    /// </summary>
+    protected string? ResolveListenerBaseUrl(string? url, string tenantSlug)
+    {
+        try
+        {
+            return ConnectorUrl.ResolveBase(url, ConnectorName);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Logger.LogWarning(
+                "{ConnectorName} URL for tenant {TenantSlug} cannot be resolved to an absolute http(s) URL ({Reason}), will rely on polling",
+                ConnectorName, tenantSlug, ex.Message);
+
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NightscoutConnectorBackgroundService.cs
@@ -123,17 +123,10 @@ public class NightscoutConnectorBackgroundService
 
         // Tenants may store a bare host with no scheme. Normalise through the same helper the sync
         // path uses so a URL that polls fine does not fail here on Uri parsing.
-        var socketUrl = NightscoutConnectorService.ResolveBaseUrl(config.Url);
-
-        if (!Uri.TryCreate(socketUrl, UriKind.Absolute, out var socketUri))
-        {
-            Logger.LogWarning(
-                "Nightscout URL {Url} for tenant {TenantSlug} is not a valid absolute URI, will rely on polling",
-                socketUrl, tenantSlug);
+        if (ResolveListenerBaseUrl(config.Url, tenantSlug) is not { } socketUrl)
             return;
-        }
 
-        var client = new SocketIO(socketUri, new SocketIOOptions
+        var client = new SocketIO(new Uri(socketUrl), new SocketIOOptions
         {
             Reconnection = true,
             ReconnectionAttempts = ReconnectionAttempts,

--- a/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/NocturneRemoteConnectorBackgroundService.cs
@@ -75,7 +75,10 @@ public class NocturneRemoteConnectorBackgroundService
                 if (!config.Enabled || string.IsNullOrWhiteSpace(config.Url))
                     continue;
 
-                var hubUrl = $"{config.Url.TrimEnd('/')}/hubs/data";
+                if (ResolveListenerBaseUrl(config.Url, tenant.Slug) is not { } baseUrl)
+                    continue;
+
+                var hubUrl = $"{baseUrl}/hubs/data";
                 var tenantId = tenant.Id;
 
                 var connection = new HubConnectionBuilder()

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/AspireAttributes.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/AspireAttributes.cs
@@ -147,6 +147,15 @@ public class ConnectorRegistrationAttribute(
     public int DefaultStaleThresholdMinutes { get; set; } = 60;
 
     /// <summary>
+    ///     The name <paramref name="configType"/> answers to in messages, falling back to its type
+    ///     name less the <c>Configuration</c> suffix for a config that declares no registration of
+    ///     its own.
+    /// </summary>
+    public static string NameFor(Type configType) =>
+        configType.GetCustomAttribute<ConnectorRegistrationAttribute>()?.ConnectorName
+        ?? configType.Name.Replace("Configuration", "");
+
+    /// <summary>
     ///     The registration <paramref name="configType"/> declares itself.
     /// </summary>
     /// <remarks>

--- a/src/Connectors/Nocturne.Connectors.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Extensions/HttpClientExtensions.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Models.Net;
 using Polly;
 
@@ -46,12 +47,7 @@ public static class HttpClientExtensions
                 .ConfigureHttpClient(client =>
                 {
                     if (baseUrl != null)
-                    {
-                        var url = baseUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-                            ? baseUrl
-                            : $"https://{baseUrl}";
-                        client.BaseAddress = new Uri(url);
-                    }
+                        client.BaseAddress = BaseAddressFor(baseUrl, builder.Name);
 
                     client.DefaultRequestHeaders.Accept.Clear();
                     client.DefaultRequestHeaders.Accept.Add(
@@ -179,5 +175,19 @@ public static class HttpClientExtensions
 
             return builder;
         }
+    }
+
+    /// <summary>
+    ///     A base address whose path ends in a slash. Without one, resolving a relative request
+    ///     against it drops the last path segment, so an instance hosted under a subpath would
+    ///     lose that subpath.
+    /// </summary>
+    private static Uri BaseAddressFor(string baseUrl, string connectorName)
+    {
+        var resolved = new Uri(ConnectorUrl.ResolveBase(baseUrl, connectorName));
+
+        return resolved.AbsolutePath.EndsWith('/')
+            ? resolved
+            : new UriBuilder(resolved) { Path = $"{resolved.AbsolutePath}/" }.Uri;
     }
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Models/BaseConnectorConfiguration.cs
@@ -19,9 +19,7 @@ public abstract class BaseConnectorConfiguration : IConnectorConfiguration
     ///     Gets the connector name from the ConnectorRegistration attribute.
     ///     Used for error messages and logging.
     /// </summary>
-    private string ConnectorName =>
-        GetType().GetCustomAttribute<ConnectorRegistrationAttribute>()?.ConnectorName
-        ?? GetType().Name.Replace("Configuration", "");
+    protected string ConnectorName => ConnectorRegistrationAttribute.NameFor(GetType());
 
     /// <summary>
     ///     Gets the environment variable prefix from the ConnectorRegistration attribute.

--- a/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorServerResolverOfT.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Services/ConnectorServerResolverOfT.cs
@@ -1,4 +1,5 @@
 using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Utilities;
 
@@ -33,10 +34,5 @@ public class ConnectorServerResolver<TConfig>(
     }
 
     private static Uri BuildUri(string server)
-    {
-        var url = server.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-            ? server
-            : $"https://{server}";
-        return new Uri(url);
-    }
+        => new(ConnectorUrl.ResolveBase(server, ConnectorRegistrationAttribute.NameFor(typeof(TConfig))));
 }

--- a/src/Connectors/Nocturne.Connectors.Core/Utilities/ConnectorUrl.cs
+++ b/src/Connectors/Nocturne.Connectors.Core/Utilities/ConnectorUrl.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nocturne.Connectors.Core.Utilities;
+
+public static class ConnectorUrl
+{
+    /// <summary>
+    ///     <inheritdoc cref="TryResolveBase" path="/summary"/>
+    /// </summary>
+    /// <param name="url">The URL as stored in the tenant's connector configuration.</param>
+    /// <param name="connectorName">Names the connector in the rejection messages.</param>
+    /// <exception cref="InvalidOperationException">
+    ///     <paramref name="url"/> is blank; or carries a scheme other than http/https; or is
+    ///     neither, and does not read as a host — a leading slash, a colon introducing something
+    ///     other than a port, or anything that will not parse once behind <c>https://</c>.
+    /// </exception>
+    public static string ResolveBase(string? url, string connectorName)
+    {
+        // Blank is separated from the rest only to name it in the message.
+        if (string.IsNullOrWhiteSpace(url))
+            throw new InvalidOperationException($"{connectorName} URL is not configured");
+
+        return TryResolveBase(url, out var resolved)
+            ? resolved
+            : throw new InvalidOperationException($"{connectorName} URL must be http or https");
+    }
+
+    /// <summary>
+    ///     A tenant-configured instance URL as an absolute origin with no trailing slash. A value
+    ///     carrying no scheme of its own is taken for a host and given <c>https</c>, so
+    ///     <c>httpbin.example.com</c> resolves to a host and not to a scheme.
+    /// </summary>
+    public static bool TryResolveBase(string? url, [NotNullWhen(true)] out string? resolved)
+    {
+        resolved = null;
+
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var absolute)
+            && (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps))
+        {
+            resolved = url.TrimEnd('/');
+            return true;
+        }
+
+        // Any other explicit scheme is out. Tested before the scheme-less reading, because
+        // prepending https:// to "file:/etc/passwd" produces something that still parses.
+        if (url.StartsWith('/') || !ColonIntroducesOnlyAPort(url))
+            return false;
+
+        var implied = $"https://{url}";
+        if (!Uri.TryCreate(implied, UriKind.Absolute, out _))
+            return false;
+
+        resolved = implied.TrimEnd('/');
+        return true;
+    }
+
+    /// <summary>
+    ///     A scheme and a <c>host:port</c> cannot be told apart by charset — a scheme may contain the
+    ///     dots and dashes a hostname does — so what follows the first colon decides: digits to the end
+    ///     of the value or to the first path separator, and it is a port.
+    /// </summary>
+    internal static bool ColonIntroducesOnlyAPort(string candidate)
+    {
+        var authority = candidate.AsSpan();
+
+        if (authority[0] == '[')
+        {
+            var close = authority.IndexOf(']');
+            if (close < 0)
+                return false;
+
+            authority = authority[(close + 1)..];
+        }
+
+        var colon = authority.IndexOf(':');
+        if (colon < 0)
+            return true;
+
+        var afterColon = authority[(colon + 1)..];
+        var slash = afterColon.IndexOf('/');
+        var port = slash < 0 ? afterColon : afterColon[..slash];
+
+        return port.Length > 0 && !port.ContainsAnyExcept("0123456789");
+    }
+}

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/NightscoutConnectorService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
 using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Constants;
 using Nocturne.Core.Models;
@@ -60,7 +61,7 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
     private async Task<bool> AuthenticateWithConfigAsync(TConfig config)
     {
         _currentConfig = config;
-        _resolvedBaseUrl = ResolveBaseUrl(config.Url);
+        _resolvedBaseUrl = ConnectorUrl.ResolveBase(config.Url, "Nightscout");
 
         if (string.IsNullOrEmpty(config.ApiSecret))
         {
@@ -722,24 +723,6 @@ public class NightscoutConnectorServiceBase<TConfig> : BaseConnectorService<TCon
             url += $"&find[created_at][$lte]={to.Value.ToUniversalTime():o}";
 
         return url;
-    }
-
-    /// <summary>
-    /// Normalises a tenant-configured Nightscout URL: supplies <c>https://</c> when the tenant
-    /// stored a bare host, and trims any trailing slash so callers can append paths directly.
-    /// </summary>
-    /// <param name="configUrl">The URL as stored in the tenant's connector configuration.</param>
-    /// <exception cref="InvalidOperationException">The configured URL is null or empty.</exception>
-    public static string ResolveBaseUrl(string configUrl)
-    {
-        if (string.IsNullOrEmpty(configUrl))
-            throw new InvalidOperationException("Nightscout URL is not configured");
-
-        var url = configUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-            ? configUrl
-            : $"https://{configUrl}";
-
-        return url.TrimEnd('/');
     }
 
     private Dictionary<string, string> GetAuthHeaders()

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutWriteBackSink.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutWriteBackSink.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Core.Contracts.Events;
 
@@ -113,12 +114,7 @@ public abstract class NightscoutWriteBackSink<T> : IDataEventSink<T>
     }
 
     private static string ResolveAbsoluteUrl(string configUrl, string endpoint)
-    {
-        var baseUrl = configUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-            ? configUrl
-            : $"https://{configUrl}";
-        return $"{baseUrl.TrimEnd('/')}{endpoint}";
-    }
+        => $"{ConnectorUrl.ResolveBase(configUrl, "Nightscout")}{endpoint}";
 
     private List<T> FilterItems(IReadOnlyList<T> items)
     {

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Configurations/NocturneRemoteConnectorConfiguration.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Configurations/NocturneRemoteConnectorConfiguration.cs
@@ -1,5 +1,6 @@
 using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Core.Constants;
 
 namespace Nocturne.Connectors.NocturneRemote.Configurations;
@@ -56,4 +57,11 @@ public class NocturneRemoteConnectorConfiguration : BaseConnectorConfiguration
     /// </summary>
     [ConnectorProperty(ConnectorPropertyKey.MaxCount, DefaultValue = "500", MinValue = 50, MaxValue = 5000)]
     public int MaxCount { get; set; } = 500;
+
+    /// <summary>
+    ///     <inheritdoc cref="ConnectorUrl.ResolveBase" path="/summary"/> A method, not a property,
+    ///     so the configuration loader's JSON clone neither carries it nor trips its guard on a
+    ///     half-filled configuration.
+    /// </summary>
+    public string ResolveBaseUrl() => ConnectorUrl.ResolveBase(Url, ConnectorName);
 }

--- a/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
+++ b/src/Connectors/Nocturne.Connectors.NocturneRemote/Services/NocturneRemoteConnectorService.cs
@@ -592,14 +592,7 @@ public class NocturneRemoteConnectorService : BaseConnectorService<NocturneRemot
 
     private void ResolveConfiguration(NocturneRemoteConnectorConfiguration config)
     {
-        if (string.IsNullOrEmpty(config.Url))
-            throw new InvalidOperationException("Remote Nocturne URL is not configured");
-
-        var url = config.Url.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-            ? config.Url
-            : $"https://{config.Url}";
-
-        _resolvedBaseUrl = url.TrimEnd('/');
+        _resolvedBaseUrl = config.ResolveBaseUrl();
 
         _authHeaders = !string.IsNullOrEmpty(config.Token)
             ? new Dictionary<string, string> { ["Authorization"] = $"Bearer {config.Token}" }

--- a/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorConfigurationUriValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Connectors/ConnectorConfigurationUriValidationTests.cs
@@ -13,7 +13,7 @@ namespace Nocturne.API.Tests.Connectors;
 /// <summary>
 /// What a <c>format: "uri"</c> connector field will accept into storage. Every connector taking a
 /// member-supplied base URL declares that format, and the stored value is later prepended with
-/// <c>https://</c> if it does not already start with <c>http</c>.
+/// <c>https://</c> if it carries no http/https scheme of its own.
 /// </summary>
 /// <remarks>
 /// The address a URL resolves to is judged at the sink, not here — this is about which strings are

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/AlertEngineSelectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/AlertEngineSelectionTests.cs
@@ -7,6 +7,7 @@ using Nocturne.API.Extensions;
 using Nocturne.API.Services.Alerts;
 using Nocturne.API.Services.Alerts.Engines;
 using Nocturne.API.Services.Alerts.Evaluators;
+using Nocturne.API.Tests.TestDoubles;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Contracts.Repositories;
 using Xunit;

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/EngineTestHarness.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/EngineTestHarness.cs
@@ -150,20 +150,3 @@ internal static class EngineTestHarness
         };
     }
 }
-
-/// <summary>Minimal capturing logger for asserting structured log events.</summary>
-internal sealed class ListLogger<T> : ILogger<T>
-{
-    public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = new();
-
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-
-    public bool IsEnabled(LogLevel logLevel) => true;
-
-    public void Log<TState>(
-        LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-        Func<TState, Exception?, string> formatter)
-    {
-        Entries.Add((logLevel, formatter(state, exception), exception));
-    }
-}

--- a/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/ShadowAlertEngineTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Alerts/Engines/ShadowAlertEngineTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Nocturne.Alerts.ParityCorpus.Generator.Harness;
 using Nocturne.API.Services.Alerts.Engines;
+using Nocturne.API.Tests.TestDoubles;
 using Nocturne.Core.Contracts.Alerts;
 using Nocturne.Core.Models;
 using Nocturne.Core.Models.Alerts;

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NightscoutRealtimeListenerTests.cs
@@ -1,12 +1,14 @@
 using System.Collections.Concurrent;
+using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.BackgroundServices;
+using Nocturne.API.Tests.TestDoubles;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Models;
+using Nocturne.Connectors.Core.Utilities;
 using Nocturne.Connectors.Nightscout.Configurations;
 using Nocturne.Connectors.Nightscout.Services;
 using Nocturne.Core.Contracts.Connectors;
@@ -166,7 +168,7 @@ public class NightscoutRealtimeListenerTests
             Url = "http://127.0.0.1:9",
         };
 
-        var logger = new CapturingLogger();
+        var logger = new ListLogger<NightscoutConnectorBackgroundService>();
         var serviceProvider = BuildServiceProvider(connectionString, config);
         var sut = new NightscoutConnectorBackgroundService(serviceProvider, logger);
 
@@ -175,15 +177,16 @@ public class NightscoutRealtimeListenerTests
 
         // Assert — the connect failed (nothing is listening on port 9), but it must have failed by
         // actually attempting to connect, not by rejecting our own options.
-        Assert.DoesNotContain(logger.Exceptions, ex => ex is ArgumentOutOfRangeException);
+        Assert.DoesNotContain(logger.Entries, e => e.Exception is ArgumentOutOfRangeException);
     }
 
     /// <summary>
     /// Tenants may store a bare host with no scheme; the polling path normalises this via
-    /// ResolveBaseUrl. The listener path must not blow up on Uri parsing where polling succeeds.
+    /// <see cref="ConnectorUrl.ResolveBase"/>. The listener must reach the connect step against
+    /// the same resolved origin rather than be turned away by its absolute-URI guard.
     /// </summary>
     [Fact]
-    public async Task StartRealtimeListenersAsync_SchemelessUrl_DoesNotThrowUriFormatException()
+    public async Task StartRealtimeListenersAsync_SchemelessUrl_ConnectsToResolvedOrigin()
     {
         // Arrange — a bare host, as three production tenants have stored
         var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
@@ -195,7 +198,7 @@ public class NightscoutRealtimeListenerTests
             Url = "127.0.0.1:9",
         };
 
-        var logger = new CapturingLogger();
+        var logger = new ListLogger<NightscoutConnectorBackgroundService>();
         var serviceProvider = BuildServiceProvider(connectionString, config);
         var sut = new NightscoutConnectorBackgroundService(serviceProvider, logger);
 
@@ -203,7 +206,9 @@ public class NightscoutRealtimeListenerTests
         await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
 
         // Assert
-        Assert.DoesNotContain(logger.Exceptions, ex => ex is UriFormatException);
+        logger.Entries.Should().Contain(e =>
+            e.Message.Contains("Failed to connect Socket.IO")
+            && e.Message.Contains("https://127.0.0.1:9"));
     }
 
     /// <summary>
@@ -239,6 +244,36 @@ public class NightscoutRealtimeListenerTests
         Assert.DoesNotContain(dead, SocketClients(sut).Values);
     }
 
+    /// <summary>
+    /// A stored URL the resolver refuses is the listener's to report: it cannot connect, and
+    /// letting the rejection reach the per-tenant catch would file it as an unexpected error.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_UnresolvableUrl_ReportsItAndSkipsTenant()
+    {
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NightscoutConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "ftp://x",
+        };
+
+        var logger = new ListLogger<NightscoutConnectorBackgroundService>();
+        var sut = new NightscoutConnectorBackgroundService(
+            BuildServiceProvider(connectionString, config), logger);
+
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+
+        logger.Entries.Should().Contain(e =>
+            e.Message.Contains("cannot be resolved to an absolute http(s) URL")
+            && e.Message.Contains("test-tenant"));
+        logger.Entries.Should().NotContain(e =>
+            e.Message.Contains("Unexpected error starting real-time listener"));
+        logger.Entries.Should().NotContain(e => e.Message.Contains("Failed to connect Socket.IO"));
+    }
+
     #region Helpers
 
     /// <summary>
@@ -248,37 +283,6 @@ public class NightscoutRealtimeListenerTests
         => (ConcurrentDictionary<Guid, SocketIO>)typeof(NightscoutConnectorBackgroundService)
             .GetField("_socketClients", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .GetValue(sut)!;
-
-    /// <summary>
-    /// Captures exceptions passed to the logger so tests can assert on how a failure surfaced.
-    /// </summary>
-    private sealed class CapturingLogger : ILogger<NightscoutConnectorBackgroundService>
-    {
-        private readonly List<Exception> _exceptions = [];
-
-        public IReadOnlyList<Exception> Exceptions
-        {
-            get { lock (_exceptions) return _exceptions.ToList(); }
-        }
-
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-            if (exception is null)
-                return;
-
-            lock (_exceptions)
-                _exceptions.Add(exception);
-        }
-    }
 
     /// <summary>
     /// Invokes the protected StartRealtimeListenersAsync via reflection.

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
@@ -1,8 +1,10 @@
+using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Services.BackgroundServices;
+using Nocturne.API.Tests.TestDoubles;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.NocturneRemote.Configurations;
 using Nocturne.Core.Contracts.Multitenancy;
@@ -125,6 +127,66 @@ public class NocturneRemoteRealtimeListenerTests
 
         // Act & Assert — should skip the tenant without throwing
         await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Pins the listener's own call site: a tenant storing a bare host must reach the connect
+    /// step against the resolved absolute hub URI, rather than being turned away by the
+    /// absolute-URI guard in front of it.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_SchemelessUrl_ConnectsToResolvedHubUri()
+    {
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NocturneRemoteConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "127.0.0.1:9",
+            Token = "test-token",
+        };
+
+        var logger = new ListLogger<NocturneRemoteConnectorBackgroundService>();
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            BuildServiceProvider(connectionString, config), logger);
+
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+
+        logger.Entries.Should().Contain(e =>
+            e.Message.Contains("Failed to connect SignalR")
+            && e.Message.Contains("https://127.0.0.1:9/hubs/data"));
+    }
+
+    /// <summary>
+    /// A stored URL the resolver refuses is the listener's to report: it cannot connect, and
+    /// letting the rejection reach the per-tenant catch would file it as an unexpected error.
+    /// </summary>
+    [Fact]
+    public async Task StartRealtimeListenersAsync_UnresolvableUrl_ReportsItAndSkipsTenant()
+    {
+        var (cleanup, connectionString) = CreateSqliteDb(addTenant: true);
+        using var _ = cleanup;
+
+        var config = new NocturneRemoteConnectorConfiguration
+        {
+            Enabled = true,
+            Url = "ftp://x",
+            Token = "test-token",
+        };
+
+        var logger = new ListLogger<NocturneRemoteConnectorBackgroundService>();
+        var sut = new NocturneRemoteConnectorBackgroundService(
+            BuildServiceProvider(connectionString, config), logger);
+
+        await InvokeStartRealtimeListenersAsync(sut, CancellationToken.None);
+
+        logger.Entries.Should().Contain(e =>
+            e.Message.Contains("cannot be resolved to an absolute http(s) URL")
+            && e.Message.Contains("test-tenant"));
+        logger.Entries.Should().NotContain(e =>
+            e.Message.Contains("Unexpected error starting real-time listener"));
+        logger.Entries.Should().NotContain(e => e.Message.Contains("Failed to connect SignalR"));
     }
 
     #region Helpers

--- a/tests/Unit/Nocturne.API.Tests/Services/Devices/ReservoirEstimationServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Devices/ReservoirEstimationServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Nocturne.API.Services.Devices;
+using Nocturne.API.Tests.TestDoubles;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.Basal;
@@ -20,7 +21,8 @@ public class ReservoirEstimationServiceTests
     private readonly Mock<IBolusRepository> _boluses = new();
     private readonly Mock<ITempBasalRepository> _tempBasals = new();
     private readonly Mock<IBasalSegmentService> _basalSegments = new();
-    private readonly CapturingLogger _logger = new();
+    // Moq cannot proxy ILogger<ReservoirEstimationService>: the generic argument is internal.
+    private readonly ListLogger<ReservoirEstimationService> _logger = new();
     private readonly ReservoirEstimationService _sut;
 
     public ReservoirEstimationServiceTests()
@@ -147,21 +149,6 @@ public class ReservoirEstimationServiceTests
         var estimate = await _sut.GetEstimateAsync(null);
 
         estimate.Should().Be(new ReservoirEstimate(0m, IsLowerBound: false, IsEstimated: true));
-    }
-
-    /// <summary>Records warning-level messages. Moq cannot proxy
-    /// <c>ILogger&lt;ReservoirEstimationService&gt;</c> because the generic argument is internal.</summary>
-    private sealed class CapturingLogger : ILogger<ReservoirEstimationService>
-    {
-        public List<string> Warnings { get; } = [];
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-        public bool IsEnabled(LogLevel logLevel) => true;
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-            if (logLevel == LogLevel.Warning)
-                Warnings.Add(formatter(state, exception));
-        }
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/TestDoubles/ListLogger.cs
+++ b/tests/Unit/Nocturne.API.Tests/TestDoubles/ListLogger.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+
+namespace Nocturne.API.Tests.TestDoubles;
+
+/// <summary>Minimal capturing logger for asserting structured log events.</summary>
+internal sealed class ListLogger<T> : ILogger<T>
+{
+    public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = new();
+
+    public IEnumerable<string> Warnings =>
+        Entries.Where(e => e.Level == LogLevel.Warning).Select(e => e.Message);
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add((logLevel, formatter(state, exception), exception));
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorClientBaseAddressTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Extensions/ConnectorClientBaseAddressTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Connectors.Core.Extensions;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Extensions;
+
+/// <summary>
+/// The base address a connector's client is registered with. A tenant-supplied value reaches this
+/// through <c>TenantUrlConnectorInstaller</c>, so it may be a bare host.
+/// </summary>
+public class ConnectorClientBaseAddressTests
+{
+    private const string ClientName = "test-connector-client";
+
+    [Theory]
+    [InlineData("httpbin.example.com", "https://httpbin.example.com/")]
+    [InlineData("http://api.example.com", "http://api.example.com/")]
+    // A base address's path is made to end in a slash, so a relative request resolves under the
+    // whole path instead of dropping its last segment.
+    [InlineData("https://api.example.com/ns/", "https://api.example.com/ns/")]
+    [InlineData("api.example.com/ns", "https://api.example.com/ns/")]
+    [InlineData("https://api.example.com/ns", "https://api.example.com/ns/")]
+    // The slash goes on the path, not on the end of the value.
+    [InlineData("https://api.example.com/ns?a=b", "https://api.example.com/ns/?a=b")]
+    [InlineData("https://api.example.com?a=b", "https://api.example.com/?a=b")]
+    public void ConnectorClient_ResolvesItsBaseAddress(string configured, string expected)
+    {
+        BaseAddressFor(configured).Should().Be(expected);
+    }
+
+    private static string? BaseAddressFor(string? configured)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddHttpClient(ClientName).ConfigureConnectorClient(configured);
+
+        using var provider = services.BuildServiceProvider();
+        using var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient(ClientName);
+
+        return client.BaseAddress?.ToString();
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorServerResolverTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Services/ConnectorServerResolverTests.cs
@@ -42,6 +42,25 @@ public class ConnectorServerResolverTests
         result!.Host.Should().Be("shareous1.dexcom.com");
     }
 
+    /// <summary>
+    /// A server constant whose name opens with the scheme's letters is still a host, and a
+    /// constant that carries its own scheme keeps it.
+    /// </summary>
+    [Theory]
+    [InlineData("httpbin.example.com", "https", "httpbin.example.com")]
+    [InlineData("http://api.example.com", "http", "api.example.com")]
+    public void Resolve_ClassifiesTheServerConstantByItsScheme(
+        string server, string expectedScheme, string expectedHost)
+    {
+        var resolver = new ConnectorServerResolver<TestConfig>(null, null, server);
+
+        var result = resolver.Resolve(CreateConfig());
+
+        result.Should().NotBeNull();
+        result!.Scheme.Should().Be(expectedScheme);
+        result.Host.Should().Be(expectedHost);
+    }
+
     [Fact]
     public void Resolve_ReturnsNull_WhenNoMappingConfigured()
     {

--- a/tests/Unit/Nocturne.Connectors.Core.Tests/Utilities/ConnectorUrlTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Core.Tests/Utilities/ConnectorUrlTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Nocturne.Connectors.Core.Utilities;
+using Xunit;
+
+namespace Nocturne.Connectors.Core.Tests.Utilities;
+
+public class ConnectorUrlTests
+{
+    [Theory]
+    [InlineData("remote.example.com", "https://remote.example.com")]
+    [InlineData("remote.example.com/", "https://remote.example.com")]
+    [InlineData("mysite.example:1337", "https://mysite.example:1337")]
+    [InlineData("[fd12:3456:789a::1]:1337", "https://[fd12:3456:789a::1]:1337")]
+    [InlineData("[fd12::1]", "https://[fd12::1]")]
+    // A host that merely starts with the scheme's letters is still a host.
+    [InlineData("httpbin.example.com", "https://httpbin.example.com")]
+    [InlineData("http://remote.example.com/", "http://remote.example.com")]
+    [InlineData("https://remote.example.com", "https://remote.example.com")]
+    [InlineData("HTTP://X/", "HTTP://X")]
+    public void ResolveBase_NormalisesConfiguredUrl(string configured, string expected)
+    {
+        ConnectorUrl.ResolveBase(configured, "Test").Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveBase_BlankUrl_Throws(string? configured)
+    {
+        FluentActions.Invoking(() => ConnectorUrl.ResolveBase(configured, "Test"))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Test URL is not configured");
+    }
+
+    [Theory]
+    [InlineData("ftp://x")]
+    [InlineData("mailto:someone@example.com")]
+    [InlineData("file:/etc/passwd")]
+    [InlineData("/relative/path")]
+    // A colon that introduces neither a port nor a scheme this connector speaks.
+    [InlineData("host:abc")]
+    [InlineData("host:")]
+    public void ResolveBase_NonHttpScheme_Throws(string configured)
+    {
+        FluentActions.Invoking(() => ConnectorUrl.ResolveBase(configured, "Test"))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Test URL must be http or https");
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Nightscout.Tests/Services/WriteBack/NightscoutWriteBackSinkEndpointTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Nightscout.Tests/Services/WriteBack/NightscoutWriteBackSinkEndpointTests.cs
@@ -69,6 +69,30 @@ public class NightscoutWriteBackSinkEndpointTests
     private NightscoutActivityWriteBackSink ActivitySink(RecordingHttpMessageHandler h)
         => new(Client(h), LoaderFor(_config), _breaker, NullLogger<NightscoutActivityWriteBackSink>.Instance);
 
+    /// <summary>
+    /// A tenant may store a bare host, and one whose name opens with the scheme's letters must
+    /// still be read as a host: taken for an absolute URL it becomes a relative request and the
+    /// write-back lands somewhere other than the tenant's instance.
+    /// </summary>
+    [Fact]
+    public async Task EntrySink_SchemelessHostNamedLikeAScheme_PostsToThatHost()
+    {
+        var handler = new RecordingHttpMessageHandler();
+        var config = new NightscoutConnectorConfiguration
+        {
+            Url = "httpbin.example.com",
+            ApiSecret = "test-secret-12345",
+            WriteBackEnabled = true,
+            WriteBackBatchSize = 50
+        };
+
+        await EntrySink(handler, config).OnCreatedAsync(
+            new Entry { Id = "1", Sgv = 120, DataSource = "nocturne" });
+
+        handler.Uris.Should().ContainSingle()
+            .Which.Should().Be(new Uri("https://httpbin.example.com/api/v1/entries"));
+    }
+
     [Fact]
     public async Task EntrySink_PostsToV1Entries()
     {


### PR DESCRIPTION
Fixes #988

`NocturneRemoteConnectorBackgroundService` built the SignalR hub URL by hand as `{config.Url.TrimEnd('/')}/hubs/data`, while the REST path resolved the same base URL through `ResolveConfiguration`, which prepends `https://` when the configured URL has no scheme. A tenant who entered a bare host got working REST sync and a realtime listener whose `WithUrl` threw `UriFormatException` into the generic per-tenant catch ("Unexpected error starting real-time listener…") on every pass, so the connector fell back to interval polling with only that generic line to explain why.

## Change

The same `StartsWith("http") ? url : $"https://{url}"` resolution existed in five places: `NightscoutConnectorServiceBase.ResolveBaseUrl` (whose listener already used it for the identical bug class), `NightscoutWriteBackSink.ResolveAbsoluteUrl`, `HttpClientExtensions.ConfigureConnectorClient`, `ConnectorServerResolver.BuildUri` and `NocturneRemoteConnectorService.ResolveConfiguration`. The fix is one owner for all of them: `ConnectorUrl.ResolveBase(url, connectorName)` in `Nocturne.Connectors.Core`. The Nightscout base-class copy is deleted and its two callers repointed; the write-back sink, the HTTP-client base-address configuration and the server resolver call it; `ConfigurationController`'s save-time validator (`IsAcceptableUri`) is the same decision plus a user-info check, so it now calls `ConnectorUrl.TryResolveBase` and save-time validation and runtime resolution share one owner; `NocturneRemoteConnectorConfiguration.ResolveBaseUrl()` is a one-line delegate (kept a method, not a property, because `ConnectorConfigurationLoader` clones configurations through JSON and a throwing getter would surface there); `ResolveConfiguration` and the hub URL both go through it. Because the resolver now either returns an absolute http(s) URI or throws, both listeners' `Uri.TryCreate` guards were dead; `ConnectorBackgroundService.ResolveListenerBaseUrl(url, tenantSlug)` (on the shared listener base, next to `ListenerNeedsStartAsync`) catches the resolver's rejection and logs "{Connector} URL for tenant {slug} cannot be resolved to an absolute http(s) URL ({reason}), will rely on polling", so a bad URL is never reported as an "Unexpected error starting real-time listener". The NocturneRemote hub URL is composed from that resolved base; the earlier `BuildHubUrl` seam is gone. Connector names in messages come from `ConnectorRegistrationAttribute.NameFor(Type)` (the attribute's name, else the type name minus `Configuration`), which `BaseConnectorConfiguration` already computed privately. The test tree's three logger doubles (`ListLogger<T>`, two `CapturingLogger` copies) collapse onto one `TestDoubles/ListLogger.cs`.

Scheme detection is `Uri.TryCreate(…, Absolute)` with an http/https scheme check instead of `StartsWith("http")`, which misread `httpbin.example.com` as already schemed. A scheme-less `host:port` parses as an absolute URI with scheme `host`, so the resolver reuses the rule `ConfigurationController`'s save-time validator already had for it (`ColonIntroducesOnlyAPort`), moved into `ConnectorUrl` so save-time validation and runtime resolution cannot drift apart.

## Behavioural deltas (both connectors, since the resolver is shared)

- A bare host resolves to `https://<host>` and the NocturneRemote realtime listener connects; hosts that merely start with `http` (`httpbin.example.com`) are now prefixed correctly; `host:port` without a scheme is prefixed.
- A whitespace-only URL is rejected as unconfigured (previously `https://   `).
- An absolute URL with a non-http(s) scheme (`ftp://x`, `mailto:`, `file:`) or a leading slash is rejected with a message naming the connector and the accepted schemes (previously `https://ftp://x`, failing at request time). `host:port` is still read as a host.
- An explicit `http://`/`https://` URL is unchanged, case preserved.
- Message wording: NocturneRemote's "Remote Nocturne URL is not configured" becomes "NocturneRemote URL is not configured"; a connector reached through the server resolver is now named in its message.
- `ConfigureConnectorClient` now gives `HttpClient.BaseAddress` a trailing slash on the path when the configured URL carries one without it (`https://x/ns` → `https://x/ns/`, via `UriBuilder`, query untouched), so relative requests resolve under the full path instead of dropping its last segment; other shapes are byte-identical.
- A value that cannot be parsed as a URL even behind `https://` (`a b`) is rejected instead of resolved; the save-time validator already answered false for it. `host:abc` and a trailing-colon `host:` now throw where both connectors previously built a URL; save-time validation already rejected both, so only rows written outside the API are affected. On the write-back sink and HTTP-client sites a whitespace URL now throws `InvalidOperationException` instead of `UriFormatException` from `new Uri`, into the same handlers.

## Tests

`ConnectorUrlTests` (Core) theory: bare host, `httpbin.example.com`, `HTTP://X/`, `host:port`, IPv6 `[…]:port`, trailing slash, blank/whitespace → throws, `ftp://`/`mailto:`/`file:`/leading slash → throws. `ConnectorClientBaseAddressTests` pins the base-address shapes; a write-back fact pins that a `httpbin.example.com` instance receives its POST at `https://httpbin.example.com/api/v1/entries` (previously a relative request resolved against the client's base address, i.e. sent elsewhere); a server-resolver theory pins the constant path. Routing the three extra sites through the owner was unpinned until these were added (all three reverted to `StartsWith` passed every suite). `NocturneRemoteRealtimeListenerTests.StartRealtimeListenersAsync_SchemelessUrl_ConnectsToResolvedHubUri` drives the real listener against a closed local port and asserts positively that the connect step is reached with `https://127.0.0.1:9/hubs/data`; the Nightscout sibling test is reshaped the same way (its previous `DoesNotContain(UriFormatException)` assertion was unfalsifiable because that listener's old guard converted the failure into a warning). One test per listener feeds a rejected URL and asserts the specific polling-fallback log with no connect attempt and no generic error (removing the catch fails it). `ConnectorClientBaseAddressTests` includes a path-plus-query row that fails under string concatenation. Mutation-proven: raw `config.Url` at the call site fails the listener test and the helper fact; `StartsWith("http")` fails exactly the `httpbin` row; `IsNullOrEmpty` fails exactly the whitespace row.

`Nocturne.Connectors.Core.Tests` 182/0, `Nocturne.Connectors.Nightscout.Tests` 70/0, `Nocturne.Connectors.NocturneRemote.Tests` 25/0, `Nocturne.API.Tests` (unit filter) 6356/0 — the save-time validator tests pass unchanged with `IsAcceptableUri` reduced to `TryResolveBase` plus its user-info check. Diff: prod +59 net (13 files), tests +206 (12 files).

Noted, not done here: `Desktop.Tray/Services/NocturneClient.cs` and `Widget.Infrastructure/NocturneApiClient.cs` build `/hubs/data` URLs by hand from their own configuration paths.
