### PR TITLE
fix(bot): acknowledge the alert the card is about, not the whole tenant

### DIFF
--- a/src/Web/packages/app/src/lib/server/bot/api-client.ts
+++ b/src/Web/packages/app/src/lib/server/bot/api-client.ts
@@ -33,6 +33,8 @@ export function buildBotApiClient(api: ApiClient): BotApiClient {
     },
     alerts: {
       acknowledge: (request, signal) => api.alerts.acknowledge(request, signal),
+      acknowledgeExcursion: (excursionId, request, signal) =>
+        api.alerts.acknowledgeExcursion(excursionId, request, signal),
       markDelivered: (deliveryId, request, signal) =>
         api.alerts.markDelivered(deliveryId, request, signal),
       markFailed: (deliveryId, request, signal) =>

--- a/src/Web/packages/bot/src/alerts/deliver.test.ts
+++ b/src/Web/packages/bot/src/alerts/deliver.test.ts
@@ -14,6 +14,24 @@ vi.mock("../lib/logger.js", () => ({
 
 const ADAPTERS_WITH_DM = ["discord", "slack", "telegram", "whatsapp", "resend"];
 
+const TENANT = "11111111-1111-1111-1111-111111111111";
+const EXCURSION = "33333333-3333-3333-3333-333333333333";
+
+/** Card elements nest through `children`, which holds arrays as well as elements. */
+function buttonValue(node: unknown, id: string): string | undefined {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = buttonValue(child, id);
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  }
+  if (node === null || typeof node !== "object") return undefined;
+  const el = node as { props?: Record<string, unknown>; children?: unknown };
+  if (el.props?.id === id) return el.props.value as string;
+  return buttonValue(el.children, id);
+}
+
 function createBot(options: { adaptersWithDm?: string[] } = {}) {
   const withDm = options.adaptersWithDm ?? ADAPTERS_WITH_DM;
 
@@ -48,7 +66,8 @@ function createEvent(
     destination,
     tenantSlug: "acme",
     payload: {
-      tenantId: "11111111-1111-1111-1111-111111111111",
+      tenantId: TENANT,
+      excursionId: EXCURSION,
       ruleName: "Urgent low",
       subjectName: "Alex",
       glucoseValue: 54,
@@ -171,6 +190,32 @@ describe("AlertDeliveryHandler adapter routing", () => {
     expect(apiBits.markFailed).toHaveBeenCalledExactlyOnceWith("delivery-1", {
       error: "Adapter 'resend' cannot open a direct message",
     });
+  });
+});
+
+describe("AlertDeliveryHandler card actions", () => {
+  it("addresses the acknowledge button at the excursion, not just the tenant", async () => {
+    const bits = createBot();
+    const apiBits = createApi();
+
+    await new AlertDeliveryHandler(bits.bot, apiBits.api).deliver(
+      createEvent("discord_dm", "123456789012345678"),
+    );
+
+    expect(buttonValue(bits.post.mock.calls[0]?.[0], "ack_alert")).toBe(
+      `${TENANT}:${EXCURSION}`,
+    );
+  });
+
+  it("leaves the mute button addressing the tenant alone", async () => {
+    const bits = createBot();
+    const apiBits = createApi();
+
+    await new AlertDeliveryHandler(bits.bot, apiBits.api).deliver(
+      createEvent("discord_dm", "123456789012345678"),
+    );
+
+    expect(buttonValue(bits.post.mock.calls[0]?.[0], "mute_30")).toBe(TENANT);
   });
 });
 

--- a/src/Web/packages/bot/src/cards/alert.tsx
+++ b/src/Web/packages/bot/src/cards/alert.tsx
@@ -1,6 +1,7 @@
 import { Card, CardText, Fields, Field, Actions, Button } from "chat";
 import type { AlertPayload } from "../types.js";
 import { formatGlucose, trendArrow } from "../lib/format.js";
+import { encodeActionValue } from "../lib/action-value.js";
 
 export function AlertCard(props: {
   payload: AlertPayload;
@@ -12,6 +13,10 @@ export function AlertCard(props: {
       ? formatGlucose(payload.glucoseValue, unit)
       : "N/A";
   const arrow = payload.trend ? trendArrow(payload.trend) : "";
+  const acknowledgeTarget = encodeActionValue({
+    tenantId: payload.tenantId,
+    excursionId: payload.excursionId,
+  });
 
   return (
     <Card title={`Alert: ${payload.ruleName}`}>
@@ -29,7 +34,7 @@ export function AlertCard(props: {
         )}
       </Fields>
       <Actions>
-        <Button id="ack_alert" value={payload.tenantId} style="primary">
+        <Button id="ack_alert" value={acknowledgeTarget} style="primary">
           Acknowledge
         </Button>
         <Button id="mute_30" value={payload.tenantId}>

--- a/src/Web/packages/bot/src/commands/alerts.test.ts
+++ b/src/Web/packages/bot/src/commands/alerts.test.ts
@@ -15,9 +15,14 @@ vi.mock("../lib/logger.js", () => ({
 
 const HOME_TENANT = "11111111-1111-1111-1111-111111111111";
 const WORK_TENANT = "22222222-2222-2222-2222-222222222222";
+const EXCURSION = "33333333-3333-3333-3333-333333333333";
 
 const HOME = candidate(HOME_TENANT, "home-clinic", "home");
 const WORK = candidate(WORK_TENANT, "work-clinic", "work");
+
+/** The value the alert card puts on its buttons: the tenant and the excursion. */
+const cardValue = (tenantId: string, excursionId: string) =>
+  `${tenantId}:${excursionId}`;
 
 function candidate(
   tenantId: string,
@@ -40,18 +45,26 @@ const asDefault = (c: DirectoryCandidate): DirectoryCandidate => ({
   isDefault: true,
 });
 
+interface ScopedAlerts {
+  acknowledge: Mock;
+  acknowledgeExcursion: Mock;
+}
+
 function createContext(candidates: DirectoryCandidate[] | null) {
   const resolve = vi.fn().mockResolvedValue(candidates);
   const ambientAcknowledge = vi.fn().mockResolvedValue(undefined);
-  const acknowledgeBySlug = new Map<string, Mock>();
+  const alertsBySlug = new Map<string, ScopedAlerts>();
 
   const scopedApiFactory = vi.fn((tenantSlug: string) => {
-    let acknowledge = acknowledgeBySlug.get(tenantSlug);
-    if (!acknowledge) {
-      acknowledge = vi.fn().mockResolvedValue(undefined);
-      acknowledgeBySlug.set(tenantSlug, acknowledge);
+    let alerts = alertsBySlug.get(tenantSlug);
+    if (!alerts) {
+      alerts = {
+        acknowledge: vi.fn().mockResolvedValue(undefined),
+        acknowledgeExcursion: vi.fn().mockResolvedValue(undefined),
+      };
+      alertsBySlug.set(tenantSlug, alerts);
     }
-    return { alerts: { acknowledge } } as unknown as BotApiClient;
+    return { alerts } as unknown as BotApiClient;
   });
 
   const context: BotRequestContext = {
@@ -64,7 +77,7 @@ function createContext(candidates: DirectoryCandidate[] | null) {
     resolvedLink: null,
   };
 
-  return { context, resolve, scopedApiFactory, ambientAcknowledge, acknowledgeBySlug };
+  return { context, resolve, scopedApiFactory, ambientAcknowledge, alertsBySlug };
 }
 
 function createActionEvent(value?: string) {
@@ -98,20 +111,48 @@ describe("ack_alert action", () => {
     handler = actions.get("ack_alert")!;
   });
 
-  it("acknowledges through the client scoped to the alert's tenant", async () => {
+  it("acknowledges only the excursion the card is about", async () => {
+    const ctx = createContext([HOME, WORK]);
+    const { event, post } = createActionEvent(cardValue(WORK_TENANT, EXCURSION));
+
+    await runWithContext(ctx.context, () => handler(event));
+
+    const alerts = ctx.alertsBySlug.get("work-clinic")!;
+    expect(alerts.acknowledgeExcursion).toHaveBeenCalledExactlyOnceWith(
+      EXCURSION,
+      { acknowledgedBy: "Sam Tester" },
+    );
+    expect(alerts.acknowledge).not.toHaveBeenCalled();
+    expect(ctx.ambientAcknowledge).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledExactlyOnceWith(
+      "Acknowledged this alert. Any other active alerts are untouched.",
+    );
+  });
+
+  it("acknowledges the whole tenant for a value that names only a tenant", async () => {
     const ctx = createContext([HOME, WORK]);
     const { event, post } = createActionEvent(WORK_TENANT);
 
     await runWithContext(ctx.context, () => handler(event));
 
-    expect(ctx.resolve).toHaveBeenCalledExactlyOnceWith("discord", "discord-user-1");
-    expect(ctx.scopedApiFactory).toHaveBeenCalledExactlyOnceWith("work-clinic");
-    expect(ctx.acknowledgeBySlug.get("work-clinic")).toHaveBeenCalledExactlyOnceWith({
+    const alerts = ctx.alertsBySlug.get("work-clinic")!;
+    expect(alerts.acknowledge).toHaveBeenCalledExactlyOnceWith({
       acknowledgedBy: "Sam Tester",
     });
-    expect(ctx.acknowledgeBySlug.has("home-clinic")).toBe(false);
-    expect(ctx.ambientAcknowledge).not.toHaveBeenCalled();
+    expect(alerts.acknowledgeExcursion).not.toHaveBeenCalled();
     expect(post).toHaveBeenCalledExactlyOnceWith("All alerts acknowledged.");
+  });
+
+  it("acknowledges through the client scoped to the alert's tenant", async () => {
+    const ctx = createContext([HOME, WORK]);
+    const { event } = createActionEvent(cardValue(WORK_TENANT, EXCURSION));
+
+    await runWithContext(ctx.context, () => handler(event));
+
+    expect(ctx.resolve).toHaveBeenCalledExactlyOnceWith("discord", "discord-user-1");
+    expect(ctx.scopedApiFactory).toHaveBeenCalledExactlyOnceWith("work-clinic");
+    expect(ctx.alertsBySlug.has("home-clinic")).toBe(false);
+    expect(ctx.ambientAcknowledge).not.toHaveBeenCalled();
   });
 
   it("falls back to the only link when the button carries no tenant", async () => {
@@ -121,15 +162,17 @@ describe("ack_alert action", () => {
     await runWithContext(ctx.context, () => handler(event));
 
     expect(ctx.scopedApiFactory).toHaveBeenCalledExactlyOnceWith("home-clinic");
-    expect(ctx.acknowledgeBySlug.get("home-clinic")).toHaveBeenCalledExactlyOnceWith({
-      acknowledgedBy: "Sam Tester",
-    });
+    expect(
+      ctx.alertsBySlug.get("home-clinic")!.acknowledge,
+    ).toHaveBeenCalledExactlyOnceWith({ acknowledgedBy: "Sam Tester" });
     expect(post).toHaveBeenCalledExactlyOnceWith("All alerts acknowledged.");
   });
 
   it("tells an unlinked user to connect and calls no api", async () => {
     const ctx = createContext([]);
-    const { event, post, postEphemeral } = createActionEvent(WORK_TENANT);
+    const { event, post, postEphemeral } = createActionEvent(
+      cardValue(WORK_TENANT, EXCURSION),
+    );
 
     await runWithContext(ctx.context, () => handler(event));
 
@@ -145,7 +188,9 @@ describe("ack_alert action", () => {
 
   it("treats a missing directory response as unlinked", async () => {
     const ctx = createContext(null);
-    const { event, post, postEphemeral } = createActionEvent(WORK_TENANT);
+    const { event, post, postEphemeral } = createActionEvent(
+      cardValue(WORK_TENANT, EXCURSION),
+    );
 
     await runWithContext(ctx.context, () => handler(event));
 
@@ -157,7 +202,9 @@ describe("ack_alert action", () => {
 
   it("refuses a tenant the tapping user has no link to", async () => {
     const ctx = createContext([HOME]);
-    const { event, post, postEphemeral } = createActionEvent(WORK_TENANT);
+    const { event, post, postEphemeral } = createActionEvent(
+      cardValue(WORK_TENANT, EXCURSION),
+    );
 
     await runWithContext(ctx.context, () => handler(event));
 
@@ -172,13 +219,15 @@ describe("ack_alert action", () => {
 
   it("uses the tenant on the button over the user's default", async () => {
     const ctx = createContext([asDefault(HOME), WORK]);
-    const { event, post } = createActionEvent(WORK_TENANT);
+    const { event, post } = createActionEvent(cardValue(WORK_TENANT, EXCURSION));
 
     await runWithContext(ctx.context, () => handler(event));
 
     expect(ctx.scopedApiFactory).toHaveBeenCalledExactlyOnceWith("work-clinic");
-    expect(ctx.acknowledgeBySlug.has("home-clinic")).toBe(false);
-    expect(post).toHaveBeenCalledExactlyOnceWith("All alerts acknowledged.");
+    expect(ctx.alertsBySlug.has("home-clinic")).toBe(false);
+    expect(post).toHaveBeenCalledExactlyOnceWith(
+      "Acknowledged this alert. Any other active alerts are untouched.",
+    );
   });
 
   it("falls back to the default when the button carries no tenant", async () => {
@@ -209,11 +258,13 @@ describe("ack_alert action", () => {
 
   it("reports a failure without retrying against another tenant", async () => {
     const ctx = createContext([HOME, WORK]);
-    const { event, post } = createActionEvent(WORK_TENANT);
+    const { event, post } = createActionEvent(cardValue(WORK_TENANT, EXCURSION));
     ctx.scopedApiFactory.mockImplementation(
       () =>
         ({
-          alerts: { acknowledge: vi.fn().mockRejectedValue(new Error("503")) },
+          alerts: {
+            acknowledgeExcursion: vi.fn().mockRejectedValue(new Error("503")),
+          },
         }) as unknown as BotApiClient,
     );
 

--- a/src/Web/packages/bot/src/commands/alerts.ts
+++ b/src/Web/packages/bot/src/commands/alerts.ts
@@ -2,16 +2,29 @@ import type { Chat } from "chat";
 import { createLogger } from "../lib/logger.js";
 import { getApi } from "../lib/request-context.js";
 import { requireLinkForAction } from "../lib/require-link.js";
+import { decodeActionValue } from "../lib/action-value.js";
 
 const logger = createLogger();
 
 export function registerAlertCommands(bot: Chat) {
   bot.onAction("ack_alert", async (event) => {
     await requireLinkForAction(event, async () => {
+      const { excursionId } = decodeActionValue(event.value);
       try {
         const api = getApi();
-        await api.alerts.acknowledge({ acknowledgedBy: event.user.fullName ?? "Unknown" });
-        await event.thread?.post("All alerts acknowledged.");
+        const acknowledgedBy = event.user.fullName ?? "Unknown";
+
+        // Cards already in chat history carry only a tenant; their button still has to work.
+        if (!excursionId) {
+          await api.alerts.acknowledge({ acknowledgedBy });
+          await event.thread?.post("All alerts acknowledged.");
+          return;
+        }
+
+        await api.alerts.acknowledgeExcursion(excursionId, { acknowledgedBy });
+        await event.thread?.post(
+          "Acknowledged this alert. Any other active alerts are untouched.",
+        );
       } catch (err) {
         logger.error("Error acknowledging alert:", err);
         await event.thread?.post("Failed to acknowledge. Please try again.");

--- a/src/Web/packages/bot/src/lib/action-value.test.ts
+++ b/src/Web/packages/bot/src/lib/action-value.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { encodeActionValue, decodeActionValue } from "./action-value.js";
+
+const TENANT = "11111111-1111-1111-1111-111111111111";
+const EXCURSION = "33333333-3333-3333-3333-333333333333";
+
+describe("card button values", () => {
+  it("round-trips a tenant and an excursion", () => {
+    const value = encodeActionValue({
+      tenantId: TENANT,
+      excursionId: EXCURSION,
+    });
+
+    expect(value).toBe(`${TENANT}:${EXCURSION}`);
+    expect(decodeActionValue(value)).toEqual({
+      tenantId: TENANT,
+      excursionId: EXCURSION,
+    });
+  });
+
+  it("reads a single segment as a tenant with no excursion", () => {
+    expect(decodeActionValue(TENANT)).toEqual({
+      tenantId: TENANT,
+      excursionId: null,
+    });
+  });
+
+  it.each([undefined, null, ""])("yields neither id for %p", (value) => {
+    expect(decodeActionValue(value)).toEqual({
+      tenantId: null,
+      excursionId: null,
+    });
+  });
+
+  it("drops an excursion that names no tenant", () => {
+    expect(decodeActionValue(`:${EXCURSION}`)).toEqual({
+      tenantId: null,
+      excursionId: null,
+    });
+  });
+});

--- a/src/Web/packages/bot/src/lib/action-value.ts
+++ b/src/Web/packages/bot/src/lib/action-value.ts
@@ -1,0 +1,32 @@
+/**
+ * Encoding for the `value` a card button round-trips back to its handler.
+ *
+ * A card addresses one tenant and, when the button acts on a single alert, one
+ * excursion. Both are UUIDs, so a colon separates them unambiguously.
+ */
+const SEPARATOR = ":";
+
+export interface ActionTarget {
+  /** Tenant the card was posted for, or null if the value names none. */
+  tenantId: string | null;
+  /** Excursion the button acts on, or null if the value addresses only a tenant. */
+  excursionId: string | null;
+}
+
+export function encodeActionValue(target: {
+  tenantId: string;
+  excursionId: string;
+}): string {
+  return `${target.tenantId}${SEPARATOR}${target.excursionId}`;
+}
+
+/**
+ * A value with no second segment addresses only a tenant. An excursion is
+ * meaningless without the tenant to resolve it against, so a value whose first
+ * segment is empty yields neither.
+ */
+export function decodeActionValue(value: string | null | undefined): ActionTarget {
+  const [tenantId, excursionId] = (value ?? "").split(SEPARATOR);
+  if (!tenantId) return { tenantId: null, excursionId: null };
+  return { tenantId, excursionId: excursionId || null };
+}

--- a/src/Web/packages/bot/src/lib/require-link.ts
+++ b/src/Web/packages/bot/src/lib/require-link.ts
@@ -1,5 +1,6 @@
 import type { ActionEvent, SlashCommandEvent } from "chat";
 import { getUnscopedApi, runWithResolvedLink, type ResolvedLink } from "./request-context.js";
+import { decodeActionValue } from "./action-value.js";
 import type { DirectoryCandidate } from "../types.js";
 
 interface LinkResolutionInput {
@@ -7,7 +8,7 @@ interface LinkResolutionInput {
   platformUserId: string;
   /** Label typed as a command argument. Actions carry no text, so null. */
   labelArg: string | null;
-  /** Tenant the invocation is already bound to (a card button's value). Wins over labelArg. */
+  /** Tenant the invocation is already bound to (from a card button's value). Wins over labelArg. */
   tenantId: string | null;
   /** Appended to the ambiguity message to tell the user how to pick. */
   disambiguationHint: string;
@@ -199,13 +200,18 @@ export async function requireLink<T>(
 /**
  * Card-action entry point to {@link withResolvedLink}. An `ActionEvent` carries
  * no channel, text or command, so the tenant comes from the button's value
- * (cards that address a tenant must set it) and failures are explained as an
- * ephemeral in the thread the card was posted to.
+ * (cards that address a tenant must set it, encoded by `encodeActionValue`)
+ * and failures are explained as an ephemeral in the thread the card was posted
+ * to.
  *
  * @example
  * bot.onAction("ack_alert", async (event) => {
  *   await requireLinkForAction(event, async () => {
- *     await getApi().alerts.acknowledge({ acknowledgedBy: event.user.fullName });
+ *     const { excursionId } = decodeActionValue(event.value);
+ *     if (!excursionId) return;
+ *     await getApi().alerts.acknowledgeExcursion(excursionId, {
+ *       acknowledgedBy: event.user.fullName,
+ *     });
  *   });
  * });
  */
@@ -218,7 +224,7 @@ export async function requireLinkForAction<T>(
       platform: event.adapter.name,
       platformUserId: event.user.userId,
       labelArg: null,
-      tenantId: event.value || null,
+      tenantId: decodeActionValue(event.value).tenantId,
       disambiguationHint:
         "Set a default in Settings → Integrations → Discord, or use the matching slash command with a label.",
     },

--- a/src/Web/packages/bot/src/types.ts
+++ b/src/Web/packages/bot/src/types.ts
@@ -17,7 +17,13 @@ export interface BotApiClient {
     ): Promise<PaginatedSensorGlucose>;
   };
   alerts: {
+    /** Acknowledges every active excursion for the tenant. */
     acknowledge(request: AcknowledgeRequest, signal?: AbortSignal): Promise<void>;
+    acknowledgeExcursion(
+      excursionId: string,
+      request: AcknowledgeRequest,
+      signal?: AbortSignal,
+    ): Promise<void>;
     markDelivered(deliveryId: string, request: MarkDeliveredRequest, signal?: AbortSignal): Promise<void>;
     markFailed(deliveryId: string, request: MarkFailedRequest, signal?: AbortSignal): Promise<void>;
     getPendingDeliveries(channelType?: string[], signal?: AbortSignal): Promise<PendingDeliveryResponse[]>;


### PR DESCRIPTION
Fixes #832.

## Problem

The alert card's Acknowledge button called the tenant-wide acknowledge, so a carer clearing an overnight low card also silenced every unrelated alert firing at the time. The API already had a per-excursion acknowledge (`POST alerts/excursions/{id}/acknowledge`); nothing on the bot side used it.

## Change

- The Acknowledge button value is now `<tenantId>:<excursionId>` (`lib/action-value.ts` encodes and decodes it). The tap acknowledges only that excursion; tenant resolution reads the tenant out of the same value, so the card still acts on the tenant it was posted for.
- Reply: "Acknowledged this alert. Any other active alerts are untouched." The card it lands under already names the rule in its title.
- A value that names only a tenant (cards already in chat history) keeps the tenant-wide acknowledge and its "All alerts acknowledged." copy.
- Mute keeps the bare tenant id: its handler is a stub that ignores the value, and Telegram's 64-byte `callback_data` budget has no room for a compound value on a button that would not read it.
- `BotApiClient.alerts.acknowledgeExcursion` added and wired onto the NSwag client.

No API change. The web UI needed no change: `AlertBanner` and `FiringToast` already acknowledge one excursion, and the only tenant-wide control on the alerts page is labelled "Acknowledge all".

## Known limit, not addressed here

Telegram alert cards already fail delivery on main: the bare tenant UUID puts `callback_data` at 65 bytes against a 64-byte limit. Filed as #1177; the compound value does not change that outcome for any platform that works today.

## Tests

`@nocturne/bot` vitest 49/49 (`commands/alerts.test.ts`, `alerts/deliver.test.ts`, new `lib/action-value.test.ts`); `tsc --noEmit` clean. Mutation-checked: reverting the production files to main fails 3 tests; deleting the legacy branch fails 3; swapping segment order, decoupling excursion from tenant in decode, calling both acknowledge endpoints, and moving the compound value onto Mute each fail at least one.

https://claude.ai/code/session_014J7oqwcXbN67uk7fJfHb2M
