### PR TITLE
refactor(profiles): collapse the four schedule lookups behind IProfileScoped

### DIFF
--- a/src/API/Nocturne.API/Services/Profiles/ProfileProjectionService.cs
+++ b/src/API/Nocturne.API/Services/Profiles/ProfileProjectionService.cs
@@ -88,65 +88,16 @@ public class ProfileProjectionService : IProfileProjectionService
 
     /// <summary>
     /// Assembles a <see cref="Profile"/> from a <see cref="TherapySettings"/> record and its
-    /// correlated schedule siblings, loading them by <see cref="TherapySettings.CorrelationId"/>
-    /// when available, or by profile name as a fallback.
+    /// schedule siblings.
     /// </summary>
     private async Task<Profile> AssembleProfileAsync(TherapySettings settings, CancellationToken ct)
     {
-        BasalSchedule? basal;
-        CarbRatioSchedule? carbRatio;
-        SensitivitySchedule? sensitivity;
-        TargetRangeSchedule? targetRange;
+        var basal = ScheduleForProfileAsync(_basalRepo, settings, ct);
+        var carbRatio = ScheduleForProfileAsync(_carbRatioRepo, settings, ct);
+        var sensitivity = ScheduleForProfileAsync(_sensitivityRepo, settings, ct);
+        var targetRange = ScheduleForProfileAsync(_targetRangeRepo, settings, ct);
 
-        if (settings.CorrelationId.HasValue)
-        {
-            var correlationId = settings.CorrelationId.Value;
-
-            var basalTask = _basalRepo.GetByCorrelationIdAsync(correlationId, ct);
-            var carbRatioTask = _carbRatioRepo.GetByCorrelationIdAsync(correlationId, ct);
-            var sensitivityTask = _sensitivityRepo.GetByCorrelationIdAsync(correlationId, ct);
-            var targetRangeTask = _targetRangeRepo.GetByCorrelationIdAsync(correlationId, ct);
-
-            await Task.WhenAll(basalTask, carbRatioTask, sensitivityTask, targetRangeTask);
-
-            basal = basalTask.Result
-                .FirstOrDefault(s => s.ProfileName == settings.ProfileName);
-            carbRatio = carbRatioTask.Result
-                .FirstOrDefault(s => s.ProfileName == settings.ProfileName);
-            sensitivity = sensitivityTask.Result
-                .FirstOrDefault(s => s.ProfileName == settings.ProfileName);
-            targetRange = targetRangeTask.Result
-                .FirstOrDefault(s => s.ProfileName == settings.ProfileName);
-        }
-        else
-        {
-            var basalTask = _basalRepo.GetByProfileNameAsync(settings.ProfileName, ct);
-            var carbRatioTask = _carbRatioRepo.GetByProfileNameAsync(settings.ProfileName, ct);
-            var sensitivityTask = _sensitivityRepo.GetByProfileNameAsync(settings.ProfileName, ct);
-            var targetRangeTask = _targetRangeRepo.GetByProfileNameAsync(settings.ProfileName, ct);
-
-            await Task.WhenAll(basalTask, carbRatioTask, sensitivityTask, targetRangeTask);
-
-            basal = basalTask.Result.FirstOrDefault();
-            carbRatio = carbRatioTask.Result.FirstOrDefault();
-            sensitivity = sensitivityTask.Result.FirstOrDefault();
-            targetRange = targetRangeTask.Result.FirstOrDefault();
-        }
-
-        // A schedule the correlation id does not reach still exists under the legacy id the whole
-        // group shares, and that index is unique. Without this an AID consumer reading v1/v3 profile
-        // is served an empty basal schedule rather than an error.
-        var basalFallback = OrSharedLegacyIdAsync(_basalRepo, basal, s => s.ProfileName, settings, ct);
-        var carbRatioFallback = OrSharedLegacyIdAsync(_carbRatioRepo, carbRatio, s => s.ProfileName, settings, ct);
-        var sensitivityFallback = OrSharedLegacyIdAsync(_sensitivityRepo, sensitivity, s => s.ProfileName, settings, ct);
-        var targetRangeFallback = OrSharedLegacyIdAsync(_targetRangeRepo, targetRange, s => s.ProfileName, settings, ct);
-
-        await Task.WhenAll(basalFallback, carbRatioFallback, sensitivityFallback, targetRangeFallback);
-
-        basal = basalFallback.Result;
-        carbRatio = carbRatioFallback.Result;
-        sensitivity = sensitivityFallback.Result;
-        targetRange = targetRangeFallback.Result;
+        await Task.WhenAll(basal, carbRatio, sensitivity, targetRange);
 
         var profileData = new ProfileData
         {
@@ -162,11 +113,11 @@ public class ProfileProjectionService : IProfileProjectionService
             DelayHigh = settings.DelayHigh,
             DelayMedium = settings.DelayMedium,
             DelayLow = settings.DelayLow,
-            Basal = MapScheduleEntries(basal?.Entries),
-            CarbRatio = MapScheduleEntries(carbRatio?.Entries),
-            Sens = MapScheduleEntries(sensitivity?.Entries),
-            TargetLow = MapTargetLow(targetRange?.Entries),
-            TargetHigh = MapTargetHigh(targetRange?.Entries),
+            Basal = MapScheduleEntries(basal.Result?.Entries),
+            CarbRatio = MapScheduleEntries(carbRatio.Result?.Entries),
+            Sens = MapScheduleEntries(sensitivity.Result?.Entries),
+            TargetLow = MapTargetLow(targetRange.Result?.Entries),
+            TargetHigh = MapTargetHigh(targetRange.Result?.Entries),
         };
 
         // Extract the profile record-level ID from the legacy ID prefix (before the colon)
@@ -193,24 +144,33 @@ public class ProfileProjectionService : IProfileProjectionService
     }
 
     /// <summary>
-    /// The schedule already found by correlation id, or the one stored under the legacy id every
-    /// sibling in the group shares. The store name is re-checked rather than read off the legacy id:
-    /// a profile name may itself contain a colon, so the <c>"{profileId}:{storeName}"</c> composite
-    /// is not unambiguously parseable, and the correlation path guards on the same field.
+    /// The one schedule of its kind belonging to <paramref name="settings"/>: the correlated sibling
+    /// when the settings record carries a correlation id, otherwise the newest row filed under the
+    /// profile name, otherwise the row stored under the legacy id every sibling in the group shares.
     /// </summary>
-    private static async Task<TRecord?> OrSharedLegacyIdAsync<TRecord>(
-        ILegacyKeyedRepository<TRecord> repository,
-        TRecord? found,
-        Func<TRecord, string> profileName,
+    /// <remarks>
+    /// The store name is compared as a column rather than read off the legacy id: a profile name may
+    /// itself contain a colon, so the <c>"{profileId}:{storeName}"</c> composite is not unambiguously
+    /// parseable. Without the legacy-id step a schedule the correlation id does not reach — the
+    /// siblings are written in separate transactions, so a group can be read mid-convergence — leaves
+    /// an AID consumer of v1/v3 profile with an empty basal schedule rather than an error.
+    /// </remarks>
+    private static async Task<TRecord?> ScheduleForProfileAsync<TRecord>(
+        IProfileScopedRepository<TRecord> repository,
         TherapySettings settings,
         CancellationToken ct)
-        where TRecord : class, IV4Record
+        where TRecord : class, IV4Record, IProfileScoped
     {
+        var found = settings.CorrelationId is { } correlationId
+            ? (await repository.GetByCorrelationIdAsync(correlationId, ct))
+                .FirstOrDefault(s => s.ProfileName == settings.ProfileName)
+            : (await repository.GetByProfileNameAsync(settings.ProfileName, ct)).FirstOrDefault();
+
         if (found is not null || string.IsNullOrEmpty(settings.LegacyId))
             return found;
 
         var candidate = await repository.GetByLegacyIdAsync(settings.LegacyId, ct);
-        return candidate is not null && profileName(candidate) == settings.ProfileName ? candidate : null;
+        return candidate is not null && candidate.ProfileName == settings.ProfileName ? candidate : null;
     }
 
     private static List<TimeValue> MapScheduleEntries(List<ScheduleEntry>? entries)

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IBasalScheduleRepository.cs
@@ -7,12 +7,12 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// Repository for <see cref="BasalSchedule"/> records representing a named scheduled basal rate program.
 /// </summary>
 /// <remarks>
-/// Extends <see cref="IV4Repository{T}"/> with profile-name lookups and bulk operations used
-/// when decomposing legacy Nightscout profile uploads into discrete V4 schedule records.
+/// One of the five siblings a legacy Nightscout profile upload decomposes into; the profile-scoped
+/// lookups they share live on <see cref="IProfileScopedRepository{TRecord}"/>.
 /// </remarks>
 /// <seealso cref="BasalSchedule"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface IBasalScheduleRepository : ILegacyKeyedRepository<BasalSchedule>
+public interface IBasalScheduleRepository : IProfileScopedRepository<BasalSchedule>
 {
     /// <summary>Retrieve a page of <see cref="BasalSchedule"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -31,37 +31,6 @@ public interface IBasalScheduleRepository : ILegacyKeyedRepository<BasalSchedule
         int limit = 100,
         int offset = 0,
         bool descending = true,
-        CancellationToken ct = default
-    );
-
-    /// <summary>Retrieve all <see cref="BasalSchedule"/> records that belong to a named basal profile.</summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<BasalSchedule>> GetByProfileNameAsync(string profileName, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the most recent <see cref="BasalSchedule"/> record for the given profile name
-    /// that was active at-or-before the specified timestamp.
-    /// </summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="timestamp">The point-in-time to query against.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<BasalSchedule?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
-
-    /// <summary>
-    /// Delete all <see cref="BasalSchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
-    /// </summary>
-    /// <remarks>Used during profile decomposition to replace an entire profile upload atomically.</remarks>
-    /// <param name="prefix">Legacy ObjectId prefix to match.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Retrieve all <see cref="BasalSchedule"/> records sharing the same correlation identifier.</summary>
-    /// <param name="correlationId">Correlation ID linking related records (e.g., from one upload).</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<BasalSchedule>> GetByCorrelationIdAsync(
-        Guid correlationId,
         CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbRatioScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ICarbRatioScheduleRepository.cs
@@ -8,14 +8,14 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// </summary>
 /// <remarks>
 /// Carb ratio schedules store the time-of-day-based grams-per-unit schedules associated with a
-/// therapy settings profile. Extends <see cref="IV4Repository{T}"/> with profile-name lookups
-/// and bulk operations used during profile decomposition.
+/// therapy settings profile. The profile-scoped lookups they share with the other decomposed
+/// siblings live on <see cref="IProfileScopedRepository{TRecord}"/>.
 /// </remarks>
 /// <seealso cref="CarbRatioSchedule"/>
 /// <seealso cref="IBasalScheduleRepository"/>
 /// <seealso cref="ISensitivityScheduleRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ICarbRatioScheduleRepository : ILegacyKeyedRepository<CarbRatioSchedule>
+public interface ICarbRatioScheduleRepository : IProfileScopedRepository<CarbRatioSchedule>
 {
     /// <summary>Retrieve a page of <see cref="CarbRatioSchedule"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -34,37 +34,6 @@ public interface ICarbRatioScheduleRepository : ILegacyKeyedRepository<CarbRatio
         int limit = 100,
         int offset = 0,
         bool descending = true,
-        CancellationToken ct = default
-    );
-
-    /// <summary>Retrieve all <see cref="CarbRatioSchedule"/> records belonging to a named therapy profile.</summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<CarbRatioSchedule>> GetByProfileNameAsync(string profileName, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the most recent <see cref="CarbRatioSchedule"/> record for the given profile name
-    /// that was active at-or-before the specified timestamp.
-    /// </summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="timestamp">The point-in-time to query against.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<CarbRatioSchedule?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
-
-    /// <summary>
-    /// Delete all <see cref="CarbRatioSchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
-    /// </summary>
-    /// <remarks>Used during profile decomposition to replace an entire profile upload atomically.</remarks>
-    /// <param name="prefix">Legacy ObjectId prefix to match.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Retrieve all <see cref="CarbRatioSchedule"/> records sharing the same correlation identifier.</summary>
-    /// <param name="correlationId">Correlation ID linking related records (e.g., from one profile upload).</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<CarbRatioSchedule>> GetByCorrelationIdAsync(
-        Guid correlationId,
         CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/IProfileScopedRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/IProfileScopedRepository.cs
@@ -1,0 +1,42 @@
+using Nocturne.Core.Models.V4;
+using Nocturne.Core.Contracts.V4;
+
+namespace Nocturne.Core.Contracts.V4.Repositories;
+
+/// <summary>
+/// The lookups every <see cref="IProfileScoped"/> record type shares, so the five siblings a legacy
+/// <see cref="Profile"/> upload decomposes into can be read and replaced through one generic surface.
+/// </summary>
+/// <typeparam name="TRecord">The profile-scoped record type stored by this repository.</typeparam>
+public interface IProfileScopedRepository<TRecord> : ILegacyKeyedRepository<TRecord>
+    where TRecord : class, IV4Record, IProfileScoped
+{
+    /// <summary>Retrieve all records belonging to a named profile store, newest first.</summary>
+    /// <param name="profileName">The profile name to filter by.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IEnumerable<TRecord>> GetByProfileNameAsync(string profileName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the most recent record for the given profile name that was active at-or-before the
+    /// specified timestamp.
+    /// </summary>
+    /// <param name="profileName">The profile name to filter by.</param>
+    /// <param name="timestamp">The point-in-time to query against.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<TRecord?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
+
+    /// <summary>Retrieve all records sharing the same correlation identifier.</summary>
+    /// <param name="correlationId">Correlation ID linking related records (e.g. from one profile upload).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IEnumerable<TRecord>> GetByCorrelationIdAsync(Guid correlationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete all records whose legacy ObjectId starts with <paramref name="prefix"/>, replacing an
+    /// entire profile upload atomically during decomposition.
+    /// </summary>
+    /// <param name="prefix">Legacy ObjectId prefix to match.</param>
+    /// <param name="origin">Origin recorded against the delete.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Number of records deleted.</returns>
+    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
+}

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensitivityScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ISensitivityScheduleRepository.cs
@@ -16,7 +16,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="ICarbRatioScheduleRepository"/>
 /// <seealso cref="ITargetRangeScheduleRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ISensitivityScheduleRepository : ILegacyKeyedRepository<SensitivitySchedule>
+public interface ISensitivityScheduleRepository : IProfileScopedRepository<SensitivitySchedule>
 {
     /// <summary>Retrieve a page of <see cref="SensitivitySchedule"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -35,37 +35,6 @@ public interface ISensitivityScheduleRepository : ILegacyKeyedRepository<Sensiti
         int limit = 100,
         int offset = 0,
         bool descending = true,
-        CancellationToken ct = default
-    );
-
-    /// <summary>Retrieve all <see cref="SensitivitySchedule"/> records belonging to a named therapy profile.</summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<SensitivitySchedule>> GetByProfileNameAsync(string profileName, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the most recent <see cref="SensitivitySchedule"/> record for the given profile name
-    /// that was active at-or-before the specified timestamp.
-    /// </summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="timestamp">The point-in-time to query against.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<SensitivitySchedule?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
-
-    /// <summary>
-    /// Delete all <see cref="SensitivitySchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
-    /// </summary>
-    /// <remarks>Used during profile decomposition to replace an entire profile upload atomically.</remarks>
-    /// <param name="prefix">Legacy ObjectId prefix to match.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Retrieve all <see cref="SensitivitySchedule"/> records sharing the same correlation identifier.</summary>
-    /// <param name="correlationId">Correlation ID linking related records (e.g., from one profile upload).</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<SensitivitySchedule>> GetByCorrelationIdAsync(
-        Guid correlationId,
         CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITargetRangeScheduleRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITargetRangeScheduleRepository.cs
@@ -15,7 +15,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="IBasalScheduleRepository"/>
 /// <seealso cref="ISensitivityScheduleRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ITargetRangeScheduleRepository : ILegacyKeyedRepository<TargetRangeSchedule>
+public interface ITargetRangeScheduleRepository : IProfileScopedRepository<TargetRangeSchedule>
 {
     /// <summary>Retrieve a page of <see cref="TargetRangeSchedule"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -34,37 +34,6 @@ public interface ITargetRangeScheduleRepository : ILegacyKeyedRepository<TargetR
         int limit = 100,
         int offset = 0,
         bool descending = true,
-        CancellationToken ct = default
-    );
-
-    /// <summary>Retrieve all <see cref="TargetRangeSchedule"/> records belonging to a named therapy profile.</summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<TargetRangeSchedule>> GetByProfileNameAsync(string profileName, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the most recent <see cref="TargetRangeSchedule"/> record for the given profile name
-    /// that was active at-or-before the specified timestamp.
-    /// </summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="timestamp">The point-in-time to query against.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<TargetRangeSchedule?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
-
-    /// <summary>
-    /// Delete all <see cref="TargetRangeSchedule"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
-    /// </summary>
-    /// <remarks>Used during profile decomposition to replace an entire profile upload atomically.</remarks>
-    /// <param name="prefix">Legacy ObjectId prefix to match.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Retrieve all <see cref="TargetRangeSchedule"/> records sharing the same correlation identifier.</summary>
-    /// <param name="correlationId">Correlation ID linking related records (e.g., from one profile upload).</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<TargetRangeSchedule>> GetByCorrelationIdAsync(
-        Guid correlationId,
         CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITherapySettingsRepository.cs
+++ b/src/Core/Nocturne.Core.Contracts/V4/Repositories/ITherapySettingsRepository.cs
@@ -17,7 +17,7 @@ namespace Nocturne.Core.Contracts.V4.Repositories;
 /// <seealso cref="IBasalScheduleRepository"/>
 /// <seealso cref="ISensitivityScheduleRepository"/>
 /// <seealso cref="IV4Repository{T}"/>
-public interface ITherapySettingsRepository : ILegacyKeyedRepository<TherapySettings>
+public interface ITherapySettingsRepository : IProfileScopedRepository<TherapySettings>
 {
     /// <summary>Retrieve a page of <see cref="TherapySettings"/> records filtered by time range, device, and source.</summary>
     /// <param name="from">Inclusive start of the time window, or <c>null</c> for no lower bound.</param>
@@ -36,37 +36,6 @@ public interface ITherapySettingsRepository : ILegacyKeyedRepository<TherapySett
         int limit = 100,
         int offset = 0,
         bool descending = true,
-        CancellationToken ct = default
-    );
-
-    /// <summary>Retrieve all <see cref="TherapySettings"/> records for a named therapy profile.</summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<TherapySettings>> GetByProfileNameAsync(string profileName, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the most recent <see cref="TherapySettings"/> record for the given profile name
-    /// that was active at-or-before the specified timestamp.
-    /// </summary>
-    /// <param name="profileName">The profile name to filter by.</param>
-    /// <param name="timestamp">The point-in-time to query against.</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<TherapySettings?> GetActiveAtAsync(string profileName, DateTime timestamp, CancellationToken ct = default);
-
-    /// <summary>
-    /// Delete all <see cref="TherapySettings"/> records whose legacy ObjectId starts with <paramref name="prefix"/>.
-    /// </summary>
-    /// <remarks>Used during profile decomposition to replace an entire profile upload atomically.</remarks>
-    /// <param name="prefix">Legacy ObjectId prefix to match.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Number of records deleted.</returns>
-    Task<int> DeleteByLegacyIdPrefixAsync(string prefix, WriteOrigin origin, CancellationToken ct = default);
-
-    /// <summary>Retrieve all <see cref="TherapySettings"/> records sharing the same correlation identifier.</summary>
-    /// <param name="correlationId">Correlation ID linking related records (e.g., from one profile upload).</param>
-    /// <param name="ct">Cancellation token.</param>
-    Task<IEnumerable<TherapySettings>> GetByCorrelationIdAsync(
-        Guid correlationId,
         CancellationToken ct = default
     );
 }

--- a/src/Core/Nocturne.Core.Models/V4/BasalSchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/BasalSchedule.cs
@@ -22,7 +22,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="ProfileSummary"/>
 /// <seealso cref="TempBasal"/>
 [JsonSchemaFlatten]
-public class BasalSchedule : V4RecordBase
+public class BasalSchedule : V4RecordBase, IProfileScoped
 {
     /// <summary>
     /// Named profile this schedule belongs to

--- a/src/Core/Nocturne.Core.Models/V4/CarbRatioSchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/CarbRatioSchedule.cs
@@ -19,7 +19,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="TherapySettings"/>
 /// <seealso cref="ProfileSummary"/>
 [JsonSchemaFlatten]
-public class CarbRatioSchedule : V4RecordBase
+public class CarbRatioSchedule : V4RecordBase, IProfileScoped
 {
     /// <summary>
     /// Named profile this schedule belongs to

--- a/src/Core/Nocturne.Core.Models/V4/IProfileScoped.cs
+++ b/src/Core/Nocturne.Core.Models/V4/IProfileScoped.cs
@@ -1,0 +1,19 @@
+namespace Nocturne.Core.Models.V4;
+
+/// <summary>
+/// A record that belongs to one named profile store.
+/// </summary>
+/// <remarks>
+/// Implemented by the five record types a legacy <see cref="Profile"/> upload decomposes into, one
+/// set per store in <see cref="Profile.Store"/>.
+/// </remarks>
+/// <seealso cref="TherapySettings"/>
+/// <seealso cref="BasalSchedule"/>
+/// <seealso cref="CarbRatioSchedule"/>
+/// <seealso cref="SensitivitySchedule"/>
+/// <seealso cref="TargetRangeSchedule"/>
+public interface IProfileScoped
+{
+    /// <summary>Key of the named profile store this record belongs to.</summary>
+    string ProfileName { get; }
+}

--- a/src/Core/Nocturne.Core.Models/V4/SensitivitySchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/SensitivitySchedule.cs
@@ -19,7 +19,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="TherapySettings"/>
 /// <seealso cref="ProfileSummary"/>
 [JsonSchemaFlatten]
-public class SensitivitySchedule : V4RecordBase
+public class SensitivitySchedule : V4RecordBase, IProfileScoped
 {
     /// <summary>
     /// Named profile this schedule belongs to

--- a/src/Core/Nocturne.Core.Models/V4/TargetRangeSchedule.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TargetRangeSchedule.cs
@@ -20,7 +20,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="TherapySettings"/>
 /// <seealso cref="ProfileSummary"/>
 [JsonSchemaFlatten]
-public class TargetRangeSchedule : V4RecordBase
+public class TargetRangeSchedule : V4RecordBase, IProfileScoped
 {
     /// <summary>
     /// Named profile this schedule belongs to

--- a/src/Core/Nocturne.Core.Models/V4/TherapySettings.cs
+++ b/src/Core/Nocturne.Core.Models/V4/TherapySettings.cs
@@ -20,7 +20,7 @@ namespace Nocturne.Core.Models.V4;
 /// <seealso cref="TargetRangeSchedule"/>
 /// <seealso cref="ProfileSummary"/>
 [JsonSchemaFlatten]
-public class TherapySettings : V4RecordBase
+public class TherapySettings : V4RecordBase, IProfileScoped
 {
     /// <summary>
     /// Named profile this came from (e.g., "Default", "Weekday")

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/ProfileProjectionServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/ProfileProjectionServiceTests.cs
@@ -349,6 +349,71 @@ public class ProfileProjectionServiceTests
         _basalRepo.Verify(r => r.GetByProfileNameAsync("Default", default), Times.Once);
     }
 
+    /// <summary>
+    /// One correlation id spans every store in a profile upload, so the correlated rows carry the
+    /// other stores' schedules too. Serving one of those would hand an AID consumer another store's
+    /// basal rates, carb ratios and targets.
+    /// </summary>
+    [Fact]
+    public async Task CorrelationLookupReturnsAnotherStore_IsNotServed()
+    {
+        var correlationId = Guid.NewGuid();
+        var settings = CreateTherapySettings(correlationId: correlationId, profileName: "Default");
+
+        SetupGetLatest(settings);
+        SetupCorrelationLookups(
+            correlationId,
+            basals: [CreateBasalSchedule(correlationId, "Night")],
+            carbRatios: [CreateCarbRatioSchedule(correlationId, "Night")],
+            sensitivities: [CreateSensitivitySchedule(correlationId, "Night")],
+            targetRanges: [CreateTargetRangeSchedule(correlationId, "Night")]);
+
+        var result = await _sut.GetCurrentProfileAsync();
+
+        var data = result!.Store["Default"];
+        data.Basal.Should().BeEmpty("a schedule belonging to another store must not be served here");
+        data.CarbRatio.Should().BeEmpty();
+        data.Sens.Should().BeEmpty();
+        data.TargetLow.Should().BeEmpty();
+        data.TargetHigh.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The decoy here is what splitting the <c>"{profileId}:{storeName}"</c> legacy id on its first
+    /// colon would yield for this store, so a name-derived match would serve the wrong schedule.
+    /// </summary>
+    [Fact]
+    public async Task CorrelationLookup_MatchesTheStoreNameVerbatimWhenItContainsAColon()
+    {
+        var correlationId = Guid.NewGuid();
+        const string storeName = "u200 sedentary (120%) 4/16/24 08:09";
+        var settings = CreateTherapySettings(
+            correlationId: correlationId,
+            profileName: storeName,
+            legacyId: $"profile1:{storeName}");
+
+        SetupGetLatest(settings);
+        SetupCorrelationLookups(correlationId);
+        _basalRepo.Setup(r => r.GetByCorrelationIdAsync(correlationId, default))
+            .ReturnsAsync(
+            [
+                new BasalSchedule
+                {
+                    ProfileName = "u200 sedentary (120%) 4/16/24 08",
+                    Entries = [new ScheduleEntry { Time = "00:00", Value = 0.4, TimeAsSeconds = 0 }],
+                },
+                new BasalSchedule
+                {
+                    ProfileName = storeName,
+                    Entries = [new ScheduleEntry { Time = "00:00", Value = 1.5, TimeAsSeconds = 0 }],
+                },
+            ]);
+
+        var result = await _sut.GetCurrentProfileAsync();
+
+        result!.Store[storeName].Basal.Should().ContainSingle().Which.Value.Should().Be(1.5);
+    }
+
     [Fact]
     public async Task LegacyId_ExtractsProfileIdPrefix()
     {
@@ -436,6 +501,30 @@ public class ProfileProjectionServiceTests
         data.CarbRatio.Should().BeEmpty();
         data.Sens.Should().BeEmpty();
         data.TargetLow.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CorrelationHit_IsServedWithoutConsultingTheLegacyIdRow()
+    {
+        var correlationId = Guid.NewGuid();
+        var settings = CreateTherapySettings(correlationId: correlationId, legacyId: "profile1:Default");
+
+        SetupGetLatest(settings);
+        SetupCorrelationLookups(
+            correlationId,
+            basals: [CreateBasalSchedule(correlationId)],
+            carbRatios: [CreateCarbRatioSchedule(correlationId)],
+            sensitivities: [CreateSensitivitySchedule(correlationId)],
+            targetRanges: [CreateTargetRangeSchedule(correlationId)]);
+        SetupLegacyIdLookups("profile1:Default", "Default");
+
+        var result = await _sut.GetCurrentProfileAsync();
+
+        result!.Store["Default"].Basal.Should().ContainSingle().Which.Value.Should().Be(1.0);
+        _basalRepo.Verify(r => r.GetByLegacyIdAsync(It.IsAny<string>(), default), Times.Never);
+        _carbRatioRepo.Verify(r => r.GetByLegacyIdAsync(It.IsAny<string>(), default), Times.Never);
+        _sensitivityRepo.Verify(r => r.GetByLegacyIdAsync(It.IsAny<string>(), default), Times.Never);
+        _targetRangeRepo.Verify(r => r.GetByLegacyIdAsync(It.IsAny<string>(), default), Times.Never);
     }
 
     /// <summary>


### PR DESCRIPTION
`ProfileProjectionService.AssembleProfileAsync` carried two idioms for the same shape: a generic helper for the shared-legacy-id fallback, and sixteen hand-written lines for the correlation and profile-name paths. Copying the wrong one is the risk on a read path that serves basal rates, carb ratios, ISF and target ranges to AAPS, Loop and xDrip via `/api/v1/profile` and `/api/v3/profile`.

`BasalSchedule`, `CarbRatioSchedule`, `SensitivitySchedule`, `TargetRangeSchedule` and `TherapySettings` now declare `IProfileScoped`. The five repositories that already carried byte-identical `GetByProfileNameAsync` / `GetActiveAtAsync` / `GetByCorrelationIdAsync` / `DeleteByLegacyIdPrefixAsync` declarations inherit them once from a new `IProfileScopedRepository<TRecord>` rather than each restating them; `ILegacyKeyedRepository` was not the right place, since a dozen repositories implement it with no profile concept. One helper then resolves a schedule for all four kinds, and the `Func<TRecord, string>` selector the fallback helper needed goes away. Net −132 lines outside tests.

Behaviour is unchanged, and the constraints from the issue are preserved:

- The `ProfileName` match remains an exact column comparison against `settings.ProfileName`. Nothing is derived from the `"{profileId}:{storeName}"` legacy id, because a store name may itself contain a colon.
- When a correlation id is present, `GetByProfileNameAsync` is still never issued; the legacy-id step still runs only when the primary lookup found nothing.
- The four kinds still resolve concurrently. Each now runs its own correlation-then-fallback chain rather than the previous two batched rounds: the same degree of concurrency, and every repository call opens its own context through `ContextFactory.CreateAsync`. Faults still propagate through a single `Task.WhenAll`.
- No client-surface change. The interface adds no property (all five models already declared `ProfileName`), appears in no endpoint signature, and nothing serialises these models polymorphically; generating the OpenAPI document on this branch and on `main` produced identical output.

Three tests pin the primary path, which nothing did before (the existing suite only covered the fallback): a correlated sibling belonging to another store is not served; the colon-bearing store name from the issue is matched verbatim against a decoy named as a legacy-id split would truncate it; and a correlation hit is served without consulting the legacy-id row at all. Dropping the filter fails two, swapping the two lookups fails five, and running the legacy-id step eagerly fails the third. All three pass on `main` as well, which is the property a behaviour-preserving refactor wants.

Verified: `Nocturne.API.Tests` 6424 passed, `Nocturne.Core.Models.Tests` 839, `Nocturne.Infrastructure.Data.Tests` 911; the solution including both integration test projects builds clean. Hostile review noted one pre-existing gap, unchanged here: `GetByCorrelationIdAsync` has no `ORDER BY`, so if one correlation id ever carried two rows with the same `ProfileName`, which wins is database-order dependent.

Closes #1154.

https://claude.ai/code/session_01MqyVPKPLNu6y8YvXbdsoZ8
