### PR TITLE
fix(setup): hide the demo tenant and its visitor from first-run setup

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -147,7 +147,7 @@ public partial class SetupController : ControllerBase
 
         await using var context = await _dbFactory.CreateDbContextAsync(ct);
 
-        var tenant = await context.Tenants.AsNoTracking().FirstOrDefaultAsync(ct);
+        var tenant = await context.Tenants.AsNoTracking().ExcludeDemo().FirstOrDefaultAsync(ct);
         if (tenant == null)
             return Ok(new SlugValidationResult(false, "No tenant exists"));
 
@@ -465,11 +465,17 @@ public partial class SetupController : ControllerBase
     /// Returns the sole tenant if exactly one exists and it has no non-system members,
     /// or an error result if the preconditions are not met.
     /// </summary>
+    /// <remarks>
+    /// A demo tenant never trips the credentialed-member arm (<see cref="DemoExclusionFilter"/>),
+    /// so a demo-only instance answers <c>no_tenant_exists</c>, from which a tenant can still be
+    /// created, rather than <c>setup_already_complete</c>, which would strand the operator on a
+    /// tenant nobody can adopt.
+    /// </remarks>
     private async Task<(TenantEntity? Tenant, IActionResult? Error)> GetSoleTenantWithoutOwnerAsync(CancellationToken ct)
     {
         await using var context = await _dbFactory.CreateDbContextAsync(ct);
 
-        var tenants = await context.Tenants.Take(2).ToListAsync(ct);
+        var tenants = await context.Tenants.ExcludeDemo().Take(2).ToListAsync(ct);
 
         if (tenants.Count == 0)
             return (null, Conflict(new { error = "no_tenant_exists" }));
@@ -491,12 +497,17 @@ public partial class SetupController : ControllerBase
     }
 
     /// <summary>
-    /// The first-run owner subject: the earliest non-system active subject. Setup only runs while
-    /// no member of the tenant holds credentials, so this is the account the owner options step
-    /// created or reused. Ordered so the options and complete steps resolve the same row.
+    /// The first-run owner subject: the earliest active subject that is neither a system subject
+    /// nor the demo visitor (<see cref="DemoExclusionFilter"/>). Setup only runs while no member
+    /// of the tenant holds credentials, so this is the account the owner options step created or
+    /// reused. Ordered so the options and complete steps resolve the same row.
     /// </summary>
+    /// <remarks>
+    /// <c>subjects</c> is not tenant-scoped, so this sees every subject on the instance — the
+    /// demo visitor included, and it is older than the operator's.
+    /// </remarks>
     private static IQueryable<SubjectEntity> SetupOwnerSubjects(NocturneDbContext context) =>
-        context.Subjects.Where(s => !s.IsSystemSubject && s.IsActive).OrderBy(s => s.Id);
+        context.Subjects.ExcludeDemo().Where(s => !s.IsSystemSubject && s.IsActive).OrderBy(s => s.Id);
 
     /// <summary>
     /// Returns the first-run owner subject's id as resolved from the database, or

--- a/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
@@ -145,6 +145,10 @@ public class PlatformAdminBootstrapService
     /// shouldn't depend on every present and future call site having checked setup state
     /// first, and the setup OIDC callback in particular is reachable anonymously.
     /// </para>
+    /// <para>
+    /// Single-tenant is counted the way setup counts it (<see cref="DemoExclusionFilter"/>): an
+    /// instance serving a demo alongside the operator's one tenant is still a fresh install.
+    /// </para>
     /// </remarks>
     /// <param name="subjectId">The owner subject that just bound a credential.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -161,7 +165,7 @@ public class PlatformAdminBootstrapService
             return false;
 
         // More than one tenant means this is not a fresh install, whatever the caller thinks.
-        var tenantIds = await db.Tenants.Select(t => t.Id).Take(2).ToListAsync(cancellationToken);
+        var tenantIds = await db.Tenants.ExcludeDemo().Select(t => t.Id).Take(2).ToListAsync(cancellationToken);
         if (tenantIds.Count != 1)
             return false;
 

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DemoExclusionFilter.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DemoExclusionFilter.cs
@@ -1,0 +1,24 @@
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// The one predicate for "the rows that belong to a real operator rather than the demo".
+/// </summary>
+/// <remarks>
+/// First-run setup and the platform-admin grant that follows it decide what to do from counts and
+/// orderings over tenants and subjects. The demo contributes one of each, and neither can ever
+/// become an operator's: a demo tenant has no owner to adopt it, and a demo subject is one anyone
+/// can obtain a session for. Left in, the demo tenant reads as a tenant awaiting its first owner
+/// and the demo subject reads as the account that owner is enrolling.
+/// </remarks>
+public static class DemoExclusionFilter
+{
+    /// <summary>Drops the demo tenant.</summary>
+    public static IQueryable<TenantEntity> ExcludeDemo(this IQueryable<TenantEntity> tenants) =>
+        tenants.Where(t => !t.IsDemo);
+
+    /// <summary>Drops the demo visitor.</summary>
+    public static IQueryable<SubjectEntity> ExcludeDemo(this IQueryable<SubjectEntity> subjects) =>
+        subjects.Where(s => !s.IsDemoSubject);
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SetupControllerTests.cs
@@ -12,6 +12,7 @@ using Moq;
 using Nocturne.API.Configuration;
 using Nocturne.API.Controllers.V4;
 using Nocturne.API.Services.Auth;
+using Nocturne.API.Services.Demo;
 using Nocturne.API.Services.Identity;
 using Nocturne.API.Tests.Services.Connectors;
 using Nocturne.Core.Contracts.Auth;
@@ -471,6 +472,60 @@ public class SetupControllerTests : IDisposable
         conflict.Value.Should().BeEquivalentTo(new { error = "owner_already_exists" });
     }
 
+    [Fact]
+    public async Task OwnerOptions_WhenTheOnlyTenantIsTheDemoTenant_Returns409NoTenantExists()
+    {
+        // An operator who deletes every real tenant leaves one tenant whose member holds no
+        // credential — which must not read as a tenant awaiting its first owner.
+        await SeedDemoTenantAsync();
+
+        var result = await _controller.OwnerOptions(
+            new SetupOwnerOptionsRequest { Username = "someone", DisplayName = "Someone" },
+            CancellationToken.None);
+
+        var conflict = result.Should().BeOfType<ConflictObjectResult>().Subject;
+        conflict.Value.Should().BeEquivalentTo(new { error = "no_tenant_exists" });
+        _passkeyService.Verify(
+            s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OwnerOptions_WhenADemoTenantAccompaniesTheOwnerlessTenant_EnrolsANewSubject()
+    {
+        // A stock install provisions the demo at boot, so the operator's first-run setup runs
+        // with the demo visitor already the oldest non-system subject on the instance. Enrolling
+        // it would hand the operator's tenant to an account anyone can mint a session for.
+        var demoSubjectId = await SeedDemoTenantAsync();
+        var tenantId = Guid.CreateVersion7();
+        _dbContext.Set<TenantEntity>().Add(new TenantEntity
+        {
+            Id = tenantId, Slug = "my-instance", DisplayName = "My Instance",
+        });
+        await _dbContext.SaveChangesAsync();
+
+        Guid enrolling = default;
+        _passkeyService
+            .Setup(s => s.GenerateRegistrationOptionsAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Callback((Guid subjectId, string _) => enrolling = subjectId)
+            .ReturnsAsync(new PasskeyRegistrationOptions("{}", "challenge-token"));
+
+        var result = await _controller.OwnerOptions(
+            new SetupOwnerOptionsRequest { Username = "owner", DisplayName = "Owner" },
+            CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeOfType<SetupOwnerOptionsResponse>().Subject.TenantId.Should().Be(tenantId);
+        enrolling.Should().NotBe(demoSubjectId).And.NotBe(default(Guid));
+
+        var context = FreshContext();
+        var demoSubject = await context.Subjects.SingleAsync(s => s.Id == demoSubjectId);
+        demoSubject.Name.Should().Be(DemoTenantService.DemoMemberName);
+        demoSubject.Username.Should().BeNull();
+        (await context.TenantMembers
+            .AnyAsync(m => m.TenantId == tenantId && m.SubjectId == demoSubjectId))
+            .Should().BeFalse();
+    }
+
     // SoftLock_TenantWithOnlySystemMembers_OwnerOptionsSucceeds is an integration test — it
     // asserts what the tenant pin makes reachable, which needs real policies.
 
@@ -515,6 +570,21 @@ public class SetupControllerTests : IDisposable
         var validation = ok.Value.Should().BeOfType<SlugValidationResult>().Subject;
         validation.IsValid.Should().BeFalse();
         validation.Message.Should().Contain("reserved");
+    }
+
+    [Fact]
+    public async Task ValidateUsername_WhenTheOnlyTenantIsTheDemoTenant_ReportsNoTenant()
+    {
+        // Setup is anonymous while no credential exists anywhere, so answering off the demo
+        // tenant would make its member names probeable.
+        await SeedDemoTenantAsync();
+
+        var result = await _controller.ValidateUsername("demo", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var validation = ok.Value.Should().BeOfType<SlugValidationResult>().Subject;
+        validation.IsValid.Should().BeFalse();
+        validation.Message.Should().Contain("No tenant exists");
     }
 
     [Fact]
@@ -734,6 +804,23 @@ public class SetupControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task OwnerComplete_WhenADemoTenantAccompaniesTheSoleTenant_StillGrantsPlatformAdmin()
+    {
+        // The grant re-derives single-tenant-ness for itself, so it has to count tenants the way
+        // the guard that admitted this setup does — or a stock install's owner completes setup
+        // and still cannot reach the admin UI.
+        await SeedDemoTenantAsync();
+        var (_, subjectId) = await SeedSoleTenantWithOwnerRoleAsync();
+        StubPasskeyCompletion(subjectId);
+
+        var result = await CompleteOwnerSetupAsync();
+
+        result.Should().BeOfType<OkObjectResult>();
+        var subject = await FreshContext().Subjects.SingleAsync(s => s.Id == subjectId);
+        subject.IsPlatformAdmin.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task OwnerOptions_BeforeCeremonyCompletes_DoesNotGrantPlatformAdmin()
     {
         // An abandoned WebAuthn ceremony must not leave a credential-less subject holding
@@ -924,6 +1011,39 @@ public class SetupControllerTests : IDisposable
             IsPlatformAdmin = true,
         });
         await _dbContext.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Seeds the demo tenant in the shape <see cref="DemoTenantService.ConfigureAccessAsync"/>
+    /// leaves it: the visitor subject carries no global username and no credential, and the
+    /// membership carries the <c>demo</c> username. Returns the visitor subject's id.
+    /// </summary>
+    /// <remarks>
+    /// Seeded first in every test that uses it, so its UUIDv7 subject id sorts ahead of the
+    /// operator's — which is the ordering that makes it the first-run owner candidate.
+    /// </remarks>
+    private async Task<Guid> SeedDemoTenantAsync()
+    {
+        var tenantId = Guid.CreateVersion7();
+        var subjectId = Guid.CreateVersion7();
+
+        _dbContext.Set<TenantEntity>().Add(new TenantEntity
+        {
+            Id = tenantId, Slug = "demo", DisplayName = "Demo", IsDemo = true,
+        });
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId, Name = DemoTenantService.DemoMemberName,
+            IsActive = true, IsSystemSubject = false, IsDemoSubject = true,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(), TenantId = tenantId, SubjectId = subjectId,
+            Username = DemoTenantService.DemoMemberUsername,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        return subjectId;
     }
 
     /// <summary>


### PR DESCRIPTION
The anonymous first-run setup endpoints refuse once the instance is established, and that refusal has two arms: more than one tenant exists, or the sole tenant holds a member with a passkey or a linked OIDC identity. The demo satisfies neither on its own. Its visitor signs in by demo session and holds no credential, which `TenantSetupMiddleware` already states as deliberate. What has kept the flow closed is only that provisioning a demo requires `platform_admin`, so an instance serving a demo has always had a real tenant beside it and trips the first arm. That is an operational convention rather than something the code enforces: an operator who deletes every real tenant leaves the demo as a sole ownerless tenant, and an anonymous visitor can then run the first-owner flow against it and reach `GrantFirstOwnerPlatformAdminAsync` (via `POST /api/v4/setup/owner/complete` or `GET /api/v4/setup/oidc/callback`).

Setup looks at two things, and the demo has to be invisible in both.

**Tenants**, because a demo tenant cannot be adopted. `GetSoleTenantWithoutOwnerAsync` now excludes it, so a demo-only instance answers `no_tenant_exists`. That response, and not `setup_already_complete`, is the right one: the instance genuinely has no tenant anybody can adopt, and a tenant can still be created from that state (tenant creation is gated separately on whether any credentialed account exists anywhere, which on a demo-only instance is correctly "no"). `setup_already_complete` would assert an owner exists when none does, and would strand the operator on a tenant nobody can ever own.

**Subjects**, because `subjects` is not tenant-scoped. The demo visitor is created at boot with `IsActive` set and `IsSystemSubject` clear, so it was the oldest match for the first-run owner candidate. Once the tenant exclusion opens setup on an instance holding a demo beside one ownerless real tenant, `EnsureOwnerSubjectAsync` would have renamed that visitor, added it to the operator's tenant with the owner role, and bound the operator's credential to it. `DemoSessionController.CreateSession` is `[AllowAnonymous]`, so that account is one anybody can mint a session for, and the startup platform-admin pass would then hand it the flag. A stock start with the demo enabled and one tenant is enough to reach this state, so the owner-candidate query excludes demo subjects as well. Hostile review caught this on the first cut of the change.

Both exclusions are the same predicate, so it lives in one place, `DemoExclusionFilter`, alongside the existing `SourceFilter` and `ReadVisibilityFilter` query helpers.

Excluding demo tenants also redefines "the sole tenant" for the platform-admin grant that setup completion triggers, which re-derives single-tenant-ness for itself rather than trusting the caller. That count now excludes the demo too. Otherwise the owner this flow has just correctly admitted completes setup and still cannot reach the admin UI. The startup bootstrap pass needs no change: it looks for a tenant with an `owner`-role member, and the demo's visitor holds `demo-visitor`, whose permissions cannot grant roles.

The username-availability probe is anonymous under the same condition and chose its tenant the same unfiltered way, so on a demo-only instance it answered off the demo tenant's memberships, a name oracle over exactly the tenant setup must not look at. It uses the same filter now.

**Behavioural change:** a demo tenant no longer counts towards "more than one tenant", so an instance holding a demo alongside a single ownerless real tenant now opens setup on the real tenant. In that state setup enrols a freshly created subject; the demo visitor is not renamed, not made a member of that tenant, and not offered a credential.

**Known gap, not addressed here:** on a demo-only instance `TenantResolutionMiddleware.GetSoleTenantAsync` still filters only on `IsActive`, so the apex resolves to the demo tenant and the web wizard sees a 200 `setupRequired` status, skips tenant creation, and calls `owner/options`, which now correctly answers `no_tenant_exists`, a code the web does not handle. A demo-only operator therefore remains stranded in the UI until #1160 lands; the API path (create a tenant, then run setup) works today. The same unfiltered sole-tenant count in `DevAuthController` belongs with that change.

Tests: four cases in `SetupControllerTests` covering the demo-only refusal, the demo-plus-real-tenant enrolment (asserting the exact subject enrolled is not the demo visitor, and that the visitor is neither renamed nor made a member), the username probe, and the platform-admin grant with a demo present. Each of the four `ExcludeDemo()` sites was reverted individually and reddens at least one named test. `tests/Unit/Nocturne.API.Tests`: 6426 passed, 0 failed, 5 skipped.

Closes #949.

https://claude.ai/code/session_015rBvU3xLf4L35RjjUBeJmJ
