### PR TITLE
perf(db): pin autoanalyze on tenant-scoped tables so new tenants reach the planner

### DIFF
--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -533,9 +533,7 @@ if (!isNSwagGeneration && !app.Environment.IsEnvironment("Testing"))
         // so they cannot drift from the code. Runs under the migrator role like migrations.
         await DatabaseInitializationExtensions.ReconcileShareRlsPoliciesAsync(migratorConnectionString, logger);
 
-        // Pin the autoanalyze cadence on tenant-scoped tables so a newly provisioned tenant enters
-        // the planner statistics within minutes of its backfill rather than days. Same role and
-        // idempotency as the RLS reconciler.
+        // Apply the tenant-table storage parameters; see TenantTableStorageParameters for why.
         await DatabaseInitializationExtensions.ReconcileTenantTableStorageParametersAsync(migratorConnectionString, logger);
 
         // Background job records left Pending/Running by a previous process are orphans —

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -533,6 +533,11 @@ if (!isNSwagGeneration && !app.Environment.IsEnvironment("Testing"))
         // so they cannot drift from the code. Runs under the migrator role like migrations.
         await DatabaseInitializationExtensions.ReconcileShareRlsPoliciesAsync(migratorConnectionString, logger);
 
+        // Pin the autoanalyze cadence on tenant-scoped tables so a newly provisioned tenant enters
+        // the planner statistics within minutes of its backfill rather than days. Same role and
+        // idempotency as the RLS reconciler.
+        await DatabaseInitializationExtensions.ReconcileTenantTableStorageParametersAsync(migratorConnectionString, logger);
+
         // Background job records left Pending/Running by a previous process are orphans —
         // the detached tasks died with it. Mark them Interrupted so polls report the truth.
         await DatabaseInitializationExtensions.MarkInterruptedJobsAsync(migratorConnectionString, logger);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/TenantTableStorageParameters.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/TenantTableStorageParameters.cs
@@ -1,0 +1,69 @@
+namespace Nocturne.Infrastructure.Data.Configuration;
+
+/// <summary>
+/// The storage parameters Nocturne pins on every tenant-scoped table, and the SQL that reads and
+/// writes them. Applied at startup by
+/// <see cref="Extensions.DatabaseInitializationExtensions.ReconcileTenantTableStorageParametersAsync"/>.
+/// </summary>
+/// <remarks>
+/// PostgreSQL re-samples a table's planner statistics only after
+/// <c>autovacuum_analyze_scale_factor</c> (default 0.1) of its rows change. On a multi-tenant
+/// table of millions of rows that is days, and a tenant provisioned in between is invisible to
+/// the planner: its <c>tenant_id</c> is in no most-common-values list, every scan filtered on it
+/// is estimated at one row, and the plans chosen on that estimate are the wrong ones. Measured in
+/// production on 2026-09-05: the latest-glucose read for a day-old tenant ran a 1.1M-buffer
+/// nested loop for 61 rows (650 ms, 90 % of database CPU) where the same read for an established
+/// tenant took 3 ms. At 0.01 the re-sample follows within an autovacuum nap of the tenant's
+/// first ~1 % of the table landing, a fraction of an initial backfill. The analyze sample size is
+/// fixed (300 × <c>default_statistics_target</c> rows), so the cost of the extra analyzes does
+/// not grow with the table.
+/// </remarks>
+public static class TenantTableStorageParameters
+{
+    /// <summary>The storage parameter pinned on every tenant-scoped table.</summary>
+    public const string AnalyzeScaleFactorName = "autovacuum_analyze_scale_factor";
+
+    /// <summary>
+    /// The pinned value. PostgreSQL stores a storage parameter as the text it was given and
+    /// <see cref="DriftQuerySql"/> compares that text, so this must stay in canonical form
+    /// (no trailing zeros) or every startup re-applies it.
+    /// </summary>
+    public const string AnalyzeScaleFactor = "0.01";
+
+    /// <summary>
+    /// Selects, from the table names in <c>$1</c>, those whose stored
+    /// <see cref="AnalyzeScaleFactorName"/> (parameter <c>$2</c>) is absent or differs from
+    /// <c>$3</c>. Only these need DDL, so a steady-state startup issues none.
+    /// </summary>
+    public const string DriftQuerySql =
+        """
+        SELECT c.relname::text
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND c.relname::text = ANY($1)
+          AND coalesce(
+                (SELECT o.option_value
+                 FROM pg_options_to_table(c.reloptions) o
+                 WHERE o.option_name = $2),
+                '') <> $3
+        ORDER BY c.relname
+        """;
+
+    /// <summary>
+    /// Pins <see cref="AnalyzeScaleFactorName"/> on <paramref name="table"/>. <c>ALTER TABLE … SET</c>
+    /// takes a <c>SHARE UPDATE EXCLUSIVE</c> lock, which reads and writes do not conflict with but an
+    /// autovacuum of the same table does, so the statement runs under a 3 s <c>lock_timeout</c>
+    /// scoped to its transaction rather than queue behind one.
+    /// </summary>
+    /// <param name="table">The snake_case table name.</param>
+    public static string BuildSetSql(string table)
+    {
+        SqlIdentifier.Require(table, nameof(table));
+        return $"""
+            SET LOCAL lock_timeout = '3s';
+            ALTER TABLE {table} SET ({AnalyzeScaleFactorName} = {AnalyzeScaleFactor});
+            """;
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/TenantTableStorageParameters.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/TenantTableStorageParameters.cs
@@ -10,49 +10,47 @@ namespace Nocturne.Infrastructure.Data.Configuration;
 /// <c>autovacuum_analyze_scale_factor</c> (default 0.1) of its rows change. On a multi-tenant
 /// table of millions of rows that is days, and a tenant provisioned in between is invisible to
 /// the planner: its <c>tenant_id</c> is in no most-common-values list, every scan filtered on it
-/// is estimated at one row, and the plans chosen on that estimate are the wrong ones. Measured in
-/// production on 2026-09-05: the latest-glucose read for a day-old tenant ran a 1.1M-buffer
-/// nested loop for 61 rows (650 ms, 90 % of database CPU) where the same read for an established
-/// tenant took 3 ms. At 0.01 the re-sample follows within an autovacuum nap of the tenant's
-/// first ~1 % of the table landing, a fraction of an initial backfill. The analyze sample size is
-/// fixed (300 × <c>default_statistics_target</c> rows), so the cost of the extra analyzes does
-/// not grow with the table.
+/// is estimated at one row, and the plans chosen on that estimate are the wrong ones. At 0.01 a
+/// tenant is analysed within an autovacuum nap of its rows exceeding about 1 % of the table,
+/// which a connector backfill crosses early; a tenant below that waits for the same 1 % of
+/// aggregate churn, and pays the mis-plan only over its own rows, since the tenant-leading
+/// indexes confine the wrong scan to them. The analyze sample size is fixed
+/// (300 × <c>default_statistics_target</c> rows), so the extra analyzes do not grow with the
+/// table. The value is a ceiling: a lower value an operator has set on a table is kept, a higher
+/// or absent one is replaced.
 /// </remarks>
 public static class TenantTableStorageParameters
 {
     /// <summary>The storage parameter pinned on every tenant-scoped table.</summary>
     public const string AnalyzeScaleFactorName = "autovacuum_analyze_scale_factor";
 
-    /// <summary>
-    /// The pinned value. PostgreSQL stores a storage parameter as the text it was given and
-    /// <see cref="DriftQuerySql"/> compares that text, so this must stay in canonical form
-    /// (no trailing zeros) or every startup re-applies it.
-    /// </summary>
+    /// <summary>The ceiling applied to <see cref="AnalyzeScaleFactorName"/>.</summary>
     public const string AnalyzeScaleFactor = "0.01";
 
     /// <summary>
     /// Selects, from the table names in <c>$1</c>, those whose stored
-    /// <see cref="AnalyzeScaleFactorName"/> (parameter <c>$2</c>) is absent or differs from
-    /// <c>$3</c>. Only these need DDL, so a steady-state startup issues none.
+    /// <see cref="AnalyzeScaleFactorName"/> (parameter <c>$2</c>) is absent or numerically above
+    /// <c>$3</c>. Only these need DDL, so a steady-state startup issues none. PostgreSQL stores the
+    /// option as the text it was given, so the comparison casts rather than matching text.
     /// </summary>
     public const string DriftQuerySql =
         """
         SELECT c.relname::text
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
+        LEFT JOIN LATERAL (
+            SELECT o.option_value
+            FROM pg_options_to_table(c.reloptions) o
+            WHERE o.option_name = $2) stored ON true
         WHERE n.nspname = 'public'
           AND c.relkind = 'r'
           AND c.relname::text = ANY($1)
-          AND coalesce(
-                (SELECT o.option_value
-                 FROM pg_options_to_table(c.reloptions) o
-                 WHERE o.option_name = $2),
-                '') <> $3
+          AND (stored.option_value IS NULL OR stored.option_value::numeric > $3::numeric)
         ORDER BY c.relname
         """;
 
     /// <summary>
-    /// Pins <see cref="AnalyzeScaleFactorName"/> on <paramref name="table"/>. <c>ALTER TABLE … SET</c>
+    /// Sets <see cref="AnalyzeScaleFactorName"/> on <paramref name="table"/>. <c>ALTER TABLE … SET</c>
     /// takes a <c>SHARE UPDATE EXCLUSIVE</c> lock, which reads and writes do not conflict with but an
     /// autovacuum of the same table does, so the statement runs under a 3 s <c>lock_timeout</c>
     /// scoped to its transaction rather than queue behind one.

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data.Configuration;
 using Nocturne.Infrastructure.Data.Interceptors;
 using Nocturne.Infrastructure.Data.Security;
 using Npgsql;
@@ -206,6 +207,80 @@ public static class DatabaseInitializationExtensions
                 await dataSource.DisposeAsync();
             }
         }
+    }
+
+    /// <summary>
+    /// Pins <see cref="TenantTableStorageParameters"/> on every tenant-scoped table so a tenant's
+    /// rows enter the planner statistics soon after they arrive (see the remarks there for the
+    /// production measurement behind it). Runs under the migrator role right after migrations,
+    /// like <see cref="ReconcileShareRlsPoliciesAsync"/>, and derives the table set from the EF
+    /// model so a new tenant-scoped entity is covered on its first startup. Only tables whose stored
+    /// value is absent or different are altered, so a steady-state startup issues no DDL. A table
+    /// whose lock cannot be taken within the statement's <c>lock_timeout</c> (an autovacuum of it
+    /// is running) is skipped with a warning and picked up on the next startup.
+    /// </summary>
+    /// <param name="migratorConnectionString">Connection string for the schema-owning migrator role.</param>
+    /// <param name="logger">Logger for progress and diagnostics.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The number of tables altered.</returns>
+    public static async Task<int> ReconcileTenantTableStorageParametersAsync(
+        string migratorConnectionString,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        await using var dataSource = new NpgsqlDataSourceBuilder(migratorConnectionString).Build();
+
+        var optionsBuilder = new DbContextOptionsBuilder<NocturneDbContext>();
+        optionsBuilder.UseNpgsql(dataSource);
+        using var context = new NocturneDbContext(optionsBuilder.Options);
+        var tables = ShareRlsPolicy.TenantScopedTableNames(context.Model);
+
+        await using var connection = await dataSource.OpenConnectionAsync(cancellationToken);
+
+        var drifted = new List<string>();
+        await using (var query = connection.CreateCommand())
+        {
+            query.CommandText = TenantTableStorageParameters.DriftQuerySql;
+            query.Parameters.AddWithValue(tables.ToArray());
+            query.Parameters.AddWithValue(TenantTableStorageParameters.AnalyzeScaleFactorName);
+            query.Parameters.AddWithValue(TenantTableStorageParameters.AnalyzeScaleFactor);
+            await using var reader = await query.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+                drifted.Add(reader.GetString(0));
+        }
+
+        var altered = 0;
+        foreach (var table in drifted)
+        {
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+            try
+            {
+                await using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = TenantTableStorageParameters.BuildSetSql(table);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+                altered++;
+            }
+            catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.LockNotAvailable)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                logger.LogWarning(
+                    "Skipped pinning {Parameter} on {Table}: {Message}. It will be retried on the next startup.",
+                    TenantTableStorageParameters.AnalyzeScaleFactorName, table, ex.MessageText);
+            }
+        }
+
+        if (altered > 0)
+        {
+            logger.LogInformation(
+                "Pinned {Parameter} = {Value} on {Count} tenant-scoped tables.",
+                TenantTableStorageParameters.AnalyzeScaleFactorName,
+                TenantTableStorageParameters.AnalyzeScaleFactor,
+                altered);
+        }
+
+        return altered;
     }
 
     /// <summary>

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DatabaseInitializationExtensions.cs
@@ -210,14 +210,13 @@ public static class DatabaseInitializationExtensions
     }
 
     /// <summary>
-    /// Pins <see cref="TenantTableStorageParameters"/> on every tenant-scoped table so a tenant's
-    /// rows enter the planner statistics soon after they arrive (see the remarks there for the
-    /// production measurement behind it). Runs under the migrator role right after migrations,
-    /// like <see cref="ReconcileShareRlsPoliciesAsync"/>, and derives the table set from the EF
-    /// model so a new tenant-scoped entity is covered on its first startup. Only tables whose stored
-    /// value is absent or different are altered, so a steady-state startup issues no DDL. A table
-    /// whose lock cannot be taken within the statement's <c>lock_timeout</c> (an autovacuum of it
-    /// is running) is skipped with a warning and picked up on the next startup.
+    /// Applies <see cref="TenantTableStorageParameters"/> to every tenant-scoped table (the
+    /// rationale lives there). Runs under the migrator role right after migrations, like
+    /// <see cref="ReconcileShareRlsPoliciesAsync"/>, and derives the table set from the EF model so
+    /// a new tenant-scoped entity is covered on its first startup. Only tables whose stored value
+    /// is absent or above the ceiling are altered, so a steady-state startup issues no DDL. A table
+    /// whose lock cannot be taken within the statement's <c>lock_timeout</c> is skipped with a
+    /// warning and picked up on the next startup.
     /// </summary>
     /// <param name="migratorConnectionString">Connection string for the schema-owning migrator role.</param>
     /// <param name="logger">Logger for progress and diagnostics.</param>
@@ -266,7 +265,7 @@ public static class DatabaseInitializationExtensions
             {
                 await transaction.RollbackAsync(cancellationToken);
                 logger.LogWarning(
-                    "Skipped pinning {Parameter} on {Table}: {Message}. It will be retried on the next startup.",
+                    "Skipped setting {Parameter} on {Table}: {Message}. It will be retried on the next startup.",
                     TenantTableStorageParameters.AnalyzeScaleFactorName, table, ex.MessageText);
             }
         }
@@ -274,7 +273,7 @@ public static class DatabaseInitializationExtensions
         if (altered > 0)
         {
             logger.LogInformation(
-                "Pinned {Parameter} = {Value} on {Count} tenant-scoped tables.",
+                "Set {Parameter} = {Value} on {Count} tenant-scoped tables.",
                 TenantTableStorageParameters.AnalyzeScaleFactorName,
                 TenantTableStorageParameters.AnalyzeScaleFactor,
                 altered);

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Security/ShareRlsPolicy.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Security/ShareRlsPolicy.cs
@@ -17,10 +17,9 @@ public static class ShareRlsPolicy
     /// <summary>Name of the RESTRICTIVE FOR SELECT policy applied to every tenant-scoped table.</summary>
     public const string PolicyName = "share_category_read";
 
-    // Table and scope identifiers come from the model and Scope constants, never user
-    // input; the patterns are belt-and-suspenders so a malformed identifier fails closed
-    // (throws) rather than being interpolated into DDL.
-    private static readonly Regex TableNamePattern = new("^[a-z_][a-z0-9_]*$", RegexOptions.Compiled);
+    // Scope identifiers come from the Scope constants, never user input; the pattern is
+    // belt-and-suspenders so a malformed one fails closed (throws) rather than being
+    // interpolated into DDL. Table and column identifiers go through SqlIdentifier.
     private static readonly Regex ScopePattern = new(@"^[a-z]+\.[a-z]+$", RegexOptions.Compiled);
 
     /// <summary>
@@ -55,12 +54,11 @@ public static class ShareRlsPolicy
     /// <c>null</c> when the table is exempt (catalog data with no per-row time).</param>
     public static string BuildPolicySql(string table, string? governingScope, string? recencyColumn = null)
     {
-        if (!TableNamePattern.IsMatch(table))
-            throw new ArgumentException($"Unsafe table identifier '{table}'.", nameof(table));
+        SqlIdentifier.Require(table, nameof(table));
         if (governingScope is not null && !ScopePattern.IsMatch(governingScope))
             throw new ArgumentException($"Unsafe scope identifier '{governingScope}'.", nameof(governingScope));
-        if (recencyColumn is not null && !TableNamePattern.IsMatch(recencyColumn))
-            throw new ArgumentException($"Unsafe column identifier '{recencyColumn}'.", nameof(recencyColumn));
+        if (recencyColumn is not null)
+            SqlIdentifier.Require(recencyColumn, nameof(recencyColumn));
 
         var usingExpr = "current_setting('app.is_share', true) IS DISTINCT FROM 'true'";
         if (governingScope is not null)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/SqlIdentifier.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/SqlIdentifier.cs
@@ -1,0 +1,22 @@
+using System.Text.RegularExpressions;
+
+namespace Nocturne.Infrastructure.Data;
+
+/// <summary>
+/// Guards identifiers that startup DDL interpolates into SQL text. They come from the EF model
+/// and from constants, never from user input; the check is belt-and-suspenders so a malformed
+/// identifier fails closed (throws) rather than being interpolated.
+/// </summary>
+internal static class SqlIdentifier
+{
+    private static readonly Regex Pattern = new("^[a-z_][a-z0-9_]*$", RegexOptions.Compiled);
+
+    /// <summary>Returns <paramref name="identifier"/> when it is a plain snake_case identifier.</summary>
+    /// <exception cref="ArgumentException">The identifier is not a plain snake_case name.</exception>
+    public static string Require(string identifier, string paramName)
+    {
+        if (!Pattern.IsMatch(identifier))
+            throw new ArgumentException($"Unsafe identifier '{identifier}'.", paramName);
+        return identifier;
+    }
+}

--- a/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
@@ -106,6 +106,14 @@
             database owner your provider gave you rather than the literal
             <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">postgres</code> user.
         </li>
+        <li>
+            At startup Nocturne sets
+            <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">autovacuum_analyze_scale_factor = 0.01</code>
+            on each of its tenant-scoped tables, so a newly added tenant's rows reach the query
+            planner's statistics within minutes rather than after a tenth of the table has changed.
+            It re-applies the value on every start; a different value set by hand on those tables
+            does not persist.
+        </li>
     </ul>
 
     <SupportNocturne />

--- a/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
@@ -110,9 +110,9 @@
             At startup Nocturne sets
             <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">autovacuum_analyze_scale_factor = 0.01</code>
             on each of its tenant-scoped tables, so a newly added tenant's rows reach the query
-            planner's statistics within minutes rather than after a tenth of the table has changed.
-            It re-applies the value on every start; a different value set by hand on those tables
-            does not persist.
+            planner's statistics once they exceed about 1% of the table rather than a tenth of it.
+            The value is a ceiling: a lower value set by hand on those tables is kept, a higher or
+            missing one is replaced on the next start.
         </li>
     </ul>
 

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
@@ -80,6 +80,11 @@ public class RlsCompletenessFixture : IAsyncLifetime
             MigratorConnectionString,
             NullLogger.Instance);
 
+        // Pin the tenant-table storage parameters, exactly as the API does at startup.
+        await DatabaseInitializationExtensions.ReconcileTenantTableStorageParametersAsync(
+            MigratorConnectionString,
+            NullLogger.Instance);
+
         await using var context = new NocturneDbContext(
             new DbContextOptionsBuilder<NocturneDbContext>().UseNpgsql(MigratorConnectionString).Options);
 

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/Rls/RlsCompletenessFixture.cs
@@ -80,7 +80,7 @@ public class RlsCompletenessFixture : IAsyncLifetime
             MigratorConnectionString,
             NullLogger.Instance);
 
-        // Pin the tenant-table storage parameters, exactly as the API does at startup.
+        // Apply the tenant-table storage parameters, exactly as the API does at startup.
         await DatabaseInitializationExtensions.ReconcileTenantTableStorageParametersAsync(
             MigratorConnectionString,
             NullLogger.Instance);

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/StorageParameters/TenantTableStorageParameterTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/StorageParameters/TenantTableStorageParameterTests.cs
@@ -8,8 +8,9 @@ namespace Nocturne.Infrastructure.Data.Tests.StorageParameters;
 
 /// <summary>
 /// Asserts, against a real PostgreSQL, what the startup reconciler leaves in <c>pg_class.reloptions</c>:
-/// every tenant-scoped table carries the pinned <c>autovacuum_analyze_scale_factor</c>, a run over an
-/// already-pinned database alters nothing, and a value changed or reset by hand is put back. The
+/// every tenant-scoped table carries the <c>autovacuum_analyze_scale_factor</c> ceiling, a run over an
+/// already-reconciled database alters nothing, a value raised or reset by hand is put back, a value
+/// lowered by hand is kept, and a table whose lock is held is skipped rather than stalling. The
 /// expected table set comes from the fixture, which walks <see cref="ITenantScoped"/> CLR types
 /// rather than asking the reconciler what it was told to do.
 /// </summary>
@@ -26,7 +27,7 @@ public class TenantTableStorageParameterTests
     public TenantTableStorageParameterTests(RlsCompletenessFixture fx) => _fx = fx;
 
     [Fact]
-    public async Task EveryTenantScopedTable_CarriesThePinnedAnalyzeScaleFactor()
+    public async Task EveryTenantScopedTable_CarriesTheAnalyzeScaleFactorCeiling()
     {
         _fx.TenantScopedTableNames.Should().NotBeEmpty();
 
@@ -36,7 +37,7 @@ public class TenantTableStorageParameterTests
         {
             stored.Should().ContainKey(table, $"{table} is a tenant-scoped table and must exist");
             stored[table].Should().Be(TenantTableStorageParameters.AnalyzeScaleFactor,
-                $"{table} must carry the pinned {TenantTableStorageParameters.AnalyzeScaleFactorName}");
+                $"{table} must carry the {TenantTableStorageParameters.AnalyzeScaleFactorName} ceiling");
         }
     }
 
@@ -49,7 +50,7 @@ public class TenantTableStorageParameterTests
     }
 
     [Fact]
-    public async Task Reconcile_OverAPinnedDatabase_AltersNothing()
+    public async Task Reconcile_OverAReconciledDatabase_AltersNothing()
     {
         var altered = await ReconcileAsync();
 
@@ -57,7 +58,7 @@ public class TenantTableStorageParameterTests
     }
 
     [Fact]
-    public async Task Reconcile_RestoresAValueChangedByHand()
+    public async Task Reconcile_LowersAValueRaisedByHand()
     {
         await ExecuteAsMigratorAsync(
             $"ALTER TABLE {ProbeTable} SET ({TenantTableStorageParameters.AnalyzeScaleFactorName} = 0.2)");
@@ -66,6 +67,48 @@ public class TenantTableStorageParameterTests
         var altered = await ReconcileAsync();
 
         altered.Should().Be(1);
+        (await ReadStoredValuesAsync())[ProbeTable].Should().Be(TenantTableStorageParameters.AnalyzeScaleFactor);
+    }
+
+    [Fact]
+    public async Task Reconcile_KeepsAStricterValueSetByHand()
+    {
+        await ExecuteAsMigratorAsync(
+            $"ALTER TABLE {ProbeTable} SET ({TenantTableStorageParameters.AnalyzeScaleFactorName} = 0.005)");
+        try
+        {
+            var altered = await ReconcileAsync();
+
+            altered.Should().Be(0, "an operator's lower value is under the ceiling and must be kept");
+            (await ReadStoredValuesAsync())[ProbeTable].Should().Be("0.005");
+        }
+        finally
+        {
+            await RestoreProbeTableAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Reconcile_SkipsATableWhoseLockIsHeld_AndAltersItOnceReleased()
+    {
+        await ExecuteAsMigratorAsync(
+            $"ALTER TABLE {ProbeTable} RESET ({TenantTableStorageParameters.AnalyzeScaleFactorName})");
+
+        // ALTER TABLE … SET needs SHARE UPDATE EXCLUSIVE, which is self-conflicting; holding it from
+        // another session stands in for an autovacuum of the table.
+        await using var holder = await _fx.OpenMigratorConnectionAsync();
+        await using var holding = await holder.BeginTransactionAsync();
+        await using (var lockCmd = new NpgsqlCommand($"LOCK TABLE {ProbeTable} IN SHARE UPDATE EXCLUSIVE MODE", holder, holding))
+            await lockCmd.ExecuteNonQueryAsync();
+
+        var whileHeld = await ReconcileAsync();
+
+        whileHeld.Should().Be(0, "the lock_timeout must skip the table instead of waiting or throwing");
+        (await ReadStoredValuesAsync())[ProbeTable].Should().BeNull();
+
+        await holding.RollbackAsync();
+
+        (await ReconcileAsync()).Should().Be(1, "the skipped table is picked up on the next run");
         (await ReadStoredValuesAsync())[ProbeTable].Should().Be(TenantTableStorageParameters.AnalyzeScaleFactor);
     }
 
@@ -100,7 +143,19 @@ public class TenantTableStorageParameterTests
         finally
         {
             await ExecuteAsMigratorAsync($"ALTER TABLE {ProbeTable} RESET (autovacuum_vacuum_scale_factor)");
+            await RestoreProbeTableAsync();
         }
+    }
+
+    /// <summary>
+    /// Puts the probe table back to the reconciled state whatever a test left behind: a value
+    /// under the ceiling would otherwise survive the next reconcile and leak into the other tests.
+    /// </summary>
+    private async Task RestoreProbeTableAsync()
+    {
+        await ExecuteAsMigratorAsync(
+            $"ALTER TABLE {ProbeTable} RESET ({TenantTableStorageParameters.AnalyzeScaleFactorName})");
+        await ReconcileAsync();
     }
 
     private Task<int> ReconcileAsync() =>

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/StorageParameters/TenantTableStorageParameterTests.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/StorageParameters/TenantTableStorageParameterTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Nocturne.Infrastructure.Data.Configuration;
+using Nocturne.Infrastructure.Data.Extensions;
+using Nocturne.Infrastructure.Data.Tests.Rls;
+using Npgsql;
+
+namespace Nocturne.Infrastructure.Data.Tests.StorageParameters;
+
+/// <summary>
+/// Asserts, against a real PostgreSQL, what the startup reconciler leaves in <c>pg_class.reloptions</c>:
+/// every tenant-scoped table carries the pinned <c>autovacuum_analyze_scale_factor</c>, a run over an
+/// already-pinned database alters nothing, and a value changed or reset by hand is put back. The
+/// expected table set comes from the fixture, which walks <see cref="ITenantScoped"/> CLR types
+/// rather than asking the reconciler what it was told to do.
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection("RLS completeness")]
+public class TenantTableStorageParameterTests
+{
+    private readonly RlsCompletenessFixture _fx;
+
+    // One tenant-scoped table to disturb by hand; the collection runs its tests sequentially,
+    // and each test that disturbs it ends with the reconciled state restored.
+    private const string ProbeTable = "boluses";
+
+    public TenantTableStorageParameterTests(RlsCompletenessFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task EveryTenantScopedTable_CarriesThePinnedAnalyzeScaleFactor()
+    {
+        _fx.TenantScopedTableNames.Should().NotBeEmpty();
+
+        var stored = await ReadStoredValuesAsync();
+
+        foreach (var table in _fx.TenantScopedTableNames)
+        {
+            stored.Should().ContainKey(table, $"{table} is a tenant-scoped table and must exist");
+            stored[table].Should().Be(TenantTableStorageParameters.AnalyzeScaleFactor,
+                $"{table} must carry the pinned {TenantTableStorageParameters.AnalyzeScaleFactorName}");
+        }
+    }
+
+    [Fact]
+    public void TableSet_CoversTheTablesTheProductionMeasurementWasTakenOn()
+    {
+        // The reconciler derives its set from the model; if either of these ever stopped being
+        // tenant-scoped the fix would silently no longer cover the tables it was written for.
+        _fx.TenantScopedTableNames.Should().Contain(["linked_records", "sensor_glucose"]);
+    }
+
+    [Fact]
+    public async Task Reconcile_OverAPinnedDatabase_AltersNothing()
+    {
+        var altered = await ReconcileAsync();
+
+        altered.Should().Be(0, "a steady-state startup must issue no DDL");
+    }
+
+    [Fact]
+    public async Task Reconcile_RestoresAValueChangedByHand()
+    {
+        await ExecuteAsMigratorAsync(
+            $"ALTER TABLE {ProbeTable} SET ({TenantTableStorageParameters.AnalyzeScaleFactorName} = 0.2)");
+        (await ReadStoredValuesAsync())[ProbeTable].Should().Be("0.2");
+
+        var altered = await ReconcileAsync();
+
+        altered.Should().Be(1);
+        (await ReadStoredValuesAsync())[ProbeTable].Should().Be(TenantTableStorageParameters.AnalyzeScaleFactor);
+    }
+
+    [Fact]
+    public async Task Reconcile_RestoresAValueResetByHand()
+    {
+        await ExecuteAsMigratorAsync(
+            $"ALTER TABLE {ProbeTable} RESET ({TenantTableStorageParameters.AnalyzeScaleFactorName})");
+        (await ReadStoredValuesAsync())[ProbeTable].Should().BeNull("RESET removes the parameter entirely");
+
+        var altered = await ReconcileAsync();
+
+        altered.Should().Be(1);
+        (await ReadStoredValuesAsync())[ProbeTable].Should().Be(TenantTableStorageParameters.AnalyzeScaleFactor);
+    }
+
+    [Fact]
+    public async Task Reconcile_LeavesOtherStorageParametersAlone()
+    {
+        // An operator's own tuning on a different parameter must survive the reconcile; only the
+        // parameter Nocturne owns is written.
+        await ExecuteAsMigratorAsync($"ALTER TABLE {ProbeTable} SET (autovacuum_vacuum_scale_factor = 0.05)");
+        await ExecuteAsMigratorAsync(
+            $"ALTER TABLE {ProbeTable} RESET ({TenantTableStorageParameters.AnalyzeScaleFactorName})");
+        try
+        {
+            (await ReconcileAsync()).Should().Be(1);
+
+            (await ReadStoredValuesAsync())[ProbeTable].Should().Be(TenantTableStorageParameters.AnalyzeScaleFactor);
+            (await ReadStoredValueAsync(ProbeTable, "autovacuum_vacuum_scale_factor")).Should().Be("0.05");
+        }
+        finally
+        {
+            await ExecuteAsMigratorAsync($"ALTER TABLE {ProbeTable} RESET (autovacuum_vacuum_scale_factor)");
+        }
+    }
+
+    private Task<int> ReconcileAsync() =>
+        DatabaseInitializationExtensions.ReconcileTenantTableStorageParametersAsync(
+            _fx.MigratorConnectionString, NullLogger.Instance);
+
+    private async Task ExecuteAsMigratorAsync(string sql)
+    {
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>Every public table's stored analyze scale factor, or <c>null</c> when absent.</summary>
+    private Task<Dictionary<string, string?>> ReadStoredValuesAsync() =>
+        ReadStoredValuesAsync(TenantTableStorageParameters.AnalyzeScaleFactorName);
+
+    private async Task<string?> ReadStoredValueAsync(string table, string parameter) =>
+        (await ReadStoredValuesAsync(parameter))[table];
+
+    private async Task<Dictionary<string, string?>> ReadStoredValuesAsync(string parameter)
+    {
+        await using var conn = await _fx.OpenMigratorConnectionAsync();
+        await using var cmd = new NpgsqlCommand(
+            """
+            SELECT c.relname::text,
+                   (SELECT o.option_value
+                    FROM pg_options_to_table(c.reloptions) o
+                    WHERE o.option_name = $1)
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public' AND c.relkind = 'r'
+            """, conn);
+        cmd.Parameters.AddWithValue(parameter);
+
+        var result = new Dictionary<string, string?>(StringComparer.Ordinal);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            result[reader.GetString(0)] = reader.IsDBNull(1) ? null : reader.GetString(1);
+        return result;
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/TenantTableStorageParametersTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/TenantTableStorageParametersTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Nocturne.Infrastructure.Data.Configuration;
 
 namespace Nocturne.Infrastructure.Data.Tests.Configuration;
@@ -13,16 +12,6 @@ public class TenantTableStorageParametersTests
 
         sql.Should().Contain("SET LOCAL lock_timeout = '3s';");
         sql.Should().Contain("ALTER TABLE linked_records SET (autovacuum_analyze_scale_factor = 0.01);");
-    }
-
-    [Fact]
-    public void AnalyzeScaleFactor_IsCanonicalText()
-    {
-        // The drift query compares the stored option text verbatim; a non-canonical constant
-        // (trailing zero, leading plus) would make every startup re-apply it.
-        decimal.Parse(TenantTableStorageParameters.AnalyzeScaleFactor, CultureInfo.InvariantCulture)
-            .ToString(CultureInfo.InvariantCulture)
-            .Should().Be(TenantTableStorageParameters.AnalyzeScaleFactor);
     }
 
     [Theory]

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/TenantTableStorageParametersTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/TenantTableStorageParametersTests.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+using Nocturne.Infrastructure.Data.Configuration;
+
+namespace Nocturne.Infrastructure.Data.Tests.Configuration;
+
+[Trait("Category", "Unit")]
+public class TenantTableStorageParametersTests
+{
+    [Fact]
+    public void BuildSetSql_PinsTheParameterUnderALockTimeout()
+    {
+        var sql = TenantTableStorageParameters.BuildSetSql("linked_records");
+
+        sql.Should().Contain("SET LOCAL lock_timeout = '3s';");
+        sql.Should().Contain("ALTER TABLE linked_records SET (autovacuum_analyze_scale_factor = 0.01);");
+    }
+
+    [Fact]
+    public void AnalyzeScaleFactor_IsCanonicalText()
+    {
+        // The drift query compares the stored option text verbatim; a non-canonical constant
+        // (trailing zero, leading plus) would make every startup re-apply it.
+        decimal.Parse(TenantTableStorageParameters.AnalyzeScaleFactor, CultureInfo.InvariantCulture)
+            .ToString(CultureInfo.InvariantCulture)
+            .Should().Be(TenantTableStorageParameters.AnalyzeScaleFactor);
+    }
+
+    [Theory]
+    [InlineData("boluses; DROP TABLE x")]
+    [InlineData("bad-name")]
+    [InlineData("Boluses")]
+    [InlineData("")]
+    public void BuildSetSql_UnsafeTable_Throws(string table)
+    {
+        var act = () => TenantTableStorageParameters.BuildSetSql(table);
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Problem

A tenant provisioned after a big table's last autoanalyze is absent from that table's `tenant_id` most-common-values list, so the planner estimates one row for every tenant-scoped scan and picks plans that are right for one row and wrong for 20k. Observed on the hosted instance on 2026-09-05: the "latest glucose excluding non-primary duplicates" anti-join (`ReadVisibilityFilter.ExcludeNonPrimary` via `SensorGlucoseRepository.GetAsync`) for a day-old tenant chose `ix_linked_records_tenant_created` + Filter over `ix_linked_records_tenant_type_not_primary`, walking ~430k rows per call: 650 ms and 1.1M buffer hits for 61 rows, ~90% of database CPU. The same read for an established tenant takes under 3 ms. At the default `autovacuum_analyze_scale_factor` of 0.1, `linked_records` (6.8M rows) needs ~685k modifications before it re-samples, so the wrong plan persists for days and recurs on every onboarding. A manual `ANALYZE` dropped the query to 0.4 ms.

## Change

At API startup, after migrations and the share-RLS reconciler, `ReconcileTenantTableStorageParametersAsync` runs under the migrator role and sets `autovacuum_analyze_scale_factor = 0.01` on every tenant-scoped table (set derived from the EF model, so a new tenant-scoped entity is covered on its first boot). The value is a ceiling: a table whose stored value is absent or numerically above 0.01 is altered; an operator's lower value is kept. A steady-state startup issues no DDL. Each `ALTER TABLE … SET` runs under a 3 s `lock_timeout` in its own transaction; a table whose SHARE UPDATE EXCLUSIVE lock cannot be taken (an autovacuum of it is running) is skipped with a warning and picked up next start.

At 0.01 a tenant is analysed within an autovacuum nap of its rows exceeding about 1% of the table, which a connector backfill crosses early. A tenant that stays below 1% waits for the same 1% of aggregate churn, and pays the mis-plan only over its own rows, since the tenant-leading indexes confine the wrong scan to them. The analyze sample is a fixed 300 × `default_statistics_target` rows, so the extra analyzes do not grow with the table.

Also: `SqlIdentifier.Require` replaces the private identifier regex in `ShareRlsPolicy` (same pattern, same exception type and parameter name).

## Tests

- Unit: `TenantTableStorageParametersTests` (SQL shape, unsafe identifiers).
- Integration (`RLS completeness` collection, real PostgreSQL 17.6): every `ITenantScoped` table carries the value (expected set walked from CLR types, not the reconciler's list); a reconciled database alters nothing; a value raised or reset by hand is put back; a lower hand-set value is kept; other storage parameters are untouched; a table whose SHARE UPDATE EXCLUSIVE lock is held from a second session is skipped and altered once released.
- Reviewed by a fresh-context hostile reviewer; its findings (threshold wording, ceiling semantics, a test asserting a false premise, missing lock-timeout test, duplicated rationale) are all applied.

## Docs

One bullet on the BYO PostgreSQL page describing the parameter and the ceiling behaviour.
