### PR TITLE
Login form: lead with the last-used sign-in method and offer WebAuthn conditional mediation

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/OidcController.cs
@@ -253,6 +253,10 @@ public class OidcController : ControllerBase
 
         // Set session cookies
         SetSessionCookies(result.Tokens!);
+        Response.SetLastSignInCookie(
+            SessionCookieExtensions.SignInMethods.Oidc,
+            result.ProviderId?.ToString(),
+            _options);
 
         await _auditService.LogAsync(AuthAuditEventType.Login, result.Tokens?.SubjectId, success: true,
             ipAddress: GetClientIpAddress(), userAgent: Request.Headers.UserAgent,

--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -584,6 +584,8 @@ public class PasskeyController : ControllerBase
                     UserAgent: Request.Headers.UserAgent.ToString()));
 
             Response.SetSessionCookies(session, _oidcOptions);
+            Response.SetLastSignInCookie(
+                SessionCookieExtensions.SignInMethods.Passkey, providerId: null, _oidcOptions);
 
             await _auditService.LogAsync(AuthAuditEventType.Login, assertionResult.SubjectId, success: true,
                 ipAddress: HttpContext.Connection.RemoteIpAddress?.ToString(),

--- a/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/TotpController.cs
@@ -283,6 +283,9 @@ public class TotpController : ControllerBase
                 UserAgent: Request.Headers.UserAgent.ToString()));
 
         Response.SetSessionCookies(session, _oidcOptions);
+        // The passkey was the method chosen at the login form; this step is its second factor.
+        Response.SetLastSignInCookie(
+            SessionCookieExtensions.SignInMethods.Passkey, providerId: null, _oidcOptions);
 
         await _subjectService.UpdateLastLoginAsync(result.SubjectId);
 

--- a/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/SessionCookieExtensions.cs
@@ -18,6 +18,29 @@ public static class SessionCookieExtensions
     public const string IsAuthenticatedCookieName = "IsAuthenticated";
 
     /// <summary>
+    /// The non-HttpOnly preference cookie naming the method that last completed a sign-in, so the
+    /// login form can lead with it instead of a fixed order. Written by
+    /// <see cref="SetLastSignInCookie"/>; the web app only reads it.
+    /// </summary>
+    public const string LastSignInCookieName = "LastSignIn";
+
+    /// <summary>
+    /// The sign-in methods <see cref="LastSignInCookieName"/> can name. The web app's
+    /// <c>last-sign-in.ts</c> parses these same values.
+    /// </summary>
+    public static class SignInMethods
+    {
+        public const string Passkey = "passkey";
+        public const string Oidc = "oidc";
+    }
+
+    /// <summary>
+    /// How long the sign-in hint outlives the sign-in that wrote it. It is the memory a
+    /// signed-out visitor comes back to, so it has to survive far longer than any session.
+    /// </summary>
+    private static readonly TimeSpan LastSignInLifetime = TimeSpan.FromDays(365);
+
+    /// <summary>
     /// Derive the session-cookie <c>Domain</c> attribute from the configured base domain, so a
     /// session established on one tenant subdomain is carried to the apex dashboard and to sibling
     /// tenants the subject belongs to. Returns null (host-only cookies) when widening is unsafe.
@@ -133,6 +156,36 @@ public static class SessionCookieExtensions
             Domain = options.Cookie.SessionDomain,
             Expires = refreshExpiresAt,
         });
+    }
+
+    /// <summary>
+    /// Record which method just completed a sign-in, so the login form can lead with it next time.
+    /// Written at the same <c>Domain</c> as the session cookies, so one answer serves a tenant
+    /// subdomain, its siblings and the apex alike.
+    /// </summary>
+    /// <param name="method">One of <see cref="SignInMethods"/>.</param>
+    /// <param name="providerId">The identity provider, for <see cref="SignInMethods.Oidc"/>.</param>
+    /// <remarks>
+    /// Not folded into <see cref="SetSessionCookies(HttpResponse, string, string, DateTimeOffset, OidcOptions)"/>:
+    /// a silent token refresh writes session cookies too and knows nothing about how the session
+    /// began, so it would overwrite the hint with a guess. Deliberately not cleared on sign-out.
+    /// </remarks>
+    public static void SetLastSignInCookie(
+        this HttpResponse response, string method, string? providerId, OidcOptions options)
+    {
+        response.Cookies.Append(
+            LastSignInCookieName,
+            string.IsNullOrEmpty(providerId) ? method : $"{method}:{providerId}",
+            new CookieOptions
+            {
+                HttpOnly = false,
+                Secure = options.Cookie.Secure,
+                SameSite = MapSameSiteMode(options.Cookie.SameSite),
+                Path = options.Cookie.Path,
+                Domain = options.Cookie.SessionDomain,
+                IsEssential = true,
+                Expires = DateTimeOffset.UtcNow.Add(LastSignInLifetime),
+            });
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
+++ b/src/API/Nocturne.API/Services/Auth/OidcAuthService.cs
@@ -405,7 +405,7 @@ public class OidcAuthService : IOidcAuthService
             provider.Name
         );
 
-        return OidcCallbackResult.Succeeded(tokens, userInfo, stateData.ReturnUrl);
+        return OidcCallbackResult.Succeeded(tokens, userInfo, stateData.ReturnUrl, provider.Id);
     }
 
     /// <summary>

--- a/src/Core/Nocturne.Core.Contracts/Auth/IOidcAuthService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IOidcAuthService.cs
@@ -249,12 +249,19 @@ public class OidcCallbackResult
     public Guid? SubjectId { get; set; }
 
     /// <summary>
+    /// The provider that authenticated the identity. <see cref="OidcUserInfo.ProviderName"/> is
+    /// for display; this is the id the login form keys its buttons by.
+    /// </summary>
+    public Guid? ProviderId { get; set; }
+
+    /// <summary>
     /// Create a successful result
     /// </summary>
     public static OidcCallbackResult Succeeded(
         OidcTokenResponse tokens,
         OidcUserInfo userInfo,
-        string? returnUrl = null
+        string? returnUrl = null,
+        Guid? providerId = null
     ) =>
         new()
         {
@@ -263,6 +270,7 @@ public class OidcCallbackResult
             UserInfo = userInfo,
             ReturnUrl = returnUrl,
             SubjectId = tokens.SubjectId,
+            ProviderId = providerId,
         };
 
     /// <summary>

--- a/src/Web/packages/app/src/app.d.ts
+++ b/src/Web/packages/app/src/app.d.ts
@@ -1,6 +1,7 @@
 // See https://svelte.dev/docs/kit/types#app
 // for information about these interfaces
 import { ApiClient, UserDisplayPreferences } from "$lib/api";
+import type { LastSignIn } from "$lib/components/auth/last-sign-in";
 
 
 export interface ServerSettings {
@@ -105,6 +106,8 @@ declare global {
 				history: number;
 				focusHours: number;
 			};
+			/** Resolved by the root layout from the hint cookie the API writes. */
+			lastSignIn: LastSignIn | null;
 		}
 
 		// Main PageData interface that allows additional properties for reports

--- a/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte
+++ b/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ComponentProps } from "svelte";
+  import { Badge } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
   import { Label } from "$lib/components/ui/label";
@@ -14,10 +15,7 @@
   } from "lucide-svelte";
   import * as InputOTP from "$lib/components/ui/input-otp";
   import { FormError, FormField, useSubmission } from "$lib/forms";
-  import {
-    startAuthentication,
-    type PublicKeyCredentialRequestOptionsJSON,
-  } from "@simplewebauthn/browser";
+  import { WebAuthnAbortService } from "@simplewebauthn/browser";
   import {
     getOidcProviders,
     setAuthCookies,
@@ -30,7 +28,14 @@
     loginComplete,
   } from "$lib/api/generated/passkeys.generated.remote";
   import { goto, invalidateAll } from "$app/navigation";
-  import { describePasskeyError, parseCeremonyOptions } from "./passkey-errors";
+  import { page } from "$app/state";
+  import { describePasskeyError } from "./passkey-errors";
+  import {
+    offerPasskeyInAutofill,
+    runPasskeyAssertion,
+    type CeremonyOptionsResponse,
+  } from "./passkey-login";
+  import { isLastUsed, withLastUsedFirst } from "./last-sign-in";
   import { signInMethodLabels } from "./labels";
 
   interface Props {
@@ -48,6 +53,24 @@
   let { returnUrl = "/", onSuccess, tenantless = false }: Props = $props();
 
   const oidcQuery = getOidcProviders();
+
+  /**
+   * The method that last completed a sign-in on this browser, read from the cookie the API wrote
+   * (see `last-sign-in.ts`). It decides which control leads, so that someone who signs in with an
+   * identity provider is not shown the passkey button first every time.
+   */
+  const lastSignIn = $derived(page.data.lastSignIn ?? null);
+
+  const providers = $derived(oidcQuery.current?.providers ?? []);
+  const hasOidc = $derived(
+    (oidcQuery.current?.enabled ?? false) && providers.length > 0
+  );
+  const orderedProviders = $derived(withLastUsedFirst(providers, lastSignIn));
+  /** Whether an identity provider leads the form, ahead of the passkey controls. */
+  const providerFirst = $derived(
+    isLastUsed(lastSignIn, "oidc", orderedProviders[0]?.id)
+  );
+  const passkeyLastUsed = $derived(isLastUsed(lastSignIn, "passkey"));
 
   // UI mode
   type LoginMode = "default" | "username" | "recovery" | "totp";
@@ -135,63 +158,67 @@
   }
 
   /**
-   * Discoverable ("just tap the button") passkey sign-in. The WebAuthn ceremony
-   * runs in the browser, so this path can't work without JavaScript.
+   * A passkey sign-in the visitor asked for by pressing a button, so a failure is theirs to see.
+   * The WebAuthn ceremony runs in the browser, which is why neither entry point has a
+   * server-side counterpart that works without JavaScript.
    */
+  async function signInWithPasskey(
+    requestOptions: () => Promise<CeremonyOptionsResponse>
+  ) {
+    isLoading = true;
+    passkeyError = null;
+
+    try {
+      await handleAuthResult(
+        await runPasskeyAssertion(requestOptions, loginComplete)
+      );
+    } catch (err) {
+      console.error("Passkey sign-in failed:", err);
+      passkeyError = describePasskeyError(err, "login");
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  /** Discoverable ("just tap the button") passkey sign-in. */
   async function handleDiscoverableLogin(event: SubmitEvent) {
     event.preventDefault();
-    isLoading = true;
-    passkeyError = null;
-
-    try {
-      const response = await discoverableLoginOptions();
-      const options = parseCeremonyOptions<PublicKeyCredentialRequestOptionsJSON>(
-        response.options
-      );
-      const challengeToken = response.challengeToken ?? "";
-
-      const assertion = await startAuthentication({ optionsJSON: options });
-
-      const result = await loginComplete({
-        assertionResponseJson: JSON.stringify(assertion),
-        challengeToken,
-      });
-      await handleAuthResult(result);
-    } catch (err) {
-      console.error("Discoverable passkey sign-in failed:", err);
-      passkeyError = describePasskeyError(err, "login");
-    } finally {
-      isLoading = false;
-    }
+    await signInWithPasskey(discoverableLoginOptions);
   }
 
-  /** Username-first passkey sign-in. Also JavaScript-only, same reason. */
+  /** Username-first passkey sign-in. */
   async function handleUsernameLogin(event: SubmitEvent) {
     event.preventDefault();
-    isLoading = true;
-    passkeyError = null;
-
-    try {
-      const response = await loginOptions({ username: username.trim() });
-      const options = parseCeremonyOptions<PublicKeyCredentialRequestOptionsJSON>(
-        response.options
-      );
-      const challengeToken = response.challengeToken ?? "";
-
-      const assertion = await startAuthentication({ optionsJSON: options });
-
-      const result = await loginComplete({
-        assertionResponseJson: JSON.stringify(assertion),
-        challengeToken,
-      });
-      await handleAuthResult(result);
-    } catch (err) {
-      console.error("Username passkey sign-in failed:", err);
-      passkeyError = describePasskeyError(err, "login");
-    } finally {
-      isLoading = false;
-    }
+    await signInWithPasskey(() => loginOptions({ username: username.trim() }));
   }
+
+  /**
+   * While the username field is on screen, offer the passkey in the browser's own autofill
+   * dropdown rather than making the visitor press anything. The challenge has to be requested
+   * before they touch the field, so this starts on the way in and is abandoned on the way out:
+   * a browser allows only one WebAuthn request at a time, and a stale one would swallow the
+   * explicit buttons. Silent throughout — a browser without conditional mediation, and a
+   * dropdown nobody used, are both just the ordinary form.
+   */
+  $effect(() => {
+    if (mode !== "username" || tenantless || !passkeysSupported) return;
+
+    let abandoned = false;
+
+    void offerPasskeyInAutofill(async () => {
+      const result = await runPasskeyAssertion(
+        discoverableLoginOptions,
+        loginComplete,
+        true
+      );
+      if (!abandoned) await handleAuthResult(result);
+    }).catch(() => {});
+
+    return () => {
+      abandoned = true;
+      WebAuthnAbortService.cancelCeremony();
+    };
+  });
 
   function loginWithProvider(providerId: string) {
     isRedirecting = true;
@@ -236,6 +263,82 @@
   {/if}
 {/snippet}
 
+{#snippet lastUsedBadge()}
+  <Badge variant="secondary" class="ml-2 text-[10px] uppercase">
+    Last used
+  </Badge>
+{/snippet}
+
+{#snippet divider(label: string)}
+  <div class="relative">
+    <div class="absolute inset-0 flex items-center">
+      <span class="w-full border-t"></span>
+    </div>
+    <div class="relative flex justify-center text-xs uppercase">
+      <span class="bg-background px-2 text-muted-foreground">{label}</span>
+    </div>
+  </div>
+{/snippet}
+
+{#snippet passkeyButtons()}
+  <!-- Primary: discoverable passkey sign-in. Needs JavaScript for the
+       WebAuthn ceremony, so there is no server-side counterpart. -->
+  <form onsubmit={handleDiscoverableLogin}>
+    <Button
+      type="submit"
+      data-testid="passkey-sign-in"
+      class="w-full h-12"
+      size="lg"
+      disabled={isLoading || isRedirecting || !passkeysSupported}
+    >
+      {#if isLoading}
+        <Loader2 class="mr-2 h-5 w-5 animate-spin" />
+        Waiting for passkey...
+      {:else}
+        <Fingerprint class="mr-2 h-5 w-5" />
+        {signInMethodLabels.passkey}
+        {#if passkeyLastUsed}{@render lastUsedBadge()}{/if}
+      {/if}
+    </Button>
+  </form>
+
+  <!-- Secondary: username-based sign-in -->
+  <Button
+    variant="outline"
+    class="w-full"
+    disabled={isLoading || isRedirecting || !passkeysSupported}
+    onclick={() => switchMode("username")}
+  >
+    <User class="mr-2 h-4 w-4" />
+    {signInMethodLabels.username}
+  </Button>
+{/snippet}
+
+{#snippet providerButtons()}
+  <div class="space-y-3">
+    {#each orderedProviders as provider}
+      <Button
+        variant="outline"
+        class="w-full h-11 relative"
+        style={getButtonStyle(provider.buttonColor)}
+        disabled={isLoading || isRedirecting || !provider.id}
+        onclick={() => provider.id && loginWithProvider(provider.id)}
+      >
+        {#if isRedirecting && selectedProvider === provider.id}
+          <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+          Redirecting...
+        {:else}
+          {@render providerIcon(provider.name)}
+          Sign in with {provider.name}
+          {#if isLastUsed(lastSignIn, "oidc", provider.id)}
+            {@render lastUsedBadge()}
+          {/if}
+        {/if}
+      </Button>
+    {/each}
+  </div>
+{/snippet}
+
 {#snippet otherMethodLinks()}
   <Button
     variant="link"
@@ -265,9 +368,6 @@
     <Loader2 class="h-8 w-8 animate-spin text-primary" />
   </div>
 {:else}
-  {@const oidc = oidcQuery.current}
-  {@const hasOidc = oidc?.enabled && oidc.providers.length > 0}
-
   <div class="space-y-4">
     {#if tenantless}
       <p class="text-sm text-muted-foreground">
@@ -291,72 +391,23 @@
     <FormError issues={passkeyError} focusOnShow />
 
     {#if mode === "default"}
-      {#if !tenantless}
-        <!-- Primary: discoverable passkey sign-in. Needs JavaScript for the
-             WebAuthn ceremony, so there is no server-side counterpart. -->
-        <form onsubmit={handleDiscoverableLogin}>
-          <Button
-            type="submit"
-            data-testid="passkey-sign-in"
-            class="w-full h-12"
-            size="lg"
-            disabled={isLoading || isRedirecting || !passkeysSupported}
-          >
-            {#if isLoading}
-              <Loader2 class="mr-2 h-5 w-5 animate-spin" />
-              Waiting for passkey...
-            {:else}
-              <Fingerprint class="mr-2 h-5 w-5" />
-              {signInMethodLabels.passkey}
-            {/if}
-          </Button>
-        </form>
-
-        <!-- Secondary: username-based sign-in -->
-        <Button
-          variant="outline"
-          class="w-full"
-          disabled={isLoading || isRedirecting || !passkeysSupported}
-          onclick={() => switchMode("username")}
-        >
-          <User class="mr-2 h-4 w-4" />
-          {signInMethodLabels.username}
-        </Button>
+      <!-- The method that last worked leads; everything else keeps its usual place. -->
+      {#if providerFirst}
+        {@render providerButtons()}
       {/if}
 
-      {#if hasOidc && oidc}
-        {#if !tenantless}
-          <div class="relative">
-            <div class="absolute inset-0 flex items-center">
-              <span class="w-full border-t"></span>
-            </div>
-            <div class="relative flex justify-center text-xs uppercase">
-              <span class="bg-background px-2 text-muted-foreground">
-                Or continue with
-              </span>
-            </div>
-          </div>
+      {#if !tenantless}
+        {#if providerFirst}
+          {@render divider("Or continue with a passkey")}
         {/if}
+        {@render passkeyButtons()}
+      {/if}
 
-        <div class="space-y-3">
-          {#each oidc.providers as provider}
-            <Button
-              variant="outline"
-              class="w-full h-11 relative"
-              style={getButtonStyle(provider.buttonColor)}
-              disabled={isLoading || isRedirecting || !provider.id}
-              onclick={() => provider.id && loginWithProvider(provider.id)}
-            >
-              {#if isRedirecting && selectedProvider === provider.id}
-                <Loader2 class="mr-2 h-4 w-4 animate-spin" />
-                Redirecting...
-              {:else}
-                {@render providerIcon(provider.name)}
-                Sign in with {provider.name}
-              {/if}
-            </Button>
-          {/each}
-        </div>
+      {#if hasOidc && !providerFirst}
+        {#if !tenantless}
+          {@render divider("Or continue with")}
+        {/if}
+        {@render providerButtons()}
       {/if}
 
       {#if !tenantless}

--- a/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/auth/LoginForm.svelte.test.ts
@@ -1,6 +1,8 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { page as appState } from "$app/state";
+import type { LastSignIn } from "./last-sign-in";
 
 /**
  * On a tenantless host every passkey, authenticator and recovery-code control is hidden,
@@ -52,10 +54,22 @@ vi.mock("$lib/api/generated/passkeys.generated.remote", () => ({
 
 import LoginForm from "./LoginForm.svelte";
 
+/** The layout server load puts the parsed hint cookie here; the form only reads it. */
+function setLastSignIn(hint: LastSignIn | null) {
+  appState.data = { lastSignIn: hint };
+}
+
+/** The visible sign-in buttons, in the order they are rendered. */
+async function buttonOrder(): Promise<string[]> {
+  const buttons = await page.getByRole("button").elements();
+  return buttons.map((b) => b.textContent?.replace(/\s+/g, " ").trim() ?? "");
+}
+
 describe("LoginForm on a tenantless host", () => {
   beforeEach(() => {
     providers = [];
     providersLoading = false;
+    setLastSignIn(null);
   });
 
   it("renders a provider sign-in button when a provider is available", async () => {
@@ -80,5 +94,86 @@ describe("LoginForm on a tenantless host", () => {
     await expect
       .element(page.getByRole("button", { name: /^Sign in with/ }))
       .not.toBeInTheDocument();
+  });
+});
+
+/**
+ * The form leads with whichever method last worked, so somebody who signs in with an identity
+ * provider is not shown the passkey button first on every visit. The hint is a cookie the API
+ * writes next to the session cookies; the layout load parses it into page data.
+ */
+describe("LoginForm ordering by last-used method", () => {
+  const GOOGLE = "2f6a4c9e-1d3b-4a58-9f27-8c0b5e6d1a44";
+  const GITHUB = "9b1c33d0-77aa-4e12-b0d5-0c4f2a91e775";
+
+  beforeEach(() => {
+    providersLoading = false;
+    providers = [
+      { id: GOOGLE, name: "Google" },
+      { id: GITHUB, name: "GitHub" },
+    ];
+    setLastSignIn(null);
+  });
+
+  it("leads with the passkey button when nothing has been used yet", async () => {
+    render(LoginForm, { props: {} });
+
+    const order = await buttonOrder();
+    expect(order[0]).toBe("Sign in with passkey");
+    expect(order.indexOf("Sign in with Google")).toBeGreaterThan(
+      order.indexOf("Sign in with username")
+    );
+    await expect
+      .element(page.getByText("Last used"))
+      .not.toBeInTheDocument();
+  });
+
+  it("leads with the provider that last worked, and says so", async () => {
+    setLastSignIn({ method: "oidc", providerId: GITHUB });
+
+    render(LoginForm, { props: {} });
+
+    const order = await buttonOrder();
+    expect(order[0]).toBe("Sign in with GitHub Last used");
+    // Ahead of the other provider and ahead of both passkey controls.
+    expect(order.indexOf("Sign in with Google")).toBeGreaterThan(0);
+    expect(order.indexOf("Sign in with passkey")).toBeGreaterThan(0);
+
+    // One badge, on one button.
+    await expect.element(page.getByText("Last used")).toBeVisible();
+    expect(order.filter((label) => label.includes("Last used"))).toHaveLength(1);
+  });
+
+  it("badges the passkey button when that is what last worked", async () => {
+    setLastSignIn({ method: "passkey", providerId: null });
+
+    render(LoginForm, { props: {} });
+
+    const order = await buttonOrder();
+    expect(order[0]).toBe("Sign in with passkey Last used");
+    expect(order.filter((label) => label.includes("Last used"))).toHaveLength(1);
+  });
+
+  it("keeps the operator's provider order when the hint names none of them", async () => {
+    setLastSignIn({ method: "oidc", providerId: "00000000-0000-0000-0000-000000000000" });
+
+    render(LoginForm, { props: {} });
+
+    const order = await buttonOrder();
+    expect(order[0]).toBe("Sign in with passkey");
+    expect(order.indexOf("Sign in with Google")).toBeLessThan(
+      order.indexOf("Sign in with GitHub")
+    );
+  });
+
+  it("badges the provider on a tenantless host too", async () => {
+    setLastSignIn({ method: "oidc", providerId: GITHUB });
+
+    render(LoginForm, { props: { tenantless: true } });
+
+    const order = await buttonOrder();
+    expect(order[0]).toBe("Sign in with GitHub Last used");
+    // Nothing tenant-scoped is offered here, so the badge has to survive on its own.
+    expect(order).not.toContain("Sign in with passkey");
   });
 });

--- a/src/Web/packages/app/src/lib/components/auth/last-sign-in.test.ts
+++ b/src/Web/packages/app/src/lib/components/auth/last-sign-in.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  isLastUsed,
+  parseLastSignIn,
+  withLastUsedFirst,
+} from "./last-sign-in";
+
+/**
+ * The wire values here are the ones `SessionCookieExtensions.SetLastSignInCookie` writes. Both
+ * sides are pinned: `SetLastSignInCookie_names_the_provider_the_login_form_keys_its_buttons_by`
+ * asserts the same shape from the API's end.
+ */
+const PROVIDER_ID = "2f6a4c9e-1d3b-4a58-9f27-8c0b5e6d1a44";
+
+describe("parseLastSignIn", () => {
+  it("reads a method with no provider", () => {
+    expect(parseLastSignIn("passkey")).toEqual({
+      method: "passkey",
+      providerId: null,
+    });
+  });
+
+  it("reads the provider an identity-provider sign-in names", () => {
+    expect(parseLastSignIn(`oidc:${PROVIDER_ID}`)).toEqual({
+      method: "oidc",
+      providerId: PROVIDER_ID,
+    });
+  });
+
+  it.each([
+    ["no cookie", undefined],
+    ["an empty cookie", ""],
+    ["a method this version does not know", "smartcard"],
+    ["a method this version does not know, with a provider", "saml:abc"],
+    ["a value that is only a separator", ":"],
+  ])("treats %s as no hint at all", (_case, value) => {
+    expect(parseLastSignIn(value)).toBeNull();
+  });
+
+  it("keeps a provider id that contains a colon whole", () => {
+    // The writer joins on the first colon only, so an id with one must not be truncated.
+    expect(parseLastSignIn("oidc:urn:example:idp")).toEqual({
+      method: "oidc",
+      providerId: "urn:example:idp",
+    });
+  });
+
+  it("reports no provider when the hint names none", () => {
+    expect(parseLastSignIn("oidc:")).toEqual({
+      method: "oidc",
+      providerId: null,
+    });
+  });
+});
+
+describe("isLastUsed", () => {
+  it("matches only the provider the hint names", () => {
+    const hint = parseLastSignIn(`oidc:${PROVIDER_ID}`);
+
+    expect(isLastUsed(hint, "oidc", PROVIDER_ID)).toBe(true);
+    expect(isLastUsed(hint, "oidc", "0000ffff-0000-0000-0000-000000000000")).toBe(
+      false
+    );
+  });
+
+  it("matches a provider id whatever case it is written in", () => {
+    // The API writes a lowercase GUID; nothing guarantees the provider list agrees.
+    expect(
+      isLastUsed(parseLastSignIn(`oidc:${PROVIDER_ID}`), "oidc", PROVIDER_ID.toUpperCase())
+    ).toBe(true);
+  });
+
+  it("does not match a passkey hint to a provider button", () => {
+    const hint = parseLastSignIn("passkey");
+
+    expect(isLastUsed(hint, "passkey")).toBe(true);
+    expect(isLastUsed(hint, "oidc", PROVIDER_ID)).toBe(false);
+  });
+
+  it("matches nothing without a hint", () => {
+    expect(isLastUsed(null, "passkey")).toBe(false);
+    expect(isLastUsed(null, "oidc", PROVIDER_ID)).toBe(false);
+  });
+
+  it("does not match a provider-less hint to a provider button", () => {
+    expect(isLastUsed(parseLastSignIn("oidc"), "oidc", PROVIDER_ID)).toBe(false);
+  });
+});
+
+describe("withLastUsedFirst", () => {
+  const providers = [
+    { id: "aaaaaaaa-0000-0000-0000-000000000000", name: "Alpha" },
+    { id: PROVIDER_ID, name: "Beta" },
+    { id: "cccccccc-0000-0000-0000-000000000000", name: "Gamma" },
+  ];
+
+  it("moves the last-used provider to the front", () => {
+    const ordered = withLastUsedFirst(
+      providers,
+      parseLastSignIn(`oidc:${PROVIDER_ID}`)
+    );
+
+    expect(ordered.map((p) => p.name)).toEqual(["Beta", "Alpha", "Gamma"]);
+  });
+
+  it("leaves the operator's order alone when nothing matches", () => {
+    for (const hint of [null, parseLastSignIn("passkey"), parseLastSignIn("oidc:nope")]) {
+      expect(withLastUsedFirst(providers, hint).map((p) => p.name)).toEqual([
+        "Alpha",
+        "Beta",
+        "Gamma",
+      ]);
+    }
+  });
+
+  it("does not mutate the list it was given", () => {
+    withLastUsedFirst(providers, parseLastSignIn(`oidc:${PROVIDER_ID}`));
+
+    expect(providers.map((p) => p.name)).toEqual(["Alpha", "Beta", "Gamma"]);
+  });
+});

--- a/src/Web/packages/app/src/lib/components/auth/last-sign-in.ts
+++ b/src/Web/packages/app/src/lib/components/auth/last-sign-in.ts
@@ -1,0 +1,79 @@
+/**
+ * The sign-in method that last worked, so the login form can lead with it.
+ *
+ * The API writes the hint alongside the session cookies (see
+ * `SessionCookieExtensions.SetLastSignInCookie`), which is the only place that knows the Domain
+ * the session is scoped to — a hint written on one tenant's subdomain has to be readable on the
+ * apex and on sibling tenants. This side only reads it. The value is `passkey`, or `oidc:` and
+ * the provider's id; it names no person and no account.
+ */
+
+/** Methods the hint can name. A value outside this set is treated as no hint at all. */
+export const SIGN_IN_METHODS = ["passkey", "oidc"] as const;
+
+export type SignInMethod = (typeof SIGN_IN_METHODS)[number];
+
+export interface LastSignIn {
+  method: SignInMethod;
+  /** The identity provider, for `oidc`. Null for every other method. */
+  providerId: string | null;
+}
+
+/** Anything with an id, so this works on the generated provider type without redeclaring it. */
+interface Identified {
+  id?: string | null;
+}
+
+/**
+ * Read the hint cookie's value. Returns null for an absent, empty or unrecognised value, so a
+ * hint from a future version degrades to the default ordering rather than hiding a button.
+ */
+export function parseLastSignIn(
+  value: string | null | undefined
+): LastSignIn | null {
+  if (!value) return null;
+
+  const separator = value.indexOf(":");
+  const method = separator < 0 ? value : value.slice(0, separator);
+  if (!isSignInMethod(method)) return null;
+
+  const providerId = separator < 0 ? "" : value.slice(separator + 1).trim();
+  return { method, providerId: providerId.length > 0 ? providerId : null };
+}
+
+/**
+ * Whether the hint names this control. An `oidc` hint names one provider, so it matches only
+ * that button; every other method has a single button and matches on the method alone.
+ */
+export function isLastUsed(
+  hint: LastSignIn | null | undefined,
+  method: SignInMethod,
+  providerId?: string | null
+): boolean {
+  if (!hint || hint.method !== method) return false;
+  if (method !== "oidc") return true;
+  if (!hint.providerId || !providerId) return false;
+  return hint.providerId.toLowerCase() === providerId.toLowerCase();
+}
+
+/**
+ * The providers with the last-used one first. Their configured order is otherwise untouched, so
+ * the list a visitor with no hint sees is the one the operator ordered.
+ */
+export function withLastUsedFirst<T extends Identified>(
+  providers: readonly T[],
+  hint: LastSignIn | null | undefined
+): T[] {
+  const index = providers.findIndex((provider) =>
+    isLastUsed(hint, "oidc", provider.id)
+  );
+  if (index <= 0) return [...providers];
+
+  const ordered = [...providers];
+  const [lastUsed] = ordered.splice(index, 1);
+  return [lastUsed!, ...ordered];
+}
+
+function isSignInMethod(value: string): value is SignInMethod {
+  return SIGN_IN_METHODS.some((method) => method === value);
+}

--- a/src/Web/packages/app/src/lib/components/auth/passkey-login.test.ts
+++ b/src/Web/packages/app/src/lib/components/auth/passkey-login.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { offerPasskeyInAutofill } from "./passkey-login";
+
+/**
+ * Conditional mediation has to ask the server for a challenge before the visitor has done
+ * anything, and a browser that cannot honour it would be left holding a pending WebAuthn request
+ * that swallows the explicit sign-in buttons. So the feature detection gates the request, not the
+ * other way round.
+ */
+describe("offerPasskeyInAutofill", () => {
+  it("asks for nothing when the browser cannot offer a passkey in autofill", async () => {
+    const assertion = vi.fn();
+
+    const result = await offerPasskeyInAutofill(assertion, async () => false);
+
+    expect(assertion).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("runs the ceremony when the browser can", async () => {
+    const assertion = vi.fn(async () => "signed-in");
+
+    const result = await offerPasskeyInAutofill(assertion, async () => true);
+
+    expect(assertion).toHaveBeenCalledOnce();
+    expect(result).toBe("signed-in");
+  });
+
+  it("lets a failed ceremony reach the caller, which reports nothing to the visitor", async () => {
+    const assertion = vi.fn(async () => {
+      throw new Error("NotAllowedError");
+    });
+
+    await expect(
+      offerPasskeyInAutofill(assertion, async () => true)
+    ).rejects.toThrow("NotAllowedError");
+  });
+});

--- a/src/Web/packages/app/src/lib/components/auth/passkey-login.ts
+++ b/src/Web/packages/app/src/lib/components/auth/passkey-login.ts
@@ -1,0 +1,63 @@
+/**
+ * The WebAuthn half of signing in with a passkey, shared by the three ways in: the discoverable
+ * button, the username form, and the browser's autofill dropdown.
+ */
+
+import {
+  browserSupportsWebAuthnAutofill,
+  startAuthentication,
+  type PublicKeyCredentialRequestOptionsJSON,
+} from "@simplewebauthn/browser";
+import { parseCeremonyOptions } from "./passkey-errors";
+
+/** What every passkey-options endpoint answers with. */
+export interface CeremonyOptionsResponse {
+  options?: string | null;
+  challengeToken?: string | null;
+}
+
+export interface AssertionSubmission {
+  assertionResponseJson: string;
+  challengeToken: string;
+}
+
+/**
+ * Fetch a challenge, run the assertion, and submit it.
+ *
+ * @param useBrowserAutofill Offer the passkey in the autofill dropdown rather than prompting
+ * straight away. Requires an `<input>` whose `autocomplete` ends in `webauthn` to be on the page,
+ * and resolves only if the visitor picks the passkey from that dropdown.
+ */
+export async function runPasskeyAssertion<T>(
+  requestOptions: () => Promise<CeremonyOptionsResponse>,
+  submit: (assertion: AssertionSubmission) => Promise<T>,
+  useBrowserAutofill = false
+): Promise<T> {
+  const response = await requestOptions();
+  const optionsJSON =
+    parseCeremonyOptions<PublicKeyCredentialRequestOptionsJSON>(
+      response.options
+    );
+
+  const assertion = await startAuthentication({ optionsJSON, useBrowserAutofill });
+
+  return submit({
+    assertionResponseJson: JSON.stringify(assertion),
+    challengeToken: response.challengeToken ?? "",
+  });
+}
+
+/**
+ * Run `assertion` only where the browser can put a passkey in the autofill dropdown.
+ *
+ * Conditional mediation needs a challenge fetched before the visitor has done anything, so the
+ * guard comes first: a browser without it must not be asked for one, and must not have a
+ * ceremony started that would block the explicit buttons.
+ */
+export async function offerPasskeyInAutofill<T>(
+  assertion: () => Promise<T>,
+  isAvailable: () => Promise<boolean> = browserSupportsWebAuthnAutofill
+): Promise<T | null> {
+  if (!(await isAvailable())) return null;
+  return assertion();
+}

--- a/src/Web/packages/app/src/lib/config/auth-cookies.ts
+++ b/src/Web/packages/app/src/lib/config/auth-cookies.ts
@@ -12,6 +12,7 @@ import {
   COOKIE_PLATFORM_ACCESS_NAME,
   COOKIE_GUEST_SESSION_NAME,
   COOKIE_RECOVERY_SESSION_NAME,
+  COOKIE_LAST_SIGN_IN_NAME,
 } from "./constants";
 
 export function getAccessTokenCookieName(): string {
@@ -29,6 +30,7 @@ export const AUTH_COOKIE_NAMES = {
   guestSession: COOKIE_GUEST_SESSION_NAME,
   recoverySession: COOKIE_RECOVERY_SESSION_NAME,
   isAuthenticated: "IsAuthenticated",
+  lastSignIn: COOKIE_LAST_SIGN_IN_NAME,
 } as const;
 
 /**

--- a/src/Web/packages/app/src/lib/config/constants.ts
+++ b/src/Web/packages/app/src/lib/config/constants.ts
@@ -28,6 +28,10 @@ export const COOKIE_GUEST_SESSION_NAME = "nocturne-guest-session";
 // the API accepts it for passkey enrolment only, so it has to reach that ceremony and
 // nothing about it makes the visitor signed in.
 export const COOKIE_RECOVERY_SESSION_NAME = ".Nocturne.RecoverySession";
+// Which method last completed a sign-in, written by the API next to the session cookies so it
+// carries the same Domain. A functional preference, not a credential: it outlives sign-out on
+// purpose, because a signed-out visitor is who it is for.
+export const COOKIE_LAST_SIGN_IN_NAME = "LastSignIn";
 
 // OpenTelemetry service identity (build-time, not deployment config)
 export const OTEL_SERVICE_NAME = "nocturne-web";

--- a/src/Web/packages/app/src/lib/server/auth-cookie-propagation.test.ts
+++ b/src/Web/packages/app/src/lib/server/auth-cookie-propagation.test.ts
@@ -348,3 +348,33 @@ describe("propagateAuthCookies with a same-name pair", () => {
     expect(calls.filter((c) => c.opts.domain === ".nocturne.run")).toHaveLength(2);
   });
 });
+
+describe("propagateAuthCookies and the last-used sign-in hint", () => {
+  it("forwards the hint the API wrote, so the passkey flow records one at all", () => {
+    const { cookies, calls } = createRecordingCookies();
+
+    // The passkey and authenticator sign-ins complete inside a remote function, so the API's
+    // Set-Cookie lands on a server-to-server response and reaches the browser only through here.
+    propagateAuthCookies(
+      [
+        `${AUTH_COOKIE_NAMES.lastSignIn}=passkey; Path=/; Domain=.nocturne.run; Secure; SameSite=Lax; Max-Age=31536000`,
+      ],
+      cookies
+    );
+
+    expect(calls).toEqual([
+      {
+        op: "set",
+        name: AUTH_COOKIE_NAMES.lastSignIn,
+        value: "passkey",
+        opts: {
+          path: "/",
+          domain: ".nocturne.run",
+          secure: true,
+          sameSite: "lax",
+          maxAge: 31536000,
+        },
+      },
+    ]);
+  });
+});

--- a/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
+++ b/src/Web/packages/app/src/lib/server/auth-cookie-propagation.ts
@@ -36,6 +36,10 @@ const AUTH_COOKIE_SET: ReadonlySet<string> = new Set([
   // register cannot be enrolled. Its deletion matters too: the API spends the cookie once the
   // credential exists.
   AUTH_COOKIE_NAMES.recoverySession,
+  // The passkey and authenticator sign-ins complete inside a remote function, so the API's
+  // Set-Cookie for the last-used-method hint has to be forwarded or only the OIDC flow — which
+  // is a browser redirect — would ever record one.
+  AUTH_COOKIE_NAMES.lastSignIn,
 ]);
 
 /**

--- a/src/Web/packages/app/src/lib/test-stubs/app-state.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/app-state.ts
@@ -1,13 +1,16 @@
 /**
  * Stub for $app/state in browser test environment.
  */
+/** Route data. Declared wide so a test can stand in whatever its component reads. */
+const data: Record<string, unknown> = {};
+
 export const page = {
   url: new URL("http://localhost"),
   params: {},
   route: { id: "" },
   status: 200,
   error: null,
-  data: {},
+  data,
   form: null,
   state: {},
 };

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -6,6 +6,8 @@ import {
   parseDashboardSlugs,
 } from "$lib/server/tenantless-host";
 import { getRequestStatus } from "$lib/server/request-status";
+import { AUTH_COOKIE_NAMES } from "$lib/config/auth-cookies";
+import { parseLastSignIn } from "$lib/components/auth/last-sign-in";
 import {
   LANGUAGE_COOKIE_NAME,
   PREFS_COOKIE_NAME,
@@ -82,5 +84,8 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
     tenantless,
     baseDomain,
     dashboardSlugs,
+    // Read here rather than from document.cookie so the login form renders its "Last used" badge
+    // in the server markup, and the buttons don't reorder under the visitor on hydration.
+    lastSignIn: parseLastSignIn(cookies.get(AUTH_COOKIE_NAMES.lastSignIn)),
   };
 };

--- a/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Extensions/SessionCookieExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Nocturne.API.Extensions;
@@ -249,6 +250,108 @@ public sealed class SessionCookieExtensionsTests
     }
 
     [Fact]
+    public void SetLastSignInCookie_is_readable_by_page_script_at_the_session_scope()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.SetLastSignInCookie(
+            SessionCookieExtensions.SignInMethods.Passkey, providerId: null, Options(".nocturne.run"));
+
+        var written = Written(cookies(), SessionCookieExtensions.LastSignInCookieName);
+
+        // Same Domain as the session cookies, or the hint written on a tenant subdomain would be
+        // invisible to the apex login form and to sibling tenants.
+        written.Should()
+            .Contain("domain=.nocturne.run")
+            .And.NotContain("httponly", "the login form reads this from the browser")
+            .And.Contain("secure")
+            .And.Contain("samesite=lax");
+
+        // A session-length hint would be forgotten by the visitor's next sign-in, which is the
+        // only moment it is worth anything.
+        var expires = ExpiryOf(written);
+        expires.Should().BeAfter(DateTimeOffset.UtcNow.AddDays(300));
+    }
+
+    [Fact]
+    public void SetLastSignInCookie_names_the_method_alone_when_there_is_no_provider()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.SetLastSignInCookie(
+            SessionCookieExtensions.SignInMethods.Passkey, providerId: null, Options(".nocturne.run"));
+
+        ValueOf(Written(cookies(), SessionCookieExtensions.LastSignInCookieName))
+            .Should().Be("passkey");
+    }
+
+    [Fact]
+    public void SetLastSignInCookie_names_the_provider_the_login_form_keys_its_buttons_by()
+    {
+        var (response, cookies) = NewResponse();
+        var providerId = Guid.Parse("2f6a4c9e-1d3b-4a58-9f27-8c0b5e6d1a44");
+
+        response.SetLastSignInCookie(
+            SessionCookieExtensions.SignInMethods.Oidc, providerId.ToString(), Options(".nocturne.run"));
+
+        // The web app's last-sign-in parser splits on the first colon; a shape change here
+        // silently stops the badge ever matching a provider.
+        ValueOf(Written(cookies(), SessionCookieExtensions.LastSignInCookieName))
+            .Should().Be($"oidc:{providerId}");
+    }
+
+    [Fact]
+    public void SetLastSignInCookie_stays_host_scoped_when_the_session_cookies_do()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.SetLastSignInCookie(
+            SessionCookieExtensions.SignInMethods.Passkey, providerId: null, Options(null));
+
+        Written(cookies(), SessionCookieExtensions.LastSignInCookieName).Should().NotContain("domain=");
+    }
+
+    [Fact]
+    public void SetLastSignInCookie_carries_no_identity()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.SetLastSignInCookie(
+            SessionCookieExtensions.SignInMethods.Oidc, "2f6a4c9e-1d3b-4a58-9f27-8c0b5e6d1a44",
+            Options(".nocturne.run"));
+
+        // Readable by any script on any subdomain, including the anonymous share hosts.
+        var value = ValueOf(Written(cookies(), SessionCookieExtensions.LastSignInCookieName));
+        value.Split(':').Should().HaveCount(2, "only the method and the provider belong in here");
+    }
+
+    [Fact]
+    public void ClearSessionCookies_leaves_the_sign_in_hint_alone()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.ClearSessionCookies(Options(".nocturne.run"));
+
+        // Signing out is exactly when the hint has to survive: it is what the login form reads.
+        cookies().Should().NotContain(c =>
+            c.StartsWith($"{SessionCookieExtensions.LastSignInCookieName}=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SetSessionCookies_does_not_guess_a_sign_in_method()
+    {
+        var (response, cookies) = NewResponse();
+
+        response.SetSessionCookies("access", "refresh", DateTimeOffset.UtcNow.AddMinutes(5),
+            Options(".nocturne.run"));
+
+        // A silent token refresh funnels through here and knows nothing about how the session
+        // began, so folding the hint in would overwrite a true answer with a guess.
+        cookies().Should().NotContain(c =>
+            c.StartsWith($"{SessionCookieExtensions.LastSignInCookieName}=", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void SetStateCookie_stamps_the_state_domain_so_the_apex_callback_can_read_it()
     {
         var (response, cookies) = NewResponse();
@@ -310,6 +413,23 @@ public sealed class SessionCookieExtensionsTests
         headers.Should().AllSatisfy(h => h.Should().Contain("expires=Thu, 01 Jan 1970"));
         headers.Should().ContainSingle(h => h.Contains("domain=.nocturne.run", StringComparison.OrdinalIgnoreCase));
     }
+
+    /// <summary>The cookie's value as the browser will hold it: ASP.NET escapes it on write.</summary>
+    private static string ValueOf(string setCookieHeader)
+    {
+        var pair = setCookieHeader.Split(';', 2)[0];
+        return Uri.UnescapeDataString(pair[(pair.IndexOf('=') + 1)..]);
+    }
+
+    /// <summary>The cookie's Expires attribute.</summary>
+    private static DateTimeOffset ExpiryOf(string setCookieHeader) =>
+        DateTimeOffset.Parse(
+            setCookieHeader
+                .Split(';')
+                .Select(part => part.Trim())
+                .Single(part => part.StartsWith("expires=", StringComparison.OrdinalIgnoreCase))
+                ["expires=".Length..],
+            CultureInfo.InvariantCulture);
 
     /// <summary>The live (non-expiring) Set-Cookie header for a cookie name.</summary>
     private static string Written(IReadOnlyList<string> cookies, string name) =>


### PR DESCRIPTION
Closes #1179.

## What

The login form now remembers which method last signed you in on this browser and
leads with it, and it offers your passkey in the browser's own autofill dropdown
while the username field is on screen.

- On a successful sign-in the API writes a non-HttpOnly `LastSignIn` hint cookie
  next to the session cookies, at the same `Domain`, so one answer serves a tenant
  subdomain, its siblings and the apex. It records only the method (`passkey`, or
  `oidc:<providerId>`) — no account, no personal data. Written by the passkey
  completion, the authenticator second step and the OIDC callback.
- The matching control gets a "Last used" badge and moves to the top of the list.
  Nothing auto-redirects — the visitor still chooses.
- The username input carries `autocomplete="username webauthn"` and, where the
  browser supports `PublicKeyCredential.isConditionalMediationAvailable()`, starts
  a conditional WebAuthn request so a passkey can be picked from autofill. It is
  abandoned (AbortController) before any explicit ceremony, since a browser allows
  only one WebAuthn request at a time. Browsers without it silently get the
  ordinary form.
- Tenantless hosts still offer only the identity providers, and keep the badge.

## How

- A single cookie writer (`SetLastSignInCookie`) appends the hint alongside the
  session cookies; a silent token refresh deliberately does not touch it.
- The web app reads the cookie server-side in the root layout, so the badge is in
  the SSR markup and the buttons do not reorder on hydration.
- The passkey ceremony is extracted into one helper shared by the button, the
  username form and the autofill path; feature detection gates the conditional
  request rather than following it.

## Tests

- Cookie parse and unknown-value tolerance; provider match is case-insensitive.
- Badge presence and button ordering, including the tenantless host.
- The conditional-mediation guard: feature detection false ⇒ no request.
- Cookie forwarding through the remote-function response.
- API-side cookie shape (`SessionCookieExtensionsTests`).

The `LastSignIn` hint cookie is non-HttpOnly by design (the client reads it to
order the form) and carries only a method identifier, never an account or
personal data. Deployments that publish a cookie disclosure should list it as a
functional preference cookie.
