### PR TITLE
refactor(api): type the body-weight batch create, and hand it to the shared base

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/BodyWeightController.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
@@ -109,10 +108,8 @@ public class BodyWeightController(IBodyWeightService bodyWeightService)
     }
 
     /// <summary>
-    /// Create one or more body weight records (single object or array)
+    /// Create one or more body weight records
     /// </summary>
-    // Untyped so one route takes either a bare record or an array of them. Seven published SDKs
-    // are generated from this operation, so the request shape cannot be tightened in place.
     [HttpPost("batch")]
     [RequireDeclaredWriteScope]
     [ProducesResponseType(typeof(IEnumerable<BodyWeight>), 200)]
@@ -120,24 +117,9 @@ public class BodyWeightController(IBodyWeightService bodyWeightService)
     [ProducesResponseType(500)]
     [ErrorEnvelope]
     public Task<ActionResult<IEnumerable<BodyWeight>>> CreateBodyWeights(
-        [FromBody] object bodyWeights,
+        [FromBody] BodyWeight[] bodyWeights,
         CancellationToken cancellationToken = default
-    )
-    {
-        if (bodyWeights is null)
-            return Task.FromResult<ActionResult<IEnumerable<BodyWeight>>>(
-                Problem(detail: "Body weight data is required", statusCode: 400, title: "Bad Request"));
-
-        if (bodyWeights is not JsonElement json)
-            return Task.FromResult<ActionResult<IEnumerable<BodyWeight>>>(
-                Problem(detail: "Invalid data format", statusCode: 400, title: "Bad Request"));
-
-        List<BodyWeight> models = json.ValueKind == JsonValueKind.Array
-            ? JsonSerializer.Deserialize<List<BodyWeight>>(json.GetRawText()) ?? []
-            : JsonSerializer.Deserialize<BodyWeight>(json.GetRawText()) is { } single ? [single] : [];
-
-        return CreateResponseAsync(models, cancellationToken);
-    }
+    ) => CreateResponseAsync(bodyWeights, cancellationToken);
 
     /// <summary>
     /// Update an existing body weight record

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using FluentAssertions;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
@@ -291,9 +290,8 @@ public class V4BulkValidationTests
     public async Task BodyWeightBatch_OverTheCap_IsRejected()
     {
         var service = new Mock<IBodyWeightService>();
-        var body = JsonSerializer.SerializeToElement(Fill(1001, () => new BodyWeight()));
 
-        var result = await BodyWeights(service).CreateBodyWeights(body);
+        var result = await BodyWeights(service).CreateBodyWeights(Fill(1001, () => new BodyWeight()));
 
         Rejected(result.Result, "Bulk operations are limited to 1000 body weight records per request");
         service.Verify(
@@ -305,9 +303,8 @@ public class V4BulkValidationTests
     public async Task BodyWeightBatch_EmptyPayload_IsRejected()
     {
         var service = new Mock<IBodyWeightService>();
-        var body = JsonSerializer.SerializeToElement(Array.Empty<BodyWeight>());
 
-        var result = await BodyWeights(service).CreateBodyWeights(body);
+        var result = await BodyWeights(service).CreateBodyWeights([]);
 
         Rejected(result.Result, "Body weight data is required");
         service.Verify(

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/HealthRecordResponseContractTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Health/HealthRecordResponseContractTests.cs
@@ -1,9 +1,12 @@
-using System.Text.Json;
+using System.Text;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Controllers.V4.Health;
 using Nocturne.API.Models.Requests.V4;
@@ -176,39 +179,22 @@ public class HealthRecordResponseContractTests
             Times.Never);
     }
 
-    // ── The batch route takes one record or many ────────────────────
+    // ── The batch route takes an array of records ───────────────────
 
     [Fact]
-    public async Task Batch_create_with_an_array_body_reaches_the_service_with_every_record()
+    public async Task Batch_create_reaches_the_service_with_every_record()
     {
         var written = CaptureBodyWeights();
-        var body = JsonSerializer.SerializeToElement(new[]
-        {
+
+        var result = await BodyWeight().CreateBodyWeights([
             new BodyWeight { Mills = 1_781_000_000_000, WeightKg = 80.5m },
             new BodyWeight { Mills = 1_781_000_060_000, WeightKg = 81.0m },
-        });
-
-        var result = await BodyWeight().CreateBodyWeights(body);
+        ]);
 
         result.Result.Should().BeOfType<OkObjectResult>()
             .Which.Value.Should().BeAssignableTo<IEnumerable<BodyWeight>>()
             .Which.Should().HaveCount(2);
         written().Select(w => w.WeightKg).Should().Equal([80.5m, 81.0m]);
-    }
-
-    [Fact]
-    public async Task Batch_create_with_a_bare_object_body_reaches_the_service_with_one_record()
-    {
-        var written = CaptureBodyWeights();
-        var body = JsonSerializer.SerializeToElement(
-            new BodyWeight { Mills = 1_781_000_000_000, WeightKg = 80.5m });
-
-        var result = await BodyWeight().CreateBodyWeights(body);
-
-        result.Result.Should().BeOfType<OkObjectResult>()
-            .Which.Value.Should().BeAssignableTo<IEnumerable<BodyWeight>>()
-            .Which.Should().ContainSingle("a single object is accepted as a batch of one");
-        written().Single().WeightKg.Should().Be(80.5m);
     }
 
     [Fact]
@@ -219,12 +205,38 @@ public class HealthRecordResponseContractTests
         Problem(result.Result, 400).Detail.Should().Be("Body weight data is required");
     }
 
+    /// <summary>
+    /// The batch route's declared body type is what every published SDK's method signature is
+    /// generated from, so the shape the wire accepts is pinned through MVC's own binding rather
+    /// than left to the signature.
+    /// </summary>
     [Fact]
-    public async Task Batch_create_with_a_body_that_is_not_json_answers_400()
+    public async Task Batch_create_binds_an_array_body_and_refuses_a_bare_record()
     {
-        var result = await BodyWeight().CreateBodyWeights("not a json element");
+        var bodyType = typeof(BodyWeightController)
+            .GetMethod(nameof(BodyWeightController.CreateBodyWeights))!
+            .GetParameters()[0]
+            .ParameterType;
+        const string record = """{"weightKg":80.5,"mills":1781000000000}""";
 
-        Problem(result.Result, 400).Detail.Should().Be("Invalid data format");
+        (await BindBodyAsync(bodyType, $"[{record}]")).HasError.Should().BeFalse();
+        (await BindBodyAsync(bodyType, record)).HasError.Should().BeTrue();
+    }
+
+    /// <summary>Runs MVC's JSON body binding, which is what answers 400 before an action runs.</summary>
+    private static Task<InputFormatterResult> BindBodyAsync(Type bodyType, string json)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.ContentType = "application/json";
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        return new SystemTextJsonInputFormatter(new JsonOptions(), NullLogger<SystemTextJsonInputFormatter>.Instance)
+            .ReadAsync(new InputFormatterContext(
+                httpContext,
+                modelName: string.Empty,
+                modelState: new ModelStateDictionary(),
+                metadata: new EmptyModelMetadataProvider().GetMetadataForType(bodyType),
+                readerFactory: (stream, encoding) => new StreamReader(stream, encoding)));
     }
 
     // ── Update ──────────────────────────────────────────────────────


### PR DESCRIPTION
`POST /api/v4/body-weight/batch` took its request body as `object` and hand-branched on `JsonElement` to accept either a bare record or an array of them. It was the only request body in the V4 Health family that was not typed, and NSwag can only describe an `object` body as an empty schema, so every published SDK (the `sdk/filter-v4-spec.js` filter keeps all of `/api/v4/**`) generated the operation untyped.

The generated TypeScript client method goes from

```ts
createBodyWeights(bodyWeights: any, signal?: AbortSignal): Promise<BodyWeight[]>
```

to

```ts
createBodyWeights(bodyWeights: BodyWeight[], signal?: AbortSignal): Promise<BodyWeight[]>
```

and the OpenAPI request body from `"schema": {}` to an array of `BodyWeight`. Both confirmed by regenerating the client before and after.

**This is a breaking change for SDK consumers and needs its own release-notes line.**

- Callers posting an array are unaffected. The same JSON binds, and the route still answers 200 with the created records, matching the `HeartRate` and `StepCount` batch creates.
- Callers posting a bare record now receive a 400 from model binding, where before the record was unwrapped into a batch of one. That 400 is MVC's `ValidationProblemDetails` (an `errors` map and no `detail`), not the previous `detail: "Invalid data format"`. `POST /api/v4/body-weight` remains the single-record route and is unchanged.
- A read-only-scoped caller posting a malformed body now sees that 400 before the write-scope 403, because model validation runs ahead of the scope filter. The sibling batch routes already behave this way.

The issue's option 2 named `UpsertBodyWeightRequest[]`. No such type exists, the single-record POST on this same controller already takes `BodyWeight`, and the two siblings sit on a different base with their own request DTOs, so the body is `BodyWeight[]` rather than a new duplicate of the model. Typing rather than deleting keeps bulk body-weight create reachable (no other route offers it) and removes the one untyped body in the family.

With a real type, the action delegates straight to the batch create `HealthRecordControllerBase` already provides, which removes the branching, the bespoke reply, and a null check `ValidateBulkSize` already performs. The controller loses 20 lines and gains 3.

Tests: the batch contract tests post a typed array of two records; a new test reads the action's declared body type and runs MVC's `SystemTextJsonInputFormatter` over an array body and a bare record, so the break is pinned rather than incidental. Removing the type does not compile the existing tests, so that test is the runtime guard. `tests/Unit/Nocturne.API.Tests` 6432 passed, 0 failed, 5 skipped. Hostile review also confirmed removing `[RequireDeclaredWriteScope]` from the action is caught by the V4 write-scope sweep.

Closes #1055.

https://claude.ai/code/session_01MqyVPKPLNu6y8YvXbdsoZ8
