### PR TITLE
fix: unblock the uploader API-key dialog and stop evicting guest sessions

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/MyTenantsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/MyTenantsController.cs
@@ -41,17 +41,40 @@ public class MyTenantsController : ControllerBase
         _config = config.Value;
     }
 
+    /// <summary>
+    /// Resolves the subject the caller answers for, or the response to send in its place.
+    /// Three credentials authenticate without a subject of their own: a guest session, whose grant
+    /// records the data owner instead; the instance key, a service credential; and development
+    /// auto-authentication. None of them is a member of any tenant, so each gets
+    /// <paramref name="noMemberships"/> rather than a rejection — a 401 reads as an expired
+    /// credential and bounces a live session to the login page.
+    /// </summary>
+    private ActionResult? ResolveOwnSubject<T>(
+        T noMemberships, out AuthContext caller, out Guid subjectId)
+    {
+        caller = HttpContext.GetAuthContext() ?? AuthContext.Unauthenticated();
+        subjectId = Guid.Empty;
+
+        if (!caller.IsAuthenticated)
+            return Unauthorized();
+
+        if (caller.SubjectId is not { } id)
+            return Ok(noMemberships);
+
+        subjectId = id;
+        return null;
+    }
+
     /// <inheritdoc cref="ITenantService.GetTenantsForSubjectAsync"/>
     [HttpGet]
     [RemoteQuery]
     [ProducesResponseType(typeof(List<TenantDto>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetMyTenants(CancellationToken ct)
     {
-        var authContext = HttpContext.GetAuthContext();
-        if (authContext?.SubjectId == null)
-            return Unauthorized();
+        if (ResolveOwnSubject(new List<TenantDto>(), out _, out var subjectId) is { } answer)
+            return answer;
 
-        var tenants = await _tenantService.GetTenantsForSubjectAsync(authContext.SubjectId.Value, ct);
+        var tenants = await _tenantService.GetTenantsForSubjectAsync(subjectId, ct);
         return Ok(tenants);
     }
 
@@ -61,22 +84,22 @@ public class MyTenantsController : ControllerBase
     [ProducesResponseType(typeof(TenantOverviewResponse), StatusCodes.Status200OK)]
     public async Task<ActionResult<TenantOverviewResponse>> GetOverview(CancellationToken ct)
     {
-        var authContext = HttpContext.GetAuthContext();
-        if (authContext?.SubjectId == null)
-            return Unauthorized();
+        if (ResolveOwnSubject(new TenantOverviewResponse([]), out var caller, out var subjectId)
+            is { } answer)
+            return answer;
 
         // This endpoint is tenantless, so MemberScopeMiddleware has not applied the membership
         // restriction — the service resolves it per tenant through MemberScopeResolver, which needs
         // the credential type to know whether the token's scopes are a ceiling at all.
-        // InstanceKey/PlatformAccess are superuser auth types, matching MemberScopeMiddleware's
-        // handling: they never reach membership resolution there, so stand in a full-access grant.
+        // PlatformAccess is a superuser auth type, matching MemberScopeMiddleware's handling: it
+        // never reaches membership resolution there, so stand in a full-access grant.
         IReadOnlySet<string> tokenScopes =
-            authContext.AuthType is AuthType.InstanceKey or AuthType.PlatformAccess
+            caller.AuthType is AuthType.PlatformAccess
                 ? new HashSet<string> { Scope.FullAccess }
                 : HttpContext.GetGrantedScopes();
 
         var overview = await _overviewService.GetOverviewAsync(
-            authContext.SubjectId.Value, tokenScopes, authContext.AuthType, ct);
+            subjectId, tokenScopes, caller.AuthType, ct);
         return Ok(overview);
     }
 

--- a/src/Web/packages/app/src/lib/components/connectors/UploaderSetupDialog.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/UploaderSetupDialog.svelte
@@ -41,6 +41,9 @@
 
   function handleRequestApiKey() {
     if (!selectedUploader) return;
+    // Dialogs layer by declaration order rather than open order, so a second one opened over
+    // this one can land underneath it and take no input. Hand off by stepping aside.
+    open = false;
     onRequestApiKey?.(getUploaderName(selectedUploader), ["health.readwrite"]);
   }
 

--- a/src/Web/packages/app/src/lib/components/connectors/UploaderSetupDialog.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/UploaderSetupDialog.svelte.test.ts
@@ -1,0 +1,72 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, beforeEach } from "vitest";
+import { vi } from "vitest";
+import { UploaderPlatform, type UploaderApp } from "$api-clients";
+
+let createImpl: () => Promise<{ token?: string }>;
+
+vi.mock("$lib/api/generated/directGrants.generated.remote", () => ({
+  list: () => Promise.resolve([]),
+  create: () => createImpl(),
+  revoke: () => Promise.resolve(),
+}));
+
+import Wrapper from "./uploader-setup-dialog-test-wrapper.svelte";
+
+const JUGGLUCO: UploaderApp = {
+  id: "juggluco",
+  platform: UploaderPlatform.Android,
+};
+
+const instructions = () => page.getByText("Set up Juggluco");
+const tokenDialog = () => page.getByRole("dialog");
+
+describe("uploader setup to API token hand-off", () => {
+  beforeEach(() => {
+    createImpl = () => Promise.resolve({ token: "noc_created" });
+  });
+
+  it("opens the token dialog where the user can actually type into it", async () => {
+    render(Wrapper, { selectedUploader: JUGGLUCO });
+
+    await expect.element(instructions()).toBeVisible();
+    await page.getByRole("button", { name: "Generate API key" }).click();
+
+    // Clicking hit-tests: while the instructions are still open over it, the label field
+    // belongs to the covered subtree and takes no input.
+    await page.getByLabelText("Label").click();
+    await expect.element(instructions()).not.toBeInTheDocument();
+  });
+
+  it("brings the instructions back when the token dialog closes", async () => {
+    render(Wrapper, { selectedUploader: JUGGLUCO });
+
+    await page.getByRole("button", { name: "Generate API key" }).click();
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    await expect.element(instructions()).toBeVisible();
+  });
+
+  it("brings them back when the create fails, and keeps the reason", async () => {
+    createImpl = () =>
+      Promise.reject({ status: 400, body: { message: "Label already used." } });
+
+    render(Wrapper, { selectedUploader: JUGGLUCO });
+
+    await page.getByRole("button", { name: "Generate API key" }).click();
+    await tokenDialog().getByRole("button", { name: "Create token" }).click();
+
+    await expect.element(instructions()).toBeVisible();
+    await expect.element(page.getByText("Label already used.")).toBeVisible();
+  });
+
+  it("leaves the page alone for a token created from the section itself", async () => {
+    render(Wrapper, { selectedUploader: JUGGLUCO, open: false });
+
+    await page.getByRole("button", { name: "Create token" }).click();
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    await expect.element(instructions()).not.toBeInTheDocument();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/connectors/uploader-setup-dialog-test-wrapper.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/uploader-setup-dialog-test-wrapper.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import ApiTokens from "$lib/components/settings/ApiTokens.svelte";
+  import UploaderSetupDialog from "./UploaderSetupDialog.svelte";
+  import { createUploaderTokenHandoff } from "$routes/(authenticated)/settings/connectors/uploader-token-handoff";
+  import type { UploaderApp } from "$lib/api/generated/nocturne-api-client";
+
+  interface Props {
+    selectedUploader: UploaderApp | null;
+    open?: boolean;
+  }
+
+  let { selectedUploader, open = true }: Props = $props();
+
+  let setupOpen = $state(open);
+  let tokenCreateOpen = $state(false);
+  let prefillLabel = $state("");
+  let prefillScopes = $state<string[]>([]);
+
+  const uploaderHandoff = createUploaderTokenHandoff();
+</script>
+
+<!-- The connectors page's own wiring, in its own declaration order: the token dialog's portal
+     anchors ahead of the uploader dialog's. -->
+<ApiTokens
+  bind:createOpen={tokenCreateOpen}
+  {prefillLabel}
+  {prefillScopes}
+  onCreateClose={() => {
+    if (uploaderHandoff.resumes()) setupOpen = true;
+  }}
+/>
+
+<UploaderSetupDialog
+  bind:open={setupOpen}
+  {selectedUploader}
+  onRequestApiKey={(label, scopes) => {
+    prefillLabel = label;
+    prefillScopes = scopes;
+    uploaderHandoff.handOff();
+    tokenCreateOpen = true;
+  }}
+/>

--- a/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/CurrentBGDisplay.svelte.test.ts
@@ -27,7 +27,9 @@ vi.mock("$lib/stores/settings-store.svelte", () => ({
   }),
 }));
 
-import CurrentBGDisplay from "./CurrentBGDisplay.svelte";
+// The value indicator uses Tooltip.Root, whose provider Sidebar.Provider supplies in the
+// app layout; the wrapper stands in for it.
+import CurrentBGDisplay from "./current-bg-display-test-wrapper.svelte";
 
 describe("CurrentBGDisplay", () => {
   it("renders status text without reading a Symbol timeSinceReading value", () => {

--- a/src/Web/packages/app/src/lib/components/dashboard/current-bg-display-test-wrapper.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/current-bg-display-test-wrapper.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import * as Tooltip from "$lib/components/ui/tooltip";
+  import CurrentBGDisplay from "./CurrentBGDisplay.svelte";
+
+  interface Props {
+    showPills?: boolean;
+  }
+
+  let { showPills = true }: Props = $props();
+</script>
+
+<Tooltip.Provider>
+  <CurrentBGDisplay {showPills} />
+</Tooltip.Provider>

--- a/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte
@@ -35,10 +35,12 @@
     createOpen = $bindable(false),
     prefillLabel = "",
     prefillScopes = [] as string[],
+    onCreateClose,
   }: {
     createOpen?: boolean;
     prefillLabel?: string;
     prefillScopes?: string[];
+    onCreateClose?: () => void;
   } = $props();
 
   // ============================================================================
@@ -117,7 +119,7 @@
       await loadGrants();
     } catch (err) {
       errorMessage = describeSubmitError(err, "Failed to create token.");
-      showCreateDialog = false;
+      closeCreateDialog();
     } finally {
       isCreating = false;
     }
@@ -134,12 +136,16 @@
     }
   }
 
+  // The only close path. bits-ui reports its own dismissals (escape, overlay, the X) through
+  // onOpenChange but says nothing about a programmatic one, so anything that closes this dialog
+  // from script comes through here.
   function closeCreateDialog() {
     showCreateDialog = false;
     createdToken = null;
     copiedToken = false;
     newTokenLabel = "";
     newTokenScopes = [];
+    onCreateClose?.();
   }
 
   // ============================================================================
@@ -302,7 +308,10 @@
 {/if}
 
 <!-- Create Token Dialog -->
-<Dialog.Root bind:open={showCreateDialog}>
+<Dialog.Root
+  bind:open={showCreateDialog}
+  onOpenChange={(open) => !open && closeCreateDialog()}
+>
   <Dialog.Content class="max-w-lg max-h-[90vh] overflow-y-auto">
     {#if createdToken}
       <!-- Token created - show the value -->

--- a/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/settings/ApiTokens.svelte.test.ts
@@ -1,0 +1,43 @@
+import { render } from "vitest-browser-svelte";
+import { page, userEvent } from "vitest/browser";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("$lib/api/generated/directGrants.generated.remote", () => ({
+  list: () => Promise.resolve([]),
+  create: () => Promise.resolve({}),
+  revoke: () => Promise.resolve(),
+}));
+
+import ApiTokens from "./ApiTokens.svelte";
+
+async function openCreateDialog() {
+  const onCreateClose = vi.fn();
+
+  render(ApiTokens, { createOpen: true, onCreateClose });
+
+  await expect.element(page.getByText("Create API token")).toBeVisible();
+  expect(onCreateClose).not.toHaveBeenCalled();
+
+  return onCreateClose;
+}
+
+describe("ApiTokens", () => {
+  it("reports the create dialog closing from its own footer", async () => {
+    const onCreateClose = await openCreateDialog();
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    expect(onCreateClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports it closing when the dialog dismisses itself", async () => {
+    const onCreateClose = await openCreateDialog();
+
+    await userEvent.keyboard("{Escape}");
+
+    await expect
+      .element(page.getByText("Create API token"))
+      .not.toBeInTheDocument();
+    expect(onCreateClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Web/packages/app/src/lib/test-stubs/app-server.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/app-server.ts
@@ -27,6 +27,11 @@ export function getRequestEvent(): never {
   throw new Error("getRequestEvent is not available in browser tests");
 }
 
+/** Reached only from inside a command's `refreshes`, which no browser test runs. */
+export function requested(): never {
+  throw new Error("requested is not available in browser tests");
+}
+
 type Implementation = (arg?: unknown) => unknown;
 
 // The framework's `(schema, fn)` and `(fn)` overloads both end at `fn`. Only

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -48,6 +48,7 @@
   import DeduplicationDialog from "$lib/components/connectors/DeduplicationDialog.svelte";
   import AppLogo from "$lib/components/ui/AppLogo.svelte";
   import UploaderSetupDialog from "$lib/components/connectors/UploaderSetupDialog.svelte";
+  import { createUploaderTokenHandoff } from "./uploader-token-handoff";
   import ConnectorDetailsDialog from "$lib/components/connectors/ConnectorDetailsDialog.svelte";
   import ManualSyncDialog, { type BatchSyncResult } from "$lib/components/connectors/ManualSyncDialog.svelte";
   import DemoDataSection from "$lib/components/connectors/DemoDataSection.svelte";
@@ -140,6 +141,7 @@
   let apiTokenCreateOpen = $state(false);
   let apiTokenPrefillLabel = $state("");
   let apiTokenPrefillScopes = $state<string[]>([]);
+  const uploaderHandoff = createUploaderTokenHandoff();
 
   // Deduplication state
   let showDeduplicationDialog = $state(false);
@@ -716,6 +718,9 @@
         bind:createOpen={apiTokenCreateOpen}
         prefillLabel={apiTokenPrefillLabel}
         prefillScopes={apiTokenPrefillScopes}
+        onCreateClose={() => {
+          if (uploaderHandoff.resumes()) showSetupDialog = true;
+        }}
       />
     </div>
   {/if}
@@ -728,6 +733,7 @@
   onRequestApiKey={(label, scopes) => {
     apiTokenPrefillLabel = label;
     apiTokenPrefillScopes = scopes;
+    uploaderHandoff.handOff();
     apiTokenCreateOpen = true;
   }}
 />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/uploader-token-handoff.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/uploader-token-handoff.ts
@@ -1,0 +1,23 @@
+/**
+ * The uploader setup dialog closes to hand an API-key request over to the token dialog, because
+ * two open dialogs layer by declaration order and the token dialog is declared first. This
+ * remembers that the hand-off happened, so the instructions can be brought back when the token
+ * dialog closes — and only then: the API tokens section opens the same dialog on its own.
+ */
+export function createUploaderTokenHandoff() {
+  let requestedByUploader = false;
+
+  return {
+    /** Records that the token dialog about to open was asked for by the uploader dialog. */
+    handOff() {
+      requestedByUploader = true;
+    },
+
+    /** True when the token dialog closing should bring the uploader dialog back. */
+    resumes() {
+      if (!requestedByUploader) return false;
+      requestedByUploader = false;
+      return true;
+    },
+  };
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MyTenantsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/MyTenantsControllerTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Configuration;
+using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.API.Services.Identity;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Authorization;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Identity;
+
+/// <summary>
+/// <c>GET /api/v4/me/tenants</c> and its overview both answer for the caller's own subject. A
+/// credential that carries no subject is a member of nothing, which is an empty answer rather
+/// than a rejected credential.
+/// </summary>
+[Trait("Category", "Unit")]
+public class MyTenantsControllerTests
+{
+    private readonly Mock<ITenantService> _tenantService = new();
+    private readonly Mock<ITenantOverviewService> _overviewService = new();
+    private readonly Guid _subjectId = Guid.CreateVersion7();
+
+    [Theory]
+    [MemberData(nameof(SubjectlessCredentials))]
+    public async Task A_subjectless_session_belongs_to_no_tenant_and_is_not_rejected(
+        AuthType authType)
+    {
+        var controller = CreateController(Subjectless(authType));
+
+        var result = await controller.GetMyTenants(CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeAssignableTo<IEnumerable<TenantDto>>()
+            .Which.Should().BeEmpty();
+        _tenantService.Verify(
+            s => s.GetTenantsForSubjectAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [MemberData(nameof(SubjectlessCredentials))]
+    public async Task A_subjectless_session_gets_an_empty_overview_and_is_not_rejected(
+        AuthType authType)
+    {
+        var controller = CreateController(Subjectless(authType));
+
+        var result = await controller.GetOverview(CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeOfType<TenantOverviewResponse>()
+            .Which.Tenants.Should().BeEmpty();
+        _overviewService.Verify(
+            s => s.GetOverviewAsync(
+                It.IsAny<Guid>(), It.IsAny<IReadOnlySet<string>>(), It.IsAny<AuthType>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_member_gets_the_tenants_their_subject_belongs_to()
+    {
+        var tenant = new TenantDto(
+            Guid.CreateVersion7(), "sleepy", "Sleepy", true, DateTime.UtcNow);
+        _tenantService
+            .Setup(s => s.GetTenantsForSubjectAsync(_subjectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([tenant]);
+
+        var controller = CreateController(new AuthContext
+        {
+            IsAuthenticated = true,
+            AuthType = AuthType.SessionCookie,
+            SubjectId = _subjectId,
+        });
+
+        var result = await controller.GetMyTenants(CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeAssignableTo<IEnumerable<TenantDto>>()
+            .Which.Should().ContainSingle().Which.Should().Be(tenant);
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_rejected()
+    {
+        var controller = CreateController(AuthContext.Unauthenticated());
+
+        var result = await controller.GetMyTenants(CancellationToken.None);
+
+        result.Should().BeOfType<UnauthorizedResult>();
+    }
+
+    /// <summary>
+    /// The credentials that authenticate without a subject of their own: a guest session, the
+    /// instance key, and the development auto-authentication context, which mints
+    /// <see cref="AuthType.ApiKey"/> with no subject.
+    /// </summary>
+    public static TheoryData<AuthType> SubjectlessCredentials =>
+        [AuthType.Guest, AuthType.InstanceKey, AuthType.ApiKey];
+
+    private static AuthContext Subjectless(AuthType authType) => new()
+    {
+        IsAuthenticated = true,
+        AuthType = authType,
+        SubjectId = null,
+    };
+
+    private MyTenantsController CreateController(AuthContext authContext)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["AuthContext"] = authContext;
+
+        return new MyTenantsController(
+            _tenantService.Object,
+            _overviewService.Object,
+            Options.Create(new OperatorConfiguration()))
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+}


### PR DESCRIPTION
Two old user reports, verified against main before touching anything; a third verified and found already fixed.

**#189, guest sessions evicted.** A guest link authenticates without a subject of its own (the owner rides on `ActingAsSubjectId`), so `GET /api/v4/me/tenants` and `/me/tenants/overview` rejected it as unauthorized purely because `SubjectId` was null. The web app maps a 401 there to a redirect to `/auth/login`, and the sidebar issues that query on every page, so a guest holding a live session was bounced off every page it was issued for. A credential with no subject is a member of no tenant, which is an empty list rather than a rejected credential. Both reads now resolve the caller through one private helper that answers 401 only when the request is not authenticated at all and an empty result when it authenticates without a subject; that covers guest sessions, the instance key and the dev auto-auth credential, and the tests are theories over all three. Creating a tenant still refuses a subjectless caller, because there is no honest empty answer to a write. The overview's scope check no longer names `InstanceKey`, which could never reach it.

**#533, API-key dialog behind the uploader dialog.** On Settings → Connectors, opening an uploader (e.g. Juggluco) and then "Generate API key" put the token dialog behind the instructions still on screen, where it could not be filled in. Every `Dialog.Content` portals to the end of `<body>` when its component is created rather than when it opens, so two open dialogs layer in declaration order, and `ApiTokens` is declared above `UploaderSetupDialog` on that page. `Dialog.Content` does expose bits-ui's `portalProps`, but `to` needs a portal target anchored later in `<body>` than the uploader's and the page has none, and `disabled` would render the content inline in the scrolling settings column; closing on handoff is the smaller change. The uploader dialog now closes as it hands the request off, and reopens when the token dialog closes so the user lands back on the instructions with the key in hand. The three-line flag that ties those together lives in `uploader-token-handoff.ts`, imported by the page and by the test harness alike. A token created from the section's own button never reopens the uploader. All closes of the token dialog, including a failed create, go through one path, so the flag cannot go stale. **Behavioural change:** the uploader instructions close when you click "Generate API key" and return when you finish or cancel. On a failed create the reason is shown in the section's banner behind the reopened instructions; surfacing it inside the dialog instead is a possible follow-up.

Tests: the uploader harness renders the real `ApiTokens` and the real `UploaderSetupDialog` in page order and clicks into the token dialog after the handoff (this times out on "subtree intercepts pointer events" without the fix), then covers cancel-return, failed-create-return-with-reason, and the section-button negative; `ApiTokens` is tested for both its footer and Escape close paths, each firing the close callback exactly once. Every guard was mutation-checked by hostile review.

Writing the browser tests required the `$app/server` test stub to carry `requested`, the export generated commands use for their invalidation lists. Without it five component test files failed to import and ran zero tests; four now run and pass untouched, and `CurrentBGDisplay`'s needed the tooltip provider `Sidebar.Provider` gives it in the app layout. `fix/clock-face-no-data` (#1171) adds the byte-identical export for the same reason, so either branch can land first. The browser suite goes from 342 passing with five empty files to 360 passing with none; the same three pre-existing timeouts remain.

Verified and **not** changed: **#611** (mobile BG ignoring the mmol preference) was real when filed. The header interpolated the raw mg/dL value beside a unit-aware delta, which is exactly what the screenshot shows (143 next to +0.3), and was fixed by #553 three days before the report. A component test rendering the mobile header with the mmol preference passes on main unmodified, so it was not committed.

`tests/Unit/Nocturne.API.Tests` 6441 passed, 0 failed, 5 skipped.

Closes #189. Closes #533.

https://claude.ai/code/session_01MqyVPKPLNu6y8YvXbdsoZ8
