### PR TITLE
fix(aspire): pin pgAdmin to a static host port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ The `--skip-worktree` bits may be cleared by git during branch switches that tou
 
 ### Worktrees
 
-Git worktrees are supported. In the main checkout, `aspire start` uses persistent Postgres (named volume, pgAdmin), binds the gateway to `https://nocturne.localhost:1612` (tenants at `https://<slug>.nocturne.localhost:1612`), and pins nocturne-api to `http://localhost:1610`. In a worktree, Postgres is automatically ephemeral (anonymous volume, no pgAdmin) and ports are dynamic.
+Git worktrees are supported. In the main checkout, `aspire start` uses persistent Postgres (named volume, pgAdmin at `http://localhost:1611`), binds the gateway to `https://nocturne.localhost:1612` (tenants at `https://<slug>.nocturne.localhost:1612`), and pins nocturne-api to `http://localhost:1610`. In a worktree, Postgres is automatically ephemeral (anonymous volume, no pgAdmin) and ports are dynamic.
 
 **Always use `--isolated` when running Aspire from a worktree** to avoid dashboard port collisions with the main instance:
 

--- a/src/Aspire/Nocturne.Aspire.Host/Program.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Program.cs
@@ -146,9 +146,11 @@ class Program
                     .WithDataVolume(ServiceNames.Volumes.PostgresData);
             }
 
-            if (builder.Environment.IsDevelopment() && persistence == PersistenceMode.Persistent)
+            if (builder.ExecutionContext.IsRunMode
+                && builder.Environment.IsDevelopment()
+                && persistence == PersistenceMode.Persistent)
             {
-                postgres.WithPgAdmin();
+                postgres.WithPgAdmin(pgAdmin => pgAdmin.WithHostPort(1611));
             }
 
             postgres.PublishAsDockerComposeService(


### PR DESCRIPTION
Fixes #50.

`postgres.WithPgAdmin()` had no host port, so Aspire assigned a random one and the pgAdmin URL changed on every `aspire start`. It is now pinned to 1611, alongside the existing nocturne-api 1610 and gateway 1612 pins, and the branch is additionally gated on run mode.

The run-mode gate matters because `scripts/publish-release.cs` forces `NOCTURNE_DB_PERSISTENCE=persistent` for bundle generation, which satisfied the old `IsDevelopment() && Persistent` condition; a fixed host port can now never reach a published compose bundle. No committed bundle under `deploy/` contains pgAdmin, so nothing needs regenerating.

`CLAUDE.md` names the port. A worktree forced persistent with `NOCTURNE_DB_PERSISTENCE=persistent` reaches this branch too and will contend for 1611 with a running main stack, the same way it already does for 1610.

Verified: `Aspire.Hosting.PostgreSQL` 13.3.0 exposes `WithPgAdmin(Action<IResourceBuilder<PgAdminContainerResource>>)` and `WithHostPort` on that resource; the AppHost builds with 0 errors; 1611 appears nowhere else in this repo or the Cloud AppHost.
