### PR TITLE
test(rls): catch loop-free DML, CTE and EXECUTE loop headers, and name the share policy at startup

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -340,9 +340,17 @@ public static class DatabaseInitializationExtensions
 
     /// <summary>
     /// Verifies that every supplied tenant-scoped table has Row Level Security
-    /// enabled, forced, and at least one policy. Also checks table ownership and
+    /// enabled, forced, at least one policy, and the share-category policy
+    /// <see cref="ShareRlsPolicy.PolicyName"/> by name. Also checks table ownership and
     /// default privileges, and warns if the connected database user is a superuser
     /// or has BYPASSRLS.
+    ///
+    /// Naming the share policy is what makes a partial reconcile visible: every
+    /// tenant-scoped table carries <c>tenant_isolation</c> from its migration, so a
+    /// table the reconciler skipped still has a non-zero policy count.
+    /// <see cref="ReconcileShareRlsPoliciesAsync"/> applies that policy to every table in
+    /// this same set immediately before this check runs, so the expectation is the
+    /// reconciler's own output rather than a second list.
     ///
     /// Runs at API startup after migrations so accidentally adding a new
     /// tenant-scoped table without an accompanying RLS migration fails loud
@@ -385,7 +393,7 @@ public static class DatabaseInitializationExtensions
             SELECT c.relname,
                    c.relrowsecurity,
                    c.relforcerowsecurity,
-                   (SELECT COUNT(*) FROM pg_policy p WHERE p.polrelid = c.oid) AS policy_count
+                   ARRAY(SELECT p.polname::text FROM pg_policy p WHERE p.polrelid = c.oid) AS policies
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
             WHERE n.nspname = 'public'
@@ -393,7 +401,7 @@ public static class DatabaseInitializationExtensions
               AND c.relname = ANY(@tables);
             """;
 
-        var rows = new List<(string Table, bool RlsEnabled, bool RlsForced, long PolicyCount)>();
+        var rows = new List<(string Table, bool RlsEnabled, bool RlsForced, string[] Policies)>();
 
         await using (var cmd = connection.CreateCommand())
         {
@@ -410,7 +418,7 @@ public static class DatabaseInitializationExtensions
                     reader.GetString(0),
                     reader.GetBoolean(1),
                     reader.GetBoolean(2),
-                    reader.GetInt64(3)));
+                    reader.GetFieldValue<string[]>(3)));
             }
         }
 
@@ -418,7 +426,11 @@ public static class DatabaseInitializationExtensions
         var missing = tables.Where(t => !foundTables.Contains(t)).ToArray();
         var notEnabled = rows.Where(r => !r.RlsEnabled).Select(r => r.Table).ToArray();
         var notForced = rows.Where(r => r.RlsEnabled && !r.RlsForced).Select(r => r.Table).ToArray();
-        var noPolicy = rows.Where(r => r.RlsEnabled && r.PolicyCount == 0).Select(r => r.Table).ToArray();
+        var noPolicy = rows.Where(r => r.RlsEnabled && r.Policies.Length == 0).Select(r => r.Table).ToArray();
+        var noSharePolicy = rows
+            .Where(r => r.RlsEnabled && r.Policies.Length > 0 && !r.Policies.Contains(ShareRlsPolicy.PolicyName))
+            .Select(r => r.Table)
+            .ToArray();
 
         var problems = new List<string>();
         if (missing.Length > 0)
@@ -437,13 +449,20 @@ public static class DatabaseInitializationExtensions
         {
             problems.Add($"no policy defined on: {string.Join(", ", noPolicy)}");
         }
+        if (noSharePolicy.Length > 0)
+        {
+            problems.Add($"'{ShareRlsPolicy.PolicyName}' policy missing on: {string.Join(", ", noSharePolicy)}");
+        }
 
         if (problems.Count > 0)
         {
             var message =
-                "Row Level Security self-check failed. Tenant-scoped tables must have RLS enabled, forced, and at least one policy. " +
+                "Row Level Security self-check failed. Tenant-scoped tables must have RLS enabled, forced, a " +
+                $"tenant_isolation policy and the '{ShareRlsPolicy.PolicyName}' policy. " +
                 string.Join("; ", problems) +
-                ". Add a migration that runs ENABLE + FORCE ROW LEVEL SECURITY and creates a tenant_isolation policy.";
+                ". Add a migration that runs ENABLE + FORCE ROW LEVEL SECURITY and creates a tenant_isolation " +
+                $"policy; a missing '{ShareRlsPolicy.PolicyName}' means the table was not in the set " +
+                $"{nameof(ReconcileShareRlsPoliciesAsync)} just reconciled.";
             logger.LogCritical("{Message}", message);
             throw new InvalidOperationException(message);
         }

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsEnforcementTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsEnforcementTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Security;
 using Npgsql;
 using Xunit;
 
@@ -45,6 +46,41 @@ public class RlsEnforcementTests
 
         await act.Should().NotThrowAsync(
             "VerifyRlsAsync is the canonical schema fingerprint — failing means a tenant-scoped table is missing RLS, FORCE RLS, a policy, or correct ownership");
+    }
+
+    /// <summary>
+    /// The share-category policy is the one a partial reconcile drops, and the one a policy
+    /// count cannot miss: tenant_isolation is still there, so the table reads as policied.
+    /// </summary>
+    [Fact]
+    public async Task MissingSharePolicy_IsNamed_EvenThoughTenantIsolationRemains()
+    {
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+
+        var verify = () => DatabaseInitializationExtensions.VerifyRlsAsync(
+            conn, _fx.TenantScopedTableNames.ToArray(), NullLogger.Instance);
+
+        try
+        {
+            await using (var drop = conn.CreateCommand())
+            {
+                drop.CommandText = $"DROP POLICY {ShareRlsPolicy.PolicyName} ON {SampleTable}";
+                await drop.ExecuteNonQueryAsync();
+            }
+
+            // The policy name alone is in every failure message's fixed prefix; only the
+            // per-problem fragment shows the table was actually named.
+            (await verify.Should().ThrowAsync<InvalidOperationException>())
+                .Which.Message.Should().Contain(
+                    $"'{ShareRlsPolicy.PolicyName}' policy missing on: {SampleTable}");
+        }
+        finally
+        {
+            await DatabaseInitializationExtensions.ReconcileShareRlsPoliciesAsync(
+                _fx.MigratorConnectionString, NullLogger.Instance);
+        }
+
+        await verify.Should().NotThrowAsync("the reconciler restored the policy");
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/DataMigrationTenantContextGuardTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Match = System.Text.RegularExpressions.Match;
 
 namespace Nocturne.Infrastructure.Data.Tests.Migrations;
 
@@ -9,15 +10,35 @@ namespace Nocturne.Infrastructure.Data.Tests.Migrations;
 /// own loop bounds from a tenant-scoped table: the driving SELECT runs outside any tenant
 /// context, returns no rows, and the whole migration is a silent no-op that still records as
 /// applied. Drive the loop off <c>tenants</c>, which carries no RLS.
+/// <para>
+/// The same silent no-op needs no loop at all — a bare <c>UPDATE</c> on a tenant-scoped table
+/// matches zero rows — so loop sources and loop-free DML are checked separately. A finding only
+/// counts from the migration that brought its table under RLS onwards; see
+/// <see cref="RlsBeginsAt"/>.
+/// </para>
+/// <para>
+/// Shapes this cannot see, which review has to catch: a DML target it cannot read off the
+/// statement, i.e. an interpolated <c>{table}</c> hole or a PL/pgSQL variable; DML issued
+/// through the <c>migrationBuilder.UpdateData</c>/<c>DeleteData</c>/<c>InsertData</c> builder
+/// calls rather than raw SQL, of which nothing shipped has an example; <c>MERGE INTO</c>, which
+/// no shipped migration uses; a <c>LATERAL</c> loop source that is a bare function rather than
+/// a subquery, since <c>CROSS JOIN LATERAL (SELECT … FROM x)</c> binds <c>x</c> off the inner
+/// <c>FROM</c> but <c>CROSS JOIN LATERAL unnest(…)</c> has no inner <c>FROM</c> to bind; a loop
+/// source whose leading token is not an identifier once C# escaping is undone, an interpolated
+/// <c>{table}</c> hole being the shape that reaches here; and a tenant context established
+/// earlier in <c>Up</c> for an unrelated statement — including a <c>set_config(…, '', false)</c>
+/// that resets it — since ordering is checked once per <c>Up</c> rather than per statement.
+/// </para>
 /// </summary>
 [Trait("Category", "Unit")]
 public class DataMigrationTenantContextGuardTests
 {
     /// <summary>
     /// Shipped migrations whose driving SELECT reads a tenant-scoped table. Each was a silent
-    /// no-op on every deployment. They stay as-is because an applied migration is history and
-    /// rewriting it would not re-run; the fix is a new migration that redoes the work. Nothing
-    /// may be added here.
+    /// no-op on every deployment, and each still owes the work it did not do. An entry here is a
+    /// record of that debt, not an absolution: an applied migration cannot be repaired by
+    /// rewriting it, so the remediation is a new migration that redoes the work under a tenant
+    /// loop. Nothing may be added here.
     /// </summary>
     private static readonly IReadOnlySet<string> KnownNoOpMigrations = new HashSet<string>(StringComparer.Ordinal)
     {
@@ -27,13 +48,73 @@ public class DataMigrationTenantContextGuardTests
     };
 
     /// <summary>
-    /// Matches a PL/pgSQL <c>FOR &lt;var&gt; IN SELECT ... FROM &lt;source&gt;</c> header, binding the
-    /// source of the FIRST FROM after the SELECT. Anchoring to the first FROM keeps a derived
-    /// table (<c>FROM (VALUES ...)</c>) or a set-returning function (<c>FROM jsonb_array_elements(...)</c>)
-    /// from being skipped over in favour of a later, unrelated table name.
+    /// Shipped migrations that run DML on a table already under RLS with no tenant context
+    /// established earlier in the same <c>Up</c>. Each matched no row on every deployment, and
+    /// each still owes that work — except <c>DeviceIdentityUnification</c>, whose backfill was
+    /// harmless because the <c>AddColumn</c> it follows already carries the same value as its
+    /// default. Same history rule as <see cref="KnownNoOpMigrations"/>: nothing may be added here.
     /// </summary>
-    private static readonly Regex LoopHeader = new(
-        @"FOR\s+\w+\s+IN\s+SELECT\s+(?:(?!\bFROM\b).)*?\s+FROM\s+(\S+)",
+    private static readonly IReadOnlySet<string> KnownContextlessDmlMigrations = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "20260320105641_DeviceIdentityUnification",
+        "20260415032253_MigrateHeartRateStepCountToTimestamp",
+        "20260503010303_RipOutSchedulesAndEscalationSteps",
+    };
+
+    /// <summary>
+    /// Migrations whose tenant loop is driven by a query assembled at runtime, which this guard
+    /// cannot read. An entry here is a hand-review claim that the query touches no tenant-scoped
+    /// table before the GUC is set; it is not a shipped-history amnesty, because nothing shipped
+    /// uses the shape.
+    /// </summary>
+    private static readonly IReadOnlySet<string> KnownDynamicLoopMigrations =
+        new HashSet<string>(StringComparer.Ordinal);
+
+    private static readonly Regex LoopHeaderStart = new(
+        @"FOR\s+\w+\s+IN\s+",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static readonly Regex LoopTerminator = new(
+        @"\bLOOP\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// The source list after each <c>FROM</c> or <c>JOIN</c>, ending at the clause keyword that
+    /// closes it. Taking every list, not just the first table of the first one, is what makes a
+    /// CTE header visible: its outer <c>FROM</c> names the CTE, and the tenant-scoped table
+    /// actually read is the <c>FROM</c> inside — and a scoped table reached by <c>JOIN</c> or by
+    /// a comma is as blind as one reached by <c>FROM</c>.
+    /// </summary>
+    private static readonly Regex QuerySource = new(
+        @"\b(FROM|JOIN)\s+(.*?)(?=\b(?:WHERE|GROUP|HAVING|WINDOW|ORDER|LIMIT|OFFSET|FETCH"
+        + @"|UNION|INTERSECT|EXCEPT|RETURNING|LOOP|ON|USING|JOIN|LEFT|RIGHT|FULL|INNER|OUTER"
+        + @"|CROSS|NATURAL|SELECT)\b|$)",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// The table a comma-separated source-list item names, matched against the item with its
+    /// C#-escaped quotes already undone so a quoted identifier is one. An item that does not
+    /// start with an identifier — a row constructor in <c>FROM (VALUES …)</c>, a literal inside
+    /// one — names no table and is skipped rather than resolved to a stray token.
+    /// </summary>
+    private static readonly Regex SourceItem = new(
+        @"^\s*(?:ONLY\s+)?(""?[A-Za-z_][\w""$.]*)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex RenameTable = new(
+        @"RenameTable\(\s*name:\s*""([^""]+)""\s*,\s*(?:schema:[^,]*,\s*)?newName:\s*""([^""]+)""",
+        RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static readonly Regex DynamicLoopQuery = new(
+        @"^\s*EXECUTE\b",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static readonly Regex DmlTarget = new(
+        @"\b(UPDATE|DELETE\s+FROM|INSERT\s+INTO)\s+(?:ONLY\s+)?(\S+)",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static readonly Regex TenantContext = new(
+        @"set_config\s*\(\s*'app\.current_tenant_id'",
         RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
 
     private static readonly IReadOnlySet<string> ScopedTables = MigrationSourceFiles.TenantScopedTableNames();
@@ -41,52 +122,438 @@ public class DataMigrationTenantContextGuardTests
     [Fact]
     public void NoDataMigrationDrivesItsTenantLoopOffATenantScopedTable()
     {
-        var offenders = MigrationSourceFiles.All()
-            .Where(f => !KnownNoOpMigrations.Contains(MigrationSourceFiles.Name(f)))
-            .SelectMany(f => ScopedLoopSources(f).Select(t => $"{MigrationSourceFiles.Name(f)} -> FROM {t}"))
-            .ToList();
-
-        offenders.Should().BeEmpty(
+        Offenders(ScopedLoopSources, KnownNoOpMigrations).Should().BeEmpty(
             "a tenant loop must be driven off the tenants table; reading its bounds from a "
             + "tenant-scoped table under FORCE RLS returns no rows and makes the migration a no-op");
     }
 
     [Fact]
-    public void TheGuardCanSeeMigrationsAndTenantScopedTables()
+    public void NoDataMigrationDrivesItsTenantLoopOffARuntimeBuiltQuery()
     {
-        // Either set going empty makes the guard above pass vacuously. A named table catches the
-        // narrower regression too: a set that still holds most tables but has quietly dropped some.
+        Offenders(DynamicLoopSources, KnownDynamicLoopMigrations).Should().BeEmpty(
+            "a loop source assembled at runtime cannot be read here, so it has to be reviewed by "
+            + "hand and named in the allowlist rather than passing unexamined");
+    }
+
+    [Fact]
+    public void NoDataMigrationRunsTenantScopedDmlWithoutATenantContext()
+    {
+        Offenders(ContextlessScopedDml, KnownContextlessDmlMigrations).Should().BeEmpty(
+            "DML on a tenant-scoped table under FORCE RLS matches no row until "
+            + "app.current_tenant_id is set, so the migration records as applied having done nothing");
+    }
+
+    [Fact]
+    public void TheGuardCanSeeMigrationsTenantScopedTablesAndWhenEachCameUnderRls()
+    {
+        // Any of these going empty makes the guards above pass vacuously. A named table catches
+        // the narrower regression too: a set that still holds most tables but has quietly dropped
+        // some. An unresolved RLS origin exempts its table outright, so none may be blank.
         MigrationSourceFiles.All().Should().NotBeEmpty();
         MigrationSourceFiles.TenantScopedTableNames().Should().Contain("sensor_glucose");
+        RlsBeginsAt.Value.Should().NotContainValue(string.Empty);
+
+        // devices is pump_devices renamed, and only pump_devices appears in the enabling
+        // migration; losing the rename hop dates it to 20260409020854_AddRlsToNewTenantTables,
+        // which is later than the migration whose contextless backfill has to be reported.
+        RlsBeginsAt.Value["devices"].Should().Be("20260227034745_EnforceMultitenancy");
     }
 
     [Fact]
     public void EveryAllowlistedMigrationStillExistsAndStillOffends()
     {
-        var stillOffending = MigrationSourceFiles.All()
-            .Where(f => KnownNoOpMigrations.Contains(MigrationSourceFiles.Name(f)))
-            .Where(f => ScopedLoopSources(f).Count > 0)
-            .Select(MigrationSourceFiles.Name)
-            .ToHashSet(StringComparer.Ordinal);
+        foreach (var (allowlist, detect) in Allowlists)
+        {
+            var stillOffending = MigrationSourceFiles.All()
+                .Where(f => allowlist.Contains(MigrationSourceFiles.Name(f)))
+                .Where(f => Findings(f, detect).Count > 0)
+                .Select(MigrationSourceFiles.Name)
+                .ToHashSet(StringComparer.Ordinal);
 
-        stillOffending.Should().BeEquivalentTo(KnownNoOpMigrations,
-            "an allowlist entry that no longer matches is stale and hides a regression");
+            stillOffending.Should().BeEquivalentTo(allowlist,
+                "an allowlist entry that no longer matches is stale and hides a regression");
+        }
+    }
+
+    [Fact]
+    public void ACteLoopHeaderBindsTheTableInsideTheCte()
+    {
+        const string up = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN
+                    WITH stale AS (SELECT tenant_id FROM sensor_glucose WHERE device IS NULL)
+                    SELECT * FROM stale
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.tenant_id::text, true);
+                END LOOP;
+            END $$;
+            """;
+
+        Details(ScopedLoopSources(up)).Should().Equal("FROM sensor_glucose");
+    }
+
+    [Fact]
+    public void ACteLoopHeaderEndingAtTheTableNameStillBindsIt()
+    {
+        const string up = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN
+                    WITH stale AS (SELECT DISTINCT tenant_id FROM sensor_glucose)
+                    SELECT * FROM stale
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.tenant_id::text, true);
+                END LOOP;
+            END $$;
+            """;
+
+        Details(ScopedLoopSources(up)).Should().Equal("FROM sensor_glucose");
+    }
+
+    [Fact]
+    public void EveryLoopSourceIsBoundNotJustTheFirst()
+    {
+        const string up = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN SELECT t.id FROM tenants t JOIN sensor_glucose sg ON sg.tenant_id = t.id
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.id::text, true);
+                END LOOP;
+            END $$;
+            """;
+
+        Details(ScopedLoopSources(up)).Should().Equal("JOIN sensor_glucose");
+    }
+
+    [Fact]
+    public void ACommaJoinedLoopSourceIsBound()
+    {
+        const string up = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN SELECT t.id FROM tenants t, sensor_glucose sg WHERE sg.tenant_id = t.id
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.id::text, true);
+                END LOOP;
+            END $$;
+            """;
+
+        Details(ScopedLoopSources(up)).Should().Equal("FROM sensor_glucose");
+    }
+
+    [Fact]
+    public void AnOnlyQualifiedLoopSourceIsBound()
+    {
+        const string up = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN SELECT tenant_id FROM ONLY sensor_glucose
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.tenant_id::text, true);
+                END LOOP;
+            END $$;
+            """;
+
+        Details(ScopedLoopSources(up)).Should().Equal("FROM sensor_glucose");
+    }
+
+    [Fact]
+    public void AQuotedSchemaQualifiedLoopSourceIsBound()
+    {
+        const string up = """
+            migrationBuilder.Sql("DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN SELECT tenant_id FROM \"public\".\"sensor_glucose\"
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.tenant_id::text, true);
+                END LOOP;
+            END $$;");
+            """;
+
+        Details(ScopedLoopSources(up)).Should().Equal("FROM sensor_glucose");
+    }
+
+    [Fact]
+    public void AnOnlyQualifiedQuotedLoopSourceBindsTheTableAndNotTheOnly()
+    {
+        const string up = """
+            migrationBuilder.Sql("DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN SELECT tenant_id FROM ONLY \"public\".\"sensor_glucose\"
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.tenant_id::text, true);
+                END LOOP;
+            END $$;");
+            """;
+
+        Details(ScopedLoopSources(up)).Should().Equal("FROM sensor_glucose");
+    }
+
+    [Fact]
+    public void TheWordLoopInsideAStringLiteralInTheHeaderDoesNotTruncateIt()
+    {
+        const string up = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN SELECT t.id, 'LOOP' AS tag FROM tenants t JOIN sensor_glucose sg ON sg.tenant_id = t.id
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.id::text, true);
+                END LOOP;
+            END $$;
+            """;
+
+        Details(ScopedLoopSources(up)).Should().Equal("JOIN sensor_glucose");
+    }
+
+    [Fact]
+    public void ACommentedWordLoopInsideTheHeaderDoesNotTruncateIt()
+    {
+        const string up = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN
+                    -- one row per tenant, then loop over them
+                    SELECT DISTINCT tenant_id FROM sensor_glucose
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.tenant_id::text, true);
+                END LOOP;
+            END $$;
+            """;
+
+        Details(ScopedLoopSources(up)).Should().Equal("FROM sensor_glucose");
+    }
+
+    [Fact]
+    public void AnExecuteLoopHeaderIsReportedRatherThanPassing()
+    {
+        const string up = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN EXECUTE format('SELECT tenant_id FROM %I', 'sensor_glucose')
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.tenant_id::text, true);
+                END LOOP;
+            END $$;
+            """;
+
+        DynamicLoopSources(up).Should().ContainSingle();
+        ScopedLoopSources(up).Should().BeEmpty("an EXECUTE header binds no table to read");
+    }
+
+    [Fact]
+    public void LoopFreeDmlOnATenantScopedTableIsDetected()
+    {
+        const string up = "migrationBuilder.Sql(\"UPDATE sensor_glucose SET device = 'unknown';\");";
+
+        Details(ContextlessScopedDml(up)).Should().Equal("UPDATE sensor_glucose");
+    }
+
+    [Fact]
+    public void DmlTargetIsReadThroughQuotesSchemaQualifiersAndAClosingParen()
+    {
+        const string up = """
+            migrationBuilder.Sql("DELETE FROM alert_invites")
+            migrationBuilder.Sql("UPDATE \"sensor_glucose\" SET device = 'unknown';");
+            migrationBuilder.Sql("UPDATE public.heart_rates SET rate = 0;");
+            """;
+
+        Details(ContextlessScopedDml(up)).Should().Equal(
+            "DELETE FROM alert_invites", "UPDATE sensor_glucose", "UPDATE heart_rates");
+    }
+
+    [Fact]
+    public void ATableNameEndedByACSharpEscapeIsStillRead()
+    {
+        const string dml = """
+            migrationBuilder.Sql("UPDATE sensor_glucose\n  SET device = 'unknown';");
+            """;
+        const string loop = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN SELECT tenant_id FROM sensor_glucose\n  WHERE device IS NULL
+                LOOP
+                    PERFORM set_config('app.current_tenant_id', r.tenant_id::text, true);
+                END LOOP;
+            END $$;
+            """;
+
+        Details(ContextlessScopedDml(dml)).Should().Equal("UPDATE sensor_glucose");
+        Details(ScopedLoopSources(loop)).Should().Equal("FROM sensor_glucose");
+    }
+
+    [Fact]
+    public void DmlPrecededByATenantContextIsNotDetected()
+    {
+        const string up = """
+            DO $$ DECLARE r RECORD; BEGIN
+                FOR r IN SELECT id FROM tenants LOOP
+                    PERFORM set_config('app.current_tenant_id', r.id::text, true);
+                    UPDATE sensor_glucose SET device = 'unknown';
+                END LOOP;
+            END $$;
+            """;
+
+        ContextlessScopedDml(up).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DmlPrecededOnlyByACommentedOutTenantContextIsDetected()
+    {
+        const string up = """
+            // PERFORM set_config('app.current_tenant_id', r.id::text, true);
+            migrationBuilder.Sql("UPDATE sensor_glucose SET device = 'unknown';");
+            """;
+
+        Details(ContextlessScopedDml(up)).Should().Equal("UPDATE sensor_glucose");
+    }
+
+    [Fact]
+    public void DmlOnATableThatIsNotTenantScopedIsNotDetected()
+    {
+        const string up = "migrationBuilder.Sql(\"UPDATE tenants SET display_name = trim(display_name);\");";
+
+        ContextlessScopedDml(up).Should().BeEmpty();
+    }
+
+    private static readonly (IReadOnlySet<string> Allowlist, Detector Detect)[] Allowlists =
+    [
+        (KnownNoOpMigrations, ScopedLoopSources),
+        (KnownContextlessDmlMigrations, ContextlessScopedDml),
+        (KnownDynamicLoopMigrations, DynamicLoopSources),
+    ];
+
+    private delegate IReadOnlyList<(string Table, string Detail)> Detector(string up);
+
+    private static IReadOnlyList<string> Offenders(Detector detect, IReadOnlySet<string> allowlist) =>
+        MigrationSourceFiles.All()
+            .Where(f => !allowlist.Contains(MigrationSourceFiles.Name(f)))
+            .SelectMany(f => Findings(f, detect))
+            .ToList();
+
+    private static IReadOnlyList<string> Findings(string file, Detector detect)
+    {
+        var migration = MigrationSourceFiles.Name(file);
+
+        return detect(MigrationSourceFiles.UpBody(file))
+            .Where(x => string.CompareOrdinal(migration, RlsBeginsAt.Value.GetValueOrDefault(x.Table, "")) >= 0)
+            .Select(x => $"{migration} -> {x.Detail}")
+            .ToList();
+    }
+
+    private static IEnumerable<string> Details(IEnumerable<(string Table, string Detail)> findings) =>
+        findings.Select(x => x.Detail);
+
+    /// <summary>
+    /// The migration each tenant-scoped table came under RLS in: the first that both enables
+    /// row-level security and names the table. Statements before that point ran against
+    /// an unpoliced table and did the work they were written to do, so a finding there is noise.
+    /// Read off the migration sources rather than a hand-kept list, and read off comment-blanked
+    /// text so a commented-out <c>ENABLE</c> cannot move the boundary later. A table whose origin
+    /// cannot be resolved maps to the empty string, which precedes every migration name and so
+    /// exempts nothing.
+    /// <para>
+    /// A renamed table keeps the policies it held under its old name, and the old name is the
+    /// only thing the enabling migration records, so a <c>RenameTable</c> in <c>Up</c> carries
+    /// the origin across — otherwise <c>devices</c> would date from the migration that renamed
+    /// <c>pump_devices</c> onto it rather than from the one that policied it.
+    /// </para>
+    /// </summary>
+    private static readonly Lazy<IReadOnlyDictionary<string, string>> RlsBeginsAt = new(() =>
+    {
+        var enablers = MigrationSourceFiles.All()
+            .Select(f => (Name: MigrationSourceFiles.Name(f),
+                          Source: MigrationSourceFiles.WithCommentsBlanked(MigrationSourceFiles.Source(f))))
+            .Where(m => m.Source.Contains("ENABLE ROW LEVEL SECURITY", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        string Enabler(string table) => enablers
+            .FirstOrDefault(m => Regex.IsMatch(m.Source, $@"\b{Regex.Escape(table)}\b"))
+            .Name ?? string.Empty;
+
+        var begins = ScopedTables.ToDictionary(t => t, Enabler, StringComparer.Ordinal);
+
+        foreach (var file in MigrationSourceFiles.All())
+        {
+            var migration = MigrationSourceFiles.Name(file);
+
+            foreach (Match rename in RenameTable.Matches(MigrationSourceFiles.UpBody(file)))
+            {
+                var from = rename.Groups[1].Value.ToLowerInvariant();
+                var to = rename.Groups[2].Value.ToLowerInvariant();
+                var inherited = begins.TryGetValue(from, out var known) && known.Length > 0 ? known : Enabler(from);
+
+                if (inherited.Length == 0 || string.CompareOrdinal(inherited, migration) > 0)
+                    continue;
+
+                if (!begins.TryGetValue(to, out var current) || current.Length == 0
+                    || string.CompareOrdinal(inherited, current) < 0)
+                    begins[to] = inherited;
+            }
+        }
+
+        return begins;
+    });
+
+    /// <summary>
+    /// Tenant-scoped tables the <c>Up</c> drives a tenant loop off. Scanned as raw text: this
+    /// detects offenders, and <see cref="MigrationSourceFiles.WithCommentsBlanked"/> withholds
+    /// evidence, so a stray <c>/*</c> inside a SQL literal would blank a live loop out of view. A
+    /// commented-out loop is therefore reported — the cheap direction to be wrong in.
+    /// </summary>
+    private static IReadOnlyList<(string Table, string Detail)> ScopedLoopSources(string up) =>
+        LoopQueries(up)
+            .Where(q => !DynamicLoopQuery.IsMatch(q))
+            .SelectMany(q => QuerySource.Matches(q).SelectMany(m => m.Groups[2].Value
+                .Split(',')
+                .Select(item => SourceItem.Match(MigrationSourceFiles.Unescaped(item)))
+                .Where(item => item.Success)
+                .Select(item => (Keyword: m.Groups[1].Value.ToUpperInvariant(),
+                                 Table: MigrationSourceFiles.BareTableName(item.Groups[1].Value)))))
+            .Where(x => ScopedTables.Contains(x.Table))
+            .Select(x => (x.Table, $"{x.Keyword} {x.Table}"))
+            .ToList();
+
+    private static IReadOnlyList<(string Table, string Detail)> DynamicLoopSources(string up) =>
+        LoopQueries(up)
+            .Where(q => DynamicLoopQuery.IsMatch(q))
+            .Select(_ => (string.Empty, "loop source assembled at runtime (EXECUTE)"))
+            .ToList();
+
+    /// <summary>
+    /// DML naming a tenant-scoped table with no <c>set_config('app.current_tenant_id', …)</c>
+    /// ahead of it in the same <c>Up</c>. Targets are read off raw text so a comment cannot hide
+    /// one; the establishing call is read off comment-blanked text — which preserves offsets — so
+    /// a commented-out one cannot excuse one.
+    /// </summary>
+    private static IReadOnlyList<(string Table, string Detail)> ContextlessScopedDml(string up)
+    {
+        var context = TenantContext.Match(MigrationSourceFiles.WithCommentsBlanked(up));
+        var establishedAt = context.Success ? context.Index : int.MaxValue;
+
+        return DmlTarget.Matches(up)
+            .Where(m => m.Index < establishedAt)
+            .Select(m => (Verb: Regex.Replace(m.Groups[1].Value.ToUpperInvariant(), @"\s+", " "),
+                          Table: MigrationSourceFiles.BareTableName(m.Groups[2].Value)))
+            .Where(x => ScopedTables.Contains(x.Table))
+            .Select(x => (x.Table, $"{x.Verb} {x.Table}"))
+            .ToList();
     }
 
     /// <summary>
-    /// Tenant-scoped tables the migration's <c>Up</c> drives a tenant loop off. Scanned as raw
-    /// text: this detects offenders, and
-    /// <see cref="MigrationSourceFiles.WithCommentsBlanked"/> withholds evidence, so a stray
-    /// <c>/*</c> inside a SQL literal would blank a live loop out of view. A commented-out loop
-    /// is therefore reported — the cheap direction to be wrong in.
+    /// The driving query of each PL/pgSQL <c>FOR &lt;var&gt; IN &lt;query&gt; LOOP</c> header,
+    /// whole rather than one table off it. A plain <c>SELECT</c>, a <c>WITH</c> that binds its
+    /// real sources inside a CTE, and an <c>EXECUTE</c> that binds nothing are all this shape;
+    /// telling them apart is the callers' job.
+    /// <para>
+    /// The header is found in raw text, so a stray <c>/*</c> cannot blank a live loop out of
+    /// view, but its terminator is found in text with comments and single-quoted SQL literals
+    /// blanked — which preserves offsets — so the word <c>loop</c> in a comment or a literal
+    /// inside the header does not truncate the query short of the tables it reads. Any other
+    /// spelling of <c>LOOP</c> the blanking does not cover (a dollar-quoted literal, say) still
+    /// would. An unterminated header runs to the end of <c>Up</c>, binding more sources than the
+    /// loop really has rather than fewer.
+    /// </para>
     /// </summary>
-    private static IReadOnlyList<string> ScopedLoopSources(string file)
+    private static IEnumerable<string> LoopQueries(string up)
     {
-        var up = MigrationSourceFiles.UpBody(file);
+        var blanked = MigrationSourceFiles.WithCommentsAndSqlLiteralsBlanked(up);
 
-        return LoopHeader.Matches(up)
-            .Select(m => MigrationSourceFiles.BareTableName(m.Groups[1].Value))
-            .Where(ScopedTables.Contains)
-            .ToList();
+        foreach (Match header in LoopHeaderStart.Matches(up))
+        {
+            var query = header.Index + header.Length;
+            var terminator = LoopTerminator.Match(blanked, query);
+            yield return up[query..(terminator.Success ? terminator.Index : up.Length)];
+        }
     }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/MigrationSourceFiles.cs
@@ -33,15 +33,34 @@ internal static class MigrationSourceFiles
 
     /// <summary>
     /// The bare table name in a captured SQL or builder reference: the leading segment, before any
-    /// argument list, alias or trailing punctuation, unquoted and lowercased. <c>tbl(col)</c>,
-    /// <c>"tbl"(col)</c> and <c>tbl (col)</c> all yield <c>tbl</c>. A derived table
+    /// argument list, alias or trailing punctuation, unqualified, unquoted and lowercased.
+    /// <c>tbl(col)</c>, <c>tbl)</c>, <c>public.tbl</c> and <c>"tbl"</c> all yield <c>tbl</c>. The
+    /// capture is migration source, not SQL, so the whitespace ending the name may be a C# escape
+    /// sequence and a quote around it is escaped as well: the escaped quote is unescaped first,
+    /// then a backslash ends the name like any other delimiter. A derived table
     /// (<c>(VALUES …)</c>) yields an empty string, which matches no table.
     /// </summary>
     public static string BareTableName(string captured) =>
-        Regex.Split(captured, @"[(;,\s]")[0].Trim('"').ToLowerInvariant();
+        Regex.Split(Unescaped(captured), @"[();,\s\\]")[0]
+            .Split('.')[^1]
+            .Trim('"')
+            .ToLowerInvariant();
+
+    /// <summary>
+    /// A captured reference with C#-escaped quotes turned back into quotes, for anything that has
+    /// to recognise the shape of a reference rather than just its leading segment.
+    /// </summary>
+    public static string Unescaped(string captured) =>
+        captured.Replace("\\\"", "\"", StringComparison.Ordinal);
 
     /// <summary>Migration name — the file name a guard reports and an allowlist keys on.</summary>
     public static string Name(string file) => Path.GetFileNameWithoutExtension(file);
+
+    /// <summary>
+    /// Whole source text, for the questions <see cref="UpBody"/> cannot answer: a migration's
+    /// table list is routinely a class-level array its <c>Up</c> only loops over.
+    /// </summary>
+    public static string Source(string file) => File.ReadAllText(file);
 
     /// <summary>
     /// Text of the migration's <c>Up</c> method. Only <c>Up</c> runs on the startup migration
@@ -55,7 +74,7 @@ internal static class MigrationSourceFiles
     /// </exception>
     public static string UpBody(string file)
     {
-        var source = File.ReadAllText(file);
+        var source = Source(file);
         var start = source.IndexOf("void Up(", StringComparison.Ordinal);
 
         if (start < 0)
@@ -77,11 +96,21 @@ internal static class MigrationSourceFiles
     /// detects offenders, withheld evidence is a false green, so scan raw text there instead.
     /// </para>
     /// </summary>
-    public static string WithCommentsBlanked(string source)
+    public static string WithCommentsBlanked(string source) => Blanked(source, Comment);
+
+    /// <summary>
+    /// <see cref="WithCommentsBlanked"/>, additionally blanking single-quoted SQL literals, for
+    /// questions about SQL structure that a keyword inside a literal would answer wrongly.
+    /// Comments go first, so an apostrophe in prose cannot pair with a real literal's quote.
+    /// </summary>
+    public static string WithCommentsAndSqlLiteralsBlanked(string source) =>
+        Blanked(WithCommentsBlanked(source), SqlLiteral);
+
+    private static string Blanked(string source, Regex region)
     {
         var blanked = source.ToCharArray();
 
-        foreach (Match match in Comment.Matches(source))
+        foreach (Match match in region.Matches(source))
             for (var i = match.Index; i < match.Index + match.Length; i++)
                 if (blanked[i] is not ('\r' or '\n'))
                     blanked[i] = ' ';
@@ -105,6 +134,10 @@ internal static class MigrationSourceFiles
     });
 
     private static readonly Regex TimestampPrefixed = new(@"^\d{14}_", RegexOptions.Compiled);
+
+    private static readonly Regex SqlLiteral = new(
+        "'[^']*'",
+        RegexOptions.Singleline | RegexOptions.Compiled);
 
     private static readonly Regex Comment = new(
         @"/\*.*?\*/|//[^\r\n]*|--[^\r\n]*",

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/UniqueIndexDeduplicationGuardTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Migrations/UniqueIndexDeduplicationGuardTests.cs
@@ -147,16 +147,13 @@ public class UniqueIndexDeduplicationGuardTests
 
     /// <summary>
     /// The table a captured reference names, or <see cref="UnresolvedTable"/> when it is not a
-    /// plain name — an interpolated <c>{table}</c> hole, or a loop variable. A schema qualifier is
-    /// dropped so <c>public.x</c> and <c>x</c> are one table on both the index and the
-    /// <c>CREATE TABLE</c> side; splitting them would red-build a schema-qualified new table.
+    /// plain name — an interpolated <c>{table}</c> hole, or a loop variable.
     /// </summary>
     private static string ResolveTable(string captured)
     {
         var bare = MigrationSourceFiles.BareTableName(captured);
-        var unqualified = bare[(bare.LastIndexOf('.') + 1)..];
 
-        return PlainTableName.IsMatch(unqualified) ? unqualified : UnresolvedTable;
+        return PlainTableName.IsMatch(bare) ? bare : UnresolvedTable;
     }
 
     private static IReadOnlySet<string> TablesCreatedIn(string up) =>


### PR DESCRIPTION
The data-migration tenant-context guard knew one shape of the defect it exists to catch: a `FOR <var> IN SELECT … FROM <table>` loop header. Three shapes with identical damage passed it.

A bare `UPDATE <tenant-scoped table>` matches zero rows under FORCE RLS and still records as applied, with no loop for the regex to see. A `FOR r IN WITH t AS (SELECT … FROM x) SELECT * FROM t` header binds `t`, not `x`. A `FOR r IN EXECUTE format(…)` header binds nothing.

Loop headers are now captured whole, up to a `LOOP` found on comment-and-literal-blanked text, and every source in the driving query is bound: each `FROM`/`JOIN` list, split on commas, each item resolved after C# escaping is undone, so `ONLY`, schema qualifiers, quoted identifiers, CTE bodies, lateral subqueries and comma joins all reach the tenant-scoped set. An `EXECUTE` header is reported as unreadable, so it must be reviewed and named in an allowlist rather than passing unexamined; that allowlist ships empty. A second detector requires a `set_config('app.current_tenant_id', …)` ahead of any `UPDATE`/`DELETE FROM`/`INSERT INTO` naming a tenant-scoped table in the same `Up`.

Findings are dated against the migration that brought each table under RLS, resolved from the migration sources and following `RenameTable` so a renamed table inherits its original's date, rather than a hand-kept list. Statements written before a table was policied are therefore not reported as no-ops they never were; that disposes of five pre-RLS hits without allowlisting them.

Three shipped migrations are caught and allowlisted as history, on the same terms as the existing entries (an applied migration cannot be repaired by rewriting it); the allowlist doc describes them as debt, not absolution:

- `20260415032253_MigrateHeartRateStepCountToTimestamp`: the `mills` → `timestamp` backfill on `heart_rates` and `step_counts` matched no rows, and `mills` was dropped in the same `Up`.
- `20260503010303_RipOutSchedulesAndEscalationSteps`: the `alert_invites` clear-out and the `escalating` → `resolved` fix-up on `alert_instances` both matched no rows.
- `20260320105641_DeviceIdentityUnification`: the `devices.category` backfill matched no rows; harmless, because the column was added with that value as its default.

The first two are tracked in #1168; the remedy is a new migration that redoes the work under a tenant loop.

Behavioural change at startup: `VerifyRlsAsync` flagged a table only when it had zero policies. Every tenant-scoped table carries `tenant_isolation` from its migration, so a table the share-policy reconciler skipped read as healthy, the exact regression class the share-policy work was meant to prevent. The check now asserts `share_category_read` by name and reports which table is missing it. The expectation is the set `ReconcileShareRlsPoliciesAsync` just wrote (it runs immediately before this check on every boot, over the same model-derived table set, and gives a table with no governing scope a deny policy), so a healthy database sees no change. Failure behaviour is unchanged: `LogCritical` followed by `InvalidOperationException`, aborting startup.

The guard's remaining blind spots are listed in its class doc: a `MERGE INTO`, an interpolated `{table}` hole, a `LOOP` inside a dollar-quoted literal, a lateral bare-function item, and the once-per-`Up` ordering check, which a `set_config` reset also satisfies.

An integration test drops the share policy from one table and asserts the check names both the policy and the table. Each guard extension has a fixture migration source that is caught, and each was mutation-checked by four rounds of hostile review, which also caught a mis-dated renamed table and an escaped-quote regression along the way. `Nocturne.Infrastructure.Data.Tests` 929 unit and 113 integration pass.

Closes #976.

https://claude.ai/code/session_01MqyVPKPLNu6y8YvXbdsoZ8
