### PR TITLE
perf(data): lead the hot read indexes with tenant_id, and drop the duplicated tenant FKs

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -24,6 +24,35 @@ public static class DatabaseInitializationExtensions
     /// The runtime connection interceptor is attached so the role-attribute
     /// guard runs on the migrator connection too.
     /// </summary>
+    /// <summary>
+    /// The migrator data source, with server notices forwarded to <paramref name="logger"/>.
+    /// <para>
+    /// A migration that decides something at runtime — which constraints matched a shape, which
+    /// index it had to rebuild, whether it could take a lock before giving up — can only report it
+    /// with <c>RAISE NOTICE</c>, and a notice reaches no log by default: the server's
+    /// <c>log_min_messages</c> is <c>warning</c>, and Npgsql surfaces it as a connection event with
+    /// no subscriber. Forwarding it is the only record such a migration leaves, because one that
+    /// completes gets its history row and is never run again.
+    /// </para>
+    /// </summary>
+    internal static NpgsqlDataSource BuildMigratorDataSource(string migratorConnectionString, ILogger logger)
+    {
+        var builder = new NpgsqlDataSourceBuilder(migratorConnectionString);
+
+        builder.UsePhysicalConnectionInitializer(
+            connection => connection.Notice += Forward,
+            connection =>
+            {
+                connection.Notice += Forward;
+                return Task.CompletedTask;
+            });
+
+        return builder.Build();
+
+        void Forward(object? _, NpgsqlNoticeEventArgs args) =>
+            logger.LogInformation("Migration notice: {Notice}", args.Notice.MessageText);
+    }
+
     public static async Task RunMigrationsAsync(
         string migratorConnectionString,
         ILogger logger,
@@ -35,7 +64,7 @@ public static class DatabaseInitializationExtensions
         {
             logger.LogInformation("Running PostgreSQL database migrations under migrator role...");
 
-            dataSource = new NpgsqlDataSourceBuilder(migratorConnectionString).Build();
+            dataSource = BuildMigratorDataSource(migratorConnectionString, logger);
 
             // On a cold start (e.g. `docker compose up -d` with a fresh volume) the
             // database container may not be accepting TCP connections yet when the

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -16,16 +16,8 @@ namespace Nocturne.Infrastructure.Data.Extensions;
 public static class DatabaseInitializationExtensions
 {
     /// <summary>
-    /// Runs EF Core migrations against the database using a dedicated migrator
-    /// connection string. Builds a throwaway NpgsqlDataSource + DbContextOptions
-    /// so the migrator DbContext is never registered in the main DI container
-    /// and cannot be accidentally resolved at request time.
-    ///
-    /// The runtime connection interceptor is attached so the role-attribute
-    /// guard runs on the migrator connection too.
-    /// </summary>
-    /// <summary>
-    /// The migrator data source, with server notices forwarded to <paramref name="logger"/>.
+    /// The migrator <see cref="NocturneDbContext"/>, with server notices forwarded to
+    /// <paramref name="logger"/>.
     /// <para>
     /// A migration that decides something at runtime — which constraints matched a shape, which
     /// index it had to rebuild, whether it could take a lock before giving up — can only report it
@@ -34,25 +26,56 @@ public static class DatabaseInitializationExtensions
     /// no subscriber. Forwarding it is the only record such a migration leaves, because one that
     /// completes gets its history row and is never run again.
     /// </para>
+    /// <para>
+    /// The subscription has to be on the connection EF executes against, which is why this builds
+    /// the context rather than configuring the data source.
+    /// <c>NpgsqlDataSourceBuilder.UsePhysicalConnectionInitializer</c> looks like the natural hook
+    /// and is not one: it hands out a throwaway <see cref="NpgsqlConnection"/> wrapper for
+    /// initialisation only, so the handler list dies with that instance and the connection EF later
+    /// takes from the pool has none. Subscribing there is silent, not wrong-looking.
+    /// </para>
     /// </summary>
-    internal static NpgsqlDataSource BuildMigratorDataSource(string migratorConnectionString, ILogger logger)
+    internal static NocturneDbContext CreateMigratorContext(
+        NpgsqlDataSource dataSource,
+        TenantConnectionInterceptor interceptor,
+        ILogger logger)
     {
-        var builder = new NpgsqlDataSourceBuilder(migratorConnectionString);
+        var optionsBuilder = new DbContextOptionsBuilder<NocturneDbContext>();
 
-        builder.UsePhysicalConnectionInitializer(
-            connection => connection.Notice += Forward,
-            connection =>
-            {
-                connection.Notice += Forward;
-                return Task.CompletedTask;
-            });
+        // A migration can include long-running DDL — e.g. building an index on a
+        // multi-million-row table — that exceeds Npgsql's default 30s command timeout.
+        // A timed-out migration command surfaces as a transient failure and crashes
+        // startup; under `restart: unless-stopped` the next boot re-runs the migration
+        // from scratch, so the build is killed and restarted forever — an unbreakable
+        // crash loop. Give migration DDL ample time to complete.
+        optionsBuilder.UseNpgsql(
+            dataSource,
+            npgsql => npgsql.CommandTimeout((int)TimeSpan.FromHours(1).TotalSeconds));
+        optionsBuilder.AddInterceptors(interceptor);
 
-        return builder.Build();
+        var context = new NocturneDbContext(optionsBuilder.Options);
 
-        void Forward(object? _, NpgsqlNoticeEventArgs args) =>
-            logger.LogInformation("Migration notice: {Notice}", args.Notice.MessageText);
+        // Survives the open/close churn EF does around every suppressTransaction boundary:
+        // the DbConnection instance is stable for the context's lifetime, only its physical
+        // connector is returned to the pool and retaken.
+        if (context.Database.GetDbConnection() is NpgsqlConnection npgsql)
+        {
+            npgsql.Notice += (_, args) =>
+                logger.LogInformation("Migration notice: {Notice}", args.Notice.MessageText);
+        }
+
+        return context;
     }
 
+    /// <summary>
+    /// Runs EF Core migrations against the database using a dedicated migrator
+    /// connection string. Builds a throwaway NpgsqlDataSource + DbContextOptions
+    /// so the migrator DbContext is never registered in the main DI container
+    /// and cannot be accidentally resolved at request time.
+    ///
+    /// The runtime connection interceptor is attached so the role-attribute
+    /// guard runs on the migrator connection too.
+    /// </summary>
     public static async Task RunMigrationsAsync(
         string migratorConnectionString,
         ILogger logger,
@@ -64,7 +87,7 @@ public static class DatabaseInitializationExtensions
         {
             logger.LogInformation("Running PostgreSQL database migrations under migrator role...");
 
-            dataSource = BuildMigratorDataSource(migratorConnectionString, logger);
+            dataSource = new NpgsqlDataSourceBuilder(migratorConnectionString).Build();
 
             // On a cold start (e.g. `docker compose up -d` with a fresh volume) the
             // database container may not be accepting TCP connections yet when the
@@ -85,19 +108,7 @@ public static class DatabaseInitializationExtensions
                 logger,
                 cancellationToken);
 
-            var optionsBuilder = new DbContextOptionsBuilder<NocturneDbContext>();
-            // A migration can include long-running DDL — e.g. building an index on a
-            // multi-million-row table — that exceeds Npgsql's default 30s command timeout.
-            // A timed-out migration command surfaces as a transient failure and crashes
-            // startup; under `restart: unless-stopped` the next boot re-runs the migration
-            // from scratch, so the build is killed and restarted forever — an unbreakable
-            // crash loop. Give migration DDL ample time to complete.
-            optionsBuilder.UseNpgsql(
-                dataSource,
-                npgsql => npgsql.CommandTimeout((int)TimeSpan.FromHours(1).TotalSeconds));
-            optionsBuilder.AddInterceptors(interceptor);
-
-            using var context = new NocturneDbContext(optionsBuilder.Options);
+            using var context = CreateMigratorContext(dataSource, interceptor, logger);
             await context.Database.MigrateAsync(cancellationToken);
 
             logger.LogInformation("PostgreSQL database migrations completed");

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904121828_AddTenantLeadingReadIndexes.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904121828_AddTenantLeadingReadIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904121828_AddTenantLeadingReadIndexes")]
+    partial class AddTenantLeadingReadIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904121828_AddTenantLeadingReadIndexes.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904121828_AddTenantLeadingReadIndexes.cs
@@ -1,0 +1,129 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <summary>
+    /// Adds the tenant-leading read indexes, all through
+    /// <see cref="ConcurrentIndexBuilder"/> — see there for why CONCURRENTLY, and for what an
+    /// interrupted build leaves behind.
+    /// </summary>
+    public partial class AddTenantLeadingReadIndexes : Migration
+    {
+        /// <summary>
+        /// Tables taking the shared <c>(tenant_id, data_source, timestamp DESC)</c> watermark index.
+        /// Mirrors <c>NocturneDbContext.V4TimeSeriesRecordEntities</c>.
+        /// </summary>
+        private static readonly string[] WatermarkedTables =
+        [
+            "aps_snapshots",
+            "basal_injections",
+            "basal_schedules",
+            "bg_checks",
+            "bolus_calculations",
+            "boluses",
+            "calibrations",
+            "carb_intakes",
+            "carb_ratio_schedules",
+            "device_events",
+            "meter_glucose",
+            "notes",
+            "pump_snapshots",
+            "sensitivity_schedules",
+            "sensor_glucose",
+            "target_range_schedules",
+            "therapy_settings",
+            "uploader_snapshots",
+        ];
+
+        /// <summary>Mirrors <c>NocturneDbContext.V4SnapshotEntities</c>.</summary>
+        private static readonly string[] SnapshotTables =
+        [
+            "aps_snapshots",
+            "pump_snapshots",
+            "uploader_snapshots",
+        ];
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            foreach (var table in WatermarkedTables)
+            {
+                ConcurrentIndexBuilder.Build(
+                    migrationBuilder,
+                    $"ix_{table}_tenant_source_timestamp",
+                    $"ON {table} (tenant_id, data_source, \"timestamp\" DESC) WHERE deleted_at IS NULL");
+            }
+
+            foreach (var table in SnapshotTables)
+            {
+                ConcurrentIndexBuilder.Build(
+                    migrationBuilder,
+                    $"ix_{table}_tenant_timestamp",
+                    $"ON {table} (tenant_id, \"timestamp\" DESC) WHERE deleted_at IS NULL");
+            }
+
+            ConcurrentIndexBuilder.Build(
+                migrationBuilder,
+                "ix_linked_records_tenant_created",
+                "ON linked_records (tenant_id, sys_created_at)");
+
+            ConcurrentIndexBuilder.Build(
+                migrationBuilder,
+                "ix_linked_records_tenant_type_timestamp",
+                "ON linked_records (tenant_id, record_type, source_timestamp)");
+
+            // Superseded by the tenant-leading index above, which the same reads enter on: the
+            // table is reachable only through the tenant query filter and the tenant_isolation RLS
+            // policy, so no reader wants a record_type prefix without a tenant. Conditional on the
+            // replacement having been built and validated, so an interrupted run cannot leave the
+            // window reads with neither index.
+            migrationBuilder.Sql("""
+                DO $$
+                BEGIN
+                    SET LOCAL lock_timeout = '3s';
+                    IF EXISTS (
+                        SELECT 1 FROM pg_index
+                        WHERE indexrelid = to_regclass('public.ix_linked_records_tenant_type_timestamp')
+                          AND indisvalid)
+                    THEN
+                        EXECUTE 'DROP INDEX IF EXISTS public.ix_linked_records_type_timestamp';
+                    ELSE
+                        RAISE NOTICE
+                            'keeping ix_linked_records_type_timestamp: its replacement is absent or invalid';
+                    END IF;
+                END $$;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            ConcurrentIndexBuilder.Build(
+                migrationBuilder,
+                "ix_linked_records_type_timestamp",
+                "ON linked_records (record_type, source_timestamp)");
+
+            foreach (var name in new[]
+            {
+                "ix_linked_records_tenant_type_timestamp",
+                "ix_linked_records_tenant_created",
+            })
+            {
+                ConcurrentIndexBuilder.Drop(migrationBuilder, name);
+            }
+
+            foreach (var table in SnapshotTables)
+            {
+                ConcurrentIndexBuilder.Drop(migrationBuilder, $"ix_{table}_tenant_timestamp");
+            }
+
+            foreach (var table in WatermarkedTables)
+            {
+                ConcurrentIndexBuilder.Drop(migrationBuilder, $"ix_{table}_tenant_source_timestamp");
+            }
+        }
+
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904123124_DropRedundantTenantForeignKeysAndUnreadIndexes.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904123124_DropRedundantTenantForeignKeysAndUnreadIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904123124_DropRedundantTenantForeignKeysAndUnreadIndexes")]
+    partial class DropRedundantTenantForeignKeysAndUnreadIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904123124_DropRedundantTenantForeignKeysAndUnreadIndexes.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904123124_DropRedundantTenantForeignKeysAndUnreadIndexes.cs
@@ -18,8 +18,8 @@ namespace Nocturne.Infrastructure.Data.Migrations
     /// That skip is permanent. The migration still completes, so it takes its
     /// <c>__EFMigrationsHistory</c> row and is never run again; a table skipped here keeps its
     /// duplicate until a later migration removes it. The notice naming the table is the only
-    /// record, which is why the migrator data source forwards notices
-    /// (<see cref="Extensions.DatabaseInitializationExtensions.BuildMigratorDataSource"/>).
+    /// record, which is why the migrator context forwards notices
+    /// (<see cref="Extensions.DatabaseInitializationExtensions.CreateMigratorContext"/>).
     /// </para>
     /// </summary>
     public partial class DropRedundantTenantForeignKeysAndUnreadIndexes : Migration

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904123124_DropRedundantTenantForeignKeysAndUnreadIndexes.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260904123124_DropRedundantTenantForeignKeysAndUnreadIndexes.cs
@@ -1,0 +1,178 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <summary>
+    /// Removes the second, identical tenant foreign key from the tables that carry two, and the
+    /// three indexes no query can enter on.
+    /// <para>
+    /// Dropping a constraint takes an AccessExclusiveLock on its table, so each table is its own
+    /// statement and therefore its own transaction, under a short <c>lock_timeout</c>. A table
+    /// whose lock cannot be taken is left alone with a notice rather than failing the migration:
+    /// migrations run at API startup, so raising here would crash-loop the API over a redundancy
+    /// that is harmless to keep.
+    /// </para>
+    /// <para>
+    /// That skip is permanent. The migration still completes, so it takes its
+    /// <c>__EFMigrationsHistory</c> row and is never run again; a table skipped here keeps its
+    /// duplicate until a later migration removes it. The notice naming the table is the only
+    /// record, which is why the migrator data source forwards notices
+    /// (<see cref="Extensions.DatabaseInitializationExtensions.BuildMigratorDataSource"/>).
+    /// </para>
+    /// </summary>
+    public partial class DropRedundantTenantForeignKeysAndUnreadIndexes : Migration
+    {
+        /// <summary>
+        /// Tables that carried two identical tenant foreign keys: the snake_case one
+        /// <c>20260227034745_EnforceMultitenancy</c> added in a loop, and the EF-conventional one
+        /// <c>20260415045216_AddTenantCascadeDeletes</c> added afterwards behind a guard that only
+        /// looked for its own name.
+        /// </summary>
+        private static readonly string[] TablesWithDuplicateTenantForeignKey =
+        [
+            "aps_snapshots",
+            "basal_schedules",
+            "bg_checks",
+            "bolus_calculations",
+            "boluses",
+            "calibrations",
+            "carb_intakes",
+            "carb_ratio_schedules",
+            "clock_faces",
+            "compression_low_suggestions",
+            "connector_configurations",
+            "connector_food_entries",
+            "data_source_metadata",
+            "device_events",
+            "devices",
+            "discrepancy_analyses",
+            "discrepancy_details",
+            "foods",
+            "heart_rates",
+            "in_app_notifications",
+            "linked_records",
+            "meter_glucose",
+            "notes",
+            "pump_snapshots",
+            "sensitivity_schedules",
+            "sensor_glucose",
+            "settings",
+            "state_spans",
+            "step_counts",
+            "target_range_schedules",
+            "temp_basals",
+            "therapy_settings",
+            "tracker_definitions",
+            "tracker_instances",
+            "tracker_notification_thresholds",
+            "tracker_presets",
+            "treatment_foods",
+            "uploader_snapshots",
+            "user_food_favorites",
+        ];
+
+        /// <summary>
+        /// Indexes no statement can enter on. <c>correlation_id</c> on these two tables holds
+        /// <c>TraceId</c>, which is written for diagnostics and never filtered; the temp-basal
+        /// reads that mention <c>end_timestamp</c> all bound <c>start_timestamp</c> as well and
+        /// enter on <c>ix_temp_basals_tenant_start_timestamp</c>.
+        /// </summary>
+        private static readonly string[] UnreadIndexes =
+        [
+            "ix_mutation_audit_log_correlation",
+            "ix_read_access_log_correlation",
+            "ix_temp_basals_end_timestamp",
+        ];
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Matched on shape rather than name, and only where an equivalent constraint survives,
+            // so no table can be left without its cascade. A name pattern would miss devices,
+            // which carries the stem it had before the rename from pump_devices.
+            foreach (var table in TablesWithDuplicateTenantForeignKey)
+            {
+                migrationBuilder.Sql($"""
+                    DO $$
+                    DECLARE dup record;
+                    BEGIN
+                        SET LOCAL lock_timeout = '3s';
+                        FOR dup IN
+                            SELECT c.conname
+                            FROM pg_constraint c
+                            WHERE c.contype = 'f'
+                              AND c.conrelid = '{table}'::regclass
+                              AND c.confrelid = 'tenants'::regclass
+                              AND c.conname <> 'FK_{table}_tenants_tenant_id'
+                              AND EXISTS (
+                                  SELECT 1 FROM pg_constraint keep
+                                  WHERE keep.contype = 'f'
+                                    AND keep.conrelid = c.conrelid
+                                    AND keep.confrelid = c.confrelid
+                                    AND keep.conkey = c.conkey
+                                    AND keep.confkey = c.confkey
+                                    AND keep.confdeltype = c.confdeltype
+                                    AND keep.confupdtype = c.confupdtype
+                                    AND keep.conname = 'FK_{table}_tenants_tenant_id')
+                        LOOP
+                            EXECUTE format('ALTER TABLE {table} DROP CONSTRAINT %I', dup.conname);
+                            RAISE NOTICE 'dropped redundant % on {table}', dup.conname;
+                        END LOOP;
+                    EXCEPTION WHEN lock_not_available THEN
+                        RAISE NOTICE 'skipped {table}: could not take the lock within 3s';
+                    END $$;
+                    """, suppressTransaction: true);
+            }
+
+            foreach (var name in UnreadIndexes)
+            {
+                ConcurrentIndexBuilder.Drop(migrationBuilder, name);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            ConcurrentIndexBuilder.Build(
+                migrationBuilder,
+                "ix_temp_basals_end_timestamp",
+                "ON temp_basals (end_timestamp)");
+
+            ConcurrentIndexBuilder.Build(
+                migrationBuilder,
+                "ix_read_access_log_correlation",
+                "ON read_access_log (correlation_id) WHERE correlation_id IS NOT NULL");
+
+            ConcurrentIndexBuilder.Build(
+                migrationBuilder,
+                "ix_mutation_audit_log_correlation",
+                "ON mutation_audit_log (correlation_id) WHERE correlation_id IS NOT NULL");
+
+            // NOT VALID because the rows were already checked by the surviving constraint that
+            // never went away: validating 39 tables again would re-read every one of them under
+            // ShareRowExclusive, which is a second outage rather than a rollback. Restores the
+            // naming the loop in EnforceMultitenancy used, which for devices predates its rename
+            // from pump_devices. A constraint Up removed from a table outside this list was, by
+            // the predicate that selected it, redundant with a cascade that is still in place.
+            foreach (var table in TablesWithDuplicateTenantForeignKey)
+            {
+                var name = table == "devices" ? "fk_pump_devices_tenant_id" : $"fk_{table}_tenant_id";
+
+                migrationBuilder.Sql($"""
+                    DO $$
+                    BEGIN
+                        SET LOCAL lock_timeout = '3s';
+                        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{name}') THEN
+                            ALTER TABLE {table} ADD CONSTRAINT {name}
+                                FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE NOT VALID;
+                        END IF;
+                    EXCEPTION WHEN lock_not_available THEN
+                        RAISE NOTICE 'skipped {table}: could not take the lock within 3s';
+                    END $$;
+                    """, suppressTransaction: true);
+            }
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/ConcurrentIndexBuilder.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/ConcurrentIndexBuilder.cs
@@ -1,0 +1,65 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Nocturne.Infrastructure.Data.Migrations;
+
+/// <summary>
+/// Builds an index with <c>CONCURRENTLY</c>, which every index over one of the large record tables
+/// needs. A plain <c>CREATE INDEX</c> takes a <c>ShareLock</c>, which blocks every write to that
+/// table until the build finishes — on the tables the connectors ingest into, that is dropped
+/// uploads. Batching them into one transaction is worse on both counts: it holds every one of
+/// those locks until the commit, and a failure part-way discards all the completed work, so under
+/// <c>restart: unless-stopped</c> each crash-loop iteration starts again from nothing. That is the
+/// same trap the hour-long command timeout in
+/// <see cref="Extensions.DatabaseInitializationExtensions.RunMigrationsAsync"/> exists to avoid.
+/// A self-hosted deployment may also run more than one API replica, where a lock held for the
+/// length of a multi-GB build is not confined to one process's startup.
+/// <para>
+/// <c>CONCURRENTLY</c> cannot run inside a transaction, so the migration is not atomic and an
+/// interrupted build leaves an <c>indisvalid = false</c> index behind. <c>IF NOT EXISTS</c> does
+/// not repair that — it matches the relation name and skips, so the retry reports success over an
+/// index the planner will never use. Every build therefore drops its own invalid remains first,
+/// conditional on invalidity so a retry does not rebuild what already succeeded.
+/// </para>
+/// <para>
+/// One consequence of leaving the transaction, for the multi-replica case above: EF's migration
+/// lock is <c>LOCK TABLE … IN ACCESS EXCLUSIVE MODE</c> on the history table, not an advisory
+/// lock, so it is transaction-scoped and released at each <c>suppressTransaction</c> boundary
+/// rather than held for the migration. Two replicas starting together can therefore interleave,
+/// and one's invalid-index drop can land on the other's in-flight build. It self-heals — the
+/// interrupted build leaves remains the next iteration clears — but a deployment scaling the API
+/// should migrate once before scaling out rather than rely on that.
+/// </para>
+/// </summary>
+internal static class ConcurrentIndexBuilder
+{
+    /// <param name="migrationBuilder">The migration being written.</param>
+    /// <param name="name">Unqualified index name. Resolved against <c>public</c> for the validity
+    /// probe, matching the schema these migrations create in.</param>
+    /// <param name="definition">Everything after the index name: <c>ON table (cols) WHERE …</c>.</param>
+    public static void Build(MigrationBuilder migrationBuilder, string name, string definition)
+    {
+        migrationBuilder.Sql($"""
+            DO $$
+            BEGIN
+                SET LOCAL lock_timeout = '3s';
+                IF EXISTS (
+                    SELECT 1 FROM pg_index
+                    WHERE indexrelid = to_regclass('public.{name}') AND NOT indisvalid)
+                THEN
+                    EXECUTE 'DROP INDEX public.{name}';
+                    RAISE NOTICE 'dropped invalid {name} left by an interrupted build';
+                END IF;
+            END $$;
+            """);
+
+        migrationBuilder.Sql(
+            $"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} {definition};",
+            suppressTransaction: true);
+    }
+
+    /// <summary>Drops an index without blocking writers, for the reverse direction.</summary>
+    public static void Drop(MigrationBuilder migrationBuilder, string name) =>
+        migrationBuilder.Sql(
+            $"DROP INDEX CONCURRENTLY IF EXISTS {name};",
+            suppressTransaction: true);
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -630,6 +630,36 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
                 .IsDescending();
         }
 
+        // The connector watermark -- V4RepositoryBase.GetLatestTimestampAsync -- asks for the
+        // newest timestamp of one tenant and one data source. With neither column leading, the
+        // planner walks ix_<table>_timestamp backwards across every other tenant's rows, so a
+        // tenant whose newest row for that source is old reads most of the table to return one
+        // value. The deleted_at filter keeps the scan index-only: soft-deleted rows left in the
+        // index have to be skipped a heap fetch at a time, which is why it is not a size saving.
+        foreach (var entity in V4TimeSeriesRecordEntities.Select(t => modelBuilder.Entity(t)))
+        {
+            entity.HasIndex(
+                    nameof(ITenantScoped.TenantId),
+                    nameof(IV4TimeSeriesEntity.DataSource),
+                    nameof(IV4TimeSeriesEntity.Timestamp))
+                .HasDatabaseName($"ix_{entity.Metadata.GetTableName()}_tenant_source_timestamp")
+                .IsDescending(false, false, true)
+                .HasFilter("deleted_at IS NULL");
+        }
+
+        // GetLatestAsync and GetLatestBeforeAsync read a snapshot table newest-first for one
+        // tenant, with no data source to pin, so the watermark index above cannot serve them.
+        // ix_<table>_timestamp answers them today at 2,452 to 20,368 index tuples read per scan.
+        foreach (var entity in V4SnapshotEntities.Select(t => modelBuilder.Entity(t)))
+        {
+            entity.HasIndex(
+                    nameof(ITenantScoped.TenantId),
+                    nameof(IV4TimeSeriesEntity.Timestamp))
+                .HasDatabaseName($"ix_{entity.Metadata.GetTableName()}_tenant_timestamp")
+                .IsDescending(false, true)
+                .HasFilter("deleted_at IS NULL");
+        }
+
         // The legacy-id uniqueness must drop soft-deleted rows, or the next resync of a
         // system-swept legacy id is a 23505 — see SoftDeleteDedupExtensions.GetBlockingLegacyIdsAsync.
         foreach (var entity in V4LegacyIdRecordEntities.Select(t => modelBuilder.Entity(t)))
@@ -1330,14 +1360,17 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
         modelBuilder
             .Entity<LinkedRecordEntity>()
-            .HasIndex(l => new { l.RecordType, l.RecordId })
-            .HasDatabaseName("ix_linked_records_record");
-
-        modelBuilder
-            .Entity<LinkedRecordEntity>()
             .HasIndex(l => new { l.TenantId, l.RecordType, l.RecordId })
             .IsUnique()
             .HasDatabaseName("ix_linked_records_tenant_type_id");
+
+        // DeduplicationService.ReconcileNewLinksAsync pages the tenant's links by creation order.
+        // The unique index above leads with tenant_id but then record_type, so it can only supply
+        // the tenant and the rest is a filter plus a sort of everything that tenant owns.
+        modelBuilder
+            .Entity<LinkedRecordEntity>()
+            .HasIndex(l => new { l.TenantId, l.SysCreatedAt })
+            .HasDatabaseName("ix_linked_records_tenant_created");
 
         modelBuilder
             .Entity<LinkedRecordEntity>()
@@ -1349,10 +1382,15 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             })
             .HasDatabaseName("ix_linked_records_type_canonical_primary");
 
+        // Every read of this table is tenant-scoped, by the global query filter and again by the
+        // tenant_isolation RLS policy, so leading on record_type made the window scan span all
+        // tenants -- 41,414 index tuples read per scan, the worst ratio in the schema. Serves the
+        // dedup window reads whether or not they also pin is_primary, which is selective enough to
+        // leave as a filter.
         modelBuilder
             .Entity<LinkedRecordEntity>()
-            .HasIndex(l => new { l.RecordType, l.SourceTimestamp })
-            .HasDatabaseName("ix_linked_records_type_timestamp");
+            .HasIndex(l => new { l.TenantId, l.RecordType, l.SourceTimestamp })
+            .HasDatabaseName("ix_linked_records_tenant_type_timestamp");
 
         // Partial index for the NOT EXISTS anti-join in read queries —
         // only non-primary rows enter the index, keeping it small.
@@ -1600,14 +1638,14 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
         modelBuilder
             .Entity<TempBasalEntity>()
-            .HasIndex(e => e.StartTimestamp)
-            .HasDatabaseName("ix_temp_basals_start_timestamp")
-            .IsDescending();
+            .HasIndex(e => e.EndTimestamp)
+            .HasDatabaseName("ix_temp_basals_end_timestamp");
 
         modelBuilder
             .Entity<TempBasalEntity>()
-            .HasIndex(e => e.EndTimestamp)
-            .HasDatabaseName("ix_temp_basals_end_timestamp");
+            .HasIndex(e => e.StartTimestamp)
+            .HasDatabaseName("ix_temp_basals_start_timestamp")
+            .IsDescending();
 
         modelBuilder
             .Entity<TempBasalEntity>()

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1638,11 +1638,6 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
         modelBuilder
             .Entity<TempBasalEntity>()
-            .HasIndex(e => e.EndTimestamp)
-            .HasDatabaseName("ix_temp_basals_end_timestamp");
-
-        modelBuilder
-            .Entity<TempBasalEntity>()
             .HasIndex(e => e.StartTimestamp)
             .HasDatabaseName("ix_temp_basals_start_timestamp")
             .IsDescending();
@@ -2089,10 +2084,6 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             entity.HasIndex(e => new { e.TenantId, e.SubjectId, e.CreatedAt })
                 .HasDatabaseName("ix_mutation_audit_log_subject");
 
-            entity.HasIndex(e => e.TraceId)
-                .HasDatabaseName("ix_mutation_audit_log_correlation")
-                .HasFilter("correlation_id IS NOT NULL");
-
             entity.HasIndex(e => new { e.TenantId, e.CreatedAt })
                 .HasDatabaseName("ix_mutation_audit_log_created");
         });
@@ -2107,10 +2098,6 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
             entity.HasIndex(e => new { e.TenantId, e.CreatedAt })
                 .HasDatabaseName("ix_read_access_log_created");
-
-            entity.HasIndex(e => e.TraceId)
-                .HasDatabaseName("ix_read_access_log_correlation")
-                .HasFilter("correlation_id IS NOT NULL");
         });
 
         modelBuilder.Entity<TenantAuditConfigEntity>(entity =>

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/MigrationNoticeForwardingTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/MigrationNoticeForwardingTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Interceptors;
+using Npgsql;
+
+namespace Nocturne.Infrastructure.Data.Tests.Rls;
+
+/// <summary>
+/// A migration that decides something at runtime reports it with <c>RAISE NOTICE</c> and nothing
+/// else: the two that skip work — the redundant-foreign-key drop that cannot take its lock, and
+/// the <c>ix_linked_records_type_timestamp</c> drop whose replacement is missing — still complete,
+/// so they take their history row and never run again. The notice is the whole record.
+/// <para>
+/// It is also silent by default at both ends. The server logs at <c>warning</c>, and Npgsql raises
+/// a notice as an event on the executing <see cref="NpgsqlConnection"/>, so a subscription placed
+/// anywhere else compiles, runs, and captures nothing.
+/// </para>
+/// </summary>
+/// <remarks>
+/// Reuses the seedless RLS fixture for a migrator connection string; raises its own notice rather
+/// than running a migration.
+/// </remarks>
+[Collection("RLS completeness")]
+[Trait("Category", "Integration")]
+public class MigrationNoticeForwardingTests
+{
+    private const string Message = "notice forwarding is wired";
+
+    private readonly RlsCompletenessFixture _fixture;
+
+    public MigrationNoticeForwardingTests(RlsCompletenessFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task ANoticeRaisedOnTheMigratorContext_ReachesTheLogger()
+    {
+        var captured = new List<string>();
+
+        await using var dataSource =
+            new NpgsqlDataSourceBuilder(_fixture.MigratorConnectionString).Build();
+
+        using var context = DatabaseInitializationExtensions.CreateMigratorContext(
+            dataSource,
+            new TenantConnectionInterceptor(),
+            new CapturingLogger(captured));
+
+        await context.Database.ExecuteSqlRawAsync(
+            $"DO $$ BEGIN RAISE NOTICE '{Message}'; END $$;");
+
+        captured.Should().ContainMatch($"*{Message}*",
+            "a migration that skips work says so only by raising a notice, and the skip is "
+            + "permanent — so a notice that reaches no log leaves the skip unobservable");
+    }
+
+    /// <summary>
+    /// EF reopens the connection around every <c>suppressTransaction</c> boundary, and both new
+    /// migrations cross several. A subscription that does not survive that would capture the first
+    /// notice and lose the rest.
+    /// </summary>
+    [Fact]
+    public async Task NoticesSurviveTheOpenAndCloseAroundEachSuppressedTransaction()
+    {
+        var captured = new List<string>();
+
+        await using var dataSource =
+            new NpgsqlDataSourceBuilder(_fixture.MigratorConnectionString).Build();
+
+        using var context = DatabaseInitializationExtensions.CreateMigratorContext(
+            dataSource,
+            new TenantConnectionInterceptor(),
+            new CapturingLogger(captured));
+
+        for (var i = 0; i < 3; i++)
+        {
+            await context.Database.OpenConnectionAsync();
+            await context.Database.ExecuteSqlRawAsync(
+                $"DO $$ BEGIN RAISE NOTICE '{Message} {i}'; END $$;");
+            await context.Database.CloseConnectionAsync();
+        }
+
+        captured.Should().HaveCount(3, "each cycle raises one notice and all three have to arrive");
+    }
+
+    private sealed class CapturingLogger(List<string> sink) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) => sink.Add(formatter(state, exception));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/ModelIndexesMatchDatabaseTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/ModelIndexesMatchDatabaseTests.cs
@@ -1,0 +1,160 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System.Text.RegularExpressions;
+
+namespace Nocturne.Infrastructure.Data.Tests.Rls;
+
+/// <summary>
+/// Guards the join between the model's index declarations and the DDL that is supposed to build
+/// them. Several migrations create indexes through <c>migrationBuilder.Sql</c> rather than
+/// <c>CreateIndex</c> — CONCURRENTLY cannot be expressed any other way, and EF conflates two
+/// indexes over the same property set — which means the model and the database agree only by the
+/// author having typed the same thing twice. EF's own pending-model-changes check does not close
+/// this: it compares the model against the snapshot, and the snapshot is generated from the model,
+/// so a migration whose SQL names the wrong index, table or column, or omits the filter, stays
+/// green while production silently lacks what the model claims it has.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reuses the seedless RLS fixture: this inspects schema metadata only.
+/// </para>
+/// <para>
+/// One-directional by construction: it walks what the model declares and looks for it in the
+/// database, so it cannot see an index the database has and the model does not — which is the
+/// class the duplicated tenant foreign keys belonged to. Access method, <c>INCLUDE</c> columns and
+/// <c>NULLS NOT DISTINCT</c> are not compared either; the model declares none of them today.
+/// </para>
+/// </remarks>
+[Collection("RLS completeness")]
+[Trait("Category", "Integration")]
+public class ModelIndexesMatchDatabaseTests
+{
+    private readonly RlsCompletenessFixture _fixture;
+
+    public ModelIndexesMatchDatabaseTests(RlsCompletenessFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task EveryModelIndex_ExistsInTheDatabaseWithTheDeclaredShape()
+    {
+        var declared = DeclaredIndexes();
+        declared.Should().HaveCountGreaterThan(150,
+            "an empty or tiny set would let the comparison below pass vacuously");
+
+        var actual = await LoadDatabaseIndexesAsync();
+
+        var mismatched = declared
+            .Where(d => !actual.TryGetValue(d.Key, out var found) || found != d.Value)
+            .Select(d => actual.TryGetValue(d.Key, out var found)
+                ? $"{d.Key}: model has {d.Value}, database has {found}"
+                : $"{d.Key}: declared on the model, absent from the database")
+            .OrderBy(m => m, StringComparer.Ordinal)
+            .ToList();
+
+        mismatched.Should().BeEmpty(
+            "a migration that builds an index in raw SQL has to build the shape the model "
+            + "declares, or the model is describing something production does not have:{0}{1}",
+            Environment.NewLine,
+            string.Join(Environment.NewLine, mismatched));
+    }
+
+    /// <summary>
+    /// Every index the model declares, as name -> table, ordered columns and predicate.
+    /// <para>
+    /// Sort direction is deliberately not compared. Every index here leads with <c>tenant_id</c>
+    /// under an equality predicate, so a backward scan serves the other direction and the two
+    /// builds are interchangeable — and the estate already disagrees with itself:
+    /// <c>ix_boluses_tenant_timestamp</c>, <c>ix_carb_intakes_tenant_timestamp</c> and
+    /// <c>ix_temp_basals_tenant_start_timestamp</c> are DESC in production and ASC in a database
+    /// built from the same migrations today, because
+    /// <c>20260511122202_AddCompositePerformanceIndexes</c> writes DESC behind
+    /// <c>CREATE INDEX IF NOT EXISTS</c> over names <c>20260511000001_AddTenantTimestampIndexes</c>
+    /// had already created ASC. Asserting direction would fail on that history rather than on new
+    /// drift.
+    /// </para>
+    /// </summary>
+    private static Dictionary<string, string> DeclaredIndexes()
+    {
+        using var context = new NocturneDbContext(
+            new DbContextOptionsBuilder<NocturneDbContext>()
+                .UseNpgsql("Host=localhost;Database=nocturne;Username=test;Password=test")
+                .Options);
+
+        // The runtime model drops IsDescending and GetFilter; only the design-time one keeps them.
+        return context.GetService<IDesignTimeModel>().Model.GetEntityTypes()
+            .SelectMany(e => e.GetIndexes())
+            .DistinctBy(i => i.GetDatabaseName())
+            .ToDictionary(
+                i => i.GetDatabaseName()!,
+                i => Shape(
+                    i.DeclaringEntityType.GetTableName()!,
+                    i.Properties.Select(p => p.GetColumnName()),
+                    i.GetFilter(),
+                    i.IsUnique),
+                StringComparer.Ordinal);
+    }
+
+    private async Task<Dictionary<string, string>> LoadDatabaseIndexesAsync()
+    {
+        await using var conn = await _fixture.OpenMigratorConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+
+        // Expression indexes report attnum 0 and have no attribute row, so they drop out of the
+        // aggregate and would read as a column mismatch; the model declares none today, and one
+        // added later should fail here rather than pass unchecked.
+        cmd.CommandText = """
+            SELECT c.relname,
+                   t.relname,
+                   (SELECT string_agg(a.attname, ',' ORDER BY k.ord)
+                    FROM unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord)
+                    JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum),
+                   COALESCE(pg_get_expr(i.indpred, i.indrelid), ''),
+                   i.indisunique
+            FROM pg_index i
+            JOIN pg_class c ON c.oid = i.indexrelid
+            JOIN pg_class t ON t.oid = i.indrelid
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public' AND i.indisvalid;
+            """;
+
+        var found = new Dictionary<string, string>(StringComparer.Ordinal);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            found[reader.GetString(0)] = Shape(
+                reader.GetString(1),
+                reader.IsDBNull(2) ? [] : reader.GetString(2).Split(','),
+                reader.GetString(3),
+                reader.GetBoolean(4));
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// One comparable string per index. Uniqueness is in the comparison because it is a
+    /// correctness property rather than a performance one — a raw-SQL migration that rebuilt
+    /// ix_sensor_glucose_tenant_source_sync_id without it would silently stop enforcing the
+    /// connector dedup invariant.
+    /// </summary>
+    private static string Shape(string table, IEnumerable<string> columns, string? filter, bool unique) =>
+        $"{(unique ? "unique " : string.Empty)}{table}({string.Join(',', columns)}) "
+        + $"where {NormalisePredicate(filter)}";
+
+    /// <summary>
+    /// Postgres re-renders a predicate on the way in: it parenthesises, quotes identifiers it
+    /// chose to quote, and makes literal casts explicit (<c>status = 'pending'</c> comes back as
+    /// <c>status::text = 'pending'::text</c>). Strips all three so only a predicate that is
+    /// genuinely different, or missing, reads as a mismatch.
+    /// </summary>
+    private static string NormalisePredicate(string? filter)
+    {
+        var stripped = Regex.Replace(filter ?? string.Empty, "::[a-z ]+", string.Empty);
+
+        return new string(stripped
+            .Where(ch => !char.IsWhiteSpace(ch) && ch is not ('(' or ')' or '"'))
+            .ToArray())
+            .ToLowerInvariant();
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/ModelConventionTests.cs
@@ -56,6 +56,43 @@ public class ModelConventionTests
                 && i.IsUnique
                 && i.GetFilter() == "legacy_id IS NOT NULL AND deleted_at IS NULL");
 
+    /// <summary>
+    /// <see cref="Nocturne.Infrastructure.Data.Repositories.V4.V4RepositoryBase{TModel,TEntity}"/>
+    /// watermarks each connector sync on the newest timestamp for one tenant and data source. The
+    /// filter is load-bearing rather than a size saving: soft-deleted rows left in the index have
+    /// to be skipped a heap fetch at a time, which costs the index-only scan.
+    /// </summary>
+    [Fact]
+    public void EveryV4RecordTable_HasTheTenantSourceWatermarkIndex() =>
+        AssertFamily(
+            NocturneDbContext.V4TimeSeriesRecordEntities,
+            "_tenant_source_timestamp",
+            i => Columns(i).SequenceEqual([
+                    nameof(ITenantScoped.TenantId),
+                    nameof(IV4TimeSeriesEntity.DataSource),
+                    nameof(IV4TimeSeriesEntity.Timestamp)])
+                && !i.IsUnique
+                && i.IsDescending is not null
+                && i.IsDescending.SequenceEqual([false, false, true])
+                && i.GetFilter() == "deleted_at IS NULL");
+
+    /// <summary>
+    /// GetLatestAsync and GetLatestBeforeAsync pin no data source, so the watermark index above
+    /// cannot serve them.
+    /// </summary>
+    [Fact]
+    public void EverySnapshotTable_HasTheTenantLeadingTimestampIndex() =>
+        AssertFamily(
+            NocturneDbContext.V4SnapshotEntities,
+            "_tenant_timestamp",
+            i => Columns(i).SequenceEqual([
+                    nameof(ITenantScoped.TenantId),
+                    nameof(IV4TimeSeriesEntity.Timestamp)])
+                && !i.IsUnique
+                && i.IsDescending is not null
+                && i.IsDescending.SequenceEqual([false, true])
+                && i.GetFilter() == "deleted_at IS NULL");
+
     [Fact]
     public void EveryCorrelatedTable_HasACorrelationIdIndex() =>
         AssertFamily(


### PR DESCRIPTION
> **The 23 indexes in this PR are already built on production**, out of band, before this
> merge. All 23 verified `indisvalid`; 0 invalid indexes cluster-wide. Every build here is
> `IF NOT EXISTS`, so the migration skips them and completes in seconds rather than holding
> the API — and with it alert evaluation — offline for tens of minutes. Verified on a
> throwaway database: the same migration ran in **4 seconds** over prebuilt indexes.
>
> Avoid deploying between 03:20 and 03:24 UTC: the second migration drops
> `ix_linked_records_type_timestamp` under a 3s lock_timeout with no exception handler, and
> would fail on the nightly backup's ACCESS SHARE lock.

# perf(data): lead the hot read indexes with tenant_id

## What this is

A production `pg_stat_statements` window of 51.9 days, ~1,012,000s of total execution time, has six of the ten costliest statements doing the same thing: scanning a whole table to answer a question about one tenant. Between them they are roughly half of all query time.

In every case the index they land on either omits `tenant_id` or buries it behind a column the query does not constrain. This adds the missing tenant-leading indexes.

## The three shapes

### 1. Connector watermark — `max(timestamp)` per tenant and source

`V4RepositoryBase.GetLatestTimestampAsync(source)` is inherited by every V4 repository and called on each sync cycle. The predicate is `tenant_id = ? AND deleted_at IS NULL AND data_source = ?`, but the only matching index was the global `ix_<table>_timestamp`, so the planner walked it backwards discarding everything that did not match.

Measured on production, `aps_snapshots`, for a tenant with no rows for the requested source:

```
Execution Time: 10956.633 ms
Buffers: shared hit=1360568 read=574188 dirtied=1011
Index Scan using ix_aps_snapshots_timestamp
  Rows Removed by Filter: 1,989,865
```

The 74 ms *mean* hides this completely: the query is instant when the tenant's newest row happens to sit near the global maximum and catastrophic otherwise.

Reproduced on a scratch database seeded to the same shape, then fixed with `(tenant_id, data_source, timestamp DESC) WHERE deleted_at IS NULL`:

| | Before | After |
|---|---|---|
| Time | 10.57 ms | **0.105 ms** |
| Buffers | 592 | **4** |
| Plan | Index Scan + filter | **Index Only Scan** |

**On the partial predicate.** It is not there to save space — with no soft-deleted rows the filtered and unfiltered indexes are byte-identical. It is there because soft-deleted rows otherwise sit in the index and have to be skipped one heap fetch at a time. With 30,000 soft-deleted rows for the tenant:

| | Buffers | Time |
|---|---|---|
| Unfiltered index | 20,246 | 4.882 ms |
| `WHERE deleted_at IS NULL` | **3** | **0.082 ms** |

Applied through the existing `ConfigureSharedRecordIndexes` loop over `V4TimeSeriesRecordEntities`, so it lands on all 18 tables that inherit the base method rather than being hand-repeated.

### 2. Dedup reconcile paging — `linked_records`

`DeduplicationService.ReconcileNewLinksAsync` pages the tenant's links by creation order:

```csharp
.Where(lr => lr.SysCreatedAt >= cutoff)
.OrderBy(lr => lr.SysCreatedAt)
.Take(batchSize)
```

The unique `(tenant_id, record_type, record_id)` index can supply the tenant and nothing else, so the rest was a filter plus a sort of everything that tenant owns. Production plan: 371,049 rows discarded to return 271, 145,000 buffers, and two parallel workers launched on each of 3.01M calls (22.5% of all query time).

Worth noting the cold-start case is worse than the steady state — a tenant with no watermark yet gets `cutoff = DateTime.MinValue`, i.e. the entire table.

With `(tenant_id, sys_created_at)`:

| | Before | After |
|---|---|---|
| Empty result | 26.85 ms / 9,340 buffers | **0.185 ms / 3 buffers** |
| 1,000 rows | 70.93 ms / 9,264 buffers | **0.370 ms / 26 buffers** |

Sort node gone, both parallel workers gone, and the `LIMIT` now actually short-circuits.

### 3. Dedup window reads — `linked_records`

Two shapes, one with `is_primary` and one without, both bounded by a `source_timestamp` range. They were entering on `ix_linked_records_type_timestamp`, which leads on `record_type` with no tenant, so each window scan spanned every tenant's rows.

Both fit a single `(tenant_id, record_type, source_timestamp)` index — `is_primary` is selective enough to leave as a filter — which is why this is one new index rather than two.

That leaves `ix_linked_records_type_timestamp` with no reader, so it goes — and it is the worst index in the schema by tuples read per scan, at 41,414. The table is reachable only through the tenant query filter and the `tenant_isolation` RLS policy, so a `record_type` prefix without a tenant cannot be what anyone wants.

## Also in here

`LinkedRecordEntity` declared `HasIndex(l => new { l.RecordType, l.RecordId })` twice — once as `ix_linked_records_record`, and again further down as the partial `ix_linked_records_non_primary_record`. EF keys an index by its property set, so the second declaration had been silently overwriting the first ever since the partial index was added; the index it named was created by `AddRlsWithCheckAndCompositeIndexes` and already dropped by `AddQueryPerformanceIndexes`, so no schema change is owed — only the dead declaration, which is removed here.

## Migration notes

Every table here is large enough in production that the `ShareLock` of a plain `CREATE INDEX` would block every write to it for the duration — on the connector ingest tables, that is dropped uploads, so all of it is `CREATE INDEX CONCURRENTLY` via `migrationBuilder.Sql(..., suppressTransaction: true)`, following `20260511122202_AddCompositePerformanceIndexes`.

The consequence is that the migration is **not atomic**. `IF NOT EXISTS` makes a retry safe for the common case, but if a `CONCURRENTLY` build is interrupted Postgres leaves an *invalid* index behind, which `IF NOT EXISTS` will then skip over. If this migration fails partway, check for invalid indexes before re-running:

```sql
SELECT c.relname FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE NOT i.indisvalid;
```

## Deploy procedure — build these before the deploy, not during it

**This must not be deployed by merging and letting the migration run unattended.**

`RunMigrationsAsync` runs at `Program.cs:529`, *before* Kestrel serves. This PR adds 23
`CREATE INDEX CONCURRENTLY` builds over roughly 14 GB of heap — `aps_snapshots` (5,071 MB) and
`linked_records` (3,858 MB) are each indexed twice, `sensor_glucose` (2,955 MB) once. `CONCURRENTLY`
is two full passes and cannot use parallel workers, so `max_parallel_maintenance_workers` and
`maintenance_work_mem` do not help. Expect **10–30+ minutes**.

On this platform that is not just downtime. While the API is down **alert evaluation does not run**,
so every tenant loses glucose alerting for the duration, with no warning.

Because every build in the migration is `IF NOT EXISTS`, building them ahead of time makes the
migration a no-op that completes in seconds. Do that.

### 1. Build them against production, ahead of the deploy

Safe to run against the live database — that is what `CONCURRENTLY` is for — and safe to stop
between statements.

**Do not paste more than one of these into a single `psql -c`.** psql wraps a multi-statement `-c`
in one transaction, and `CONCURRENTLY` cannot run inside one:

```
ERROR:  CREATE INDEX CONCURRENTLY cannot run inside a transaction block
```

One statement per `-c` is fine. To run the whole set in one go, feed them on stdin instead — which
is also the form that keeps the password out of the transcript:

```bash
ssh nocturne-cloud 'cd /opt/nocturne-cloud && PGPW=$(grep "^PG_PASSWORD=" .env | cut -d= -f2-) &&   docker compose -f aspire/AppHost/aspire-output/docker-compose.yaml                  -f aspire/AppHost/aspire-output/docker-compose.override.yaml                  --env-file .env exec -T -e PGPASSWORD="$PGPW"     postgres psql -U postgres -d nocturne-postgres' <<'SQL'
-- paste the statements below here
SQL
```

Each prints `CREATE INDEX` when it finishes.

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_aps_snapshots_tenant_source_timestamp
  ON aps_snapshots (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_basal_injections_tenant_source_timestamp
  ON basal_injections (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_basal_schedules_tenant_source_timestamp
  ON basal_schedules (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_bg_checks_tenant_source_timestamp
  ON bg_checks (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_bolus_calculations_tenant_source_timestamp
  ON bolus_calculations (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_boluses_tenant_source_timestamp
  ON boluses (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_calibrations_tenant_source_timestamp
  ON calibrations (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_carb_intakes_tenant_source_timestamp
  ON carb_intakes (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_carb_ratio_schedules_tenant_source_timestamp
  ON carb_ratio_schedules (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_device_events_tenant_source_timestamp
  ON device_events (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_meter_glucose_tenant_source_timestamp
  ON meter_glucose (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_notes_tenant_source_timestamp
  ON notes (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_pump_snapshots_tenant_source_timestamp
  ON pump_snapshots (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_sensitivity_schedules_tenant_source_timestamp
  ON sensitivity_schedules (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_sensor_glucose_tenant_source_timestamp
  ON sensor_glucose (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_target_range_schedules_tenant_source_timestamp
  ON target_range_schedules (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_therapy_settings_tenant_source_timestamp
  ON therapy_settings (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_uploader_snapshots_tenant_source_timestamp
  ON uploader_snapshots (tenant_id, data_source, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_aps_snapshots_tenant_timestamp
  ON aps_snapshots (tenant_id, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_pump_snapshots_tenant_timestamp
  ON pump_snapshots (tenant_id, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_uploader_snapshots_tenant_timestamp
  ON uploader_snapshots (tenant_id, "timestamp" DESC) WHERE deleted_at IS NULL;

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_linked_records_tenant_created
  ON linked_records (tenant_id, sys_created_at);

CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_linked_records_tenant_type_timestamp
  ON linked_records (tenant_id, record_type, source_timestamp);
```

### 2. Watch progress, from a second session

The large tables take minutes each and print nothing until they finish. To see where one is:

```sql
SELECT c.relname AS table_name,
       p.phase,
       p.blocks_done, p.blocks_total,
       round(100.0 * p.blocks_done / NULLIF(p.blocks_total, 0), 1) AS pct
FROM pg_stat_progress_create_index p
JOIN pg_class c ON c.oid = p.relid;
```

`CONCURRENTLY` makes two passes over the heap, so the phase goes
`building index` → `index validation: scanning index` → `index validation: sorting tuples` →
`index validation: scanning table`. Two passes is the cost of not blocking writers.

### 3. Confirm all 23 exist and are valid

`CONCURRENTLY` can fail and leave an `indisvalid = false` index that `IF NOT EXISTS` will then skip
over, so presence alone is not enough. Named exactly, because a `LIKE '%_tenant_source_timestamp'` also matches the pre-existing
`heart_rates` and `step_counts` indexes and would report 25. This must return 23 rows, all `t`:

```sql
SELECT c.relname, i.indisvalid
FROM pg_index i
JOIN pg_class c ON c.oid = i.indexrelid
WHERE c.relname IN (
    'ix_aps_snapshots_tenant_source_timestamp',
    'ix_basal_injections_tenant_source_timestamp',
    'ix_basal_schedules_tenant_source_timestamp',
    'ix_bg_checks_tenant_source_timestamp',
    'ix_bolus_calculations_tenant_source_timestamp',
    'ix_boluses_tenant_source_timestamp',
    'ix_calibrations_tenant_source_timestamp',
    'ix_carb_intakes_tenant_source_timestamp',
    'ix_carb_ratio_schedules_tenant_source_timestamp',
    'ix_device_events_tenant_source_timestamp',
    'ix_meter_glucose_tenant_source_timestamp',
    'ix_notes_tenant_source_timestamp',
    'ix_pump_snapshots_tenant_source_timestamp',
    'ix_sensitivity_schedules_tenant_source_timestamp',
    'ix_sensor_glucose_tenant_source_timestamp',
    'ix_target_range_schedules_tenant_source_timestamp',
    'ix_therapy_settings_tenant_source_timestamp',
    'ix_uploader_snapshots_tenant_source_timestamp',
    'ix_aps_snapshots_tenant_timestamp',
    'ix_pump_snapshots_tenant_timestamp',
    'ix_uploader_snapshots_tenant_timestamp',
    'ix_linked_records_tenant_created',
    'ix_linked_records_tenant_type_timestamp')
ORDER BY 1;
```

Anything reporting `f`: `DROP INDEX CONCURRENTLY <name>;` and re-run that one statement. Do not
merge until all 23 are `t`.

### 4. Then merge

The migration finds all 23 present and valid and skips through them. The one remaining statement is
the `ix_linked_records_type_timestamp` drop, which is gated on its replacement being valid — so if
step 2 was skipped or incomplete, it keeps the old index rather than leaving that read path with
neither.


## Verification

- Full migration history applied to a clean PostgreSQL 17 database: 20 `*_tenant_source_timestamp` indexes present (18 new plus the 2 that already existed on `heart_rates` and `step_counts`, no name collisions), `ix_linked_records_type_timestamp` gone, 0 invalid indexes.
- `dotnet ef migrations has-pending-model-changes` — clean.
- `Down` rolls the schema back to a byte-equal index count.

## Write cost

`linked_records` takes 72.6M updates with `n_tup_hot_upd = 0`, so every update writes to every index on the table and two more indexes is a real cost. It is not close, though: the two queries they serve are ~34% of total database time against an added write cost on the order of a few hundred seconds across the same window. The `ix_linked_records_type_timestamp` drop also gives one back, so the index count on that table is unchanged.

---

# fix(data): drop the duplicated tenant foreign keys and the unreadable indexes



## 1. Every tenant-scoped table older than April carries its cascade foreign key twice

39 of the 79 tables with a foreign key to `tenants` have two of them, byte-identical:

```
fk_sensor_glucose_tenant_id          | FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
FK_sensor_glucose_tenants_tenant_id  | FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
```

Postgres validates each independently, so every write takes two `KEY SHARE` locks on the same row of a 71-row table. `SELECT 1 FROM ONLY tenants x WHERE id = $1 FOR KEY SHARE` shows **56,243,052 calls** over 52 days, about half redundant.

### How it happened

- `20260227034745_EnforceMultitenancy` looped `TenantScopedTables` calling `AddForeignKey(name: $"fk_{table}_tenant_id", …)` alongside enabling RLS.
- `20260415045216_AddTenantCascadeDeletes` then added EF's conventional `FK_<table>_tenants_tenant_id` to every `ITenantScoped` entity, guarded by `IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '<the uppercase name>')`.

The guard only looked for its own name, so the 39 tables that already had the snake_case one got a second. The 40 created afterwards only ever got one.

### This is not an EF model bug

`ConfigureTenantCascadeDeletes` produces only the conventional name, and the snake_case constraints appear nowhere in the model or the snapshot — EF has never known they exist, which is why no migration has ever offered to remove them. Dropping them is permanent; nothing regenerates them.

Verified rather than assumed: a fresh database built from the full migration history reproduces production exactly — 40 tables with one FK, 39 with two.

### The drop

Matched on shape, not name, and only where an equivalent constraint survives, so no table can lose its cascade. Name matching would have missed `devices`, which still carries `fk_pump_devices_tenant_id` from before it was renamed from `pump_devices`.

**Each table is its own statement and therefore its own transaction**, under a 3 s `lock_timeout`. Dropping a constraint takes `ACCESS EXCLUSIVE`, and holding 39 of those to a single commit — on `sensor_glucose`, `linked_records`, `boluses` and the rest — is an unbounded platform-wide stall the moment one `ALTER TABLE` queues behind an in-flight statement. A table whose lock does not arrive is skipped with a `RAISE NOTICE` rather than failing: migrations run at API startup, so raising would crash-loop the API over a redundancy that is harmless to keep until the next deploy.

After: all 79 tables have exactly one FK, all `ON DELETE CASCADE`, all validated.

## 2. Three indexes with no caller

| Index | Size | Why |
|---|---:|---|
| `ix_mutation_audit_log_correlation` | 47 MB | Indexes `TraceId`. Nothing in the codebase filters on it — write-only diagnostic data. |
| `ix_read_access_log_correlation` | 3.2 MB | Same column, same story, sibling table. |
| `ix_temp_basals_end_timestamp` | 53 MB | Every read mentioning `end_timestamp` also bounds `start_timestamp` and enters on `ix_temp_basals_tenant_start_timestamp`. |

All three are `idx_scan = 0` **and** `idx_tup_read = 0`. That pairing matters — see below.

## What I refused to drop, and why the usual metric lies

This is the part worth reading. Three separate ways `idx_scan` misleads on this database, each of which nearly cost a real index:

**A unique index reports zero however busy it is.** Constraint enforcement does not increment `idx_scan`. Proof from this same database: `PK_device_status_extras`, `PK_read_access_log` and `PK_auth_audit_log` all report `idx_scan = 0` while being inserted into constantly. So `ix_sensor_glucose_tenant_source_sync_id` (UNIQUE, 56 MB, 0 scans) is not idle — it covers 411,795 live rows and enforces the connector dedup invariant. Dropping it is a correctness change that silently admits duplicate `sync_identifier` rows.

This also contaminates the headline number. Of the "150 unused indexes, 250 MB" the audit started from, **58 are unique or primary keys (64 MB) and are evidence of nothing.**

**A low scan count can hide enormous work.** `ix_mutation_audit_log_entity` shows 8 scans — and 20,325,055 tuples read, 2.5M per scan, as a bitmap filter ahead of the heap. Losing it takes the largest audit tenant from 0.112 ms to 1,831.8 ms. `idx_tup_read`, not `idx_scan`, is the metric that finds these.

**A low scan count can mean the caller is broken rather than absent.** `ix_mutation_audit_log_created` (209 MB, 159 scans) looks marginal only because `AuditRetentionService` has never successfully deleted a row — its RLS pin was reset between EF commands, so the DELETE compared `tenant_id` against NULL and matched nothing. Once that is fixed the daily per-tenant purge enters on exactly this index.

Also kept:

- **`ix_aps_snapshots_correlation_id`** (62 MB, 0 scans) — `DeviceStatusProjectionService:205` is live code behind an `aps == null` guard, reachable for a tenant uploading pump data with no APS payload. Cold, not dead.
- **The `*_device_id` / `*_patient_device_id` cluster** — every one of those FKs is `ON DELETE SET NULL`, so a device delete without the index is a sequential scan of a multi-million-row table. Their 29–51 scans *are* those referential actions.

## Verification

- Full history on a clean database: 79/79 tables with exactly one cascade FK, all validated, 0 invalid indexes, the three indexes gone.
- `Down` restores the 40/39 split exactly, with all 39 restored **`NOT VALID`** — the rows were already checked by the constraint that never went away, and revalidating 39 tables would be a second outage rather than a rollback.
- `has-pending-model-changes` clean in both directions.
