### PR TITLE
fix(alerts): persist the alarm profile's emergency-contact visual settings

### DIFF
--- a/src/Core/Nocturne.Core.Models/Configuration/AlarmProfileConfiguration.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/AlarmProfileConfiguration.cs
@@ -305,6 +305,18 @@ public class AlarmVisualSettings
     /// </summary>
     [JsonPropertyName("wakeScreen")]
     public bool WakeScreen { get; set; } = true;
+
+    /// <summary>
+    /// Whether to show emergency contacts during the alarm overlay
+    /// </summary>
+    [JsonPropertyName("showEmergencyContacts")]
+    public bool ShowEmergencyContacts { get; set; }
+
+    /// <summary>
+    /// Custom instructions to display to emergency contacts
+    /// </summary>
+    [JsonPropertyName("emergencyInstructions")]
+    public string? EmergencyInstructions { get; set; }
 }
 
 /// <summary>

--- a/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
@@ -509,7 +509,7 @@ public class NotificationSettings
 {
     /// <summary>
     /// xDrip+-style alarm configuration stored as JSONB.
-    /// Contains all alarm profiles, quiet hours, channels, and emergency contacts.
+    /// Contains all alarm profiles, channels, and emergency contacts.
     /// </summary>
     [JsonPropertyName("alarmConfiguration")]
     public UserAlarmConfiguration AlarmConfiguration { get; set; } = new();

--- a/src/Web/packages/app/src/lib/components/settings/AlarmProfileDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/AlarmProfileDialog.svelte
@@ -61,11 +61,6 @@
     if (!copy.schedule.activeDays) {
       copy.schedule.activeDays = [];
     }
-    // Ensure visual.showEmergencyContacts is initialized
-    if (copy.visual.showEmergencyContacts === undefined) {
-      copy.visual.showEmergencyContacts =
-        p.alarmType === "UrgentLow" || p.alarmType === "UrgentHigh";
-    }
     return copy;
   }
 

--- a/src/Web/packages/app/src/lib/types/alarm-profile.test.ts
+++ b/src/Web/packages/app/src/lib/types/alarm-profile.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { UserAlarmConfigurationSchema } from "$lib/api/generated/schemas";
+import { createDefaultUserAlarmConfiguration } from "$lib/types/alarm-profile";
+
+/**
+ * The settings store sends this factory's output as the alarm configuration, so any field it
+ * declares that the server model lacks is dropped on save and reverted by the server's echo.
+ */
+describe("createDefaultUserAlarmConfiguration", () => {
+  it("builds a payload the server model accepts in full", () => {
+    const payload = JSON.parse(
+      JSON.stringify(createDefaultUserAlarmConfiguration())
+    );
+
+    const result = UserAlarmConfigurationSchema.safeParse(payload);
+
+    expect(result.error?.issues ?? []).toEqual([]);
+  });
+});

--- a/src/Web/packages/app/src/lib/types/alarm-profile.ts
+++ b/src/Web/packages/app/src/lib/types/alarm-profile.ts
@@ -74,7 +74,7 @@ export interface AlarmVisualSettings {
   /** Whether to show emergency contacts during alarm overlay */
   showEmergencyContacts: boolean;
   /** Custom instructions for emergency contacts */
-  emergencyInstructions?: string;
+  emergencyInstructions?: string | null;
 }
 
 /** Snooze settings for an alarm */
@@ -248,20 +248,8 @@ export interface UserAlarmConfiguration {
   customSounds: CustomSoundReference[];
   /** Emergency contacts to notify for urgent alarms */
   emergencyContacts: EmergencyContactConfig[];
-  /** Quiet hours configuration */
-  quietHours: QuietHoursConfig;
   /** Notification channels configuration */
   channels: NotificationChannelsConfig;
-}
-
-/** Quiet hours configuration for reducing alarm volume during sleep */
-export interface QuietHoursConfig {
-  enabled: boolean;
-  startTime: string;
-  endTime: string;
-  allowCritical: boolean;
-  reduceVolume: boolean;
-  quietVolume: number;
 }
 
 /** Built-in sound presets */
@@ -603,14 +591,6 @@ export function createDefaultUserAlarmConfiguration(): UserAlarmConfiguration {
       createDefaultAlarmProfile("Low"),
       createDefaultAlarmProfile("UrgentLow"),
     ],
-    quietHours: {
-      enabled: false,
-      startTime: "22:00",
-      endTime: "07:00",
-      allowCritical: true,
-      reduceVolume: true,
-      quietVolume: 30,
-    },
     customSounds: [],
     emergencyContacts: [],
     channels: {

--- a/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Profiles/UISettingsServiceTests.cs
@@ -45,6 +45,28 @@ public class UISettingsServiceTests
     }
 
     [Fact]
+    public async Task SaveAlarmConfigurationAsync_preservesTheEmergencyContactVisualSettings()
+    {
+        var context = NewContext();
+        var service = NewService(context);
+        var config = AlarmConfiguration("fresh", 123);
+        config.Profiles[0].Visual = new AlarmVisualSettings
+        {
+            ShowEmergencyContacts = true,
+            EmergencyInstructions = "Spare key is under the mat",
+        };
+
+        await service.SaveAlarmConfigurationAsync(config);
+
+        foreach (var stored in await EveryAlarmReadPath(service))
+        {
+            var visual = stored.Profiles.Should().ContainSingle().Subject.Visual;
+            visual.ShowEmergencyContacts.Should().BeTrue();
+            visual.EmergencyInstructions.Should().Be("Spare key is under the mat");
+        }
+    }
+
+    [Fact]
     public async Task SaveAlarmConfigurationAsync_winsOverCopiesLeftByTheEarlierLayout()
     {
         var context = NewContext();


### PR DESCRIPTION
The frontend alarm model declared two visual fields the server model lacked: `showEmergencyContacts`, which is bound to a switch and gates a section of the alarm overlay and the preview, and `emergencyInstructions`. The save succeeded with 200, the server round-tripped the configuration without them (the JSONB writer has no extension-data bag, so unknown members are dropped), and the store wrote the echo back over local state, so the switch reverted on every save with nothing telling the user. `AlarmProfileDialog` re-derived a default when the field came back undefined, which hid the loss further.

`AlarmVisualSettings` gains both fields. The configuration lives in a JSON settings column, so there is no migration. The dialog's re-initialisation is deleted: the server now always emits the key (V4 responses do not omit defaults), so the branch was dead. The frontend type for the instructions is `string | null` to match what the server actually sends when none are set.

`quietHours` was declared and built by the factory but read by nothing anywhere in `src/Web`, and had no server counterpart (the server's do-not-disturb schedule is a separate subsystem that this never touched). It also failed the generated schema's `additionalProperties: false`. It is deleted rather than implemented.

**Behavioural notes worth reading before merge:**

- The C# default for `ShowEmergencyContacts` is `false`. The frontend factory defaults it to on for UrgentHigh/UrgentLow profiles, so a freshly created urgent profile shows the section, an existing tenant's urgent profile does not until they switch it on, and the demo tenant's `default-urgent-low` profile does not. For existing tenants this is not a regression: the live overlay read the field off the store, and the store held the server's echo, which never carried it, so the effective value was always off. The dialog merely displayed an on-switch that did nothing. A one-line release note is enough; a data backfill would newly enable a feature nobody had.
- Now that the field persists, `AlarmGeneralTab` auto-filling the default emergency instruction text when a profile is switched to UrgentLow becomes durable user data shown during an emergency, where before it was discarded on every save. That is what the switch always promised, but it is new safety-relevant behaviour and is called out here for that reason.

With both discrepancies gone the generated `UserAlarmConfiguration` schema accepts the payload the settings store builds in full, which is the precondition for moving the alarm saves onto remote functions (the `as unknown as UserAlarmConfiguration` casts in the store are why this drift was silent; deriving the hand-written model from the generated types is the follow-up #1149 asks for and is not attempted here).

Tests: a C# test round-trips the two fields through the real settings serialiser and every alarm read path; a vitest parses the factory's output against the generated schema and fails on either stray field (verified against the parent commit's model). Note that `@nocturne/app` vitest is not executed by any CI job today, so the schema guard is local-only. `Nocturne.API.Tests` `UISettingsServiceTests` 19/19; `svelte-check` unchanged at 51 errors.

Closes #1149.

https://claude.ai/code/session_01MqyVPKPLNu6y8YvXbdsoZ8
