### PR TITLE
fix(migrations): make the composite-index migration retryable end to end

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260511122202_AddCompositePerformanceIndexes.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260511122202_AddCompositePerformanceIndexes.cs
@@ -4,42 +4,39 @@
 
 namespace Nocturne.Infrastructure.Data.Migrations
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Every statement here is re-runnable, because the concurrent build at the end cannot be
+    /// transactional: a failure in it leaves everything before it committed. A plain
+    /// <c>CREATE INDEX</c> would then fail the retry on its own first statement, and
+    /// <see cref="ConcurrentIndexBuilder"/>'s repair of the interrupted build would never be
+    /// reached.
+    /// </summary>
     public partial class AddCompositePerformanceIndexes : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateIndex(
-                name: "ix_therapy_settings_tenant_timestamp",
-                table: "therapy_settings",
-                columns: new[] { "tenant_id", "timestamp" },
-                descending: new[] { false, true });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_therapy_settings_tenant_timestamp " +
+                "ON therapy_settings (tenant_id, timestamp DESC);");
 
-            // Idempotent: name overlaps with AddTenantTimestampIndexes (20260511000001),
-            // which creates the same index without descending ordering. Skip recreation
-            // if it already exists so both ordering choices work in sequence.
+            // AddTenantTimestampIndexes (20260511000001) creates this name without the descending
+            // ordering, so on an instance that ran it the ordering here never takes effect.
             migrationBuilder.Sql(
                 "CREATE INDEX IF NOT EXISTS ix_temp_basals_tenant_start_timestamp " +
                 "ON temp_basals (tenant_id, start_timestamp DESC);");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_target_range_schedules_tenant_profile_timestamp",
-                table: "target_range_schedules",
-                columns: new[] { "tenant_id", "profile_name", "timestamp" },
-                descending: new[] { false, false, true });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_target_range_schedules_tenant_profile_timestamp " +
+                "ON target_range_schedules (tenant_id, profile_name, timestamp DESC);");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_sensitivity_schedules_tenant_profile_timestamp",
-                table: "sensitivity_schedules",
-                columns: new[] { "tenant_id", "profile_name", "timestamp" },
-                descending: new[] { false, false, true });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_sensitivity_schedules_tenant_profile_timestamp " +
+                "ON sensitivity_schedules (tenant_id, profile_name, timestamp DESC);");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_carb_ratio_schedules_tenant_profile_timestamp",
-                table: "carb_ratio_schedules",
-                columns: new[] { "tenant_id", "profile_name", "timestamp" },
-                descending: new[] { false, false, true });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_carb_ratio_schedules_tenant_profile_timestamp " +
+                "ON carb_ratio_schedules (tenant_id, profile_name, timestamp DESC);");
 
             migrationBuilder.Sql(
                 "CREATE INDEX IF NOT EXISTS ix_carb_intakes_tenant_timestamp " +
@@ -49,53 +46,32 @@ namespace Nocturne.Infrastructure.Data.Migrations
                 "CREATE INDEX IF NOT EXISTS ix_boluses_tenant_timestamp " +
                 "ON boluses (tenant_id, timestamp DESC);");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_basal_schedules_tenant_profile_timestamp",
-                table: "basal_schedules",
-                columns: new[] { "tenant_id", "profile_name", "timestamp" },
-                descending: new[] { false, false, true });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_basal_schedules_tenant_profile_timestamp " +
+                "ON basal_schedules (tenant_id, profile_name, timestamp DESC);");
 
             // Partial index for deduplication subqueries: WHERE tenant_id=? AND record_type=? AND NOT is_primary.
-            // Added via raw SQL to avoid EF Core conflating it with the existing full unique index on the same columns.
-            // CONCURRENTLY avoids an AccessExclusiveLock on linked_records (6M rows) during migration;
-            // suppressTransaction is required because CONCURRENTLY cannot run inside a transaction block.
-            migrationBuilder.Sql(
-                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_linked_records_tenant_type_not_primary " +
-                "ON linked_records (tenant_id, record_type, record_id) WHERE NOT is_primary;",
-                suppressTransaction: true);
+            // Raw SQL rather than CreateIndex so EF Core does not conflate it with the existing
+            // full unique index on the same columns.
+            ConcurrentIndexBuilder.Build(
+                migrationBuilder,
+                "ix_linked_records_tenant_type_not_primary",
+                "ON linked_records (tenant_id, record_type, record_id) WHERE NOT is_primary");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "ix_therapy_settings_tenant_timestamp",
-                table: "therapy_settings");
-
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_therapy_settings_tenant_timestamp;");
             migrationBuilder.Sql("DROP INDEX IF EXISTS ix_temp_basals_tenant_start_timestamp;");
-
-            migrationBuilder.DropIndex(
-                name: "ix_target_range_schedules_tenant_profile_timestamp",
-                table: "target_range_schedules");
-
-            migrationBuilder.DropIndex(
-                name: "ix_sensitivity_schedules_tenant_profile_timestamp",
-                table: "sensitivity_schedules");
-
-            migrationBuilder.DropIndex(
-                name: "ix_carb_ratio_schedules_tenant_profile_timestamp",
-                table: "carb_ratio_schedules");
-
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_target_range_schedules_tenant_profile_timestamp;");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_sensitivity_schedules_tenant_profile_timestamp;");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_carb_ratio_schedules_tenant_profile_timestamp;");
             migrationBuilder.Sql("DROP INDEX IF EXISTS ix_carb_intakes_tenant_timestamp;");
             migrationBuilder.Sql("DROP INDEX IF EXISTS ix_boluses_tenant_timestamp;");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS ix_basal_schedules_tenant_profile_timestamp;");
 
-            migrationBuilder.DropIndex(
-                name: "ix_basal_schedules_tenant_profile_timestamp",
-                table: "basal_schedules");
-
-            migrationBuilder.Sql(
-                "DROP INDEX CONCURRENTLY IF EXISTS ix_linked_records_tenant_type_not_primary;",
-                suppressTransaction: true);
+            ConcurrentIndexBuilder.Drop(migrationBuilder, "ix_linked_records_tenant_type_not_primary");
         }
     }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/ConcurrentIndexBuildGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/ConcurrentIndexBuildGuardTests.cs
@@ -1,0 +1,52 @@
+using System.Text.RegularExpressions;
+using Nocturne.Infrastructure.Data.Migrations;
+
+namespace Nocturne.Infrastructure.Data.Tests.Migrations;
+
+/// <summary>
+/// An interrupted <c>CONCURRENTLY</c> build leaves an <c>indisvalid = false</c> index that still
+/// owns the name, and <c>IF NOT EXISTS</c> matches it and skips — so the retry reports success over
+/// an index no query can use and every write still maintains.
+/// <see cref="ConcurrentIndexBuilder"/> is the only shape that repairs that, so a migration
+/// writing the statement itself has no way back from its own first failure.
+/// </summary>
+[Trait("Category", "Unit")]
+public class ConcurrentIndexBuildGuardTests
+{
+    [Fact]
+    public void NoMigrationBuildsAConcurrentIndexOutsideConcurrentIndexBuilder()
+    {
+        var offenders = MigrationSourceFiles.All()
+            .Where(f => RawConcurrentBuild.IsMatch(File.ReadAllText(f)))
+            .Select(MigrationSourceFiles.Name)
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "a concurrent build must go through ConcurrentIndexBuilder.Build, which drops the "
+            + "invalid remains of an interrupted earlier run before rebuilding");
+    }
+
+    [Fact]
+    public void TheGuardSeesMigrationsAndTheShapeItForbids()
+    {
+        // Nothing offends any more, so an empty file set or a broken pattern clears the guard above.
+        MigrationSourceFiles.All().Should().NotBeEmpty();
+
+        RawConcurrentBuild
+            .IsMatch("""Sql("CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_x ON t (c);");""")
+            .Should().BeTrue();
+
+        RawConcurrentBuild
+            .IsMatch("""Sql("CREATE UNIQUE INDEX CONCURRENTLY ix_x ON t (c);");""")
+            .Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Matched against raw text rather than
+    /// <see cref="MigrationSourceFiles.WithCommentsBlanked"/>: this path detects offenders, where
+    /// withheld evidence reads as a pass.
+    /// </summary>
+    private static readonly Regex RawConcurrentBuild = new(
+        @"CREATE\s+(UNIQUE\s+)?INDEX\s+CONCURRENTLY",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+}


### PR DESCRIPTION
`20260511122202_AddCompositePerformanceIndexes` builds `ix_linked_records_tenant_type_not_primary` with a bare `CREATE INDEX CONCURRENTLY IF NOT EXISTS`. That statement cannot recover from its own failure: an interrupted concurrent build leaves an index with `indisvalid = false` that still owns the name, so `IF NOT EXISTS` matches it and skips. The retry then reports success over an index no query can use and every write still maintains. On `linked_records` that is both a lost access path and permanent write amplification. PostgreSQL's documented recovery is `DROP INDEX` then rebuild, which `ConcurrentIndexBuilder` already does for every concurrent build written since; this routes the one that predates it through the same helper. The guarded drop is conditional on `NOT indisvalid`, so a valid index is never dropped and rebuilt.

That alone was not enough, and hostile review proved it on a live Postgres: the five `CreateIndex` calls earlier in `Up` emitted plain `CREATE INDEX` without `IF NOT EXISTS`, and EF commits them before the non-transactional concurrent build runs. A retry after an interrupted build therefore failed on its own first statement (`42P07: relation … already exists`) and never reached the repair. Those five are now raw `CREATE INDEX IF NOT EXISTS`, the form the file's other three indexes already used; plain `CREATE INDEX` is transactional, so `IF NOT EXISTS` carries no invalid-index hazard there. `Down` is eight symmetric `DROP INDEX IF EXISTS`. The generated migration script differs from the previous one in exactly five lines, each adding only `IF NOT EXISTS`; index definitions, ordering and transaction boundaries are byte-identical, and the model snapshot is untouched.

**Behavioural scope.** An instance that already applied this migration cleanly sees nothing: the history row is present and it never re-runs. A fresh install ends in the same schema. An instance whose run was interrupted anywhere in this migration, which previously needed an operator to drop the committed indexes by hand, now retries to completion and repairs an invalid concurrent index on the way. Verified on postgres:17 by applying the chain, deleting the history row, marking the index invalid, and re-running `database update`: the old body fails with `42P07`, the new body completes with all nine indexes `indisvalid = t`, and a Down/Up round trip is clean.

The migration also stated the wrong lock mode: it claimed a plain `CREATE INDEX` takes an `AccessExclusiveLock`. It takes a `ShareLock`; `ACCESS EXCLUSIVE` is what `DROP INDEX` takes. The correct rationale already lives on `ConcurrentIndexBuilder`, so the restatement is removed rather than fixed in a second place. This was the only false instance in the repo.

`ConcurrentIndexBuildGuardTests` holds every migration to the builder, matching `CREATE [UNIQUE] INDEX CONCURRENTLY` in raw source. It carries no allowlist (the one offender is fixed here) and pins its own detector. `ConcurrentIndexBuilder.Build` cannot express `UNIQUE` today, so the first unique concurrent index will need the helper extended rather than written raw.

`tests/Unit/Nocturne.Infrastructure.Data.Tests` 913 passed; reverting the migration reddens the guard naming the file.

Closes #1156.

https://claude.ai/code/session_01MqyVPKPLNu6y8YvXbdsoZ8
