### PR TITLE
fix(multitenancy): name the inactive-tenant refusal and give it somewhere to go

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Platform/SupportController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/SupportController.cs
@@ -163,7 +163,12 @@ public class SupportController(
     /// Returns operator support configuration for the frontend.
     /// When no operator is configured, accountBilling is null and the default GitHub flow applies.
     /// </summary>
+    /// <remarks>
+    /// Anonymous because the hosts that most need the operator's address — an inactive tenant's,
+    /// and the apex with no tenant — are the ones no session can be established on.
+    /// </remarks>
     [HttpGet("config")]
+    [AllowAnonymous]
     [RemoteQuery]
     [ProducesResponseType(typeof(SupportConfigResponse), StatusCodes.Status200OK)]
     public ActionResult<SupportConfigResponse> GetSupportConfig()

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -62,6 +62,13 @@ public class TenantResolutionMiddleware
     }
 
     /// <summary>
+    /// The operator's own support and billing links, read from configuration alone. Named once
+    /// because it is on both lists below and a typo would silently split them.
+    /// </summary>
+    private static readonly TenantlessPath SupportConfigPath =
+        new("/api/v4/support/config", HttpMethods.Get);
+
+    /// <summary>
     /// Paths that operate across all tenants and don't require a resolved tenant context.
     /// These are allowed through even when no matching tenant is found.
     /// </summary>
@@ -94,6 +101,8 @@ public class TenantResolutionMiddleware
         // only presentation: the dashboard tiles render glucose in the units held here, so a 404
         // shows an mmol/L user their children's readings in mg/dL.
         "/api/v4/user/preferences",
+        // A host that resolves no tenant still needs somewhere to send the visitor.
+        SupportConfigPath,
         "/api/v4/chat-identity/directory/resolve",
         "/api/v4/chat-identity/directory/pending-links",
         // OIDC login can be initiated from the apex (no subdomain) — e.g. the
@@ -183,9 +192,33 @@ public class TenantResolutionMiddleware
     ];
 
     /// <summary>
+    /// The slice of <see cref="TenantlessAllowedPaths"/> still served when the resolved tenant is
+    /// inactive. None of these reads tenant data.
+    /// </summary>
+    /// <remarks>
+    /// <c>/api/v4/status</c> is deliberately not here: it answers for the tenant, and a 200 there
+    /// would have the web shell render the app over an API refusing every read.
+    /// </remarks>
+    private static readonly TenantlessPath[] InactiveTenantAllowedPaths =
+    [
+        "/health",
+        "/alive",
+        SupportConfigPath,
+    ];
+
+    /// <summary>
+    /// The machine-readable code an inactive tenant's refusal carries, alongside
+    /// <c>setup_required</c> on the fresh-install 503.
+    /// </summary>
+    public const string TenantInactiveCode = "tenant_inactive";
+
+    /// <summary>
     /// The entries themselves, for the guard that asserts each one still names a routed endpoint.
     /// </summary>
     public static IReadOnlyList<TenantlessPath> TenantlessPaths => TenantlessAllowedPaths;
+
+    /// <summary>The inactive-tenant slice, for the guard that asserts it is one.</summary>
+    public static IReadOnlyList<TenantlessPath> InactiveTenantPaths => InactiveTenantAllowedPaths;
 
     /// <summary>
     /// Whether a request is served without a resolved tenant. Public so the authorization
@@ -198,6 +231,14 @@ public class TenantResolutionMiddleware
     /// </param>
     public static bool IsTenantlessAllowed(string path, string? method = null) =>
         TenantlessAllowedPaths.Any(p => p.Matches(path, method));
+
+    /// <summary>
+    /// Whether a request is served even though the resolved tenant is inactive.
+    /// </summary>
+    /// <param name="path">The request path.</param>
+    /// <param name="method">The request method, or null to ask about any method.</param>
+    public static bool IsInactiveTenantAllowed(string path, string? method = null) =>
+        InactiveTenantAllowedPaths.Any(p => p.Matches(path, method));
 
     public async Task InvokeAsync(HttpContext context)
     {
@@ -323,8 +364,16 @@ public class TenantResolutionMiddleware
 
         if (!tenantContext.IsActive)
         {
+            if (IsInactiveTenantAllowed(path, context.Request.Method))
+            {
+                await _next(context);
+                return;
+            }
+
             _logger.LogWarning("Tenant '{Slug}' is inactive", slug);
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsJsonAsync(new { error = TenantInactiveCode });
             return;
         }
 

--- a/src/Web/packages/app/src/hooks.server.ts
+++ b/src/Web/packages/app/src/hooks.server.ts
@@ -23,6 +23,7 @@ import { clientAddressHeaders } from "$lib/server/client-address";
 import { getOriginalProto, getEffectiveHost, getOriginalHost, isShareHost } from "$lib/server/request-host";
 import {
   STATIC_ASSET_PREFIXES,
+  TENANT_INACTIVE_PATH,
   statusProbeRedirect,
 } from "$lib/server/public-routes";
 import { SHARE_UNAVAILABLE_PATH } from "$lib/share-host";
@@ -192,13 +193,14 @@ const readinessHandle: Handle = async ({ event, resolve }) => {
   const pathname = event.url.pathname;
 
   // Skip the status probe entirely for static assets, for pages that ARE
-  // the setup/recovery/auth/share-unavailable destinations (probing those would cause infinite
+  // the setup/recovery/auth/share-unavailable/tenant-inactive destinations (probing those would cause infinite
   // redirect loops), and for external webhook/bot endpoints that must respond
   // regardless of setup state — third-party services like Discord cannot
   // follow HTML redirects and will treat any non-2xx as a hard failure.
   const skipProbe =
     STATIC_ASSET_PREFIXES.some((p) => pathname.startsWith(p)) ||
     pathname.startsWith(SHARE_UNAVAILABLE_PATH) ||
+    pathname.startsWith(TENANT_INACTIVE_PATH) ||
     pathname.startsWith("/setup") ||
     pathname.startsWith("/auth") ||
     pathname.startsWith("/api/v4/webhooks") ||
@@ -242,6 +244,7 @@ const readinessHandle: Handle = async ({ event, resolve }) => {
         isShareHost: event.locals.isShareHost,
         apiStatus: (error as any).status,
         recoveryMode: body.recoveryMode === true,
+        errorCode: typeof body.error === "string" ? body.error : undefined,
         marketingUrl: env.MARKETING_URL,
       });
 

--- a/src/Web/packages/app/src/lib/components/shared/DeadEndCard.svelte
+++ b/src/Web/packages/app/src/lib/components/shared/DeadEndCard.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { ComponentType, Snippet } from "svelte";
+  import * as Card from "$lib/components/ui/card";
+
+  interface Props {
+    icon: ComponentType;
+    title: string;
+    children: Snippet;
+  }
+
+  const { icon: Icon, title, children }: Props = $props();
+</script>
+
+<div class="container mx-auto px-4 py-16 flex justify-center">
+  <Card.Root class="w-full max-w-md">
+    <Card.Header class="items-center text-center">
+      <div class="mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+        <Icon class="h-6 w-6 text-muted-foreground" />
+      </div>
+      <Card.Title>{title}</Card.Title>
+    </Card.Header>
+    <Card.Content class="space-y-3 text-center text-sm text-muted-foreground">
+      {@render children()}
+    </Card.Content>
+  </Card.Root>
+</div>

--- a/src/Web/packages/app/src/lib/components/shared/index.ts
+++ b/src/Web/packages/app/src/lib/components/shared/index.ts
@@ -1,2 +1,3 @@
 // Shared components used across the app
 export { default as GlucoseValueIndicator } from "@nocturne/ui/ui/glucose-value-indicator.svelte";
+export { default as DeadEndCard } from "./DeadEndCard.svelte";

--- a/src/Web/packages/app/src/lib/server/public-routes.test.ts
+++ b/src/Web/packages/app/src/lib/server/public-routes.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { statusProbeRedirect } from "./public-routes";
+import {
+  TENANT_INACTIVE_CODE,
+  TENANT_INACTIVE_PATH,
+  statusProbeRedirect,
+} from "./public-routes";
 import { SHARE_UNAVAILABLE_PATH } from "$lib/share-host";
 
 describe("statusProbeRedirect", () => {
@@ -45,8 +49,30 @@ describe("statusProbeRedirect", () => {
     ).toEqual({ location: "https://nocturne.run", status: 302 });
   });
 
+  it("sends an inactive tenant's host to the page that explains it", () => {
+    expect(
+      statusProbeRedirect({
+        ...selfHosted,
+        apiStatus: 403,
+        errorCode: TENANT_INACTIVE_CODE,
+      })
+    ).toEqual({ location: TENANT_INACTIVE_PATH, status: 303 });
+  });
+
+  it("keeps a share host on its own page when its tenant is the inactive one", () => {
+    // The share page names nothing; a stranger holding a link learns only that it isn't working.
+    expect(
+      statusProbeRedirect({
+        ...selfHosted,
+        isShareHost: true,
+        apiStatus: 403,
+        errorCode: TENANT_INACTIVE_CODE,
+      })
+    ).toEqual({ location: SHARE_UNAVAILABLE_PATH, status: 303 });
+  });
+
   it("sends nowhere on a status neither branch answers for", () => {
-    // 403 is among them: only a share host reads it as a suspended tenant.
+    // 403 is among them: without the code, only a share host reads it as a dead host.
     for (const apiStatus of [401, 403, 500, undefined, null, "404"]) {
       expect(statusProbeRedirect({ ...selfHosted, apiStatus }), String(apiStatus)).toBeNull();
     }

--- a/src/Web/packages/app/src/lib/server/public-routes.ts
+++ b/src/Web/packages/app/src/lib/server/public-routes.ts
@@ -7,6 +7,12 @@ import { SHARE_UNAVAILABLE_PATH } from "$lib/share-host";
 /** Static asset paths that bypass all middleware. */
 export const STATIC_ASSET_PREFIXES = ["/_app", "/assets", "/favicon.ico"] as const;
 
+/** Where a host whose tenant is inactive goes; nothing else on it can be signed into or read. */
+export const TENANT_INACTIVE_PATH = "/tenant/inactive";
+
+/** The code the API's inactive-tenant refusal carries, mirroring the API's TenantInactiveCode. */
+export const TENANT_INACTIVE_CODE = "tenant_inactive";
+
 /** What the request hooks know about a status probe that failed. */
 export interface StatusProbeFailure {
   /** Whether the request arrived on a public share host ({token}.share.{base-domain}). */
@@ -15,6 +21,8 @@ export interface StatusProbeFailure {
   apiStatus: unknown;
   /** Whether the API's 503 body declared recovery mode. */
   recoveryMode: boolean;
+  /** The machine-readable code the API's error body carried, if it carried one. */
+  errorCode?: string;
   /** The marketing site to land an unresolvable non-share host on, if one is configured. */
   marketingUrl: string | undefined;
 }
@@ -26,7 +34,7 @@ export interface StatusProbeFailure {
  * instance-wide destination below: it holds no session for the recovery sign-in, the marketing site
  * belongs to a different domain, and /setup offers a first-run wizard on an instance a share link
  * only resolves on once it is past setup. The three statuses it claims mean an unresolvable token
- * (404), a suspended tenant (403) and an API that is itself unready (503) — the page it lands on
+ * (404), an inactive tenant (403) and an API that is itself unready (503) — the page it lands on
  * names none of them, only that the link is not working, because from here they are indistinguishable
  * to the visitor and only one of them is even permanent.
  */
@@ -34,10 +42,15 @@ export function statusProbeRedirect({
   isShareHost,
   apiStatus,
   recoveryMode,
+  errorCode,
   marketingUrl,
 }: StatusProbeFailure): { location: string; status: 302 | 303 } | null {
   if (isShareHost && (apiStatus === 404 || apiStatus === 403 || apiStatus === 503)) {
     return { location: SHARE_UNAVAILABLE_PATH, status: 303 };
+  }
+
+  if (apiStatus === 403 && errorCode === TENANT_INACTIVE_CODE) {
+    return { location: TENANT_INACTIVE_PATH, status: 303 };
   }
 
   // Any 503 (setup_required, no tenants, or an unparseable body) means the instance isn't ready.

--- a/src/Web/packages/app/src/routes/(unauthenticated)/share/unavailable/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/share/unavailable/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import * as Card from "$lib/components/ui/card";
+  import { DeadEndCard } from "$lib/components/shared";
   import { Link2Off } from "lucide-svelte";
 </script>
 
@@ -8,29 +8,17 @@
   <meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
-<div class="container mx-auto px-4 py-16 flex justify-center">
-  <Card.Root class="w-full max-w-md">
-    <Card.Header class="items-center text-center">
-      <div
-        class="mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-muted"
-      >
-        <Link2Off class="h-6 w-6 text-muted-foreground" />
-      </div>
-      <Card.Title>This share link isn't working</Card.Title>
-    </Card.Header>
-    <Card.Content class="space-y-3 text-center text-sm text-muted-foreground">
-      <!-- A rotated link, a suspended tenant and an API that is briefly unready all land here and
-           are indistinguishable from the browser, so the page names none of them. Prompting for a
-           replacement link first would be actively harmful: rotating is how the owner would supply
-           one, and it permanently breaks the link for every other recipient. -->
-      <p>
-        It may have been turned off or replaced, or the service may be
-        temporarily unavailable.
-      </p>
-      <p>
-        Try again in a few minutes. If it still doesn't work, ask the person who
-        shared it to check the link.
-      </p>
-    </Card.Content>
-  </Card.Root>
-</div>
+<DeadEndCard icon={Link2Off} title="This share link isn't working">
+  <!-- A rotated link, an inactive tenant and an API that is briefly unready all land here and
+       are indistinguishable from the browser, so the copy names none of them. Prompting for a
+       replacement link first would be actively harmful: rotating is how the owner would supply
+       one, and it permanently breaks the link for every other recipient. -->
+  <p>
+    It may have been turned off or replaced, or the service may be temporarily
+    unavailable.
+  </p>
+  <p>
+    Try again in a few minutes. If it still doesn't work, ask the person who
+    shared it to check the link.
+  </p>
+</DeadEndCard>

--- a/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/+page.server.ts
@@ -1,0 +1,22 @@
+import type { SupportChannelConfig } from "$api/generated/nocturne-api-client";
+import type { PageServerLoad } from "./$types";
+
+/**
+ * The operator's billing address as a link, or null when there is nothing to link to.
+ *
+ * Api mode is an issue-intake endpoint the app POSTs to, not a page: rendering it as an href
+ * would send the visitor to a route with no GET.
+ */
+export function resolveBillingLink(
+  config: SupportChannelConfig | null | undefined
+): { url: string; label: string | null } | null {
+  if (config?.mode !== "redirect" || !config.url) return null;
+
+  return { url: config.url, label: config.label ?? null };
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+  const config = await locals.apiClient.support.getSupportConfig().catch(() => null);
+
+  return { billingLink: resolveBillingLink(config?.accountBilling) };
+};

--- a/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/+page.svelte
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { DeadEndCard } from "$lib/components/shared";
+  import { Button } from "$lib/components/ui/button";
+  import { PauseCircle } from "lucide-svelte";
+
+  let { data } = $props();
+
+  const billingLink = $derived(data.billingLink);
+</script>
+
+<svelte:head>
+  <title>Account inactive</title>
+  <meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<DeadEndCard icon={PauseCircle} title="This account is inactive">
+  <!-- The browser cannot tell why an account is inactive, so the copy does not guess. -->
+  <p>
+    This Nocturne account isn't active at the moment, so there's nothing here to
+    sign in to.
+  </p>
+  {#if billingLink}
+    <p>
+      If you look after this account, you can check on it where the account is
+      managed.
+    </p>
+    <Button href={billingLink.url} target="_blank" rel="noopener noreferrer">
+      {billingLink.label ?? "Manage this account"}
+    </Button>
+  {:else}
+    <p>
+      If you look after this account, contact whoever runs this Nocturne
+      service.
+    </p>
+  {/if}
+  <p>
+    If someone shares their data with you here, let them know so they can look
+    into it.
+  </p>
+</DeadEndCard>

--- a/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.test.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { resolveBillingLink } from "./+page.server";
+
+describe("resolveBillingLink", () => {
+  it("links the operator's billing page in redirect mode", () => {
+    expect(
+      resolveBillingLink({
+        mode: "redirect",
+        url: "https://nocturne.run/account",
+        label: "Manage your subscription",
+      })
+    ).toEqual({ url: "https://nocturne.run/account", label: "Manage your subscription" });
+  });
+
+  it("offers no link in api mode", () => {
+    // The hosted deployment configures api mode against a POST-only issue-intake endpoint, so a
+    // link here would send a lapsed customer to a route with no GET.
+    expect(
+      resolveBillingLink({ mode: "api", url: "https://nocturne.run/api/support" })
+    ).toBeNull();
+  });
+
+  it("offers no link when the operator configured none", () => {
+    expect(resolveBillingLink(null)).toBeNull();
+    expect(resolveBillingLink(undefined)).toBeNull();
+    expect(resolveBillingLink({ mode: "redirect", url: "" })).toBeNull();
+  });
+
+  it("carries a redirect with no label, which the page names itself", () => {
+    expect(resolveBillingLink({ mode: "redirect", url: "https://example.test" }))
+      .toEqual({ url: "https://example.test", label: null });
+  });
+});

--- a/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/TenantlessDemoSubjectCoverageTests.cs
@@ -121,6 +121,7 @@ public class TenantlessDemoSubjectCoverageTests
             ["SetupController.OidcCallback"] = FirstRunOnly,
 
             ["StatusController.GetStatus"] = "reports the deployment's version, settings and setup state to any caller, signed in or not; reads no session",
+            ["SupportController.GetSupportConfig"] = "returns the operator's own support and billing links from deployment configuration; reads no session and names no tenant",
             ["TlsAuthorizationController.Authorize"] = "answers the edge's on-demand-TLS ask for a hostname; it takes no credential and reads no session",
             ["TotpController.Login"] = "mints the session; the subject comes from the passkey step-up token, and it additionally requires membership of the resolved tenant, which a tenantless host has none of",
         };

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareInactiveTenantTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareInactiveTenantTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Multitenancy;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Multitenancy;
+
+/// <summary>
+/// An inactive tenant's subdomain in <see cref="TenantResolutionMiddleware"/>. The refusal has to
+/// name itself, because the person on the other side of it is usually the account holder and the
+/// web app can only explain what it can recognise; and it has to leave the liveness probes and the
+/// operator's address answering, because a probe cannot otherwise tell a suspended deployment from
+/// a broken one and the page explaining the refusal has nowhere to point.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class TenantResolutionMiddlewareInactiveTenantTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _root;
+    private const string BaseDomain = "nocturne.example";
+    private const string Slug = "lapsed";
+
+    public TenantResolutionMiddlewareInactiveTenantTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<NocturneDbContext>(o => o
+            .UseSqlite(_connection)
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
+        services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext());
+        services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
+        services.AddMemoryCache();
+        _root = services.BuildServiceProvider();
+
+        using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
+        seed.Database.EnsureCreated();
+        seed.Tenants.Add(new TenantEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Slug = Slug,
+            DisplayName = Slug,
+            IsActive = false,
+        });
+        seed.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _root.Dispose();
+        _connection.Dispose();
+    }
+
+    private TenantResolutionMiddleware Build(RequestDelegate next) => new(
+        next,
+        NullLogger<TenantResolutionMiddleware>.Instance,
+        Options.Create(new BaseDomainOptions { BaseDomain = BaseDomain }),
+        _root.GetRequiredService<IMemoryCache>());
+
+    private static DefaultHttpContext Request(IServiceScope scope, string path, string method = "GET")
+    {
+        var ctx = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
+        ctx.Request.Headers["X-Forwarded-Host"] = $"{Slug}.{BaseDomain}";
+        ctx.Request.Path = path;
+        ctx.Request.Method = method;
+        ctx.Response.Body = new MemoryStream();
+        return ctx;
+    }
+
+    private async Task<(bool NextCalled, DefaultHttpContext Context, string Body)> InvokeAsync(
+        string path, string method = "GET")
+    {
+        using var scope = _root.CreateScope();
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+        var ctx = Request(scope, path, method);
+
+        await mw.InvokeAsync(ctx);
+
+        ctx.Response.Body.Position = 0;
+        var body = await new StreamReader(ctx.Response.Body).ReadToEndAsync();
+        return (nextCalled, ctx, body);
+    }
+
+    [Theory]
+    [InlineData("/api/v4/sensorglucose")]
+    [InlineData("/api/v4/status")]
+    [InlineData("/api/auth/oidc/session")]
+    public async Task Refuses_with_a_code_the_web_app_can_recognise(string path)
+    {
+        var (nextCalled, ctx, body) = await InvokeAsync(path);
+
+        nextCalled.Should().BeFalse();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        JsonDocument.Parse(body).RootElement.GetProperty("error").GetString()
+            .Should().Be(TenantResolutionMiddleware.TenantInactiveCode);
+    }
+
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/alive")]
+    public async Task Liveness_probes_answer_without_resolving_the_tenant(string path)
+    {
+        using var scope = _root.CreateScope();
+        var nextCalled = false;
+        var mw = Build(_ => { nextCalled = true; return Task.CompletedTask; });
+        var ctx = Request(scope, path);
+
+        await mw.InvokeAsync(ctx);
+
+        nextCalled.Should().BeTrue();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        scope.ServiceProvider.GetRequiredService<ITenantAccessor>().IsResolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task The_operators_address_is_readable_so_the_refusal_can_be_explained()
+    {
+        var (nextCalled, ctx, _) = await InvokeAsync("/api/v4/support/config");
+
+        nextCalled.Should().BeTrue();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public async Task Only_the_method_the_slice_names_is_served()
+    {
+        var (nextCalled, ctx, _) = await InvokeAsync("/api/v4/support/config", HttpMethods.Post);
+
+        nextCalled.Should().BeFalse();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    /// <summary>
+    /// The inactive slice is a subset of the tenantless list, not a second list that could drift
+    /// into admitting something the tenantless surface itself does not.
+    /// </summary>
+    [Fact]
+    public void Every_inactive_entry_is_also_tenantless_allowed()
+    {
+        TenantResolutionMiddleware.InactiveTenantPaths.Should().NotBeEmpty();
+
+        foreach (var entry in TenantResolutionMiddleware.InactiveTenantPaths)
+        {
+            TenantResolutionMiddleware.IsTenantlessAllowed(entry.Path, entry.Method)
+                .Should().BeTrue("{0} is served on an inactive tenant's host but is not on the "
+                    + "tenantless list it is meant to be a slice of", entry.Path);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #991.

## Problem

An inactive tenant's host answered a bare 403 on every path. A probe could not tell it from a broken deployment, and the web app had no branch for it: the visitor was redirected to a sign-in that could never succeed.

## Change

**API** (`TenantResolutionMiddleware`)
- The 403 carries `{"error":"tenant_inactive"}`, alongside the fresh-install 503's `setup_required`.
- A three-entry slice of the tenantless allowlist (`/health`, `/alive`, `GET /api/v4/support/config`) is evaluated before the activity check. The path entry is declared once and shared by both lists; a test asserts the slice is a subset. `/api/v4/status` is deliberately not in it: it answers for the tenant, and a 200 there would render the app over an API refusing every read.
- `GET /api/v4/support/config` becomes anonymous. It reads deployment configuration alone and names no tenant or subject.
- The share-host inactive branch stays bodiless on purpose: a stranger holding a share link should not learn that a tenant exists but is suspended.

**Web**
- `statusProbeRedirect` gains a 403 + `tenant_inactive` branch to `/tenant/inactive`, placed after the share-host branch so share hosts keep their opaque page.
- New `/tenant/inactive` page states that the account is inactive (not why, which the browser cannot know) and carries the operator's link when one is configured in redirect mode. An api-mode operator's URL is a POST-only issue-intake endpoint, so those deployments get the generic "contact whoever runs this service" copy and no link on this page yet.
- The page shares a new `DeadEndCard` shell with `share/unavailable`, which loses its copy of the markup.

## Behaviour deltas on an inactive tenant's host

| Path | Before | After |
|---|---|---|
| `/health`, `/alive` | 403, no body | normal status, no tenant resolved |
| `GET /api/v4/support/config` | 403 | 200 (operator `{mode,url,label}` only) |
| Everything else incl. `/api/v4/status` and data paths | 403, no body | 403 + `{"error":"tenant_inactive"}` |
| Browser | 303 to a sign-in that cannot succeed | 303 to `/tenant/inactive` |

Also new: `GET /api/v4/support/config` answers anonymously on the apex.

## Tests

`TenantResolutionMiddlewareInactiveTenantTests` (8: code in body on three refused paths, liveness paths answer without resolving a tenant, support config readable, method narrowing, subset guard); `TenantlessDemoSubjectCoverageTests` gains the `AnonymousExempt` classification. Web: `public-routes.test.ts` (inactive branch, share host wins, unknown 403 unchanged), `billing-link.test.ts` (api mode yields no link). Unit `Nocturne.API.Tests` 6448/0; app vitest baseline unchanged. Mutation-checked in two hostile review rounds: method ignored, `/api/v4/status` allowed, wrong code in body, path entry removed from the tenantless list, web branch reordered, and mode gate removed each fail at least one test.

Follow-ups filed: #1175 (tenant switcher label and unordered default tenant, split out of this issue's body).

https://claude.ai/code/session_014J7oqwcXbN67uk7fJfHb2M
