### PR TITLE
fix(deploy): probe the demo pod on a path that is served

### DIFF
--- a/deploy/helm/nocturne/templates/demo-deployment.yaml
+++ b/deploy/helm/nocturne/templates/demo-deployment.yaml
@@ -65,7 +65,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /ready
+              path: /health
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/src/Services/Nocturne.Services.Demo/Program.cs
+++ b/src/Services/Nocturne.Services.Demo/Program.cs
@@ -78,11 +78,10 @@ public class Program
         builder.Services.AddSingleton<DemoServiceHealthCheck>();
         builder
             .Services.AddHealthChecks()
-            .AddCheck<DemoServiceHealthCheck>("demo-service", tags: ["live", "ready"]);
+            .AddCheck<DemoServiceHealthCheck>("demo-service", tags: ["live"]);
 
         var app = builder.Build();
 
-        // Map default health check endpoints (includes /health, /alive, /ready)
         app.MapDefaultEndpoints();
 
         // Map lifecycle endpoints

--- a/tests/Unit/Nocturne.Aspire.ServiceDefaults.Tests/Deployment/HelmProbePathCoverageTests.cs
+++ b/tests/Unit/Nocturne.Aspire.ServiceDefaults.Tests/Deployment/HelmProbePathCoverageTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Nocturne.Aspire.ServiceDefaults.Tests.Deployment;
+
+/// <summary>
+/// Every <c>httpGet</c> path in the Helm chart must name a route the service actually serves.
+/// A probe on an unserved path never succeeds: the pod stays NotReady and the Deployment never
+/// becomes Available, so a rollout wait never converges even though the chart installed cleanly.
+/// </summary>
+public class HelmProbePathCoverageTests
+{
+    private static readonly IReadOnlyList<string> MappedPaths = MapDefaultEndpointPaths();
+
+    private static readonly IReadOnlyList<(string File, int Line, string Path)> ProbePaths =
+        ReadHttpGetPaths();
+
+    [Fact]
+    public void EveryChartProbePathIsMappedByServiceDefaults()
+    {
+        var unserved = ProbePaths
+            .Where(probe => !MappedPaths.Contains(probe.Path, StringComparer.OrdinalIgnoreCase))
+            .Select(probe => $"{probe.File}:{probe.Line} {probe.Path}")
+            .OrderBy(d => d, StringComparer.Ordinal)
+            .ToList();
+
+        unserved.Should().BeEmpty(
+            "a probe on a path nothing answers can only ever fail, so the pod it guards never "
+            + "becomes Ready. Mapped: " + string.Join(", ", MappedPaths) + ". Unserved:\n  "
+            + string.Join("\n  ", unserved));
+    }
+
+    /// <summary>
+    /// Non-vacuity: both halves of the comparison are derived, so either returning nothing would
+    /// pass the guard above while proving nothing.
+    /// </summary>
+    [Fact]
+    public void BothSidesOfTheComparisonAreDiscovered()
+    {
+        MappedPaths.Should().BeEquivalentTo(["/health", "/alive"],
+            "the probe paths are checked against what MapDefaultEndpoints maps, so a change there "
+            + "is a chart change too");
+
+        ProbePaths.Select(p => p.Path).Should().Contain("/alive",
+            "the API and demo deployments both probe liveness over HTTP, so finding no such path "
+            + "means the template scan has stopped working");
+    }
+
+    private static IReadOnlyList<string> MapDefaultEndpointPaths()
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.AddDefaultHealthChecks();
+        var app = builder.Build();
+        app.MapDefaultEndpoints();
+
+        return ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(source => source.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(endpoint => "/" + endpoint.RoutePattern.RawText!.TrimStart('/'))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static IReadOnlyList<(string File, int Line, string Path)> ReadHttpGetPaths()
+    {
+        var found = new List<(string, int, string)>();
+
+        foreach (var file in Directory.EnumerateFiles(TemplateDirectory(), "*.y*ml", SearchOption.AllDirectories))
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].Trim() != "httpGet:")
+                {
+                    continue;
+                }
+
+                var indent = IndentOf(lines[i]);
+                for (var j = i + 1; j < lines.Length && IndentOf(lines[j]) > indent; j++)
+                {
+                    var key = lines[j].Trim();
+                    if (key.StartsWith("path:", StringComparison.Ordinal))
+                    {
+                        found.Add((
+                            Path.GetFileName(file),
+                            j + 1,
+                            key["path:".Length..].Trim().Trim('"', '\'')));
+                    }
+                }
+            }
+        }
+
+        return found;
+    }
+
+    private static int IndentOf(string line) =>
+        line.Trim().Length == 0 ? int.MaxValue : line.Length - line.TrimStart().Length;
+
+    private static string TemplateDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "nocturne.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        return Path.Combine(
+            dir?.FullName ?? throw new InvalidOperationException(
+                "Could not locate the repo root (nocturne.sln) above " + AppContext.BaseDirectory),
+            "deploy", "helm", "nocturne", "templates");
+    }
+}


### PR DESCRIPTION
`MapDefaultEndpoints` maps `/health` and `/alive`, and has never mapped `/ready`. The Helm chart's demo deployment set its readiness probe to `/ready`, so the probe 404'd every 10 seconds, the pod never became Ready, the Deployment never reported Available, and a rollout wait never converged. No Service selects the demo pod, so demo data generation itself was unaffected. `helm install` still succeeded, which is why this went unnoticed.

The probe now matches what the API deployment already does: `/alive` for liveness, `/health` for readiness. Mapping a new `/ready` endpoint in ServiceDefaults was the other way to close this; nothing else in the repo asks for one, so pointing the probe at the existing endpoint is the smaller change. **Behavioural change to the chart:** demo pods that previously never became Ready now do.

Two other statements of the same non-existent endpoint go with it: a comment above the demo service's `MapDefaultEndpoints` call asserting that `/ready` is among the mapped paths, and a `"ready"` health-check tag that no predicate reads. Removing the tag changes nothing at runtime: `/alive` filters on `"live"`, which is kept, and `/health` applies no predicate.

To stop the chart drifting from the served surface again, `HelmProbePathCoverageTests` compares every `httpGet` path in the chart templates against the routes `MapDefaultEndpoints` actually maps. Both sides are discovered rather than listed (the mapped set is read off the endpoint data source of a built `WebApplication`; the probe paths are scanned out of the templates, including `startupProbe` and quoted values), and a second test pins that neither side can silently return nothing. Same guard shape as #971 added for the tenantless allow-list.

The issue also named a `path == "/ready"` entry in `SiteSecurityMiddleware`'s bypass list. That file no longer exists (removed with site lockdown in #1034), so there is no second list to guard.

Closes #974.

https://claude.ai/code/session_015rBvU3xLf4L35RjjUBeJmJ
