### PR TITLE
fix(api): require treatments.readwrite on the v4 activity write actions

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/ActivityController.cs
@@ -19,9 +19,15 @@ namespace Nocturne.API.Controllers.V4.Health;
 /// </summary>
 /// <remarks>
 /// This endpoint merges several data categories: writes are routed by record content to the
-/// heart-rate, step-count, sleep, or state-span tables. Because the destination varies per record,
-/// the category write scope is enforced per record via <see cref="ActivityWriteScopeGuard"/> rather
-/// than a single <c>RequireScope</c> attribute.
+/// heart-rate, step-count, sleep, or state-span tables. Writes are gated in two layers — a baseline
+/// <c>RequireScope</c> admits the caller, and the destination's own category scope is then enforced
+/// per record via <see cref="ActivityWriteScopeGuard"/>, because the destination is not known until
+/// the body has been read.
+/// <para>
+/// The baseline is <c>treatments.readwrite</c>, the category a StateSpan-backed activity reads
+/// under: <see cref="IActivityDecomposer.RequiredWriteScope"/> is null for those records, so the
+/// per-record guard alone gates nothing for them.
+/// </para>
 /// </remarks>
 [ApiController]
 [Tags("Health")]
@@ -121,6 +127,7 @@ public class ActivityController : ControllerBase
     /// Create one or more activity records
     /// </summary>
     [HttpPost]
+    [RequireScope(Scope.TreatmentsReadWrite)]
     [ProducesResponseType(typeof(IEnumerable<Activity>), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<Activity>>> CreateActivities(
@@ -145,6 +152,7 @@ public class ActivityController : ControllerBase
     /// Update an existing activity record
     /// </summary>
     [HttpPut("{id}")]
+    [RequireScope(Scope.TreatmentsReadWrite)]
     [ProducesResponseType(typeof(Activity), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<Activity>> UpdateActivity(
@@ -177,6 +185,7 @@ public class ActivityController : ControllerBase
     /// Delete an activity record by ID
     /// </summary>
     [HttpDelete("{id}")]
+    [RequireScope(Scope.TreatmentsReadWrite)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteActivity(

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ActivityControllerScopeTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ActivityControllerScopeTests.cs
@@ -20,9 +20,9 @@ namespace Nocturne.API.Tests.Authorization;
 /// Asserts that <c>ActivityController</c> actually calls
 /// <see cref="Nocturne.API.Authorization.ActivityWriteScopeGuard"/> and
 /// <see cref="Nocturne.API.Authorization.ActivityReadScopeGuard"/>. The guard suites exercise those
-/// functions in isolation, so removing a call from a handler would leave them and the attribute
-/// sweep in <see cref="V4WriteScopeGatingTests"/> green while the endpoint became ungated — the
-/// activity endpoints are exempted from the sweep precisely because their gate is a method call.
+/// functions in isolation, so removing a call from a handler would leave them green and the
+/// attribute sweep in <see cref="V4WriteScopeGatingTests"/> satisfied by the write actions' baseline
+/// <c>treatments.readwrite</c> alone, while the per-record category gate was gone.
 /// </summary>
 public class ActivityControllerScopeTests
 {

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -118,9 +118,10 @@ public class V4WriteScopeGatingTests
         /// <summary>
         /// The required scope depends on the record being written, so no attribute scan can see it.
         /// The controller calls a per-record guard in the handler instead. Every action filed under
-        /// this reason must be covered by a route-level test that drives the real gate, so the
-        /// exemption is asserted rather than trusted — see
-        /// <see cref="PerRecordGuardedActions_AreCoveredByARouteLevelTest"/>.
+        /// this reason must be covered by a test that drives the real gate, so the exemption is
+        /// asserted rather than trusted — see
+        /// <see cref="PerRecordGuardedActions_HaveABehaviouralTest"/>, which requires that of every
+        /// action calling a per-record guard, exempt or not.
         /// </summary>
         public const string PerRecordGuard = "per-record scope enforced in the handler";
 
@@ -244,14 +245,6 @@ public class V4WriteScopeGatingTests
     private static readonly IReadOnlyDictionary<string, string> GateExemptWriteActions =
         new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            // A single activity payload decomposes into a different data category per record, so the
-            // required scope is not known until the handler has read the body. ActivityController
-            // calls ActivityWriteScopeGuard.FindMissingScope per record instead, which no attribute
-            // scan can see.
-            ["ActivityController.CreateActivities"] = NotDataCategory.PerRecordGuard,
-            ["ActivityController.UpdateActivity"] = NotDataCategory.PerRecordGuard,
-            ["ActivityController.DeleteActivity"] = NotDataCategory.PerRecordGuard,
-
             // state_spans holds four data categories behind one table and the caller picks which by
             // setting Category in the body, so StateSpanWriteScopeGuard resolves the scope per
             // record. A flat controller scope under-gated three of the four — notably DataExclusion,
@@ -367,6 +360,11 @@ public class V4WriteScopeGatingTests
 
             // Controllers that gate with a per-action [RequireScope] rather than a declaration. Their
             // categories are their own dedicated tables.
+            // treatments: the baseline admitting an activity write, underneath the per-record
+            // ActivityWriteScopeGuard that gates the record's own category. The rationale for the
+            // category is on ActivityController itself.
+            ["ActivityController"] = Scope.TreatmentsReadWrite,
+
             ["SleepController"] = Scope.SleepReadWrite,
             ["HeartRateController"] = Scope.HeartRateReadWrite,
             ["StepCountController"] = Scope.StepCountReadWrite,
@@ -596,11 +594,18 @@ public class V4WriteScopeGatingTests
     }
 
     /// <summary>
-    /// The per-record exemptions are the one reason whose mechanism is a method call in the handler,
-    /// which no attribute scan can see — delete the call and the sweep stays green. So each one must
-    /// be covered by a test that drives the real handler. That coverage is listed here rather than
-    /// discovered, so adding a per-record exemption without adding a behavioural test fails.
+    /// A per-record gate is a method call in the handler, which no attribute scan can see — delete
+    /// the call and every sweep here stays green. So each action making one must be covered by a
+    /// test that drives the real handler. The requirement holds whether or not the action also
+    /// carries a baseline scope attribute: a baseline narrows what a caller can reach, it does not
+    /// substitute for the record's own category.
     /// </summary>
+    /// <remarks>
+    /// The population is discovered from the call itself rather than from
+    /// <see cref="GateExemptWriteActions"/>, so an action that gains a baseline attribute — and with
+    /// it an exit from the exemption list — keeps its coverage requirement. The coverage side stays
+    /// listed, so adding a per-record gate without a behavioural test fails.
+    /// </remarks>
     [Fact]
     public void PerRecordGuardedActions_HaveABehaviouralTest()
     {
@@ -610,18 +615,73 @@ public class V4WriteScopeGatingTests
             "StateSpansController.CreateStateSpan",
             "StateSpansController.UpdateStateSpan",
             "StateSpansController.DeleteStateSpan",
-            // ActivityWriteScopeGuardTests covers the guard; the handler wiring is asserted by
-            // ActivityControllerScopeTests.
+            // ActivityControllerV4Tests drives all three through the real handler.
             "ActivityController.CreateActivities",
             "ActivityController.UpdateActivity",
             "ActivityController.DeleteActivity",
         };
 
-        GateExemptWriteActions
-            .Where(entry => entry.Value == NotDataCategory.PerRecordGuard)
-            .Select(entry => entry.Key)
-            .Should().BeEquivalentTo(covered,
-                "every per-record-guarded action needs a test that drives its handler");
+        var guarded = V4Controllers()
+            .SelectMany(c => WriteActions(c)
+                .Where(CallsAPerRecordGuard)
+                .Select(a => $"{c.Name}.{a.Name}"))
+            .ToList();
+
+        guarded.Should().NotBeEmpty(
+            "the scan must find the per-record guard calls, or this test passes vacuously");
+
+        guarded.Should().BeEquivalentTo(covered,
+            "every per-record-guarded action needs a test that drives its handler");
+    }
+
+    /// <summary>
+    /// Whether the action's body calls a <c>*WriteScopeGuard.FindMissingScope</c>. Read from the
+    /// compiled IL because the call is the gate: a source-text or attribute check would not notice
+    /// the call being deleted, which is the failure this exists to catch.
+    /// </summary>
+    private static bool CallsAPerRecordGuard(MethodInfo action)
+    {
+        // An async action's body is the compiler-generated MoveNext; the action method itself only
+        // starts the state machine, so the call is not in its IL.
+        var body = action.GetCustomAttribute<AsyncStateMachineAttribute>() is { } asyncMachine
+            ? asyncMachine.StateMachineType.GetMethod(
+                "MoveNext", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            : action;
+
+        var il = body?.GetMethodBody()?.GetILAsByteArray();
+        if (body is null || il is null)
+            return false;
+
+        const byte Call = 0x28;
+        const byte Callvirt = 0x6F;
+
+        // Every offset is probed rather than the instruction stream decoded: an operand byte that
+        // happens to look like a call yields a token that either fails to resolve or resolves to
+        // some unrelated member, and only the name match below counts.
+        for (var i = 0; i + 4 < il.Length; i++)
+        {
+            if (il[i] != Call && il[i] != Callvirt)
+                continue;
+
+            MethodBase? callee;
+            try
+            {
+                callee = body.Module.ResolveMethod(
+                    BitConverter.ToInt32(il, i + 1),
+                    body.DeclaringType?.GetGenericArguments(),
+                    body.IsGenericMethodDefinition ? body.GetGenericArguments() : null);
+            }
+            catch (ArgumentException)
+            {
+                continue;
+            }
+
+            if (callee?.Name == "FindMissingScope"
+                && callee.DeclaringType?.Name.EndsWith("WriteScopeGuard", StringComparison.Ordinal) == true)
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/ActivityControllerV4Tests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/ActivityControllerV4Tests.cs
@@ -107,6 +107,32 @@ public class ActivityControllerV4Tests
             Times.Never);
     }
 
+    /// <summary>
+    /// The payload here is a regular activity, which needs no category scope of its own — only the
+    /// record being edited is a sleep session, so the gate has to look at both.
+    /// </summary>
+    [Fact]
+    public async Task UpdateActivity_ExistingRecordIsSleep_WithoutSleepScope_ReturnsForbidden()
+    {
+        const string id = "sleep-session-1";
+        GrantScopes(Scope.TreatmentsReadWrite);
+        _service.Setup(x => x.GetActivityByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Activity { Id = id, Type = "sleep" });
+        _decomposer.Setup(d => d.RequiredWriteScope(It.Is<Activity>(a => a.Type == "sleep")))
+            .Returns(Scope.SleepReadWrite);
+
+        var result = await _controller.UpdateActivity(
+            id,
+            new UpsertActivityRequest { Type = "exercise", Mills = 1700000000000 },
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<ObjectResult>()
+            .Which.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        _service.Verify(
+            x => x.UpdateActivityAsync(It.IsAny<string>(), It.IsAny<Activity>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     [Fact]
     public async Task DeleteActivity_ExistingRecordIsSleep_WithoutSleepScope_ReturnsForbidden()
     {


### PR DESCRIPTION
The v4 `ActivityController` carried only a class-level `[Authorize]` on POST, PUT and DELETE. The per-record `ActivityWriteScopeGuard` gates each record by the write scope of the storage it routes to, but `IActivityDecomposer.RequiredWriteScope` returns null for a regular (StateSpan-backed) activity, so that guard neither covered nor was meant to cover them. There was no floor underneath it.

This adds `[RequireScope(Scope.TreatmentsReadWrite)]` to the three write actions, underneath the existing per-record guard. `treatments.readwrite` is the scope the v1 activity writes require and the category a StateSpan-backed activity reads under. DELETE takes the same scope rather than v1's `FullAccess`: no v4 delete requires full access, and every other one requires its own category's readwrite scope, including `StateSpansController`, which deletes the very same rows.

**Behavioural change.** Credentials that could previously create, update and delete regular activities (exercise, illness, travel) through `/api/v4/activity` and no longer can:

- the **Viewer** and **Clinician** seed roles, and any custom role without `treatments.readwrite`;
- **guest links**, which are issued read-only scopes but are authenticated sessions;
- **followers** and any other read-scoped credential.

Unaffected: **Owner** and a legacy `api-secret` (both normalise to `*`), **Admin** and **Caretaker** (both hold `treatments.readwrite`).

**Second narrowing.** The attribute admits the request, not the record, so a credential holding only a category write scope also loses this merged endpoint: an OAuth or `noc_` grant with `sleep.readwrite`, `heartrate.readwrite` or `stepcount.readwrite` but not `treatments.readwrite`, and legacy `api:activity:*` tokens (which `ScopeTranslator` maps to those three and nothing else). They keep `/api/v4/sleep`, `/api/v4/heartrate` and `/api/v4/stepcount`, which require only their own category, or can be granted `treatments.readwrite`. A per-record baseline would avoid this, but it would be a handler-level gate again, invisible to the attribute sweep and back to the probe below. No in-repo caller writes to `/api/v4/activity`; the only external reference is a GET in the NocturneRemote connector.

`RequireScopeAttribute` is an `IAuthorizationFilter`, which MVC runs before model binding, so the 403 now precedes the id lookup in `DeleteActivity`. An unscoped caller can no longer distinguish a real id from a missing one by its 404.

On the test side, the three actions leave `GateExemptWriteActions` and pick up the generic per-action gate assertions. Leaving that list would also have removed them from the meta-test that requires a behavioural test behind every per-record guard, while the hazard it exists for (deleting the guard call leaves every attribute sweep green) was unchanged. The meta-test now discovers its population from the compiled IL of each write action, so it covers a per-record guard whether or not the action also carries a baseline attribute, and fails when the scan finds nothing rather than passing vacuously. Verified by mutation: deleting the `FindMissingScope` call from `DeleteActivity` reddens it here and does not on `main`.

That meta-test also listed `UpdateActivity` as behaviourally covered when nothing drove its handler, so the missing case is added: editing an existing sleep session with a regular-activity payload must be rejected, which needs the existing record's category and not just the payload's.

`tests/Unit/Nocturne.API.Tests`: 6426 passed, 0 failed, 5 skipped.

Fixes #992.

https://claude.ai/code/session_015rBvU3xLf4L35RjjUBeJmJ
