### PR TITLE
fix(web): green the @nocturne/app node baseline

### DIFF
--- a/src/Web/packages/app/src/lib/api/remote-catch-guard.test.ts
+++ b/src/Web/packages/app/src/lib/api/remote-catch-guard.test.ts
@@ -82,25 +82,47 @@ interface Offence {
   line: number;
 }
 
-function sourceFiles(): string[] {
+interface SourceFile {
+  file: string;
+  source: string;
+}
+
+let cachedSources: SourceFile[] | undefined;
+
+/**
+ * Every source file under `src/` with its text. Walking the tree and reading
+ * ~800 files synchronously is the entire cost of this file — the pattern
+ * matching below is milliseconds — so both guards share one pass rather than
+ * each taking its own.
+ */
+function sources(): SourceFile[] {
   // readdirSync yields the platform's separator, so the directory exclusions
   // below would only bite on posix if the paths were left as they arrive.
-  return readdirSync(SRC, { recursive: true, encoding: "utf8" })
+  cachedSources ??= readdirSync(SRC, { recursive: true, encoding: "utf8" })
     .map((file) => file.replaceAll("\\", "/"))
     .filter(
       (file) =>
         /\.(svelte|ts)$/.test(file) &&
         !file.endsWith(".test.ts") &&
         !/(^|\/)(generated|test-stubs)(\/|$)/.test(file)
-    );
+    )
+    .map((file) => ({ file, source: readFileSync(`${SRC}/${file}`, "utf8") }));
+
+  return cachedSources;
 }
+
+/**
+ * Budget for a guard that reads the whole source tree. The default five seconds
+ * is sized for logic tests; a cold file cache alone can put these reads an order
+ * of magnitude above it.
+ */
+const WALK_TIMEOUT_MS = 60_000;
 
 function offences(): { found: Offence[]; scanned: number } {
   const found: Offence[] = [];
   let scanned = 0;
 
-  for (const file of sourceFiles()) {
-    const source = readFileSync(`${SRC}/${file}`, "utf8");
+  for (const { file, source } of sources()) {
     const imported = remoteImports(source);
     if (imported.length === 0) continue;
     scanned++;
@@ -140,10 +162,9 @@ const RAW_FALLBACK = /\berrorMessage\((?:[^()]|\([^()]*\))*\)\s*(?:\?\?|\|\|)/g;
 
 function rawFallbacks(): { found: Offence[]; scanned: number } {
   const found: Offence[] = [];
-  const files = sourceFiles();
+  const files = sources();
 
-  for (const file of files) {
-    const source = readFileSync(`${SRC}/${file}`, "utf8");
+  for (const { file, source } of files) {
     for (const match of source.matchAll(RAW_FALLBACK)) {
       found.push({
         file,
@@ -156,12 +177,16 @@ function rawFallbacks(): { found: Offence[]; scanned: number } {
 }
 
 describe("fallbacks beside a remote call's reason", () => {
-  it("are reached through a helper that knows who wrote it", () => {
-    const { found, scanned } = rawFallbacks();
+  it(
+    "are reached through a helper that knows who wrote it",
+    () => {
+      const { found, scanned } = rawFallbacks();
 
-    expect(scanned).toBeGreaterThan(400);
-    expect(found).toEqual([]);
-  });
+      expect(scanned).toBeGreaterThan(400);
+      expect(found).toEqual([]);
+    },
+    WALK_TIMEOUT_MS
+  );
 
   it("still recognises a raw fallback when it sees one", () => {
     const lossy = `oidcError = errorMessage(err) ?? "Failed to delete provider.";`;
@@ -179,15 +204,19 @@ describe("fallbacks beside a remote call's reason", () => {
 });
 
 describe("catches around generated remote calls", () => {
-  it("bind the error, or say why they do not", () => {
-    const { found, scanned } = offences();
+  it(
+    "bind the error, or say why they do not",
+    () => {
+      const { found, scanned } = offences();
 
-    // An empty result is the pass condition, so a walk that read nothing — a
-    // moved source root, a separator the filter did not expect — would pass
-    // for the wrong reason. Assert it found files to judge.
-    expect(scanned).toBeGreaterThan(20);
-    expect(found).toEqual([]);
-  });
+      // An empty result is the pass condition, so a walk that read nothing — a
+      // moved source root, a separator the filter did not expect — would pass
+      // for the wrong reason. Assert it found files to judge.
+      expect(scanned).toBeGreaterThan(20);
+      expect(found).toEqual([]);
+    },
+    WALK_TIMEOUT_MS
+  );
 
   it("still recognises a discarded reason when it sees one", () => {
     // The guard is only worth its cost if it fails on the shape it exists to

--- a/src/Web/packages/app/src/lib/stores/appearance-store.ssr.test.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.ssr.test.ts
@@ -22,7 +22,9 @@ describe("appearance-store SSR resolution", () => {
   it("renders the request's units, not the module default", async () => {
     const body = await ssr([mmol]);
 
-    expect(body).toContain("5.6");
+    // The reader renders bg(100), and 100 / MGDL_PER_MMOL (18.0182) is 5.5499…,
+    // which formats to one decimal place as 5.5.
+    expect(body).toContain("5.5");
     expect(body).toContain("mmol/L");
     expect(body).toContain("3.9-10 mmol/L");
     expect(body).not.toContain("mg/dL");


### PR DESCRIPTION
Fixes #1152.

## The wrong expectation

`appearance-store.ssr.test.ts` expected `bg(100)` to render "5.6", which is what dividing by 18 gives. The shared `MGDL_PER_MMOL` is the exact 18.0182 (mirror-tested against `GlucoseConstants.MgdlPerMmol`), so the code renders "5.5". The expectation is corrected to "5.5"; the fixture stays at 100 mg/dL because the sibling test asserts "100" on the same reader, and this value is the one that discriminates the exact constant from the approximation (18 would give "5.6").

## The load-flaky guard

`remote-catch-guard.test.ts` walked and `readFileSync`'d the whole source tree twice, once per guard, and each pass is about 800 synchronous reads. Measured in a loaded full run the second guard reached 3.2 s against vitest's 5 s default, so the file failed in a full suite and passed alone. Both guards now share one memoised pass (the second guard drops to about 15 ms), and the two tree-walking tests declare a 60 s budget sized for a cold file cache. The `scanned` floors still catch a walk that reads nothing (removing `.svelte` from the filter fails both).

## Result

Three consecutive full `@nocturne/app` node runs: 92 files, 1050 passed, 1 skipped, 0 failed. The suite's "baseline unchanged" claim can now be checked in one run.
