### PR TITLE
fix(data): one survivor rule, registry-driven orphan sweep, paged dedup

### DIFF
--- a/src/API/Nocturne.API/Services/BackgroundServices/SoftDeleteCleanupService.cs
+++ b/src/API/Nocturne.API/Services/BackgroundServices/SoftDeleteCleanupService.cs
@@ -1,5 +1,9 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Services;
 
 namespace Nocturne.API.Services.BackgroundServices;
 
@@ -17,18 +21,18 @@ public class SoftDeleteCleanupService(
     private const int BatchSize = 10_000;
 
     /// <summary>
-    /// All v4 tables with a deleted_at column.
+    /// Every table this service purges: the one behind each tenant-scoped soft-deletable entity.
+    /// Restricted to tenant-scoped entities because <see cref="PurgeBatchedAsync"/> relies on
+    /// row-level security to keep its raw DELETE inside one tenant.
     /// </summary>
-    private static readonly string[] V4Tables =
-    [
-        "aps_snapshots", "basal_schedules", "bg_checks", "bolus_calculations",
-        "boluses", "calibrations", "carb_intakes", "carb_ratio_schedules",
-        "device_events", "device_status_extras",
-        "devices", "meter_glucose", "notes", "patient_devices",
-        "patient_insulins", "patient_records", "pump_snapshots",
-        "sensitivity_schedules", "sensor_glucose", "target_range_schedules",
-        "temp_basals", "therapy_settings", "uploader_snapshots"
-    ];
+    internal static IReadOnlyList<string> SoftDeletableTables(IModel model) =>
+        [.. model.GetEntityTypes()
+            .Where(t => typeof(ISoftDeletable).IsAssignableFrom(t.ClrType)
+                        && typeof(ITenantScoped).IsAssignableFrom(t.ClrType))
+            .Select(t => t.GetTableName())
+            .OfType<string>()
+            .Distinct()
+            .Order()];
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -69,6 +73,7 @@ public class SoftDeleteCleanupService(
             .ToListAsync(ct);
 
         var configMap = configs.ToDictionary(c => c.TenantId, c => c.SoftDeleteRetentionDays);
+        var tables = SoftDeletableTables(configContext.Model);
 
         foreach (var tenantId in allTenantIds)
         {
@@ -80,20 +85,20 @@ public class SoftDeleteCleanupService(
 
                 var totalDeleted = 0;
 
-                foreach (var table in V4Tables)
+                foreach (var table in tables)
                 {
                     var tableDeleted = await PurgeBatchedAsync(tenantId, table, cutoff, ct);
                     totalDeleted += tableDeleted;
                 }
 
-                // Clean up orphaned linked_records
-                await CleanupOrphanedLinkedRecordsAsync(tenantId, ct);
+                var orphanedLinks = await CleanupOrphanedLinkedRecordsAsync(tenantId, ct);
 
-                if (totalDeleted > 0)
+                if (totalDeleted > 0 || orphanedLinks > 0)
                 {
                     logger.LogInformation(
-                        "Soft-delete cleanup for tenant {TenantId}: hard-deleted {Count} expired records (retention: {Days} days)",
-                        tenantId, totalDeleted, retentionDays);
+                        "Soft-delete cleanup for tenant {TenantId}: hard-deleted {Count} expired records "
+                        + "and {OrphanedLinks} orphaned links (retention: {Days} days)",
+                        tenantId, totalDeleted, orphanedLinks, retentionDays);
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -108,6 +113,12 @@ public class SoftDeleteCleanupService(
     /// <summary>
     /// Deletes records from the specified table with deleted_at before the cutoff, in batches
     /// of <see cref="BatchSize"/> to avoid WAL bloat and long-running transactions.
+    /// <para>
+    /// The tenant reach the DELETE needs comes from
+    /// <see cref="RlsPinningExtensions.CreateTenantPinnedContextAsync"/> and cannot come from a
+    /// <c>set_config</c> issued as its own command: EF opens and closes the connection around
+    /// each command, and the close discards the session variable.
+    /// </para>
     /// </summary>
     /// <returns>Total number of records deleted.</returns>
     private async Task<int> PurgeBatchedAsync(
@@ -118,12 +129,7 @@ public class SoftDeleteCleanupService(
 
         do
         {
-            await using var db = await contextFactory.CreateDbContextAsync(ct);
-
-            // Set RLS context for the tenant-scoped table
-            await db.Database.ExecuteSqlRawAsync(
-                "SELECT set_config('app.current_tenant_id', {0}, false)",
-                [tenantId.ToString()], ct);
+            await using var db = await contextFactory.CreateTenantPinnedContextAsync(tenantId, ct);
 
             // Delete a batch using ctid for efficient sub-select.
             // Table name is from our code (not user input) so interpolation is safe.
@@ -141,34 +147,13 @@ public class SoftDeleteCleanupService(
     }
 
     /// <summary>
-    /// Removes linked_records that reference hard-deleted records. Best-effort: orphans don't
-    /// cause incorrect behavior, just stale dedup metadata.
+    /// Removes linked_records that reference hard-deleted records, and links of a record type that
+    /// no longer has a table behind it.
     /// </summary>
-    private async Task CleanupOrphanedLinkedRecordsAsync(Guid tenantId, CancellationToken ct)
+    /// <returns>The number of links deleted.</returns>
+    private async Task<int> CleanupOrphanedLinkedRecordsAsync(Guid tenantId, CancellationToken ct)
     {
-        await using var db = await contextFactory.CreateDbContextAsync(ct);
-
-        await db.Database.ExecuteSqlRawAsync(
-            "SELECT set_config('app.current_tenant_id', {0}, false)",
-            [tenantId.ToString()], ct);
-
-        // RecordType enum values are stored lowercase (e.g. "sensorglucose", "bolus")
-        var dedupTypes = new Dictionary<string, string>
-        {
-            ["sensorglucose"] = "sensor_glucose",
-            ["bolus"] = "boluses",
-            ["carbintake"] = "carb_intakes",
-            ["bgcheck"] = "bg_checks",
-            ["tempbasal"] = "temp_basals"
-        };
-
-        foreach (var (recordType, sourceTable) in dedupTypes)
-        {
-#pragma warning disable EF1002
-            await db.Database.ExecuteSqlRawAsync(
-                $"DELETE FROM linked_records WHERE record_type = {{0}} AND record_id NOT IN (SELECT id FROM {sourceTable})",
-                [recordType], ct);
-#pragma warning restore EF1002
-        }
+        await using var db = await contextFactory.CreateTenantPinnedContextAsync(tenantId, ct);
+        return await DeduplicationService.DeleteOrphanedLinksAsync(db, ct);
     }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -595,10 +595,9 @@ public class DeduplicationService : IDeduplicationService
 
         // 7. A wide join reaches up to ten minutes back, so it can land earlier than the group's
         //    primary — and unlike reconcile-merged groups, ingest-formed groups are never revisited
-        //    by MergeDuplicateGroupsAsync. Re-derive the primary here with the same survivor rule
-        //    MergeDuplicateGroupsAsync uses, or the event time the group displays would depend on
-        //    which connector synced first. Scoped to wide joins: the tight path's sticky primary is
-        //    long-standing behaviour.
+        //    by MergeDuplicateGroupsAsync. Re-derive the primary here, or the event time the group
+        //    displays would depend on which connector synced first. Scoped to wide joins: the tight
+        //    path's sticky primary is long-standing behaviour.
         if (wideJoinedCanonicals.Count > 0)
         {
             var joined = wideJoinedCanonicals.ToList();
@@ -608,26 +607,10 @@ public class DeduplicationService : IDeduplicationService
 
             var rowInfo = await LoadRecordInfoAsync(recordType, rows.Select(r => r.RecordId).ToHashSet(), ct);
 
-            // Reads hide soft-deleted records and non-primary links alike, so promoting either a
-            // deleted record or an orphaned link would render the whole group as nothing. A record
-            // id missing from rowInfo is an orphaned link and is treated like a deleted one.
-            bool IsPromotable(LinkedRecordEntity r) =>
-                rowInfo.TryGetValue(r.RecordId, out var ri) && !ri.IsDeleted;
-
             var repointed = false;
             foreach (var group in rows.GroupBy(r => r.CanonicalId))
             {
-                // Earliest promotable record, falling back to earliest overall when the group holds
-                // nothing promotable — the same survivor rule as the reconcile merge.
-                var survivor = group
-                    .Where(IsPromotable)
-                    .OrderBy(r => r.SourceTimestamp)
-                    .ThenBy(r => r.RecordId)
-                    .FirstOrDefault()
-                    ?? group
-                        .OrderBy(r => r.SourceTimestamp)
-                        .ThenBy(r => r.RecordId)
-                        .First();
+                var survivor = PickSurvivor(group, rowInfo);
 
                 // A group with no primary at all renders as nothing, so repair it while the
                 // survivor is already in hand.
@@ -656,16 +639,34 @@ public class DeduplicationService : IDeduplicationService
     }
 
     /// <summary>
+    /// The link a canonical group's <see cref="LinkedRecordEntity.IsPrimary"/> belongs on: the
+    /// earliest promotable record, falling back to the earliest overall when the group holds
+    /// nothing promotable. Reads hide soft-deleted records and non-primary links alike, so
+    /// promoting either a deleted record or an orphaned link renders the whole group as nothing —
+    /// a record id missing from <paramref name="rowInfo"/> is an orphaned link and is no more
+    /// promotable than a deleted one. <see cref="LinkedRecordEntity.RecordId"/> settles a
+    /// timestamp tie, which a cross-source pair normally has.
+    /// </summary>
+    internal static LinkedRecordEntity PickSurvivor(
+        IEnumerable<LinkedRecordEntity> rows,
+        IReadOnlyDictionary<Guid, RecordInfo> rowInfo)
+    {
+        var ordered = rows.OrderBy(r => r.SourceTimestamp).ThenBy(r => r.RecordId).ToList();
+
+        return ordered.FirstOrDefault(r => rowInfo.TryGetValue(r.RecordId, out var ri) && !ri.IsDeleted)
+               ?? ordered[0];
+    }
+
+    /// <summary>
     /// Collapses duplicate canonical groups for a record type within the current tenant.
     /// Two groups merge when their primary records fall within <see cref="MatchingWindowMillis"/>
     /// of each other and their <see cref="MatchCriteria"/> match; merging is transitive
     /// (union-find) and source-agnostic, mirroring insert-time <see cref="DeduplicateBatchAsync"/>
     /// semantics. A second pass then applies the same wide rules the insert path uses, so a
     /// cross-source pair missed at ingest (out-of-order connector syncs) heals here.
-    /// For each merged super-group the surviving primary is the earliest-timestamp
-    /// non-deleted record (falling back to earliest-overall when every record is soft-deleted);
-    /// all linked rows are re-pointed to the survivor's canonical id and <c>IsPrimary</c> is set
-    /// on exactly the survivor.
+    /// For each merged super-group <see cref="PickSurvivor"/> chooses the surviving primary; all
+    /// linked rows are re-pointed to the survivor's canonical id and <c>IsPrimary</c> is set on
+    /// exactly the survivor.
     /// </summary>
     /// <param name="recordType">The record type whose canonical groups are reconciled.</param>
     /// <param name="candidateCanonicalIds">
@@ -1047,18 +1048,7 @@ public class DeduplicationService : IDeduplicationService
             var rowIds = rows.Select(r => r.RecordId).ToHashSet();
             var rowInfo = await LoadRecordInfoAsync(recordType, rowIds, ct);
 
-            // Survivor = earliest-timestamp non-deleted record; fall back to earliest-overall
-            // only if every record in the group is soft-deleted. A record id missing from rowInfo
-            // is an orphaned link: reads hide it exactly as they hide a deleted record, so it is
-            // never promotable. Same rule as the ingest path's primary re-derivation.
-            bool IsDeleted(LinkedRecordEntity r) =>
-                !rowInfo.TryGetValue(r.RecordId, out var ri) || ri.IsDeleted;
-
-            var survivor = rows
-                .Where(r => !IsDeleted(r))
-                .OrderBy(r => r.SourceTimestamp)
-                .FirstOrDefault()
-                ?? rows.OrderBy(r => r.SourceTimestamp).First();
+            var survivor = PickSurvivor(rows, rowInfo);
 
             // Re-point every row to the survivor's canonical id and fix the IsPrimary invariant.
             foreach (var r in rows)
@@ -1411,37 +1401,48 @@ public class DeduplicationService : IDeduplicationService
     /// <summary>
     /// One record type's <see cref="DeduplicateAllAsync"/> phase. <see cref="Name"/> is reported as
     /// <see cref="DeduplicationProgress.CurrentPhase"/>, so callers observe it.
+    /// <see cref="RecordIds"/> is every id a link of this type can point at: the type's rows with
+    /// <see cref="NocturneDbContext.SoftDeleteFilterKey"/> lifted, because a soft-deleted record is
+    /// still linked. Tenant isolation stays on, which the <see cref="ITenantScoped"/> constraint on
+    /// <see cref="Phase{TEntity}"/> is what guarantees.
     /// </summary>
     private sealed record TypePhase(
         RecordType RecordType,
         string Name,
         Func<NocturneDbContext, CancellationToken, Task<int>> CountAsync,
+        Func<NocturneDbContext, IQueryable<Guid>> RecordIds,
         PhaseRunner RunAsync);
 
     /// <summary>
     /// Builds one <see cref="TypePhase"/>. <paramref name="timestamp"/> both orders the query and
-    /// supplies the event time, so a type whose event time is not <c>Timestamp</c> states it once.
+    /// supplies the event time, so a type whose event time is not <c>Timestamp</c> states it once;
+    /// <paramref name="id"/> serves the same two purposes.
     /// </summary>
     private static TypePhase Phase<TEntity>(
         RecordType recordType,
         string name,
         Func<NocturneDbContext, IQueryable<TEntity>> set,
         Expression<Func<TEntity, DateTime>> timestamp,
-        Func<TEntity, Guid> id,
+        Expression<Func<TEntity, Guid>> id,
         Func<TEntity, string?> dataSource,
-        Func<TEntity, MatchCriteria> criteria) where TEntity : class
+        Func<TEntity, MatchCriteria> criteria) where TEntity : class, ITenantScoped
     {
         var eventTime = timestamp.Compile();
+        var recordId = id.Compile();
 
         return new TypePhase(
             recordType,
             name,
             (context, ct) => set(context).CountAsync(ct),
+            context => set(context)
+                .IgnoreQueryFilters([NocturneDbContext.SoftDeleteFilterKey])
+                .Select(id),
             (service, totalRecords, startOffset, progress, ct) => service.DeduplicateTypeAsync(
                 recordType,
-                set(service._context).OrderBy(timestamp),
+                set(service._context),
+                timestamp,
                 e => new DeduplicationInput(
-                    id(e),
+                    recordId(e),
                     new DateTimeOffset(eventTime(e), TimeSpan.Zero).ToUnixTimeMilliseconds(),
                     dataSource(e) ?? DeduplicationInput.UnknownDataSource,
                     criteria(e)),
@@ -1485,6 +1486,42 @@ public class DeduplicationService : IDeduplicationService
             static c => c.StateSpans, static s => s.StartTimestamp,
             static s => s.Id, static s => s.Source, MatchCriteriaMapper.From)
     ];
+
+    /// <summary>
+    /// The record types <see cref="DeduplicateAllAsync"/> covers, in processing order. Internal so
+    /// a test can drive itself off the registry instead of restating it.
+    /// </summary>
+    internal static IReadOnlyList<RecordType> DeduplicatedRecordTypes { get; } =
+        [.. TypePhases.Select(static p => p.RecordType)];
+
+    /// <summary>
+    /// Deletes the links of <paramref name="context"/>'s tenant that have nothing left to point at:
+    /// a record id no longer in its type's table, and a record type no <see cref="RecordType"/>
+    /// member names, which no caller can read back — <see cref="GetLinkedRecordsAsync"/> drops a row
+    /// whose key does not parse. A soft-deleted record is not an orphan.
+    /// </summary>
+    /// <returns>The number of links deleted.</returns>
+    public static async Task<int> DeleteOrphanedLinksAsync(
+        NocturneDbContext context, CancellationToken ct = default)
+    {
+        var namedTypes = Enum.GetValues<RecordType>().Select(RecordTypeKeys.Key).ToList();
+
+        var deleted = await context.LinkedRecords
+            .Where(lr => !namedTypes.Contains(lr.RecordType))
+            .ExecuteDeleteAsync(ct);
+
+        foreach (var phase in TypePhases)
+        {
+            var recordTypeStr = RecordTypeKeys.Key(phase.RecordType);
+            var recordIds = phase.RecordIds(context);
+
+            deleted += await context.LinkedRecords
+                .Where(lr => lr.RecordType == recordTypeStr && !recordIds.Contains(lr.RecordId))
+                .ExecuteDeleteAsync(ct);
+        }
+
+        return deleted;
+    }
 
     /// <inheritdoc />
     public async Task<DeduplicationResult> DeduplicateAllAsync(
@@ -1692,9 +1729,19 @@ public class DeduplicationService : IDeduplicationService
                && owner == tenantId;
     }
 
+    /// <summary>
+    /// Pages <paramref name="set"/> in <paramref name="timestamp"/> order into
+    /// <see cref="DeduplicateBatchAsync"/>. A page ends on a whole timestamp — the run of rows
+    /// sharing the last one is drained with it — so the cursor can advance strictly past it and no
+    /// row is read twice or skipped, without needing an order over record ids that both the
+    /// database and the CLR agree on. A canonical group split across pages still collapses: each
+    /// page's links are persisted before the next page's matching-window query re-reads them,
+    /// the same seam <see cref="DeduplicateBatchAsync"/> already documents for its own chunking.
+    /// </summary>
     private async Task<(int processed, int groups, int linked, int duplicates)> DeduplicateTypeAsync<TEntity>(
         RecordType recordType,
-        IQueryable<TEntity> query,
+        IQueryable<TEntity> set,
+        Expression<Func<TEntity, DateTime>> timestamp,
         Func<TEntity, DeduplicationInput> toInput,
         string phaseName,
         int totalRecords,
@@ -1703,19 +1750,56 @@ public class DeduplicationService : IDeduplicationService
         CancellationToken ct) where TEntity : class
     {
         const int batchSize = 500;
-        var allEntities = await query.ToListAsync(ct);
-        var inputs = allEntities.Select(toInput).ToList();
+
+        // One paging predicate serves every entity type, so the ordering column arrives as a
+        // property name rather than an expression to compose into it.
+        if (timestamp.Body is not MemberExpression timestampMember)
+        {
+            throw new ArgumentException(
+                "The ordering expression must be a simple member access (e => e.Timestamp): the "
+                + "keyset predicate reads that property by name.",
+                nameof(timestamp));
+        }
+
+        var timestampProperty = timestampMember.Member.Name;
+        var eventTime = timestamp.Compile();
+
+        var ordered = set
+            .AsNoTracking()
+            .OrderBy(e => EF.Property<DateTime>(e, timestampProperty));
 
         var totalProcessed = 0;
         var totalGroups = 0;
         var totalLinked = 0;
         var totalDuplicates = 0;
+        DateTime? cursor = null;
 
-        foreach (var chunk in inputs.Chunk(batchSize))
+        while (true)
         {
             ct.ThrowIfCancellationRequested();
 
-            var result = await DeduplicateBatchAsync(recordType, chunk, ct);
+            var page = await (cursor is { } after
+                    ? ordered.Where(e => EF.Property<DateTime>(e, timestampProperty) > after)
+                    : ordered)
+                .Take(batchSize)
+                .ToListAsync(ct);
+
+            if (page.Count == 0)
+                break;
+
+            var pageEnd = eventTime(page[^1]);
+            if (page.Count == batchSize)
+            {
+                var tail = await ordered
+                    .Where(e => EF.Property<DateTime>(e, timestampProperty) == pageEnd)
+                    .ToListAsync(ct);
+
+                page = [.. page.Where(e => eventTime(e) < pageEnd), .. tail];
+            }
+
+            cursor = pageEnd;
+
+            var result = await DeduplicateBatchAsync(recordType, page.Select(toInput).ToList(), ct);
             totalProcessed += result.Processed;
             totalGroups += result.GroupsCreated;
             totalLinked += result.RecordsLinked;

--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/SoftDeleteCleanupTablesTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/SoftDeleteCleanupTablesTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Services.BackgroundServices;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Tests.Services.BackgroundServices;
+
+/// <summary>
+/// Pins the set of tables <see cref="SoftDeleteCleanupService"/> purges.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SoftDeleteCleanupTablesTests
+{
+    private static readonly string[] Expected =
+    [
+        "aps_snapshots", "basal_injections", "basal_schedules", "bg_checks", "body_weights",
+        "bolus_calculations", "boluses", "calibrations", "carb_intakes", "carb_ratio_schedules",
+        "device_events", "device_status_extras", "devices", "heart_rates", "meter_glucose",
+        "notes", "patient_devices", "patient_insulins", "patient_records", "pump_snapshots",
+        "sensitivity_schedules", "sensor_glucose", "state_spans", "step_counts",
+        "target_range_schedules", "temp_basals", "therapy_settings", "uploader_snapshots"
+    ];
+
+    [Fact]
+    public void SoftDeletableTables_CoversEveryTenantScopedSoftDeletableTable()
+    {
+        var options = new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+        using var context = new NocturneDbContext(options);
+
+        var tables = SoftDeleteCleanupService.SoftDeletableTables(context.Model);
+
+        tables.Should().Equal(Expected);
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -251,6 +251,64 @@ public class DeduplicationReconcileTests : IDisposable
         links.Single(l => l.IsPrimary).RecordId.Should().Be(live); // earliest non-deleted
     }
 
+    /// <summary>
+    /// A pair of record ids whose relative order under <see cref="Comparer{T}.Default"/> is fixed,
+    /// so a tie-break assertion does not depend on generated ids.
+    /// </summary>
+    private static readonly Guid LowerRecordId = Guid.Parse("00000000-0000-0000-0000-00000000000a");
+    private static readonly Guid HigherRecordId = Guid.Parse("00000000-0000-0000-0000-00000000000b");
+
+    [Fact]
+    public void PickSurvivor_BreaksATimestampTieOnRecordId()
+    {
+        // A cross-source pair normally shares the millisecond, so the timestamp decides nothing and
+        // the choice must not fall out of whichever row the database returned first.
+        var info = Promotable(LowerRecordId, HigherRecordId);
+
+        DeduplicationService.PickSurvivor(TiedRows(LowerRecordId, HigherRecordId), info)
+            .RecordId.Should().Be(LowerRecordId);
+        DeduplicationService.PickSurvivor(TiedRows(HigherRecordId, LowerRecordId), info)
+            .RecordId.Should().Be(LowerRecordId);
+    }
+
+    [Fact]
+    public void PickSurvivor_TreatsAMissingRecordAsUnpromotable()
+    {
+        // An orphaned link reads exactly as a deleted record, so promoting it would render the
+        // whole canonical group as nothing.
+        DeduplicationService.PickSurvivor(
+                TiedRows(LowerRecordId, HigherRecordId), Promotable(HigherRecordId))
+            .RecordId.Should().Be(HigherRecordId);
+    }
+
+    [Fact]
+    public void PickSurvivor_FallsBackToTheEarliestWhenNothingIsPromotable()
+    {
+        var deleted = new Dictionary<Guid, DeduplicationService.RecordInfo>
+        {
+            [LowerRecordId] = new(new MatchCriteria(), IsDeleted: true),
+            [HigherRecordId] = new(new MatchCriteria(), IsDeleted: true)
+        };
+
+        DeduplicationService.PickSurvivor(TiedRows(HigherRecordId, LowerRecordId), deleted)
+            .RecordId.Should().Be(LowerRecordId);
+    }
+
+    /// <summary>
+    /// Two links sharing one source timestamp, in the given order.
+    /// </summary>
+    private static LinkedRecordEntity[] TiedRows(Guid first, Guid second) =>
+    [
+        new() { RecordId = first, SourceTimestamp = 1_700_000_000_000, IsPrimary = true },
+        new() { RecordId = second, SourceTimestamp = 1_700_000_000_000 }
+    ];
+
+    /// <summary>
+    /// Record info marking every listed id as present and not deleted.
+    /// </summary>
+    private static Dictionary<Guid, DeduplicationService.RecordInfo> Promotable(params Guid[] ids) =>
+        ids.ToDictionary(id => id, _ => new DeduplicationService.RecordInfo(new MatchCriteria(), IsDeleted: false));
+
     [Fact]
     public async Task MergeDuplicateGroupsAsync_MergesTransitiveThreeGroupChain()
     {
@@ -777,6 +835,242 @@ public class DeduplicationReconcileTests : IDisposable
         var rows = await _context.DedupReconcileState.IgnoreQueryFilters()
             .Where(s => s.TenantId == TestTenantId).CountAsync();
         rows.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeduplicateAllAsync_PagesPastTheBatchSizeWithoutSkippingOrRereadingARow()
+    {
+        // 503 readings in 251 groups, spaced far enough apart that only same-timestamp readings
+        // match. The 250th group holds three, so the 500-row page boundary lands inside it and the
+        // page has to drain the rest of that timestamp before the cursor can move past it.
+        const int groupsBeforeBoundary = 249;
+        var readings = new List<SensorGlucoseEntity>();
+        for (var group = 0; group <= groupsBeforeBoundary + 1; group++)
+        {
+            var atGroup = group == groupsBeforeBoundary ? 3 : 2;
+            for (var i = 0; i < atGroup; i++)
+            {
+                readings.Add(new SensorGlucoseEntity
+                {
+                    Id = Guid.CreateVersion7(),
+                    TenantId = TestTenantId,
+                    Mgdl = 120,
+                    Timestamp = WideBase.AddMinutes(15 * group),
+                    DataSource = $"connector-{i}"
+                });
+            }
+        }
+
+        _context.SensorGlucose.AddRange(readings);
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        var result = await _service.DeduplicateAllAsync();
+
+        result.Success.Should().BeTrue();
+        result.SensorGlucoseProcessed.Should().Be(readings.Count);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().ToListAsync();
+        links.Should().HaveCount(readings.Count);
+        links.Select(l => l.CanonicalId).Distinct().Should().HaveCount(groupsBeforeBoundary + 2);
+        links.Count(l => l.IsPrimary).Should().Be(groupsBeforeBoundary + 2);
+    }
+
+    [Theory]
+    [MemberData(nameof(DeduplicatedRecordTypes))]
+    public async Task DeleteOrphanedLinksAsync_SweepsAnOrphanOfEveryDeduplicatedType(RecordType recordType)
+    {
+        AddLink(recordType, Guid.CreateVersion7(), ToMills(WideBase), "glooko-connector",
+            Guid.CreateVersion7(), isPrimary: true);
+        await _context.SaveChangesAsync();
+
+        var deleted = await DeduplicationService.DeleteOrphanedLinksAsync(_context);
+
+        deleted.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().ToListAsync();
+        links.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Every type the dedup registry covers, so a type added there without a case in
+    /// <see cref="AddRecord"/> fails these theories rather than going untested.
+    /// </summary>
+    public static TheoryData<RecordType> DeduplicatedRecordTypes =>
+        [.. DeduplicationService.DeduplicatedRecordTypes];
+
+    [Theory]
+    [MemberData(nameof(DeduplicatedRecordTypes))]
+    public async Task DeleteOrphanedLinksAsync_KeepsALinkToALiveRecordOfEveryDeduplicatedType(
+        RecordType recordType)
+    {
+        // A type the sweep does not recognise has every one of its links swept, live record or not,
+        // so this is what separates the nine from an unknown key.
+        var recordId = AddRecord(recordType);
+        AddPrimaryLink(recordType, recordId, ToMills(WideBase), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        await DeduplicationService.DeleteOrphanedLinksAsync(_context);
+
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().ToListAsync();
+        links.Should().ContainSingle().Which.RecordId.Should().Be(recordId);
+    }
+
+    /// <summary>
+    /// Adds one live record of <paramref name="recordType"/> for the test tenant and returns its id.
+    /// </summary>
+    private Guid AddRecord(RecordType recordType)
+    {
+        var id = Guid.CreateVersion7();
+        object entity = recordType switch
+        {
+            RecordType.SensorGlucose => new SensorGlucoseEntity { Id = id, Mgdl = 120, Timestamp = WideBase },
+            RecordType.Bolus => new BolusEntity { Id = id, Insulin = 2, Timestamp = WideBase },
+            RecordType.CarbIntake => new CarbIntakeEntity { Id = id, Carbs = 30, Timestamp = WideBase },
+            RecordType.BGCheck => new BGCheckEntity { Id = id, Glucose = 120, Timestamp = WideBase },
+            RecordType.DeviceEvent => new DeviceEventEntity { Id = id, EventType = "SiteChange", Timestamp = WideBase },
+            RecordType.Note => new NoteEntity { Id = id, Text = "note", Timestamp = WideBase },
+            RecordType.BolusCalculation => new BolusCalculationEntity { Id = id, CarbInput = 30, Timestamp = WideBase },
+            RecordType.TempBasal => new TempBasalEntity
+            {
+                Id = id, Rate = 0.5, StartTimestamp = WideBase, Origin = "Manual"
+            },
+            RecordType.StateSpan => new StateSpanEntity
+            {
+                Id = id, Category = nameof(StateSpanCategory.Exercise), State = "Running", StartTimestamp = WideBase
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(recordType), recordType, "No table backs this type")
+        };
+
+        ((ITenantScoped)entity).TenantId = TestTenantId;
+        _context.Add(entity);
+        return id;
+    }
+
+    [Theory]
+    [InlineData("entry")]
+    [InlineData("treatment")]
+    [InlineData("meterglucose")]
+    [InlineData("sleepstage")]
+    public async Task DeleteOrphanedLinksAsync_SweepsALinkNoRecordTypeMemberNames(string recordType)
+    {
+        // Keys earlier builds wrote. No RecordType member names any of them, so
+        // GetLinkedRecordsAsync drops the row and nothing can read it back.
+        AddRawLink(recordType, TestTenantId);
+        await _context.SaveChangesAsync();
+
+        var deleted = await DeduplicationService.DeleteOrphanedLinksAsync(_context);
+
+        deleted.Should().Be(1);
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().ToListAsync();
+        links.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Adds a primary link carrying <paramref name="recordType"/> verbatim, for the keys the
+    /// <see cref="RecordType"/> enum cannot express. Returns the link's id.
+    /// </summary>
+    private Guid AddRawLink(string recordType, Guid tenantId)
+    {
+        var id = Guid.CreateVersion7();
+        _context.LinkedRecords.Add(new LinkedRecordEntity
+        {
+            Id = id,
+            TenantId = tenantId,
+            CanonicalId = Guid.CreateVersion7(),
+            RecordType = recordType,
+            RecordId = Guid.CreateVersion7(),
+            SourceTimestamp = ToMills(WideBase),
+            DataSource = "glooko-connector",
+            IsPrimary = true
+        });
+        return id;
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DeleteOrphanedLinksAsync_KeepsALinkToAnExistingRecord(bool softDeleted)
+    {
+        // A soft-deleted record is not an orphan: PickSurvivor still reads it, and the group falls
+        // back to it when every member is deleted.
+        var recordId = await AddCarb(WideBase, "glooko-connector", 50,
+            deletedAt: softDeleted ? WideBase.AddHours(1) : null);
+        AddPrimaryLink(RecordType.CarbIntake, recordId, ToMills(WideBase), "glooko-connector");
+        await _context.SaveChangesAsync();
+
+        await DeduplicationService.DeleteOrphanedLinksAsync(_context);
+
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().ToListAsync();
+        links.Should().ContainSingle().Which.RecordId.Should().Be(recordId);
+    }
+
+    [Fact]
+    public async Task DeleteOrphanedLinksAsync_LeavesAnotherTenantsOrphanAlone()
+    {
+        var otherTenant = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        using (var seedContext = new NocturneDbContext(_contextOptions))
+        {
+            seedContext.TenantId = otherTenant;
+            seedContext.Tenants.Add(new TenantEntity { Id = otherTenant, Slug = "other" });
+            seedContext.LinkedRecords.Add(new LinkedRecordEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantId = otherTenant,
+                CanonicalId = Guid.CreateVersion7(),
+                RecordType = "carbintake",
+                RecordId = Guid.CreateVersion7(),
+                SourceTimestamp = ToMills(WideBase),
+                DataSource = "glooko-connector",
+                IsPrimary = true
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        await DeduplicationService.DeleteOrphanedLinksAsync(_context);
+
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().ToListAsync();
+        links.Should().ContainSingle().Which.TenantId.Should().Be(otherTenant);
+    }
+
+    [Fact]
+    public async Task DeleteOrphanedLinksAsync_SweepsALinkWhoseRecordBelongsToAnotherTenant()
+    {
+        // Ignoring the query filters to reach soft-deleted records also drops tenant scoping, so
+        // the record-id set has to re-apply it: another tenant's record must not vouch for a link
+        // in this one, and this one's sweep must not reach that tenant's own link.
+        var otherTenant = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var theirRecordId = Guid.CreateVersion7();
+        var theirLinkId = Guid.CreateVersion7();
+
+        using (var seedContext = new NocturneDbContext(_contextOptions))
+        {
+            seedContext.TenantId = otherTenant;
+            seedContext.Tenants.Add(new TenantEntity { Id = otherTenant, Slug = "other" });
+            seedContext.CarbIntakes.Add(new CarbIntakeEntity
+            {
+                Id = theirRecordId, TenantId = otherTenant, Carbs = 30, Timestamp = WideBase
+            });
+            seedContext.LinkedRecords.Add(new LinkedRecordEntity
+            {
+                Id = theirLinkId,
+                TenantId = otherTenant,
+                CanonicalId = Guid.CreateVersion7(),
+                RecordType = "carbintake",
+                RecordId = theirRecordId,
+                SourceTimestamp = ToMills(WideBase),
+                DataSource = "glooko-connector",
+                IsPrimary = true
+            });
+            await seedContext.SaveChangesAsync();
+        }
+
+        // The test tenant's link points at the other tenant's record, so it is an orphan here.
+        AddPrimaryLink(RecordType.CarbIntake, theirRecordId, ToMills(WideBase), "mylife-connector");
+        await _context.SaveChangesAsync();
+
+        await DeduplicationService.DeleteOrphanedLinksAsync(_context);
+
+        var links = await _context.LinkedRecords.IgnoreQueryFilters().ToListAsync();
+        links.Should().ContainSingle().Which.Id.Should().Be(theirLinkId);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #1095

## 1. One survivor rule

The ingest re-derivation and the reconcile merge both claimed to apply "the same survivor rule", but the reconcile copy lacked `ThenBy(RecordId)`, so a cross-source pair sharing a millisecond promoted a non-deterministic primary. `PickSurvivor(rows, rowInfo)` is the one rule (promotable rows first, then earliest `SourceTimestamp`, then lowest `RecordId`); both sites call it and the two "same rule" comments are gone.

## 2. Paged, untracked dedup-all

`DeduplicateTypeAsync` materialised the whole table tracked and then chunked the dedup. It now pages `AsNoTracking` on the phase's timestamp column and streams each page into `DeduplicateBatchAsync`. Pages end on a whole timestamp (a page that fills exactly drains the remaining rows sharing its last timestamp), so the cursor advances strictly and no row is skipped or re-read; a `(timestamp, id)` keyset was rejected because .NET's `Guid` ordering does not match Postgres `uuid` ordering. Cross-page groups are handled the way the existing internal `Chunk(500)` already relied on: `DeduplicateBatchAsync` re-reads persisted links in its matching window per batch.

## 3. Registry-driven orphan sweep and purge tables

The orphan-link sweep hand-maintained a 5-entry `record_type → table` map covering 5 of the 9 dedup participants; `V4Tables` omitted `state_spans` (and `basal_injections`, `body_weights`, `heart_rates`, `step_counts`). Both now have one owner: `TypePhase` gains a `RecordIds` queryable built from the `set` lambda it already had, and `DeduplicationService.DeleteOrphanedLinksAsync` issues one tenant-scoped `ExecuteDeleteAsync` per registry type plus one for any `record_type` that no `RecordType` member names. `DeduplicationService` is the only writer of `linked_records` (no raw SQL, migration, tool or import writes it) and today writes only the nine registry keys, so the only historical values are `entry`/`treatment` (before 670d08ae8) and `meterglucose` (written between 670d08ae8 and 39fd23b5c). The predicate follows the enum rather than the registry on purpose: a key no `RecordType` member names cannot be read back at all (`GetLinkedRecordsAsync` parses the column as the enum). With #1126 merged, `Entry`/`Treatment` and the two endpoints that read those rows are gone, so on main this sweeps `entry`, `treatment` and `meterglucose`. The deletes use the keyed `IgnoreQueryFilters([SoftDeleteFilterKey])` form the repo's purge helpers document (parameterless would lift tenant isolation), so tenant scoping comes from the query filter rather than a hand-written predicate. The purge table list is read off the EF model (`ISoftDeletable && ITenantScoped` entities), the tenant-scoped restriction being the explicit statement of the RLS assumption the raw batched DELETE relies on.

## The purge has never deleted a row (pre-existing, fixed here)

Verified while reviewing: `PurgeBatchedAsync` issued `set_config('app.current_tenant_id', …)` and the raw `DELETE` as two separate `ExecuteSqlRawAsync` calls on a context whose `TenantId` was never set. EF opens and closes the connection per command (measured with a counting interceptor: one open/close per call); `TenantConnectionInterceptor` runs `RESET app.current_tenant_id` on close and sets the GUC on open only when `ctx.TenantId != Guid.Empty`; startup additionally refuses `NoResetOnClose`, so the pool discards the session GUC regardless. Under FORCE RLS the `DELETE` therefore ran with a null tenant setting and affected zero rows, and `totalDeleted == 0` suppressed the only log line that would have said so. Both the purge and the orphan sweep now use the existing `RlsPinningExtensions.CreateTenantPinnedContextAsync`, and the two dead `set_config` commands are deleted.

**Weight:** on the first cleanup cycle after deploy, every tenant's expired soft-deleted rows across all 28 tables are hard-deleted for the first time, in 10k-row batches per table; on a long-lived instance that is the whole backlog since the service was written. The cutoff is unchanged (`SoftDeleteRetentionPolicy.ResolveDays`). The orphan-link sweep that follows it in the same cycle is unbatched (nine anti-join deletes plus one `NOT IN` delete; PostgreSQL `DELETE` has no `LIMIT` and `ExecuteDeleteAsync` cannot batch), so its first effective run covers every link left behind by that purge. Both counts are now returned and logged together, so the cycle can no longer run silently. `AuditRetentionService` has the same defect and is filed as #1138.

## Behavioural deltas

- Reconcile merge on a timestamp tie now picks the lower `RecordId` deterministically; already-merged groups keep their primary until merged again.
- Orphan links are swept for `deviceevent`, `note`, `boluscalculation`, `statespan` too, and the historical `entry`/`treatment`/`meterglucose` link rows (no `RecordType` member names them, so nothing can read them) are deleted on the next cleanup cycle.
- The orphan sweep is provider-agnostic (no raw SQL) and tenant-scoped through the tenant query filter on a pinned context (previously RLS only).
- Expired soft-deleted rows in `state_spans`, `basal_injections`, `body_weights`, `heart_rates`, `step_counts` are now hard-purged after the tenant's retention period (they never were before). All five tables are RLS-forced. Purge order is alphabetical.
- Dedup-all batch boundaries land on timestamp runs instead of multiples of 500 of the loaded list; a page can exceed 500 rows when more than 500 share one timestamp (`DeduplicateBatchAsync` re-chunks). One extra query per full page and one empty page per phase.

## Tests

`DeduplicationReconcileTests`: tie broken on `RecordId` and fallback to the earliest when nothing is promotable (fixed GUIDs); a live-record-per-type theory over the registry (proves a de-registered type is not silently swept as "unknown"); unknown-type rows swept; paging past the batch size with a tail-drain case. `SoftDeleteCleanupTablesTests` pins the model-derived table set. Mutation-proven: dropping the `ThenBy` fails 2; removing `Note` from `TypePhases` fails the live-record row; removing the tail-drain drops exactly one processed row; `ISoftDeletable → IV4Entity` in the table predicate loses 9 tables.

A cross-tenant test proves a link whose record lives only in another tenant is swept in the calling tenant and the other tenant's link survives (a parameterless `IgnoreQueryFilters()` on the delete fails it); removing a surviving member from the predicate's source makes that type's orphan sweep swallow a live record's link and fails the per-type keep test. `Nocturne.Infrastructure.Data.Tests` 888/0, `Nocturne.API.Tests` (unit filter) 6395/0 on the rebased branch. Diff: prod +69 net (2 files), tests +329. The theory over the deduplicated types reads the registry (`DeduplicationService.DeduplicatedRecordTypes`), so a tenth phase fails loudly instead of going uncovered. The integration-level tie test was deleted: `MergeDuplicateGroupsAsync` loads rows with no `ORDER BY`, so a merge-path tie test cannot be made deterministic; the `PickSurvivor` unit tests hold the rule. Rebased onto main after #1126 merged.
