### PR TITLE
test(data): use the shared SQLite arrangement in the dedup reconcile tests

### DIFF
--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationReconcileTests.cs
@@ -990,7 +990,7 @@ public class DeduplicationReconcileTests : IDisposable
     public async Task DeleteOrphanedLinksAsync_LeavesAnotherTenantsOrphanAlone()
     {
         var otherTenant = Guid.Parse("00000000-0000-0000-0000-000000000002");
-        using (var seedContext = new NocturneDbContext(_contextOptions))
+        using (var seedContext = _db.CreateContext())
         {
             seedContext.TenantId = otherTenant;
             seedContext.Tenants.Add(new TenantEntity { Id = otherTenant, Slug = "other" });
@@ -1024,7 +1024,7 @@ public class DeduplicationReconcileTests : IDisposable
         var theirRecordId = Guid.CreateVersion7();
         var theirLinkId = Guid.CreateVersion7();
 
-        using (var seedContext = new NocturneDbContext(_contextOptions))
+        using (var seedContext = _db.CreateContext())
         {
             seedContext.TenantId = otherTenant;
             seedContext.Tenants.Add(new TenantEntity { Id = otherTenant, Slug = "other" });


### PR DESCRIPTION
Main does not compile since #1137 (shared SQLite arrangement, removed the private `_contextOptions` field) and #1140 (two new tests that seed another tenant through `new NocturneDbContext(_contextOptions)`) were merged independently:

```
DeduplicationReconcileTests.cs(993,56): error CS0103: The name '_contextOptions' does not exist in the current context
DeduplicationReconcileTests.cs(1027,56): error CS0103: The name '_contextOptions' does not exist in the current context
```

The two seed contexts now come from `_db.CreateContext()`, as the file's existing seed at line 117 already does after #1137. `SqliteTestDatabase.CreateContext()` builds on the same options; the tests then override `TenantId` to the other tenant as before.

`Nocturne.Infrastructure.Data.Tests`: 897 passed / 0 failed. The `Tests` workflow on main and on every open PR is red until this lands; the `Build and Publish with Aspire` failure on main is the separate `publish-glucose-chart` npm step.
