### PR TITLE
fix(api): authorize chat-identity links by ownership, not tenant membership

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityController.cs
@@ -19,9 +19,9 @@ namespace Nocturne.API.Controllers.V4.Identity;
 [ApiController]
 [Tags("Identity")]
 [Authorize]
-// Every endpoint here binds or reads a chat identity for a subject. The demo's subject is
-// shared, so one visitor's Discord or Telegram binding would be enumerable and revocable by
-// the next — GetLinks lists by tenant, not by subject.
+// Every endpoint here binds or reads a chat identity for a subject. The demo's subject is shared,
+// so ownership does not separate one visitor from the next: a visitor's Discord or Telegram
+// binding would be the next visitor's to read and revoke.
 [DenyDemoSubject]
 [Route("api/v4/chat-identity")]
 public class ChatIdentityController : ControllerBase
@@ -58,13 +58,25 @@ public class ChatIdentityController : ControllerBase
             ?? throw new InvalidOperationException("Authenticated request has no subject id");
     }
 
+    /// <summary>The rows a by-id request from this caller may reach.</summary>
+    /// <seealso cref="ChatLinkScope"/>
+    private ChatLinkScope OwnedByCaller()
+        => ChatLinkScope.ForOwner(_tenantAccessor.TenantId, GetUserIdOrThrow());
+
     /// <summary>List active chat identity links for the current tenant.</summary>
     /// <remarks>
+    /// <para>
     /// The list stays tenant-scoped, so a chat account linked to several tenants shows a
     /// non-default row here while its default sits on a row this tenant cannot see. Naming that
     /// row's label closes the gap without widening the list, and it is filled in only for the
     /// caller's own links: a co-member's chat account may be linked to tenants the caller has no
     /// part in, and its label is that tenant's slug.
+    /// </para>
+    /// <para>
+    /// A co-member's row is listed so the tenant's bot routing is legible, but the chat account
+    /// behind it is the co-member's and not this tenant's to hand out, so
+    /// <see cref="ChatIdentityLinkResponse.PlatformUserId"/> is withheld on the same terms.
+    /// </para>
     /// </remarks>
     [HttpGet]
     [RemoteQuery]
@@ -78,8 +90,9 @@ public class ChatIdentityController : ControllerBase
         var responses = new List<ChatIdentityLinkResponse>(links.Count);
         foreach (var link in links)
         {
-            var response = MapResponse(link);
-            if (link.NocturneUserId == subjectId)
+            var ownedByCaller = link.NocturneUserId == subjectId;
+            var response = MapResponse(link, ownedByCaller);
+            if (ownedByCaller)
             {
                 var holder = await _service.GetDefaultAsync(link.Platform, link.PlatformUserId, ct);
                 response.DefaultLabel = holder?.Label;
@@ -92,6 +105,10 @@ public class ChatIdentityController : ControllerBase
     }
 
     /// <summary>Claim a pending link token after /connect slash command auth.</summary>
+    /// <remarks>
+    /// A token carries no subject, and a chat account already linked to this tenant keeps the
+    /// link it has, so the row this returns may belong to another subject and predate the claim.
+    /// </remarks>
     [HttpPost("links/claim")]
     [RemoteCommand(Invalidates = ["GetLinks"])]
     [ProducesResponseType(typeof(ChatIdentityLinkResponse), StatusCodes.Status200OK)]
@@ -101,21 +118,7 @@ public class ChatIdentityController : ControllerBase
         var tenantId = _tenantAccessor.TenantId;
         var userId = GetUserIdOrThrow();
         var entry = await _service.ClaimPendingLinkAsync(tenantId, userId, body.Token, ct);
-        return Ok(MapResponse(entry));
-    }
-
-    /// <summary>Directly create a link for the current tenant (used by OAuth2 finalize hop).</summary>
-    [HttpPost("links/direct")]
-    [RemoteCommand(Invalidates = ["GetLinks"])]
-    [ProducesResponseType(typeof(ChatIdentityLinkResponse), StatusCodes.Status200OK)]
-    public async Task<ActionResult<ChatIdentityLinkResponse>> CreateDirectLink(
-        [FromBody] CreateDirectLinkRequest body, CancellationToken ct)
-    {
-        var tenantId = _tenantAccessor.TenantId;
-        var userId = GetUserIdOrThrow();
-        var entry = await _service.CreateDirectLinkAsync(
-            tenantId, userId, body.Platform, body.PlatformUserId, ct);
-        return Ok(MapResponse(entry));
+        return Ok(MapResponse(entry, ownedByCaller: entry.NocturneUserId == userId));
     }
 
     /// <inheritdoc cref="ChatIdentityService.SetDefaultAsync"/>
@@ -125,10 +128,9 @@ public class ChatIdentityController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> SetDefault(Guid id, CancellationToken ct)
     {
-        var tenantId = _tenantAccessor.TenantId;
         try
         {
-            await _service.SetDefaultAsync(tenantId, id, ct);
+            await _service.SetDefaultAsync(OwnedByCaller(), id, ct);
         }
         catch (KeyNotFoundException)
         {
@@ -144,13 +146,13 @@ public class ChatIdentityController : ControllerBase
     public async Task<ActionResult> UpdateLink(
         Guid id, [FromBody] UpdateChatIdentityLinkRequest body, CancellationToken ct)
     {
-        var tenantId = _tenantAccessor.TenantId;
+        var scope = OwnedByCaller();
         try
         {
             if (body.Label is not null)
-                await _service.RenameLabelAsync(tenantId, id, body.Label, ct);
+                await _service.RenameLabelAsync(scope, id, body.Label, ct);
             if (body.DisplayName is not null)
-                await _service.UpdateDisplayNameAsync(tenantId, id, body.DisplayName, ct);
+                await _service.UpdateDisplayNameAsync(scope, id, body.DisplayName, ct);
         }
         catch (KeyNotFoundException)
         {
@@ -166,10 +168,9 @@ public class ChatIdentityController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> RevokeLink(Guid id, CancellationToken ct)
     {
-        var tenantId = _tenantAccessor.TenantId;
         try
         {
-            await _service.RevokeAsync(tenantId, id, ct);
+            await _service.RevokeAsync(OwnedByCaller(), id, ct);
         }
         catch (KeyNotFoundException)
         {
@@ -201,14 +202,16 @@ public class ChatIdentityController : ControllerBase
         });
     }
 
-    private static ChatIdentityLinkResponse MapResponse(ChatIdentityDirectoryEntry e)
+    private static ChatIdentityLinkResponse MapResponse(
+        ChatIdentityDirectoryEntry e, bool ownedByCaller)
         => new()
         {
             Id = e.Id,
             TenantId = e.TenantId,
             NocturneUserId = e.NocturneUserId,
             Platform = e.Platform,
-            PlatformUserId = e.PlatformUserId,
+            PlatformUserId = ownedByCaller ? e.PlatformUserId : null,
+            IsOwnedByCaller = ownedByCaller,
             PlatformChannelId = e.PlatformChannelId,
             Label = e.Label,
             DisplayName = e.DisplayName,
@@ -227,7 +230,13 @@ public class ChatIdentityLinkResponse
     public Guid TenantId { get; set; }
     public Guid NocturneUserId { get; set; }
     public string Platform { get; set; } = string.Empty;
-    public string PlatformUserId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The chat account this link routes, or <c>null</c> on a link belonging to another subject.
+    /// </summary>
+    /// <seealso cref="ChatIdentityController.GetLinks"/>
+    public string? PlatformUserId { get; set; }
+
     public string? PlatformChannelId { get; set; }
     public string Label { get; set; } = string.Empty;
     public string DisplayName { get; set; } = string.Empty;
@@ -240,6 +249,12 @@ public class ChatIdentityLinkResponse
     /// </summary>
     public string? DefaultLabel { get; set; }
 
+    /// <summary>
+    /// Whether the caller's own subject owns this link, and so whether the by-id endpoints on
+    /// <see cref="ChatIdentityController"/> will act on it rather than answering 404.
+    /// </summary>
+    public bool IsOwnedByCaller { get; set; }
+
     public string DisplayUnit { get; set; } = "mg/dL";
     public bool IsActive { get; set; }
     public DateTime CreatedAt { get; set; }
@@ -248,12 +263,6 @@ public class ChatIdentityLinkResponse
 public class ClaimChatIdentityLinkRequest
 {
     public string Token { get; set; } = string.Empty;
-}
-
-public class CreateDirectLinkRequest
-{
-    public string Platform { get; set; } = string.Empty;
-    public string PlatformUserId { get; set; } = string.Empty;
 }
 
 public class UpdateChatIdentityLinkRequest

--- a/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityDirectoryController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ChatIdentityDirectoryController.cs
@@ -105,11 +105,11 @@ public class ChatIdentityDirectoryController : ControllerBase
     {
         // Cross-tenant by design: the bot authenticates with the instance key from the apex host
         // and identifies the row by the chat account on it, not by a tenant.
-        var row = await _directory.GetByIdAsync(id, tenantScope: null, ct);
+        var row = await _directory.GetByIdAsync(id, ChatLinkScope.Unscoped, ct);
         if (row is null) return NotFound();
         if (row.Platform != body.Platform || row.PlatformUserId != body.PlatformUserId)
             return Forbid();
-        await _directory.RevokeAsync(id, tenantScope: null, ct);
+        await _directory.RevokeAsync(id, ChatLinkScope.Unscoped, ct);
         return NoContent();
     }
 }

--- a/src/API/Nocturne.API/Services/Chat/ChatIdentityDirectoryService.cs
+++ b/src/API/Nocturne.API/Services/Chat/ChatIdentityDirectoryService.cs
@@ -30,8 +30,9 @@ namespace Nocturne.API.Services.Chat;
 /// no choice to make, so that survivor becomes the default — the same unambiguous call the
 /// first-link rule makes, and what stops deleting the default from leaving none. Two or more
 /// survivors is a real choice between tenants, which the bot asks the user to make rather than
-/// guessing for them. That promotion is unscoped because one link per tenant per platform user
-/// puts every survivor in a different tenant from the revoked link.
+/// guessing for them. That promotion is <see cref="ChatLinkScope.Unscoped"/> because one link per
+/// tenant per platform user puts every survivor in a different tenant from the revoked link, and
+/// nothing requires the same subject across a chat account's links either.
 /// </para>
 /// <para>
 /// Each method opens its own <see cref="Microsoft.EntityFrameworkCore.DbContext"/> from the
@@ -86,19 +87,17 @@ public sealed class ChatIdentityDirectoryService(
     }
 
     /// <summary>
-    /// Returns a directory entry by its ID, or null if not found.
+    /// Returns a directory entry by its ID, or null if no entry with that ID is in
+    /// <paramref name="scope"/>.
     /// </summary>
     /// <param name="id">The directory entry ID.</param>
-    /// <param name="tenantScope">
-    /// Tenant the entry must belong to, or <c>null</c> for a deliberately cross-tenant lookup
-    /// (the instance-key directory endpoints the chat bots call from the apex host).
-    /// </param>
+    /// <param name="scope"><see cref="ChatLinkScope"/></param>
     /// <param name="ct">Cancellation token.</param>
-    public async Task<ChatIdentityDirectoryEntry?> GetByIdAsync(Guid id, Guid? tenantScope, CancellationToken ct)
+    public async Task<ChatIdentityDirectoryEntry?> GetByIdAsync(Guid id, ChatLinkScope scope, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
         return await db.ChatIdentityDirectory
-            .Where(ScopedToId(id, tenantScope))
+            .Where(ScopedToId(id, scope))
             .FirstOrDefaultAsync(ct);
     }
 
@@ -175,12 +174,12 @@ public sealed class ChatIdentityDirectoryService(
 
     /// <summary>Designates a link as the default for the platform user, clearing the previous default in a transaction.</summary>
     /// <param name="linkId">The directory entry to make default.</param>
-    /// <param name="tenantScope">Tenant the entry must belong to, or <c>null</c> for a cross-tenant caller.</param>
+    /// <param name="scope"><see cref="ChatLinkScope"/></param>
     /// <param name="ct">Cancellation token.</param>
-    public async Task SetDefaultAsync(Guid linkId, Guid? tenantScope, CancellationToken ct)
+    public async Task SetDefaultAsync(Guid linkId, ChatLinkScope scope, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
-        var target = await db.ChatIdentityDirectory.Where(ScopedToId(linkId, tenantScope)).FirstOrDefaultAsync(ct)
+        var target = await db.ChatIdentityDirectory.Where(ScopedToId(linkId, scope)).FirstOrDefaultAsync(ct)
             ?? throw new KeyNotFoundException($"Chat identity directory link {linkId} not found");
 
         // NpgsqlRetryingExecutionStrategy requires user-initiated transactions
@@ -213,13 +212,13 @@ public sealed class ChatIdentityDirectoryService(
 
     /// <summary>Renames a link's label, throwing if the new label collides with an existing one.</summary>
     /// <param name="linkId">The directory entry to rename.</param>
-    /// <param name="tenantScope">Tenant the entry must belong to, or <c>null</c> for a cross-tenant caller.</param>
+    /// <param name="scope"><see cref="ChatLinkScope"/></param>
     /// <param name="newLabel">The new routing label.</param>
     /// <param name="ct">Cancellation token.</param>
-    public async Task RenameLabelAsync(Guid linkId, Guid? tenantScope, string newLabel, CancellationToken ct)
+    public async Task RenameLabelAsync(Guid linkId, ChatLinkScope scope, string newLabel, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
-        var target = await db.ChatIdentityDirectory.Where(ScopedToId(linkId, tenantScope)).FirstOrDefaultAsync(ct)
+        var target = await db.ChatIdentityDirectory.Where(ScopedToId(linkId, scope)).FirstOrDefaultAsync(ct)
             ?? throw new KeyNotFoundException($"Chat identity directory link {linkId} not found");
 
         target.Label = newLabel;
@@ -239,13 +238,13 @@ public sealed class ChatIdentityDirectoryService(
 
     /// <summary>Updates the display name shown to the chat platform user for a link.</summary>
     /// <param name="linkId">The directory entry to update.</param>
-    /// <param name="tenantScope">Tenant the entry must belong to, or <c>null</c> for a cross-tenant caller.</param>
+    /// <param name="scope"><see cref="ChatLinkScope"/></param>
     /// <param name="newDisplayName">The new display name.</param>
     /// <param name="ct">Cancellation token.</param>
-    public async Task UpdateDisplayNameAsync(Guid linkId, Guid? tenantScope, string newDisplayName, CancellationToken ct)
+    public async Task UpdateDisplayNameAsync(Guid linkId, ChatLinkScope scope, string newDisplayName, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
-        var target = await db.ChatIdentityDirectory.Where(ScopedToId(linkId, tenantScope)).FirstOrDefaultAsync(ct)
+        var target = await db.ChatIdentityDirectory.Where(ScopedToId(linkId, scope)).FirstOrDefaultAsync(ct)
             ?? throw new KeyNotFoundException($"Chat identity directory link {linkId} not found");
 
         target.DisplayName = newDisplayName;
@@ -257,14 +256,14 @@ public sealed class ChatIdentityDirectoryService(
     /// default.
     /// </summary>
     /// <param name="linkId">The directory entry to delete.</param>
-    /// <param name="tenantScope">Tenant the entry must belong to, or <c>null</c> for a cross-tenant caller.</param>
+    /// <param name="scope"><see cref="ChatLinkScope"/></param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The number of rows deleted: 0 when the entry does not exist in that scope.</returns>
-    public async Task<int> RevokeAsync(Guid linkId, Guid? tenantScope, CancellationToken ct)
+    public async Task<int> RevokeAsync(Guid linkId, ChatLinkScope scope, CancellationToken ct)
     {
         await using var db = await contextFactory.CreateDbContextAsync(ct);
         var target = await db.ChatIdentityDirectory.AsNoTracking()
-            .Where(ScopedToId(linkId, tenantScope))
+            .Where(ScopedToId(linkId, scope))
             .FirstOrDefaultAsync(ct);
         if (target is null)
         {
@@ -272,7 +271,7 @@ public sealed class ChatIdentityDirectoryService(
         }
 
         var deleted = await db.ChatIdentityDirectory
-            .Where(ScopedToId(linkId, tenantScope))
+            .Where(ScopedToId(linkId, scope))
             .ExecuteDeleteAsync(ct);
         if (deleted == 0)
         {
@@ -282,22 +281,24 @@ public sealed class ChatIdentityDirectoryService(
         var survivors = await GetCandidatesAsync(target.Platform, target.PlatformUserId, ct);
         if (survivors is [{ IsDefault: false } survivor])
         {
-            await SetDefaultAsync(survivor.Id, tenantScope: null, ct);
+            await SetDefaultAsync(survivor.Id, ChatLinkScope.Unscoped, ct);
         }
 
         return deleted;
     }
 
-    /// <summary>
-    /// Predicate matching one directory entry by ID, additionally constrained to a tenant when
-    /// <paramref name="tenantScope"/> is supplied. <c>chat_identity_directory</c> is a global
-    /// table with no query filter and no RLS policy — the bots resolve it cross-tenant from the
-    /// apex host — so an ID on its own is never enough for a tenant-authenticated caller.
-    /// </summary>
-    private static Expression<Func<ChatIdentityDirectoryEntry, bool>> ScopedToId(Guid id, Guid? tenantScope)
-        => tenantScope is { } tenantId
-            ? d => d.Id == id && d.TenantId == tenantId
-            : d => d.Id == id;
+    /// <summary>Predicate matching one directory entry by ID within <paramref name="scope"/>.</summary>
+    /// <seealso cref="ChatLinkScope"/>
+    private static Expression<Func<ChatIdentityDirectoryEntry, bool>> ScopedToId(Guid id, ChatLinkScope scope)
+    {
+        if (scope.Owner is not { } owner)
+        {
+            return d => d.Id == id;
+        }
+
+        var (tenantId, subjectId) = owner;
+        return d => d.Id == id && d.TenantId == tenantId && d.NocturneUserId == subjectId;
+    }
 
     private static string ResolveUniqueLabel(
         IReadOnlyCollection<string> existingLabels, string suggested)

--- a/src/API/Nocturne.API/Services/Chat/ChatIdentityService.cs
+++ b/src/API/Nocturne.API/Services/Chat/ChatIdentityService.cs
@@ -5,20 +5,18 @@ using Nocturne.Infrastructure.Data.Entities;
 namespace Nocturne.API.Services.Chat;
 
 /// <summary>
-/// Tenant-scoped facade over <see cref="ChatIdentityDirectoryService"/> and
-/// <see cref="ChatIdentityPendingLinkService"/>. Handles pending-token claim flows,
-/// direct link creation, and read-only pending link lookups.
+/// Facade over <see cref="ChatIdentityDirectoryService"/> and
+/// <see cref="ChatIdentityPendingLinkService"/> for callers authenticated as a tenant subject.
+/// Handles pending-token claim flows and read-only pending link lookups.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <see cref="ClaimPendingLinkAsync"/> validates that the consumed token belongs to the
-/// requested tenant: if the token's <c>TenantSlug</c> hint is set it must match the tenant's
-/// slug (case-insensitive), otherwise any tenant may claim it. This check prevents a token
-/// issued in a Discord DM targeted at tenant A from being redeemed against tenant B.
-/// </para>
-/// <para>
-/// <see cref="CreateDirectLinkAsync"/> bypasses the pending-token flow entirely and is
-/// intended for administrative link creation (e.g. from the management UI).
+/// Proof that the caller controls the chat account comes from the pending token, which is issued
+/// only after the account authorises the bot, so <see cref="ClaimPendingLinkAsync"/> is the sole
+/// way a link enters the directory from here. It also validates that the consumed token belongs
+/// to the requested tenant: if the token's <c>TenantSlug</c> hint is set it must match the
+/// tenant's slug (case-insensitive), otherwise any tenant may claim it. This check prevents a
+/// token issued in a Discord DM targeted at tenant A from being redeemed against tenant B.
 /// </para>
 /// <para>
 /// <see cref="GetPendingAsync"/> is a read-only lookup safe for the OAuth2 authorise page;
@@ -78,50 +76,26 @@ public sealed class ChatIdentityService(
         return entry;
     }
 
-    /// <summary>Creates a chat identity link directly, bypassing the pending-token flow.</summary>
-    public async Task<ChatIdentityDirectoryEntry> CreateDirectLinkAsync(
-        Guid tenantId, Guid userId, string platform, string platformUserId, CancellationToken ct)
-    {
-        await using var db = await contextFactory.CreateDbContextAsync(ct);
-        var tenant = await db.Tenants.AsNoTracking()
-            .Where(t => t.Id == tenantId)
-            .Select(t => new { t.Slug, t.DisplayName })
-            .FirstAsync(ct);
-
-        return await directory.CreateLinkAsync(
-            platform, platformUserId, tenantId, userId, tenant.Slug, tenant.DisplayName, ct);
-    }
-
     /// <summary>Designates a chat identity link as the default for the platform user.</summary>
-    public Task SetDefaultAsync(Guid tenantId, Guid linkId, CancellationToken ct)
-        => directory.SetDefaultAsync(linkId, RequireTenant(tenantId), ct);
+    public Task SetDefaultAsync(ChatLinkScope scope, Guid linkId, CancellationToken ct)
+        => directory.SetDefaultAsync(linkId, scope, ct);
 
     /// <summary>Renames the label on a chat identity link.</summary>
-    public Task RenameLabelAsync(Guid tenantId, Guid linkId, string newLabel, CancellationToken ct)
-        => directory.RenameLabelAsync(linkId, RequireTenant(tenantId), newLabel, ct);
+    public Task RenameLabelAsync(ChatLinkScope scope, Guid linkId, string newLabel, CancellationToken ct)
+        => directory.RenameLabelAsync(linkId, scope, newLabel, ct);
 
     /// <summary>Updates the display name on a chat identity link.</summary>
-    public Task UpdateDisplayNameAsync(Guid tenantId, Guid linkId, string newDisplayName, CancellationToken ct)
-        => directory.UpdateDisplayNameAsync(linkId, RequireTenant(tenantId), newDisplayName, ct);
+    public Task UpdateDisplayNameAsync(ChatLinkScope scope, Guid linkId, string newDisplayName, CancellationToken ct)
+        => directory.UpdateDisplayNameAsync(linkId, scope, newDisplayName, ct);
 
     /// <summary>Permanently removes a chat identity link.</summary>
-    /// <exception cref="KeyNotFoundException">The link does not belong to <paramref name="tenantId"/>.</exception>
-    public async Task RevokeAsync(Guid tenantId, Guid linkId, CancellationToken ct)
+    /// <exception cref="KeyNotFoundException">The link is not in <paramref name="scope"/>.</exception>
+    public async Task RevokeAsync(ChatLinkScope scope, Guid linkId, CancellationToken ct)
     {
-        var deleted = await directory.RevokeAsync(linkId, RequireTenant(tenantId), ct);
+        var deleted = await directory.RevokeAsync(linkId, scope, ct);
         if (deleted == 0)
             throw new KeyNotFoundException($"Chat identity directory link {linkId} not found");
     }
-
-    /// <summary>
-    /// Returns the tenant every mutation on this facade is scoped to. An unresolved tenant is
-    /// rejected rather than passed through as an unscoped (cross-tenant) operation.
-    /// </summary>
-    private static Guid RequireTenant(Guid tenantId)
-        => tenantId != Guid.Empty
-            ? tenantId
-            : throw new InvalidOperationException(
-                "Chat identity link management requires a resolved tenant.");
 
     /// <summary>
     /// Read-only lookup for the authorize page. Does NOT consume the token.

--- a/src/API/Nocturne.API/Services/Chat/ChatLinkScope.cs
+++ b/src/API/Nocturne.API/Services/Chat/ChatLinkScope.cs
@@ -1,0 +1,44 @@
+namespace Nocturne.API.Services.Chat;
+
+/// <summary>
+/// Which rows a by-id operation on <see cref="ChatIdentityDirectoryService"/> may reach.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>chat_identity_directory</c> is a global table with no query filter and no RLS policy, so an
+/// id on its own reaches every tenant. <see cref="Unscoped"/> is for the instance-key chat bots,
+/// which resolve and revoke by chat account from the apex host and carry no tenant.
+/// </para>
+/// <para>
+/// <see cref="ForOwner"/> is for a tenant-authenticated caller. Tenant membership alone is not
+/// ownership of a chat identity: a co-member's row routes a chat account the caller does not
+/// control, and both <see cref="ChatIdentityDirectoryService.SetDefaultAsync"/> and the successor
+/// promotion inside <see cref="ChatIdentityDirectoryService.RevokeAsync"/> repoint that account's
+/// default across every tenant it is linked to.
+/// </para>
+/// </remarks>
+public sealed class ChatLinkScope
+{
+    private ChatLinkScope((Guid TenantId, Guid SubjectId)? owner) => Owner = owner;
+
+    /// <summary>
+    /// The tenant and subject the caller is confined to, or <c>null</c> for a cross-tenant caller.
+    /// </summary>
+    public (Guid TenantId, Guid SubjectId)? Owner { get; }
+
+    /// <summary>Reaches a row in any tenant, owned by any subject.</summary>
+    public static ChatLinkScope Unscoped { get; } = new(null);
+
+    /// <summary>
+    /// Reaches only the row <paramref name="subjectId"/> owns in <paramref name="tenantId"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Either id is <see cref="Guid.Empty"/>. Such a scope matches no row, so without this the
+    /// caller could not tell an unresolved tenant or subject from a link that does not exist.
+    /// </exception>
+    public static ChatLinkScope ForOwner(Guid tenantId, Guid subjectId)
+        => tenantId != Guid.Empty && subjectId != Guid.Empty
+            ? new((tenantId, subjectId))
+            : throw new InvalidOperationException(
+                "A chat identity link operation requires a resolved tenant and owning subject.");
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/integrations/discord/+page.svelte
@@ -215,46 +215,48 @@
 										{/if}
 									</div>
 								</div>
-								<div class="flex gap-1 shrink-0">
-									{#if !link.isDefault}
+								{#if link.isOwnedByCaller}
+									<div class="flex gap-1 shrink-0">
+										{#if !link.isDefault}
+											<Button
+												size="icon"
+												variant="ghost"
+												title="Set as default"
+												disabled={isSettingDefault === link.id}
+												onclick={() => handleSetDefault(link.id ?? "")}
+											>
+												{#if isSettingDefault === link.id}
+													<Loader2 class="size-4 animate-spin" />
+												{:else}
+													<Star class="size-4" />
+												{/if}
+											</Button>
+										{/if}
 										<Button
+											type="button"
 											size="icon"
 											variant="ghost"
-											title="Set as default"
-											disabled={isSettingDefault === link.id}
-											onclick={() => handleSetDefault(link.id ?? "")}
+											title="Edit"
+											onclick={() => startEdit(link.id ?? "", link.label ?? "", link.displayName ?? "")}
 										>
-											{#if isSettingDefault === link.id}
+											<Pencil class="size-4" />
+										</Button>
+										<Button
+											type="button"
+											size="icon"
+											variant="ghost"
+											title="Revoke"
+											disabled={isRevoking === link.id}
+											onclick={() => handleRevokeLink(link.id ?? "")}
+										>
+											{#if isRevoking === link.id}
 												<Loader2 class="size-4 animate-spin" />
 											{:else}
-												<Star class="size-4" />
+												<Link2Off class="size-4" />
 											{/if}
 										</Button>
-									{/if}
-									<Button
-										type="button"
-										size="icon"
-										variant="ghost"
-										title="Edit"
-										onclick={() => startEdit(link.id ?? "", link.label ?? "", link.displayName ?? "")}
-									>
-										<Pencil class="size-4" />
-									</Button>
-									<Button
-										type="button"
-										size="icon"
-										variant="ghost"
-										title="Revoke"
-										disabled={isRevoking === link.id}
-										onclick={() => handleRevokeLink(link.id ?? "")}
-									>
-										{#if isRevoking === link.id}
-											<Loader2 class="size-4 animate-spin" />
-										{:else}
-											<Link2Off class="size-4" />
-										{/if}
-									</Button>
-								</div>
+									</div>
+								{/if}
 							</div>
 						{/if}
 					</div>

--- a/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/DemoSubjectGatedEndpointsTests.cs
@@ -53,11 +53,10 @@ public class DemoSubjectGatedEndpointsTests
         { typeof(OidcController), nameof(OidcController.GetLinkedIdentities) },
         { typeof(OidcController), nameof(OidcController.UnlinkIdentity) },
 
-        // Chat identity bindings. GetLinks lists by tenant, not by subject, so one
-        // visitor's Discord or Telegram binding is enumerable by all of them.
+        // Chat identity bindings. The shared subject owns every visitor's binding, so one
+        // visitor's Discord or Telegram binding is readable and revocable by all of them.
         { typeof(ChatIdentityController), nameof(ChatIdentityController.GetLinks) },
         { typeof(ChatIdentityController), nameof(ChatIdentityController.ClaimLink) },
-        { typeof(ChatIdentityController), nameof(ChatIdentityController.CreateDirectLink) },
         { typeof(ChatIdentityController), nameof(ChatIdentityController.RevokeLink) },
 
         // Guest links: credential-minting, and the demo member satisfies the

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ChatIdentityControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ChatIdentityControllerTests.cs
@@ -8,40 +8,92 @@ using Nocturne.API.Controllers.V4.Identity;
 using Nocturne.API.Services.Chat;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
-using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Controllers.V4.Identity;
 
 /// <summary>
 /// Covers what the tenant-scoped link list tells a member about a chat account whose default sits
-/// on a link in a tenant this list does not show.
+/// on a link in a tenant this list does not show, and that a link the caller does not own is
+/// neither disclosed to nor mutable by them.
 /// </summary>
 [Trait("Category", "Unit")]
-public class ChatIdentityControllerTests
+public class ChatIdentityControllerTests : IDisposable
 {
     private const string Platform = "discord";
-    private const string ChatUser = "discord-user-a";
+    private const string CallerChatUser = "discord-user-a";
+    private const string CoMemberChatUser = "discord-user-b";
 
-    private readonly Guid _tenantId = Guid.NewGuid();
-    private readonly Guid _otherTenantId = Guid.NewGuid();
-    private readonly Guid _callerSubjectId = Guid.NewGuid();
-    private readonly DbContextOptions<NocturneDbContext> _dbOptions =
-        new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
+    private readonly SqliteTestDatabase _db;
+    private readonly ChatIdentityService _service;
+    private readonly Guid _tenantId;
+    private readonly Guid _otherTenantId;
+    private readonly Guid _callerSubjectId;
+    private readonly Guid _coMemberSubjectId;
 
-    private NocturneDbContext CreateDbContext() => new(_dbOptions);
-
-    private void InsertLink(Guid tenantId, Guid subjectId, string label, bool isDefault)
+    public ChatIdentityControllerTests()
     {
-        using var db = CreateDbContext();
+        _db = TestDbContextFactory.CreateSqlite();
+        _service = new ChatIdentityService(
+            new ChatIdentityDirectoryService(
+                _db.ContextFactory, Mock.Of<ILogger<ChatIdentityDirectoryService>>()),
+            new ChatIdentityPendingLinkService(
+                _db.ContextFactory, Mock.Of<ILogger<ChatIdentityPendingLinkService>>()),
+            _db.ContextFactory,
+            Mock.Of<ILogger<ChatIdentityService>>());
+
+        _tenantId = NewTenant();
+        _otherTenantId = NewTenant();
+        _callerSubjectId = NewSubject();
+        _coMemberSubjectId = NewSubject();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    /// <summary>
+    /// Inserts a tenant and returns its id. chat_identity_directory.tenant_id is a real FK, so a
+    /// link cannot point at a tenant that was never created.
+    /// </summary>
+    private Guid NewTenant()
+    {
+        var id = Guid.CreateVersion7();
+        using var db = _db.CreateContext();
+        db.Tenants.Add(new TenantEntity
+        {
+            Id = id,
+            Slug = $"t-{id:n}"[..20],
+            DisplayName = "Test Tenant",
+        });
+        db.SaveChanges();
+        return id;
+    }
+
+    /// <summary>
+    /// Inserts a subject and returns its id. chat_identity_directory.nocturne_user_id is a real
+    /// FK, so a link cannot point at a subject that was never created.
+    /// </summary>
+    private Guid NewSubject()
+    {
+        var id = Guid.CreateVersion7();
+        using var db = _db.CreateContext();
+        db.Subjects.Add(new SubjectEntity { Id = id, Name = $"s-{id:n}"[..20] });
+        db.SaveChanges();
+        return id;
+    }
+
+    private Guid InsertLink(
+        Guid tenantId, Guid subjectId, string label, bool isDefault,
+        string platformUserId = CallerChatUser)
+    {
+        var id = Guid.CreateVersion7();
+        using var db = _db.CreateContext();
         db.ChatIdentityDirectory.Add(new ChatIdentityDirectoryEntry
         {
-            Id = Guid.CreateVersion7(),
+            Id = id,
             Platform = Platform,
-            PlatformUserId = ChatUser,
+            PlatformUserId = platformUserId,
             TenantId = tenantId,
             NocturneUserId = subjectId,
             Label = label,
@@ -51,24 +103,33 @@ public class ChatIdentityControllerTests
             CreatedAt = DateTime.UtcNow,
         });
         db.SaveChanges();
+        return id;
     }
 
-    private ChatIdentityController CreateController(bool withSubject = true)
+    /// <summary>
+    /// Issues a pending link token with no tenant slug hint, which any tenant may claim.
+    /// </summary>
+    private string InsertPendingToken(string platformUserId)
     {
-        var factory = new Mock<IDbContextFactory<NocturneDbContext>>();
-        factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateDbContext);
+        var token = Convert.ToHexString(Guid.CreateVersion7().ToByteArray());
+        using var db = _db.CreateContext();
+        db.ChatIdentityPendingLinks.Add(new ChatIdentityPendingLinkEntity
+        {
+            Token = token,
+            Platform = Platform,
+            PlatformUserId = platformUserId,
+            TenantSlug = null,
+            Source = "connect-slash",
+            ExpiresAt = DateTime.UtcNow.AddMinutes(10),
+        });
+        db.SaveChanges();
+        return token;
+    }
 
-        var service = new ChatIdentityService(
-            new ChatIdentityDirectoryService(
-                factory.Object, Mock.Of<ILogger<ChatIdentityDirectoryService>>()),
-            new ChatIdentityPendingLinkService(
-                factory.Object, Mock.Of<ILogger<ChatIdentityPendingLinkService>>()),
-            factory.Object,
-            Mock.Of<ILogger<ChatIdentityService>>());
-
+    private ChatIdentityController CreateController(bool withSubject = true, Guid? tenantId = null)
+    {
         var tenantAccessor = new Mock<ITenantAccessor>();
-        tenantAccessor.SetupGet(t => t.TenantId).Returns(_tenantId);
+        tenantAccessor.SetupGet(t => t.TenantId).Returns(tenantId ?? _tenantId);
 
         var httpContext = new DefaultHttpContext();
         httpContext.Items["AuthContext"] = new AuthContext
@@ -78,11 +139,27 @@ public class ChatIdentityControllerTests
             TenantId = _tenantId,
         };
 
-        return new ChatIdentityController(service, tenantAccessor.Object)
+        return new ChatIdentityController(_service, tenantAccessor.Object)
         {
             ControllerContext = new ControllerContext { HttpContext = httpContext },
         };
     }
+
+    private async Task<bool> LinkExists(Guid id)
+    {
+        await using var db = _db.CreateContext();
+        return await db.ChatIdentityDirectory.AnyAsync(d => d.Id == id);
+    }
+
+    private async Task<ChatIdentityDirectoryEntry> Reload(Guid id)
+    {
+        await using var db = _db.CreateContext();
+        return await db.ChatIdentityDirectory.AsNoTracking().SingleAsync(d => d.Id == id);
+    }
+
+    private static ChatIdentityLinkResponse OkLink(ActionResult<ChatIdentityLinkResponse> result)
+        => result.Result.Should().BeOfType<OkObjectResult>().Subject
+            .Value.Should().BeOfType<ChatIdentityLinkResponse>().Subject;
 
     private static ChatIdentityLinkResponse SingleLink(ActionResult<List<ChatIdentityLinkResponse>> result)
         => result.Result.Should().BeOfType<OkObjectResult>().Subject
@@ -105,8 +182,8 @@ public class ChatIdentityControllerTests
     [Fact]
     public async Task GetLinks_leaves_the_default_label_off_a_link_belonging_to_another_subject()
     {
-        InsertLink(_tenantId, Guid.NewGuid(), "lily", isDefault: false);
-        InsertLink(_otherTenantId, Guid.NewGuid(), "oliver", isDefault: true);
+        InsertLink(_tenantId, _coMemberSubjectId, "lily", isDefault: false, platformUserId: CoMemberChatUser);
+        InsertLink(_otherTenantId, _coMemberSubjectId, "oliver", isDefault: true, platformUserId: CoMemberChatUser);
 
         var link = SingleLink(await CreateController().GetLinks(CancellationToken.None));
 
@@ -135,5 +212,196 @@ public class ChatIdentityControllerTests
 
         link.Label.Should().Be("lily");
         link.DefaultLabel.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetLinks_returns_the_platform_user_id_on_the_callers_own_link()
+    {
+        InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: true);
+
+        var link = SingleLink(await CreateController().GetLinks(CancellationToken.None));
+
+        link.PlatformUserId.Should().Be(CallerChatUser);
+    }
+
+    [Fact]
+    public async Task GetLinks_withholds_the_platform_user_id_on_a_co_members_link()
+    {
+        InsertLink(_tenantId, _coMemberSubjectId, "oliver", isDefault: true, platformUserId: CoMemberChatUser);
+
+        var link = SingleLink(await CreateController().GetLinks(CancellationToken.None));
+
+        link.Label.Should().Be("oliver", "the row is still listed");
+        link.PlatformUserId.Should().BeNull(
+            "a co-member's chat account is theirs, and enumerating it is not a tenant privilege");
+    }
+
+    [Fact]
+    public async Task GetLinks_marks_the_callers_own_link_as_owned()
+    {
+        InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: true);
+
+        var link = SingleLink(await CreateController().GetLinks(CancellationToken.None));
+
+        link.IsOwnedByCaller.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetLinks_marks_a_co_members_link_as_not_owned()
+    {
+        InsertLink(_tenantId, _coMemberSubjectId, "oliver", isDefault: true, platformUserId: CoMemberChatUser);
+
+        var link = SingleLink(await CreateController().GetLinks(CancellationToken.None));
+
+        link.IsOwnedByCaller.Should().BeFalse(
+            "the settings page offers set-default, edit and revoke on this flag, and all three 404");
+    }
+
+    [Fact]
+    public async Task ClaimLink_reports_the_new_link_as_owned()
+    {
+        var token = InsertPendingToken(CallerChatUser);
+
+        var result = await CreateController().ClaimLink(
+            new ClaimChatIdentityLinkRequest { Token = token }, CancellationToken.None);
+
+        var link = OkLink(result);
+        link.NocturneUserId.Should().Be(_callerSubjectId);
+        link.IsOwnedByCaller.Should().BeTrue();
+        link.PlatformUserId.Should().Be(CallerChatUser);
+    }
+
+    [Fact]
+    public async Task ClaimLink_reports_a_pre_existing_co_members_row_as_not_owned()
+    {
+        InsertLink(_tenantId, _coMemberSubjectId, "oliver", isDefault: true);
+        var token = InsertPendingToken(CallerChatUser);
+
+        var result = await CreateController().ClaimLink(
+            new ClaimChatIdentityLinkRequest { Token = token }, CancellationToken.None);
+
+        var link = OkLink(result);
+        link.NocturneUserId.Should().Be(_coMemberSubjectId,
+            "a chat account already linked to this tenant keeps the link it has");
+        link.IsOwnedByCaller.Should().BeFalse(
+            "the by-id endpoints refuse this row, so the settings page must not offer them");
+    }
+
+    [Fact]
+    public async Task RevokeLink_refuses_a_co_members_link()
+    {
+        var coMemberLink = InsertLink(
+            _tenantId, _coMemberSubjectId, "oliver", isDefault: true, platformUserId: CoMemberChatUser);
+
+        var result = await CreateController().RevokeLink(coMemberLink, CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+        (await LinkExists(coMemberLink)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RevokeLink_refuses_the_callers_own_link_in_another_tenant()
+    {
+        var elsewhere = InsertLink(_otherTenantId, _callerSubjectId, "oliver", isDefault: true);
+
+        var result = await CreateController().RevokeLink(elsewhere, CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+        (await LinkExists(elsewhere)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RevokeLink_refuses_a_credential_that_carries_no_subject()
+    {
+        var link = InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: true);
+
+        var act = async () => await CreateController(withSubject: false)
+            .RevokeLink(link, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        (await LinkExists(link)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RevokeLink_refuses_a_request_whose_tenant_did_not_resolve()
+    {
+        var link = InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: true);
+
+        var act = async () => await CreateController(tenantId: Guid.Empty)
+            .RevokeLink(link, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        (await LinkExists(link)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RevokeLink_removes_the_callers_own_link()
+    {
+        var own = InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: true);
+
+        var result = await CreateController().RevokeLink(own, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        (await LinkExists(own)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SetDefault_refuses_a_co_members_link_and_leaves_their_default_alone()
+    {
+        var coMemberHere = InsertLink(
+            _tenantId, _coMemberSubjectId, "oliver", isDefault: false, platformUserId: CoMemberChatUser);
+        var coMemberElsewhere = InsertLink(
+            _otherTenantId, _coMemberSubjectId, "rose", isDefault: true, platformUserId: CoMemberChatUser);
+
+        var result = await CreateController().SetDefault(coMemberHere, CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+        (await Reload(coMemberHere)).IsDefault.Should().BeFalse();
+        (await Reload(coMemberElsewhere)).IsDefault.Should().BeTrue(
+            "a co-member's bare bot commands keep resolving to the tenant they chose");
+    }
+
+    [Fact]
+    public async Task SetDefault_promotes_the_callers_own_link()
+    {
+        var own = InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: false);
+
+        var result = await CreateController().SetDefault(own, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        (await Reload(own)).IsDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateLink_refuses_a_co_members_link()
+    {
+        var coMemberLink = InsertLink(
+            _tenantId, _coMemberSubjectId, "oliver", isDefault: true, platformUserId: CoMemberChatUser);
+
+        var result = await CreateController().UpdateLink(
+            coMemberLink,
+            new UpdateChatIdentityLinkRequest { Label = "stolen", DisplayName = "Stolen" },
+            CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+        var unchanged = await Reload(coMemberLink);
+        unchanged.Label.Should().Be("oliver");
+        unchanged.DisplayName.Should().Be("oliver");
+    }
+
+    [Fact]
+    public async Task UpdateLink_renames_the_callers_own_link()
+    {
+        var own = InsertLink(_tenantId, _callerSubjectId, "lily", isDefault: true);
+
+        var result = await CreateController().UpdateLink(
+            own,
+            new UpdateChatIdentityLinkRequest { Label = "rose", DisplayName = "Rose" },
+            CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        var renamed = await Reload(own);
+        renamed.Label.Should().Be("rose");
+        renamed.DisplayName.Should().Be("Rose");
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Chat/ChatIdentityDirectoryServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Chat/ChatIdentityDirectoryServiceTests.cs
@@ -446,10 +446,10 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
         a.IsDefault.Should().BeTrue();
         b.IsDefault.Should().BeFalse();
 
-        await _service.SetDefaultAsync(b.Id, tenantScope: null, ct: default);
+        await _service.SetDefaultAsync(b.Id, ChatLinkScope.Unscoped, ct: default);
 
-        var aAfter = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
-        var bAfter = await _service.GetByIdAsync(b.Id, tenantScope: null, ct: default);
+        var aAfter = await _service.GetByIdAsync(a.Id, ChatLinkScope.Unscoped, ct: default);
+        var bAfter = await _service.GetByIdAsync(b.Id, ChatLinkScope.Unscoped, ct: default);
         aAfter!.IsDefault.Should().BeFalse();
         bAfter!.IsDefault.Should().BeTrue();
     }
@@ -457,7 +457,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     [Fact]
     public async Task SetDefaultAsync_throws_when_link_not_found()
     {
-        var act = async () => await _service.SetDefaultAsync(Guid.CreateVersion7(), tenantScope: null, ct: default);
+        var act = async () => await _service.SetDefaultAsync(Guid.CreateVersion7(), ChatLinkScope.Unscoped, ct: default);
         await act.Should().ThrowAsync<KeyNotFoundException>();
     }
 
@@ -467,8 +467,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task RenameLabelAsync_updates_label()
     {
         var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
-        await _service.RenameLabelAsync(a.Id, tenantScope: null, "rose", ct: default);
-        var after = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
+        await _service.RenameLabelAsync(a.Id, ChatLinkScope.Unscoped, "rose", ct: default);
+        var after = await _service.GetByIdAsync(a.Id, ChatLinkScope.Unscoped, ct: default);
         after!.Label.Should().Be("rose");
     }
 
@@ -478,7 +478,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
         await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
         var b = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
 
-        var act = async () => await _service.RenameLabelAsync(b.Id, tenantScope: null, "lily", ct: default);
+        var act = async () => await _service.RenameLabelAsync(b.Id, ChatLinkScope.Unscoped, "lily", ct: default);
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
@@ -488,8 +488,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task UpdateDisplayNameAsync_updates_display_name()
     {
         var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
-        await _service.UpdateDisplayNameAsync(a.Id, tenantScope: null, "Lily Renamed", ct: default);
-        var after = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
+        await _service.UpdateDisplayNameAsync(a.Id, ChatLinkScope.Unscoped, "Lily Renamed", ct: default);
+        var after = await _service.GetByIdAsync(a.Id, ChatLinkScope.Unscoped, ct: default);
         after!.DisplayName.Should().Be("Lily Renamed");
     }
 
@@ -499,8 +499,8 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task RevokeAsync_hard_deletes_row()
     {
         var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
-        await _service.RevokeAsync(a.Id, tenantScope: null, ct: default);
-        var after = await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default);
+        await _service.RevokeAsync(a.Id, ChatLinkScope.Unscoped, ct: default);
+        var after = await _service.GetByIdAsync(a.Id, ChatLinkScope.Unscoped, ct: default);
         after.Should().BeNull();
     }
 
@@ -508,18 +508,19 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task RevokeAsync_promotes_the_sole_survivor_when_the_default_is_deleted()
     {
         var tenantA = NewTenant();
-        var a = await _service.CreateLinkAsync(Platform, UserA, tenantA, NewSubject(), "lily", "Lily", default);
+        var subjectA = NewSubject();
+        var a = await _service.CreateLinkAsync(Platform, UserA, tenantA, subjectA, "lily", "Lily", default);
         var b = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
         var elsewhere = await _service.CreateLinkAsync(Platform, UserB, NewTenant(), NewSubject(), "rose", "Rose", default);
         a.IsDefault.Should().BeTrue();
         b.IsDefault.Should().BeFalse();
 
-        await _service.RevokeAsync(a.Id, tenantScope: tenantA, ct: default);
+        await _service.RevokeAsync(a.Id, ChatLinkScope.ForOwner(tenantA, subjectA), ct: default);
 
-        var bAfter = await _service.GetByIdAsync(b.Id, tenantScope: null, ct: default);
+        var bAfter = await _service.GetByIdAsync(b.Id, ChatLinkScope.Unscoped, ct: default);
         bAfter!.IsDefault.Should().BeTrue(
             "the survivor is in another tenant than the revoked link, so a tenant-scoped promotion would miss it");
-        var elsewhereAfter = await _service.GetByIdAsync(elsewhere.Id, tenantScope: null, ct: default);
+        var elsewhereAfter = await _service.GetByIdAsync(elsewhere.Id, ChatLinkScope.Unscoped, ct: default);
         elsewhereAfter!.IsDefault.Should().BeTrue("another chat account's links are not survivors of this one");
     }
 
@@ -530,7 +531,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
         InsertLink(UserA, NewTenant(), "oliver", isDefault: false);
         var before = await _service.GetCandidatesAsync(Platform, UserA, default);
 
-        await _service.RevokeAsync(before.Single(d => d.Label == "lily").Id, tenantScope: null, ct: default);
+        await _service.RevokeAsync(before.Single(d => d.Label == "lily").Id, ChatLinkScope.Unscoped, ct: default);
 
         var survivors = await _service.GetCandidatesAsync(Platform, UserA, default);
         survivors.Should().ContainSingle().Which.IsDefault.Should().BeTrue();
@@ -540,11 +541,12 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task RevokeAsync_leaves_no_default_when_more_than_one_link_survives()
     {
         var tenantA = NewTenant();
-        var a = await _service.CreateLinkAsync(Platform, UserA, tenantA, NewSubject(), "lily", "Lily", default);
+        var subjectA = NewSubject();
+        var a = await _service.CreateLinkAsync(Platform, UserA, tenantA, subjectA, "lily", "Lily", default);
         await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
         await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "rose", "Rose", default);
 
-        await _service.RevokeAsync(a.Id, tenantScope: tenantA, ct: default);
+        await _service.RevokeAsync(a.Id, ChatLinkScope.ForOwner(tenantA, subjectA), ct: default);
 
         var survivors = await _service.GetCandidatesAsync(Platform, UserA, default);
         survivors.Should().HaveCount(2);
@@ -573,7 +575,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     {
         var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
         var b = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "oliver", "Oliver", default);
-        await _service.SetDefaultAsync(b.Id, tenantScope: null, ct: default);
+        await _service.SetDefaultAsync(b.Id, ChatLinkScope.Unscoped, ct: default);
         await _service.CreateLinkAsync(Platform, UserB, NewTenant(), NewSubject(), "rose", "Rose", default);
 
         var result = await _service.GetDefaultAsync(Platform, UserA, default);
@@ -600,7 +602,7 @@ public class ChatIdentityDirectoryServiceTests : IDisposable
     public async Task GetByIdAsync_returns_link_or_null()
     {
         var a = await _service.CreateLinkAsync(Platform, UserA, NewTenant(), NewSubject(), "lily", "Lily", default);
-        (await _service.GetByIdAsync(a.Id, tenantScope: null, ct: default)).Should().NotBeNull();
-        (await _service.GetByIdAsync(Guid.CreateVersion7(), tenantScope: null, ct: default)).Should().BeNull();
+        (await _service.GetByIdAsync(a.Id, ChatLinkScope.Unscoped, ct: default)).Should().NotBeNull();
+        (await _service.GetByIdAsync(Guid.CreateVersion7(), ChatLinkScope.Unscoped, ct: default)).Should().BeNull();
     }
 }


### PR DESCRIPTION
Closes #987.

## What was wrong

`ChatIdentityController` authorized its by-id actions on **tenant membership alone**, and one action on neither. `chat_identity_directory` is a global table with no query filter and no RLS policy, and the default flag it carries decides which tenant a bare bot command from a chat account resolves to — so membership is the wrong authority: a co-member's row routes a chat account the caller does not control.

**`POST links/direct` was a chat-account takeover.** It took `platform` + `platformUserId` from the body under bare `[Authorize]` with no proof the caller controls that account, so any authenticated user of any tenant could bind a victim's Discord snowflake and then set-default it, repointing the victim's bare `/bg` and card taps at the attacker's tenant.

## What this does

**Deletes `POST links/direct`.** Its doc comment claimed the OAuth2 finalize hop as its consumer; that flow actually goes `createPending` -> `claimLink`, and a sweep of the web app, bot, bridge, portal, scripts, docs and tests — plus an on-disk sweep including untracked and gitignored files, and the regenerated client layer — found no caller at all.

**Introduces `ChatLinkScope`**, replacing the nullable `tenantScope` threaded through the directory service's by-id methods. `Unscoped` is the instance-key bots resolving the global table from the apex host; `ForOwner(tenant, subject)` is a tenant-authenticated caller. `ScopedToId` stays the one site that turns a scope into a WHERE-clause predicate, so set-default, patch and delete share a single ownership rule rather than three gates, and a future by-id method cannot forget it.

**`GetLinks`** keeps its rows but withholds `PlatformUserId` on rows belonging to another subject, on the same terms as `DefaultLabel`.

**`IsOwnedByCaller`** was added because the by-id endpoints now answer 404 for a link the caller does not own, which would have made the Discord settings page offer set-default, edit and revoke on every co-member row and fail every time. The page gates that action group on it. The flag is *stated* rather than inferred from `PlatformUserId` being null, which would couple the page to the disclosure rule.

`ClaimLink` **computes** the flag rather than asserting it. `CreateLinkAsync` matches an existing row on `(Platform, PlatformUserId, TenantId)` and not on `NocturneUserId`, so a claim can return a row belonging to another subject — the pre-fix code hardcoded `ownedByCaller: true` there, which would have reintroduced the same UI defect through the one path that did not compute it.

## Please read before merging

**This cannot retroactively invalidate rows the hole already created.** A row an attacker bound pre-fix — the victim's snowflake in the attacker's tenant under the attacker's own subject — *satisfies* the new ownership predicate, because the attacker genuinely owns it, and can still be set-default afterwards. `ChatIdentityDirectoryEntry` carries no provenance column, so such rows are indistinguishable from OAuth-claimed ones. **A one-time review of `chat_identity_directory`** for chat accounts whose links span subjects, or that the holder does not recognise, is worth doing. Exploitation required pre-positioning before this ships.

## Wire contract

`PlatformUserId` becomes nullable and `IsOwnedByCaller` is added. `links/direct` and `CreateDirectLinkRequest` leave the v4 spec — `sdk/filter-v4-spec.js` includes every `/api/v4/**` path unconditionally, so the operation shipped in all seven published SDKs and **drops out of their next release**.

A subjectless but tenant-resolved credential now throws where it previously proceeded tenant-scoped through set-default, patch and delete. Such a credential cannot own a chat identity, so failing closed is the right direction, but it is a change rather than a tidy-up.

## Verification

- API unit suite **6415 passed / 0 failed / 5 skipped** (baseline `origin/main` 6401/0). Web typecheck unchanged at 51 errors.
- Tests moved onto the shared SQLite arrangement because the owner-succeeds paths run `ExecuteDelete`/`ExecuteUpdate` in a transaction, which InMemory cannot execute — on InMemory only the *refusal* halves would have been provable.
- Hostile review (fable): **8 of 9 mutations killed**; the survivor unscopes the `ExecuteDelete` predicate while the scoped read still gates entry, which is near-equivalent. It could not construct a violating case against the unscoped successor promotion after trying five angles, and confirmed `Unscoped` is unreachable from any tenant-authenticated path.
