### PR TITLE
feat(v4): one bulk create on the CRUD base, and hooks instead of copy-pasted overrides

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Base/V4BulkValidation.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4BulkValidation.cs
@@ -5,6 +5,16 @@ using Nocturne.API.Models.Requests.V4;
 namespace Nocturne.API.Controllers.V4.Base;
 
 /// <summary>
+/// How a bulk endpoint names what it takes, in the three places a rejection message needs it:
+/// <c>"Bolus data is required"</c>, <c>"limited to 1000 boluses per request"</c>,
+/// <c>"Timestamp must be set on every bolus"</c>.
+/// </summary>
+/// <param name="Subject">The payload's name, capitalised as it opens a sentence ("Bolus").</param>
+/// <param name="Singular">One item ("bolus").</param>
+/// <param name="Plural">Many items ("boluses").</param>
+public readonly record struct V4BulkNaming(string Subject, string Singular, string Plural);
+
+/// <summary>
 /// The checks a V4 bulk create-or-update endpoint runs over its payload before it maps or
 /// persists anything.
 /// </summary>

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4BulkValidation.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4BulkValidation.cs
@@ -9,9 +9,6 @@ namespace Nocturne.API.Controllers.V4.Base;
 /// <c>"Bolus data is required"</c>, <c>"limited to 1000 boluses per request"</c>,
 /// <c>"Timestamp must be set on every bolus"</c>.
 /// </summary>
-/// <param name="Subject">The payload's name, capitalised as it opens a sentence ("Bolus").</param>
-/// <param name="Singular">One item ("bolus").</param>
-/// <param name="Plural">Many items ("boluses").</param>
 public readonly record struct V4BulkNaming(string Subject, string Singular, string Plural);
 
 /// <summary>
@@ -72,7 +69,7 @@ public static class V4BulkValidation
     /// <returns>The error response to return, or <c>null</c> when the payload is usable.</returns>
     public static async Task<ObjectResult?> ValidateBulkAsync<TRequest>(
         this ControllerBase controller,
-        TRequest[]? requests,
+        IReadOnlyList<TRequest>? requests,
         string subject,
         string singular,
         string plural,
@@ -93,7 +90,7 @@ public static class V4BulkValidation
         if (controller.HttpContext?.RequestServices?.GetService(typeof(IValidator<TRequest>)) is not IValidator<TRequest> validator)
             return null;
 
-        for (var index = 0; index < items.Length; index++)
+        for (var index = 0; index < items.Count; index++)
         {
             var result = await validator.ValidateAsync(items[index], ct);
             if (result.IsValid)

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -99,9 +99,11 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// <param name="requests">The records to write, at most <see cref="V4BulkValidation.MaxItems"/> of them.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <remarks>
-    /// Array semantics are per-item, not all-or-nothing: on the record types whose repository upserts
-    /// on the sync key, an item carrying both `dataSource` and `syncIdentifier` updates the row already
-    /// matched by that pair; every other item inserts.
+    /// Array semantics are per-item, not all-or-nothing. A record type whose repository derives from
+    /// <c>SyncUpsertRepositoryBase</c> — sensor glucose, meter readings, boluses, carb intakes, basal
+    /// injections and the device-status snapshots — updates in place the row already matched by an
+    /// item's (`dataSource`, `syncIdentifier`) pair; every other type, and every item not carrying both
+    /// halves of that pair, inserts.
     ///
     /// The payload is validated as a whole — an empty body, more than the cap, an item with an unset
     /// `timestamp`, an item supplying `syncIdentifier` without `dataSource`, or an item any registered
@@ -115,13 +117,13 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public virtual async Task<ActionResult<TModel[]>> CreateBulk(
-        [FromBody] TCreateRequest[] requests, CancellationToken ct = default)
+        [FromBody] IReadOnlyList<TCreateRequest> requests, CancellationToken ct = default)
     {
         var naming = BulkNaming;
         if (await this.ValidateBulkAsync(requests, naming.Subject, naming.Singular, naming.Plural, ct) is { } invalid)
             return invalid;
 
-        var models = new List<TModel>(requests.Length);
+        var models = new List<TModel>(requests.Count);
         foreach (var request in requests)
             models.Add(MapCreateToModel(request));
 
@@ -299,6 +301,12 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// Hook called once a bulk payload has mapped and before it persists. Override to enrich or
     /// attribute the batch in one pass, mutating <paramref name="models"/> in place.
     /// </summary>
+    /// <remarks>
+    /// An override that needs the same work <see cref="OnBeforeCreateAsync"/> does per item should
+    /// call it in a loop rather than keep a second copy — unless the work has a batch form, as device
+    /// attribution does in <see cref="Services.Devices.PatientDeviceAttribution.ApplyManyAsync"/>,
+    /// where one pass for the payload is the point of the endpoint.
+    /// </remarks>
     /// <param name="models">The mapped records, positionally aligned with <paramref name="requests"/>.</param>
     /// <param name="requests">The inbound requests, for the fields the domain model does not carry.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -96,14 +96,14 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     }
 
     /// <summary>Creates or updates many records in one request, and returns them.</summary>
-    /// <param name="requests">The records to write, at most <see cref="V4BulkValidation.MaxItems"/> of them.</param>
+    /// <param name="requests">The records to write, at most 1000 of them.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <remarks>
-    /// Array semantics are per-item, not all-or-nothing. A record type whose repository derives from
-    /// <c>SyncUpsertRepositoryBase</c> — sensor glucose, meter readings, boluses, carb intakes, basal
-    /// injections and the device-status snapshots — updates in place the row already matched by an
-    /// item's (`dataSource`, `syncIdentifier`) pair; every other type, and every item not carrying both
-    /// halves of that pair, inserts.
+    /// Array semantics are per-item, not all-or-nothing. Of the types reachable here, boluses, basal
+    /// injections and sensor glucose upsert on the sync key: an item carrying both `dataSource` and
+    /// `syncIdentifier` updates in place the row already matched by that pair. Every other type —
+    /// notes, device events, BG checks, calibrations, meter readings and bolus calculations — inserts,
+    /// as does any item not carrying both halves of the pair.
     ///
     /// The payload is validated as a whole — an empty body, more than the cap, an item with an unset
     /// `timestamp`, an item supplying `syncIdentifier` without `dataSource`, or an item any registered

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using OpenApi.Remote.Attributes;
 using Nocturne.API.Attributes;
+using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
@@ -32,9 +33,9 @@ namespace Nocturne.API.Controllers.V4.Base;
 public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateRequest, TRepository>(TRepository repository)
     : V4ReadOnlyControllerBase<TModel, TRepository>(repository), IWriteScopedController
     where TModel : class, IV4Record
-    where TCreateRequest : class
+    where TCreateRequest : class, IBulkUpsertRequest
     where TUpdateRequest : class
-    where TRepository : IV4Repository<TModel>
+    where TRepository : IV4Repository<TModel>, IBulkCreateRepository<TModel>
 {
     /// <summary>
     /// The OAuth readwrite scope for this controller's data category (see <see cref="Scope"/>),
@@ -43,6 +44,11 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// (guest links, follower and public-share grants), which must not be able to write.
     /// </summary>
     public abstract string WriteScope { get; }
+
+    /// <summary>
+    /// How <see cref="CreateBulk"/> names this controller's records when it rejects a payload.
+    /// </summary>
+    protected abstract V4BulkNaming BulkNaming { get; }
 
     /// <summary>
     /// Maps a create request DTO to the domain model.
@@ -84,6 +90,43 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+    }
+
+    /// <summary>Creates or updates many records in one request, and returns them.</summary>
+    /// <param name="requests">The records to write, at most <see cref="V4BulkValidation.MaxItems"/> of them.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <remarks>
+    /// Array semantics are per-item, not all-or-nothing: on the record types whose repository upserts
+    /// on the sync key, an item carrying both `dataSource` and `syncIdentifier` updates the row already
+    /// matched by that pair; every other item inserts.
+    ///
+    /// The payload is validated as a whole — an empty body, more than the cap, an item with an unset
+    /// `timestamp`, an item supplying `syncIdentifier` without `dataSource`, or an item any registered
+    /// validator rejects, all fail the request with `400 Bad Request` before anything is persisted.
+    ///
+    /// On success, responds with `201 Created` and the written records.
+    /// </remarks>
+    [HttpPost("bulk")]
+    [RequireDeclaredWriteScope]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public virtual async Task<ActionResult<TModel[]>> CreateBulk(
+        [FromBody] TCreateRequest[] requests, CancellationToken ct = default)
+    {
+        var naming = BulkNaming;
+        if (await this.ValidateBulkAsync(requests, naming.Subject, naming.Singular, naming.Plural, ct) is { } invalid)
+            return invalid;
+
+        var models = new List<TModel>(requests.Length);
+        foreach (var request in requests)
+            models.Add(MapCreateToModel(request));
+
+        if (await OnBeforeBulkCreateAsync(models, requests, ct) is { } error)
+            return error;
+
+        var written = (await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct)).ToArray();
+        return StatusCode(StatusCodes.Status201Created, await OnAfterBulkCreateAsync(written, ct));
     }
 
     /// <summary>Updates an existing record by ID and returns the updated record.</summary>
@@ -222,6 +265,34 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The record, potentially enriched by the hook.</returns>
     protected virtual Task<TModel> OnAfterCreateAsync(TModel created, CancellationToken ct) => Task.FromResult(created);
+
+    /// <summary>
+    /// Hook called once a bulk payload has mapped and before it persists. Override to enrich or
+    /// attribute the batch in one pass, mutating <paramref name="models"/> in place.
+    /// </summary>
+    /// <param name="models">The mapped records, positionally aligned with <paramref name="requests"/>.</param>
+    /// <param name="requests">The inbound requests, for the fields the domain model does not carry.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A problem result rejecting the whole request, or <c>null</c> to persist.</returns>
+    protected virtual Task<ObjectResult?> OnBeforeBulkCreateAsync(
+        IReadOnlyList<TModel> models, IReadOnlyList<TCreateRequest> requests, CancellationToken ct)
+        => Task.FromResult<ObjectResult?>(null);
+
+    /// <summary>
+    /// Hook called after a bulk create. Runs <see cref="OnAfterCreateAsync"/> once per written record,
+    /// so a per-record side effect fires exactly as often as it would through <see cref="Create"/>.
+    /// Override where the effect is batch-wide rather than per-record.
+    /// </summary>
+    /// <param name="written">The records as persisted.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The records, potentially enriched by the hook.</returns>
+    protected virtual async Task<TModel[]> OnAfterBulkCreateAsync(TModel[] written, CancellationToken ct)
+    {
+        for (var i = 0; i < written.Length; i++)
+            written[i] = await OnAfterCreateAsync(written[i], ct);
+
+        return written;
+    }
 
     /// <summary>
     /// Hook called after a record is restored. Override to add post-restore side effects

--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -87,6 +87,9 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
+        if (await OnBeforeCreateAsync(model, request, ct) is { } error)
+            return error;
+
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
@@ -155,6 +158,9 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
 
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
+
+        if (await OnBeforeUpdateAsync(model, request, existing, ct) is { } error)
+            return error;
 
         try
         {
@@ -265,6 +271,29 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The record, potentially enriched by the hook.</returns>
     protected virtual Task<TModel> OnAfterCreateAsync(TModel created, CancellationToken ct) => Task.FromResult(created);
+
+    /// <summary>
+    /// Hook called once a create request has mapped and cleared the timestamp guard, and before it
+    /// persists. Override to enrich or attribute the record, mutating <paramref name="model"/> in place.
+    /// </summary>
+    /// <param name="model">The mapped record.</param>
+    /// <param name="request">The inbound request, for the fields the domain model does not carry.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A problem result rejecting the request, or <c>null</c> to persist.</returns>
+    protected virtual Task<ObjectResult?> OnBeforeCreateAsync(TModel model, TCreateRequest request, CancellationToken ct)
+        => Task.FromResult<ObjectResult?>(null);
+
+    /// <summary>
+    /// Hook called once an update request has mapped and cleared the timestamp guard, and before it
+    /// persists. Override to enrich or attribute the record, mutating <paramref name="model"/> in place.
+    /// </summary>
+    /// <param name="model">The mapped record.</param>
+    /// <param name="request">The inbound request, for the fields the domain model does not carry.</param>
+    /// <param name="existing">The stored record this update replaces.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A problem result rejecting the request, or <c>null</c> to persist.</returns>
+    protected virtual Task<ObjectResult?> OnBeforeUpdateAsync(TModel model, TUpdateRequest request, TModel existing, CancellationToken ct)
+        => Task.FromResult<ObjectResult?>(null);
 
     /// <summary>
     /// Hook called once a bulk payload has mapped and before it persists. Override to enrich or

--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
@@ -85,47 +85,19 @@ public class DeviceEventController(
         return Ok(new PaginatedResponse<DeviceEvent> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });
     }
 
-    public override async Task<ActionResult<DeviceEvent>> Create([FromBody] UpsertDeviceEventRequest request, CancellationToken ct = default)
-    {
-        var model = MapCreateToModel(request);
+    /// <inheritdoc/>
+    /// <remarks>
+    /// V4 REST writes bypass the connector/decomposer ingest paths, so attribution happens here —
+    /// otherwise direct API records stay unstamped.
+    /// </remarks>
+    protected override Task<ObjectResult?> OnBeforeCreateAsync(
+        DeviceEvent model, UpsertDeviceEventRequest request, CancellationToken ct)
+        => ApplyAttributionAsync(model, request, existing: null, ct);
 
-        if (model.Timestamp == default)
-            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-
-        // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
-        // direct API records stay unstamped.
-        if (await ApplyAttributionAsync(model, request, existing: null, ct) is { } error)
-            return error;
-
-        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
-        created = await OnAfterCreateAsync(created, ct);
-        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
-    }
-
-    public override async Task<ActionResult<DeviceEvent>> Update(Guid id, [FromBody] UpsertDeviceEventRequest request, CancellationToken ct = default)
-    {
-        var existing = await Repository.GetByIdAsync(id, ct);
-        if (existing is null)
-            return NotFound();
-
-        var model = MapUpdateToModel(id, request, existing);
-
-        if (model.Timestamp == default)
-            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-
-        if (await ApplyAttributionAsync(model, request, existing.PatientDeviceId, ct) is { } error)
-            return error;
-
-        try
-        {
-            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
-            return Ok(updated);
-        }
-        catch (KeyNotFoundException)
-        {
-            return NotFound();
-        }
-    }
+    /// <inheritdoc/>
+    protected override Task<ObjectResult?> OnBeforeUpdateAsync(
+        DeviceEvent model, UpsertDeviceEventRequest request, DeviceEvent existing, CancellationToken ct)
+        => ApplyAttributionAsync(model, request, existing.PatientDeviceId, ct);
 
     protected override DeviceEvent MapCreateToModel(UpsertDeviceEventRequest request) => new()
     {
@@ -161,15 +133,15 @@ public class DeviceEventController(
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Attributed one at a time rather than in a single stamper pass: the device categories a device
-    /// event can be attributed to are derived from its own event type, so a batch has no one category
-    /// list to share.
+    /// One item at a time rather than a single stamper pass: the device categories a device event can
+    /// be attributed to are derived from its own event type, so a batch has no one category list to
+    /// share.
     /// </remarks>
     protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
         IReadOnlyList<DeviceEvent> models, IReadOnlyList<UpsertDeviceEventRequest> requests, CancellationToken ct)
     {
         for (var i = 0; i < models.Count; i++)
-            if (await ApplyAttributionAsync(models[i], requests[i], existing: null, ct) is { } error)
+            if (await OnBeforeCreateAsync(models[i], requests[i], ct) is { } error)
                 return error;
 
         return null;

--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
@@ -133,16 +133,29 @@ public class DeviceEventController(
 
     /// <inheritdoc/>
     /// <remarks>
-    /// One item at a time rather than a single stamper pass: the device categories a device event can
-    /// be attributed to are derived from its own event type, so a batch has no one category list to
-    /// share.
+    /// One stamper pass per distinct category list rather than one for the payload: the categories a
+    /// device event can be attributed to are derived from its own event type. There is no batch-level
+    /// source for the same reason as the other bulk writers — per-record DataSource drives matching.
     /// </remarks>
     protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
         IReadOnlyList<DeviceEvent> models, IReadOnlyList<UpsertDeviceEventRequest> requests, CancellationToken ct)
     {
-        for (var i = 0; i < models.Count; i++)
-            if (await OnBeforeCreateAsync(models[i], requests[i], ct) is { } error)
-                return error;
+        // DeviceAttributionCategories.DeviceEvent hands back one of two cached lists, so this is two
+        // passes however long the payload is; were it ever to allocate per call, the grouping would
+        // degrade to one pass per item rather than becoming wrong.
+        var byCategories = models
+            .Select((model, i) => (Model: model, requests[i].PatientDeviceId))
+            .GroupBy(item => DeviceAttributionCategories.DeviceEvent(item.Model.EventType));
+
+        foreach (var group in byCategories)
+        {
+            var error = await PatientDeviceAttribution.ApplyManyAsync(
+                [.. group.Select(item => ((IDeviceAttributed)item.Model, item.PatientDeviceId))],
+                patientDevices, deviceStamper, group.Key, batchSource: null, ct);
+
+            if (error is not null)
+                return Problem(detail: error, statusCode: 400, title: "Bad Request");
+        }
 
         return null;
     }

--- a/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Devices/DeviceEventController.cs
@@ -52,6 +52,9 @@ public class DeviceEventController(
     /// </remarks>
     public override string WriteScope => Scope.DevicesReadWrite;
 
+    /// <inheritdoc/>
+    protected override V4BulkNaming BulkNaming => new("Device event", "event", "events");
+
     /// <summary>
     /// Lists device events. Adds an optional <c>patientDeviceId</c> query filter on top of the base list
     /// surface: when set, only events linked to that registered device are returned. Pagination totals
@@ -155,6 +158,22 @@ public class DeviceEventController(
         SyncIdentifier = existing.SyncIdentifier,
         AdditionalProperties = existing.AdditionalProperties,
     };
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Attributed one at a time rather than in a single stamper pass: the device categories a device
+    /// event can be attributed to are derived from its own event type, so a batch has no one category
+    /// list to share.
+    /// </remarks>
+    protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
+        IReadOnlyList<DeviceEvent> models, IReadOnlyList<UpsertDeviceEventRequest> requests, CancellationToken ct)
+    {
+        for (var i = 0; i < models.Count; i++)
+            if (await ApplyAttributionAsync(models[i], requests[i], existing: null, ct) is { } error)
+                return error;
+
+        return null;
+    }
 
     /// <summary>
     /// Settles the event's device attribution from the request. Returns a 400 result when an explicit

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/BGCheckController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/BGCheckController.cs
@@ -39,6 +39,9 @@ public class BGCheckController(IBGCheckRepository repo)
     /// </remarks>
     public override string WriteScope => Scope.GlucoseReadWrite;
 
+    /// <inheritdoc/>
+    protected override V4BulkNaming BulkNaming => new("BG check", "check", "checks");
+
     /// <summary>
     /// Maps a <see cref="UpsertBGCheckRequest"/> to a new <see cref="BGCheck"/> domain model for creation.
     /// </summary>

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/CalibrationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/CalibrationController.cs
@@ -34,6 +34,9 @@ public class CalibrationController(ICalibrationRepository repo)
     public override string WriteScope => Scope.GlucoseReadWrite;
 
     /// <inheritdoc/>
+    protected override V4BulkNaming BulkNaming => new("Calibration", "calibration", "calibrations");
+
+    /// <inheritdoc/>
     /// <remarks>
     /// Never cached, per <see cref="Profiles.ProfileController.GetProfileSummary"/>: a calibration the
     /// patient just entered must not be invisible until a cached list body expires.

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
@@ -41,6 +41,9 @@ public class MeterGlucoseController(
     public override string WriteScope => Scope.GlucoseReadWrite;
 
     /// <inheritdoc/>
+    protected override V4BulkNaming BulkNaming => new("Meter glucose", "reading", "readings");
+
+    /// <inheritdoc/>
     /// <remarks>
     /// Never cached, per <see cref="Profiles.ProfileController.GetProfileSummary"/>: a fingerstick the
     /// patient just entered must not be invisible until a cached list body expires.
@@ -136,6 +139,19 @@ public class MeterGlucoseController(
         CreatedAt = existing.CreatedAt,
         AdditionalProperties = existing.AdditionalProperties,
     };
+
+    /// <inheritdoc/>
+    protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
+        IReadOnlyList<MeterGlucose> models, IReadOnlyList<UpsertMeterGlucoseRequest> requests, CancellationToken ct)
+    {
+        // Per-record DataSource drives matching, so no batch-level source is needed for a
+        // mixed-source bulk upload.
+        var error = await PatientDeviceAttribution.ApplyManyAsync(
+            [.. models.Select((m, i) => ((IDeviceAttributed)m, requests[i].PatientDeviceId))],
+            patientDevices, deviceStamper, DeviceAttributionCategories.MeterGlucose, batchSource: null, ct);
+
+        return error is null ? null : Problem(detail: error, statusCode: 400, title: "Bad Request");
+    }
 
     /// <summary>
     /// Settles the reading's device attribution from the request. Returns a 400 result when an explicit

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
@@ -111,11 +111,6 @@ public class MeterGlucoseController(
     };
 
     /// <inheritdoc/>
-    /// <remarks>
-    /// The batch form rather than a loop over <see cref="OnBeforeCreateAsync"/>: one stamper pass
-    /// resolves the whole payload, and per-record DataSource drives matching, so no batch-level
-    /// source is needed for a mixed-source upload.
-    /// </remarks>
     protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
         IReadOnlyList<MeterGlucose> models, IReadOnlyList<UpsertMeterGlucoseRequest> requests, CancellationToken ct)
     {

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/MeterGlucoseController.cs
@@ -58,48 +58,18 @@ public class MeterGlucoseController(
         => base.GetAll(from, to, limit, offset, sort, device, source, ct);
 
     /// <inheritdoc/>
-    public override async Task<ActionResult<MeterGlucose>> Create([FromBody] UpsertMeterGlucoseRequest request, CancellationToken ct = default)
-    {
-        var model = MapCreateToModel(request);
-
-        if (model.Timestamp == default)
-            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-
-        // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
-        // direct API records stay unstamped and only ever surface as pseudo-devices.
-        if (await ApplyAttributionAsync(model, request, existing: null, ct) is { } error)
-            return error;
-
-        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
-        created = await OnAfterCreateAsync(created, ct);
-        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
-    }
+    /// <remarks>
+    /// V4 REST writes bypass the connector/decomposer ingest paths, so attribution happens here —
+    /// otherwise direct API records stay unstamped and only ever surface as pseudo-devices.
+    /// </remarks>
+    protected override Task<ObjectResult?> OnBeforeCreateAsync(
+        MeterGlucose model, UpsertMeterGlucoseRequest request, CancellationToken ct)
+        => ApplyAttributionAsync(model, request, existing: null, ct);
 
     /// <inheritdoc/>
-    public override async Task<ActionResult<MeterGlucose>> Update(Guid id, [FromBody] UpsertMeterGlucoseRequest request, CancellationToken ct = default)
-    {
-        var existing = await Repository.GetByIdAsync(id, ct);
-        if (existing is null)
-            return NotFound();
-
-        var model = MapUpdateToModel(id, request, existing);
-
-        if (model.Timestamp == default)
-            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-
-        if (await ApplyAttributionAsync(model, request, existing.PatientDeviceId, ct) is { } error)
-            return error;
-
-        try
-        {
-            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
-            return Ok(updated);
-        }
-        catch (KeyNotFoundException)
-        {
-            return NotFound();
-        }
-    }
+    protected override Task<ObjectResult?> OnBeforeUpdateAsync(
+        MeterGlucose model, UpsertMeterGlucoseRequest request, MeterGlucose existing, CancellationToken ct)
+        => ApplyAttributionAsync(model, request, existing.PatientDeviceId, ct);
 
     /// <summary>
     /// Maps a <see cref="UpsertMeterGlucoseRequest"/> to a new <see cref="MeterGlucose"/> domain model for creation.
@@ -141,11 +111,14 @@ public class MeterGlucoseController(
     };
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// The batch form rather than a loop over <see cref="OnBeforeCreateAsync"/>: one stamper pass
+    /// resolves the whole payload, and per-record DataSource drives matching, so no batch-level
+    /// source is needed for a mixed-source upload.
+    /// </remarks>
     protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
         IReadOnlyList<MeterGlucose> models, IReadOnlyList<UpsertMeterGlucoseRequest> requests, CancellationToken ct)
     {
-        // Per-record DataSource drives matching, so no batch-level source is needed for a
-        // mixed-source bulk upload.
         var error = await PatientDeviceAttribution.ApplyManyAsync(
             [.. models.Select((m, i) => ((IDeviceAttributed)m, requests[i].PatientDeviceId))],
             patientDevices, deviceStamper, DeviceAttributionCategories.MeterGlucose, batchSource: null, ct);

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -143,11 +143,6 @@ public class SensorGlucoseController(
     };
 
     /// <inheritdoc/>
-    /// <remarks>
-    /// Attribution is the batch form rather than a loop over <see cref="OnBeforeCreateAsync"/>: one
-    /// stamper pass resolves the whole payload, and per-record DataSource drives matching, so no
-    /// batch-level source is needed for a mixed-source upload.
-    /// </remarks>
     protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
         IReadOnlyList<SensorGlucose> models, IReadOnlyList<UpsertSensorGlucoseRequest> requests, CancellationToken ct)
     {

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -45,6 +45,9 @@ public class SensorGlucoseController(
     /// <remarks>CGM readings are glucose data; the legacy equivalent is a v1 entry.</remarks>
     public override string WriteScope => Scope.GlucoseReadWrite;
 
+    /// <inheritdoc/>
+    protected override V4BulkNaming BulkNaming => new("Sensor glucose", "reading", "readings");
+
     /// <summary>
     /// Lists sensor glucose readings. Adds an optional <c>patientDeviceId</c> query filter on top of the base
     /// list surface: when set, results are that registered device's raw readings (canonical stream selection is
@@ -166,42 +169,33 @@ public class SensorGlucoseController(
         }
     }
 
-    /// <summary>
-    /// Create multiple sensor glucose readings in bulk (max 1000).
-    /// </summary>
-    [HttpPost("bulk")]
-    [RequireDeclaredWriteScope]
-    [ProducesResponseType(typeof(SensorGlucose[]), StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    public async Task<ActionResult<SensorGlucose[]>> CreateSensorGlucoseBulk(
-        [FromBody] UpsertSensorGlucoseRequest[] requests,
-        CancellationToken ct = default)
+    /// <inheritdoc/>
+    protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
+        IReadOnlyList<SensorGlucose> models, IReadOnlyList<UpsertSensorGlucoseRequest> requests, CancellationToken ct)
     {
-        if (await this.ValidateBulkAsync(requests, "Sensor glucose", "reading", "readings", ct) is { } invalid)
-            return invalid;
-
-        var models = requests.Select(MapCreateToModel).ToList();
-
         for (var i = 0; i < models.Count; i++)
             await glucoseResolver.ResolveAsync(models[i], requests[i].GlucoseProcessing, requests[i].SmoothedMgdl, requests[i].UnsmoothedMgdl, ct);
 
-        // Attribute the batch before persisting (see Create). Per-record DataSource drives matching,
-        // so no batch-level source is needed for a mixed-source bulk upload.
-        var attributionError = await PatientDeviceAttribution.ApplyManyAsync(
+        // Per-record DataSource drives matching, so no batch-level source is needed for a
+        // mixed-source bulk upload.
+        var error = await PatientDeviceAttribution.ApplyManyAsync(
             [.. models.Select((m, i) => ((IDeviceAttributed)m, requests[i].PatientDeviceId))],
             patientDevices, deviceStamper, DeviceAttributionCategories.SensorGlucose, batchSource: null, ct);
-        if (attributionError is not null)
-            return Problem(detail: attributionError, statusCode: 400, title: "Bad Request");
 
-        var created = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
-        var createdArray = created.ToArray();
+        return error is null ? null : Problem(detail: error, statusCode: 400, title: "Bad Request");
+    }
 
-        // Alarms evaluate against the canonical stream, not the just-created batch.
-        if (createdArray.Any(r => r.Mgdl > 0))
+    /// <inheritdoc/>
+    /// <remarks>
+    /// One pass for the whole batch: alarms evaluate against the canonical stream rather than the
+    /// records just written, so a per-record pass would repeat the same evaluation.
+    /// </remarks>
+    protected override async Task<SensorGlucose[]> OnAfterBulkCreateAsync(SensorGlucose[] written, CancellationToken ct)
+    {
+        if (written.Any(r => r.Mgdl > 0))
             await alertEvaluator.EvaluateAsync(ct);
 
-        return StatusCode(201, createdArray);
+        return written;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Glucose/SensorGlucoseController.cs
@@ -84,24 +84,25 @@ public class SensorGlucoseController(
         return Ok(new PaginatedResponse<SensorGlucose> { Data = data, Pagination = new PaginationInfo(limit, offset, total) });
     }
 
-    public override async Task<ActionResult<SensorGlucose>> Create([FromBody] UpsertSensorGlucoseRequest request, CancellationToken ct = default)
+    /// <inheritdoc/>
+    /// <remarks>
+    /// V4 REST writes bypass the connector/decomposer ingest paths, so attribution happens here —
+    /// otherwise direct API records stay unstamped and only ever surface as pseudo-devices. The
+    /// canonical stream still governs reads.
+    /// </remarks>
+    protected override async Task<ObjectResult?> OnBeforeCreateAsync(
+        SensorGlucose model, UpsertSensorGlucoseRequest request, CancellationToken ct)
     {
-        var model = MapCreateToModel(request);
+        await ResolveGlucoseAsync(model, request, ct);
+        return await ApplyAttributionAsync(model, request, existing: null, ct);
+    }
 
-        if (model.Timestamp == default)
-            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-
-        await glucoseResolver.ResolveAsync(model, request.GlucoseProcessing, request.SmoothedMgdl, request.UnsmoothedMgdl, ct);
-
-        // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
-        // direct API records stay unstamped and only ever surface as pseudo-devices. The canonical
-        // stream still governs reads.
-        if (await ApplyAttributionAsync(model, request, existing: null, ct) is { } error)
-            return error;
-
-        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
-        created = await OnAfterCreateAsync(created, ct);
-        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+    /// <inheritdoc/>
+    protected override async Task<ObjectResult?> OnBeforeUpdateAsync(
+        SensorGlucose model, UpsertSensorGlucoseRequest request, SensorGlucose existing, CancellationToken ct)
+    {
+        await ResolveGlucoseAsync(model, request, ct);
+        return await ApplyAttributionAsync(model, request, existing.PatientDeviceId, ct);
     }
 
     protected override SensorGlucose MapCreateToModel(UpsertSensorGlucoseRequest request) => new()
@@ -141,43 +142,18 @@ public class SensorGlucoseController(
         AdditionalProperties = existing.AdditionalProperties,
     };
 
-    public override async Task<ActionResult<SensorGlucose>> Update(Guid id, [FromBody] UpsertSensorGlucoseRequest request, CancellationToken ct = default)
-    {
-        var existing = await Repository.GetByIdAsync(id, ct);
-        if (existing is null)
-            return NotFound();
-
-        var model = MapUpdateToModel(id, request, existing);
-
-        if (model.Timestamp == default)
-            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-
-        await glucoseResolver.ResolveAsync(model, request.GlucoseProcessing, request.SmoothedMgdl, request.UnsmoothedMgdl, ct);
-
-        if (await ApplyAttributionAsync(model, request, existing.PatientDeviceId, ct) is { } error)
-            return error;
-
-        try
-        {
-            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
-
-            return Ok(updated);
-        }
-        catch (KeyNotFoundException)
-        {
-            return NotFound();
-        }
-    }
-
     /// <inheritdoc/>
+    /// <remarks>
+    /// Attribution is the batch form rather than a loop over <see cref="OnBeforeCreateAsync"/>: one
+    /// stamper pass resolves the whole payload, and per-record DataSource drives matching, so no
+    /// batch-level source is needed for a mixed-source upload.
+    /// </remarks>
     protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
         IReadOnlyList<SensorGlucose> models, IReadOnlyList<UpsertSensorGlucoseRequest> requests, CancellationToken ct)
     {
         for (var i = 0; i < models.Count; i++)
-            await glucoseResolver.ResolveAsync(models[i], requests[i].GlucoseProcessing, requests[i].SmoothedMgdl, requests[i].UnsmoothedMgdl, ct);
+            await ResolveGlucoseAsync(models[i], requests[i], ct);
 
-        // Per-record DataSource drives matching, so no batch-level source is needed for a
-        // mixed-source bulk upload.
         var error = await PatientDeviceAttribution.ApplyManyAsync(
             [.. models.Select((m, i) => ((IDeviceAttributed)m, requests[i].PatientDeviceId))],
             patientDevices, deviceStamper, DeviceAttributionCategories.SensorGlucose, batchSource: null, ct);
@@ -197,6 +173,9 @@ public class SensorGlucoseController(
 
         return written;
     }
+
+    private Task ResolveGlucoseAsync(SensorGlucose model, UpsertSensorGlucoseRequest request, CancellationToken ct) =>
+        glucoseResolver.ResolveAsync(model, request.GlucoseProcessing, request.SmoothedMgdl, request.UnsmoothedMgdl, ct);
 
     /// <summary>
     /// Settles the reading's device attribution from the request. Returns a 400 result when an explicit

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -51,6 +51,9 @@ public class BasalInjectionController(
     public override string WriteScope => Scope.TreatmentsReadWrite;
 
     /// <inheritdoc/>
+    protected override V4BulkNaming BulkNaming => new("Basal injection", "injection", "injections");
+
+    /// <inheritdoc/>
     public override async Task<ActionResult<BasalInjection>> Create(
         [FromBody] CreateBasalInjectionRequest request, CancellationToken ct = default)
     {
@@ -144,46 +147,25 @@ public class BasalInjectionController(
         CreatedAt = existing.CreatedAt,
     };
 
-    /// <summary>
-    /// Create or update basal injections in bulk (max 1000).
-    /// </summary>
-    /// <remarks>
-    /// Array semantics are per-item upsert, not all-or-nothing: each injection carrying both
-    /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
-    /// insert. Every item is validated with the same rules as the single create; validation
-    /// failures reject the whole request with `400 Bad Request` before anything is persisted.
-    /// </remarks>
-    [HttpPost("bulk")]
-    [RequireDeclaredWriteScope]
-    [ProducesResponseType(typeof(BasalInjection[]), StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    public async Task<ActionResult<BasalInjection[]>> CreateBasalInjectionsBulk(
-        [FromBody] CreateBasalInjectionRequest[] requests,
-        CancellationToken ct = default)
+    /// <inheritdoc/>
+    protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
+        IReadOnlyList<BasalInjection> models, IReadOnlyList<CreateBasalInjectionRequest> requests, CancellationToken ct)
     {
-        if (await this.ValidateBulkAsync(requests, "Basal injection", "injection", "injections", ct) is { } invalid)
-            return invalid;
-
-        var models = new List<BasalInjection>(requests.Length);
-        foreach (var request in requests)
+        for (var i = 0; i < models.Count; i++)
         {
-            if (ValidateUnitsAndTimestamp(request.Units, request.Timestamp) is { } unitsOrTsProblem)
+            if (ValidateUnitsAndTimestamp(requests[i].Units, requests[i].Timestamp) is { } unitsOrTsProblem)
                 return unitsOrTsProblem;
 
             // Resolved per item: the active-at-injection-time window check depends on each
             // item's timestamp, so a per-insulin cache would skip it.
-            var (insulin, insulinProblem) = await ResolveInsulinAsync(request.PatientInsulinId, request.Timestamp, ct);
+            var (insulin, insulinProblem) = await ResolveInsulinAsync(requests[i].PatientInsulinId, requests[i].Timestamp, ct);
             if (insulinProblem is not null)
                 return insulinProblem;
 
-            var model = MapCreateToModel(request);
-            model.InsulinContext = insulin is null ? null : BuildContext(insulin);
-            models.Add(model);
+            models[i].InsulinContext = insulin is null ? null : BuildContext(insulin);
         }
 
-        var persisted = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
-        return StatusCode(201, persisted.ToArray());
+        return null;
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusCalculationController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusCalculationController.cs
@@ -33,6 +33,9 @@ public class BolusCalculationController(IBolusCalculationRepository repo)
     /// <remarks>Bolus calculations sit in the treatments share category alongside the boluses they explain.</remarks>
     public override string WriteScope => Scope.TreatmentsReadWrite;
 
+    /// <inheritdoc/>
+    protected override V4BulkNaming BulkNaming => new("Bolus calculation", "calculation", "calculations");
+
     protected override BolusCalculation MapCreateToModel(UpsertBolusCalculationRequest request) => new()
     {
         Timestamp = request.Timestamp.UtcDateTime,

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -138,11 +138,6 @@ public class BolusController(
     };
 
     /// <inheritdoc/>
-    /// <remarks>
-    /// Attribution is the batch form rather than a loop over <see cref="OnBeforeCreateAsync"/>: one
-    /// stamper pass resolves the whole payload, and per-record DataSource drives matching, so no
-    /// batch-level source is needed for a mixed-source upload.
-    /// </remarks>
     protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
         IReadOnlyList<Bolus> models, IReadOnlyList<CreateBolusRequest> requests, CancellationToken ct)
     {

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -44,6 +44,9 @@ public class BolusController(
     public override string WriteScope => Scope.TreatmentsReadWrite;
 
     /// <inheritdoc/>
+    protected override V4BulkNaming BulkNaming => new("Bolus", "bolus", "boluses");
+
+    /// <inheritdoc/>
     /// <remarks>
     /// Never cached, per <see cref="Profiles.ProfileController.GetProfileSummary"/>: a just-entered
     /// bolus must not be invisible until a cached list body expires.
@@ -163,45 +166,20 @@ public class BolusController(
         AdditionalProperties = existing.AdditionalProperties,
     };
 
-    /// <summary>
-    /// Create or update boluses in bulk (max 1000).
-    /// </summary>
-    /// <remarks>
-    /// Array semantics are per-item upsert, not all-or-nothing: each bolus carrying both
-    /// `dataSource` and `syncIdentifier` updates the row already matched by that pair; all others
-    /// insert. Validation failures reject the whole request with `400 Bad Request` before anything
-    /// is persisted.
-    /// </remarks>
-    [HttpPost("bulk")]
-    [RequireDeclaredWriteScope]
-    [ProducesResponseType(typeof(Bolus[]), StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    public async Task<ActionResult<Bolus[]>> CreateBolusesBulk(
-        [FromBody] CreateBolusRequest[] requests,
-        CancellationToken ct = default)
+    /// <inheritdoc/>
+    protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
+        IReadOnlyList<Bolus> models, IReadOnlyList<CreateBolusRequest> requests, CancellationToken ct)
     {
-        if (await this.ValidateBulkAsync(requests, "Bolus", "bolus", "boluses", ct) is { } invalid)
-            return invalid;
+        for (var i = 0; i < models.Count; i++)
+            await EnrichInsulinContextAsync(models[i], requests[i].PatientInsulinId, ct);
 
-        var models = new List<Bolus>(requests.Length);
-        foreach (var request in requests)
-        {
-            var model = MapCreateToModel(request);
-            await EnrichInsulinContextAsync(model, request.PatientInsulinId, ct);
-            models.Add(model);
-        }
-
-        // Attribute the batch before persisting (see Create). Per-record DataSource drives matching,
-        // so no batch-level source is needed for a mixed-source bulk upload.
-        var attributionError = await PatientDeviceAttribution.ApplyManyAsync(
+        // Per-record DataSource drives matching, so no batch-level source is needed for a
+        // mixed-source bulk upload.
+        var error = await PatientDeviceAttribution.ApplyManyAsync(
             [.. models.Select((m, i) => ((IDeviceAttributed)m, requests[i].PatientDeviceId))],
             patientDevices, deviceStamper, DeviceAttributionCategories.Bolus, batchSource: null, ct);
-        if (attributionError is not null)
-            return Problem(detail: attributionError, statusCode: 400, title: "Bad Request");
 
-        var persisted = await Repository.BulkCreateAsync(models, WriteOrigin.Live, ct);
-        return StatusCode(201, persisted.ToArray());
+        return error is null ? null : Problem(detail: error, statusCode: 400, title: "Bad Request");
     }
 
     /// <summary>

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BolusController.cs
@@ -61,51 +61,22 @@ public class BolusController(
         => base.GetAll(from, to, limit, offset, sort, device, source, ct);
 
     /// <inheritdoc/>
-    public override async Task<ActionResult<Bolus>> Create([FromBody] CreateBolusRequest request, CancellationToken ct = default)
+    /// <remarks>
+    /// V4 REST writes bypass the connector/decomposer ingest paths, so attribution happens here —
+    /// otherwise direct API records stay unstamped and only ever surface as pseudo-devices.
+    /// </remarks>
+    protected override async Task<ObjectResult?> OnBeforeCreateAsync(Bolus model, CreateBolusRequest request, CancellationToken ct)
     {
-        var model = MapCreateToModel(request);
-
-        if (model.Timestamp == default)
-            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-
         await EnrichInsulinContextAsync(model, request.PatientInsulinId, ct);
-
-        // V4 REST writes bypass the connector/decomposer ingest paths, so attribute here — otherwise
-        // direct API records stay unstamped and only ever surface as pseudo-devices.
-        if (await ApplyAttributionAsync(model, request.PatientDeviceId, existing: null, ct) is { } error)
-            return error;
-
-        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
-        created = await OnAfterCreateAsync(created, ct);
-        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        return await ApplyAttributionAsync(model, request.PatientDeviceId, existing: null, ct);
     }
 
     /// <inheritdoc/>
-    public override async Task<ActionResult<Bolus>> Update(Guid id, [FromBody] UpdateBolusRequest request, CancellationToken ct = default)
+    protected override async Task<ObjectResult?> OnBeforeUpdateAsync(
+        Bolus model, UpdateBolusRequest request, Bolus existing, CancellationToken ct)
     {
-        var existing = await Repository.GetByIdAsync(id, ct);
-        if (existing is null)
-            return NotFound();
-
-        var model = MapUpdateToModel(id, request, existing);
-
-        if (model.Timestamp == default)
-            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
-
         await EnrichInsulinContextAsync(model, request.PatientInsulinId, ct);
-
-        if (await ApplyAttributionAsync(model, request.PatientDeviceId, existing.PatientDeviceId, ct) is { } error)
-            return error;
-
-        try
-        {
-            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
-            return Ok(updated);
-        }
-        catch (KeyNotFoundException)
-        {
-            return NotFound();
-        }
+        return await ApplyAttributionAsync(model, request.PatientDeviceId, existing.PatientDeviceId, ct);
     }
 
     /// <summary>Maps a <see cref="CreateBolusRequest"/> to a new <see cref="Bolus"/> domain model.</summary>
@@ -167,14 +138,17 @@ public class BolusController(
     };
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Attribution is the batch form rather than a loop over <see cref="OnBeforeCreateAsync"/>: one
+    /// stamper pass resolves the whole payload, and per-record DataSource drives matching, so no
+    /// batch-level source is needed for a mixed-source upload.
+    /// </remarks>
     protected override async Task<ObjectResult?> OnBeforeBulkCreateAsync(
         IReadOnlyList<Bolus> models, IReadOnlyList<CreateBolusRequest> requests, CancellationToken ct)
     {
         for (var i = 0; i < models.Count; i++)
             await EnrichInsulinContextAsync(models[i], requests[i].PatientInsulinId, ct);
 
-        // Per-record DataSource drives matching, so no batch-level source is needed for a
-        // mixed-source bulk upload.
         var error = await PatientDeviceAttribution.ApplyManyAsync(
             [.. models.Select((m, i) => ((IDeviceAttributed)m, requests[i].PatientDeviceId))],
             patientDevices, deviceStamper, DeviceAttributionCategories.Bolus, batchSource: null, ct);

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/NoteController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/NoteController.cs
@@ -34,6 +34,9 @@ public class NoteController(INoteRepository repo)
     /// <remarks>Notes are the V4 form of a legacy text treatment (Note/Announcement/Question).</remarks>
     public override string WriteScope => Scope.TreatmentsReadWrite;
 
+    /// <inheritdoc/>
+    protected override V4BulkNaming BulkNaming => new("Note", "note", "notes");
+
     protected override Note MapCreateToModel(UpsertNoteRequest request) => new()
     {
         Timestamp = request.Timestamp.UtcDateTime,

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertBGCheckRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertBGCheckRequest.cs
@@ -7,7 +7,7 @@ namespace Nocturne.API.Models.Requests.V4;
 /// </summary>
 /// <seealso cref="Validators.V4.UpsertBGCheckRequestValidator"/>
 /// <seealso cref="Nocturne.API.Controllers.V4.Glucose.BGCheckController"/>
-public class UpsertBGCheckRequest
+public class UpsertBGCheckRequest : IBulkUpsertRequest
 {
     /// <summary>
     /// When the BG check was performed.

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertBolusCalculationRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertBolusCalculationRequest.cs
@@ -100,9 +100,6 @@ public class UpsertBolusCalculationRequest : IBulkUpsertRequest
     /// </summary>
     public double? PreBolus { get; set; }
 
-    /// <summary>
-    /// Always <c>null</c>: <see cref="Nocturne.Core.Models.V4.BolusCalculation"/> carries no sync key, so a bulk
-    /// payload of these has nothing for the upsert to match on.
-    /// </summary>
+    // Bolus calculations carry no sync key.
     string? IBulkUpsertRequest.SyncIdentifier => null;
 }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertBolusCalculationRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertBolusCalculationRequest.cs
@@ -8,7 +8,7 @@ namespace Nocturne.API.Models.Requests.V4;
 /// </summary>
 /// <seealso cref="Validators.V4.UpsertBolusCalculationRequestValidator"/>
 /// <seealso cref="Nocturne.API.Controllers.V4.Treatments.BolusCalculationController"/>
-public class UpsertBolusCalculationRequest
+public class UpsertBolusCalculationRequest : IBulkUpsertRequest
 {
     /// <summary>
     /// When the bolus calculation was performed.
@@ -99,4 +99,10 @@ public class UpsertBolusCalculationRequest
     /// Pre-bolus time in minutes (insulin given before eating).
     /// </summary>
     public double? PreBolus { get; set; }
+
+    /// <summary>
+    /// Always <c>null</c>: <see cref="Nocturne.Core.Models.V4.BolusCalculation"/> carries no sync key, so a bulk
+    /// payload of these has nothing for the upsert to match on.
+    /// </summary>
+    string? IBulkUpsertRequest.SyncIdentifier => null;
 }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertCalibrationRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertCalibrationRequest.cs
@@ -5,7 +5,7 @@ namespace Nocturne.API.Models.Requests.V4;
 /// </summary>
 /// <seealso cref="Validators.V4.UpsertCalibrationRequestValidator"/>
 /// <seealso cref="Nocturne.API.Controllers.V4.Glucose.CalibrationController"/>
-public class UpsertCalibrationRequest
+public class UpsertCalibrationRequest : IBulkUpsertRequest
 {
     /// <summary>
     /// When the calibration was performed.
@@ -46,4 +46,10 @@ public class UpsertCalibrationRequest
     /// Calibration scale factor.
     /// </summary>
     public double? Scale { get; set; }
+
+    /// <summary>
+    /// Always <c>null</c>: <see cref="Nocturne.Core.Models.V4.Calibration"/> carries no sync key, so a bulk
+    /// payload of these has nothing for the upsert to match on.
+    /// </summary>
+    string? IBulkUpsertRequest.SyncIdentifier => null;
 }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertCalibrationRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertCalibrationRequest.cs
@@ -47,9 +47,6 @@ public class UpsertCalibrationRequest : IBulkUpsertRequest
     /// </summary>
     public double? Scale { get; set; }
 
-    /// <summary>
-    /// Always <c>null</c>: <see cref="Nocturne.Core.Models.V4.Calibration"/> carries no sync key, so a bulk
-    /// payload of these has nothing for the upsert to match on.
-    /// </summary>
+    // Calibrations carry no sync key.
     string? IBulkUpsertRequest.SyncIdentifier => null;
 }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertDeviceEventRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertDeviceEventRequest.cs
@@ -7,7 +7,7 @@ namespace Nocturne.API.Models.Requests.V4;
 /// </summary>
 /// <seealso cref="Validators.V4.UpsertDeviceEventRequestValidator"/>
 /// <seealso cref="Nocturne.API.Controllers.V4.Devices.DeviceEventController"/>
-public class UpsertDeviceEventRequest
+public class UpsertDeviceEventRequest : IBulkUpsertRequest
 {
     /// <summary>
     /// When the device event occurred.

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertMeterGlucoseRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertMeterGlucoseRequest.cs
@@ -5,7 +5,7 @@ namespace Nocturne.API.Models.Requests.V4;
 /// </summary>
 /// <seealso cref="Validators.V4.UpsertMeterGlucoseRequestValidator"/>
 /// <seealso cref="Nocturne.API.Controllers.V4.Glucose.MeterGlucoseController"/>
-public class UpsertMeterGlucoseRequest
+public class UpsertMeterGlucoseRequest : IBulkUpsertRequest
 {
     /// <summary>
     /// When the meter reading was taken.
@@ -46,4 +46,10 @@ public class UpsertMeterGlucoseRequest
     /// Glucose reading in mg/dL (validated 0-10,000).
     /// </summary>
     public double Mgdl { get; set; }
+
+    /// <summary>
+    /// Always <c>null</c>: <see cref="Nocturne.Core.Models.V4.MeterGlucose"/> carries no sync key, so a bulk
+    /// payload of these has nothing for the upsert to match on.
+    /// </summary>
+    string? IBulkUpsertRequest.SyncIdentifier => null;
 }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertMeterGlucoseRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertMeterGlucoseRequest.cs
@@ -47,9 +47,6 @@ public class UpsertMeterGlucoseRequest : IBulkUpsertRequest
     /// </summary>
     public double Mgdl { get; set; }
 
-    /// <summary>
-    /// Always <c>null</c>: <see cref="Nocturne.Core.Models.V4.MeterGlucose"/> carries no sync key, so a bulk
-    /// payload of these has nothing for the upsert to match on.
-    /// </summary>
+    // Meter readings carry no sync key.
     string? IBulkUpsertRequest.SyncIdentifier => null;
 }

--- a/src/API/Nocturne.API/Models/Requests/V4/UpsertNoteRequest.cs
+++ b/src/API/Nocturne.API/Models/Requests/V4/UpsertNoteRequest.cs
@@ -5,7 +5,7 @@ namespace Nocturne.API.Models.Requests.V4;
 /// </summary>
 /// <seealso cref="Validators.V4.UpsertNoteRequestValidator"/>
 /// <seealso cref="Nocturne.API.Controllers.V4.Treatments.NoteController"/>
-public class UpsertNoteRequest
+public class UpsertNoteRequest : IBulkUpsertRequest
 {
     /// <summary>
     /// When the note was created.

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using FluentAssertions;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
@@ -7,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Controllers.V4;
+using Nocturne.API.Controllers.V4.Base;
 using Nocturne.API.Controllers.V4.Devices;
 using Nocturne.API.Controllers.V4.Glucose;
 using Nocturne.API.Controllers.V4.Health;
@@ -139,17 +142,103 @@ public class V4BulkValidationTests
 
     // ── The wording each endpoint gives them ────────────────────────
 
+    /// <summary>
+    /// Every controller reached through <see cref="V4CrudControllerBase{TModel,TCreateRequest,TUpdateRequest,TRepository}"/>,
+    /// driven through its own <c>bulk</c> action, so a new one cannot ship with wording nobody read.
+    /// The controllers below this are the bulk endpoints that do NOT come off that base and so are
+    /// still named one at a time.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(CrudControllers))]
+    public async Task EveryCrudBulkEndpoint_NamesTheDataItTakes(Type controllerType)
+    {
+        var naming = BulkNamingOf(controllerType);
+
+        naming.Subject.Should().MatchRegex("^[A-Z]", "the subject opens a sentence");
+        naming.Singular.Should().Be(naming.Singular.ToLowerInvariant(), "the singular sits mid-sentence");
+        naming.Plural.Should().Be(naming.Plural.ToLowerInvariant(), "the plural sits mid-sentence");
+        naming.Plural.Should().NotBe(naming.Singular, "one item and many read differently");
+
+        Rejected(await DriveBulkAsync(controllerType, 0), $"{naming.Subject} data is required");
+        Rejected(
+            await DriveBulkAsync(controllerType, V4BulkValidation.MaxItems + 1),
+            $"Bulk operations are limited to {V4BulkValidation.MaxItems} {naming.Plural} per request");
+        Rejected(await DriveBulkAsync(controllerType, 1), $"Timestamp must be set on every {naming.Singular}");
+    }
+
+    public static TheoryData<Type> CrudControllers()
+    {
+        var controllers = typeof(V4BulkValidation).Assembly.GetTypes()
+            .Where(t => t is { IsAbstract: false, IsGenericTypeDefinition: false } && DerivesFromCrudBase(t))
+            .OrderBy(t => t.FullName, StringComparer.Ordinal)
+            .ToList();
+
+        controllers.Should().NotBeEmpty("the sweep proves nothing if it discovers no controllers");
+
+        var data = new TheoryData<Type>();
+        foreach (var type in controllers)
+            data.Add(type);
+
+        return data;
+    }
+
+    private static bool DerivesFromCrudBase(Type type)
+    {
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == typeof(V4CrudControllerBase<,,,>))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reads <c>BulkNaming</c> off an unconstructed controller and posts <paramref name="count"/>
+    /// freshly-constructed requests to its <c>CreateBulk</c>. The getter returns a constant and the
+    /// payload never clears validation, so no dependency is reached — several of these controllers
+    /// take a <c>NocturneDbContext</c>, which has no mockable constructor.
+    /// </summary>
+    private static ControllerBase UnconstructedController(Type controllerType)
+    {
+        var controller = (ControllerBase)RuntimeHelpers.GetUninitializedObject(controllerType);
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+        return controller;
+    }
+
+    private static V4BulkNaming BulkNamingOf(Type controllerType)
+    {
+        var property = controllerType.GetProperty("BulkNaming", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"{controllerType.Name} declares no BulkNaming");
+
+        return (V4BulkNaming)property.GetValue(UnconstructedController(controllerType))!;
+    }
+
+    private static async Task<ActionResult?> DriveBulkAsync(Type controllerType, int count)
+    {
+        var action = controllerType.GetMethod("CreateBulk")
+            ?? throw new InvalidOperationException($"{controllerType.Name} exposes no CreateBulk");
+
+        var requestType = action.GetParameters()[0].ParameterType.GetGenericArguments()[0];
+        var payload = Array.CreateInstance(requestType, count);
+        for (var i = 0; i < count; i++)
+            payload.SetValue(Activator.CreateInstance(requestType), i);
+
+        var task = (Task)action.Invoke(UnconstructedController(controllerType), [payload, CancellationToken.None])!;
+        await task;
+
+        var actionResultOfT = task.GetType().GetProperty("Result")!.GetValue(task)!;
+        return (ActionResult?)actionResultOfT.GetType().GetProperty("Result")!.GetValue(actionResultOfT);
+    }
+
     [Fact]
     public async Task EmptyPayload_NamesTheDataTheEndpointTakes()
     {
         Rejected((await ApsController().CreateApsSnapshots([])).Result, "APS snapshot data is required");
         Rejected((await PumpController().CreatePumpSnapshots([])).Result, "Pump snapshot data is required");
         Rejected((await UploaderController().CreateUploaderSnapshots([])).Result, "Uploader snapshot data is required");
-        Rejected((await BasalInjections().CreateBulk([])).Result, "Basal injection data is required");
-        Rejected((await Boluses().CreateBulk([])).Result, "Bolus data is required");
         Rejected((await CarbIntakes().CreateCarbIntakesBulk([])).Result, "Carb intake data is required");
         Rejected((await TempBasals().CreateTempBasals([])).Result, "Temp basal data is required");
-        Rejected((await SensorGlucose().CreateBulk([])).Result, "Sensor glucose data is required");
     }
 
     [Fact]
@@ -162,50 +251,11 @@ public class V4BulkValidationTests
             (await UploaderController().CreateUploaderSnapshots(Fill(1001, () => new UpsertUploaderSnapshotRequest()))).Result,
             "Bulk operations are limited to 1000 snapshots per request");
         Rejected(
-            (await BasalInjections().CreateBulk(Fill(1001, () => new CreateBasalInjectionRequest { Timestamp = T0, Units = 1 }))).Result,
-            "Bulk operations are limited to 1000 injections per request");
-        Rejected(
-            (await Boluses().CreateBulk(Fill(1001, () => new CreateBolusRequest()))).Result,
-            "Bulk operations are limited to 1000 boluses per request");
-        Rejected(
             (await CarbIntakes().CreateCarbIntakesBulk(Fill(1001, () => new CreateCarbIntakeRequest()))).Result,
             "Bulk operations are limited to 1000 intakes per request");
         Rejected(
             (await TempBasals().CreateTempBasals(Fill(1001, () => new CreateTempBasalRequest()))).Result,
             "Bulk operations are limited to 1000 temp basals per request");
-        Rejected(
-            (await SensorGlucose().CreateBulk(Fill(1001, () => new UpsertSensorGlucoseRequest()))).Result,
-            "Bulk operations are limited to 1000 readings per request");
-    }
-
-    // ── Endpoints that did not run the full preamble before ─────────
-
-    [Fact]
-    public async Task SensorGlucoseBulk_RejectsAnUnsetTimestamp()
-    {
-        var repo = new Mock<ISensorGlucoseRepository>();
-
-        var result = await SensorGlucose(repo).CreateBulk(
-            [new UpsertSensorGlucoseRequest { Timestamp = T0, Mgdl = 120 }, new UpsertSensorGlucoseRequest { Mgdl = 115 }]);
-
-        Rejected(result.Result, "Timestamp must be set on every reading");
-        repo.Verify(
-            r => r.BulkCreateAsync(It.IsAny<IEnumerable<Core.Models.V4.SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
-            Times.Never);
-    }
-
-    [Fact]
-    public async Task BasalInjectionBulk_RejectsAnUnsetTimestamp()
-    {
-        var repo = new Mock<IBasalInjectionRepository>();
-
-        var result = await BasalInjections(repo).CreateBulk(
-            [new CreateBasalInjectionRequest { Timestamp = T0, Units = 12 }, new CreateBasalInjectionRequest { Timestamp = default, Units = 12 }]);
-
-        Rejected(result.Result, "Timestamp must be set on every injection");
-        repo.Verify(
-            r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
-            Times.Never);
     }
 
     [Fact]
@@ -428,17 +478,6 @@ public class V4BulkValidationTests
 
     private static UploaderSnapshotController UploaderController() =>
         WithContext(new UploaderSnapshotController(Mock.Of<IUploaderSnapshotRepository>()));
-
-    private static BasalInjectionController BasalInjections(Mock<IBasalInjectionRepository>? repo = null) =>
-        WithContext(new BasalInjectionController(
-            (repo ?? new Mock<IBasalInjectionRepository>()).Object, Mock.Of<IPatientInsulinRepository>()));
-
-    private static BolusController Boluses() =>
-        WithContext(new BolusController(
-            Mock.Of<IBolusRepository>(),
-            Mock.Of<IPatientInsulinRepository>(),
-            Mock.Of<IPatientDeviceRepository>(),
-            Mock.Of<IPatientDeviceStamper>()));
 
     // The database context is only reached past the preamble, which is all these tests exercise.
     private static NutritionController CarbIntakes() =>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
@@ -143,10 +143,28 @@ public class V4BulkValidationTests
     // ── The wording each endpoint gives them ────────────────────────
 
     /// <summary>
-    /// Every controller reached through <see cref="V4CrudControllerBase{TModel,TCreateRequest,TUpdateRequest,TRepository}"/>,
-    /// driven through its own <c>bulk</c> action, so a new one cannot ship with wording nobody read.
-    /// The controllers below this are the bulk endpoints that do NOT come off that base and so are
-    /// still named one at a time.
+    /// The words every controller reached through
+    /// <see cref="V4CrudControllerBase{TModel,TCreateRequest,TUpdateRequest,TRepository}"/> puts in its
+    /// <c>bulk</c> rejections, pinned as literals rather than read back off the controller — a naming
+    /// this table agrees with is a naming somebody chose.
+    /// </summary>
+    private static readonly Dictionary<Type, V4BulkNaming> ExpectedNaming = new()
+    {
+        [typeof(BasalInjectionController)] = new("Basal injection", "injection", "injections"),
+        [typeof(BGCheckController)] = new("BG check", "check", "checks"),
+        [typeof(BolusCalculationController)] = new("Bolus calculation", "calculation", "calculations"),
+        [typeof(BolusController)] = new("Bolus", "bolus", "boluses"),
+        [typeof(CalibrationController)] = new("Calibration", "calibration", "calibrations"),
+        [typeof(DeviceEventController)] = new("Device event", "event", "events"),
+        [typeof(MeterGlucoseController)] = new("Meter glucose", "reading", "readings"),
+        [typeof(NoteController)] = new("Note", "note", "notes"),
+        [typeof(SensorGlucoseController)] = new("Sensor glucose", "reading", "readings"),
+    };
+
+    /// <summary>
+    /// Drives every one of those controllers' own <c>bulk</c> action and checks the three rejections
+    /// against <see cref="ExpectedNaming"/>. The bulk endpoints that do NOT come off that base are
+    /// still named one at a time, below.
     /// </summary>
     [Theory]
     [MemberData(nameof(CrudControllers))]
@@ -154,6 +172,7 @@ public class V4BulkValidationTests
     {
         var naming = BulkNamingOf(controllerType);
 
+        naming.Should().Be(ExpectedNaming[controllerType]);
         naming.Subject.Should().MatchRegex("^[A-Z]", "the subject opens a sentence");
         naming.Singular.Should().Be(naming.Singular.ToLowerInvariant(), "the singular sits mid-sentence");
         naming.Plural.Should().Be(naming.Plural.ToLowerInvariant(), "the plural sits mid-sentence");
@@ -173,7 +192,9 @@ public class V4BulkValidationTests
             .OrderBy(t => t.FullName, StringComparer.Ordinal)
             .ToList();
 
-        controllers.Should().NotBeEmpty("the sweep proves nothing if it discovers no controllers");
+        controllers.Should().HaveCount(
+            ExpectedNaming.Count, "a new CRUD controller ships with a reviewed row in ExpectedNaming");
+        controllers.Should().OnlyContain(t => ExpectedNaming.ContainsKey(t));
 
         var data = new TheoryData<Type>();
         foreach (var type in controllers)

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4BulkValidationTests.cs
@@ -145,11 +145,11 @@ public class V4BulkValidationTests
         Rejected((await ApsController().CreateApsSnapshots([])).Result, "APS snapshot data is required");
         Rejected((await PumpController().CreatePumpSnapshots([])).Result, "Pump snapshot data is required");
         Rejected((await UploaderController().CreateUploaderSnapshots([])).Result, "Uploader snapshot data is required");
-        Rejected((await BasalInjections().CreateBasalInjectionsBulk([])).Result, "Basal injection data is required");
-        Rejected((await Boluses().CreateBolusesBulk([])).Result, "Bolus data is required");
+        Rejected((await BasalInjections().CreateBulk([])).Result, "Basal injection data is required");
+        Rejected((await Boluses().CreateBulk([])).Result, "Bolus data is required");
         Rejected((await CarbIntakes().CreateCarbIntakesBulk([])).Result, "Carb intake data is required");
         Rejected((await TempBasals().CreateTempBasals([])).Result, "Temp basal data is required");
-        Rejected((await SensorGlucose().CreateSensorGlucoseBulk([])).Result, "Sensor glucose data is required");
+        Rejected((await SensorGlucose().CreateBulk([])).Result, "Sensor glucose data is required");
     }
 
     [Fact]
@@ -162,10 +162,10 @@ public class V4BulkValidationTests
             (await UploaderController().CreateUploaderSnapshots(Fill(1001, () => new UpsertUploaderSnapshotRequest()))).Result,
             "Bulk operations are limited to 1000 snapshots per request");
         Rejected(
-            (await BasalInjections().CreateBasalInjectionsBulk(Fill(1001, () => new CreateBasalInjectionRequest { Timestamp = T0, Units = 1 }))).Result,
+            (await BasalInjections().CreateBulk(Fill(1001, () => new CreateBasalInjectionRequest { Timestamp = T0, Units = 1 }))).Result,
             "Bulk operations are limited to 1000 injections per request");
         Rejected(
-            (await Boluses().CreateBolusesBulk(Fill(1001, () => new CreateBolusRequest()))).Result,
+            (await Boluses().CreateBulk(Fill(1001, () => new CreateBolusRequest()))).Result,
             "Bulk operations are limited to 1000 boluses per request");
         Rejected(
             (await CarbIntakes().CreateCarbIntakesBulk(Fill(1001, () => new CreateCarbIntakeRequest()))).Result,
@@ -174,7 +174,7 @@ public class V4BulkValidationTests
             (await TempBasals().CreateTempBasals(Fill(1001, () => new CreateTempBasalRequest()))).Result,
             "Bulk operations are limited to 1000 temp basals per request");
         Rejected(
-            (await SensorGlucose().CreateSensorGlucoseBulk(Fill(1001, () => new UpsertSensorGlucoseRequest()))).Result,
+            (await SensorGlucose().CreateBulk(Fill(1001, () => new UpsertSensorGlucoseRequest()))).Result,
             "Bulk operations are limited to 1000 readings per request");
     }
 
@@ -185,7 +185,7 @@ public class V4BulkValidationTests
     {
         var repo = new Mock<ISensorGlucoseRepository>();
 
-        var result = await SensorGlucose(repo).CreateSensorGlucoseBulk(
+        var result = await SensorGlucose(repo).CreateBulk(
             [new UpsertSensorGlucoseRequest { Timestamp = T0, Mgdl = 120 }, new UpsertSensorGlucoseRequest { Mgdl = 115 }]);
 
         Rejected(result.Result, "Timestamp must be set on every reading");
@@ -199,7 +199,7 @@ public class V4BulkValidationTests
     {
         var repo = new Mock<IBasalInjectionRepository>();
 
-        var result = await BasalInjections(repo).CreateBasalInjectionsBulk(
+        var result = await BasalInjections(repo).CreateBulk(
             [new CreateBasalInjectionRequest { Timestamp = T0, Units = 12 }, new CreateBasalInjectionRequest { Timestamp = default, Units = 12 }]);
 
         Rejected(result.Result, "Timestamp must be set on every injection");
@@ -332,7 +332,7 @@ public class V4BulkValidationTests
     {
         var repo = new Mock<ISensorGlucoseRepository>();
 
-        var result = await WithValidators(SensorGlucose(repo)).CreateSensorGlucoseBulk(
+        var result = await WithValidators(SensorGlucose(repo)).CreateBulk(
             [new UpsertSensorGlucoseRequest { Timestamp = T0, Mgdl = -1 }]);
 
         Rejected(result.Result, "Sensor glucose at index 0 is invalid: Mgdl: Mgdl must be between 0 and 10000");
@@ -344,7 +344,7 @@ public class V4BulkValidationTests
     [Fact]
     public async Task SensorGlucoseBulk_NamesTheIndexOfTheOffendingReading()
     {
-        var result = await WithValidators(SensorGlucose()).CreateSensorGlucoseBulk(
+        var result = await WithValidators(SensorGlucose()).CreateBulk(
         [
             new UpsertSensorGlucoseRequest { Timestamp = T0, Mgdl = 120 },
             new UpsertSensorGlucoseRequest { Timestamp = T0.AddMinutes(5), Mgdl = 115 },
@@ -361,7 +361,7 @@ public class V4BulkValidationTests
         repo.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<Core.Models.V4.SensorGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IEnumerable<Core.Models.V4.SensorGlucose> models, WriteOrigin _, CancellationToken _) => [.. models]);
 
-        var result = await WithValidators(SensorGlucose(repo)).CreateSensorGlucoseBulk(
+        var result = await WithValidators(SensorGlucose(repo)).CreateBulk(
         [
             new UpsertSensorGlucoseRequest
             {

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudBulkCreateTests.cs
@@ -1,0 +1,260 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Controllers.V4.Base;
+using Nocturne.API.Controllers.V4.Treatments;
+using Nocturne.API.Models.Requests.V4;
+using Nocturne.API.Services.Devices;
+using Nocturne.Core.Contracts.Devices;
+using Nocturne.Core.Contracts.V4;
+using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.V4;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Base;
+
+/// <summary>
+/// The bulk create <see cref="V4CrudControllerBase{TModel,TCreateRequest,TUpdateRequest,TRepository}"/>
+/// gives every derived controller, exercised at two of them: what reaches the repository, what comes
+/// back, and what the cap and the timestamp guard reject.
+/// </summary>
+[Trait("Category", "Unit")]
+public class V4CrudBulkCreateTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 7, 1, 12, 0, 0, TimeSpan.Zero);
+
+    // ── Boluses ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Boluses_WritesEveryItemAndReturnsThem()
+    {
+        var repo = EchoingBolusRepository();
+
+        var result = await Boluses(repo).CreateBulk(
+        [
+            new CreateBolusRequest { Timestamp = T0, Insulin = 1.0 },
+            new CreateBolusRequest { Timestamp = T0.AddMinutes(5), Insulin = 2.5 },
+            new CreateBolusRequest { Timestamp = T0.AddMinutes(10), Insulin = 3.0 },
+        ]);
+
+        var created = Created(result);
+        created.Should().HaveCount(3);
+        created.Select(b => b.Insulin).Should().Equal(1.0, 2.5, 3.0);
+        created.Select(b => b.Timestamp).Should().Equal(T0.UtcDateTime, T0.AddMinutes(5).UtcDateTime, T0.AddMinutes(10).UtcDateTime);
+    }
+
+    [Fact]
+    public async Task Boluses_OverTheCap_IsRejectedAndNothingIsWritten()
+    {
+        var repo = new Mock<IBolusRepository>();
+
+        var result = await Boluses(repo).CreateBulk(
+            [.. Enumerable.Repeat(0, V4BulkValidation.MaxItems + 1).Select(_ => new CreateBolusRequest { Timestamp = T0, Insulin = 1.0 })]);
+
+        Rejected(result.Result, $"Bulk operations are limited to {V4BulkValidation.MaxItems} boluses per request");
+        NothingWritten(repo);
+    }
+
+    [Fact]
+    public async Task Boluses_AtTheCap_IsAccepted()
+    {
+        var repo = EchoingBolusRepository();
+
+        var result = await Boluses(repo).CreateBulk(
+            [.. Enumerable.Repeat(0, V4BulkValidation.MaxItems).Select(_ => new CreateBolusRequest { Timestamp = T0, Insulin = 1.0 })]);
+
+        Created(result).Should().HaveCount(V4BulkValidation.MaxItems);
+    }
+
+    [Fact]
+    public async Task Boluses_OneUnsetTimestamp_RejectsTheWholeBatch()
+    {
+        var repo = new Mock<IBolusRepository>();
+
+        var result = await Boluses(repo).CreateBulk(
+        [
+            new CreateBolusRequest { Timestamp = T0, Insulin = 1.0 },
+            new CreateBolusRequest { Timestamp = default, Insulin = 2.0 },
+            new CreateBolusRequest { Timestamp = T0.AddMinutes(10), Insulin = 3.0 },
+        ]);
+
+        Rejected(result.Result, "Timestamp must be set on every bolus");
+        NothingWritten(repo);
+    }
+
+    [Fact]
+    public async Task Boluses_ResentBatch_CarriesTheSameSyncKeys_SoTheUpsertStillMatches()
+    {
+        var repo = EchoingBolusRepository();
+        var written = new List<List<Bolus>>();
+        repo.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<Bolus>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<Bolus> models, WriteOrigin _, CancellationToken _) =>
+            {
+                var batch = models.ToList();
+                written.Add(batch);
+                return batch;
+            });
+
+        CreateBolusRequest[] Payload() =>
+        [
+            new() { Timestamp = T0, Insulin = 1.0, DataSource = "trio", SyncIdentifier = "upstream-1" },
+            new() { Timestamp = T0.AddMinutes(5), Insulin = 2.0, DataSource = "trio", SyncIdentifier = "upstream-2" },
+        ];
+
+        await Boluses(repo).CreateBulk(Payload());
+        await Boluses(repo).CreateBulk(Payload());
+
+        written.Should().HaveCount(2);
+        written[0].Select(b => (b.DataSource, b.SyncIdentifier)).Should()
+            .Equal(written[1].Select(b => (b.DataSource, b.SyncIdentifier)));
+        written[1].Select(b => (b.DataSource, b.SyncIdentifier)).Should()
+            .Equal(("trio", "upstream-1"), ("trio", "upstream-2"));
+    }
+
+    [Fact]
+    public async Task Boluses_SyncIdentifierWithoutDataSource_IsRejected()
+    {
+        var repo = new Mock<IBolusRepository>();
+
+        var result = await Boluses(repo).CreateBulk(
+            [new CreateBolusRequest { Timestamp = T0, Insulin = 1.0, SyncIdentifier = "upstream-1" }]);
+
+        Rejected(result.Result, "DataSource is required when SyncIdentifier is supplied");
+        NothingWritten(repo);
+    }
+
+    // ── Notes ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Notes_WriteEveryItemAndReturnThem()
+    {
+        var repo = EchoingNoteRepository();
+
+        var result = await Notes(repo).CreateBulk(
+        [
+            new UpsertNoteRequest { Timestamp = T0, Text = "site change" },
+            new UpsertNoteRequest { Timestamp = T0.AddMinutes(5), Text = "felt low" },
+        ]);
+
+        var created = Created(result);
+        created.Should().HaveCount(2);
+        created.Select(n => n.Text).Should().Equal("site change", "felt low");
+    }
+
+    [Fact]
+    public async Task Notes_OverTheCap_IsRejectedAndNothingIsWritten()
+    {
+        var repo = new Mock<INoteRepository>();
+
+        var result = await Notes(repo).CreateBulk(
+            [.. Enumerable.Repeat(0, V4BulkValidation.MaxItems + 1).Select(_ => new UpsertNoteRequest { Timestamp = T0 })]);
+
+        Rejected(result.Result, $"Bulk operations are limited to {V4BulkValidation.MaxItems} notes per request");
+        repo.Verify(
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<Note>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Notes_OneUnsetTimestamp_RejectsTheWholeBatch()
+    {
+        var repo = new Mock<INoteRepository>();
+
+        var result = await Notes(repo).CreateBulk(
+        [
+            new UpsertNoteRequest { Timestamp = T0, Text = "one" },
+            new UpsertNoteRequest { Text = "two" },
+        ]);
+
+        Rejected(result.Result, "Timestamp must be set on every note");
+        repo.Verify(
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<Note>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Notes_ResentBatch_CarriesTheSameSyncKeys_SoTheUpsertStillMatches()
+    {
+        var repo = new Mock<INoteRepository>();
+        var written = new List<List<Note>>();
+        repo.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<Note>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<Note> models, WriteOrigin _, CancellationToken _) =>
+            {
+                var batch = models.ToList();
+                written.Add(batch);
+                return batch;
+            });
+
+        UpsertNoteRequest[] Payload() =>
+        [
+            new() { Timestamp = T0, Text = "one", DataSource = "trio", SyncIdentifier = "note-1" },
+            new() { Timestamp = T0.AddMinutes(5), Text = "two", DataSource = "trio", SyncIdentifier = "note-2" },
+        ];
+
+        await Notes(repo).CreateBulk(Payload());
+        await Notes(repo).CreateBulk(Payload());
+
+        written.Should().HaveCount(2);
+        written[1].Select(n => (n.DataSource, n.SyncIdentifier)).Should()
+            .Equal(("trio", "note-1"), ("trio", "note-2"));
+        written[0].Select(n => (n.DataSource, n.SyncIdentifier)).Should()
+            .Equal(written[1].Select(n => (n.DataSource, n.SyncIdentifier)));
+    }
+
+    // ── Arrangement ─────────────────────────────────────────────────
+
+    private static TModel[] Created<TModel>(ActionResult<TModel[]> result)
+    {
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status201Created);
+        return objectResult.Value.Should().BeAssignableTo<TModel[]>().Subject;
+    }
+
+    private static void Rejected(ActionResult? result, string detail)
+    {
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+
+        var problem = objectResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Detail.Should().Be(detail);
+    }
+
+    private static void NothingWritten(Mock<IBolusRepository> repo) => repo.Verify(
+        r => r.BulkCreateAsync(It.IsAny<IEnumerable<Bolus>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+
+    private static Mock<IBolusRepository> EchoingBolusRepository()
+    {
+        var repo = new Mock<IBolusRepository>();
+        repo.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<Bolus>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<Bolus> models, WriteOrigin _, CancellationToken _) => [.. models]);
+        return repo;
+    }
+
+    private static Mock<INoteRepository> EchoingNoteRepository()
+    {
+        var repo = new Mock<INoteRepository>();
+        repo.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<Note>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<Note> models, WriteOrigin _, CancellationToken _) => [.. models]);
+        return repo;
+    }
+
+    private static BolusController Boluses(Mock<IBolusRepository> repo) =>
+        WithContext(new BolusController(
+            repo.Object,
+            Mock.Of<IPatientInsulinRepository>(),
+            Mock.Of<IPatientDeviceRepository>(),
+            Mock.Of<IPatientDeviceStamper>()));
+
+    private static NoteController Notes(Mock<INoteRepository> repo) =>
+        WithContext(new NoteController(repo.Object));
+
+    private static TController WithContext<TController>(TController controller)
+        where TController : ControllerBase
+    {
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+        return controller;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudBulkCreateTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudBulkCreateTests.cs
@@ -20,6 +20,12 @@ namespace Nocturne.API.Tests.Controllers.V4.Base;
 /// gives every derived controller, exercised at two of them: what reaches the repository, what comes
 /// back, and what the cap and the timestamp guard reject.
 /// </summary>
+/// <remarks>
+/// Whether a re-sent sync key updates a row or inserts one is the repository's to decide, and only
+/// the types deriving from <c>SyncUpsertRepositoryBase</c> upsert on it (notes do not). What the
+/// controller owes either way is to hand the request's own (DataSource, SyncIdentifier) to the
+/// repository unaltered on every send, which is what these assert.
+/// </remarks>
 [Trait("Category", "Unit")]
 public class V4CrudBulkCreateTests
 {
@@ -85,7 +91,7 @@ public class V4CrudBulkCreateTests
     }
 
     [Fact]
-    public async Task Boluses_ResentBatch_CarriesTheSameSyncKeys_SoTheUpsertStillMatches()
+    public async Task Boluses_HandTheRequestsSyncKeysToTheRepository_OnEverySend()
     {
         var repo = EchoingBolusRepository();
         var written = new List<List<Bolus>>();
@@ -175,7 +181,7 @@ public class V4CrudBulkCreateTests
     }
 
     [Fact]
-    public async Task Notes_ResentBatch_CarriesTheSameSyncKeys_SoTheUpsertStillMatches()
+    public async Task Notes_HandTheRequestsSyncKeysToTheRepository_OnEverySend()
     {
         var repo = new Mock<INoteRepository>();
         var written = new List<List<Note>>();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Nocturne.API.Controllers.V4.Base;
+using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.V4;
@@ -29,10 +30,12 @@ public class TestRecord : IV4Record
     public Dictionary<string, object?>? AdditionalProperties { get; set; }
 }
 
-public class TestCreateRequest
+public class TestCreateRequest : IBulkUpsertRequest
 {
-    public DateTime Timestamp { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
     public string? Device { get; set; }
+    public string? DataSource { get; set; }
+    public string? SyncIdentifier { get; set; }
 }
 
 public class TestUpdateRequest
@@ -41,7 +44,7 @@ public class TestUpdateRequest
     public string? Device { get; set; }
 }
 
-public interface ITestRecordRepository : IV4Repository<TestRecord>;
+public interface ITestRecordRepository : IV4Repository<TestRecord>, IBulkCreateRepository<TestRecord>;
 
 [ApiController]
 [Route("api/v4/test")]
@@ -50,10 +53,13 @@ public class TestCrudController(ITestRecordRepository repository)
 {
     public override string WriteScope => Scope.GlucoseReadWrite;
 
+    protected override V4BulkNaming BulkNaming => new("Test record", "record", "records");
+
     protected override TestRecord MapCreateToModel(TestCreateRequest request) => new()
     {
-        Timestamp = request.Timestamp,
+        Timestamp = request.Timestamp.UtcDateTime,
         Device = request.Device,
+        DataSource = request.DataSource,
     };
 
     protected override TestRecord MapUpdateToModel(Guid id, TestUpdateRequest request, TestRecord existing) => new()
@@ -65,6 +71,18 @@ public class TestCrudController(ITestRecordRepository repository)
         LegacyId = existing.LegacyId,
         CreatedAt = existing.CreatedAt,
     };
+}
+
+/// <summary>A controller that records how often the base ran the per-record after-create hook.</summary>
+public class CountingCrudController(ITestRecordRepository repository) : TestCrudController(repository)
+{
+    public int AfterCreateCalls { get; private set; }
+
+    protected override Task<TestRecord> OnAfterCreateAsync(TestRecord created, CancellationToken ct)
+    {
+        AfterCreateCalls++;
+        return base.OnAfterCreateAsync(created, ct);
+    }
 }
 
 #endregion
@@ -179,7 +197,7 @@ public class V4CrudControllerBaseTests
     public async Task Create_Valid_Returns201()
     {
         var request = new TestCreateRequest { Timestamp = DateTime.UtcNow, Device = "test" };
-        var model = new TestRecord { Id = Guid.NewGuid(), Timestamp = request.Timestamp, Device = request.Device };
+        var model = new TestRecord { Id = Guid.NewGuid(), Timestamp = request.Timestamp.UtcDateTime, Device = request.Device };
         _repo.Setup(r => r.CreateAsync(It.IsAny<TestRecord>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(model);
 
@@ -259,6 +277,71 @@ public class V4CrudControllerBaseTests
         var result = await _controller.Delete(id);
 
         result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task CreateBulk_WritesEveryItemAndReturnsThem()
+    {
+        _repo.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<TestRecord>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<TestRecord> models, WriteOrigin _, CancellationToken _) => [.. models]);
+
+        var result = await _controller.CreateBulk(
+        [
+            new TestCreateRequest { Timestamp = DateTimeOffset.UtcNow, Device = "a" },
+            new TestCreateRequest { Timestamp = DateTimeOffset.UtcNow.AddMinutes(1), Device = "b" },
+        ]);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(201);
+        objectResult.Value.Should().BeOfType<TestRecord[]>()
+            .Which.Select(r => r.Device).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public async Task CreateBulk_OverTheCap_ReturnsBadRequest()
+    {
+        var result = await _controller.CreateBulk(
+            [.. Enumerable.Repeat(0, V4BulkValidation.MaxItems + 1).Select(_ => new TestCreateRequest { Timestamp = DateTimeOffset.UtcNow })]);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        objectResult.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Be($"Bulk operations are limited to {V4BulkValidation.MaxItems} records per request");
+        _repo.Verify(
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<TestRecord>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateBulk_DefaultTimestampOnOneItem_RejectsTheWholeBatch()
+    {
+        var result = await _controller.CreateBulk(
+        [
+            new TestCreateRequest { Timestamp = DateTimeOffset.UtcNow },
+            new TestCreateRequest { Timestamp = default },
+        ]);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        _repo.Verify(
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<TestRecord>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateBulk_RunsTheAfterCreateHookOncePerRecord()
+    {
+        _repo.Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<TestRecord>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<TestRecord> models, WriteOrigin _, CancellationToken _) => [.. models]);
+        var controller = new CountingCrudController(_repo.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+        await controller.CreateBulk(
+            [.. Enumerable.Repeat(0, 4).Select(_ => new TestCreateRequest { Timestamp = DateTimeOffset.UtcNow })]);
+
+        controller.AfterCreateCalls.Should().Be(4);
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Base/V4CrudControllerBaseTests.cs
@@ -73,6 +73,38 @@ public class TestCrudController(ITestRecordRepository repository)
     };
 }
 
+/// <summary>
+/// A controller whose before-write hooks always reject, with a detail no guard produces. A response
+/// carrying that detail proves the hook ran; a response carrying a guard's detail proves it did not.
+/// </summary>
+public class RejectingCrudController(ITestRecordRepository repository) : TestCrudController(repository)
+{
+    public const string HookDetail = "hook ran";
+
+    public int BeforeCreateCalls { get; private set; }
+
+    public int BeforeUpdateCalls { get; private set; }
+
+    protected override Task<ObjectResult?> OnBeforeCreateAsync(TestRecord model, TestCreateRequest request, CancellationToken ct)
+    {
+        BeforeCreateCalls++;
+        return Task.FromResult<ObjectResult?>(Problem(detail: HookDetail, statusCode: 400, title: "Bad Request"));
+    }
+
+    protected override Task<ObjectResult?> OnBeforeUpdateAsync(TestRecord model, TestUpdateRequest request, TestRecord existing, CancellationToken ct)
+    {
+        BeforeUpdateCalls++;
+        return Task.FromResult<ObjectResult?>(Problem(detail: HookDetail, statusCode: 400, title: "Bad Request"));
+    }
+
+    protected override Task<ObjectResult?> OnBeforeBulkCreateAsync(
+        IReadOnlyList<TestRecord> models, IReadOnlyList<TestCreateRequest> requests, CancellationToken ct)
+    {
+        BeforeCreateCalls++;
+        return Task.FromResult<ObjectResult?>(Problem(detail: HookDetail, statusCode: 400, title: "Bad Request"));
+    }
+}
+
 /// <summary>A controller that records how often the base ran the per-record after-create hook.</summary>
 public class CountingCrudController(ITestRecordRepository repository) : TestCrudController(repository)
 {
@@ -265,6 +297,103 @@ public class V4CrudControllerBaseTests
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
         objectResult.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task Create_DefaultTimestamp_IsRejectedBeforeTheBeforeCreateHookRuns()
+    {
+        var controller = Rejecting();
+
+        var result = await controller.Create(new TestCreateRequest { Timestamp = default });
+
+        Detail(result.Result).Should().Be("Timestamp must be set");
+        controller.BeforeCreateCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Update_DefaultTimestamp_IsRejectedBeforeTheBeforeUpdateHookRuns()
+    {
+        var id = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TestRecord { Id = id, Timestamp = DateTime.UtcNow });
+        var controller = Rejecting();
+
+        var result = await controller.Update(id, new TestUpdateRequest { Timestamp = default });
+
+        Detail(result.Result).Should().Be("Timestamp must be set");
+        controller.BeforeUpdateCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateBulk_FailedValidation_IsRejectedBeforeTheBeforeBulkHookRuns()
+    {
+        var controller = Rejecting();
+
+        var result = await controller.CreateBulk(
+        [
+            new TestCreateRequest { Timestamp = DateTimeOffset.UtcNow },
+            new TestCreateRequest { Timestamp = default },
+        ]);
+
+        Detail(result.Result).Should().Be("Timestamp must be set on every record");
+        controller.BeforeCreateCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Create_TimestampSet_ReachesTheBeforeCreateHook()
+    {
+        var controller = Rejecting();
+
+        var result = await controller.Create(new TestCreateRequest { Timestamp = DateTimeOffset.UtcNow });
+
+        Detail(result.Result).Should().Be(RejectingCrudController.HookDetail);
+        controller.BeforeCreateCalls.Should().Be(1);
+        _repo.Verify(
+            r => r.CreateAsync(It.IsAny<TestRecord>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Update_TimestampSet_ReachesTheBeforeUpdateHook()
+    {
+        var id = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TestRecord { Id = id, Timestamp = DateTime.UtcNow });
+        var controller = Rejecting();
+
+        var result = await controller.Update(id, new TestUpdateRequest { Timestamp = DateTime.UtcNow });
+
+        Detail(result.Result).Should().Be(RejectingCrudController.HookDetail);
+        controller.BeforeUpdateCalls.Should().Be(1);
+        _repo.Verify(
+            r => r.UpdateAsync(id, It.IsAny<TestRecord>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateBulk_ValidPayload_ReachesTheBeforeBulkHook()
+    {
+        var controller = Rejecting();
+
+        var result = await controller.CreateBulk([new TestCreateRequest { Timestamp = DateTimeOffset.UtcNow }]);
+
+        Detail(result.Result).Should().Be(RejectingCrudController.HookDetail);
+        controller.BeforeCreateCalls.Should().Be(1);
+        _repo.Verify(
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<TestRecord>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private RejectingCrudController Rejecting() => new(_repo.Object)
+    {
+        ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+    };
+
+    private static string? Detail(ActionResult? result)
+    {
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        return objectResult.Value.Should().BeOfType<ProblemDetails>().Subject.Detail;
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/BolusControllerTests.cs
@@ -325,7 +325,7 @@ public class BolusControllerTests
             .Callback<IEnumerable<Bolus>, WriteOrigin, CancellationToken>((b, _, _) => persisted = b.ToList())
             .ReturnsAsync((IEnumerable<Bolus> b, WriteOrigin _, CancellationToken _) => b);
 
-        await CreateController().CreateBolusesBulk(requests);
+        await CreateController().CreateBulk(requests);
 
         persisted.Should().NotBeNull();
         persisted!.Should().SatisfyRespectively(

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/DeviceEventControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/DeviceEventControllerTests.cs
@@ -54,6 +54,42 @@ public class DeviceEventControllerTests
             .ReturnsAsync(new PatientDevice { Id = patientDeviceId, DeviceCategory = DeviceCategory.InsulinPump });
 
     [Fact]
+    public async Task CreateBulk_StampsEveryEventThatDidNotClearAttribution()
+    {
+        var stamped = Guid.NewGuid();
+        _deviceStamperMock
+            .Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+                It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
+                (records, _, _, _) =>
+                {
+                    foreach (var record in records)
+                        record.PatientDeviceId = stamped;
+                })
+            .Returns(Task.CompletedTask);
+
+        IEnumerable<DeviceEvent>? persisted = null;
+        _repoMock
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<DeviceEvent>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<DeviceEvent>, WriteOrigin, CancellationToken>((e, _, _) => persisted = e.ToList())
+            .ReturnsAsync((IEnumerable<DeviceEvent> e, WriteOrigin _, CancellationToken _) => e);
+
+        await CreateController().CreateBulk(
+        [
+            ValidRequest(patientDeviceId: Guid.Empty),
+            ValidRequest(eventType: DeviceEventType.SensorChange),
+        ]);
+
+        persisted.Should().NotBeNull();
+        persisted!.Should().SatisfyRespectively(
+            cleared => cleared.PatientDeviceId.Should().BeNull(),
+            attributed => attributed.PatientDeviceId.Should().Be(stamped));
+    }
+
+    [Fact]
     public async Task Create_PersistsExplicitPatientDeviceId()
     {
         var patientDeviceId = Guid.NewGuid();

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/DeviceEventControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/DeviceEventControllerTests.cs
@@ -54,9 +54,10 @@ public class DeviceEventControllerTests
             .ReturnsAsync(new PatientDevice { Id = patientDeviceId, DeviceCategory = DeviceCategory.InsulinPump });
 
     [Fact]
-    public async Task CreateBulk_StampsEveryEventThatDidNotClearAttribution()
+    public async Task CreateBulk_StampsEachEventTypeWithItsOwnCategories()
     {
         var stamped = Guid.NewGuid();
+        var passes = new List<(IReadOnlyList<DeviceCategory> Categories, DeviceEventType[] Events)>();
         _deviceStamperMock
             .Setup(s => s.StampAsync(
                 It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
@@ -64,8 +65,9 @@ public class DeviceEventControllerTests
                 It.IsAny<string?>(),
                 It.IsAny<CancellationToken>()))
             .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
-                (records, _, _, _) =>
+                (records, categories, _, _) =>
                 {
+                    passes.Add((categories, [.. records.Cast<DeviceEvent>().Select(e => e.EventType)]));
                     foreach (var record in records)
                         record.PatientDeviceId = stamped;
                 })
@@ -79,14 +81,24 @@ public class DeviceEventControllerTests
 
         await CreateController().CreateBulk(
         [
-            ValidRequest(patientDeviceId: Guid.Empty),
+            ValidRequest(eventType: DeviceEventType.SiteChange),
             ValidRequest(eventType: DeviceEventType.SensorChange),
+            ValidRequest(patientDeviceId: Guid.Empty, eventType: DeviceEventType.ReservoirChange),
+            ValidRequest(eventType: DeviceEventType.SensorStart),
         ]);
+
+        passes.Should().HaveCount(2, "one pass per distinct category list, not one per item");
+        passes.Should().ContainSingle(pass => pass.Categories.Single() == DeviceCategory.CGM)
+            .Which.Events.Should().Equal(DeviceEventType.SensorChange, DeviceEventType.SensorStart);
+        passes.Should().ContainSingle(pass => pass.Categories.Single() == DeviceCategory.InsulinPump)
+            .Which.Events.Should().Equal(DeviceEventType.SiteChange);
 
         persisted.Should().NotBeNull();
         persisted!.Should().SatisfyRespectively(
+            site => site.PatientDeviceId.Should().Be(stamped),
+            sensorChange => sensorChange.PatientDeviceId.Should().Be(stamped),
             cleared => cleared.PatientDeviceId.Should().BeNull(),
-            attributed => attributed.PatientDeviceId.Should().Be(stamped));
+            sensorStart => sensorStart.PatientDeviceId.Should().Be(stamped));
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/MeterGlucoseControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/MeterGlucoseControllerTests.cs
@@ -6,6 +6,7 @@ using Nocturne.API.Controllers.V4.Glucose;
 using Nocturne.API.Models.Requests.V4;
 using Nocturne.Core.Contracts.Devices;
 using Nocturne.Core.Contracts.V4.Repositories;
+using Nocturne.Core.Models;
 using Nocturne.Core.Models.V4;
 using Xunit;
 using Nocturne.Core.Contracts.V4;
@@ -167,6 +168,44 @@ public class MeterGlucoseControllerTests
         updated!.PatientDeviceId.Should().BeNull();
         VerifyStamperNeverRan();
     }
+
+    [Fact]
+    public async Task CreateBulk_StampsEveryReadingThatDidNotClearAttribution()
+    {
+        var stamped = Guid.NewGuid();
+        StampAllWith(stamped);
+        IEnumerable<MeterGlucose>? persisted = null;
+        _repoMock
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<MeterGlucose>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<MeterGlucose>, WriteOrigin, CancellationToken>((m, _, _) => persisted = m.ToList())
+            .ReturnsAsync((IEnumerable<MeterGlucose> m, WriteOrigin _, CancellationToken _) => m);
+
+        await CreateController().CreateBulk(
+        [
+            new UpsertMeterGlucoseRequest { Timestamp = DateTimeOffset.UtcNow, Mgdl = 120, PatientDeviceId = Guid.Empty },
+            new UpsertMeterGlucoseRequest { Timestamp = DateTimeOffset.UtcNow.AddMinutes(-5), Mgdl = 95 },
+        ]);
+
+        persisted.Should().NotBeNull();
+        persisted!.Should().SatisfyRespectively(
+            cleared => cleared.PatientDeviceId.Should().BeNull(),
+            attributed => attributed.PatientDeviceId.Should().Be(stamped));
+    }
+
+    private void StampAllWith(Guid patientDeviceId) =>
+        _deviceStamperMock
+            .Setup(s => s.StampAsync(
+                It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
+                It.IsAny<IReadOnlyList<DeviceCategory>>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<IDeviceAttributed>, IReadOnlyList<DeviceCategory>, string?, CancellationToken>(
+                (records, _, _, _) =>
+                {
+                    foreach (var record in records)
+                        record.PatientDeviceId = patientDeviceId;
+                })
+            .Returns(Task.CompletedTask);
 
     private void SetupExisting(Guid id, Guid? patientDeviceId) =>
         _repoMock

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/SensorGlucoseControllerTests.cs
@@ -101,7 +101,7 @@ public class SensorGlucoseControllerTests
         var controller = CreateController();
 
         // Act
-        var result = await controller.CreateSensorGlucoseBulk(requests);
+        var result = await controller.CreateBulk(requests);
 
         // Assert
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
@@ -198,7 +198,7 @@ public class SensorGlucoseControllerTests
 
         var controller = CreateController();
 
-        await controller.CreateSensorGlucoseBulk(requests);
+        await controller.CreateBulk(requests);
 
         _deviceStamperMock.Verify(s => s.StampAsync(
             It.IsAny<IReadOnlyList<IDeviceAttributed>>(),
@@ -392,7 +392,7 @@ public class SensorGlucoseControllerTests
             .Callback<IEnumerable<SensorGlucose>, WriteOrigin, CancellationToken>((m, _, _) => persisted = m.ToList())
             .ReturnsAsync((IEnumerable<SensorGlucose> m, WriteOrigin _, CancellationToken _) => m);
 
-        await CreateController().CreateSensorGlucoseBulk(requests);
+        await CreateController().CreateBulk(requests);
 
         persisted.Should().NotBeNull();
         persisted!.Should().SatisfyRespectively(

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
@@ -27,6 +27,47 @@ public class BasalInjectionControllerTests
         return controller;
     }
 
+    [Fact]
+    public async Task CreateBulk_UnitsOutsideTheAllowedRange_RejectsTheWholeBatch()
+    {
+        var result = await CreateController().CreateBulk(
+        [
+            new CreateBasalInjectionRequest { Timestamp = DateTimeOffset.UtcNow, Units = 12 },
+            new CreateBasalInjectionRequest { Timestamp = DateTimeOffset.UtcNow, Units = 0 },
+        ]);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        objectResult.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Be("Units must be > 0 and <= 500.");
+        _repoMock.Verify(
+            r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateBulk_ResolvesTheInsulinContextPerInjection()
+    {
+        var insulin = BasalInsulin();
+        _insulinRepoMock.Setup(r => r.GetByIdAsync(insulin.Id, It.IsAny<CancellationToken>())).ReturnsAsync(insulin);
+        IEnumerable<BasalInjection>? persisted = null;
+        _repoMock
+            .Setup(r => r.BulkCreateAsync(It.IsAny<IEnumerable<BasalInjection>>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<BasalInjection>, WriteOrigin, CancellationToken>((b, _, _) => persisted = b.ToList())
+            .ReturnsAsync((IEnumerable<BasalInjection> b, WriteOrigin _, CancellationToken _) => b);
+
+        await CreateController().CreateBulk(
+        [
+            new CreateBasalInjectionRequest { Timestamp = DateTimeOffset.UtcNow, Units = 12, PatientInsulinId = insulin.Id },
+            new CreateBasalInjectionRequest { Timestamp = DateTimeOffset.UtcNow, Units = 10 },
+        ]);
+
+        persisted.Should().NotBeNull();
+        persisted!.Should().SatisfyRespectively(
+            referenced => referenced.InsulinContext!.PatientInsulinId.Should().Be(insulin.Id),
+            unreferenced => unreferenced.InsulinContext.Should().BeNull());
+    }
+
     private static PatientInsulin BasalInsulin(
         Guid? id = null,
         InsulinRole role = InsulinRole.Basal,


### PR DESCRIPTION
Fixes #217.

## Problem

Bulk create existed for sensor glucose, boluses and basal injections as three hand-written actions with duplicated preambles, and not at all for notes, device events, BG checks, calibrations, meter glucose or bolus calculations. Uploaders backfilling those types had to POST one record at a time.

## Change

**One `CreateBulk` on `V4CrudControllerBase`** (`POST …/bulk`, `[RequireDeclaredWriteScope]`, 201 with the written array). It runs the shared `ValidateBulkAsync` preamble (whole-batch 400 on empty, over the 1000 cap, an unset timestamp, `syncIdentifier` without `dataSource`, or a validator failure), maps each request, calls `OnBeforeBulkCreateAsync`, writes through `Repository.BulkCreateAsync` (the same path that applies the sync-key upsert and tombstone rules), then `OnAfterBulkCreateAsync` (default: the per-record `OnAfterCreateAsync` once per written record). A `BulkNaming` record supplies the words the 400s use.

- The three bespoke bulk actions are deleted; their glucose resolution, insulin enrichment and device attribution live in hooks. Sensor glucose evaluates alerts once per batch, as before.
- Six new routes: `observations/notes/bulk`, `observations/device-events/bulk`, `observations/bg-checks/bulk`, `glucose/calibrations/bulk`, `glucose/meter/bulk`, `insulin/calculations/bulk`. No route removed or renamed. Naming is `bulk`, which already carried seven routes and the whole vocabulary; `batch` had one.
- **Symmetric `OnBeforeCreateAsync`/`OnBeforeUpdateAsync` hooks** replaced the copy-pasted `Create`/`Update` overrides in Bolus, SensorGlucose, MeterGlucose and DeviceEvent (−73 lines). BasalInjection keeps its overrides on purpose: it answers an idempotent hit with 200 and validates units before mapping.
- DeviceEvent bulk attribution groups by category list, so a batch costs at most two stamper passes.

Of the types reachable through `CreateBulk`, boluses, basal injections and sensor glucose upsert on the sync key; the other six insert (their repositories do not derive from `SyncUpsertRepositoryBase`). Notes and device events therefore do not meet the issue's per-item idempotency criterion; that is the same decision as #1066 item 2 and is recorded there.

**SDK-visible:** operation ids for the three existing bulk routes become `SensorGlucose_CreateBulk`, `Bolus_CreateBulk`, `BasalInjection_CreateBulk` (generated method `createBulk`). Nothing in this repo called the old ids. The OpenAPI surface is otherwise unchanged (626 operations); every bulk operation now publishes its description, which the three old actions had and then briefly lost during this work because NSwag does not resolve XML docs for a `T[]` parameter of a generic type parameter, hence `IReadOnlyList<TCreateRequest>`.

Net +21 production lines for six endpoints added, three folded and eight overrides deleted.

## Tests

`V4CrudBulkCreateTests` (Bolus and Note: writes N, over-cap 400 with nothing written, at-cap accepted, one unset timestamp rejects the batch, sync keys reach the repository), `V4CrudControllerBaseTests` (synthetic controller: bulk writes, hook-ordering in both directions via a rejecting controller), per-controller bulk-hook tests for MeterGlucose, DeviceEvent (per-group categories) and BasalInjection, and a reflective sweep in `V4BulkValidationTests` over every CRUD-base controller checking `BulkNaming` against a nine-row literal table and the three 400 wordings. Unit `Nocturne.API.Tests` 6471/0/5 skipped. Three hostile review rounds; mutations killed include removing validation, dropping sync keys, hooks before the guard, wrong category per group, swapped wording, and a controller missing from the table.
