### PR TITLE
refactor(data): make the API's Postgres composition resolvable and guarded from tests

### DIFF
--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -95,13 +95,18 @@ var aspirePostgreSqlConnection = builder.Configuration.GetConnectionString(Servi
         $"ConnectionStrings:{ServiceNames.PostgreSql} is required."));
 var migratorConnectionString = builder.Configuration.GetConnectionString($"{ServiceNames.PostgreSql}-migrator");
 
+var postgreSqlOptions = PostgreSqlConfiguration.ResolveForEnvironment(
+    aspirePostgreSqlConnection,
+    builder.Configuration,
+    builder.Environment.IsDevelopment());
+
+// Registered whether or not the pool is built, so the resolution above is observable from a test
+// host, which always runs as Testing and so never reaches the registration below.
+builder.Services.AddSingleton(postgreSqlOptions);
+
 if (!isTesting)
 {
-    builder.Services.AddPostgreSqlInfrastructure(
-        PostgreSqlConfiguration.ResolveForEnvironment(
-            aspirePostgreSqlConnection,
-            builder.Configuration,
-            builder.Environment.IsDevelopment()));
+    builder.Services.AddPostgreSqlInfrastructure(postgreSqlOptions);
 }
 else
 {

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -28,6 +28,7 @@ using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Cache.Extensions;
 using Nocturne.Core.Contracts.Entries;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Configuration;
 using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Interceptors;
 using OpenTelemetry.Logs;
@@ -97,14 +98,10 @@ var migratorConnectionString = builder.Configuration.GetConnectionString($"{Serv
 if (!isTesting)
 {
     builder.Services.AddPostgreSqlInfrastructure(
-        aspirePostgreSqlConnection,
-        builder.Configuration,
-        config =>
-        {
-            config.EnableDetailedErrors = builder.Environment.IsDevelopment();
-            config.EnableSensitiveDataLogging = builder.Environment.IsDevelopment();
-        }
-    );
+        PostgreSqlConfiguration.ResolveForEnvironment(
+            aspirePostgreSqlConnection,
+            builder.Configuration,
+            builder.Environment.IsDevelopment()));
 }
 else
 {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgreSqlConfiguration.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgreSqlConfiguration.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Configuration;
+
 namespace Nocturne.Infrastructure.Data.Configuration;
 
 /// <summary>
@@ -60,4 +62,72 @@ public class PostgreSqlConfiguration
     /// Increase alongside Postgres max_connections when deploying at high concurrency.
     /// </summary>
     public int MaxPoolSize { get; set; } = 100;
+
+    /// <summary>
+    /// Resolves the options the runtime pool is built from: the compiled-in defaults on this type,
+    /// with <see cref="SectionName"/> bound over them and <paramref name="configure"/> applied last
+    /// for values the host only knows at startup.
+    /// </summary>
+    /// <param name="connectionString">
+    /// The connection string the host resolved. Always wins over the section's own
+    /// <see cref="ConnectionString"/> key, which the design-time factory reads and a self-hoster
+    /// may have pointed at the migrator role.
+    /// </param>
+    /// <param name="configuration">
+    /// Configuration to bind the section from. <see langword="null"/> is a decision to run on
+    /// compiled-in defaults.
+    /// </param>
+    /// <param name="configure">Overrides applied after the section.</param>
+    public static PostgreSqlConfiguration Resolve(
+        string connectionString,
+        IConfiguration? configuration,
+        Action<PostgreSqlConfiguration>? configure = null)
+    {
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            throw new ArgumentException(
+                "Connection string cannot be null or empty",
+                nameof(connectionString)
+            );
+        }
+
+        var config = new PostgreSqlConfiguration { ConnectionString = connectionString };
+        configuration?.GetSection(SectionName).Bind(config);
+
+        // Restored after the bind, not before it: see the connectionString parameter.
+        config.ConnectionString = connectionString;
+
+        configure?.Invoke(config);
+
+        if (string.IsNullOrEmpty(config.ConnectionString))
+        {
+            throw new InvalidOperationException(
+                "Connection string was cleared by the configure action"
+            );
+        }
+
+        return config;
+    }
+
+    /// <summary>
+    /// Resolves the options the API itself runs on: <see cref="Resolve"/> plus the EF diagnostics
+    /// the host derives from its environment. Both leak query parameters — patient data — into
+    /// logs and error text, so they follow development and nothing else.
+    /// </summary>
+    /// <param name="connectionString">The connection string the host resolved.</param>
+    /// <param name="configuration">Configuration to bind <see cref="SectionName"/> from.</param>
+    /// <param name="isDevelopment">Whether the host is running in the Development environment.</param>
+    public static PostgreSqlConfiguration ResolveForEnvironment(
+        string connectionString,
+        IConfiguration configuration,
+        bool isDevelopment)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return Resolve(connectionString, configuration, config =>
+        {
+            config.EnableDetailedErrors = isDevelopment;
+            config.EnableSensitiveDataLogging = isDevelopment;
+        });
+    }
 }

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgreSqlConfiguration.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Configuration/PostgreSqlConfiguration.cs
@@ -65,41 +65,28 @@ public class PostgreSqlConfiguration
 
     /// <summary>
     /// Resolves the options the runtime pool is built from: the compiled-in defaults on this type,
-    /// with <see cref="SectionName"/> bound over them and <paramref name="configure"/> applied last
-    /// for values the host only knows at startup.
+    /// with the <see cref="SectionName"/> section bound over them and <paramref name="configure"/>
+    /// applied last, for values the host only knows at startup. A <see langword="null"/>
+    /// <paramref name="configuration"/> is a decision to run on compiled-in defaults. An empty
+    /// <paramref name="connectionString"/> passes through so a host that never opens the pool can
+    /// still resolve its options; the registration that builds the pool is what rejects it.
     /// </summary>
-    /// <param name="connectionString">
-    /// The connection string the host resolved. Always wins over the section's own
-    /// <see cref="ConnectionString"/> key, which the design-time factory reads and a self-hoster
-    /// may have pointed at the migrator role.
-    /// </param>
-    /// <param name="configuration">
-    /// Configuration to bind the section from. <see langword="null"/> is a decision to run on
-    /// compiled-in defaults.
-    /// </param>
-    /// <param name="configure">Overrides applied after the section.</param>
     public static PostgreSqlConfiguration Resolve(
         string connectionString,
         IConfiguration? configuration,
         Action<PostgreSqlConfiguration>? configure = null)
     {
-        if (string.IsNullOrEmpty(connectionString))
-        {
-            throw new ArgumentException(
-                "Connection string cannot be null or empty",
-                nameof(connectionString)
-            );
-        }
-
         var config = new PostgreSqlConfiguration { ConnectionString = connectionString };
         configuration?.GetSection(SectionName).Bind(config);
 
-        // Restored after the bind, not before it: see the connectionString parameter.
+        // Restored after the bind, not before it. PostgreSql:ConnectionString is a documented key
+        // that the design-time factory reads, so a self-hoster may well have it set; letting it
+        // survive here would repoint the runtime pool at whatever role that key names.
         config.ConnectionString = connectionString;
 
         configure?.Invoke(config);
 
-        if (string.IsNullOrEmpty(config.ConnectionString))
+        if (!string.IsNullOrEmpty(connectionString) && string.IsNullOrEmpty(config.ConnectionString))
         {
             throw new InvalidOperationException(
                 "Connection string was cleared by the configure action"
@@ -111,12 +98,9 @@ public class PostgreSqlConfiguration
 
     /// <summary>
     /// Resolves the options the API itself runs on: <see cref="Resolve"/> plus the EF diagnostics
-    /// the host derives from its environment. Both leak query parameters — patient data — into
-    /// logs and error text, so they follow development and nothing else.
+    /// the host derives from its environment. Both put query parameters — patient data — into logs
+    /// and exception text, so they follow development and nothing a deployment can set.
     /// </summary>
-    /// <param name="connectionString">The connection string the host resolved.</param>
-    /// <param name="configuration">Configuration to bind <see cref="SectionName"/> from.</param>
-    /// <param name="isDevelopment">Whether the host is running in the Development environment.</param>
     public static PostgreSqlConfiguration ResolveForEnvironment(
         string connectionString,
         IConfiguration configuration,

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
@@ -24,32 +24,6 @@ namespace Nocturne.Infrastructure.Data.Extensions;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
-    /// <summary>
-    /// Add PostgreSQL data services, taking the connection string from
-    /// <c>PostgreSql:ConnectionString</c>.
-    /// </summary>
-    /// <param name="services">Service collection</param>
-    /// <param name="configuration">Configuration</param>
-    /// <returns>Service collection for chaining</returns>
-    public static IServiceCollection AddPostgreSqlInfrastructure(
-        this IServiceCollection services,
-        IConfiguration configuration
-    )
-    {
-        var connectionString = configuration
-            .GetSection(PostgreSqlConfiguration.SectionName)[nameof(PostgreSqlConfiguration.ConnectionString)];
-
-        if (string.IsNullOrEmpty(connectionString))
-        {
-            throw new InvalidOperationException(
-                "PostgreSQL connection string must be provided in configuration section 'PostgreSql:ConnectionString'"
-            );
-        }
-
-        return services.AddPostgreSqlInfrastructure(
-            PostgreSqlConfiguration.Resolve(connectionString, configuration));
-    }
-
     // Replaces the registered IDbContextFactory<NocturneDbContext> with a decorator that
     // normalizes the carrier properties on every acquisition. Applied immediately after
     // AddDbContextFactory so the descriptor it wraps is the registered factory.
@@ -107,26 +81,19 @@ public static class ServiceCollectionExtensions
     /// every other overload resolves its options through
     /// <see cref="PostgreSqlConfiguration.Resolve"/> and lands here.
     /// </summary>
-    /// <param name="services">Service collection</param>
-    /// <param name="config">Resolved PostgreSQL options</param>
     /// <returns>Service collection for chaining</returns>
     public static IServiceCollection AddPostgreSqlInfrastructure(
         this IServiceCollection services,
         PostgreSqlConfiguration config
     )
     {
-        // Register configuration
-        services.Configure<PostgreSqlConfiguration>(options =>
+        if (string.IsNullOrEmpty(config.ConnectionString))
         {
-            options.ConnectionString = config.ConnectionString;
-            options.EnableSensitiveDataLogging = config.EnableSensitiveDataLogging;
-            options.EnableDetailedErrors = config.EnableDetailedErrors;
-            options.MaxRetryCount = config.MaxRetryCount;
-            options.MaxRetryDelaySeconds = config.MaxRetryDelaySeconds;
-            options.CommandTimeoutSeconds = config.CommandTimeoutSeconds;
-            options.StatementTimeoutSeconds = config.StatementTimeoutSeconds;
-            options.MaxPoolSize = config.MaxPoolSize;
-        });
+            throw new ArgumentException(
+                "Connection string cannot be null or empty",
+                nameof(config)
+            );
+        }
 
         // Register interceptors as singletons so caches are shared across all DbContext instances.
         services.TryAddSingleton<TenantConnectionInterceptor>();

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/ServiceCollectionExtensions.cs
@@ -25,7 +25,8 @@ namespace Nocturne.Infrastructure.Data.Extensions;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Add PostgreSQL data services to the service collection
+    /// Add PostgreSQL data services, taking the connection string from
+    /// <c>PostgreSql:ConnectionString</c>.
     /// </summary>
     /// <param name="services">Service collection</param>
     /// <param name="configuration">Configuration</param>
@@ -35,113 +36,18 @@ public static class ServiceCollectionExtensions
         IConfiguration configuration
     )
     {
-        // Register configuration
-        var configSection = configuration.GetSection(PostgreSqlConfiguration.SectionName);
-        services.Configure<PostgreSqlConfiguration>(configSection);
+        var connectionString = configuration
+            .GetSection(PostgreSqlConfiguration.SectionName)[nameof(PostgreSqlConfiguration.ConnectionString)];
 
-        var postgreSqlConfig =
-            configSection.Get<PostgreSqlConfiguration>() ?? new PostgreSqlConfiguration();
-
-        // Validate configuration
-        if (string.IsNullOrEmpty(postgreSqlConfig.ConnectionString))
+        if (string.IsNullOrEmpty(connectionString))
         {
             throw new InvalidOperationException(
                 "PostgreSQL connection string must be provided in configuration section 'PostgreSql:ConnectionString'"
             );
         }
 
-        // Register interceptors as singletons so caches are shared across all DbContext instances.
-        services.TryAddSingleton<TenantConnectionInterceptor>();
-        services.TryAddSingleton<MutationAuditInterceptor>();
-
-        // Audit config cache (singleton — uses IDbContextFactory internally)
-        services.TryAddSingleton<ITenantAuditConfigCache, TenantAuditConfigCache>();
-
-        // Register NpgsqlDataSource as a singleton - this manages the connection pool
-        var dataSource = PostgresRuntimeOptions.BuildRuntimeDataSource(postgreSqlConfig);
-        services.AddSingleton(dataSource);
-
-        // Non-pooled: each acquisition is a fresh context, discarded after use. A faulted context
-        // is never returned to a pool and reused, so a fault cannot poison later callers. Database
-        // connections are pooled by the NpgsqlDataSource singleton.
-        services.AddDbContextFactory<NocturneDbContext>(
-            (sp, options) =>
-            {
-                options.UseNpgsql(
-                    dataSource,
-                    npgsqlOptions =>
-                    {
-                        npgsqlOptions.EnableRetryOnFailure(
-                            maxRetryCount: postgreSqlConfig.MaxRetryCount,
-                            maxRetryDelay: TimeSpan.FromSeconds(postgreSqlConfig.MaxRetryDelaySeconds),
-                            errorCodesToAdd: null
-                        );
-
-                        npgsqlOptions.CommandTimeout(postgreSqlConfig.CommandTimeoutSeconds);
-                    }
-                );
-
-                if (postgreSqlConfig.EnableSensitiveDataLogging)
-                {
-                    options.EnableSensitiveDataLogging();
-                }
-
-                if (postgreSqlConfig.EnableDetailedErrors)
-                {
-                    options.EnableDetailedErrors();
-                }
-
-                options.EnableServiceProviderCaching();
-                options.AddInterceptors(
-                    sp.GetRequiredService<TenantConnectionInterceptor>(),
-                    sp.GetRequiredService<MutationAuditInterceptor>());
-            }
-        );
-
-        // Normalize the context carriers to fail-closed defaults on every acquisition, so raw
-        // IDbContextFactory callers start from a known-safe tenant/subject/share state. See
-        // CarrierResettingDbContextFactory.
-        DecorateWithCarrierReset(services);
-
-        // Register scoped NocturneDbContext that sets TenantId from ITenantAccessor.
-        // All existing constructor injections of NocturneDbContext continue to work.
-        // The context is disposed when the scope ends.
-        services.AddScoped(sp =>
-        {
-            var factory = sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
-            var context = factory.CreateDbContext();
-            var tenantAccessor = sp.GetService<ITenantAccessor>();
-            if (tenantAccessor?.IsResolved == true)
-            {
-                context.TenantId = tenantAccessor.TenantId;
-            }
-            // Mark the scoped context as a share when the request is one. Carrier defaults (CSV
-            // null) are already set by CarrierResettingDbContextFactory; this path never resolves
-            // the CSV, so a share reading PHI here is denied (fail-closed) — share PHI reads go
-            // through ITenantDbContextFactory, which carries the CSV.
-            context.IsShareContext = sp.GetService<ICategoryReadContext>()?.IsShare == true;
-            return context;
-        });
-
-        // Per-request public-share category context, read by the factory and the scoped
-        // context above to stamp the RLS carrier properties.
-        services.AddScoped<ICategoryReadContext, CategoryReadContext>();
-
-        // Register tenant-aware context factory for V4 repositories
-        services.AddScoped<ITenantDbContextFactory, TenantDbContextFactory>();
-
-        // Register deduplication service (required by repositories)
-        services.AddScoped<IDeduplicationService, DeduplicationService>();
-
-        // Register all repositories via their port interfaces
-        services.AddScoped<IFoodRepository, FoodRepository>();
-
-        services.AddScoped<ISettingsRepository, SettingsRepository>();
-
-        // Register avatar storage
-        services.AddScoped<IAvatarStore, DatabaseAvatarStore>();
-
-        return services;
+        return services.AddPostgreSqlInfrastructure(
+            PostgreSqlConfiguration.Resolve(connectionString, configuration));
     }
 
     // Replaces the registered IDbContextFactory<NocturneDbContext> with a decorator that
@@ -193,35 +99,22 @@ public static class ServiceCollectionExtensions
         IConfiguration? configuration,
         Action<PostgreSqlConfiguration>? configure = null
     )
+        => services.AddPostgreSqlInfrastructure(
+            PostgreSqlConfiguration.Resolve(connectionString, configuration, configure));
+
+    /// <summary>
+    /// Add PostgreSQL data services from already-resolved options. The single registration path:
+    /// every other overload resolves its options through
+    /// <see cref="PostgreSqlConfiguration.Resolve"/> and lands here.
+    /// </summary>
+    /// <param name="services">Service collection</param>
+    /// <param name="config">Resolved PostgreSQL options</param>
+    /// <returns>Service collection for chaining</returns>
+    public static IServiceCollection AddPostgreSqlInfrastructure(
+        this IServiceCollection services,
+        PostgreSqlConfiguration config
+    )
     {
-        if (string.IsNullOrEmpty(connectionString))
-        {
-            throw new ArgumentException(
-                "Connection string cannot be null or empty",
-                nameof(connectionString)
-            );
-        }
-
-        // Create and configure options. The section is bound first so an explicit configure
-        // action — which carries values the host derives at startup — still wins over it.
-        var config = new PostgreSqlConfiguration { ConnectionString = connectionString };
-        configuration?.GetSection(PostgreSqlConfiguration.SectionName).Bind(config);
-
-        // Restored after the bind, not before it. PostgreSql:ConnectionString is a documented key
-        // that the design-time factory reads, so a self-hoster may well have it set; letting it
-        // survive here would repoint the runtime pool at whatever role that key names.
-        config.ConnectionString = connectionString;
-
-        configure?.Invoke(config);
-
-        // Validate connection string is still set after configure action
-        if (string.IsNullOrEmpty(config.ConnectionString))
-        {
-            throw new InvalidOperationException(
-                "Connection string was cleared by the configure action"
-            );
-        }
-
         // Register configuration
         services.Configure<PostgreSqlConfiguration>(options =>
         {

--- a/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
+++ b/tests/Integration/Nocturne.Infrastructure.Data.Tests/V4Goldens/V4GoldenFixture.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.Core.Contracts.Audit;
@@ -71,13 +70,6 @@ public class V4GoldenFixture : IAsyncLifetime
             MigratorConnectionString,
             NullLogger.Instance);
 
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["PostgreSql:ConnectionString"] = appConnectionString,
-            })
-            .Build();
-
         var services = new ServiceCollection();
         services.AddLogging();
         // MutationAuditInterceptor resolves IHttpContextAccessor (registered by the API in prod).
@@ -87,7 +79,7 @@ public class V4GoldenFixture : IAsyncLifetime
         // own scope to a user without leaking that attribution into the next test.
         services.AddScoped<TestAuditContext>();
         services.AddScoped<IAuditContext>(sp => sp.GetRequiredService<TestAuditContext>());
-        services.AddPostgreSqlInfrastructure(config);
+        services.AddPostgreSqlInfrastructure(appConnectionString, configuration: null);
         // Capturing broadcaster: the V4 repos resolve IV4RecordBroadcaster<T> via the open generic, so
         // the real chokepoint fires into BroadcastCapture (additive — existing goldens ignore it).
         services.AddSingleton<BroadcastCapture>();

--- a/tests/Unit/Nocturne.API.Tests/Configuration/PostgreSqlOptionsCompositionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Configuration/PostgreSqlOptionsCompositionTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.API.Tests.Infrastructure;
+using Nocturne.Infrastructure.Data.Configuration;
+
+namespace Nocturne.API.Tests.Configuration;
+
+/// <summary>
+/// Guards the composition in <c>Program.cs</c> that assembles the PostgreSQL options. The pool is
+/// only built outside the Testing environment, but the options are resolved and registered either
+/// way, so a test host can observe what the host would have handed the registration.
+/// </summary>
+[Trait("Category", "Unit")]
+public class PostgreSqlOptionsCompositionTests
+{
+    private sealed class TunedPoolFactory : AuthenticationTestFactory
+    {
+        internal const int MaxPoolSize = 37;
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+
+            // Host configuration, not ConfigureAppConfiguration: the factory's app-configuration
+            // sources are applied at Build(), by which time the top-level statements that resolve
+            // these options have already read the configuration.
+            builder.UseSetting(
+                $"{PostgreSqlConfiguration.SectionName}:{nameof(PostgreSqlConfiguration.MaxPoolSize)}",
+                MaxPoolSize.ToString());
+        }
+    }
+
+    [Fact]
+    public void HostConfiguration_ReachesTheResolvedPostgreSqlOptions()
+    {
+        using var factory = new TunedPoolFactory();
+
+        var options = factory.Services.GetRequiredService<PostgreSqlConfiguration>();
+
+        options.MaxPoolSize.Should().Be(
+            TunedPoolFactory.MaxPoolSize,
+            "the host must resolve its database options from its own configuration");
+        options.EnableDetailedErrors.Should().BeFalse("Testing is not Development");
+        options.EnableSensitiveDataLogging.Should().BeFalse("Testing is not Development");
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgreSqlConfigurationResolveTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgreSqlConfigurationResolveTests.cs
@@ -1,58 +1,22 @@
-using Microsoft.Extensions.Configuration;
 using Nocturne.Infrastructure.Data.Configuration;
 
 namespace Nocturne.Infrastructure.Data.Tests.Configuration;
 
 /// <summary>
-/// Guards <see cref="PostgreSqlConfiguration.ResolveForEnvironment"/> — the assembly of the
-/// options the API's own PostgreSQL registration is given. The registration itself sits behind
-/// <c>if (!isTesting)</c> in <c>Program.cs</c> and every fixture forces the Testing environment,
-/// so nothing that boots the host can observe it; these drive the resolution directly instead.
+/// Guards <see cref="PostgreSqlConfiguration.ResolveForEnvironment"/>, the assembly of the options
+/// the API's own PostgreSQL registration is given. The registration itself sits behind
+/// <c>if (!isTesting)</c> in <c>Program.cs</c> and every fixture forces the Testing environment, so
+/// nothing that boots the host reaches it; these drive the resolution directly instead.
 /// </summary>
 [Trait("Category", "Unit")]
 public class PostgreSqlConfigurationResolveTests
 {
-    private const string ConnectionString = "Host=localhost;Database=nocturne;Username=nocturne_app;Password=pw";
-
-    private static IConfiguration SectionWith(params (string Key, string Value)[] settings) =>
-        new ConfigurationBuilder()
-            .AddInMemoryCollection(settings.ToDictionary(
-                s => $"{PostgreSqlConfiguration.SectionName}:{s.Key}",
-                s => (string?)s.Value))
-            .Build();
-
-    [Fact]
-    public void ConfiguredSection_ReachesEverySettingOnTheResolvedOptions()
-    {
-        var config = PostgreSqlConfiguration.ResolveForEnvironment(
-            ConnectionString,
-            SectionWith(
-                ("MaxPoolSize", "33"),
-                ("StatementTimeoutSeconds", "12"),
-                ("CommandTimeoutSeconds", "45"),
-                ("MaxRetryCount", "7"),
-                ("MaxRetryDelaySeconds", "90")),
-            isDevelopment: false);
-
-        config.MaxPoolSize.Should().Be(33);
-        config.StatementTimeoutSeconds.Should().Be(12);
-        config.CommandTimeoutSeconds.Should().Be(45);
-        config.MaxRetryCount.Should().Be(7);
-        config.MaxRetryDelaySeconds.Should().Be(90);
-        config.ConnectionString.Should().Be(ConnectionString);
-    }
-
-    /// <summary>
-    /// The regression the extracted resolution exists to catch: dropping the configuration — the
-    /// argument that was previously passed by a line no test could reach — has to change the
-    /// resolved options, or nothing observes it being passed at all.
-    /// </summary>
     [Fact]
     public void ConfiguredSection_ResolvesDifferentlyFromTheCompiledInDefaults()
     {
         var configured = PostgreSqlConfiguration.ResolveForEnvironment(
-            ConnectionString,
-            SectionWith(("MaxPoolSize", "33"), ("StatementTimeoutSeconds", "12")),
+            PostgreSqlSection.AppConnectionString,
+            PostgreSqlSection.With(("MaxPoolSize", "33"), ("StatementTimeoutSeconds", "12")),
             isDevelopment: false);
 
         var defaults = new PostgreSqlConfiguration();
@@ -61,21 +25,21 @@ public class PostgreSqlConfigurationResolveTests
         configured.StatementTimeoutSeconds.Should().NotBe(defaults.StatementTimeoutSeconds);
     }
 
+    /// <summary>
+    /// <c>PostgreSql:ConnectionString</c> is a real key that the design-time factory reads, so a
+    /// self-hoster running <c>dotnet ef</c> may have it pointed at the migrator role. The host's
+    /// own connection string has to survive the bind, or the runtime pool connects as that role.
+    /// </summary>
     [Fact]
-    public void EmptySection_KeepsTheDocumentedDefaults()
+    public void SuppliedConnectionString_SurvivesTheBind()
     {
         var config = PostgreSqlConfiguration.ResolveForEnvironment(
-            ConnectionString,
-            new ConfigurationBuilder().Build(),
+            PostgreSqlSection.AppConnectionString,
+            PostgreSqlSection.With(
+                ("ConnectionString", "Host=WRONGHOST;Database=nocturne;Username=nocturne_migrator;Password=pw")),
             isDevelopment: false);
 
-        var defaults = new PostgreSqlConfiguration();
-
-        config.MaxPoolSize.Should().Be(defaults.MaxPoolSize);
-        config.StatementTimeoutSeconds.Should().Be(defaults.StatementTimeoutSeconds);
-        config.CommandTimeoutSeconds.Should().Be(defaults.CommandTimeoutSeconds);
-        config.MaxRetryCount.Should().Be(defaults.MaxRetryCount);
-        config.MaxRetryDelaySeconds.Should().Be(defaults.MaxRetryDelaySeconds);
+        config.ConnectionString.Should().Be(PostgreSqlSection.AppConnectionString);
     }
 
     [Theory]
@@ -84,8 +48,8 @@ public class PostgreSqlConfigurationResolveTests
     public void EfDiagnostics_FollowTheEnvironment(bool isDevelopment)
     {
         var config = PostgreSqlConfiguration.ResolveForEnvironment(
-            ConnectionString,
-            new ConfigurationBuilder().Build(),
+            PostgreSqlSection.AppConnectionString,
+            PostgreSqlSection.With(),
             isDevelopment);
 
         config.EnableDetailedErrors.Should().Be(isDevelopment);
@@ -93,30 +57,20 @@ public class PostgreSqlConfigurationResolveTests
     }
 
     /// <summary>
-    /// Both flags put query parameters — patient data — into logs and exception text, so a
-    /// deployed appsettings or environment variable must not be able to turn them on outside
-    /// development.
+    /// Both flags put query parameters — patient data — into logs and exception text, so a deployed
+    /// appsettings or environment variable must not be able to turn them on outside development.
     /// </summary>
     [Fact]
     public void EfDiagnosticsInConfiguration_CannotOverrideTheEnvironment()
     {
         var config = PostgreSqlConfiguration.ResolveForEnvironment(
-            ConnectionString,
-            SectionWith(
+            PostgreSqlSection.AppConnectionString,
+            PostgreSqlSection.With(
                 ("EnableSensitiveDataLogging", "true"),
                 ("EnableDetailedErrors", "true")),
             isDevelopment: false);
 
         config.EnableSensitiveDataLogging.Should().BeFalse();
         config.EnableDetailedErrors.Should().BeFalse();
-    }
-
-    [Fact]
-    public void MissingConfiguration_FailsRatherThanFallingBackToDefaults()
-    {
-        var resolve = () => PostgreSqlConfiguration.ResolveForEnvironment(
-            ConnectionString, configuration: null!, isDevelopment: false);
-
-        resolve.Should().Throw<ArgumentNullException>();
     }
 }

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgreSqlConfigurationResolveTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgreSqlConfigurationResolveTests.cs
@@ -1,0 +1,122 @@
+using Microsoft.Extensions.Configuration;
+using Nocturne.Infrastructure.Data.Configuration;
+
+namespace Nocturne.Infrastructure.Data.Tests.Configuration;
+
+/// <summary>
+/// Guards <see cref="PostgreSqlConfiguration.ResolveForEnvironment"/> — the assembly of the
+/// options the API's own PostgreSQL registration is given. The registration itself sits behind
+/// <c>if (!isTesting)</c> in <c>Program.cs</c> and every fixture forces the Testing environment,
+/// so nothing that boots the host can observe it; these drive the resolution directly instead.
+/// </summary>
+[Trait("Category", "Unit")]
+public class PostgreSqlConfigurationResolveTests
+{
+    private const string ConnectionString = "Host=localhost;Database=nocturne;Username=nocturne_app;Password=pw";
+
+    private static IConfiguration SectionWith(params (string Key, string Value)[] settings) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.ToDictionary(
+                s => $"{PostgreSqlConfiguration.SectionName}:{s.Key}",
+                s => (string?)s.Value))
+            .Build();
+
+    [Fact]
+    public void ConfiguredSection_ReachesEverySettingOnTheResolvedOptions()
+    {
+        var config = PostgreSqlConfiguration.ResolveForEnvironment(
+            ConnectionString,
+            SectionWith(
+                ("MaxPoolSize", "33"),
+                ("StatementTimeoutSeconds", "12"),
+                ("CommandTimeoutSeconds", "45"),
+                ("MaxRetryCount", "7"),
+                ("MaxRetryDelaySeconds", "90")),
+            isDevelopment: false);
+
+        config.MaxPoolSize.Should().Be(33);
+        config.StatementTimeoutSeconds.Should().Be(12);
+        config.CommandTimeoutSeconds.Should().Be(45);
+        config.MaxRetryCount.Should().Be(7);
+        config.MaxRetryDelaySeconds.Should().Be(90);
+        config.ConnectionString.Should().Be(ConnectionString);
+    }
+
+    /// <summary>
+    /// The regression the extracted resolution exists to catch: dropping the configuration — the
+    /// argument that was previously passed by a line no test could reach — has to change the
+    /// resolved options, or nothing observes it being passed at all.
+    /// </summary>
+    [Fact]
+    public void ConfiguredSection_ResolvesDifferentlyFromTheCompiledInDefaults()
+    {
+        var configured = PostgreSqlConfiguration.ResolveForEnvironment(
+            ConnectionString,
+            SectionWith(("MaxPoolSize", "33"), ("StatementTimeoutSeconds", "12")),
+            isDevelopment: false);
+
+        var defaults = new PostgreSqlConfiguration();
+
+        configured.MaxPoolSize.Should().NotBe(defaults.MaxPoolSize);
+        configured.StatementTimeoutSeconds.Should().NotBe(defaults.StatementTimeoutSeconds);
+    }
+
+    [Fact]
+    public void EmptySection_KeepsTheDocumentedDefaults()
+    {
+        var config = PostgreSqlConfiguration.ResolveForEnvironment(
+            ConnectionString,
+            new ConfigurationBuilder().Build(),
+            isDevelopment: false);
+
+        var defaults = new PostgreSqlConfiguration();
+
+        config.MaxPoolSize.Should().Be(defaults.MaxPoolSize);
+        config.StatementTimeoutSeconds.Should().Be(defaults.StatementTimeoutSeconds);
+        config.CommandTimeoutSeconds.Should().Be(defaults.CommandTimeoutSeconds);
+        config.MaxRetryCount.Should().Be(defaults.MaxRetryCount);
+        config.MaxRetryDelaySeconds.Should().Be(defaults.MaxRetryDelaySeconds);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EfDiagnostics_FollowTheEnvironment(bool isDevelopment)
+    {
+        var config = PostgreSqlConfiguration.ResolveForEnvironment(
+            ConnectionString,
+            new ConfigurationBuilder().Build(),
+            isDevelopment);
+
+        config.EnableDetailedErrors.Should().Be(isDevelopment);
+        config.EnableSensitiveDataLogging.Should().Be(isDevelopment);
+    }
+
+    /// <summary>
+    /// Both flags put query parameters — patient data — into logs and exception text, so a
+    /// deployed appsettings or environment variable must not be able to turn them on outside
+    /// development.
+    /// </summary>
+    [Fact]
+    public void EfDiagnosticsInConfiguration_CannotOverrideTheEnvironment()
+    {
+        var config = PostgreSqlConfiguration.ResolveForEnvironment(
+            ConnectionString,
+            SectionWith(
+                ("EnableSensitiveDataLogging", "true"),
+                ("EnableDetailedErrors", "true")),
+            isDevelopment: false);
+
+        config.EnableSensitiveDataLogging.Should().BeFalse();
+        config.EnableDetailedErrors.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MissingConfiguration_FailsRatherThanFallingBackToDefaults()
+    {
+        var resolve = () => PostgreSqlConfiguration.ResolveForEnvironment(
+            ConnectionString, configuration: null!, isDevelopment: false);
+
+        resolve.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgreSqlSection.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgreSqlSection.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Configuration;
+using Nocturne.Infrastructure.Data.Configuration;
+
+namespace Nocturne.Infrastructure.Data.Tests.Configuration;
+
+/// <summary>
+/// Builds the configuration inputs the PostgreSQL resolution and registration take: a connection
+/// string standing in for the one the host resolved, and a configuration carrying nothing but the
+/// <see cref="PostgreSqlConfiguration.SectionName"/> section.
+/// </summary>
+internal static class PostgreSqlSection
+{
+    internal const string AppConnectionString =
+        "Host=localhost;Database=nocturne;Username=nocturne_app;Password=pw";
+
+    internal static IConfiguration With(params (string Key, string Value)[] settings) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.ToDictionary(
+                s => $"{PostgreSqlConfiguration.SectionName}:{s.Key}",
+                s => (string?)s.Value))
+            .Build();
+}

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgresRuntimeOptionsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Configuration/PostgresRuntimeOptionsTests.cs
@@ -15,15 +15,6 @@ namespace Nocturne.Infrastructure.Data.Tests.Configuration;
 [Trait("Category", "Unit")]
 public class PostgresRuntimeOptionsTests
 {
-    private const string ConnectionString = "Host=localhost;Database=nocturne;Username=nocturne_app;Password=pw";
-
-    private static IConfiguration SectionWith(params (string Key, string Value)[] settings) =>
-        new ConfigurationBuilder()
-            .AddInMemoryCollection(settings.ToDictionary(
-                s => $"{PostgreSqlConfiguration.SectionName}:{s.Key}",
-                s => (string?)s.Value))
-            .Build();
-
     /// <summary>
     /// Reads the pool the registration actually built. The data source is registered as a
     /// singleton instance, so this needs no provider and touches nothing else in the graph.
@@ -33,7 +24,7 @@ public class PostgresRuntimeOptionsTests
         Action<PostgreSqlConfiguration>? configure = null)
     {
         var services = new ServiceCollection();
-        services.AddPostgreSqlInfrastructure(ConnectionString, configuration, configure);
+        services.AddPostgreSqlInfrastructure(PostgreSqlSection.AppConnectionString, configuration, configure);
 
         var dataSource = (NpgsqlDataSource)services
             .Single(d => d.ServiceType == typeof(NpgsqlDataSource))
@@ -53,7 +44,7 @@ public class PostgresRuntimeOptionsTests
     [Fact]
     public void ConfigurationSection_ReachesTheRuntimePool()
     {
-        RegisteredPool(SectionWith(("MaxPoolSize", "33"))).MaxPoolSize.Should().Be(
+        RegisteredPool(PostgreSqlSection.With(("MaxPoolSize", "33"))).MaxPoolSize.Should().Be(
             33,
             "an operator must be able to retune the pool without a code change and redeploy");
     }
@@ -61,7 +52,7 @@ public class PostgresRuntimeOptionsTests
     [Fact]
     public void ConfigurationSection_ReachesTheStatementTimeout()
     {
-        RegisteredPool(SectionWith(("StatementTimeoutSeconds", "12"))).Options.Should().Contain(
+        RegisteredPool(PostgreSqlSection.With(("StatementTimeoutSeconds", "12"))).Options.Should().Contain(
             "statement_timeout=12000",
             "the server-side cap must be settable from configuration too");
     }
@@ -76,7 +67,7 @@ public class PostgresRuntimeOptionsTests
     public void ConfigureActionClearingTheConnectionString_StillFails()
     {
         var register = () => RegisteredPool(
-            SectionWith(("MaxPoolSize", "33")),
+            PostgreSqlSection.With(("MaxPoolSize", "33")),
             config => config.ConnectionString = string.Empty);
 
         register.Should().Throw<InvalidOperationException>()
@@ -87,7 +78,7 @@ public class PostgresRuntimeOptionsTests
     public void ConfigureAction_WinsOverTheSection()
     {
         var pool = RegisteredPool(
-            SectionWith(("MaxPoolSize", "33")),
+            PostgreSqlSection.With(("MaxPoolSize", "33")),
             config => config.MaxPoolSize = 44);
 
         pool.MaxPoolSize.Should().Be(
@@ -117,7 +108,7 @@ public class PostgresRuntimeOptionsTests
     [Fact]
     public void SectionConnectionString_DoesNotDisplaceTheSuppliedOne()
     {
-        var pool = RegisteredPool(SectionWith(
+        var pool = RegisteredPool(PostgreSqlSection.With(
             ("MaxPoolSize", "33"),
             ("ConnectionString", "Host=WRONGHOST;Database=nocturne;Username=nocturne_migrator;Password=pw")));
 
@@ -135,7 +126,7 @@ public class PostgresRuntimeOptionsTests
     [Fact]
     public void MalformedValue_FailsAtStartup()
     {
-        var register = () => RegisteredPool(SectionWith(("MaxPoolSize", "not-a-number")));
+        var register = () => RegisteredPool(PostgreSqlSection.With(("MaxPoolSize", "not-a-number")));
 
         register.Should().Throw<InvalidOperationException>();
     }
@@ -150,7 +141,7 @@ public class PostgresRuntimeOptionsTests
     [Fact]
     public void StatementTimeoutThatWouldWrapIntoAValidValue_KeepsItsMagnitude()
     {
-        RegisteredPool(SectionWith(("StatementTimeoutSeconds", "5000000"))).Options
+        RegisteredPool(PostgreSqlSection.With(("StatementTimeoutSeconds", "5000000"))).Options
             .Should().Contain("statement_timeout=5000000000")
             .And.NotContain("statement_timeout=705032704");
     }


### PR DESCRIPTION
Fixes #1155.

## Problem

`Program.cs` assembled the API's Postgres options (section binding, pool size, timeouts, retry, environment-derived EF diagnostics) inside `if (!isTesting)`, and every test fixture forces `Testing`, so no test could reach it. A `null` configuration argument compiled and silently ran on compiled-in defaults. Separately, `ServiceCollectionExtensions` carried two near-verbatim copies of the whole registration body.

## Change

- `PostgreSqlConfiguration.Resolve(connectionString, configuration, configure)` holds the binding body (defaults, section bound over them, caller's connection string restored, configure applied). `ResolveForEnvironment(connectionString, configuration, isDevelopment)` adds the two EF diagnostics; `configuration` is non-nullable there, so the `null` hole is closed on the API path.
- `Program.cs` resolves the options unconditionally, registers the instance as a singleton in every environment, and passes it to the DI-heavy `AddPostgreSqlInfrastructure(options)` only outside Testing. The empty-connection-string check moved into that core, where the pool is built, so a real host with an empty connection string still aborts startup at the same point with the same message.
- `ServiceCollectionExtensions`: one core registration body. The `(IConfiguration)` overload and its 110-line duplicate are deleted (its only caller, `V4GoldenFixture`, now uses the string overload). The dead `services.Configure<PostgreSqlConfiguration>` hand copy is deleted; nothing consumed `IOptions<PostgreSqlConfiguration>`.

Behaviour is unchanged on every production path: the old bodies were diffed line by line against the new core and `Resolve`, and the pre-existing `PostgresRuntimeOptionsTests` (which drive the real registration into the `NpgsqlDataSource`) pass unmodified. Net −86 production lines.

## Tests

- `PostgreSqlOptionsCompositionTests.HostConfiguration_ReachesTheResolvedPostgreSqlOptions` (Unit API, via `UseSetting`, because a factory's `ConfigureAppConfiguration` is applied after top-level statements have read the builder): boots the host with `PostgreSql:MaxPoolSize=37` and asserts the registered options carry it with diagnostics off. Replacing the call site with `Resolve(conn, null)` fails it.
- `PostgreSqlConfigurationResolveTests`: EF diagnostics follow the environment; configuration cannot override them; the supplied connection string survives the bind (swapping bind and restore fails it).
- Shared `PostgreSqlSection` helper replaces duplicated fixture code in `PostgresRuntimeOptionsTests`.

Infrastructure.Data unit tests 941/0; Unit `Nocturne.API.Tests` 6441/0/5 skipped; the integration Data test project builds. Two hostile review rounds; mutation-checked as above plus wrong section name and pinned diagnostics.
