### PR TITLE
fix(auth): say why a passkey ceremony cannot run on this host, instead of issuing options the browser will refuse

### DIFF
--- a/deploy/helm/nocturne/README.md
+++ b/deploy/helm/nocturne/README.md
@@ -157,7 +157,7 @@ The full set of configurable values is in [`values.yaml`](./values.yaml). Highli
 
 | Key | Description |
 |---|---|
-| `baseDomain` | Public base domain the deployment is reachable at (bare host, no scheme; HTTPS is assumed at the edge). Drives tenant subdomains, the WebAuthn RP ID, OIDC redirects, and invite links. |
+| `baseDomain` | Public base domain the deployment is reachable at (bare host, no scheme; HTTPS is assumed at the edge). Drives tenant subdomains, the WebAuthn RP ID, OIDC redirects, and invite links. **Required.** |
 | `instanceKey.existingSecret` | Secret containing the shared HMAC key. **Required.** |
 | `externalDatabase.host` / `.port` / `.database` / `.sslMode` | Postgres connection details. |
 | `externalDatabase.{app,migrator,web}Secret.existingSecret` | Secret with each role's password under key `password` (override with `existingSecretKey`). |

--- a/deploy/helm/nocturne/templates/api-deployment.yaml
+++ b/deploy/helm/nocturne/templates/api-deployment.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.baseUrl }}
 {{- fail "baseUrl has been replaced by baseDomain: set a bare host (e.g. nocturne.example.com, no scheme). The public origin is derived as https://{baseDomain}." }}
 {{- end }}
+{{- if not .Values.baseDomain }}
+{{- fail "baseDomain is required: set it to the bare host people browse to (e.g. nocturne.example.com, no scheme). Left empty, the chart omits BASE_DOMAIN, the API binds passkeys to localhost, and every browser refuses the passkey prompt." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -150,6 +150,9 @@ public class PasskeyController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<PasskeyOptionsResponse>> RegisterOptions([FromBody] PasskeyRegisterOptionsRequest request)
     {
+        if (this.PasskeyHostRefusal(_passkeyService) is { } refusal)
+            return refusal;
+
         var subjectId = ResolveRegistrationSubject();
         if (subjectId == null)
         {
@@ -312,6 +315,9 @@ public class PasskeyController : ControllerBase
     public async Task<ActionResult<PasskeyOptionsResponse>> RecoveryModeOptions(
         [FromBody] PasskeyLoginOptionsRequest request)
     {
+        if (this.PasskeyHostRefusal(_passkeyService) is { } refusal)
+            return refusal;
+
         var subject = await ResolveRecoveryModeSubjectAsync(request.Username);
         if (subject == null)
         {
@@ -494,8 +500,12 @@ public class PasskeyController : ControllerBase
     [EnableRateLimiting("passkey-login")]
     [RemoteCommand]
     [ProducesResponseType(typeof(PasskeyOptionsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<PasskeyOptionsResponse>> DiscoverableLoginOptions()
     {
+        if (this.PasskeyHostRefusal(_passkeyService) is { } refusal)
+            return refusal;
+
         var tenantId = _tenantAccessor.TenantId;
         var result = await _passkeyService.GenerateDiscoverableAssertionOptionsAsync(tenantId);
 
@@ -517,6 +527,9 @@ public class PasskeyController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<PasskeyOptionsResponse>> LoginOptions([FromBody] PasskeyLoginOptionsRequest request)
     {
+        if (this.PasskeyHostRefusal(_passkeyService) is { } refusal)
+            return refusal;
+
         if (string.IsNullOrEmpty(request.Username))
         {
             return Problem(detail: "Username is required", statusCode: 400, title: "Bad Request");
@@ -916,6 +929,9 @@ public class PasskeyController : ControllerBase
     public async Task<ActionResult<PasskeyOptionsResponse>> AccessRequestOptions(
         [FromBody] AccessRequestOptionsRequest request)
     {
+        if (this.PasskeyHostRefusal(_passkeyService) is { } refusal)
+            return refusal;
+
         var tenantId = _tenantAccessor.TenantId;
         var tenant = await _dbContext.Tenants
             .FirstOrDefaultAsync(t => t.Id == tenantId);
@@ -1087,6 +1103,9 @@ public class PasskeyController : ControllerBase
         [FromBody] InviteOptionsRequest request,
         [FromServices] IMemberInviteService memberInviteService)
     {
+        if (this.PasskeyHostRefusal(_passkeyService) is { } refusal)
+            return refusal;
+
         if (string.IsNullOrWhiteSpace(request.Token) ||
             string.IsNullOrWhiteSpace(request.Username) ||
             string.IsNullOrWhiteSpace(request.DisplayName))

--- a/src/API/Nocturne.API/Controllers/V4/SetupController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/SetupController.cs
@@ -178,6 +178,9 @@ public partial class SetupController : ControllerBase
     public async Task<IActionResult> OwnerOptions(
         [FromBody] SetupOwnerOptionsRequest request, CancellationToken ct)
     {
+        if (this.PasskeyHostRefusal(_passkeyService) is { } refusal)
+            return refusal;
+
         var (tenant, error) = await GetSoleTenantWithoutOwnerAsync(ct);
         if (error != null)
             return error;

--- a/src/API/Nocturne.API/Extensions/PasskeyCeremonyHostExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/PasskeyCeremonyHostExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Nocturne.Core.Contracts.Auth;
+
+namespace Nocturne.API.Extensions;
+
+/// <summary>
+/// Refuses a WebAuthn ceremony the browser is certain to reject, in the terms an operator can act on.
+/// </summary>
+public static class PasskeyCeremonyHostExtensions
+{
+    /// <summary>
+    /// The refusal to return instead of issuing WebAuthn options, or <c>null</c> when the host
+    /// this request arrived on can complete a ceremony.
+    /// </summary>
+    /// <remarks>
+    /// Reads <see cref="HttpRequest.Host"/> rather than a forwarded header: the forwarded-headers
+    /// middleware has already resolved the public host the browser used, and the same host has to
+    /// decide both this and the tenant.
+    /// </remarks>
+    public static ActionResult? PasskeyHostRefusal(
+        this ControllerBase controller, IPasskeyService passkeyService)
+    {
+        var detail = passkeyService.DescribeRpIdMismatch(controller.Request.Host.Host);
+
+        return detail == null
+            ? null
+            : controller.Problem(detail: detail, statusCode: 400, title: "Bad Request");
+    }
+}

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -307,8 +307,14 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IPasskeyService, PasskeyService>();
         services.AddScoped<IRecoveryCodeService, RecoveryCodeService>();
         services.AddScoped<ITotpService, TotpService>();
-        // Derive WebAuthn RP config from the base domain (single source of truth)
-        var baseDomain = configuration[BaseDomainOptions.ConfigKey] ?? "localhost:1612";
+        // Derive WebAuthn RP config from the base domain (single source of truth). Blank counts as
+        // unset — it is what the shipped .env.example leaves behind, and it would otherwise build
+        // the origin "https://", which Fido2Configuration rejects with an unhandled
+        // UriFormatException the first time any passkey endpoint resolves it.
+        var configuredBaseDomain = configuration[BaseDomainOptions.ConfigKey];
+        var baseDomain = string.IsNullOrWhiteSpace(configuredBaseDomain)
+            ? "localhost:1612"
+            : configuredBaseDomain;
         var rpId = baseDomain.Split(':')[0]; // hostname without port
         var origin = $"https://{baseDomain}";
         services.AddFido2(options =>

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -308,9 +308,8 @@ public static class ServiceRegistrationExtensions
         services.AddScoped<IRecoveryCodeService, RecoveryCodeService>();
         services.AddScoped<ITotpService, TotpService>();
         // Derive WebAuthn RP config from the base domain (single source of truth). Blank counts as
-        // unset — it is what the shipped .env.example leaves behind, and it would otherwise build
-        // the origin "https://", which Fido2Configuration rejects with an unhandled
-        // UriFormatException the first time any passkey endpoint resolves it.
+        // unset: it is what the shipped .env.example leaves behind, and an origin built from it is
+        // one Fido2Configuration refuses to parse.
         var configuredBaseDomain = configuration[BaseDomainOptions.ConfigKey];
         var baseDomain = string.IsNullOrWhiteSpace(configuredBaseDomain)
             ? "localhost:1612"

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -302,6 +302,18 @@ else
         rawCorsBaseDomain, BaseDomainOptions.ConfigKey);
 }
 
+// The same key decides the WebAuthn relying-party id, which is fixed at startup and cannot fail
+// closed the way CORS does: left unset it binds to localhost, and the browser reports the
+// resulting refusal as an opaque security error that names nothing an operator can search for.
+if (string.IsNullOrWhiteSpace(rawCorsBaseDomain) && !app.Environment.IsDevelopment() && !isTesting)
+{
+    app.Logger.LogError(
+        "{ConfigKey} is not set. Passkeys are bound to 'localhost', so browsers will refuse to "
+        + "create or use one on any other address, and OIDC sign-in has no redirect URI to send. "
+        + "Set it to the address people browse to and restart.",
+        BaseDomainOptions.ConfigKey);
+}
+
 // Configure middleware pipeline
 app.UseExceptionHandler();
 app.UseStatusCodePages();

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -293,25 +293,27 @@ else if (app.Environment.IsDevelopment())
         + "disabled (loopback origins are still allowed in Development).",
         rawCorsBaseDomain);
 }
+// The key decides more than CORS, and the rest cannot fail closed the way CORS does: the
+// WebAuthn relying-party id is fixed at startup, and a browser reports the refusal it causes as
+// an opaque security error naming nothing an operator can search for. Split by cause so each
+// names the rp.id the deployment actually ended up with.
+else if (string.IsNullOrWhiteSpace(rawCorsBaseDomain))
+{
+    app.Logger.LogError(
+        "{ConfigKey} is unset or blank. Cross-origin CORS is disabled (fail closed), passkeys "
+        + "are bound to 'localhost' so browsers will refuse to create or use one on any other "
+        + "address, and OIDC sign-in has no redirect URI to send. Set it to the address people "
+        + "browse to and restart.",
+        BaseDomainOptions.ConfigKey);
+}
 else
 {
     app.Logger.LogError(
         "CORS base domain '{RawCorsBaseDomain}' is not a valid multi-label host ({ConfigKey}). "
         + "Cross-origin CORS is disabled (fail closed) — tenant and share subdomains will be "
-        + "rejected until this is corrected.",
+        + "rejected until this is corrected, and passkeys are bound to a relying-party id derived "
+        + "from the same value, so browsers will refuse them too.",
         rawCorsBaseDomain, BaseDomainOptions.ConfigKey);
-}
-
-// The same key decides the WebAuthn relying-party id, which is fixed at startup and cannot fail
-// closed the way CORS does: left unset it binds to localhost, and the browser reports the
-// resulting refusal as an opaque security error that names nothing an operator can search for.
-if (string.IsNullOrWhiteSpace(rawCorsBaseDomain) && !app.Environment.IsDevelopment() && !isTesting)
-{
-    app.Logger.LogError(
-        "{ConfigKey} is unset or blank. Passkeys are bound to 'localhost', so browsers will refuse to "
-        + "create or use one on any other address, and OIDC sign-in has no redirect URI to send. "
-        + "Set it to the address people browse to and restart.",
-        BaseDomainOptions.ConfigKey);
 }
 
 // Configure middleware pipeline

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -308,7 +308,7 @@ else
 if (string.IsNullOrWhiteSpace(rawCorsBaseDomain) && !app.Environment.IsDevelopment() && !isTesting)
 {
     app.Logger.LogError(
-        "{ConfigKey} is not set. Passkeys are bound to 'localhost', so browsers will refuse to "
+        "{ConfigKey} is unset or blank. Passkeys are bound to 'localhost', so browsers will refuse to "
         + "create or use one on any other address, and OIDC sign-in has no redirect URI to send. "
         + "Set it to the address people browse to and restart.",
         BaseDomainOptions.ConfigKey);

--- a/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
@@ -5,6 +5,7 @@ using Fido2NetLib.Serialization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using Nocturne.API.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 
@@ -61,6 +62,34 @@ public class PasskeyService : IPasskeyService
     }
 
     /// <summary>
+    /// Whether a browser at <paramref name="host"/> can complete a ceremony against the
+    /// configured rpId. WebAuthn admits the rpId's own host and any host beneath it, nothing else.
+    /// </summary>
+    /// <remarks>
+    /// Development is exempt because it is served from loopback on a port assigned at launch,
+    /// which no configured rpId can name.
+    /// </remarks>
+    private bool CanUseConfiguredRpId(string host)
+    {
+        var rpId = _fido2Config.ServerDomain;
+        return _environment.IsDevelopment()
+            || string.Equals(host, rpId, StringComparison.OrdinalIgnoreCase)
+            || host.EndsWith($".{rpId}", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc/>
+    public string? DescribeRpIdMismatch(string requestHost)
+    {
+        if (CanUseConfiguredRpId(requestHost))
+            return null;
+
+        return $"Passkeys on this server are set up for '{_fido2Config.ServerDomain}', but this "
+            + $"page is served from '{requestHost}'. A browser will only create or use a passkey "
+            + "when those match. Whoever runs this server needs to set "
+            + $"{BaseDomainOptions.ConfigKey} to the address people browse to, then restart it.";
+    }
+
+    /// <summary>
     /// Extracts the origin from the WebAuthn clientDataJSON and, if it is a
     /// subdomain of the configured rpId, adds it to the FIDO2 allowed origins.
     /// This is required for tenant subdomains where the browser
@@ -79,9 +108,7 @@ public class PasskeyService : IPasskeyService
                 return;
 
             var uri = new Uri(origin);
-            var rpId = _fido2Config.ServerDomain;
-            if (_environment.IsDevelopment() ||
-                uri.Host == rpId || uri.Host.EndsWith($".{rpId}", StringComparison.OrdinalIgnoreCase))
+            if (CanUseConfiguredRpId(uri.Host))
             {
                 ((HashSet<string>)_fido2Config.Origins).Add(origin);
 

--- a/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PasskeyService.cs
@@ -66,8 +66,10 @@ public class PasskeyService : IPasskeyService
     /// configured rpId. WebAuthn admits the rpId's own host and any host beneath it, nothing else.
     /// </summary>
     /// <remarks>
-    /// Development is exempt because it is served from loopback on a port assigned at launch,
-    /// which no configured rpId can name.
+    /// Development is exempt to keep the gateway-bypassing routes usable. The dev rpId is the
+    /// gateway's own host (<c>nocturne.localhost</c>), which the gateway and its tenant
+    /// subdomains already satisfy; what the exemption buys is reaching the API or the web app
+    /// directly on <c>localhost</c> at a port Aspire assigns.
     /// </remarks>
     private bool CanUseConfiguredRpId(string host)
     {

--- a/src/Core/Nocturne.Core.Contracts/Auth/IPasskeyService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/IPasskeyService.cs
@@ -8,6 +8,17 @@ namespace Nocturne.Core.Contracts.Auth;
 /// <seealso cref="ISubjectService"/>
 public interface IPasskeyService
 {
+    /// <summary>
+    /// Explains, for a person, why a ceremony started at <paramref name="requestHost"/> cannot
+    /// succeed against the configured relying-party id, or returns <c>null</c> when it can.
+    /// </summary>
+    /// <remarks>
+    /// The rp.id is derived from the deployment's base domain, so a mismatch is a server
+    /// misconfiguration the browser reports only as an opaque security error. Asking here lets a
+    /// ceremony be refused with the actual reason before options are issued.
+    /// </remarks>
+    string? DescribeRpIdMismatch(string requestHost);
+
     /// <summary>Generates registration options for creating a new passkey credential.</summary>
     Task<PasskeyRegistrationOptions> GenerateRegistrationOptionsAsync(Guid subjectId, string username);
 

--- a/src/Web/packages/portal/src/content/docs/authentication/passkeys.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/passkeys.svx
@@ -33,6 +33,13 @@ There are two ways in, both on the sign-in page:
   never stranded.
 </Callout>
 
+<Callout type="info" title="Running your own instance">
+  A passkey is tied to one address: the **BASE_DOMAIN** you configured. A browser will only
+  create or use one when the address in its bar is that host or a subdomain of it, so if
+  passkeys are refused on an instance you run, check that setting matches the address people
+  actually browse to and restart. See [Configuration](/docs/configuration).
+</Callout>
+
 ## The authenticator app step
 
 An **authenticator app** — Aegis, 1Password, Google Authenticator and others — shows a

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -1222,6 +1222,42 @@ public class PasskeyControllerTests : IDisposable
         Assert.Equal(400, objectResult.StatusCode);
     }
 
+    #region Relying-party host
+
+    [Fact]
+    public async Task LoginOptions_WhenTheHostCannotUseTheRpId_RefusesWithTheReason()
+    {
+        const string detail = "Passkeys on this server are set up for 'localhost' … BASE_DOMAIN";
+        _controller.HttpContext.Request.Host = new HostString("cgm.example.com");
+        _passkeyService.Setup(s => s.DescribeRpIdMismatch("cgm.example.com")).Returns(detail);
+
+        var result = await _controller.LoginOptions(new PasskeyLoginOptionsRequest { Username = "someone" });
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        objectResult.StatusCode.Should().Be(400);
+        // Only `detail` reaches the browser, so that is where the operator's instruction has to be.
+        Assert.IsType<ProblemDetails>(objectResult.Value).Detail.Should().Be(detail);
+        _passkeyService.Verify(
+            s => s.GenerateAssertionOptionsAsync(It.IsAny<string>(), It.IsAny<Guid>()),
+            Times.Never,
+            "issuing options the browser will reject is what produced the opaque error");
+    }
+
+    [Fact]
+    public async Task LoginOptions_WhenTheHostCanUseTheRpId_IssuesOptions()
+    {
+        _controller.HttpContext.Request.Host = new HostString("rhys.cgm.example.com");
+        _passkeyService
+            .Setup(s => s.GenerateAssertionOptionsAsync("someone", _tenantId))
+            .ReturnsAsync(new PasskeyAssertionOptions("{\"challenge\":\"abc\"}", "token-data"));
+
+        var result = await _controller.LoginOptions(new PasskeyLoginOptionsRequest { Username = "someone" });
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    #endregion
+
     #region Auth Status Endpoints
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -1227,7 +1227,7 @@ public class PasskeyControllerTests : IDisposable
     [Fact]
     public async Task LoginOptions_WhenTheHostCannotUseTheRpId_RefusesWithTheReason()
     {
-        const string detail = "Passkeys on this server are set up for 'localhost' … BASE_DOMAIN";
+        const string detail = "Passkeys on this server are set up for 'localhost' ... BASE_DOMAIN";
         _controller.HttpContext.Request.Host = new HostString("cgm.example.com");
         _passkeyService.Setup(s => s.DescribeRpIdMismatch("cgm.example.com")).Returns(detail);
 
@@ -1247,6 +1247,11 @@ public class PasskeyControllerTests : IDisposable
     public async Task LoginOptions_WhenTheHostCanUseTheRpId_IssuesOptions()
     {
         _controller.HttpContext.Request.Host = new HostString("rhys.cgm.example.com");
+        // Explicit, not Moq's loose default: the point of the test is that the guard consulted
+        // the service about this host and was answered, not that a null fell out of nowhere.
+        _passkeyService
+            .Setup(s => s.DescribeRpIdMismatch("rhys.cgm.example.com"))
+            .Returns((string?)null);
         _passkeyService
             .Setup(s => s.GenerateAssertionOptionsAsync("someone", _tenantId))
             .ReturnsAsync(new PasskeyAssertionOptions("{\"challenge\":\"abc\"}", "token-data"));
@@ -1254,6 +1259,7 @@ public class PasskeyControllerTests : IDisposable
         var result = await _controller.LoginOptions(new PasskeyLoginOptionsRequest { Username = "someone" });
 
         Assert.IsType<OkObjectResult>(result.Result);
+        _passkeyService.Verify(s => s.DescribeRpIdMismatch("rhys.cgm.example.com"), Times.Once);
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Extensions/PasskeyCeremonyHostExtensionsTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Extensions/PasskeyCeremonyHostExtensionsTests.cs
@@ -1,0 +1,72 @@
+using Fido2NetLib;
+using FluentAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Nocturne.API.Extensions;
+using Nocturne.API.Services.Auth;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Extensions;
+
+/// <summary>
+/// Which host the ceremony guard judges, over a real <see cref="PasskeyService"/>.
+/// </summary>
+public class PasskeyCeremonyHostExtensionsTests
+{
+    private sealed class StubController : ControllerBase;
+
+    private static StubController ControllerOn(HostString host)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Host = host;
+
+        return new StubController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+
+    private static PasskeyService ServiceFor(string rpId)
+    {
+        var fido2Config = new Fido2Configuration
+        {
+            ServerDomain = rpId,
+            ServerName = "Test",
+            Origins = new HashSet<string> { $"https://{rpId}" },
+        };
+
+        return new PasskeyService(
+            TestDbContextFactory.CreateInMemoryContext(),
+            new Fido2(fido2Config),
+            new EphemeralDataProtectionProvider(),
+            Options.Create(fido2Config),
+            NullLogger<PasskeyService>.Instance,
+            Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Production"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void PortBearingHost_IsAdmitted()
+    {
+        // The rp.id is a bare host, so the port has to come off before the comparison. An edge
+        // published on a non-default port would otherwise refuse every ceremony it serves.
+        var controller = ControllerOn(new HostString("cgm.example.com", 8443));
+
+        controller.PasskeyHostRefusal(ServiceFor("cgm.example.com")).Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void HostElsewhere_IsRefused()
+    {
+        var controller = ControllerOn(new HostString("cgm.example.com", 8443));
+
+        controller.PasskeyHostRefusal(ServiceFor("other.example.com")).Should().NotBeNull();
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Extensions/PasskeyRelyingPartyRegistrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Extensions/PasskeyRelyingPartyRegistrationTests.cs
@@ -1,0 +1,59 @@
+using Fido2NetLib;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Extensions;
+using Nocturne.API.Multitenancy;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Extensions;
+
+/// <summary>
+/// The WebAuthn relying party derived at registration time from <c>BASE_DOMAIN</c>.
+/// </summary>
+public class PasskeyRelyingPartyRegistrationTests
+{
+    private static Fido2Configuration Resolve(string? baseDomain)
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            [BaseDomainOptions.ConfigKey] = baseDomain,
+            [$"{JwtOptions.SectionName}:SecretKey"] = new string('k', 64),
+        };
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAuthenticationAndIdentity(configuration);
+
+        return services.BuildServiceProvider().GetRequiredService<IOptions<Fido2Configuration>>().Value;
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankBaseDomain_FallsBackToLocalhostRatherThanThrowing(string? baseDomain)
+    {
+        // A blank value reached Fido2Configuration.Origins as "https://", which throws
+        // UriFormatException and takes every passkey endpoint down with it.
+        var config = Resolve(baseDomain);
+
+        config.ServerDomain.Should().Be("localhost");
+        config.Origins.Should().Contain("https://localhost:1612");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ConfiguredBaseDomain_BecomesTheRelyingPartyId()
+    {
+        var config = Resolve("cgm.example.com");
+
+        config.ServerDomain.Should().Be("cgm.example.com");
+        config.Origins.Should().Contain("https://cgm.example.com");
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/PasskeyServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/PasskeyServiceTests.cs
@@ -396,6 +396,17 @@ public class PasskeyServiceTests
 
     [Fact]
     [Trait("Category", "Unit")]
+    public void DescribeRpIdMismatch_WhenHostMerelyEndsWithTheRpId_Refuses()
+    {
+        // The label boundary is the whole guarantee: "evilcgm.example.com" is a stranger's host,
+        // not a tenant. This predicate also decides which origins reach the FIDO2 allow-list.
+        var service = CreateService("Production", "cgm.example.com");
+
+        service.DescribeRpIdMismatch("evilcgm.example.com").Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public void DescribeRpIdMismatch_WhenHostIsElsewhere_NamesBothAddressesAndTheSetting()
     {
         var service = CreateService("Production", "localhost");
@@ -412,8 +423,9 @@ public class PasskeyServiceTests
     [Trait("Category", "Unit")]
     public void DescribeRpIdMismatch_InDevelopment_AllowsAnyHost()
     {
-        // Dev is served from loopback on a port assigned at launch, which no rpId can name.
-        var service = CreateService("Development", "cgm.example.com");
+        // What the exemption buys is reaching the API or the web app directly on localhost,
+        // past the gateway whose host the dev rpId already names.
+        var service = CreateService("Development", "nocturne.localhost");
 
         service.DescribeRpIdMismatch("localhost").Should().BeNull();
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/PasskeyServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/PasskeyServiceTests.cs
@@ -374,17 +374,64 @@ public class PasskeyServiceTests
 
     #endregion
 
+    #region DescribeRpIdMismatch
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DescribeRpIdMismatch_WhenHostIsTheRpId_AllowsTheCeremony()
+    {
+        var service = CreateService("Production", "cgm.example.com");
+
+        service.DescribeRpIdMismatch("cgm.example.com").Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DescribeRpIdMismatch_WhenHostIsATenantSubdomain_AllowsTheCeremony()
+    {
+        var service = CreateService("Production", "cgm.example.com");
+
+        service.DescribeRpIdMismatch("rhys.cgm.example.com").Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DescribeRpIdMismatch_WhenHostIsElsewhere_NamesBothAddressesAndTheSetting()
+    {
+        var service = CreateService("Production", "localhost");
+
+        var detail = service.DescribeRpIdMismatch("cgm.example.com");
+
+        detail.Should().NotBeNull();
+        detail.Should().Contain("localhost")
+            .And.Contain("cgm.example.com")
+            .And.Contain("BASE_DOMAIN");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DescribeRpIdMismatch_InDevelopment_AllowsAnyHost()
+    {
+        // Dev is served from loopback on a port assigned at launch, which no rpId can name.
+        var service = CreateService("Development", "cgm.example.com");
+
+        service.DescribeRpIdMismatch("localhost").Should().BeNull();
+    }
+
+    #endregion
+
     #region Helpers
 
-    private PasskeyService CreateService()
+    private PasskeyService CreateService(
+        string environmentName = "Development", string rpId = "localhost")
     {
         // We use a mock Fido2 - it won't be called for DB-only tests.
         // For methods that call Fido2, integration tests are needed.
         var fido2Config = new Fido2Configuration
         {
-            ServerDomain = "localhost",
+            ServerDomain = rpId,
             ServerName = "Test",
-            Origins = new HashSet<string> { "https://localhost" },
+            Origins = new HashSet<string> { $"https://{rpId}" },
         };
         var fido2 = new Fido2NetLib.Fido2(fido2Config);
 
@@ -392,7 +439,7 @@ public class PasskeyServiceTests
         var fido2Options = Options.Create(fido2Config);
         var logger = NullLogger<PasskeyService>.Instance;
 
-        var environment = Mock.Of<IHostEnvironment>(e => e.EnvironmentName == "Development");
+        var environment = Mock.Of<IHostEnvironment>(e => e.EnvironmentName == environmentName);
         return new PasskeyService(_dbContext, fido2, dataProtectionProvider, fido2Options, logger, environment);
     }
 


### PR DESCRIPTION
Fixes #184.

## Problem

Passkey options were issued with `rp.id = "localhost"` whenever `BASE_DOMAIN` was unset, and the browser refused them with an error the user could not act on. A present-but-blank `BASE_DOMAIN`, which is what the shipped `.env.example` leaves behind, was worse: the origin became `https://` and every passkey endpoint threw `UriFormatException`. Nothing at startup or at ceremony time said what was wrong.

## Change

- **Ceremony time.** All seven options actions (six on `PasskeyController`, `SetupController.OwnerOptions`) call one `PasskeyHostRefusal` helper before anything else. If the request host is neither the configured rp.id nor a subdomain of it, they answer `400` with a `detail` that names both hosts and says to set `BASE_DOMAIN` to the address users browse to. The predicate is the one `PasskeyService` already used for dynamic origin admission, now shared (`CanUseConfiguredRpId`, case-insensitive); Development keeps its exemption for reaching the API directly on `localhost:{port}` past the gateway.
- **Startup.** A blank or unset `BASE_DOMAIN` outside Development logs one error naming the key and the consequence (passkeys and OIDC bound to `localhost`); a single-label value logs its own. Folded into the existing CORS base-domain check so each cause logs once.
- **Blank is unset.** The rp.id/origin derivation treats whitespace as unset, so a blank `.env` value degrades to `localhost` with a diagnosable 400 instead of a 500. `BaseDomainOptions` keeps the raw value so `OidcAuthService` still throws where it did. Cookie-domain defaults are unaffected (both inputs resolve to no `Domain`).
- **Helm** gains the `fail` guard for an empty `baseDomain` that `instanceKey` already had; the README marks it required. Verified with the CI-pinned helm: `lint` with defaults treats `fail` as info exactly as the existing guards do, and every `ci/*.yaml` renders.
- **Docs**: a callout on the passkeys page ties passkeys to `BASE_DOMAIN`.

The web needed no change: a 4xx `detail` from the options call already reaches the user through `describeSubmitError`.

## Tests

`PasskeyServiceTests` (subdomain admitted, label boundary `evilcgm.example.com` refused, Development exemption), `PasskeyCeremonyHostExtensionsTests` (real service, port-bearing host admitted, other host refused), `PasskeyControllerTests` (400 with the reason; options issued when the host matches, with explicit setup and verify), `PasskeyRelyingPartyRegistrationTests` (blank and whitespace `BASE_DOMAIN` fall back without throwing; configured domain honoured). Unit `Nocturne.API.Tests` 6453/0/5 skipped. Two Fable hostile review rounds; mutations killed: subdomain clause dropped, guard removed, normalisation reverted, port kept on the compared host, dot boundary dropped.

Follow-up filed: #1189 (four hand reads of `X-Forwarded-Host` after the middleware has applied it).
