### PR TITLE
fix(api): bind the PostgreSql configuration section so its settings are reachable

### DIFF
--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -98,6 +98,7 @@ if (!isTesting)
 {
     builder.Services.AddPostgreSqlInfrastructure(
         aspirePostgreSqlConnection,
+        builder.Configuration,
         config =>
         {
             config.EnableDetailedErrors = builder.Environment.IsDevelopment();

--- a/src/API/Nocturne.API/appsettings.example.json
+++ b/src/API/Nocturne.API/appsettings.example.json
@@ -8,13 +8,21 @@
   //   dotnet user-secrets set "Oidc:Providers:0:ClientSecret" "..."
   // ==========================================================================
 
+  // This file is a live configuration source in the shipped image, so an uncommented key here
+  // overrides the C# default in PostgreSqlConfiguration. The tuning keys are left commented so
+  // that class stays the single source of truth; uncomment one only to override it.
   "PostgreSql": {
     "EnableSensitiveDataLogging": false,
-    "EnableDetailedErrors": false,
-    "MaxRetryCount": 3,
-    "MaxRetryDelaySeconds": 30,
-    "CommandTimeoutSeconds": 30,
-    "StatementTimeoutSeconds": 30
+    "EnableDetailedErrors": false
+    // Physical connections this instance may hold. It is shared with every other client of the
+    // server — a sibling service, the migrator role, your own psql — so raise the server's
+    // max_connections (default 100, less superuser_reserved_connections) before raising this, or
+    // the others start getting "sorry, too many clients already".
+    // "MaxPoolSize": 100,
+    // "MaxRetryCount": 3,
+    // "MaxRetryDelaySeconds": 30,
+    // "CommandTimeoutSeconds": 30, // client-side, per command
+    // "StatementTimeoutSeconds": 30 // server-side backstop; 0 disables
   },
 
   // Authentication

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgresRuntimeOptions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgresRuntimeOptions.cs
@@ -9,6 +9,21 @@ namespace Nocturne.Infrastructure.Data.Configuration;
 internal static class PostgresRuntimeOptions
 {
     /// <summary>
+    /// Builds the runtime app <see cref="NpgsqlDataSource"/> — the singleton that owns the
+    /// connection pool — with the pool cap and statement timeout from
+    /// <paramref name="config"/> applied.
+    /// </summary>
+    /// <param name="config">Runtime PostgreSQL configuration.</param>
+    /// <returns>A data source configured for the runtime app pool.</returns>
+    internal static NpgsqlDataSource BuildRuntimeDataSource(PostgreSqlConfiguration config)
+    {
+        var builder = new NpgsqlDataSourceBuilder(config.ConnectionString);
+        builder.ConnectionStringBuilder.MaxPoolSize = config.MaxPoolSize;
+        ApplyStatementTimeout(builder.ConnectionStringBuilder, config.StatementTimeoutSeconds);
+        return builder.Build();
+    }
+
+    /// <summary>
     /// Appends a server-side <c>statement_timeout</c> to the connection's startup options so every
     /// statement on the runtime pool is cancelled by PostgreSQL itself once it exceeds the cap —
     /// the hard backstop behind the client-side command timeout. Applied only to the runtime app
@@ -30,7 +45,11 @@ internal static class PostgresRuntimeOptions
         // statement_timeout is USERSET, so nocturne_app may set it via the startup 'options'
         // packet. Bare integer is milliseconds. Append rather than overwrite so any existing
         // startup options survive.
-        var option = $"-c statement_timeout={statementTimeoutSeconds * 1000}";
+        // Widened before scaling: the value is operator-supplied, and in int arithmetic the
+        // product overflows above 2,147,483 seconds. Some inputs wrap negative and PostgreSQL
+        // refuses them at connection open rather than at startup; worse, others wrap back into a
+        // valid range and silently apply a timeout orders of magnitude shorter than asked for.
+        var option = $"-c statement_timeout={(long)statementTimeoutSeconds * 1000}";
         builder.Options = string.IsNullOrWhiteSpace(builder.Options)
             ? option
             : $"{builder.Options} {option}";

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
@@ -58,14 +58,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ITenantAuditConfigCache, TenantAuditConfigCache>();
 
         // Register NpgsqlDataSource as a singleton - this manages the connection pool
-        var dataSourceBuilder = new Npgsql.NpgsqlDataSourceBuilder(
-            postgreSqlConfig.ConnectionString
-        );
-        dataSourceBuilder.ConnectionStringBuilder.MaxPoolSize = postgreSqlConfig.MaxPoolSize;
-        PostgresRuntimeOptions.ApplyStatementTimeout(
-            dataSourceBuilder.ConnectionStringBuilder,
-            postgreSqlConfig.StatementTimeoutSeconds);
-        var dataSource = dataSourceBuilder.Build();
+        var dataSource = PostgresRuntimeOptions.BuildRuntimeDataSource(postgreSqlConfig);
         services.AddSingleton(dataSource);
 
         // Non-pooled: each acquisition is a fresh context, discarded after use. A faulted context
@@ -183,11 +176,21 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">Service collection</param>
     /// <param name="connectionString">PostgreSQL connection string</param>
-    /// <param name="configure">Optional configuration action</param>
+    /// <param name="configuration">
+    /// Application configuration whose <see cref="PostgreSqlConfiguration.SectionName"/> section is
+    /// bound over the defaults, so every setting on <see cref="PostgreSqlConfiguration"/> is
+    /// reachable from appsettings or the environment. Deliberately has no default: passing
+    /// <see langword="null"/> is a decision to run on compiled-in defaults, and omitting it by
+    /// accident should not compile.
+    /// </param>
+    /// <param name="configure">
+    /// Optional overrides applied after the section, for values the host derives at startup.
+    /// </param>
     /// <returns>Service collection for chaining</returns>
     public static IServiceCollection AddPostgreSqlInfrastructure(
         this IServiceCollection services,
         string connectionString,
+        IConfiguration? configuration,
         Action<PostgreSqlConfiguration>? configure = null
     )
     {
@@ -199,8 +202,16 @@ public static class ServiceCollectionExtensions
             );
         }
 
-        // Create and configure options
+        // Create and configure options. The section is bound first so an explicit configure
+        // action — which carries values the host derives at startup — still wins over it.
         var config = new PostgreSqlConfiguration { ConnectionString = connectionString };
+        configuration?.GetSection(PostgreSqlConfiguration.SectionName).Bind(config);
+
+        // Restored after the bind, not before it. PostgreSql:ConnectionString is a documented key
+        // that the design-time factory reads, so a self-hoster may well have it set; letting it
+        // survive here would repoint the runtime pool at whatever role that key names.
+        config.ConnectionString = connectionString;
+
         configure?.Invoke(config);
 
         // Validate connection string is still set after configure action
@@ -232,12 +243,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ITenantAuditConfigCache, TenantAuditConfigCache>();
 
         // Register NpgsqlDataSource as a singleton - this manages the connection pool
-        var dataSourceBuilder = new Npgsql.NpgsqlDataSourceBuilder(config.ConnectionString);
-        dataSourceBuilder.ConnectionStringBuilder.MaxPoolSize = config.MaxPoolSize;
-        PostgresRuntimeOptions.ApplyStatementTimeout(
-            dataSourceBuilder.ConnectionStringBuilder,
-            config.StatementTimeoutSeconds);
-        var dataSource = dataSourceBuilder.Build();
+        var dataSource = PostgresRuntimeOptions.BuildRuntimeDataSource(config);
         services.AddSingleton(dataSource);
 
         // Non-pooled: each acquisition is a fresh context, discarded after use. A faulted context

--- a/tests/Integration/Nocturne.API.Tests/Infrastructure/ParityTestFixture.cs
+++ b/tests/Integration/Nocturne.API.Tests/Infrastructure/ParityTestFixture.cs
@@ -192,7 +192,7 @@ public class ParityTestFixture : IAsyncLifetime
                         }
 
                         // Add PostgreSQL infrastructure
-                        services.AddPostgreSqlInfrastructure(connectionString, config =>
+                        services.AddPostgreSqlInfrastructure(connectionString, configuration: null, configure: config =>
                         {
                             config.EnableDetailedErrors = true;
                             config.EnableSensitiveDataLogging = true;

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/DndWindowRepositoryTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/DndWindowRepositoryTests.cs
@@ -180,7 +180,7 @@ public class DndWindowRepositoryTests
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddHttpContextAccessor();
-        services.AddPostgreSqlInfrastructure(_fx.AppConnectionString);
+        services.AddPostgreSqlInfrastructure(_fx.AppConnectionString, configuration: null);
         return services.BuildServiceProvider();
     }
 

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCarrierResetIntegrationTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCarrierResetIntegrationTests.cs
@@ -34,7 +34,7 @@ public class RlsCarrierResetIntegrationTests
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddHttpContextAccessor();
-        services.AddPostgreSqlInfrastructure(_fx.AppConnectionString);
+        services.AddPostgreSqlInfrastructure(_fx.AppConnectionString, configuration: null);
         await using var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgresRuntimeOptionsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgresRuntimeOptionsTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Infrastructure.Data.Configuration;
+using Nocturne.Infrastructure.Data.Extensions;
+using Npgsql;
+
+namespace Nocturne.Infrastructure.Data.Tests.Configuration;
+
+/// <summary>
+/// Guards that <see cref="PostgreSqlConfiguration"/> is reachable from configuration and that the
+/// values on it reach the data source that owns the connection pool. These drive
+/// <see cref="ServiceCollectionExtensions.AddPostgreSqlInfrastructure(IServiceCollection, string, IConfiguration, Action{PostgreSqlConfiguration})"/>
+/// — the composition the API itself calls — rather than re-binding the section themselves.
+/// </summary>
+[Trait("Category", "Unit")]
+public class PostgresRuntimeOptionsTests
+{
+    private const string ConnectionString = "Host=localhost;Database=nocturne;Username=nocturne_app;Password=pw";
+
+    private static IConfiguration SectionWith(params (string Key, string Value)[] settings) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.ToDictionary(
+                s => $"{PostgreSqlConfiguration.SectionName}:{s.Key}",
+                s => (string?)s.Value))
+            .Build();
+
+    /// <summary>
+    /// Reads the pool the registration actually built. The data source is registered as a
+    /// singleton instance, so this needs no provider and touches nothing else in the graph.
+    /// </summary>
+    private static NpgsqlConnectionStringBuilder RegisteredPool(
+        IConfiguration? configuration = null,
+        Action<PostgreSqlConfiguration>? configure = null)
+    {
+        var services = new ServiceCollection();
+        services.AddPostgreSqlInfrastructure(ConnectionString, configuration, configure);
+
+        var dataSource = (NpgsqlDataSource)services
+            .Single(d => d.ServiceType == typeof(NpgsqlDataSource))
+            .ImplementationInstance!;
+
+        using (dataSource)
+        {
+            return new NpgsqlConnectionStringBuilder(dataSource.ConnectionString);
+        }
+    }
+
+    /// <summary>
+    /// The API supplies the connection string separately from the section, so without the bind
+    /// inside the registration every setting here would be unreachable in a deployed image and
+    /// retuning the pool would need a rebuild.
+    /// </summary>
+    [Fact]
+    public void ConfigurationSection_ReachesTheRuntimePool()
+    {
+        RegisteredPool(SectionWith(("MaxPoolSize", "33"))).MaxPoolSize.Should().Be(
+            33,
+            "an operator must be able to retune the pool without a code change and redeploy");
+    }
+
+    [Fact]
+    public void ConfigurationSection_ReachesTheStatementTimeout()
+    {
+        RegisteredPool(SectionWith(("StatementTimeoutSeconds", "12"))).Options.Should().Contain(
+            "statement_timeout=12000",
+            "the server-side cap must be settable from configuration too");
+    }
+
+    /// <summary>
+    /// Pins the order of the two writes to <c>ConnectionString</c>. The restore has to sit between
+    /// the bind and the configure action: moved after it, the existing "cleared by the configure
+    /// action" guard can never fire, because the restore silently repopulates what the action
+    /// cleared.
+    /// </summary>
+    [Fact]
+    public void ConfigureActionClearingTheConnectionString_StillFails()
+    {
+        var register = () => RegisteredPool(
+            SectionWith(("MaxPoolSize", "33")),
+            config => config.ConnectionString = string.Empty);
+
+        register.Should().Throw<InvalidOperationException>()
+            .WithMessage("*cleared by the configure action*");
+    }
+
+    [Fact]
+    public void ConfigureAction_WinsOverTheSection()
+    {
+        var pool = RegisteredPool(
+            SectionWith(("MaxPoolSize", "33")),
+            config => config.MaxPoolSize = 44);
+
+        pool.MaxPoolSize.Should().Be(
+            44,
+            "values the host derives at startup must override the file");
+    }
+
+    /// <summary>
+    /// Asserted through the statement timeout rather than the pool size: the pool default and
+    /// Npgsql's own default are both 100, so that comparison would hold even if the configuration
+    /// never reached the data source.
+    /// </summary>
+    [Fact]
+    public void WithoutConfiguration_TheDefaultsApply()
+    {
+        RegisteredPool().Options.Should().Contain(
+            $"statement_timeout={new PostgreSqlConfiguration().StatementTimeoutSeconds * 1000}",
+            "callers that pass no configuration must keep their existing behaviour");
+    }
+
+    /// <summary>
+    /// <c>PostgreSql:ConnectionString</c> is a real key: the section documents it and the
+    /// design-time factory reads it, so a self-hoster running <c>dotnet ef</c> may have it set to
+    /// the migrator role. Binding must not let it displace the connection string the host resolved
+    /// from <c>ConnectionStrings</c>, or the runtime pool silently connects as the wrong role.
+    /// </summary>
+    [Fact]
+    public void SectionConnectionString_DoesNotDisplaceTheSuppliedOne()
+    {
+        var pool = RegisteredPool(SectionWith(
+            ("MaxPoolSize", "33"),
+            ("ConnectionString", "Host=WRONGHOST;Database=nocturne;Username=nocturne_migrator;Password=pw")));
+
+        pool.Host.Should().Be("localhost", "the caller's connection string is the contract");
+        pool.Username.Should().Be(
+            "nocturne_app",
+            "the runtime pool must never inherit the migrator role from configuration");
+    }
+
+    /// <summary>
+    /// Binding makes a malformed value a startup failure where it was previously ignored, because
+    /// nothing read the section at all. A wrong <em>key</em> is still silently inert — Bind ignores
+    /// names it does not recognise — so this narrows the failure window rather than closing it.
+    /// </summary>
+    [Fact]
+    public void MalformedValue_FailsAtStartup()
+    {
+        var register = () => RegisteredPool(SectionWith(("MaxPoolSize", "not-a-number")));
+
+        register.Should().Throw<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// The seconds-to-milliseconds scale is widened before multiplying. The dangerous window is
+    /// not the negative wrap — PostgreSQL caps statement_timeout at 2,147,483,647 ms, so anything
+    /// above 2,147,483 s is refused at connection open either way. It is the range that wraps back
+    /// into a <em>valid</em> value: in int arithmetic 5,000,000 s scales to 705,032,704 ms, so a
+    /// connection opens cleanly and silently reaps queries at eight days instead of eight weeks.
+    /// </summary>
+    [Fact]
+    public void StatementTimeoutThatWouldWrapIntoAValidValue_KeepsItsMagnitude()
+    {
+        RegisteredPool(SectionWith(("StatementTimeoutSeconds", "5000000"))).Options
+            .Should().Contain("statement_timeout=5000000000")
+            .And.NotContain("statement_timeout=705032704");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -17,7 +17,9 @@ public class ServiceCollectionExtensionsTests
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton(Mock.Of<IHttpContextAccessor>());
-        services.AddPostgreSqlInfrastructure("Host=localhost;Database=nocturne_test;Username=nocturne_app;Password=x");
+        services.AddPostgreSqlInfrastructure(
+            "Host=localhost;Database=nocturne_test;Username=nocturne_app;Password=x",
+            configuration: null);
 
         using var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IDbContextFactory<NocturneDbContext>>();


### PR DESCRIPTION
# fix(data): bind the PostgreSql section so its settings are reachable

**Repo:** `nightscout/nocturne`
**Branch:** `fix/bind-postgresql-configuration-section`
**Base:** `main` — single commit; squash- or rebase-merge.

## Problem

`PostgreSqlConfiguration` was unreachable from configuration in any deployed image.

The API calls the `AddPostgreSqlInfrastructure` overload that takes the connection string
explicitly. That overload built its config from `new PostgreSqlConfiguration { ConnectionString = … }`
and contained no `IConfiguration` reference; only the other overload read
`GetSection("PostgreSql")`, and nothing outside tests called it. So pool size, command and
statement timeouts and retry counts were all fixed at their compiled-in values, and retuning any of
them meant a rebuild — while the section's own doc told operators they were settable.

## Fix

Bind the section **inside the registration** rather than at the call site, so the next caller
cannot trip the same wire and the behaviour is reachable from a test.

`configuration` is a **required** parameter. Omitting it does not compile: a stale
`(connectionString, lambda)` call fails with `CS1660`, since a lambda has no conversion to
`IConfiguration` and `IConfiguration` is not a delegate type — so the reorder can never silently
swap arguments. The four connection-string-only callers pass `configuration: null` explicitly,
which the parameter's XML doc defines as "run on compiled-in defaults".

Precedence is `configure > environment variable > appsettings section > C# default`.

**The supplied connection string is restored after the bind and before the configure action.**
`PostgreSql:ConnectionString` is a documented key that the design-time factory reads, so a
self-hoster running `dotnet ef` may well have it set — to the migrator role. Letting it survive the
bind would repoint the runtime application pool at whatever role it names. The ordering also
matters on the other side: moved after the action, the existing "cleared by the configure action"
guard could never fire.

Two smaller changes ride along:

- `appsettings.example.json` is a live configuration source in the shipped image, and it was the
  only appsettings file there. Its uncommented tuning keys would now shadow the C# defaults, so
  they are commented out — still discoverable documentation, with the class canonical. `MaxPoolSize`
  is added alongside them, with the caveat that the server's `max_connections` (default 100, less
  `superuser_reserved_connections`) bounds it.
- `statement_timeout` scaling is widened to `long`. The value is operator-supplied for the first
  time, and in `int` arithmetic the product overflows above 2,147,483 s. Some inputs wrap negative
  and are refused at connection open rather than at startup; worse, others wrap back into a valid
  range — 5,000,000 s becomes 705,032,704 ms — and silently apply a timeout orders of magnitude
  shorter than asked for.

Also consolidates the runtime data-source construction, previously duplicated verbatim across both
overloads, into `PostgresRuntimeOptions.BuildRuntimeDataSource`.

## Behaviour change

None in production. The deployed image's only appsettings file yields exactly two `PostgreSql`
keys, both then overridden by `IsDevelopment()`. What changes is that a malformed value now fails
at startup instead of being ignored — the point of the change, since an override an operator
believes is in effect should not silently do nothing. An unrecognised *key* stays silently inert;
`Bind` ignores names it does not know.

## Tests

Eight tests in `PostgresRuntimeOptionsTests`, all driving `AddPostgreSqlInfrastructure` — the
composition the API itself calls — and reading the `NpgsqlDataSource` off the registered
`ServiceDescriptor`, so they assert against the object production builds.

Mutation-checked; every load-bearing line has a killer:

| Mutation | Result |
|---|---|
| delete the bind | 4 of 8 fail |
| delete the connection-string restore | 1 of 8 fails |
| move the restore after `configure` | 1 of 8 fails |
| revert the `(long)` cast | 1 of 8 fails |
| drop `builder.Configuration` at the call site | compile error `CS1660` |

Suites: `Nocturne.Infrastructure.Data.Tests` 905/905, `Nocturne.API.Tests` 6401/6406 (5
pre-existing skips). The three changed integration call sites live in separate csprojs from those
suites, so `tests/Integration/Nocturne.API.Tests` and
`tests/Integration/Nocturne.Infrastructure.Data.Tests` were built explicitly — 0 errors.

## Limit of the compile-error guarantee

It covers a **dropped argument**, not every way the binding can be defeated. Passing
`configuration: null` at the call site compiles clean and reverts the effect of this PR, because
nothing reads `Program.cs` for this registration any more.

That is a deliberate act at a parameter whose doc states what null means, and the regression this
PR fixes was *omission* — which is now impossible. A source-text guard on `Program.cs` was tried
and removed: it passed when `builder.Configuration` was replaced with
`builder.Configuration.GetSection("Nope")`, so it proved a token appeared rather than that anything
was threaded.

The real fix is to extract the registration into something a test can construct — `Program.cs`'s
`!isTesting` gate makes the current shape unreachable from every fixture in the repository. Tracked
as a follow-up.
