### PR TITLE
fix(web): route connector failures through the shared error helpers

### DIFF
--- a/src/Web/packages/app/src/lib/api/ui-settings-messages.ts
+++ b/src/Web/packages/app/src/lib/api/ui-settings-messages.ts
@@ -1,0 +1,11 @@
+/**
+ * What a failed settings read tells the user.
+ *
+ * `settings/appearance` renders this alone, and it arrives there by two paths: a
+ * server failure is sanitized to it by `getUiSettings`, while a transport
+ * failure is suppressed as client-written and `SettingsStore`'s fallback stands
+ * in. The card has to read the same whichever happened, so both paths spell it
+ * once here.
+ */
+export const SETTINGS_LOAD_FAILED =
+  "We couldn't load your settings. Refresh the page to try again.";

--- a/src/Web/packages/app/src/lib/api/ui-settings.remote.test.ts
+++ b/src/Web/packages/app/src/lib/api/ui-settings.remote.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ApiException } from "$api-clients";
+import { errorMessage } from "$lib/forms/submit-error";
+
+let upstream: () => Promise<unknown>;
+let headers: Map<string, string>;
+
+vi.mock("$app/server", () => ({
+  getRequestEvent: () => ({
+    locals: { apiClient: { uiSettings: { getUISettings: () => upstream() } } },
+    request: { headers: { get: (name: string) => headers.get(name) ?? null } },
+    url: new URL("https://app.example.test/settings/appearance?tab=theme"),
+  }),
+  query: (fn: unknown) => fn,
+  command: (_schema: unknown, fn: unknown) => fn,
+}));
+
+const { getUiSettings } = await import("./ui-settings.remote");
+
+/**
+ * A reading surface forwards a server-written body verbatim, so this has to be
+ * a whole sentence with a remedy rather than a placeholder.
+ */
+const FIXED = "We couldn't load your settings. Refresh the page to try again.";
+
+const apiException = (message: string, status: number, body: string) =>
+  new ApiException(message, status, body, {}, null);
+
+/** What this query threw, which is never the thing it caught. */
+async function rejectionFor(failure: unknown): Promise<unknown> {
+  upstream = () => Promise.reject(failure);
+
+  try {
+    await getUiSettings();
+  } catch (rejection) {
+    return rejection;
+  }
+
+  throw new Error("getUiSettings resolved where it was expected to reject");
+}
+
+/** The reason it put in `error(status, message)`, read as the store reads it. */
+const reasonFor = async (failure: unknown) =>
+  errorMessage(await rejectionFor(failure));
+
+/**
+ * `SettingsStore` renders this query's rejection through `remoteErrorMessage`,
+ * whose half of the policy is documented at `RemoteErrorPolicy`. Nothing that
+ * stands in for this query can observe what its catch answers with, so the
+ * answer is pinned here.
+ */
+describe("a failed UI settings read", () => {
+  beforeEach(() => {
+    headers = new Map();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("answers a ProblemDetails body with its own sentence", async () => {
+    const reason = await reasonFor(
+      apiException(
+        "A server side error occurred.",
+        500,
+        '{"title":"Internal Server Error","detail":"Internal server error","status":500}'
+      )
+    );
+
+    expect(reason).toBe(FIXED);
+  });
+
+  it("answers an error page body with its own sentence", async () => {
+    const reason = await reasonFor(
+      apiException(
+        "An unexpected server error occurred.",
+        502,
+        "<html><head><title>502 Bad Gateway</title></head><body><center><hr>nginx/1.27.0</center></body></html>"
+      )
+    );
+
+    expect(reason).toBe(FIXED);
+  });
+
+  it("keeps a thrown ProblemDetails object's own wording out of the reason", async () => {
+    const reason = await reasonFor({
+      status: 400,
+      title: "Bad Request",
+      detail: "The tenant schema is missing column features_json",
+    });
+
+    expect(reason).toBe(FIXED);
+  });
+
+  it("carries nothing from upstream in the reason it reports", async () => {
+    const reasons = [
+      await reasonFor(
+        apiException(
+          "A server side error occurred.",
+          500,
+          '{"detail":"npgsql: connection reset"}'
+        )
+      ),
+      await reasonFor(new Error("getaddrinfo ENOTFOUND nocturne.internal")),
+    ];
+
+    for (const reason of reasons) {
+      expect(reason).toBe(FIXED);
+      expect(reason).not.toMatch(/npgsql|ENOTFOUND|nginx|server (side )?error/i);
+    }
+  });
+
+  /**
+   * The settings pages sit behind the authenticated layout, so reporting an
+   * expired session as a failed read would replace the form with a card
+   * offering no way back to signing in.
+   */
+  it("sends an expired session to the login route", async () => {
+    const rejection = await rejectionFor(
+      apiException("Not authenticated.", 401, "")
+    );
+
+    expect(rejection).toMatchObject({
+      status: 302,
+      location:
+        "/auth/login?returnUrl=%2Fsettings%2Fappearance%3Ftab%3Dtheme",
+    });
+  });
+
+  it("refuses a share host rather than redirecting it", async () => {
+    headers = new Map([["x-forwarded-host", "abc123.share.example.test"]]);
+
+    const rejection = await rejectionFor(
+      apiException("Not authenticated.", 401, "")
+    );
+
+    expect(rejection).toMatchObject({ status: 401 });
+    expect(rejection).not.toHaveProperty("location");
+  });
+});

--- a/src/Web/packages/app/src/lib/api/ui-settings.remote.ts
+++ b/src/Web/packages/app/src/lib/api/ui-settings.remote.ts
@@ -7,7 +7,7 @@
  * rather than an in-memory copy, so nothing is lost on reload.
  */
 import { getRequestEvent, query, command } from "$app/server";
-import { error } from "@sveltejs/kit";
+import { error, redirect } from "@sveltejs/kit";
 import type {
   DataQualitySettings,
   FeatureSettings,
@@ -17,6 +17,8 @@ import {
   DataQualitySettingsSchema,
   FeatureSettingsSchema,
 } from "$lib/api/generated/schemas";
+import { errorStatus } from "$lib/forms/submit-error";
+import { SETTINGS_LOAD_FAILED } from "./ui-settings-messages";
 
 export const getUiSettings = query(async () => {
   const { locals } = getRequestEvent();
@@ -24,8 +26,24 @@ export const getUiSettings = query(async () => {
   try {
     return await locals.apiClient.uiSettings.getUISettings();
   } catch (err) {
+    // Same 401 handling as a generated query: the settings pages are behind the
+    // authenticated layout, so an expired session has to reach the login route.
+    if (errorStatus(err) === 401) {
+      const { request, url } = getRequestEvent();
+      const host =
+        request.headers.get("x-forwarded-host") ??
+        request.headers.get("host") ??
+        "";
+      if (/^[^.]+\.share\./i.test(host)) throw error(401, "Unauthorized");
+
+      throw redirect(
+        302,
+        `/auth/login?returnUrl=${encodeURIComponent(url.pathname + url.search)}`
+      );
+    }
+
     console.error("Error loading UI settings:", err);
-    throw error(500, "Failed to load settings");
+    throw error(500, SETTINGS_LOAD_FAILED);
   }
 });
 

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte
@@ -5,7 +5,8 @@
   import { Separator } from "$lib/components/ui/separator";
   import * as Tooltip from "$lib/components/ui/tooltip";
   import { getDataTypeLabel } from "$lib/utils/data-type-labels";
-  import { getApiClient } from "$lib/api";
+  import { triggerConnectorSync } from "$api/generated/services.generated.remote";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import {
     Cloud,
     Loader2,
@@ -20,9 +21,9 @@
   } from "lucide-svelte";
   import type {
     ConnectorCapabilities,
-    SyncRequest,
     SyncResult,
   } from "$lib/api/generated/nocturne-api-client";
+  import type { SyncRequest } from "$lib/api/generated/schemas";
   import type { ConnectorStatusWithDescription } from "./ServerConnectorsCard.svelte";
   import { formatNumber, lastSeen } from "$lib/utils/formatting";
 
@@ -61,6 +62,45 @@
 
 
 
+  const selectedRange = () => ({
+    from: new Date(granularSyncFrom).toISOString(),
+    to: new Date(granularSyncTo).toISOString(),
+  });
+
+  /**
+   * The sync's own result stands whatever the callback does, so a refresh the
+   * caller could not complete is left to the caller to report.
+   */
+  async function notifyComplete() {
+    if (!onSyncComplete) return;
+    try {
+      await onSyncComplete();
+    } catch (e) {
+      console.error("Failed to refresh after a connector sync", e);
+    }
+  }
+
+  /**
+   * A refused sync reports itself through the same result panel as a partial
+   * one, so a rejection becomes a result rather than propagating.
+   */
+  async function requestSync(
+    connectorId: string,
+    request: SyncRequest,
+    fallback: string
+  ): Promise<SyncResult> {
+    try {
+      return await triggerConnectorSync({ id: connectorId, request });
+    } catch (e) {
+      return {
+        success: false,
+        message: describeSubmitError(e, fallback),
+        errors: [],
+        itemsSynced: {},
+      };
+    }
+  }
+
   async function triggerGranularSync() {
     const connectorId = selectedConnector?.id;
     if (!connectorId) return;
@@ -68,34 +108,16 @@
     const supportsHistoricalSync =
       selectedConnectorCapabilities?.supportsHistoricalSync ?? true;
 
-    // Fast-feedback UI
     isGranularSyncing = true;
     granularSyncResult = null;
 
     try {
-      const apiClient = getApiClient();
-      const request: SyncRequest = supportsHistoricalSync
-        ? {
-            from: new Date(granularSyncFrom),
-            to: new Date(granularSyncTo),
-          }
-        : {};
-
-      const result = await apiClient.services.triggerConnectorSync(
+      granularSyncResult = await requestSync(
         connectorId,
-        request
+        supportsHistoricalSync ? selectedRange() : {},
+        "We couldn't start the sync. Please try again."
       );
-
-      granularSyncResult = result;
-      if (onSyncComplete) await onSyncComplete();
-    } catch (e) {
-      granularSyncResult = {
-        success: false,
-        message: e instanceof Error ? e.message : "Failed to trigger sync",
-        errors: [],
-        itemsSynced: {},
-      };
-      if (onSyncComplete) await onSyncComplete();
+      await notifyComplete();
     } finally {
       isGranularSyncing = false;
     }
@@ -108,29 +130,12 @@
     foodOnlySyncResult = null;
 
     try {
-      const apiClient = getApiClient();
-      const request: SyncRequest = {
-        from: new Date(granularSyncFrom),
-        to: new Date(granularSyncTo),
-        dataTypes: ["Food" as any],
-      };
-
-      const result = await apiClient.services.triggerConnectorSync(
+      foodOnlySyncResult = await requestSync(
         connectorId,
-        request
+        { ...selectedRange(), dataTypes: ["Food"] },
+        "We couldn't download the food data. Please try again."
       );
-
-      foodOnlySyncResult = result;
-      if (result.success && onSyncComplete) {
-        await onSyncComplete();
-      }
-    } catch (e) {
-      foodOnlySyncResult = {
-        success: false,
-        message: e instanceof Error ? e.message : "Failed to sync food data",
-        errors: [],
-        itemsSynced: {},
-      };
+      if (foodOnlySyncResult.success) await notifyComplete();
     } finally {
       isFoodOnlySyncing = false;
     }

--- a/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/ConnectorDetailsDialog.svelte.test.ts
@@ -1,25 +1,35 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
-import { describe, it, expect, vi } from "vitest";
-import type { SyncResult } from "$lib/api/generated/nocturne-api-client";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { error } from "@sveltejs/kit";
+import { ApiException, type SyncResult } from "$api-clients";
+import { SyncRequestSchema } from "$lib/api/generated/schemas";
 
 let syncImpl: () => Promise<SyncResult>;
+let sentRequest: unknown;
 
-vi.mock("$lib/api", () => ({
-  getApiClient: () => ({
-    services: { triggerConnectorSync: () => syncImpl() },
-  }),
+vi.mock("$api/generated/services.generated.remote", () => ({
+  triggerConnectorSync: (payload: { request: unknown }) => {
+    sentRequest = payload.request;
+    return syncImpl();
+  },
 }));
 
 // The dialog uses Tooltip.Root, whose provider the app layout supplies; the wrapper stands in for it.
 import ConnectorDetailsDialog from "./connector-details-dialog-test-wrapper.svelte";
 
-async function syncReturning(result: SyncResult) {
-  syncImpl = async () => result;
+const FALLBACK = "We couldn't start the sync. Please try again.";
+
+async function syncing(
+  impl: () => Promise<SyncResult>,
+  onSyncComplete?: () => Promise<void>
+) {
+  syncImpl = impl;
 
   render(ConnectorDetailsDialog, {
     props: {
       open: true,
+      onSyncComplete,
       selectedConnector: {
         id: "nightscout",
         name: "Nightscout",
@@ -37,7 +47,13 @@ async function syncReturning(result: SyncResult) {
   await page.getByRole("button", { name: "Sync Now" }).click();
 }
 
+const syncReturning = (result: SyncResult) => syncing(async () => result);
+
 describe("ConnectorDetailsDialog", () => {
+  beforeEach(() => {
+    sentRequest = undefined;
+  });
+
   it("reports the count a failed sync still landed", async () => {
     await syncReturning({
       success: false,
@@ -74,5 +90,108 @@ describe("ConnectorDetailsDialog", () => {
     });
 
     await expect.element(page.getByText("(288 items)")).toBeVisible();
+  });
+
+  it("shows the server's reason when the sync was refused", async () => {
+    await syncing(async () => error(409, "A sync for this connector is already running."));
+
+    await expect
+      .element(page.getByText("A sync for this connector is already running."))
+      .toBeInTheDocument();
+  });
+
+  it("keeps a server fault behind the dialog's own wording", async () => {
+    await syncing(async () => error(500, "npgsql: connection reset"));
+
+    await expect.element(page.getByText(FALLBACK)).toBeInTheDocument();
+    expect(page.getByText("npgsql: connection reset").elements()).toHaveLength(
+      0
+    );
+  });
+
+  /**
+   * The generated client's own rejection is an `Error`, so rendering a caught
+   * `message` reads as safe and is not: it is boilerplate the client wrote,
+   * and a body it could not parse arrives as a `SyntaxError` quoting the body.
+   */
+  it("keeps the generated client's own error text out of the panel", async () => {
+    await syncing(async () => {
+      throw new ApiException(
+        "An unexpected server error occurred.",
+        500,
+        "<html><body>502 Bad Gateway</body></html>",
+        {},
+        null
+      );
+    });
+
+    await expect.element(page.getByText(FALLBACK)).toBeInTheDocument();
+    expect(
+      page.getByText("An unexpected server error occurred.").elements()
+    ).toHaveLength(0);
+    expect(page.getByText("502 Bad Gateway", { exact: false }).elements()).toHaveLength(0);
+  });
+
+  it("keeps an unparsable response body out of the panel", async () => {
+    await syncing(async () => {
+      JSON.parse("<html><body>502 Bad Gateway</body></html>");
+      throw new Error("unreachable");
+    });
+
+    await expect.element(page.getByText(FALLBACK)).toBeInTheDocument();
+    expect(page.getByText("502 Bad Gateway", { exact: false }).elements()).toHaveLength(0);
+  });
+
+  /**
+   * The command validates its payload against this schema, which takes a
+   * date-time as an ISO string and rejects a `Date`, so a range built the
+   * obvious way would fail every sync at that boundary.
+   */
+  it("sends a range the command's schema accepts", async () => {
+    await syncReturning({
+      success: true,
+      message: "",
+      errors: [],
+      itemsSynced: { Glucose: 1 },
+    });
+
+    const parsed = SyncRequestSchema.safeParse(sentRequest);
+
+    expect(parsed.error?.issues ?? []).toEqual([]);
+    expect(sentRequest).toMatchObject({
+      from: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+      to: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+    });
+  });
+
+  it("keeps a refresh the caller could not finish out of the sync's result", async () => {
+    const logged: unknown[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args) =>
+      logged.push(args.join(" "))
+    );
+
+    let calls = 0;
+    await syncing(
+      async () => ({
+        success: true,
+        message: "",
+        errors: [],
+        itemsSynced: { Glucose: 288 },
+      }),
+      async () => {
+        calls += 1;
+        throw error(500, "npgsql: connection reset");
+      }
+    );
+
+    await expect
+      .element(page.getByText("Sync initiated successfully"))
+      .toBeInTheDocument();
+    await expect.element(page.getByText("(288 items)")).toBeVisible();
+    expect(page.getByText(FALLBACK).elements()).toHaveLength(0);
+    expect(calls).toBe(1);
+    expect(logged.join(" ")).toContain("Failed to refresh after a connector sync");
+
+    vi.restoreAllMocks();
   });
 });

--- a/src/Web/packages/app/src/lib/components/connectors/connector-details-dialog-test-wrapper.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/connector-details-dialog-test-wrapper.svelte
@@ -8,12 +8,14 @@
     open?: boolean;
     selectedConnector: ConnectorStatusWithDescription | null;
     selectedConnectorCapabilities: ConnectorCapabilities | null;
+    onSyncComplete?: () => Promise<void>;
   }
 
   let {
     open = $bindable(false),
     selectedConnector,
     selectedConnectorCapabilities,
+    onSyncComplete,
   }: Props = $props();
 </script>
 
@@ -22,5 +24,6 @@
     bind:open
     {selectedConnector}
     {selectedConnectorCapabilities}
+    {onSyncComplete}
   />
 </Tooltip.Provider>

--- a/src/Web/packages/app/src/lib/forms/submit-error.test.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.test.ts
@@ -246,6 +246,51 @@ describe("the two halves of RemoteErrorPolicy", () => {
     );
   });
 
+  /**
+   * SvelteKit answers a non-2xx from `/_app/remote/*` with a body of its own,
+   * and the generated client answers an undeclared status with one of two of
+   * its own — at any status, so a bare `BadRequest()` reaches a 4xx arm
+   * carrying one. Neither names a cause, so a reader gains nothing by showing
+   * them and the suppression cannot be scoped to one arm.
+   */
+  it("agrees on a body the client wrote rather than carried, at every status", () => {
+    for (const status of [400, 409, 500, 502]) {
+      for (const message of [
+        "Failed to execute remote function",
+        "An unexpected server error occurred.",
+        "A server side error occurred.",
+      ]) {
+        const synthesized = { status, body: { message } };
+
+        expect(describeSubmitError(synthesized, WRITE_FALLBACK)).toBe(
+          WRITE_FALLBACK
+        );
+        expect(remoteErrorMessage(synthesized, READ_FALLBACK)).toBe(
+          READ_FALLBACK
+        );
+      }
+    }
+  });
+
+  /**
+   * Suppression matches four known strings, so what a server wrote about a
+   * rejected write — the reason retrying unchanged cannot fix — still reaches
+   * the person who has to change it.
+   */
+  it("still carries a 4xx reason the server worded, flattened ModelState included", () => {
+    const validation = {
+      status: 400,
+      body: { message: "units: Insulin units must be greater than zero." },
+    };
+
+    expect(describeSubmitError(validation, WRITE_FALLBACK)).toBe(
+      "units: Insulin units must be greater than zero."
+    );
+    expect(remoteErrorMessage(validation, READ_FALLBACK)).toBe(
+      "units: Insulin units must be greater than zero."
+    );
+  });
+
   it("agrees on a throttled attempt and on a 4xx the server worded", () => {
     expect(describeSubmitError({ status: 429 }, WRITE_FALLBACK)).toBe(
       RATE_LIMITED_ERROR

--- a/src/Web/packages/app/src/lib/forms/submit-error.ts
+++ b/src/Web/packages/app/src/lib/forms/submit-error.ts
@@ -36,30 +36,39 @@ export function errorMessage(err: unknown): string | undefined {
 }
 
 /**
- * The 403 bodies the client wrote itself rather than carried from the server.
+ * The bodies the client wrote itself rather than carried from the server.
  *
  * A scope refusal is usually a bare `ForbidResult`, which NSwag reports with one
  * of its own two `ApiException` messages, and an RFC-7807 refusal carrying no
  * `detail` reaches the 403 arm as its `title` — the status phrase. Only a
  * `Problem(detail: …)` refusal — the per-record scope guards — puts a sentence
- * written for a person in the body.
+ * written for a person in the body. NSwag reports an undeclared status the same
+ * way at any status, so a bare `BadRequest()` carries one of those two messages
+ * under a 400 — which is why every arm that forwards a body consults this,
+ * rather than the non-4xx one alone.
+ *
+ * SvelteKit adds the last of these when a *query*'s transport answers non-2xx.
+ * A command or form rejects with a plain `Error` carrying no body, so none of
+ * these checks ever sees one.
  *
  * Recognising the synthesized side is the only check that can be complete: these
- * three strings are constants of a pinned client and of our own codegen, while
- * what a server may write is unbounded and so cannot be matched positively.
+ * strings are constants of a pinned client, of SvelteKit and of our own codegen,
+ * whose 403 arm falls back to the status phrase. What a server may write is
+ * unbounded and so cannot be matched positively.
  */
-const CLIENT_WRITTEN_FORBIDDEN = new Set([
+const CLIENT_WRITTEN_REASONS = new Set([
   "an unexpected server error occurred.",
   "a server side error occurred.",
   "forbidden",
+  "failed to execute remote function",
 ]);
 
-/** The 403 body, when the server rather than the client wrote it. */
-function forbiddenReason(err: unknown): string | undefined {
+/** The body, when the server rather than the client wrote it. */
+function serverWrittenReason(err: unknown): string | undefined {
   const message = errorMessage(err);
   if (message === undefined) return undefined;
 
-  return CLIENT_WRITTEN_FORBIDDEN.has(message.trim().toLowerCase())
+  return CLIENT_WRITTEN_REASONS.has(message.trim().toLowerCase())
     ? undefined
     : message;
 }
@@ -102,7 +111,7 @@ function forbiddenReason(err: unknown): string | undefined {
  * - `forbiddenReason` (403). A writer's fallback ("You don't have permission to
  *   save this") beats the client's own boilerplate but loses to a refusal the
  *   server worded, so the writer takes a server-written body when there is one
- *   — see {@link CLIENT_WRITTEN_FORBIDDEN}. A reader's fallback names the exact
+ *   — see {@link CLIENT_WRITTEN_REASONS}. A reader's fallback names the exact
  *   permission and beats any body the server could send, so the reader always
  *   takes the fallback. A bare `ForbidResult` — what `[RequireScope]` produces,
  *   and so the common refusal — is client-written either way, so both halves
@@ -110,7 +119,9 @@ function forbiddenReason(err: unknown): string | undefined {
  * - `serverError` (5xx, a network failure, a thrown `Error` — anything that is
  *   not a 4xx). A person mid-task must not be shown a server's internal text,
  *   so the writer suppresses it; for a reader the body is the only clue why a
- *   panel is empty, so the reader surfaces it.
+ *   panel is empty, so the reader surfaces it — but only where the server wrote
+ *   it, the one condition both halves share; see
+ *   {@link CLIENT_WRITTEN_REASONS}.
  * - `fault`, the answer once a non-4xx is suppressed. Same reasoning as
  *   `missing`, on the other axis: a writer's fallback names the action, which
  *   is what failed, so it wins; a permission sentence would tell someone who
@@ -131,7 +142,11 @@ export interface RemoteErrorPolicy {
   readonly missing?: string;
   /** Whether a 403 the server worded itself outranks the caller's fallback. */
   readonly forbiddenReason: boolean;
-  /** Whether a body that did not come with a 4xx outranks the caller's fallback. */
+  /**
+   * Whether a server-written body that did not come with a 4xx outranks the
+   * caller's fallback.
+   * @see CLIENT_WRITTEN_REASONS
+   */
   readonly serverError: boolean;
   /**
    * Answer once a body that did not come with a 4xx is suppressed, or the
@@ -188,12 +203,13 @@ export function describeRemoteError(
   if (status === 404) return policy.missing ?? fallback;
   if (status === 403) {
     return (
-      (policy.forbiddenReason ? forbiddenReason(err) : undefined) ?? fallback
+      (policy.forbiddenReason ? serverWrittenReason(err) : undefined) ??
+      fallback
     );
   }
 
   const is4xx = status !== undefined && status >= 400 && status < 500;
-  if (is4xx || policy.serverError) return errorMessage(err) ?? fallback;
+  if (is4xx || policy.serverError) return serverWrittenReason(err) ?? fallback;
 
   return policy.fault ?? fallback;
 }

--- a/src/Web/packages/app/src/lib/stores/settings-store.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/stores/settings-store.svelte.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+
+let respond: () => Promise<unknown>;
+
+vi.mock("$api/ui-settings.remote", () => ({
+  getUiSettings: () => ({ run: () => respond() }),
+}));
+
+import { SettingsStore } from "./settings-store.svelte";
+
+/**
+ * `settings/appearance` renders its form in the `{:else}` of
+ * `{#if store.isLoading}`, so a store reporting neither loading nor loaded
+ * shows that form filled from empty state.
+ */
+describe("a settings store loading on construction", () => {
+  it("reports itself loading before the deferred read starts", () => {
+    respond = () => new Promise(() => {});
+
+    const store = new SettingsStore();
+
+    expect(store.loadingState).toBe("loading");
+    expect(store.isLoading).toBe(true);
+    expect(store.isLoaded).toBe(false);
+  });
+
+  it("does not read until the constructing render has finished", async () => {
+    let reads = 0;
+    respond = () => {
+      reads += 1;
+      return new Promise(() => {});
+    };
+
+    const store = new SettingsStore();
+
+    expect(reads).toBe(0);
+    expect(store.isLoading).toBe(true);
+
+    await vi.waitUntil(() => reads === 1);
+  });
+
+  it("reaches the loaded state once the deferred read resolves", async () => {
+    respond = async () => ({ devices: { units: "mmol" } });
+
+    const store = new SettingsStore();
+    await vi.waitUntil(() => store.isLoaded);
+
+    expect(store.loadingState).toBe("success");
+    expect(store.devices).toEqual({ units: "mmol" });
+  });
+
+  /**
+   * The card renders this on its own, so it has to be a whole sentence with a
+   * remedy either way: `getUiSettings` sanitizes to one and a reading surface
+   * forwards it, while SvelteKit's own transport reason is suppressed and the
+   * fallback below stands in.
+   */
+  it("reports a rejected read as a sentence with a remedy", async () => {
+    for (const message of [
+      "We couldn't load your settings. Refresh the page to try again.",
+      "Failed to execute remote function",
+    ]) {
+      respond = async () => {
+        throw { status: 500, body: { message } };
+      };
+
+      const store = new SettingsStore();
+      await vi.waitUntil(() => store.hasError);
+
+      expect(store.error).toBe(
+        "We couldn't load your settings. Refresh the page to try again."
+      );
+      expect(store.isLoading).toBe(false);
+    }
+  });
+});
+
+describe("reloading a settings store", () => {
+  it("waits out a read in flight and reads again", async () => {
+    const pending: Array<(value: unknown) => void> = [];
+    respond = () => new Promise((resolve) => pending.push(resolve));
+
+    const store = new SettingsStore();
+    await vi.waitUntil(() => pending.length === 1);
+
+    const reloaded = store.reload();
+    expect(store.loadingState).toBe("loading");
+
+    pending[0]({ devices: { units: "mmol" } });
+    await vi.waitUntil(() => pending.length === 2);
+    pending[1]({ devices: { units: "mg/dL" } });
+    await reloaded;
+
+    expect(store.devices).toEqual({ units: "mg/dL" });
+    expect(store.isLoaded).toBe(true);
+  });
+});

--- a/src/Web/packages/app/src/lib/stores/settings-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/settings-store.svelte.ts
@@ -8,8 +8,13 @@
 import { getContext, setContext } from "svelte";
 import { browser } from "$app/environment";
 import { getApiClient } from "$lib/api/client";
+import { getUiSettings } from "$api/ui-settings.remote";
+import { describeSubmitError } from "$lib/forms/submit-error";
+import { remoteErrorMessage } from "$lib/api/remote-error";
+import { SETTINGS_LOAD_FAILED } from "$lib/api/ui-settings-messages";
 import type {
   UISettingsConfiguration,
+  UserAlarmConfiguration as ApiUserAlarmConfiguration,
   DeviceSettings,
   AlgorithmSettings,
   FeatureSettings,
@@ -57,30 +62,38 @@ export class SettingsStore {
   private _hasChanges = $state(false);
   hasUnsavedChanges = $derived(this._hasChanges);
 
+  // `loadingState` cannot stand in for this: the constructor reports "loading"
+  // before the read has started.
+  private _loadInFlight: Promise<void> | null = null;
+
   // Track saving state
   private _isSaving = $state(false);
   isSaving = $derived(this._isSaving);
 
   constructor(autoLoad = true) {
-    // Auto-load settings when store is created in browser
     if (browser && autoLoad) {
-      this.load();
+      // `.run()` rejects during render, and the store is constructed in the
+      // layout's. Reporting the state here rather than leaving it to the
+      // deferred load keeps a consumer from rendering against an idle store.
+      this.loadingState = "loading";
+      queueMicrotask(() => this.load());
     }
   }
 
-  /**
-   * Load settings from the API
-   */
+  /** Reads the settings, joining a read already in flight. */
   async load(): Promise<void> {
     if (!browser) {
       return;
     }
 
-    // Don't reload if already loading
-    if (this.loadingState === "loading") {
-      return;
-    }
+    this._loadInFlight ??= this.read().finally(() => {
+      this._loadInFlight = null;
+    });
 
+    await this._loadInFlight;
+  }
+
+  private async read(): Promise<void> {
     this.loadingState = "loading";
     this.error = null;
 
@@ -90,8 +103,7 @@ export class SettingsStore {
       // tenant scoping and nothing to clear it on logout — so on a shared device
       // the second person to sign in inherited the first person's settings, and a
       // save that the server had rejected still read back as persisted.
-      const apiClient = getApiClient();
-      const settings = await apiClient.uiSettings.getUISettings();
+      const settings = await getUiSettings().run();
 
       this._rawSettings = settings;
 
@@ -114,16 +126,18 @@ export class SettingsStore {
       this.loadingState = "success";
       this._hasChanges = false;
     } catch (e) {
-      this.error = e instanceof Error ? e.message : "Failed to load settings";
+      this.error = remoteErrorMessage(e, SETTINGS_LOAD_FAILED);
       this.loadingState = "error";
     }
   }
 
   /**
-   * Reload settings from the API (force refresh)
+   * Reads the settings again, so a caller that has just written them sees what
+   * was stored. A read already in flight was issued before that write, so it is
+   * waited out rather than joined.
    */
   async reload(): Promise<void> {
-    this.loadingState = "idle";
+    await this._loadInFlight;
     await this.load();
   }
 
@@ -138,8 +152,6 @@ export class SettingsStore {
    * Get combined settings object for saving
    */
   getSettings(): UISettingsConfiguration {
-    // Merge alarm configuration into notifications
-    // Note: Using type assertion since our frontend types use string dates while API uses Date
     const notifications = this.notifications ? {
       ...this.notifications,
       alarmConfiguration: this.alarmConfiguration as unknown as NotificationSettings["alarmConfiguration"],
@@ -167,17 +179,15 @@ export class SettingsStore {
     this.error = null;
 
     try {
-      const settings = this.getSettings();
-      const apiClient = getApiClient();
-
-      // Save to backend API
-      const savedSettings = await apiClient.uiSettings.saveUISettings(settings);
+      const savedSettings = await getApiClient().uiSettings.saveUISettings(
+        this.getSettings()
+      );
 
       this._hasChanges = false;
       this._rawSettings = savedSettings;
       return true;
     } catch (e) {
-      this.error = e instanceof Error ? e.message : "Failed to save settings";
+      this.error = describeSubmitError(e);
       return false;
     } finally {
       this._isSaving = false;
@@ -197,8 +207,6 @@ export class SettingsStore {
     this.error = null;
 
     try {
-      const apiClient = getApiClient();
-
       const profiles = Array.isArray(this.alarmConfiguration?.profiles)
         ? this.alarmConfiguration.profiles
         : [];
@@ -213,13 +221,12 @@ export class SettingsStore {
         profiles: normalizedProfiles,
       };
 
-      // Convert to API format (the types are compatible, just use any for the API call)
-      const savedConfig = await apiClient.uiSettings.saveAlarmConfiguration(normalizedConfig as any);
+      const savedConfig = await getApiClient().uiSettings.saveAlarmConfiguration(
+        normalizedConfig as unknown as ApiUserAlarmConfiguration
+      );
 
-      // Update local state with response
       this.alarmConfiguration = savedConfig as unknown as UserAlarmConfiguration;
 
-      // Also update in notifications
       if (this.notifications) {
         this.notifications.alarmConfiguration = savedConfig as NotificationSettings["alarmConfiguration"];
       }
@@ -234,7 +241,10 @@ export class SettingsStore {
           .filter(Boolean);
         this.error = messages.length > 0 ? messages.join(" | ") : "Validation error";
       } else {
-        this.error = e instanceof Error ? e.message : "Failed to save alarm configuration";
+        this.error = describeSubmitError(
+          e,
+          "We couldn't save your alarm settings. Please try again."
+        );
       }
       return false;
     } finally {

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -209,10 +209,7 @@
     <Card class="border-destructive">
       <CardContent class="flex items-center gap-3 py-6">
         <AlertCircle class="h-5 w-5 text-destructive" />
-        <div>
-          <p class="font-medium">Failed to load settings</p>
-          <p class="text-sm text-muted-foreground">{store.error}</p>
-        </div>
+        <p class="font-medium">{store.error}</p>
       </CardContent>
     </Card>
   {:else}

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -3,13 +3,13 @@
   import {
     getServicesOverview,
     getConnectorCapabilities,
+    triggerConnectorSync,
   } from "$api/generated/services.generated.remote";
   import type {
     ServicesOverview,
     UploaderApp,
     DataSourceInfo,
     ConnectorStatusDto,
-    SyncRequest,
     ConnectorCapabilities,
   } from "$lib/api/generated/nocturne-api-client";
 
@@ -54,7 +54,7 @@
   import UploaderAppsCard from "$lib/components/connectors/UploaderAppsCard.svelte";
   import ServerConnectorsCard, { type ConnectorStatusWithDescription } from "$lib/components/connectors/ServerConnectorsCard.svelte";
   import DataSourceManageDialog from "$lib/components/connectors/DataSourceManageDialog.svelte";
-  import { getApiClient } from "$lib/api";
+  import { describeSubmitError } from "$lib/forms/submit-error";
   import { resolve } from "$app/paths";
   import { page } from "$app/state";
   import { toast } from "svelte-sonner";
@@ -132,7 +132,7 @@
   const terminalRuns = createTerminalRunTracker();
   $effect(() => {
     if (terminalRuns.hasNewlyFinishedRun(syncProgressByConnector)) {
-      connectorStatusesQuery.refresh();
+      void loadConnectorStatuses();
     }
   });
 
@@ -145,19 +145,53 @@
   let showDeduplicationDialog = $state(false);
   let isDeduplicating = $state(false);
 
+  // Whether the user has already been told these lists are stale. The effect
+  // below refreshes once per finished run, so a batch of them and the refresh
+  // that follows are one thing going wrong reported many times over.
+  let staleListReported = false;
+
+  /**
+   * A refresh rejects when it fails, and every caller here is either a click
+   * handler or a completion callback whose own outcome must not be replaced by
+   * the refresh's, so the staleness is reported on its own and swallowed. It is
+   * reported once until a refresh gets through again.
+   */
+  async function refreshQuietly(...refreshes: Array<() => Promise<void>>) {
+    const outcomes = await Promise.allSettled(
+      refreshes.map((refresh) => refresh())
+    );
+
+    for (const outcome of outcomes) {
+      if (outcome.status !== "rejected") continue;
+
+      if (!staleListReported) {
+        staleListReported = true;
+        toast.error(
+          describeSubmitError(
+            outcome.reason,
+            "This list may be out of date. Reload the page to see the latest."
+          )
+        );
+      }
+      return;
+    }
+
+    staleListReported = false;
+  }
+
   async function refreshAll() {
-    await Promise.all([
-      servicesOverviewQuery.refresh(),
-      connectorStatusesQuery.refresh(),
-    ]);
+    await refreshQuietly(
+      () => servicesOverviewQuery.refresh(),
+      () => connectorStatusesQuery.refresh()
+    );
   }
 
   async function loadServices() {
-    await servicesOverviewQuery.refresh();
+    await refreshQuietly(() => servicesOverviewQuery.refresh());
   }
 
   async function loadConnectorStatuses() {
-    await connectorStatusesQuery.refresh();
+    await refreshQuietly(() => connectorStatusesQuery.refresh());
   }
 
   async function loadConnectorCapabilitiesFor(connectorId?: string) {
@@ -199,11 +233,9 @@
 
     const to = new Date();
     const from = new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000);
-    const request: SyncRequest = { from, to };
+    const request = { from: from.toISOString(), to: to.toISOString() };
 
     try {
-      const apiClient = getApiClient();
-
       for (const connector of connectorsToSync) {
         const connectorId = connector.id;
         if (!connectorId) continue;
@@ -213,12 +245,15 @@
         let errorMsg = undefined;
 
         try {
-          const result = await apiClient.services.triggerConnectorSync(connectorId, request);
+          const result = await triggerConnectorSync({ id: connectorId, request });
           success = result.success ?? false;
           if (!success) errorMsg = result.message || "Unknown error";
         } catch (e) {
           success = false;
-          errorMsg = e instanceof Error ? e.message : "Request failed";
+          errorMsg = describeSubmitError(
+            e,
+            "We couldn't start this sync. Please try again."
+          );
         }
 
         const durationMs = performance.now() - start;
@@ -244,12 +279,15 @@
       };
 
       if (successes > 0) {
-        await Promise.all([loadServices(), loadConnectorStatuses()]);
+        await refreshAll();
       }
     } catch (e) {
       manualSyncResult = {
         success: false,
-        errorMessage: e instanceof Error ? e.message : "Failed to trigger manual sync",
+        errorMessage: describeSubmitError(
+          e,
+          "We couldn't start the sync. Please try again."
+        ),
         totalConnectors: 0,
         successfulConnectors: 0,
         failedConnectors: 0,
@@ -267,8 +305,7 @@
 
     quickSyncingById = { ...quickSyncingById, [connectorId]: true };
     try {
-      const apiClient = getApiClient();
-      const result = await apiClient.services.triggerConnectorSync(connectorId, {});
+      const result = await triggerConnectorSync({ id: connectorId, request: {} });
 
       if (result.success) {
         toast.success("Sync started");
@@ -278,7 +315,9 @@
 
       await loadConnectorStatuses();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Sync failed");
+      toast.error(
+        describeSubmitError(e, "We couldn't start the sync. Please try again.")
+      );
     } finally {
       quickSyncingById = { ...quickSyncingById, [connectorId]: false };
     }


### PR DESCRIPTION
Closes #961.

## The issue's stated mechanism is wrong; the leak is real by two others

#961 says NSwag's `ApiException.message` is a multi-line template embedding the status text and the raw response body. It is not: `ApiException` stores `message`, `status` and `response` as separate fields, and `message` is one of a small fixed set. `submit-error.ts` already hardcoded exactly those strings as "constants of a pinned client", so the repo had established this and the issue was wrong about its own cause.

The leak is real anyway:

1. A 5xx reaches `throwException(..., result: undefined)` -> a genuine `ApiException` -> `e.message` rendered as the client's internal text.
2. A **non-JSON 4xx** hits `JSON.parse(_responseText)` in the generated client, throwing a `SyntaxError` whose `.message` quotes the response body — the actual raw-error-page leak. This applies only to operations declaring a typed 4xx; it cannot occur on the settings read, which parses only on 200.

## What this does

**Two connector surfaces converted.** `ConnectorDetailsDialog` and `settings/connectors/+page.svelte` now use the existing `triggerConnectorSync` remote command — it already carried `[RemoteCommand]`, so no controller change was needed — and route failures through `describeSubmitError`.

**The settings read** moves to the pre-existing hand-written `getUiSettings`, which sanitizes every failure to one sentence. Note it needed a **401 arm** added, matching the generated-query convention: the old `getApiClient()` path was wrapped by `createAuthenticatedFetch`, which redirects to login on a 401, and without it an expired session replaced the settings form with a dead card and no route back to sign-in.

**Shared policy generalised.** SvelteKit throws `HttpError(500, "Failed to execute remote function")` whenever a remote query's transport answers non-2xx — an edge 502, or a node restart mid-deploy — and the reading half forwarded that string to the user. `CLIENT_WRITTEN_FORBIDDEN` becomes `CLIENT_WRITTEN_REASONS`, gains that string, and is now consulted on **every arm that forwards a body**, not just 403. That closes a leak the connector work would otherwise have left: a bare `return BadRequest()` (e.g. `NutritionController.cs:313`) yields an empty body, so NSwag synthesises `ApiException("An unexpected server error occurred.", 400, "")` and the codegen rethrows it verbatim — the exact string this issue is about, at a status the earlier fix did not cover.

Server-worded 4xx reasons still pass through, flattened ModelState included; suppression matches only the four synthesized constants.

## Declared behavioural deltas

- `reload()` genuinely re-reads. The re-entrancy guard moved onto a promise-valued in-flight field; its old `loadingState = "idle"` write existed only to defeat the previous guard, and leaving it would have made `reload()` a silent no-op that dropped the second of two quick saves.
- `onSyncComplete` is no longer invoked from both `try` and `catch`; a rejecting callback can neither overwrite a genuine sync result nor escape the handler.
- `triggerManualSync` is N remote round-trips where it was N plain HTTP calls, each server-side-refreshing four queries (`Promise.allSettled`, cannot reject).
- A stale-list refresh failure is reported once per episode and not again until a refresh gets through.
- The appearance page's load-failure card no longer carries a hardcoded heading above the same sentence.
- `saveUISettings` and `saveAlarmConfiguration` **stay on the direct client deliberately**: the generated Zod schema is `additionalProperties:false` at every level and the store's real payload carries `quietHours` and `profiles[].visual.showEmergencyContacts`, neither of which exists on the C# model, so validation rejects every save. The two polling stores also stay, because remote queries memoize per `(id, payload)`.

**Scope limit:** this covers *rejections*. A `success:false` 200 still renders the server's `SyncResult.message`, which is a deliberate, tested choice.

There is no test detecting a fifth string being added to the suppression set, because nothing produces one today — inert now, but a future producer would be silently suppressed.

## Verification

- Node vitest **1018 passed / 1 skipped**, the single failure being the pre-existing `appearance-store.ssr.test.ts`; touched browser files **14/14**; `pnpm check` **51 errors / 10 warnings**, unchanged from baseline, none in a touched file. Backend diff is empty.
- Four hostile-review cycles. The last validated the policy change with a **363-cell differential probe** (statuses x body shapes x all three policies): 57 cells changed, every reachable one being "client boilerplate -> the caller's own sentence", with the non-4xx, 403, 404 and 429 arms byte-identical. 12 of 13 mutations killed; the survivor is provably inert.

**Note:** CI runs no vitest for `@nocturne/app` (#982), so these tests gate nothing automatically.

## Adjacent, not fixed here

`errorMessage` is still called raw — bypassing the suppression set — at `settings/admin/+page.svelte:106,120`, `admin/tenants/+page.svelte:151`, `OidcProviderDialog.svelte:194` and `totp-errors.ts:28`, so a bare `BadRequest()` on the OIDC-provider delete surface renders "An unexpected server error occurred." today. Filed separately.
