### PR TITLE
fix(clock): render the absence of a reading, not a fabricated one

### DIFF
--- a/src/Web/packages/app/src/lib/clock-builder/factories.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/factories.ts
@@ -36,7 +36,7 @@ export function createDefaultElement(type: ClockElementType): ClockElement {
   if (info.hasFormatOption) element.format = DEFAULT_CLOCK_TIME_FORMAT;
   if (info.hasMinutesAheadOption) element.minutesAhead = 30;
   if (type === "tracker") {
-    element.show = ["name", "remaining"];
+    element.show = ["name"];
     element.visibilityThreshold = "always";
   }
   if (type === "trackers") {

--- a/src/Web/packages/app/src/lib/clock-builder/types.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/types.ts
@@ -258,8 +258,6 @@ export const VISIBILITY_OPTIONS: SelectOption[] = [
 export const TRACKER_SHOW_OPTIONS: SelectOption[] = [
   { value: "name", label: "Name" },
   { value: "icon", label: "Icon" },
-  { value: "remaining", label: "Time remaining" },
-  { value: "urgency", label: "Urgency badge" },
 ];
 
 export const TRACKER_CATEGORIES = [

--- a/src/Web/packages/app/src/lib/clock-builder/utils.test.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import type { ClockElement } from "$lib/api";
+import { clockBackgroundStyle, getElementColor } from "./utils";
+
+const dynamic = (): ClockElement => ({
+  type: "sg",
+  style: { color: "dynamic" },
+});
+
+describe("getElementColor", () => {
+  it("takes no glucose colour when there is no reading", () => {
+    expect(getElementColor(dynamic(), null)).toBe("#ffffff");
+  });
+
+  it("keeps a fixed colour whatever the reading", () => {
+    const fixed: ClockElement = { type: "sg", style: { color: "#ff0000" } };
+    expect(getElementColor(fixed, null)).toBe("#ff0000");
+    expect(getElementColor(fixed, 55)).toBe("#ff0000");
+  });
+});
+
+describe("clockBackgroundStyle", () => {
+  const settings = { bgColor: true };
+
+  it("takes the fallback, not a glucose colour, when there is no reading", () => {
+    expect(clockBackgroundStyle(settings, null, "#0a0a0a")).toBe(
+      "background-color: #0a0a0a;"
+    );
+  });
+
+  it("colours the face by a real reading", () => {
+    expect(clockBackgroundStyle(settings, 55, "#0a0a0a")).not.toBe(
+      "background-color: #0a0a0a;"
+    );
+  });
+
+  it("takes the fallback when the face is not coloured by glucose", () => {
+    expect(clockBackgroundStyle({}, 55, "#0a0a0a")).toBe(
+      "background-color: #0a0a0a;"
+    );
+    expect(clockBackgroundStyle(undefined, 55, "#0a0a0a")).toBe(
+      "background-color: #0a0a0a;"
+    );
+  });
+
+  it("prefers a background image over either", () => {
+    expect(
+      clockBackgroundStyle(
+        { bgColor: true, backgroundImage: "/face.png" },
+        55,
+        "#0a0a0a"
+      )
+    ).toContain("background-image: url(/face.png)");
+  });
+});

--- a/src/Web/packages/app/src/lib/clock-builder/utils.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/utils.ts
@@ -5,7 +5,7 @@
  * and other utilities used by the clock face builder.
  */
 
-import type { ClockElement, TrackerDefinitionDto } from "$lib/api";
+import type { ClockElement, ClockSettings, TrackerDefinitionDto } from "$lib/api";
 import {
   TEXT_ELEMENT_TYPES,
   elementInfo,
@@ -21,6 +21,8 @@ function resolveCssVar(name: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 }
 
+const DEFAULT_ELEMENT_COLOR = "#ffffff";
+
 /**
  * Get BG color based on glucose value
  */
@@ -30,6 +32,25 @@ export function getBgColor(bg: number): string {
   if (bg > 250) return resolveCssVar("--glucose-very-high");
   if (bg > 180) return resolveCssVar("--glucose-high");
   return resolveCssVar("--glucose-in-range");
+}
+
+/**
+ * Background of a whole clock face. A face set to colour itself by glucose
+ * takes `fallback` when there is no reading, rather than painting the screen
+ * with the colour of a value nothing reported.
+ */
+export function clockBackgroundStyle(
+  settings: ClockSettings | undefined,
+  currentBG: number | null,
+  fallback: string
+): string {
+  if (settings?.backgroundImage) {
+    return `background-image: url(${settings.backgroundImage}); background-size: cover; background-position: center;`;
+  }
+  if (settings?.bgColor && currentBG !== null) {
+    return `background-color: ${getBgColor(currentBG)};`;
+  }
+  return `background-color: ${fallback};`;
 }
 
 /**
@@ -90,12 +111,19 @@ export function getFontWeightClass(weight: string | undefined): string {
 }
 
 /**
- * Get element text color from style
+ * Get element text color from style. A null `currentBG` has no glucose colour:
+ * a dynamic element falls back to the static default rather than painting the
+ * absence of a reading as a severe low.
  */
-export function getElementColor(element: ClockElement, currentBG: number): string {
+export function getElementColor(
+  element: ClockElement,
+  currentBG: number | null
+): string {
   const color = element.style?.color;
-  if (color === "dynamic") return getBgColor(currentBG);
-  return color || "#ffffff";
+  if (color === "dynamic") {
+    return currentBG === null ? DEFAULT_ELEMENT_COLOR : getBgColor(currentBG);
+  }
+  return color || DEFAULT_ELEMENT_COLOR;
 }
 
 /**
@@ -112,7 +140,10 @@ export function buildCustomCssString(element: ClockElement): string {
 /**
  * Build inline style string from element.style (including custom properties)
  */
-export function buildStyleString(element: ClockElement, currentBG: number): string {
+export function buildStyleString(
+  element: ClockElement,
+  currentBG: number | null
+): string {
   const style = element.style;
   const parts: string[] = [];
 

--- a/src/Web/packages/app/src/lib/components/clock-builder/ClockElementPreview.svelte
+++ b/src/Web/packages/app/src/lib/components/clock-builder/ClockElementPreview.svelte
@@ -40,10 +40,9 @@
     <TrendArrow direction={glucose.direction} {size} />
   </div>
 {:else if element.type === "tracker"}
-  <!-- Tracker element with icon and time remaining -->
   {@const def = getTrackerDefinition(element.definitionId, trackerDefinitions)}
   {@const size = element.size || ELEMENT_INFO.tracker.defaultSize}
-  {@const showOptions = element.show ?? ["name", "remaining"]}
+  {@const showOptions = element.show ?? ["name"]}
   <div
     class="flex items-center gap-1 {getFontClass(
       element.style?.font
@@ -62,9 +61,6 @@
     {/if}
     {#if showOptions.includes("name")}
       <span class="leading-none">{def?.name ?? "Select tracker"}</span>
-    {/if}
-    {#if showOptions.includes("remaining")}
-      <span class="leading-none tabular-nums opacity-70">2d 4h</span>
     {/if}
   </div>
 {:else if value}

--- a/src/Web/packages/app/src/lib/components/clock-builder/ClockElementPreview.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/clock-builder/ClockElementPreview.svelte.test.ts
@@ -21,10 +21,18 @@ const glucose = {
   demoMode: false,
 };
 
-function preview(type: ClockElementType) {
+const noReading = {
+  currentBG: null,
+  bgDelta: 0,
+  direction: "",
+  lastUpdated: null,
+  demoMode: false,
+};
+
+function preview(type: ClockElementType, source: ClockGlucoseSource = glucose) {
   const { container } = render(ClockElementPreview, {
     element: { _id: type, type, format: "24h" },
-    glucose,
+    glucose: source,
     now,
     trackerDefinitions: [],
   });
@@ -68,6 +76,13 @@ describe("ClockElementPreview", () => {
   it("names the elements the runtime renderer has no value for", () => {
     expect(preview("summary")).toBe("Summary");
     expect(preview("trackers")).toBe("Trackers");
+  });
+
+  it("shows the no-reading face, not a fabricated one, with no reading", () => {
+    expect(preview("sg", noReading)).toBe("--");
+    // No value to show, so the builder names the element instead.
+    expect(preview("delta", noReading)).toBe(elementInfo("delta")?.name);
+    expect(preview("age", noReading)).toBe(elementInfo("age")?.name);
   });
 
   it("follows the glucose source after mount", async () => {

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
   import { browser } from "$app/environment";
   import { getClockGlucoseSource } from "$lib/stores/realtime-store.svelte";
-  import { isUnwiredElementType } from "$lib/clock-builder/types";
+  import {
+    buildCustomCssString,
+    clockBackgroundStyle,
+    getElementColor,
+    getFontClass,
+    getFontWeightClass,
+    getTrackerDefinition,
+    isUnwiredElementType,
+  } from "$lib/clock-builder";
   import { renderClockElementValue } from "$lib/components/clock/element-value";
   import TrendArrow from "$lib/components/clock/TrendArrow.svelte";
   import { createChartDataEngine } from "$lib/components/dashboard/glucose-chart/engine/chart-data-engine.svelte";
@@ -18,7 +26,6 @@
   import type {
     ClockFaceConfig,
     ClockElement,
-    ClockElementStyle,
     TrackerDefinitionDto,
   } from "$lib/api";
   import { getDefinitions } from "$api/generated/trackers.generated.remote";
@@ -85,85 +92,19 @@
     )
   );
 
-  // Resolve CSS variable to its computed value
-  function resolveCssVar(name: string): string {
-    if (!browser) return "#000000"; // fallback for SSR
-    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-  }
-
-  // Get BG color based on value
-  function getBgColor(bg: number): string {
-    if (bg < 70) return resolveCssVar("--glucose-very-low");
-    if (bg < 80) return resolveCssVar("--glucose-low");
-    if (bg > 250) return resolveCssVar("--glucose-very-high");
-    if (bg > 180) return resolveCssVar("--glucose-high");
-    return resolveCssVar("--glucose-in-range");
-  }
-
   // Tracker definitions (skipped on the anonymous public clock — see loadTrackerDefinitions)
   const definitionsQuery = loadTrackerDefinitions ? getDefinitions({}) : null;
   const trackerDefinitions = $derived<TrackerDefinitionDto[]>(
     definitionsQuery?.current ?? [],
   );
 
-  // Get tracker definition by ID
-  function getTrackerDefinition(definitionId: string | undefined) {
-    if (!definitionId) return null;
-    return trackerDefinitions.find((d) => d.id === definitionId) ?? null;
-  }
-
-  // Font class helpers
-  function getFontClass(font: string | undefined): string {
-    switch (font) {
-      case "mono":
-        return "font-mono";
-      case "serif":
-        return "font-serif";
-      case "sans":
-        return "font-sans";
-      default:
-        return "";
-    }
-  }
-
-  function getFontWeightClass(weight: string | undefined): string {
-    switch (weight) {
-      case "normal":
-        return "font-normal";
-      case "medium":
-        return "font-medium";
-      case "semibold":
-        return "font-semibold";
-      case "bold":
-        return "font-bold";
-      default:
-        return "font-medium";
-    }
-  }
-
-  // Get element color
-  function getElementColor(style: ClockElementStyle | undefined): string {
-    const color = style?.color;
-    if (color === "dynamic") return getBgColor(currentBG);
-    return color || "#ffffff";
-  }
-
-  // Build custom CSS properties string from element.style.custom
-  function buildCustomCssString(element: ClockElement): string {
-    const custom = element.style?.custom;
-    if (!custom) return "";
-    return Object.entries(custom)
-      .map(([key, value]) => `${key}: ${value}`)
-      .join("; ");
-  }
-
-  // Build inline style string
+  // Sized off `scale`, so it cannot share the builder's own style builder.
   function buildStyleString(element: ClockElement): string {
     const style = element.style;
     const parts: string[] = [];
     const size = (element.size || 20) * scale;
     parts.push(`font-size: ${size}px`);
-    parts.push(`color: ${getElementColor(style)}`);
+    parts.push(`color: ${getElementColor(element, currentBG)}`);
     parts.push(`opacity: ${style?.opacity ?? 1.0}`);
     const customCss = buildCustomCssString(element);
     if (customCss) {
@@ -185,17 +126,9 @@
     return null;
   });
 
-  // Preview background style
-  const bgStyle = $derived.by(() => {
-    if (!config?.settings) return "background-color: var(--background);";
-    if (config.settings.backgroundImage) {
-      return `background-image: url(${config.settings.backgroundImage}); background-size: cover; background-position: center;`;
-    }
-    if (config.settings.bgColor) {
-      return `background-color: ${getBgColor(currentBG)};`;
-    }
-    return "background-color: var(--background);";
-  });
+  const bgStyle = $derived(
+    clockBackgroundStyle(config?.settings, currentBG, "var(--background)")
+  );
 
   const overlayOpacity = $derived(
     config?.settings?.backgroundImage
@@ -474,19 +407,18 @@
               {@const customCss = buildCustomCssString(element)}
               <div
                 class="flex items-center"
-                style="color: {getElementColor(element.style)}; opacity: {element.style?.opacity ?? 1.0};{customCss ? ` ${customCss}` : ''}"
+                style="color: {getElementColor(element, currentBG)}; opacity: {element.style?.opacity ?? 1.0};{customCss ? ` ${customCss}` : ''}"
               >
                 <TrendArrow {direction} {size} />
               </div>
             {:else if element.type === "tracker"}
-              <!-- Tracker element with icon and time remaining -->
-              {@const def = getTrackerDefinition(element.definitionId)}
+              {@const def = getTrackerDefinition(element.definitionId, trackerDefinitions)}
               {@const size = (element.size || 14) * scale}
-              {@const showOptions = element.show ?? ["name", "remaining"]}
+              {@const showOptions = element.show ?? ["name"]}
               {@const customCss = buildCustomCssString(element)}
               <div
                 class="flex items-center gap-1 {getFontClass(element.style?.font)} {getFontWeightClass(element.style?.fontWeight)}"
-                style="color: {getElementColor(element.style)}; opacity: {element.style?.opacity ?? 1.0}; font-size: {size}px;{customCss ? ` ${customCss}` : ''}"
+                style="color: {getElementColor(element, currentBG)}; opacity: {element.style?.opacity ?? 1.0}; font-size: {size}px;{customCss ? ` ${customCss}` : ''}"
               >
                 {#if showOptions.includes("icon") && def?.category}
                   <TrackerCategoryIcon
@@ -497,9 +429,6 @@
                 {/if}
                 {#if showOptions.includes("name")}
                   <span class="leading-none">{def?.name ?? "Tracker"}</span>
-                {/if}
-                {#if showOptions.includes("remaining")}
-                  <span class="leading-none tabular-nums opacity-70">2d 4h</span>
                 {/if}
               </div>
             {:else if element.type !== "chart"}

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte.test.ts
@@ -1,0 +1,101 @@
+import { render } from "vitest-browser-svelte";
+import { describe, it, expect } from "vitest";
+import type { ClockFaceConfig } from "$lib/api";
+import type { ClockGlucoseSource } from "$lib/stores/realtime-store.svelte";
+import { TRACKER_SHOW_OPTIONS } from "$lib/clock-builder";
+import Harness from "./ClockFaceRendererHarness.test.svelte";
+
+const WHITE = "rgb(255, 255, 255)";
+
+const config: ClockFaceConfig = {
+  rows: [
+    {
+      elements: [
+        { type: "sg", size: 40, style: { color: "dynamic" } },
+        { type: "age", size: 14 },
+        { type: "tracker", size: 14, show: ["name", "remaining", "urgency"] },
+      ],
+    },
+  ],
+  settings: { staleMinutes: 15 },
+};
+
+const reading: ClockGlucoseSource = {
+  currentBG: 55,
+  bgDelta: -3,
+  direction: "Flat",
+  lastUpdated: Date.now() - 7 * 60_000,
+  demoMode: false,
+};
+
+const noReading: ClockGlucoseSource = {
+  currentBG: null,
+  bgDelta: null,
+  direction: "",
+  lastUpdated: null,
+  demoMode: false,
+};
+
+/** Computed value of a CSS variable, to compare a rendered colour against. */
+function cssColor(variable: string) {
+  const probe = document.createElement("div");
+  probe.style.backgroundColor = `var(${variable})`;
+  document.body.append(probe);
+  const color = getComputedStyle(probe).backgroundColor;
+  probe.remove();
+  return color;
+}
+
+function face(
+  glucose: ClockGlucoseSource,
+  faceConfig: ClockFaceConfig = config
+) {
+  const { container } = render(Harness, { config: faceConfig, glucose });
+  const rows = container.querySelector("[data-testid='clock-face-rows']");
+  const spans = [...(rows?.querySelectorAll("span") ?? [])];
+  return {
+    text: rows?.textContent?.trim() ?? "",
+    background: getComputedStyle(container.firstElementChild!).backgroundColor,
+    glucoseColor: (value: string) => {
+      const span = spans.find((s) => s.textContent?.trim() === value);
+      expect(span, `no element rendering "${value}"`).toBeTruthy();
+      return getComputedStyle(span!).color;
+    },
+  };
+}
+
+describe("ClockFaceRenderer", () => {
+  it("shows a placeholder in no glucose colour when there is no reading", () => {
+    const { text, glucoseColor } = face(noReading);
+
+    expect(text).toContain("--");
+    expect(text).not.toMatch(/\d/);
+    expect(glucoseColor("--")).toBe(WHITE);
+  });
+
+  it("shows the reading in its glucose colour", () => {
+    const { text, glucoseColor } = face(reading);
+
+    expect(text).toContain("55");
+    expect(text).toContain("7m ago");
+    expect(glucoseColor("55")).not.toBe(WHITE);
+  });
+
+  it("does not paint the whole face with a colour nothing reported", () => {
+    const glucoseColored = { ...config, settings: { bgColor: true } };
+    const veryLow = cssColor("--glucose-very-low");
+
+    expect(face(reading, glucoseColored).background).toBe(veryLow);
+    expect(face(noReading, glucoseColored).background).not.toBe(veryLow);
+  });
+
+  it("renders nothing for tracker parts no data source backs", () => {
+    const offered = TRACKER_SHOW_OPTIONS.map((option) => option.value);
+    expect(offered).not.toContain("remaining");
+    expect(offered).not.toContain("urgency");
+
+    // The face above still asks for both; only the name may reach the screen.
+    expect(face(reading).text).not.toContain("2d 4h");
+    expect(face(noReading).text.replace(/\s+/g, " ")).toBe("-- Tracker");
+  });
+});

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRendererHarness.test.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRendererHarness.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  // Mounts the live renderer with a source in context, the way the public clock
+  // route does, so the assertions cover the renderer the anonymous viewer gets.
+  import type { ClockFaceConfig } from "$lib/api";
+  import {
+    setClockGlucoseSource,
+    type ClockGlucoseSource,
+  } from "$lib/stores/realtime-store.svelte";
+  import ClockFaceRenderer from "./ClockFaceRenderer.svelte";
+
+  interface Props {
+    config: ClockFaceConfig;
+    glucose: ClockGlucoseSource;
+  }
+
+  let { config, glucose }: Props = $props();
+
+  // svelte-ignore state_referenced_locally
+  setClockGlucoseSource(glucose);
+</script>
+
+<ClockFaceRenderer {config} showCharts={false} loadTrackerDefinitions={false} />

--- a/src/Web/packages/app/src/lib/components/clock/element-value.test.ts
+++ b/src/Web/packages/app/src/lib/components/clock/element-value.test.ts
@@ -35,6 +35,18 @@ const glucose = {
   demoMode: false,
 };
 
+/**
+ * A tenant with no readings at all: a new tenant, or a connector not yet
+ * syncing.
+ */
+const noReading = {
+  currentBG: null,
+  bgDelta: null,
+  direction: "",
+  lastUpdated: null,
+  demoMode: false,
+};
+
 const el = (element: ClockElement): ClockElement => element;
 
 function withUnits(units: GlucoseUnits, run: () => void) {
@@ -114,6 +126,48 @@ describe("renderClockElementValue", () => {
         now
       )
     ).toBe("now");
+  });
+
+  it("renders a placeholder, not a number, when there is no reading", () => {
+    withUnits("mg/dl", () => {
+      expect(renderClockElementValue(el({ type: "sg" }), noReading, now)).toBe(
+        "--"
+      );
+    });
+    withUnits("mmol", () => {
+      expect(renderClockElementValue(el({ type: "sg" }), noReading, now)).toBe(
+        "--"
+      );
+    });
+  });
+
+  it("renders no delta and no age when there is no reading", () => {
+    expect(renderClockElementValue(el({ type: "delta" }), noReading, now)).toBe(
+      ""
+    );
+    expect(renderClockElementValue(el({ type: "age" }), noReading, now)).toBe(
+      ""
+    );
+  });
+
+  it("renders no delta from a lone reading", () => {
+    expect(
+      renderClockElementValue(
+        el({ type: "delta" }),
+        { ...glucose, bgDelta: null },
+        now
+      )
+    ).toBe("");
+  });
+
+  it("still renders the wall clock when there is no reading", () => {
+    expect(
+      renderClockElementValue(
+        el({ type: "time", format: "24h" }),
+        noReading,
+        now
+      )
+    ).toBe("14:05");
   });
 
   it("renders time in the element's pinned format", () => {

--- a/src/Web/packages/app/src/lib/components/clock/element-value.ts
+++ b/src/Web/packages/app/src/lib/components/clock/element-value.ts
@@ -18,15 +18,20 @@ export function renderClockElementValue(
   glucose: ClockGlucoseSource,
   now: Date
 ): string {
+  const { currentBG, lastUpdated } = glucose;
   switch (element.type) {
     case "sg":
-      return String(bg(glucose.currentBG));
+      return currentBG === null ? "--" : String(bg(currentBG));
     case "delta": {
+      // A delta needs a reading, and a second one to be a delta from.
+      if (currentBG === null || glucose.bgDelta === null) return "";
       const delta = bgDelta(glucose.bgDelta);
       return element.showUnits !== false ? `${delta} ${bgLabel()}` : delta;
     }
     case "age":
-      return readingAgePhrase(glucose.lastUpdated, now.getTime());
+      return lastUpdated === null
+        ? ""
+        : readingAgePhrase(lastUpdated, now.getTime());
     case "time":
       return formatClockTime(now, element.format);
     // No runtime source for insulin/carbs on board; an explicit placeholder

--- a/src/Web/packages/app/src/lib/components/clock/staleness.test.ts
+++ b/src/Web/packages/app/src/lib/components/clock/staleness.test.ts
@@ -45,6 +45,10 @@ describe("isClockReadingStale", () => {
       true
     );
   });
+
+  it("is never stale without a reading to have aged", () => {
+    expect(isClockReadingStale(15, null, lastUpdated + 60 * MIN)).toBe(false);
+  });
 });
 
 describe("readingAgeLabel", () => {

--- a/src/Web/packages/app/src/lib/components/clock/staleness.ts
+++ b/src/Web/packages/app/src/lib/components/clock/staleness.ts
@@ -15,14 +15,15 @@ export function readingAgeMinutes(lastUpdated: number, now: number): number {
 
 /**
  * Whether the reading is older than the clock face's configured stale window.
- * A `staleMinutes` of 0 or undefined disables the check.
+ * A `staleMinutes` of 0 or undefined disables the check; a null `lastUpdated`
+ * is the absence of a reading, which has no age to have outlived the window.
  */
 export function isClockReadingStale(
   staleMinutes: number | undefined,
-  lastUpdated: number,
+  lastUpdated: number | null,
   now: number
 ): boolean {
-  if (!staleMinutes) return false;
+  if (!staleMinutes || lastUpdated === null) return false;
   return readingAgeMinutes(lastUpdated, now) >= staleMinutes;
 }
 

--- a/src/Web/packages/app/src/lib/stores/clock-glucose-source.test.ts
+++ b/src/Web/packages/app/src/lib/stores/clock-glucose-source.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import type { Entry } from "$lib/websocket/types";
+import { clockGlucoseSourceOf } from "./realtime-store.svelte";
+
+const MILLS = Date.UTC(2026, 11, 31, 14, 5);
+
+type ClockSourceStore = Parameters<typeof clockGlucoseSourceOf>[0];
+
+/**
+ * The store's own `currentBG`, `lastUpdated` and `bgDelta` carry 0 and the
+ * current time for the dashboard, so a source built over those could not tell
+ * an absent reading from a real one. This stands in the entries they are
+ * derived from instead.
+ */
+function storeWith(entries: Entry[]): ClockSourceStore {
+  const sorted = [...entries].sort((a, b) => (b.mills || 0) - (a.mills || 0));
+  return {
+    currentEntry: sorted[0] ?? null,
+    previousEntry: sorted[1] ?? null,
+    direction: sorted[0]?.direction ?? "",
+    demoMode: false,
+  };
+}
+
+describe("clockGlucoseSourceOf", () => {
+  it("has no reading, age or delta when the store holds no entries", () => {
+    const source = clockGlucoseSourceOf(storeWith([]));
+
+    expect(source.currentBG).toBeNull();
+    expect(source.lastUpdated).toBeNull();
+    expect(source.bgDelta).toBeNull();
+  });
+
+  it("reads the newest entry's value and time", () => {
+    const source = clockGlucoseSourceOf(
+      storeWith([
+        { sgv: 120, mills: MILLS, direction: "Flat" },
+        { sgv: 200, mills: MILLS - 60 * 60_000 },
+      ])
+    );
+
+    expect(source.currentBG).toBe(120);
+    expect(source.lastUpdated).toBe(MILLS);
+    expect(source.direction).toBe("Flat");
+  });
+
+  it("falls back to mgdl on an entry carrying no sgv", () => {
+    const source = clockGlucoseSourceOf(
+      storeWith([{ mgdl: 88, mills: MILLS }])
+    );
+
+    expect(source.currentBG).toBe(88);
+  });
+
+  it("claims no change from a lone reading", () => {
+    const source = clockGlucoseSourceOf(
+      storeWith([{ sgv: 120, mills: MILLS }])
+    );
+
+    expect(source.bgDelta).toBeNull();
+  });
+
+  it("measures the change against the previous reading", () => {
+    const source = clockGlucoseSourceOf(
+      storeWith([
+        { sgv: 120, mills: MILLS },
+        { sgv: 113, mills: MILLS - 5 * 60_000 },
+      ])
+    );
+
+    expect(source.bgDelta).toBe(7);
+  });
+
+  it("prefers the delta the reading carried", () => {
+    const source = clockGlucoseSourceOf(
+      storeWith([
+        { sgv: 120, mills: MILLS, delta: 4 },
+        { sgv: 113, mills: MILLS - 5 * 60_000 },
+      ])
+    );
+
+    expect(source.bgDelta).toBe(4);
+  });
+
+  it("follows the store rather than sampling it once", () => {
+    const store = storeWith([]);
+    const source = clockGlucoseSourceOf(store);
+
+    expect(source.currentBG).toBeNull();
+
+    Object.assign(store, {
+      currentEntry: { sgv: 99, mills: MILLS },
+    });
+
+    expect(source.currentBG).toBe(99);
+  });
+});

--- a/src/Web/packages/app/src/lib/stores/public-clock-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/public-clock-store.svelte.ts
@@ -7,7 +7,10 @@
 
 import { getApiClient } from "$lib/api/client";
 import type { ClockGlucoseDto } from "$lib/api";
-import type { ClockGlucoseSource } from "./realtime-store.svelte";
+import {
+  clockGlucoseDelta,
+  type ClockGlucoseSource,
+} from "./realtime-store.svelte";
 
 /** Glucose only changes every ~5 min, so a 30s poll keeps a public clock current cheaply. */
 const POLL_INTERVAL_MS = 30_000;
@@ -26,20 +29,18 @@ export class PublicClockStore implements ClockGlucoseSource {
     this.clockId = clockId;
   }
 
-  currentBG = $derived(this.readings[0]?.mgdl ?? 0);
+  currentBG = $derived(this.readings[0]?.mgdl ?? null);
   direction = $derived(this.readings[0]?.direction ?? "");
-  lastUpdated = $derived(this.readings[0]?.mills ?? Date.now());
+  lastUpdated = $derived(this.readings[0]?.mills ?? null);
   demoMode = $derived(this.readings.some((r) => r.dataSource === "demo-service"));
 
-  bgDelta = $derived.by(() => {
-    const latest = this.readings[0];
-    if (latest?.delta != null) return latest.delta;
-    const previous = this.readings[1];
-    if (latest?.mgdl != null && previous?.mgdl != null) {
-      return latest.mgdl - previous.mgdl;
-    }
-    return 0;
-  });
+  bgDelta = $derived(
+    clockGlucoseDelta(
+      this.readings[0]?.delta,
+      this.readings[0]?.mgdl,
+      this.readings[1]?.mgdl
+    )
+  );
 
   /** Begin polling. No-op during SSR. */
   async start(): Promise<void> {

--- a/src/Web/packages/app/src/lib/stores/public-clock-store.test.ts
+++ b/src/Web/packages/app/src/lib/stores/public-clock-store.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getGlucose = vi.fn();
+vi.mock("$lib/api/client", () => ({
+  getApiClient: () => ({ clockFaces: { getGlucose } }),
+}));
+
+const { PublicClockStore } = await import("./public-clock-store.svelte");
+
+const MILLS = Date.UTC(2026, 11, 31, 14, 5);
+
+async function storeOf(readings: unknown[]) {
+  getGlucose.mockResolvedValue(readings);
+  const store = new PublicClockStore("clock-id");
+  await store.start();
+  store.stop();
+  return store;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("window", globalThis);
+  getGlucose.mockReset();
+});
+
+describe("PublicClockStore", () => {
+  it("has no reading, age or delta before any reading arrives", async () => {
+    const store = await storeOf([]);
+    expect(store.currentBG).toBeNull();
+    expect(store.lastUpdated).toBeNull();
+    expect(store.bgDelta).toBeNull();
+  });
+
+  it("claims no change from a lone reading", async () => {
+    const store = await storeOf([{ mgdl: 120, mills: MILLS }]);
+    expect(store.currentBG).toBe(120);
+    expect(store.lastUpdated).toBe(MILLS);
+    expect(store.bgDelta).toBeNull();
+  });
+
+  it("measures the change against the previous reading", async () => {
+    const store = await storeOf([
+      { mgdl: 120, mills: MILLS },
+      { mgdl: 113, mills: MILLS - 5 * 60_000 },
+    ]);
+    expect(store.bgDelta).toBe(7);
+  });
+
+  it("prefers the delta the reading carried", async () => {
+    const store = await storeOf([
+      { mgdl: 120, mills: MILLS, delta: 4 },
+      { mgdl: 113, mills: MILLS - 5 * 60_000 },
+    ]);
+    expect(store.bgDelta).toBe(4);
+  });
+});

--- a/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/realtime-store.svelte.ts
@@ -1181,18 +1181,72 @@ export function tryGetRealtimeStore(): RealtimeStore | null {
 }
 
 /**
- * The minimal live-glucose surface a clock face renders. Satisfied by the full
- * {@link RealtimeStore} (authenticated views) and by the lightweight polling
- * `PublicClockStore` (anonymous public clock links), so `ClockFaceRenderer`
- * works with either without knowing which one it has.
+ * The minimal live-glucose surface a clock face renders. Satisfied by the
+ * lightweight polling `PublicClockStore` (anonymous public clock links) and by
+ * {@link clockGlucoseSourceOf} over the full {@link RealtimeStore}
+ * (authenticated views), so `ClockFaceRenderer` works with either without
+ * knowing which one it has.
  */
 export interface ClockGlucoseSource {
-  readonly currentBG: number;
-  readonly bgDelta: number;
+  /** Null when there is no reading; a face must not present a stand-in as one. */
+  readonly currentBG: number | null;
+  /** Null when nothing measures a change, so no rise or fall can be claimed. */
+  readonly bgDelta: number | null;
   /** Empty when the reading carried no direction. */
   readonly direction: string;
-  readonly lastUpdated: number;
+  /** Null when there is no reading, so age and staleness have nothing to measure. */
+  readonly lastUpdated: number | null;
   readonly demoMode: boolean;
+}
+
+/**
+ * The change a face may show: the reading's own delta, else the gap to the
+ * previous reading. Null when there is neither — a lone reading is not a rise
+ * from zero.
+ */
+export function clockGlucoseDelta(
+  carried: number | null | undefined,
+  currentBG: number | null | undefined,
+  previousBG: number | null | undefined
+): number | null {
+  if (carried != null) return carried;
+  if (currentBG == null || previousBG == null) return null;
+  return currentBG - previousBG;
+}
+
+/**
+ * The store's own `currentBG`/`lastUpdated`/`bgDelta` fall back to 0 and the
+ * current time for the dashboard tiles, which cannot tell an absent reading
+ * from a real one.
+ */
+export function clockGlucoseSourceOf(
+  store: Pick<
+    RealtimeStore,
+    "currentEntry" | "previousEntry" | "direction" | "demoMode"
+  >
+): ClockGlucoseSource {
+  const mgdlOf = (entry: Entry | null) => entry?.sgv ?? entry?.mgdl ?? null;
+  return {
+    get currentBG() {
+      return mgdlOf(store.currentEntry);
+    },
+    get bgDelta() {
+      return clockGlucoseDelta(
+        store.currentEntry?.delta,
+        mgdlOf(store.currentEntry),
+        mgdlOf(store.previousEntry)
+      );
+    },
+    get direction() {
+      return store.direction;
+    },
+    get lastUpdated() {
+      return store.currentEntry?.mills ?? null;
+    },
+    get demoMode() {
+      return store.demoMode;
+    },
+  };
 }
 
 const CLOCK_GLUCOSE_SOURCE_KEY = Symbol("clock-glucose-source");
@@ -1208,5 +1262,8 @@ export function setClockGlucoseSource(source: ClockGlucoseSource): void {
  * so authenticated clock previews keep working unchanged.
  */
 export function getClockGlucoseSource(): ClockGlucoseSource {
-  return getContext<ClockGlucoseSource>(CLOCK_GLUCOSE_SOURCE_KEY) ?? getRealtimeStore();
+  return (
+    getContext<ClockGlucoseSource>(CLOCK_GLUCOSE_SOURCE_KEY) ??
+    clockGlucoseSourceOf(getRealtimeStore())
+  );
 }

--- a/src/Web/packages/app/src/lib/test-stubs/app-server.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/app-server.ts
@@ -27,6 +27,11 @@ export function getRequestEvent(): never {
   throw new Error("getRequestEvent is not available in browser tests");
 }
 
+/** Reached only from inside a command's `refreshes`, which no browser test runs. */
+export function requested(): never {
+  throw new Error("requested is not available in browser tests");
+}
+
 type Implementation = (arg?: unknown) => unknown;
 
 // The framework's `(schema, fn)` and `(fn)` overloads both end at `fn`. Only

--- a/src/Web/packages/app/src/routes/(authenticated)/clock/config/[id]/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/clock/config/[id]/+page.svelte
@@ -7,7 +7,10 @@
   import { useToastSubmission } from "$lib/forms";
   import { X, Loader2 } from "lucide-svelte";
   import { StateHistory } from "runed";
-  import { getRealtimeStore } from "$lib/stores/realtime-store.svelte";
+  import {
+    clockGlucoseSourceOf,
+    getRealtimeStore,
+  } from "$lib/stores/realtime-store.svelte";
   import { getDefinitions } from "$api/generated/trackers.generated.remote";
   import { getByIdForEdit as getClockFaceById } from "$api/clockfaces.remote";
   import { update as updateClockFace } from "$api/generated/clockFaces.generated.remote";
@@ -26,7 +29,7 @@
     toApiConfig,
     createInternalElement,
     createInternalRow,
-    getBgColor,
+    clockBackgroundStyle,
     isTrackerBelowThreshold,
   } from "$lib/clock-builder";
 
@@ -64,8 +67,8 @@
   );
 
   // Realtime store for live preview
-  const realtimeStore = getRealtimeStore();
-  const currentBG = $derived(realtimeStore.currentBG);
+  const glucose = clockGlucoseSourceOf(getRealtimeStore());
+  const currentBG = $derived(glucose.currentBG);
 
   // Tracker definitions
   const definitionsQuery = getDefinitions({});
@@ -110,11 +113,7 @@
   // Computed styles
   const hasBackgroundImage = $derived(!!config.settings?.backgroundImage);
   const previewBgStyle = $derived(
-    hasBackgroundImage
-      ? `background-image: url(${config.settings.backgroundImage}); background-size: cover; background-position: center;`
-      : config.settings?.bgColor
-        ? `background-color: ${getBgColor(currentBG)};`
-        : "background-color: #0a0a0a;"
+    clockBackgroundStyle(config.settings, currentBG, "#0a0a0a")
   );
   const overlayOpacity = $derived(
     hasBackgroundImage
@@ -447,7 +446,7 @@
       {:else}
         <ClockElementPreview
           {element}
-          glucose={realtimeStore}
+          {glucose}
           now={currentTime}
           {trackerDefinitions}
         />

--- a/src/Web/packages/app/src/routes/(unauthenticated)/clock/[id]/+page@.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/clock/[id]/+page@.svelte
@@ -90,7 +90,7 @@
     )
   );
   const timeSince = $derived(
-    readingAgeLabel(lastUpdated, currentTime.getTime())
+    lastUpdated === null ? "" : readingAgeLabel(lastUpdated, currentTime.getTime())
   );
 
   // The fallback readout is not a configured element, so it follows the viewer's


### PR DESCRIPTION
A clock face had no way to express "no reading". Both glucose sources filled the gap with a stand-in: the anonymous public store used `0 mg/dL` stamped with `Date.now()`, and the authenticated realtime store used the same 0 and current time it keeps for the dashboard tiles. A tenant with no glucose data (a new tenant, a connector not yet syncing, data cleared) therefore rendered a "0" in the very-low colour with an age of "now", a delta of "+0 mg/dL", and no stale indication. On an anonymous public clock link that reads as a just-arrived severe hypoglycaemic reading, with nothing on the face to say otherwise. If the face colours its whole background by glucose, the entire screen was hypo-red.

`ClockGlucoseSource` now carries `currentBG`, `lastUpdated` and `bgDelta` as nullable. The public store returns null when it holds no readings; the realtime store is adapted through a new `clockGlucoseSourceOf`, so the dashboard keeps the stand-ins it needs and the clock face does not inherit them; the builder's preview uses the same adapter. The shared `renderClockElementValue` shows `--` for the glucose element and nothing for the delta and age elements, matching the placeholder convention already used for IOB and COB. The delta is null when nothing measures a change: a lone reading was previously rendered as a rise from zero when authenticated, or as "+0 mg/dL" anonymously. A face whose element colour or whole background is driven by glucose takes no glucose colour without a reading; that guard now lives in one function, `clockBackgroundStyle`, used by both the renderer and the builder page. `getBgColor` keeps a non-nullable parameter so the type system proves it is never handed a stand-in, and `isClockReadingStale` answers false for an absent reading rather than measuring against a fabricated timestamp. A connection lost after readings existed keeps the last good reading and still raises the stale badge.

The tracker element's "time remaining" was the literal string `2d 4h`, in the live renderer as well as the builder preview, reachable on any saved face and on public links: a wall-mounted face read "2d 4h" forever, including after the sensor expired. There is no tracker-instance data source on the clock path, so the option is withdrawn rather than faked. The "urgency badge" option goes with it: no renderer ever had a branch for it, so ticking it has always been silently inert. **Behavioural change:** neither option appears in the tracker element's choices or its default; a saved face still carrying them renders the tracker name only.

The runtime renderer also carried private copies of the builder's colour, font, custom-CSS and tracker-lookup helpers; those are deleted in favour of the shared ones so the no-reading colour rule has one site.

What an anonymous viewer of an empty tenant's share link sees now: `--` in the face's static colour, a neutral background, no delta, no age, no stale badge, and the wall clock and text elements as normal.

Tests: a browser-mode test mounts the live renderer with a source holding no reading (placeholder, no glucose colour, no whole-face colour, no age text, no countdown) and with a low reading (very-low colour present); node tests cover the adapter, the delta derivation, the background style, the shared value renderer, the colour helper, the staleness helper, and the real public store through a mocked client. Every guard was mutation-checked by hostile review. Adding the renderer test required a `requested` export on the `$app/server` browser-test stub; `fix/old-ui-reports` adds the byte-identical export for the same reason, so either branch can land first.

Not addressed here: the public clock renders in the viewer's unit preference rather than the tenant's (needs the owner's units on the DTO), and a tracker's `visibilityThreshold` is evaluated only in the builder preview, never on the live face.

Closes #1148.

https://claude.ai/code/session_01MqyVPKPLNu6y8YvXbdsoZ8
