### PR TITLE
fix(v4): keep the stored correlation id when re-upserting a profile

### DIFF
--- a/src/API/Nocturne.API/Services/Profiles/ProfileProjectionService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/ProfileProjectionService.cs
@@ -133,6 +133,14 @@ public class ProfileProjectionService : IProfileProjectionService
             targetRange = targetRangeTask.Result.FirstOrDefault();
         }
 
+        // A schedule the correlation id does not reach still exists under the legacy id the whole
+        // group shares, and that index is unique. Without this an AID consumer reading v1/v3 profile
+        // is served an empty basal schedule rather than an error.
+        basal ??= await BySharedLegacyIdAsync(_basalRepo, settings.LegacyId, ct);
+        carbRatio ??= await BySharedLegacyIdAsync(_carbRatioRepo, settings.LegacyId, ct);
+        sensitivity ??= await BySharedLegacyIdAsync(_sensitivityRepo, settings.LegacyId, ct);
+        targetRange ??= await BySharedLegacyIdAsync(_targetRangeRepo, settings.LegacyId, ct);
+
         var profileData = new ProfileData
         {
             Dia = settings.Dia,
@@ -176,6 +184,11 @@ public class ProfileProjectionService : IProfileProjectionService
             }
         };
     }
+
+    private static async Task<TRecord?> BySharedLegacyIdAsync<TRecord>(
+        ILegacyKeyedRepository<TRecord> repository, string? legacyId, CancellationToken ct)
+        where TRecord : class, IV4Record
+        => string.IsNullOrEmpty(legacyId) ? null : await repository.GetByLegacyIdAsync(legacyId, ct);
 
     private static List<TimeValue> MapScheduleEntries(List<ScheduleEntry>? entries)
     {

--- a/src/API/Nocturne.API/Services/Profiles/ProfileProjectionService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/ProfileProjectionService.cs
@@ -136,10 +136,17 @@ public class ProfileProjectionService : IProfileProjectionService
         // A schedule the correlation id does not reach still exists under the legacy id the whole
         // group shares, and that index is unique. Without this an AID consumer reading v1/v3 profile
         // is served an empty basal schedule rather than an error.
-        basal ??= await BySharedLegacyIdAsync(_basalRepo, settings.LegacyId, ct);
-        carbRatio ??= await BySharedLegacyIdAsync(_carbRatioRepo, settings.LegacyId, ct);
-        sensitivity ??= await BySharedLegacyIdAsync(_sensitivityRepo, settings.LegacyId, ct);
-        targetRange ??= await BySharedLegacyIdAsync(_targetRangeRepo, settings.LegacyId, ct);
+        var basalFallback = OrSharedLegacyIdAsync(_basalRepo, basal, s => s.ProfileName, settings, ct);
+        var carbRatioFallback = OrSharedLegacyIdAsync(_carbRatioRepo, carbRatio, s => s.ProfileName, settings, ct);
+        var sensitivityFallback = OrSharedLegacyIdAsync(_sensitivityRepo, sensitivity, s => s.ProfileName, settings, ct);
+        var targetRangeFallback = OrSharedLegacyIdAsync(_targetRangeRepo, targetRange, s => s.ProfileName, settings, ct);
+
+        await Task.WhenAll(basalFallback, carbRatioFallback, sensitivityFallback, targetRangeFallback);
+
+        basal = basalFallback.Result;
+        carbRatio = carbRatioFallback.Result;
+        sensitivity = sensitivityFallback.Result;
+        targetRange = targetRangeFallback.Result;
 
         var profileData = new ProfileData
         {
@@ -185,10 +192,26 @@ public class ProfileProjectionService : IProfileProjectionService
         };
     }
 
-    private static async Task<TRecord?> BySharedLegacyIdAsync<TRecord>(
-        ILegacyKeyedRepository<TRecord> repository, string? legacyId, CancellationToken ct)
+    /// <summary>
+    /// The schedule already found by correlation id, or the one stored under the legacy id every
+    /// sibling in the group shares. The store name is re-checked rather than read off the legacy id:
+    /// a profile name may itself contain a colon, so the <c>"{profileId}:{storeName}"</c> composite
+    /// is not unambiguously parseable, and the correlation path guards on the same field.
+    /// </summary>
+    private static async Task<TRecord?> OrSharedLegacyIdAsync<TRecord>(
+        ILegacyKeyedRepository<TRecord> repository,
+        TRecord? found,
+        Func<TRecord, string> profileName,
+        TherapySettings settings,
+        CancellationToken ct)
         where TRecord : class, IV4Record
-        => string.IsNullOrEmpty(legacyId) ? null : await repository.GetByLegacyIdAsync(legacyId, ct);
+    {
+        if (found is not null || string.IsNullOrEmpty(settings.LegacyId))
+            return found;
+
+        var candidate = await repository.GetByLegacyIdAsync(settings.LegacyId, ct);
+        return candidate is not null && profileName(candidate) == settings.ProfileName ? candidate : null;
+    }
 
     private static List<TimeValue> MapScheduleEntries(List<ScheduleEntry>? entries)
     {

--- a/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
+++ b/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
@@ -31,9 +31,10 @@ public abstract class DecomposerBase
     /// and appends to every index on the table; Npgsql writes a <see cref="Guid"/> big-endian, so a
     /// UUID v7 id is byte-monotonic in the btree and those appends rarely refill the pages the dead
     /// entries freed — only vacuum returns an entirely empty one, and not before two cycles — which is
-    /// why density collapses rather than settling. A stored id that is not a real correlation id is
-    /// ignored, so a bad one still self-heals on the next write rather than being frozen and stamped
-    /// across the group.
+    /// why density collapses rather than settling. An empty stored id is ignored, so it still
+    /// self-heals on the next write rather than being frozen and stamped across the group; a non-empty
+    /// one is preserved regardless of origin, since nothing distinguishes a client-supplied id from a
+    /// decomposer-minted one.
     /// <para>
     /// Only an anchor record may set this, and only where the caller then stamps the rest of the group
     /// from what it reads back. Preserving per row instead lets a group fork permanently: siblings are

--- a/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
+++ b/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
@@ -22,6 +22,18 @@ public abstract class DecomposerBase
     /// stored record is known and before the write, so device-attributed types can settle their
     /// attribution against it; see <see cref="StampAttributionAsync"/>.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="preserveStoredCorrelationId"/> treats the stored correlation id as belonging to
+    /// the row rather than to the decomposition that last touched it. A decomposer mints a fresh id per
+    /// call, so re-upserting an otherwise unchanged row modifies <see cref="IV4Record.CorrelationId"/>
+    /// and makes EF emit an UPDATE — one carrying no material change, so it neither audits nor
+    /// broadcasts, but still writes a row version. The column is indexed, so that update cannot be HOT
+    /// and appends to every index on the table; the id being UUID v7 makes those appends monotonic, so
+    /// the freed space is never reused. Callers whose records are upserted in place under a stable
+    /// legacy id set this: the id still groups the same siblings, and an unchanged re-upsert then diffs
+    /// to genuinely nothing. Callers that create a side record under the freshly minted id — as
+    /// <see cref="DeviceStatusDecomposer"/> does for its extras row — must not, or the two diverge.
+    /// </remarks>
     /// <returns>The persisted record, and whether it was inserted rather than updated.</returns>
     protected async Task<(TRecord Record, bool Created)> UpsertByLegacyIdAsync<TRecord>(
         ILegacyKeyedRepository<TRecord> repository,
@@ -30,7 +42,8 @@ public abstract class DecomposerBase
         DecompositionResult result,
         WriteOrigin origin,
         CancellationToken ct,
-        Func<TRecord?, Task>? beforeWrite = null)
+        Func<TRecord?, Task>? beforeWrite = null,
+        bool preserveStoredCorrelationId = false)
         where TRecord : class, IV4Record
     {
         var existing = legacyId is null ? null : await repository.GetByLegacyIdAsync(legacyId, ct);
@@ -47,6 +60,9 @@ public abstract class DecomposerBase
             Logger.LogDebug("Created {RecordType} from legacy record {LegacyId}", recordType, legacyId);
             return (created, true);
         }
+
+        if (preserveStoredCorrelationId && existing.CorrelationId is { } storedCorrelationId)
+            model.CorrelationId = storedCorrelationId;
 
         model.Id = existing.Id;
         var updated = await repository.UpdateAsync(existing.Id, model, origin, ct);

--- a/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
+++ b/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
@@ -29,8 +29,11 @@ public abstract class DecomposerBase
     /// and makes EF emit an UPDATE — one carrying no material change, so it neither audits nor
     /// broadcasts, but still writes a row version. The column is indexed, so that update cannot be HOT
     /// and appends to every index on the table; Npgsql writes a <see cref="Guid"/> big-endian, so a
-    /// UUID v7 id is byte-monotonic in the btree and those appends never refill the pages the dead
-    /// entries freed — which is why density collapses rather than settling.
+    /// UUID v7 id is byte-monotonic in the btree and those appends rarely refill the pages the dead
+    /// entries freed — only vacuum returns an entirely empty one, and not before two cycles — which is
+    /// why density collapses rather than settling. A stored id that is not a real correlation id is
+    /// ignored, so a bad one still self-heals on the next write rather than being frozen and stamped
+    /// across the group.
     /// <para>
     /// Only an anchor record may set this, and only where the caller then stamps the rest of the group
     /// from what it reads back. Preserving per row instead lets a group fork permanently: siblings are
@@ -71,8 +74,12 @@ public abstract class DecomposerBase
             return (created, true);
         }
 
-        if (preserveStoredCorrelationId && existing.CorrelationId is { } storedCorrelationId)
+        if (preserveStoredCorrelationId
+            && existing.CorrelationId is { } storedCorrelationId
+            && storedCorrelationId != Guid.Empty)
+        {
             model.CorrelationId = storedCorrelationId;
+        }
 
         model.Id = existing.Id;
         var updated = await repository.UpdateAsync(existing.Id, model, origin, ct);

--- a/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
+++ b/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
@@ -28,7 +28,9 @@ public abstract class DecomposerBase
     /// call, so re-upserting an otherwise unchanged row modifies <see cref="IV4Record.CorrelationId"/>
     /// and makes EF emit an UPDATE — one carrying no material change, so it neither audits nor
     /// broadcasts, but still writes a row version. The column is indexed, so that update cannot be HOT
-    /// and appends to every index on the table.
+    /// and appends to every index on the table; Npgsql writes a <see cref="Guid"/> big-endian, so a
+    /// UUID v7 id is byte-monotonic in the btree and those appends never refill the pages the dead
+    /// entries freed — which is why density collapses rather than settling.
     /// <para>
     /// Only an anchor record may set this, and only where the caller then stamps the rest of the group
     /// from what it reads back. Preserving per row instead lets a group fork permanently: siblings are
@@ -36,6 +38,10 @@ public abstract class DecomposerBase
     /// while the survivors keep the old one, and a reader that loads siblings by correlation id then
     /// silently returns nothing. Rewriting the id everywhere on every sync is what currently repairs
     /// that, so removing the rewrite without converging the group would make the damage permanent.
+    /// A group whose members are not all upserted under a shared legacy id has no anchor to converge
+    /// on and must not set this at all: <see cref="DeviceStatusDecomposer"/> creates its extras row
+    /// keyed by the freshly minted id and carrying no legacy id, so preserving on one of its snapshot
+    /// siblings orphans that row outright.
     /// </para>
     /// </remarks>
     /// <returns>The persisted record, and whether it was inserted rather than updated.</returns>

--- a/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
+++ b/src/API/Nocturne.API/Services/V4/DecomposerBase.cs
@@ -28,11 +28,15 @@ public abstract class DecomposerBase
     /// call, so re-upserting an otherwise unchanged row modifies <see cref="IV4Record.CorrelationId"/>
     /// and makes EF emit an UPDATE — one carrying no material change, so it neither audits nor
     /// broadcasts, but still writes a row version. The column is indexed, so that update cannot be HOT
-    /// and appends to every index on the table; the id being UUID v7 makes those appends monotonic, so
-    /// the freed space is never reused. Callers whose records are upserted in place under a stable
-    /// legacy id set this: the id still groups the same siblings, and an unchanged re-upsert then diffs
-    /// to genuinely nothing. Callers that create a side record under the freshly minted id — as
-    /// <see cref="DeviceStatusDecomposer"/> does for its extras row — must not, or the two diverge.
+    /// and appends to every index on the table.
+    /// <para>
+    /// Only an anchor record may set this, and only where the caller then stamps the rest of the group
+    /// from what it reads back. Preserving per row instead lets a group fork permanently: siblings are
+    /// written in separate transactions, so one lost to a cancelled sync is recreated under a fresh id
+    /// while the survivors keep the old one, and a reader that loads siblings by correlation id then
+    /// silently returns nothing. Rewriting the id everywhere on every sync is what currently repairs
+    /// that, so removing the rewrite without converging the group would make the damage permanent.
+    /// </para>
     /// </remarks>
     /// <returns>The persisted record, and whether it was inserted rather than updated.</returns>
     protected async Task<(TRecord Record, bool Created)> UpsertByLegacyIdAsync<TRecord>(

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -66,8 +66,8 @@ public class ProfileDecomposer : DecomposerBase, IProfileDecomposer, IDecomposer
 
         // No system attribution here — there is no batch path to take it on (see
         // DecomposerBase.SystemAttributedBatchWrites): a profile write is a user's profile edit,
-        // and byte-identical re-upserts diff to empty (bookkeeping columns are [AuditIgnored])
-        // and are skipped.
+        // and byte-identical re-upserts diff to empty and are skipped — which holds only because the
+        // siblings keep the correlation id they were created under; see UpsertByLegacyIdAsync.
         foreach (var (storeName, profileData) in profile.Store)
         {
             var legacyId = $"{profile.Id}:{storeName}";
@@ -76,23 +76,23 @@ public class ProfileDecomposer : DecomposerBase, IProfileDecomposer, IDecomposer
             await UpsertByLegacyIdAsync(
                 _therapySettingsRepo, legacyId,
                 MapToTherapySettings(profile, profileData, storeName, legacyId, isDefault, result.CorrelationId),
-                result, origin, ct);
+                result, origin, ct, preserveStoredCorrelationId: true);
             await UpsertByLegacyIdAsync(
                 _basalScheduleRepo, legacyId,
                 MapToBasalSchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
-                result, origin, ct);
+                result, origin, ct, preserveStoredCorrelationId: true);
             await UpsertByLegacyIdAsync(
                 _carbRatioScheduleRepo, legacyId,
                 MapToCarbRatioSchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
-                result, origin, ct);
+                result, origin, ct, preserveStoredCorrelationId: true);
             await UpsertByLegacyIdAsync(
                 _sensitivityScheduleRepo, legacyId,
                 MapToSensitivitySchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
-                result, origin, ct);
+                result, origin, ct, preserveStoredCorrelationId: true);
             await UpsertByLegacyIdAsync(
                 _targetRangeScheduleRepo, legacyId,
                 MapToTargetRangeSchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
-                result, origin, ct);
+                result, origin, ct, preserveStoredCorrelationId: true);
         }
 
         return result;

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -53,9 +53,10 @@ public class ProfileDecomposer : DecomposerBase, IProfileDecomposer, IDecomposer
     /// <inheritdoc />
     public async Task<V4Models.DecompositionResult> DecomposeAsync(Profile profile, WriteOrigin origin, CancellationToken ct = default)
     {
+        var mintedCorrelationId = Guid.CreateVersion7();
         var result = new V4Models.DecompositionResult
         {
-            CorrelationId = Guid.CreateVersion7()
+            CorrelationId = mintedCorrelationId
         };
 
         if (profile.Store.Count == 0)
@@ -84,7 +85,7 @@ public class ProfileDecomposer : DecomposerBase, IProfileDecomposer, IDecomposer
                 MapToTherapySettings(profile, profileData, storeName, legacyId, isDefault, result.CorrelationId),
                 result, origin, ct, preserveStoredCorrelationId: true);
 
-            var groupCorrelationId = settings.CorrelationId ?? result.CorrelationId;
+            var groupCorrelationId = settings.CorrelationId ?? mintedCorrelationId;
 
             await UpsertByLegacyIdAsync(
                 _basalScheduleRepo, legacyId,

--- a/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
+++ b/src/API/Nocturne.API/Services/V4/ProfileDecomposer.cs
@@ -66,33 +66,42 @@ public class ProfileDecomposer : DecomposerBase, IProfileDecomposer, IDecomposer
 
         // No system attribution here — there is no batch path to take it on (see
         // DecomposerBase.SystemAttributedBatchWrites): a profile write is a user's profile edit,
-        // and byte-identical re-upserts diff to empty and are skipped — which holds only because the
-        // siblings keep the correlation id they were created under; see UpsertByLegacyIdAsync.
+        // and byte-identical re-upserts diff to empty and are skipped.
+        //
+        // The therapy settings row anchors the group's correlation id, and the four schedules are
+        // stamped with whatever it resolves to. Reading it back rather than reusing the minted id is
+        // what keeps an unchanged re-upsert free of writes, and stamping the schedules from it is
+        // what keeps the group whole: the five rows are written in five separate transactions, so a
+        // sibling lost to a cancelled sync is recreated on the next one, and it has to rejoin the
+        // group rather than fork it. ProfileProjectionService loads the schedules by this id.
         foreach (var (storeName, profileData) in profile.Store)
         {
             var legacyId = $"{profile.Id}:{storeName}";
             var isDefault = string.Equals(storeName, profile.DefaultProfile, StringComparison.OrdinalIgnoreCase);
 
-            await UpsertByLegacyIdAsync(
+            var (settings, _) = await UpsertByLegacyIdAsync(
                 _therapySettingsRepo, legacyId,
                 MapToTherapySettings(profile, profileData, storeName, legacyId, isDefault, result.CorrelationId),
                 result, origin, ct, preserveStoredCorrelationId: true);
+
+            var groupCorrelationId = settings.CorrelationId ?? result.CorrelationId;
+
             await UpsertByLegacyIdAsync(
                 _basalScheduleRepo, legacyId,
-                MapToBasalSchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
-                result, origin, ct, preserveStoredCorrelationId: true);
+                MapToBasalSchedule(profile, profileData, storeName, legacyId, groupCorrelationId),
+                result, origin, ct);
             await UpsertByLegacyIdAsync(
                 _carbRatioScheduleRepo, legacyId,
-                MapToCarbRatioSchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
-                result, origin, ct, preserveStoredCorrelationId: true);
+                MapToCarbRatioSchedule(profile, profileData, storeName, legacyId, groupCorrelationId),
+                result, origin, ct);
             await UpsertByLegacyIdAsync(
                 _sensitivityScheduleRepo, legacyId,
-                MapToSensitivitySchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
-                result, origin, ct, preserveStoredCorrelationId: true);
+                MapToSensitivitySchedule(profile, profileData, storeName, legacyId, groupCorrelationId),
+                result, origin, ct);
             await UpsertByLegacyIdAsync(
                 _targetRangeScheduleRepo, legacyId,
-                MapToTargetRangeSchedule(profile, profileData, storeName, legacyId, result.CorrelationId),
-                result, origin, ct, preserveStoredCorrelationId: true);
+                MapToTargetRangeSchedule(profile, profileData, storeName, legacyId, groupCorrelationId),
+                result, origin, ct);
         }
 
         return result;

--- a/src/Core/Nocturne.Core.Models/V4/BasalSchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/BasalSchedule.cs
@@ -9,8 +9,8 @@ namespace Nocturne.Core.Models.V4;
 /// Each entry in <see cref="Entries"/> defines the basal rate in units per hour from a given time until the
 /// next entry. Together with <see cref="CarbRatioSchedule"/>, <see cref="SensitivitySchedule"/>,
 /// <see cref="TargetRangeSchedule"/>, and <see cref="TherapySettings"/>, this forms the complete V4
-/// profile for a named profile store. All schedules decomposed from the same legacy <see cref="Profile"/>
-/// share the same <see cref="IV4Record.CorrelationId"/>.
+/// profile for a named profile store. All records decomposed from one named profile store share the same
+/// <see cref="IV4Record.CorrelationId"/>.
 /// </remarks>
 /// <seealso cref="Profile"/>
 /// <seealso cref="IV4Record"/>

--- a/src/Core/Nocturne.Core.Models/V4/CarbRatioSchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/CarbRatioSchedule.cs
@@ -7,8 +7,8 @@ namespace Nocturne.Core.Models.V4;
 /// </summary>
 /// <remarks>
 /// Each entry in <see cref="Entries"/> specifies how many grams of carbohydrate one unit of insulin
-/// covers at a given time of day. All schedules decomposed from the same legacy <see cref="Profile"/>
-/// share the same <see cref="IV4Record.CorrelationId"/>.
+/// covers at a given time of day. All records decomposed from one named profile store share the same
+/// <see cref="IV4Record.CorrelationId"/>.
 /// </remarks>
 /// <seealso cref="Profile"/>
 /// <seealso cref="IV4Record"/>

--- a/src/Core/Nocturne.Core.Models/V4/SensitivitySchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/SensitivitySchedule.cs
@@ -7,8 +7,8 @@ namespace Nocturne.Core.Models.V4;
 /// </summary>
 /// <remarks>
 /// Each entry in <see cref="Entries"/> specifies how many mg/dL one unit of insulin lowers blood glucose
-/// at a given time of day. All schedules decomposed from the same legacy <see cref="Profile"/>
-/// share the same <see cref="IV4Record.CorrelationId"/>.
+/// at a given time of day. All records decomposed from one named profile store share the same
+/// <see cref="IV4Record.CorrelationId"/>.
 /// </remarks>
 /// <seealso cref="Profile"/>
 /// <seealso cref="IV4Record"/>

--- a/src/Core/Nocturne.Core.Models/V4/TargetRangeSchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TargetRangeSchedule.cs
@@ -8,8 +8,8 @@ namespace Nocturne.Core.Models.V4;
 /// </summary>
 /// <remarks>
 /// Each entry in <see cref="Entries"/> specifies the lower and upper target glucose bounds that
-/// APS algorithms aim for at a given time of day. All schedules decomposed from the same legacy
-/// <see cref="Profile"/> share the same <see cref="IV4Record.CorrelationId"/>.
+/// APS algorithms aim for at a given time of day. All records decomposed from one named profile store share the same
+/// <see cref="IV4Record.CorrelationId"/>.
 /// </remarks>
 /// <seealso cref="Profile"/>
 /// <seealso cref="IV4Record"/>

--- a/src/Core/Nocturne.Core.Models/V4/TherapySettings.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TherapySettings.cs
@@ -9,7 +9,7 @@ namespace Nocturne.Core.Models.V4;
 /// <remarks>
 /// <see cref="TherapySettings"/> holds the non-scheduled configuration for a profile. The scheduled
 /// parameters (basal rates, carb ratios, ISF, target ranges) are stored in their respective schedule
-/// types. All records decomposed from the same legacy <see cref="Profile"/> share the same
+/// types. All records decomposed from one named profile store share the same
 /// <see cref="IV4Record.CorrelationId"/>.
 /// </remarks>
 /// <seealso cref="Profile"/>

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/ProfileProjectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/ProfileProjectionServiceTests.cs
@@ -371,6 +371,105 @@ public class ProfileProjectionServiceTests
 
     #region Helpers
 
+    /// <summary>
+    /// The five siblings are written in separate transactions, so a group can be mid-convergence when
+    /// a read arrives. The correlation lookup then finds nothing and, without this fallback, an AID
+    /// consumer reading v1/v3 profile is served an empty basal schedule rather than an error.
+    /// </summary>
+    [Fact]
+    public async Task CorrelationLookupMisses_ServesScheduleFromTheSharedLegacyId()
+    {
+        var correlationId = Guid.NewGuid();
+        var settings = CreateTherapySettings(correlationId: correlationId, legacyId: "profile1:Default");
+
+        SetupGetLatest(settings);
+        SetupCorrelationLookups(correlationId);
+        SetupLegacyIdLookups("profile1:Default", profileName: "Default");
+
+        var result = await _sut.GetCurrentProfileAsync();
+
+        var data = result!.Store["Default"];
+        data.Basal.Should().ContainSingle().Which.Value.Should().Be(1.5);
+        data.CarbRatio.Should().ContainSingle();
+        data.Sens.Should().ContainSingle();
+        data.TargetLow.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task CorrelationLookupMisses_AndNoRowUnderTheLegacyId_StaysEmpty()
+    {
+        var correlationId = Guid.NewGuid();
+        var settings = CreateTherapySettings(correlationId: correlationId, legacyId: "profile1:Default");
+
+        SetupGetLatest(settings);
+        SetupCorrelationLookups(correlationId);
+        SetupLegacyIdLookups("profile1:Default", profileName: null);
+
+        var result = await _sut.GetCurrentProfileAsync();
+
+        var data = result!.Store["Default"];
+        data.Basal.Should().BeEmpty();
+        data.CarbRatio.Should().BeEmpty();
+        data.Sens.Should().BeEmpty();
+        data.TargetLow.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The correlation path guards on <c>ProfileName</c>; the fallback must too. A profile name may
+    /// contain a colon, so the <c>"{profileId}:{storeName}"</c> legacy id cannot be parsed to recover
+    /// the store name, and a renamed row would otherwise serve one store's schedule under another's.
+    /// </summary>
+    [Fact]
+    public async Task CorrelationLookupMisses_AndTheLegacyIdRowIsADifferentStore_StaysEmpty()
+    {
+        var correlationId = Guid.NewGuid();
+        var settings = CreateTherapySettings(correlationId: correlationId, legacyId: "profile1:Default");
+
+        SetupGetLatest(settings);
+        SetupCorrelationLookups(correlationId);
+        SetupLegacyIdLookups("profile1:Default", profileName: "Night");
+
+        var result = await _sut.GetCurrentProfileAsync();
+
+        var data = result!.Store["Default"];
+        data.Basal.Should().BeEmpty("a schedule belonging to another store must not be served here");
+        data.CarbRatio.Should().BeEmpty();
+        data.Sens.Should().BeEmpty();
+        data.TargetLow.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Schedules stored under <paramref name="legacyId"/> carrying <paramref name="profileName"/>, or
+    /// no row at all when it is null.
+    /// </summary>
+    private void SetupLegacyIdLookups(string legacyId, string? profileName)
+    {
+        _basalRepo.Setup(r => r.GetByLegacyIdAsync(legacyId, default))
+            .ReturnsAsync(profileName is null ? null : new BasalSchedule
+            {
+                ProfileName = profileName,
+                Entries = [new ScheduleEntry { Time = "00:00", Value = 1.5, TimeAsSeconds = 0 }],
+            });
+        _carbRatioRepo.Setup(r => r.GetByLegacyIdAsync(legacyId, default))
+            .ReturnsAsync(profileName is null ? null : new CarbRatioSchedule
+            {
+                ProfileName = profileName,
+                Entries = [new ScheduleEntry { Time = "00:00", Value = 10.0, TimeAsSeconds = 0 }],
+            });
+        _sensitivityRepo.Setup(r => r.GetByLegacyIdAsync(legacyId, default))
+            .ReturnsAsync(profileName is null ? null : new SensitivitySchedule
+            {
+                ProfileName = profileName,
+                Entries = [new ScheduleEntry { Time = "00:00", Value = 50.0, TimeAsSeconds = 0 }],
+            });
+        _targetRangeRepo.Setup(r => r.GetByLegacyIdAsync(legacyId, default))
+            .ReturnsAsync(profileName is null ? null : new TargetRangeSchedule
+            {
+                ProfileName = profileName,
+                Entries = [new TargetRangeEntry { Time = "00:00", Low = 80, High = 120, TimeAsSeconds = 0 }],
+            });
+    }
+
     private static TherapySettings CreateTherapySettings(
         Guid? id = null,
         Guid? correlationId = null,

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
@@ -15,7 +15,9 @@ public class ProfileDecomposerTests
     /// (v1/v3 profile create/update) their audit rows are the entire mutation trail for a
     /// user's profile edit. DecomposeAsync must NOT push a SystemAuditScope — connector
     /// re-syncs are suppressed by the sync scope's system audit context instead, and
-    /// byte-identical re-upserts diff to empty ([AuditIgnored] bookkeeping) and are skipped.
+    /// byte-identical re-upserts diff to empty and are skipped — see
+    /// <see cref="DecomposeAsync_KeepsStoredCorrelationId_WhenRecordsAlreadyExist"/> for the one
+    /// column that otherwise stops that being true.
     /// </summary>
     [Fact]
     public async Task DecomposeAsync_PreservesCallerAuditAttribution()
@@ -93,6 +95,93 @@ public class ProfileDecomposerTests
             a.AuthType.Should().Be("ApiKey");
         });
     }
+
+    /// <summary>
+    /// A decomposer mints a fresh correlation id per call, so re-upserting an unchanged profile
+    /// rewrote correlation_id on all five siblings. Such an update carries no material change, so it
+    /// neither audits nor broadcasts — but the column is indexed, so the update cannot be HOT and
+    /// appends an entry to every index on the table. Because the id is UUID v7 the appends are
+    /// monotonic and never reuse freed space, which took production to 1.24% leaf density. The
+    /// stored id has to survive an update for an unchanged re-upsert to diff to nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeAsync_KeepsStoredCorrelationId_WhenRecordsAlreadyExist()
+    {
+        var stored = Guid.CreateVersion7();
+
+        var therapySettingsRepo = ExistingRecord<ITherapySettingsRepository, TherapySettings>(stored, out var therapyUpdates);
+        var basalScheduleRepo = ExistingRecord<IBasalScheduleRepository, BasalSchedule>(stored, out var basalUpdates);
+        var carbRatioScheduleRepo = ExistingRecord<ICarbRatioScheduleRepository, CarbRatioSchedule>(stored, out var carbRatioUpdates);
+        var sensitivityScheduleRepo = ExistingRecord<ISensitivityScheduleRepository, SensitivitySchedule>(stored, out var sensitivityUpdates);
+        var targetRangeScheduleRepo = ExistingRecord<ITargetRangeScheduleRepository, TargetRangeSchedule>(stored, out var targetRangeUpdates);
+
+        var decomposer = new ProfileDecomposer(
+            therapySettingsRepo.Object,
+            basalScheduleRepo.Object,
+            carbRatioScheduleRepo.Object,
+            sensitivityScheduleRepo.Object,
+            targetRangeScheduleRepo.Object,
+            NullLogger<ProfileDecomposer>.Instance);
+
+        var result = await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
+
+        result.UpdatedRecords.Should().HaveCount(5);
+
+        var written = therapyUpdates.Cast<IV4Record>()
+            .Concat(basalUpdates)
+            .Concat(carbRatioUpdates)
+            .Concat(sensitivityUpdates)
+            .Concat(targetRangeUpdates)
+            .ToList();
+
+        written.Should().HaveCount(5);
+        written.Should().AllSatisfy(record => record.CorrelationId.Should().Be(
+            stored,
+            "an unchanged re-upsert must leave correlation_id alone, or every sync writes a new row version into every index"));
+    }
+
+    /// <summary>
+    /// A repository already holding one record under any legacy id, capturing the models handed to
+    /// <c>UpdateAsync</c> so a test can assert what would actually have been written.
+    /// </summary>
+    private static Mock<TRepo> ExistingRecord<TRepo, TRecord>(Guid storedCorrelationId, out List<TRecord> updates)
+        where TRepo : class, ILegacyKeyedRepository<TRecord>
+        where TRecord : class, IV4Record, new()
+    {
+        var captured = new List<TRecord>();
+        updates = captured;
+
+        var repo = new Mock<TRepo>();
+        repo
+            .Setup(x => x.GetByLegacyIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new TRecord { Id = Guid.CreateVersion7(), CorrelationId = storedCorrelationId });
+        repo
+            .Setup(x => x.UpdateAsync(It.IsAny<Guid>(), It.IsAny<TRecord>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback((Guid _, TRecord m, WriteOrigin _, CancellationToken _) => captured.Add(m))
+            .ReturnsAsync((Guid _, TRecord m, WriteOrigin _, CancellationToken _) => m);
+        return repo;
+    }
+
+    private static Profile BuildProfile() => new()
+    {
+        Id = "profile1",
+        Mills = 1700000000000,
+        DefaultProfile = "Default",
+        EnteredBy = "test",
+        Store = new Dictionary<string, ProfileData>
+        {
+            ["Default"] = new ProfileData
+            {
+                Dia = 3.0,
+                Timezone = "UTC",
+                Basal = [new TimeValue { Time = "00:00", Value = 1.0 }],
+                CarbRatio = [new TimeValue { Time = "00:00", Value = 10.0 }],
+                Sens = [new TimeValue { Time = "00:00", Value = 50.0 }],
+                TargetLow = [new TimeValue { Time = "00:00", Value = 80.0 }],
+                TargetHigh = [new TimeValue { Time = "00:00", Value = 120.0 }],
+            },
+        },
+    };
 
     [Theory]
     [InlineData("mmol")]

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
@@ -65,28 +65,7 @@ public class ProfileDecomposerTests
             targetRangeScheduleRepo.Object,
             NullLogger<ProfileDecomposer>.Instance);
 
-        var profile = new Profile
-        {
-            Id = "profile1",
-            Mills = 1700000000000,
-            DefaultProfile = "Default",
-            EnteredBy = "test",
-            Store = new Dictionary<string, ProfileData>
-            {
-                ["Default"] = new ProfileData
-                {
-                    Dia = 3.0,
-                    Timezone = "UTC",
-                    Basal = [new TimeValue { Time = "00:00", Value = 1.0 }],
-                    CarbRatio = [new TimeValue { Time = "00:00", Value = 10.0 }],
-                    Sens = [new TimeValue { Time = "00:00", Value = 50.0 }],
-                    TargetLow = [new TimeValue { Time = "00:00", Value = 80.0 }],
-                    TargetHigh = [new TimeValue { Time = "00:00", Value = 120.0 }],
-                },
-            },
-        };
-
-        var result = await decomposer.DecomposeAsync(profile, WriteOrigin.Live);
+        var result = await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
 
         result.CreatedRecords.Should().HaveCount(5);
         attributionDuringUpsert.Should().HaveCount(5).And.AllSatisfy(a =>
@@ -100,51 +79,92 @@ public class ProfileDecomposerTests
     /// A decomposer mints a fresh correlation id per call, so re-upserting an unchanged profile
     /// rewrote correlation_id on all five siblings. Such an update carries no material change, so it
     /// neither audits nor broadcasts — but the column is indexed, so the update cannot be HOT and
-    /// appends an entry to every index on the table. Because the id is UUID v7 the appends are
-    /// monotonic and never reuse freed space, which took production to 1.24% leaf density. The
-    /// stored id has to survive an update for an unchanged re-upsert to diff to nothing at all.
+    /// appends an entry to every index on the table, which took production to 1.24% leaf density.
+    /// That the reassignment then leaves the entity clean is pinned by
+    /// <c>CorrelationIdChurnTests</c>; this asserts the id the decomposer hands down.
     /// </summary>
     [Fact]
     public async Task DecomposeAsync_KeepsStoredCorrelationId_WhenRecordsAlreadyExist()
     {
         var stored = Guid.CreateVersion7();
-
-        var therapySettingsRepo = ExistingRecord<ITherapySettingsRepository, TherapySettings>(stored, out var therapyUpdates);
-        var basalScheduleRepo = ExistingRecord<IBasalScheduleRepository, BasalSchedule>(stored, out var basalUpdates);
-        var carbRatioScheduleRepo = ExistingRecord<ICarbRatioScheduleRepository, CarbRatioSchedule>(stored, out var carbRatioUpdates);
-        var sensitivityScheduleRepo = ExistingRecord<ISensitivityScheduleRepository, SensitivitySchedule>(stored, out var sensitivityUpdates);
-        var targetRangeScheduleRepo = ExistingRecord<ITargetRangeScheduleRepository, TargetRangeSchedule>(stored, out var targetRangeUpdates);
-
-        var decomposer = new ProfileDecomposer(
-            therapySettingsRepo.Object,
-            basalScheduleRepo.Object,
-            carbRatioScheduleRepo.Object,
-            sensitivityScheduleRepo.Object,
-            targetRangeScheduleRepo.Object,
-            NullLogger<ProfileDecomposer>.Instance);
+        var written = SetUp(stored, stored, out var decomposer);
 
         var result = await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
 
         result.UpdatedRecords.Should().HaveCount(5);
+        written().Should().HaveCount(5).And.AllSatisfy(record => record.CorrelationId.Should().Be(
+            stored,
+            "an unchanged re-upsert must leave correlation_id alone, or every sync writes a new row version into every index"));
+    }
 
-        var written = therapyUpdates.Cast<IV4Record>()
+    /// <summary>
+    /// The five siblings are written in five separate transactions, so one lost to a cancelled sync is
+    /// recreated on the next one. It must rejoin the group rather than fork it: ProfileProjectionService
+    /// loads the schedules by the therapy settings row's correlation id, and on a miss serves an empty
+    /// schedule rather than failing. Rewriting every id on every sync is what repairs that today, so
+    /// preserving without converging would make a fork permanent.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeAsync_ConvergesDivergedSiblingsOntoTheAnchorsCorrelationId()
+    {
+        var anchor = Guid.CreateVersion7();
+        var forked = Guid.CreateVersion7();
+        var written = SetUp(anchor, forked, out var decomposer);
+
+        await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
+
+        written().Should().HaveCount(5).And.AllSatisfy(record => record.CorrelationId.Should().Be(
+            anchor,
+            "a sibling that drifted must be pulled back onto the therapy settings row's id"));
+    }
+
+    /// <summary>
+    /// A stored id of null must not leave the anchor on a fresh id while the siblings keep theirs.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeAsync_StampsTheWholeGroup_WhenTheAnchorHasNoStoredCorrelationId()
+    {
+        var written = SetUp(null, Guid.CreateVersion7(), out var decomposer);
+
+        await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
+
+        var ids = written().Select(r => r.CorrelationId).ToList();
+        ids.Should().HaveCount(5);
+        ids.Should().AllSatisfy(id => id.Should().NotBeNull());
+        ids.Distinct().Should().ContainSingle("the group must not fork when the anchor stored no id");
+    }
+
+    /// <summary>
+    /// Five repositories each already holding a record — the therapy settings anchor under
+    /// <paramref name="anchorCorrelationId"/> and the four schedules under
+    /// <paramref name="scheduleCorrelationId"/> — returning the models handed to <c>UpdateAsync</c>.
+    /// </summary>
+    private static Func<List<IV4Record>> SetUp(
+        Guid? anchorCorrelationId, Guid? scheduleCorrelationId, out ProfileDecomposer decomposer)
+    {
+        var therapy = ExistingRecord<ITherapySettingsRepository, TherapySettings>(anchorCorrelationId, out var therapyUpdates);
+        var basal = ExistingRecord<IBasalScheduleRepository, BasalSchedule>(scheduleCorrelationId, out var basalUpdates);
+        var carbRatio = ExistingRecord<ICarbRatioScheduleRepository, CarbRatioSchedule>(scheduleCorrelationId, out var carbRatioUpdates);
+        var sensitivity = ExistingRecord<ISensitivityScheduleRepository, SensitivitySchedule>(scheduleCorrelationId, out var sensitivityUpdates);
+        var targetRange = ExistingRecord<ITargetRangeScheduleRepository, TargetRangeSchedule>(scheduleCorrelationId, out var targetRangeUpdates);
+
+        decomposer = new ProfileDecomposer(
+            therapy.Object, basal.Object, carbRatio.Object, sensitivity.Object, targetRange.Object,
+            NullLogger<ProfileDecomposer>.Instance);
+
+        return () => therapyUpdates.Cast<IV4Record>()
             .Concat(basalUpdates)
             .Concat(carbRatioUpdates)
             .Concat(sensitivityUpdates)
             .Concat(targetRangeUpdates)
             .ToList();
-
-        written.Should().HaveCount(5);
-        written.Should().AllSatisfy(record => record.CorrelationId.Should().Be(
-            stored,
-            "an unchanged re-upsert must leave correlation_id alone, or every sync writes a new row version into every index"));
     }
 
     /// <summary>
     /// A repository already holding one record under any legacy id, capturing the models handed to
     /// <c>UpdateAsync</c> so a test can assert what would actually have been written.
     /// </summary>
-    private static Mock<TRepo> ExistingRecord<TRepo, TRecord>(Guid storedCorrelationId, out List<TRecord> updates)
+    private static Mock<TRepo> ExistingRecord<TRepo, TRecord>(Guid? storedCorrelationId, out List<TRecord> updates)
         where TRepo : class, ILegacyKeyedRepository<TRecord>
         where TRecord : class, IV4Record, new()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/V4/ProfileDecomposerTests.cs
@@ -135,6 +135,25 @@ public class ProfileDecomposerTests
     }
 
     /// <summary>
+    /// The write API binds a whole <see cref="TherapySettings"/> from the request body and validates
+    /// only the timestamp, so a caller can store an empty correlation id. Freezing that would stamp it
+    /// across all four schedules and merge the group with every other group carrying it, leaving
+    /// same-named stores to resolve against each other. It has to keep self-healing.
+    /// </summary>
+    [Fact]
+    public async Task DecomposeAsync_DoesNotPreserveAnEmptyStoredCorrelationId()
+    {
+        var written = SetUp(Guid.Empty, Guid.CreateVersion7(), out var decomposer);
+
+        await decomposer.DecomposeAsync(BuildProfile(), WriteOrigin.Live);
+
+        var ids = written().Select(r => r.CorrelationId).ToList();
+        ids.Should().HaveCount(5);
+        ids.Should().AllSatisfy(id => id.Should().NotBe(Guid.Empty).And.NotBeNull());
+        ids.Distinct().Should().ContainSingle("the group must converge on the freshly minted id");
+    }
+
+    /// <summary>
     /// Five repositories each already holding a record — the therapy settings anchor under
     /// <paramref name="anchorCorrelationId"/> and the four schedules under
     /// <paramref name="scheduleCorrelationId"/> — returning the models handed to <c>UpdateAsync</c>.

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/CorrelationIdChurnTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/CorrelationIdChurnTests.cs
@@ -12,8 +12,9 @@ namespace Nocturne.Infrastructure.Data.Tests;
 /// Pins what makes a profile re-upsert free: <c>correlation_id</c> is the only column a decomposer
 /// changes when nothing about the profile has, and it is indexed, so an update to it cannot be HOT
 /// and appends to every index on the table. Npgsql writes a <see cref="System.Guid"/> big-endian, so
-/// a UUID v7 id is byte-monotonic in the btree and those appends never refill the pages the dead
-/// entries freed — which is why production density collapsed to 1.24% rather than settling. The column
+/// a UUID v7 id is byte-monotonic in the btree and those appends rarely refill the pages the dead
+/// entries freed — only vacuum returns an entirely empty one, and not before two cycles — which is why
+/// production density collapsed to 1.24% rather than settling. The column
 /// is also <see cref="Entities.AuditIgnoredAttribute"/>, so such an update neither audits nor
 /// broadcasts, which is why the write stayed invisible while that happened.
 /// The model builds offline against the Npgsql provider (no connection needed for change tracking).

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/CorrelationIdChurnTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/CorrelationIdChurnTests.cs
@@ -11,9 +11,11 @@ namespace Nocturne.Infrastructure.Data.Tests;
 /// <summary>
 /// Pins what makes a profile re-upsert free: <c>correlation_id</c> is the only column a decomposer
 /// changes when nothing about the profile has, and it is indexed, so an update to it cannot be HOT
-/// and appends to every index on the table. It is also <see cref="Entities.AuditIgnoredAttribute"/>,
-/// so such an update neither audits nor broadcasts — which is why the write was invisible while
-/// production reached 1.24% leaf density on those indexes.
+/// and appends to every index on the table. Npgsql writes a <see cref="System.Guid"/> big-endian, so
+/// a UUID v7 id is byte-monotonic in the btree and those appends never refill the pages the dead
+/// entries freed — which is why production density collapsed to 1.24% rather than settling. The column
+/// is also <see cref="Entities.AuditIgnoredAttribute"/>, so such an update neither audits nor
+/// broadcasts, which is why the write stayed invisible while that happened.
 /// The model builds offline against the Npgsql provider (no connection needed for change tracking).
 /// </summary>
 [Trait("Category", "Unit")]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/CorrelationIdChurnTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/CorrelationIdChurnTests.cs
@@ -1,0 +1,129 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Mappers.V4;
+using Nocturne.Infrastructure.Data.Repositories.V4;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// Pins what makes a profile re-upsert free: <c>correlation_id</c> is the only column a decomposer
+/// changes when nothing about the profile has, and it is indexed, so an update to it cannot be HOT
+/// and appends to every index on the table. It is also <see cref="Entities.AuditIgnoredAttribute"/>,
+/// so such an update neither audits nor broadcasts — which is why the write was invisible while
+/// production reached 1.24% leaf density on those indexes.
+/// The model builds offline against the Npgsql provider (no connection needed for change tracking).
+/// </summary>
+[Trait("Category", "Unit")]
+public class CorrelationIdChurnTests
+{
+    private static NocturneDbContext NewContext() => OfflineDbContext.Create();
+
+    private static TherapySettingsEntity TrackedSettings(NocturneDbContext ctx, Guid correlationId)
+    {
+        var entity = new TherapySettingsEntity
+        {
+            Id = Guid.CreateVersion7(),
+            LegacyId = "profile1:Default",
+            ProfileName = "Default",
+            Timestamp = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            CorrelationId = correlationId,
+            Dia = 3.0,
+        };
+        ctx.Attach(entity);
+        return entity;
+    }
+
+    private static BasalScheduleEntity TrackedSchedule(NocturneDbContext ctx, Guid correlationId)
+    {
+        var entity = new BasalScheduleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            LegacyId = "profile1:Default",
+            ProfileName = "Default",
+            Timestamp = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            CorrelationId = correlationId,
+            EntriesJson = """[{"Time":"00:00","Value":1.5,"TimeAsSeconds":0}]""",
+        };
+        ctx.Attach(entity);
+        return entity;
+    }
+
+    [Fact]
+    public void ReassigningTheSameCorrelationId_IssuesNoUpdate()
+    {
+        var correlationId = Guid.CreateVersion7();
+        using var ctx = NewContext();
+        var entity = TrackedSettings(ctx, correlationId);
+
+        entity.CorrelationId = correlationId;
+        ctx.ChangeTracker.DetectChanges();
+
+        var entry = ctx.Entry(entity);
+        entry.State.Should().Be(EntityState.Unchanged, "no UPDATE should be issued");
+    }
+
+    [Fact]
+    public void AFreshCorrelationId_IsTheOnlyThingThatMakesAnUnchangedRowDirty()
+    {
+        using var ctx = NewContext();
+        var entity = TrackedSettings(ctx, Guid.CreateVersion7());
+
+        entity.CorrelationId = Guid.CreateVersion7();
+        ctx.ChangeTracker.DetectChanges();
+
+        var entry = ctx.Entry(entity);
+        entry.State.Should().Be(EntityState.Modified);
+        entry.Properties.Where(p => p.IsModified).Select(p => p.Metadata.Name)
+            .Should().Equal([nameof(TherapySettingsEntity.CorrelationId)],
+                "if anything else were dirty the churn would not be attributable to the correlation id alone");
+        V4MaterialChange.HasMaterialChange(entry).Should().BeFalse(
+            "the column is [AuditIgnored], which is why this write never showed up in the audit log");
+    }
+
+    /// <summary>
+    /// The whole point of preserving the id: a re-upsert that maps an unchanged profile over the
+    /// stored row must leave the entity clean, so EF emits nothing at all.
+    /// </summary>
+    [Fact]
+    public void MappingAnUnchangedProfileOverAStoredSchedule_IssuesNoUpdate()
+    {
+        var correlationId = Guid.CreateVersion7();
+        using var ctx = NewContext();
+        var entity = TrackedSchedule(ctx, correlationId);
+
+        BasalScheduleMapper.UpdateEntity(entity, new BasalSchedule
+        {
+            LegacyId = entity.LegacyId,
+            ProfileName = entity.ProfileName,
+            Timestamp = entity.Timestamp,
+            CorrelationId = correlationId,
+            Entries = [new ScheduleEntry { Time = "00:00", Value = 1.5, TimeAsSeconds = 0 }],
+        });
+        ctx.ChangeTracker.DetectChanges();
+
+        ctx.Entry(entity).State.Should().Be(EntityState.Unchanged, "no UPDATE should be issued");
+    }
+
+    [Fact]
+    public void MappingAnUnchangedProfileOverAStoredSchedule_WithAFreshId_IssuesAnUpdate()
+    {
+        using var ctx = NewContext();
+        var entity = TrackedSchedule(ctx, Guid.CreateVersion7());
+
+        BasalScheduleMapper.UpdateEntity(entity, new BasalSchedule
+        {
+            LegacyId = entity.LegacyId,
+            ProfileName = entity.ProfileName,
+            Timestamp = entity.Timestamp,
+            CorrelationId = Guid.CreateVersion7(),
+            Entries = [new ScheduleEntry { Time = "00:00", Value = 1.5, TimeAsSeconds = 0 }],
+        });
+        ctx.ChangeTracker.DetectChanges();
+
+        ctx.Entry(entity).State.Should().Be(EntityState.Modified,
+            "this is the write the fix removes; if it stops happening the other tests prove nothing");
+    }
+}


### PR DESCRIPTION
## fix(v4): keep the stored correlation id when re-upserting a profile

Branch: `fix/profile-decomposition-idempotent` (`7c302366a`)

### The problem

`ProfileDecomposer.DecomposeAsync` mints `CorrelationId = Guid.CreateVersion7()` once per call and stamps it onto all five decomposed siblings. Every connector re-sync therefore rewrote `correlation_id` on `therapy_settings`, `basal_schedules`, `carb_ratio_schedules`, `sensitivity_schedules` and `target_range_schedules` — even when the profile had not changed at all.

The comment in `DecomposeAsync` asserted the opposite:

> byte-identical re-upserts diff to empty (bookkeeping columns are `[AuditIgnored]`) and are skipped

`[AuditIgnored]` keeps a column out of `V4MaterialChange.HasMaterialChange`, which governs the **audit row and the broadcast**. It does not keep the column out of EF's change tracker, so `SaveChangesAsync` still emits the UPDATE. The re-upserts were invisible in the audit log and on the wire while writing a new row version every cycle.

Two things make that expensive rather than merely wasteful:

- `correlation_id` is indexed on all five tables, so the update cannot be HOT. `n_tup_hot_upd = 0` on all five is exactly what that predicts.
- The id is UUID **v7**, so it is time-ordered and every rewrite appends to the right-hand edge of the index.

### Production impact

| table | live rows | `n_tup_ins` | `n_tup_upd` | `n_tup_hot_upd` | autovacuums |
|---|---:|---:|---:|---:|---:|
| therapy_settings | 12,995 | 11,671 | 23,384,845 | 0 | 30,700 |
| basal_schedules | 12,273 | 11,671 | 23,384,525 | 0 | 30,645 |
| carb_ratio_schedules | 11,648 | 11,671 | 23,384,264 | 0 | 30,756 |
| sensitivity_schedules | 11,835 | 11,671 | 23,384,012 | 0 | 30,737 |
| target_range_schedules | 12,220 | 11,671 | 23,383,798 | 0 | 30,711 |

~117M updates against 58,355 inserts — roughly 1,925 rewrites per live row. Measured with `pgstattuple`, each table's `correlation_id` index sits at **1.24% leaf density**: 33 MB of index, 98.8% empty pages, to index about 12k rows. Each is larger than the table it indexes.

Autovacuum is not the fix and is not failing — it already runs every ~6 minutes on these tables. The pages are not full of dead tuples, they are nearly empty, and a B-tree does not merge sparse siblings.

Direct evidence the rows themselves are static: rows created 2026-06-06 were rewritten at 2026-09-04 10:56:57, in a burst of consecutive millisecond-apart writes matching one decomposition loop. All 12,216 sampled `correlation_id` values are UUID v7.

### The fix

**Anchor the group, do not freeze each row.** Simply preserving each row's stored id removes the churn but converts a self-healing fault into a permanent one, because the churn is currently acting as a repair loop.

The five siblings are written in five separate transactions (`DecomposeAsync`), as are the five deletes in `DeleteByLegacyIdAsync`. Lose one to a cancellation or a transient error and the next sync **creates** it under a fresh id while the surviving four **update** and keep the old one. `ProfileProjectionService.AssembleProfileAsync` loads the four schedules **only** by `settings.CorrelationId`; on a miss it does not throw and does not fall back — `MapScheduleEntries(null)` returns `[]`, pinned by `ProfileProjectionServiceTests.MissingSchedules_ProducesEmptyLists`. That service backs v1 `/api/v1/profile`, v3 `/api/v3/profile` and `DDataService`. A permanent fork therefore means an AID consumer silently receives `"basal": []`.

So: preserve the id on the **therapy settings anchor**, read it back, and stamp the four schedules from it.

- an unchanged re-upsert still writes nothing anywhere
- a sibling recreated after loss **rejoins** the group instead of forking it
- a sibling that has already drifted is **pulled back** onto the anchor
- an anchor with a null stored id no longer strands its siblings on a different id

`UpsertByLegacyIdAsync` gains an opt-in `preserveStoredCorrelationId`, set only by the anchor. It is opt-in rather than universal because `DeviceStatusDecomposer.DecomposeExtrasAsync` always `CreateAsync`es its extras row under the freshly minted `result.CorrelationId`; preserving an older id on the parent snapshots would diverge the extras row from its parents, and `DeviceStatusExtrasEntity.CorrelationId` is non-nullable and is that row's only link back.

### Read-path defence in depth

`AssembleProfileAsync` now falls back to `GetByLegacyIdAsync(settings.LegacyId)` for any schedule the correlation lookup does not reach. Every sibling carries the same `{profileId}:{storeName}`, and `ix_*_tenant_legacy_id` is unique, so the lookup is exact and single-row.

Of **51** correlation misses in production, it repairs **11 the moment this merges**, across three live tenants (`noct`, `as-notrune`, `as-nocturne`). The other 40 have no row under the shared legacy id either — genuinely absent data that no lookup can recover:

| | broken corr lookup | no row under shared legacy id | **repaired by fallback** |
|---|---:|---:|---:|
| basal | 8 | 8 | **0** |
| carb | 12 | 11 | **1** |
| sens | 16 | 11 | **5** |
| target | 15 | 10 | **5** |

Those 40 are recreated by the decomposer on the tenant's next sync, and convergence then makes the recreated row rejoin the group rather than fork it.

The fallback re-checks `ProfileName` rather than parsing it out of the legacy id. A profile name may itself contain a colon — production has `…:u200 sedentary (120%) 4/16/24 08:09` — so the composite is not unambiguously parseable, and `PUT /api/v4/profile/settings/{id}` writes `ProfileName`, `LegacyId` and `CorrelationId` with no guard. Without the check, a renamed row would be served under the wrong store name instead of visibly empty.

### Scope

Deliberately limited to `ProfileDecomposer`. `sensor_glucose` (44% HOT of 117M updates) and `boluses` (78% HOT of 18.6M) are **not** this bug — their `correlation_id` demonstrably does not change on most updates, so whatever drives their update volume is a separate question that wants its own evidence.

### Divergence measured in production (read-only)

| | |
|---|---:|
| profile groups | 12,431 |
| missing at least one of the five siblings | 57 |
| …of those, still having a `therapy_settings` anchor | 13 |
| …of those, where **the anchor itself is the missing sibling** | 44 |
| complete but carrying 2 distinct correlation ids | 5 |
| tenants those 57 groups span | 14 |
| live `therapy_settings` rows whose basal / carb / ISF / target lookup already returns nothing | 8 / 12 / 16 / 15 |
| rows with a null stored correlation id | 0 |

Every broken row was last written May–June 2026 — nothing actively syncing is broken, because the churn keeps repairing it.

Anchor-loss is **77% of observed breakage**, not an edge case. It is closed by construction: `UpsertByLegacyIdAsync` returns the persisted record, so when the anchor is absent it is created under the freshly minted id and `groupCorrelationId` becomes that id, pulling all four schedules onto it. A soft-deleted anchor behaves identically, because the partial unique index shares the `deleted_at IS NULL` predicate.

### Tests

`CorrelationIdChurnTests` (new, `Nocturne.Infrastructure.Data.Tests`) asserts the actual claim against the change tracker, following `JsonbStringComparerTests`:

- reassigning the same id leaves the entity `Unchanged`, so **no UPDATE is issued**
- a fresh id makes `CorrelationId` the *only* modified property, and `HasMaterialChange` is false — which is why the write never appeared in the audit log
- mapping an unchanged profile over a stored `BasalScheduleEntity` leaves it `Unchanged`; with a fresh id it goes `Modified`

`ProfileDecomposerTests` adds convergence coverage: diverged siblings are pulled onto the anchor, and a null anchor id still yields one id across all five. `ProfileProjectionServiceTests` covers the fallback hit, the no-row miss, and rejection of a row belonging to a different store.

Mutation-checked five ways: removing the preservation reddens the id-equality test; replacing the anchor lookup with the freshly minted id reddens 2 of 11; deleting the fallback block reddens the hit test; removing the `ProfileName` guard reddens the wrong-store test; removing the empty-guid check reddens the empty-anchor test. Full runs: `Nocturne.API.Tests` 6408 passed / 0 failed / 5 skipped, `Nocturne.Infrastructure.Data.Tests` 901 / 0.

### Expected effect

Unchanged profile re-syncs stop issuing UPDATEs entirely, so the five indexes stop growing. This does **not** reclaim the existing 165 MB — that needs a `REINDEX`, which should run after this lands rather than before, or the space is reclaimed and immediately regrows.

Measured against `pg_stat_statements` rather than `n_tup_upd` (which conflates every update shape), the five profile tables carry **86.14M correlation-only UPDATEs and ~2.79 hours of exec time in 52 days — 88.3% of the platform-wide 97.54M.** (It reads as ~92% only if the three device-status snapshot tables, ~3.4M, are left out of the denominator.)

The remaining correlation-only churn is `carb_intakes` 4.00M, `notes` 2.09M, `device_events` 1.32M, `temp_basals` 0.30M, `boluses` 0.22M. Those are left alone here: `TreatmentDecomposer` writes several siblings per legacy record and `TreatmentReadService` genuinely reads meal-bolus pairs by correlation id, so extending preservation without giving it an anchor would reproduce the permanent-fork defect this revision exists to avoid. The follow-up shape is a *dynamic* anchor — first sibling written for the event type wins — since the sibling set is deterministic per `EventType`.

`EntryDecomposer` needs no anchor at all: `DecomposeAsync` is a mutually exclusive `switch` on entry type, so one legacy `Entry` yields exactly one V4 row and a group of one cannot fork. It is simply not worth changing — `UPDATE sensor_glucose SET correlation_id` does not appear in `pg_stat_statements`.
