### PR TITLE
fix(web): offer only the dashboard widgets that exist

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/WidgetGrid.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/WidgetGrid.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
-  import { WidgetId } from "$lib/api/generated/nocturne-api-client";
-  import { DEFAULT_TOP_WIDGETS } from "$lib/types/dashboard-widgets";
-  import type { Component } from "svelte";
+  import type { WidgetId } from "$lib/api/generated/nocturne-api-client";
+  import {
+    DEFAULT_TOP_WIDGETS,
+    knownTopWidgets,
+    loadTopWidget,
+  } from "./widget-registry";
   import WidgetCard from "./widgets/WidgetCard.svelte";
 
   interface Props {
@@ -13,52 +16,25 @@
 
   let { widgets = DEFAULT_TOP_WIDGETS, maxWidgets = 3 }: Props = $props();
 
-  // Limit to max widgets
-  const displayWidgets = $derived(widgets.slice(0, maxWidgets));
-
-  // Lazy loaders — only the rendered widgets are imported
-  const widgetLoaders: Partial<Record<WidgetId, () => Promise<{ default: Component }>>> = {
-    [WidgetId.BgDelta]: () => import("./widgets/BgDeltaWidget.svelte"),
-    [WidgetId.LastUpdated]: () => import("./widgets/LastUpdatedWidget.svelte"),
-    [WidgetId.ConnectionStatus]: () => import("./widgets/ConnectionStatusWidget.svelte"),
-    [WidgetId.Meals]: () => import("./widgets/MealsWidget.svelte"),
-    [WidgetId.Trackers]: () => import("./widgets/TrackersWidget.svelte"),
-    [WidgetId.TirChart]: () => import("./widgets/TirChartWidget.svelte"),
-    [WidgetId.DailySummary]: () => import("./widgets/DailySummaryWidget.svelte"),
-    [WidgetId.Clock]: () => import("./widgets/ClockWidget.svelte"),
-    [WidgetId.Tdd]: () => import("./widgets/TddWidget.svelte"),
-  };
-
-  // Cache resolved modules so re-renders don't re-import
-  const cache = new Map<WidgetId, Promise<Component>>();
-  function loadWidget(id: WidgetId): Promise<Component> | undefined {
-    if (!cache.has(id)) {
-      const loader = widgetLoaders[id];
-      if (loader) cache.set(id, loader().then((m) => m.default));
-    }
-    return cache.get(id);
-  }
+  const displayWidgets = $derived(knownTopWidgets(widgets).slice(0, maxWidgets));
 </script>
 
 <div class="@container grid grid-cols-1 @md:grid-cols-3 gap-2 @md:gap-4">
   {#each displayWidgets as widgetId (widgetId)}
-    {@const promise = loadWidget(widgetId)}
-    {#if promise}
-      {#await promise}
-        <WidgetCard title="Loading">
-          <div class="bg-muted h-7 w-20 animate-pulse rounded"></div>
-        </WidgetCard>
-      {:then WidgetComponent}
-        <WidgetComponent />
-      {:catch}
-        <!-- A dynamic import fails on a stale chunk after a deploy. Without a
-             catch the slot renders nothing, forever, with no trace of why. -->
-        <WidgetCard title="Widget unavailable">
-          <p class="text-muted-foreground text-xs">
-            This widget couldn't be loaded. Reload the page to try again.
-          </p>
-        </WidgetCard>
-      {/await}
-    {/if}
+    {#await loadTopWidget(widgetId)}
+      <WidgetCard title="Loading">
+        <div class="bg-muted h-7 w-20 animate-pulse rounded"></div>
+      </WidgetCard>
+    {:then WidgetComponent}
+      <WidgetComponent />
+    {:catch}
+      <!-- A dynamic import fails on a stale chunk after a deploy. Without a
+           catch the slot renders nothing, forever, with no trace of why. -->
+      <WidgetCard title="Widget unavailable">
+        <p class="text-muted-foreground text-xs">
+          This widget couldn't be loaded. Reload the page to try again.
+        </p>
+      </WidgetCard>
+    {/await}
   {/each}
 </div>

--- a/src/Web/packages/app/src/lib/components/dashboard/widget-registry.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/widget-registry.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { WidgetId } from "$lib/api/generated/nocturne-api-client";
+import { knownTopWidgets } from "./widget-registry";
+
+describe("knownTopWidgets", () => {
+  it("drops ids with no widget behind them", () => {
+    expect(
+      knownTopWidgets([WidgetId.BgDelta, WidgetId.GlucoseChart, WidgetId.Tdd])
+    ).toEqual([WidgetId.BgDelta, WidgetId.Tdd]);
+  });
+
+  it("drops inherited object keys", () => {
+    expect(
+      knownTopWidgets(["toString", "constructor", "__proto__", "valueOf"])
+    ).toEqual([]);
+  });
+});

--- a/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
@@ -1,0 +1,62 @@
+/**
+ * The top widget grid's registry: every widget id that has a component, with
+ * the loader that fetches it. `WidgetId` also carries ids for the dashboard's
+ * main sections, which are not grid widgets, so this — not the enum — is the
+ * set the grid renders and the settings picker offers.
+ */
+
+import { WidgetId } from "$lib/api/generated/nocturne-api-client";
+import type { Component } from "svelte";
+
+type WidgetLoader = () => Promise<{ default: Component }>;
+
+const TOP_WIDGET_LOADERS = {
+  [WidgetId.BgDelta]: () => import("./widgets/BgDeltaWidget.svelte"),
+  [WidgetId.LastUpdated]: () => import("./widgets/LastUpdatedWidget.svelte"),
+  [WidgetId.ConnectionStatus]: () =>
+    import("./widgets/ConnectionStatusWidget.svelte"),
+  [WidgetId.Meals]: () => import("./widgets/MealsWidget.svelte"),
+  [WidgetId.Trackers]: () => import("./widgets/TrackersWidget.svelte"),
+  [WidgetId.TirChart]: () => import("./widgets/TirChartWidget.svelte"),
+  [WidgetId.DailySummary]: () => import("./widgets/DailySummaryWidget.svelte"),
+  [WidgetId.Clock]: () => import("./widgets/ClockWidget.svelte"),
+  [WidgetId.Tdd]: () => import("./widgets/TddWidget.svelte"),
+} satisfies Partial<Record<WidgetId, WidgetLoader>>;
+
+/** A widget id the grid can actually render. */
+export type TopWidgetId = keyof typeof TOP_WIDGET_LOADERS;
+
+function isTopWidgetId(id: string): id is TopWidgetId {
+  return id in TOP_WIDGET_LOADERS;
+}
+
+/** Every widget offerable in settings, in the order the picker lists them. */
+export const TOP_WIDGET_IDS: TopWidgetId[] =
+  Object.keys(TOP_WIDGET_LOADERS).filter(isTopWidgetId);
+
+export const DEFAULT_TOP_WIDGETS: TopWidgetId[] = [
+  WidgetId.BgDelta,
+  WidgetId.TirChart,
+  WidgetId.Tdd,
+];
+
+/**
+ * Selections persist per user and outlive any one release, so a stored list can
+ * name an id this build has no component for.
+ */
+export function knownTopWidgets(
+  ids: readonly WidgetId[] | undefined
+): TopWidgetId[] {
+  return (ids ?? []).filter(isTopWidgetId);
+}
+
+const cache = new Map<TopWidgetId, Promise<Component>>();
+
+export function loadTopWidget(id: TopWidgetId): Promise<Component> {
+  let loading = cache.get(id);
+  if (!loading) {
+    loading = TOP_WIDGET_LOADERS[id]().then((m) => m.default);
+    cache.set(id, loading);
+  }
+  return loading;
+}

--- a/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
@@ -1,8 +1,7 @@
 /**
- * The top widget grid's registry: every widget id that has a component, with
- * the loader that fetches it. `WidgetId` also carries ids for the dashboard's
- * main sections, which are not grid widgets, so this — not the enum — is the
- * set the grid renders and the settings picker offers.
+ * `WidgetId` also carries ids for the dashboard's main sections, which are not
+ * grid widgets, so this — not the enum — is the set the grid renders and the
+ * settings picker offers.
  */
 
 import { WidgetId } from "$lib/api/generated/nocturne-api-client";
@@ -27,7 +26,7 @@ const TOP_WIDGET_LOADERS = {
 export type TopWidgetId = keyof typeof TOP_WIDGET_LOADERS;
 
 function isTopWidgetId(id: string): id is TopWidgetId {
-  return id in TOP_WIDGET_LOADERS;
+  return Object.hasOwn(TOP_WIDGET_LOADERS, id);
 }
 
 /** Every widget offerable in settings, in the order the picker lists them. */
@@ -41,11 +40,12 @@ export const DEFAULT_TOP_WIDGETS: TopWidgetId[] = [
 ];
 
 /**
- * Selections persist per user and outlive any one release, so a stored list can
- * name an id this build has no component for.
+ * Selections persist per user, outlive any one release, and arrive from a
+ * cookie any tenant subdomain can write, so a stored list can name an id this
+ * build has no component for — or no id at all.
  */
 export function knownTopWidgets(
-  ids: readonly WidgetId[] | undefined
+  ids: readonly string[] | undefined
 ): TopWidgetId[] {
   return (ids ?? []).filter(isTopWidgetId);
 }

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
@@ -32,7 +32,6 @@
     maxWidgets = 3,
   }: Props = $props();
 
-  // Local state for drag operations
   let draggedIndex: number | null = $state(null);
   let dragOverIndex: number | null = $state(null);
 
@@ -42,7 +41,6 @@
   );
   const canAddMore = $derived(selectedWidgets.length < maxWidgets);
 
-  // Get widget display name
   function getWidgetName(id: TopWidgetId): string {
     // Convert camelCase to Title Case
     return id
@@ -53,7 +51,6 @@
       .join(' ');
   }
 
-  // Drag handlers for reordering
   function handleDragStart(event: DragEvent, index: number) {
     draggedIndex = index;
     if (event.dataTransfer) {
@@ -92,14 +89,12 @@
     dragOverIndex = null;
   }
 
-  // Add widget
   function addWidget(id: TopWidgetId) {
     if (canAddMore) {
       onchange?.([...selectedWidgets, id]);
     }
   }
 
-  // Remove widget
   function removeWidget(index: number) {
     const newValue = [...selectedWidgets];
     newValue.splice(index, 1);

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
@@ -8,19 +8,20 @@
   } from "$lib/components/ui/card";
   import { Badge } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
+  import type { WidgetId } from "$lib/api/generated/nocturne-api-client";
   import {
-    WidgetId,
-  } from "$lib/api/generated/nocturne-api-client";
-  import {
-    WIDGET_ICONS,
     DEFAULT_TOP_WIDGETS,
-  } from "$lib/types/dashboard-widgets";
+    TOP_WIDGET_IDS,
+    knownTopWidgets,
+    type TopWidgetId,
+  } from "$lib/components/dashboard/widget-registry";
+  import { WIDGET_ICONS } from "$lib/types/dashboard-widgets";
   import { GripVertical, LayoutGrid, Plus, X } from "lucide-svelte";
   interface Props {
     /** Currently selected widget IDs (ordered) */
     value: WidgetId[];
     /** Callback when widgets change */
-    onchange?: (widgets: WidgetId[]) => void;
+    onchange?: (widgets: TopWidgetId[]) => void;
     /** Maximum number of widgets allowed */
     maxWidgets?: number;
   }
@@ -35,21 +36,14 @@
   let draggedIndex: number | null = $state(null);
   let dragOverIndex: number | null = $state(null);
 
-  // Get icon component for a widget
-  function getIcon(widgetId: WidgetId) {
-    return WIDGET_ICONS[widgetId] || LayoutGrid;
-  }
-
-  // Get all available top-placement widgets
-  function getAvailableWidgets(): WidgetId[] {
-    return Object.values(WidgetId).filter(
-      (id): id is WidgetId =>
-        typeof id === 'string' && id in WIDGET_ICONS
-    );
-  }
+  const selectedWidgets = $derived(knownTopWidgets(value));
+  const availableWidgets = $derived(
+    TOP_WIDGET_IDS.filter((id) => !selectedWidgets.includes(id))
+  );
+  const canAddMore = $derived(selectedWidgets.length < maxWidgets);
 
   // Get widget display name
-  function getWidgetName(id: WidgetId): string {
+  function getWidgetName(id: TopWidgetId): string {
     // Convert camelCase to Title Case
     return id
       .replace(/([A-Z])/g, ' $1')
@@ -83,7 +77,7 @@
     event.preventDefault();
 
     if (draggedIndex !== null && draggedIndex !== targetIndex) {
-      const newValue = [...value];
+      const newValue = [...selectedWidgets];
       const [removed] = newValue.splice(draggedIndex, 1);
       newValue.splice(targetIndex, 0, removed);
       onchange?.(newValue);
@@ -99,15 +93,15 @@
   }
 
   // Add widget
-  function addWidget(id: WidgetId) {
-    if (value.length < maxWidgets) {
-      onchange?.([...value, id]);
+  function addWidget(id: TopWidgetId) {
+    if (canAddMore) {
+      onchange?.([...selectedWidgets, id]);
     }
   }
 
   // Remove widget
   function removeWidget(index: number) {
-    const newValue = [...value];
+    const newValue = [...selectedWidgets];
     newValue.splice(index, 1);
     onchange?.(newValue);
   }
@@ -124,95 +118,83 @@
     </CardDescription>
   </CardHeader>
   <CardContent class="space-y-4 @container">
-    {#if true}
-      {@const allAvailableWidgets = getAvailableWidgets()}
-      {@const availableWidgets = allAvailableWidgets.filter(
-        (id) => !value.includes(id)
-      )}
-      {@const selectedWidgets = value.filter(
-        (id): id is WidgetId =>
-          typeof id === 'string' && id in WIDGET_ICONS
-      )}
-      {@const canAddMore = value.length < maxWidgets}
-
-      <!-- Selected widgets (draggable) -->
+    <!-- Selected widgets (draggable) -->
+    <div class="space-y-2">
+      <span class="text-sm font-medium">Active Widgets</span>
       <div class="space-y-2">
-        <span class="text-sm font-medium">Active Widgets</span>
-        <div class="space-y-2">
-          {#each selectedWidgets as widgetId, index (widgetId)}
-            {@const Icon = getIcon(widgetId)}
-            <div
-              class="flex items-center gap-2 p-3 rounded-lg border bg-card transition-all
-                {dragOverIndex === index
-                ? 'border-primary bg-accent'
-                : 'border-border'}
-                {draggedIndex === index ? 'opacity-50' : ''}"
-              draggable="true"
-              ondragstart={(e) => handleDragStart(e, index)}
-              ondragover={(e) => handleDragOver(e, index)}
-              ondragleave={handleDragLeave}
-              ondrop={(e) => handleDrop(e, index)}
-              ondragend={handleDragEnd}
-              role="listitem"
+        {#each selectedWidgets as widgetId, index (widgetId)}
+          {@const Icon = WIDGET_ICONS[widgetId]}
+          <div
+            class="flex items-center gap-2 p-3 rounded-lg border bg-card transition-all
+              {dragOverIndex === index
+              ? 'border-primary bg-accent'
+              : 'border-border'}
+              {draggedIndex === index ? 'opacity-50' : ''}"
+            draggable="true"
+            ondragstart={(e) => handleDragStart(e, index)}
+            ondragover={(e) => handleDragOver(e, index)}
+            ondragleave={handleDragLeave}
+            ondrop={(e) => handleDrop(e, index)}
+            ondragend={handleDragEnd}
+            role="listitem"
+          >
+            <GripVertical class="h-4 w-4 text-muted-foreground cursor-grab" />
+            <Badge variant="outline" class="w-6 h-6 p-0 justify-center">
+              {index + 1}
+            </Badge>
+            <Icon class="h-4 w-4 text-muted-foreground" />
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-sm">{getWidgetName(widgetId)}</div>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              class="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+              onclick={() => removeWidget(index)}
             >
-              <GripVertical class="h-4 w-4 text-muted-foreground cursor-grab" />
-              <Badge variant="outline" class="w-6 h-6 p-0 justify-center">
-                {index + 1}
-              </Badge>
+              <X class="h-4 w-4" />
+            </Button>
+          </div>
+        {/each}
+
+        {#if selectedWidgets.length === 0}
+          <div
+            class="text-center py-8 text-muted-foreground border border-dashed rounded-lg"
+          >
+            <p class="text-sm">No widgets selected</p>
+            <p class="text-xs">Add widgets from the list below</p>
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    <!-- Available widgets to add -->
+    {#if availableWidgets.length > 0}
+      <div class="space-y-2">
+        <span class="text-sm font-medium text-muted-foreground">
+          Available Widgets {#if !canAddMore}(max {maxWidgets} reached){/if}
+        </span>
+        <div class="grid grid-cols-1 @sm:grid-cols-2 gap-2">
+          {#each availableWidgets as widgetId (widgetId)}
+            {@const Icon = WIDGET_ICONS[widgetId]}
+            <button
+              type="button"
+              class="flex items-center gap-2 p-2 rounded-lg border border-dashed text-left transition-colors
+                {canAddMore
+                ? 'hover:border-primary hover:bg-accent cursor-pointer'
+                : 'opacity-50 cursor-not-allowed'}"
+              onclick={() => addWidget(widgetId)}
+              disabled={!canAddMore}
+            >
+              <Plus class="h-4 w-4 text-muted-foreground" />
               <Icon class="h-4 w-4 text-muted-foreground" />
               <div class="flex-1 min-w-0">
                 <div class="font-medium text-sm">{getWidgetName(widgetId)}</div>
               </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                class="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-                onclick={() => removeWidget(index)}
-              >
-                <X class="h-4 w-4" />
-              </Button>
-            </div>
+            </button>
           {/each}
-
-          {#if selectedWidgets.length === 0}
-            <div
-              class="text-center py-8 text-muted-foreground border border-dashed rounded-lg"
-            >
-              <p class="text-sm">No widgets selected</p>
-              <p class="text-xs">Add widgets from the list below</p>
-            </div>
-          {/if}
         </div>
       </div>
-
-      <!-- Available widgets to add -->
-      {#if availableWidgets.length > 0}
-        <div class="space-y-2">
-          <span class="text-sm font-medium text-muted-foreground">
-            Available Widgets {#if !canAddMore}(max {maxWidgets} reached){/if}
-          </span>
-          <div class="grid grid-cols-1 @sm:grid-cols-2 gap-2">
-            {#each availableWidgets as widgetId (widgetId)}
-              {@const Icon = getIcon(widgetId)}
-              <button
-                type="button"
-                class="flex items-center gap-2 p-2 rounded-lg border border-dashed text-left transition-colors
-                  {canAddMore
-                  ? 'hover:border-primary hover:bg-accent cursor-pointer'
-                  : 'opacity-50 cursor-not-allowed'}"
-                onclick={() => canAddMore && addWidget(widgetId)}
-                disabled={!canAddMore}
-              >
-                <Plus class="h-4 w-4 text-muted-foreground" />
-                <Icon class="h-4 w-4 text-muted-foreground" />
-                <div class="flex-1 min-w-0">
-                  <div class="font-medium text-sm">{getWidgetName(widgetId)}</div>
-                </div>
-              </button>
-            {/each}
-          </div>
-        </div>
-      {/if}
     {/if}
 
     <p class="text-xs text-muted-foreground">

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte.test.ts
@@ -3,35 +3,32 @@ import { page } from "vitest/browser";
 import { describe, it, expect } from "vitest";
 import DashboardWidgetConfigurator from "./DashboardWidgetConfigurator.svelte";
 import { WidgetId } from "$lib/api/generated/nocturne-api-client";
-import {
-  TOP_WIDGET_IDS,
-  type TopWidgetId,
-} from "$lib/components/dashboard/widget-registry";
+import type { TopWidgetId } from "$lib/components/dashboard/widget-registry";
 
-/** Mirrors the component's camelCase-to-Title-Case label. */
-function label(id: string): string {
-  return id.replace(/([A-Z])/g, " $1").trim();
-}
+/**
+ * Spelled out rather than derived from the registry: the point of the test is
+ * that the picker cannot drift from the widgets the grid can render.
+ */
+const OFFERED = [
+  "Bg Delta",
+  "Last Updated",
+  "Connection Status",
+  "Meals",
+  "Trackers",
+  "Tir Chart",
+  "Daily Summary",
+  "Clock",
+  "Tdd",
+];
 
 describe("DashboardWidgetConfigurator", () => {
   it("offers exactly the widgets the grid has a loader for", async () => {
     render(DashboardWidgetConfigurator, { props: { value: [] } });
 
-    for (const id of TOP_WIDGET_IDS) {
-      await expect
-        .element(page.getByRole("button", { name: label(id) }))
-        .toBeVisible();
+    for (const name of OFFERED) {
+      await expect.element(page.getByRole("button", { name })).toBeVisible();
     }
-
-    const notRenderable = Object.values(WidgetId).filter(
-      (id) => !TOP_WIDGET_IDS.some((known) => known === id)
-    );
-    expect(notRenderable.length).toBeGreaterThan(0);
-    for (const id of notRenderable) {
-      await expect
-        .element(page.getByRole("button", { name: label(id) }))
-        .not.toBeInTheDocument();
-    }
+    expect(page.getByRole("button").elements()).toHaveLength(OFFERED.length);
   });
 
   it("ignores a stored widget id the grid cannot render", async () => {
@@ -45,10 +42,10 @@ describe("DashboardWidgetConfigurator", () => {
 
     expect(page.getByRole("listitem").elements()).toHaveLength(2);
     await expect
-      .element(page.getByText(label(WidgetId.GlucoseChart), { exact: true }))
+      .element(page.getByText("Glucose Chart", { exact: true }))
       .not.toBeInTheDocument();
 
-    await page.getByRole("button", { name: label(WidgetId.Clock) }).click();
+    await page.getByRole("button", { name: "Clock" }).click();
 
     expect(writes.at(-1)).toEqual([
       WidgetId.BgDelta,

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte.test.ts
@@ -1,0 +1,59 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect } from "vitest";
+import DashboardWidgetConfigurator from "./DashboardWidgetConfigurator.svelte";
+import { WidgetId } from "$lib/api/generated/nocturne-api-client";
+import {
+  TOP_WIDGET_IDS,
+  type TopWidgetId,
+} from "$lib/components/dashboard/widget-registry";
+
+/** Mirrors the component's camelCase-to-Title-Case label. */
+function label(id: string): string {
+  return id.replace(/([A-Z])/g, " $1").trim();
+}
+
+describe("DashboardWidgetConfigurator", () => {
+  it("offers exactly the widgets the grid has a loader for", async () => {
+    render(DashboardWidgetConfigurator, { props: { value: [] } });
+
+    for (const id of TOP_WIDGET_IDS) {
+      await expect
+        .element(page.getByRole("button", { name: label(id) }))
+        .toBeVisible();
+    }
+
+    const notRenderable = Object.values(WidgetId).filter(
+      (id) => !TOP_WIDGET_IDS.some((known) => known === id)
+    );
+    expect(notRenderable.length).toBeGreaterThan(0);
+    for (const id of notRenderable) {
+      await expect
+        .element(page.getByRole("button", { name: label(id) }))
+        .not.toBeInTheDocument();
+    }
+  });
+
+  it("ignores a stored widget id the grid cannot render", async () => {
+    const writes: TopWidgetId[][] = [];
+    render(DashboardWidgetConfigurator, {
+      props: {
+        value: [WidgetId.BgDelta, WidgetId.GlucoseChart, WidgetId.Tdd],
+        onchange: (widgets) => writes.push(widgets),
+      },
+    });
+
+    expect(page.getByRole("listitem").elements()).toHaveLength(2);
+    await expect
+      .element(page.getByText(label(WidgetId.GlucoseChart), { exact: true }))
+      .not.toBeInTheDocument();
+
+    await page.getByRole("button", { name: label(WidgetId.Clock) }).click();
+
+    expect(writes.at(-1)).toEqual([
+      WidgetId.BgDelta,
+      WidgetId.Tdd,
+      WidgetId.Clock,
+    ]);
+  });
+});

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -27,7 +27,8 @@ import { getContext, setContext } from "svelte";
 import { PersistedState } from "runed";
 import { setMode, mode, userPrefersMode } from "mode-watcher";
 import supportedLocales from "../../../../../supportedLocales.json";
-import { WidgetId } from "../api/generated/nocturne-api-client";
+import type { WidgetId } from "../api/generated/nocturne-api-client";
+import { DEFAULT_TOP_WIDGETS } from "../components/dashboard/widget-registry";
 import type { UserDisplayPreferences } from "$lib/api";
 import { weekStartName } from "../components/calendar/calendar-date";
 import { resolveCookieDomain } from "../utils/tenant-host";
@@ -301,7 +302,7 @@ export const nightModeSchedule = new SyncedPref<boolean>(
  */
 export const dashboardTopWidgets = new SyncedPref<WidgetId[]>(
   "nocturne-dashboard-top-widgets",
-  [WidgetId.BgDelta, WidgetId.TirChart, WidgetId.Tdd],
+  DEFAULT_TOP_WIDGETS,
   (p) => p.dashboardTopWidgets
 );
 

--- a/src/Web/packages/app/src/lib/types/dashboard-widgets.ts
+++ b/src/Web/packages/app/src/lib/types/dashboard-widgets.ts
@@ -3,14 +3,10 @@
  *
  * Widget icon mappings and helpers.
  * Types must be imported directly from '$lib/api/generated/nocturne-api-client'.
- * Widget definitions will eventually come from the backend API.
  */
 
-import {
-  WidgetId,
-  WidgetPlacement,
-  type WidgetConfig,
-} from "$lib/api/generated/nocturne-api-client";
+import { WidgetId, type WidgetConfig } from "$lib/api/generated/nocturne-api-client";
+import type { TopWidgetId } from "$lib/components/dashboard/widget-registry";
 
 import {
   TrendingUp,
@@ -20,19 +16,12 @@ import {
   ListChecks,
   BarChart3,
   CalendarDays,
-  LineChart,
-  BarChart2,
-  Syringe,
-  Activity,
-  Battery,
   PieChart,
 } from "lucide-svelte";
 import type { ComponentType } from "svelte";
 
-/**
- * Widget icon mapping - maps widget IDs to their Svelte icon components
- */
-export const WIDGET_ICONS: Partial<Record<WidgetId, ComponentType>> = {
+/** Keyed by the registry's ids, so an icon and a loader cannot exist without each other. */
+export const WIDGET_ICONS: Record<TopWidgetId, ComponentType> = {
   [WidgetId.BgDelta]: TrendingUp,
   [WidgetId.LastUpdated]: Clock,
   [WidgetId.ConnectionStatus]: Wifi,
@@ -40,33 +29,9 @@ export const WIDGET_ICONS: Partial<Record<WidgetId, ComponentType>> = {
   [WidgetId.Trackers]: ListChecks,
   [WidgetId.TirChart]: BarChart3,
   [WidgetId.DailySummary]: CalendarDays,
-  [WidgetId.GlucoseChart]: LineChart,
-  [WidgetId.Statistics]: BarChart2,
-  [WidgetId.Predictions]: TrendingUp,
-  [WidgetId.DailyStats]: CalendarDays,
-  [WidgetId.Treatments]: Syringe,
-  [WidgetId.Agp]: Activity,
-  [WidgetId.BatteryStatus]: Battery,
   [WidgetId.Clock]: Clock,
   [WidgetId.Tdd]: PieChart,
 };
-
-/**
- * Get icon component for a widget
- */
-export function getWidgetIcon(id: WidgetId): ComponentType | undefined {
-  return WIDGET_ICONS[id];
-}
-
-/**
- * Default top widgets (for when no user config exists)
- * BgDelta includes connection status + last updated info
- */
-export const DEFAULT_TOP_WIDGETS: WidgetId[] = [
-  WidgetId.BgDelta,
-  WidgetId.TirChart,
-  WidgetId.Tdd,
-];
 
 /**
  * Helper to check if a widget is enabled
@@ -80,24 +45,4 @@ export function isWidgetEnabled(
   }
   const widget = widgets.find((w) => w.id === widgetId);
   return widget?.enabled ?? true;
-}
-
-/**
- * Get enabled widgets by placement
- */
-export function getEnabledWidgetsByPlacement(
-  widgets: WidgetConfig[] | undefined,
-  placement: WidgetPlacement
-): WidgetId[] {
-  if (!widgets) {
-    // Return defaults for top placement
-    if (placement === WidgetPlacement.Top) {
-      return DEFAULT_TOP_WIDGETS;
-    }
-    return [];
-  }
-
-  return widgets
-    .filter((w) => w.placement === placement && w.enabled)
-    .map((w) => w.id) as WidgetId[];
 }

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
@@ -59,7 +59,7 @@
           key: "quick-tour.widgets",
           title: "Customizable widgets",
           description:
-            "Reorder or swap these in Settings \u2192 Appearance. You can choose from over a dozen stats.",
+            "Reorder or swap these in Settings \u2192 Appearance to show the stats you care about.",
         })}
       >
         <WidgetGrid widgets={topWidgets} maxWidgets={3} />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -77,8 +77,7 @@
   import SettingsPageSkeleton from "$lib/components/settings/SettingsPageSkeleton.svelte";
   import { browser } from "$app/environment";
   import { resolve } from "$app/paths";
-  import type { WidgetId } from "$lib/api/generated/nocturne-api-client";
-  import { knownTopWidgets } from "$lib/components/dashboard/widget-registry";
+  import { WidgetId } from "$lib/api/generated/nocturne-api-client";
   import { page } from "$app/state";
   import { coachmark } from "@nocturne/coach";
   import { describeSubmitError } from "$lib/forms/submit-error";
@@ -88,7 +87,7 @@
 
   // Dashboard widgets - use persisted state for immediate localStorage persistence
   function handleWidgetsChange(widgets: WidgetId[]) {
-    dashboardTopWidgets.current = knownTopWidgets(widgets);
+    dashboardTopWidgets.current = widgets;
   }
 
   // Theme state - reactive wrapper around store (color theme: nocturne/trio)

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/appearance/+page.svelte
@@ -77,7 +77,8 @@
   import SettingsPageSkeleton from "$lib/components/settings/SettingsPageSkeleton.svelte";
   import { browser } from "$app/environment";
   import { resolve } from "$app/paths";
-  import { WidgetId } from "$lib/api/generated/nocturne-api-client";
+  import type { WidgetId } from "$lib/api/generated/nocturne-api-client";
+  import { knownTopWidgets } from "$lib/components/dashboard/widget-registry";
   import { page } from "$app/state";
   import { coachmark } from "@nocturne/coach";
   import { describeSubmitError } from "$lib/forms/submit-error";
@@ -87,7 +88,7 @@
 
   // Dashboard widgets - use persisted state for immediate localStorage persistence
   function handleWidgetsChange(widgets: WidgetId[]) {
-    dashboardTopWidgets.current = widgets;
+    dashboardTopWidgets.current = knownTopWidgets(widgets);
   }
 
   // Theme state - reactive wrapper around store (color theme: nocturne/trio)


### PR DESCRIPTION
Fixes #534.

## Problem

The appearance picker built its catalogue from the icon map, which named all sixteen `WidgetId`s. Nine have a component; the other seven (Glucose Chart, Statistics, Predictions, Daily Stats, Treatments, AGP, Battery Status) are the dashboard's main sections and have never had a grid widget. Picking one stored an id the grid had no loader for, and because the grid sliced to `maxWidgets` before the loader lookup, the phantom also ate a slot.

## Change

- `widget-registry.ts` owns the frontend's set of renderable top widgets: the loader map, `TOP_WIDGET_IDS`, `DEFAULT_TOP_WIDGETS`, `knownTopWidgets()` and the module-level loader cache. The icon map is keyed by `TopWidgetId`, so an icon without a loader or a loader without an icon fails `pnpm check`.
- The picker lists the registry's ids; `selectedWidgets`/`availableWidgets`/`canAddMore` are `$derived` from the filtered list, and add/remove/drag operate on it. That also fixes a pre-existing bug where drag and remove indexed the raw stored list while rendering a filtered one.
- The grid filters before slicing, so a stored phantom no longer occupies a slot.
- `knownTopWidgets` uses `Object.hasOwn`, so a poisoned `nocturne-prefs` cookie carrying `constructor` or `__proto__` cannot throw inside the grid's `{#await}` and kill the dashboard render.
- The dashboard coachmark no longer promises "over a dozen stats".

The backend `WidgetId` enum, `GetAllWidgetDefinitions`, `GetDefaultWidgets` and the demo generator are untouched; the seven ids stay live as main-section toggles. The backend's own three copies of the catalogue already disagree with each other, which is #1188.

Net −39 production lines. The loader cache moved from component-instance scope to module scope; it holds only component-module promises, identical for every request, so the appearance store's no-server-module-state rule is not crossed.

## Tests

`DashboardWidgetConfigurator.svelte.test.ts` (browser): the offered buttons equal a literal list of the nine renderable widgets, and a stored phantom is dropped from the active list and from the next write. `widget-registry.test.ts` (node): inherited object keys are filtered. Mutation-checked across two hostile review rounds: reverting the component and icon map, injecting a tenth id into the catalogue, returning the input unfiltered, `hasOwn` back to `in`, and silently deleting a real widget from both maps each fail at least one test. `pnpm check` unchanged at the 51-error baseline.
