### PR TITLE
feat(share): render a share link with the owner's appearance

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Identity/ShareAppearanceController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ShareAppearanceController.cs
@@ -18,11 +18,9 @@ namespace Nocturne.API.Controllers.V4.Identity;
 /// this answers — a request that did not arrive over a share token gets the 404 an unrouted path
 /// gets, so no member or bearer token can read another member's settings through it.
 /// <para>
-/// What a viewer can read is presentation only, and is nobody's identity: glucose units, time
-/// format, region format, colour theme, prediction display and chart style. The projection is an
-/// allow-list (<see cref="UserDisplayPreferences.ToPresentationOnly"/>), so a preference added
-/// later stays private until someone decides otherwise, and the response carries no subject id,
-/// name, username, email or display language.
+/// The response carries glucose units, time format, region format, colour theme, prediction
+/// display and chart style, and no subject id, name, username, email or display language. See
+/// <see cref="UserDisplayPreferences.ToPresentationOnly"/> for what is withheld and why.
 /// </para>
 /// </remarks>
 [ApiController]

--- a/src/API/Nocturne.API/Controllers/V4/Identity/ShareAppearanceController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Identity/ShareAppearanceController.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenApi.Remote.Attributes;
+using Nocturne.API.Extensions;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Configuration;
+
+namespace Nocturne.API.Controllers.V4.Identity;
+
+/// <summary>
+/// Serves the appearance an anonymous share viewer renders the tenant's data with: units, time
+/// and date format, colour theme and chart style, taken from the link owner's own settings.
+/// </summary>
+/// <remarks>
+/// Gated by the default-deny fallback policy rather than <c>[Authorize]</c>, for the same reason
+/// as <see cref="MyPermissionsController"/>: a public share is deliberately unauthenticated, and
+/// <c>[Authorize]</c> would 401 every one of them. The share host is additionally the only place
+/// this answers — a request that did not arrive over a share token gets the 404 an unrouted path
+/// gets, so no member or bearer token can read another member's settings through it.
+/// <para>
+/// What a viewer can read is presentation only, and is nobody's identity: glucose units, time
+/// format, region format, colour theme, prediction display and chart style. The projection is an
+/// allow-list (<see cref="UserDisplayPreferences.ToPresentationOnly"/>), so a preference added
+/// later stays private until someone decides otherwise, and the response carries no subject id,
+/// name, username, email or display language.
+/// </para>
+/// </remarks>
+[ApiController]
+[Tags("Identity")]
+[Route("api/v4/share/appearance")]
+[Produces("application/json")]
+public class ShareAppearanceController : ControllerBase
+{
+    private readonly IShareLinkService _shareLinkService;
+    private readonly ITenantAccessor _tenantAccessor;
+
+    public ShareAppearanceController(IShareLinkService shareLinkService, ITenantAccessor tenantAccessor)
+    {
+        _shareLinkService = shareLinkService;
+        _tenantAccessor = tenantAccessor;
+    }
+
+    /// <summary>Get the presentation preferences the current share link is displayed with.</summary>
+    [HttpGet]
+    [RemoteQuery]
+    [ProducesResponseType(typeof(UserDisplayPreferences), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<UserDisplayPreferences>> GetShareAppearance(CancellationToken ct)
+    {
+        if (!HttpContext.IsShareAccess())
+            return NotFound();
+
+        return Ok(await _shareLinkService.GetSharedAppearanceAsync(_tenantAccessor.TenantId, ct));
+    }
+}

--- a/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
@@ -6,6 +6,7 @@ using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.Infrastructure.Data.Security;
 
 namespace Nocturne.API.Services.Auth;
@@ -201,18 +202,8 @@ public sealed class ShareLinkService : IShareLinkService
     /// <inheritdoc />
     public async Task<UserDisplayPreferences> GetSharedAppearanceAsync(Guid tenantId, CancellationToken ct = default)
     {
-        // The longest-standing owner, so a tenant with several owners renders one settled way
-        // instead of changing appearance as the membership list shifts. System subjects are
-        // excluded: the Public subject the share itself runs as never carries an owner role, and
-        // a service account's blank preferences would silently win over a person's.
         var ownerPreferences = await _dbContext.TenantMembers.AsNoTracking()
-            .Where(m => m.TenantId == tenantId
-                && m.RevokedAt == null
-                && !m.Subject!.IsSystemSubject
-                && m.Subject.IsActive
-                && m.MemberRoles.Any(mr => mr.TenantRole!.Slug == RoleSeeds.Owner))
-            .OrderBy(m => m.SysCreatedAt)
-            .ThenBy(m => m.Id)
+            .OwnersOf(tenantId)
             .Select(m => m.Subject!.Preferences)
             .FirstOrDefaultAsync(ct);
 

--- a/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
+++ b/src/API/Nocturne.API/Services/Auth/ShareLinkService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Nocturne.API.Models.Responses;
 using Nocturne.API.Multitenancy;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Security;
@@ -38,6 +39,14 @@ public interface IShareLinkService
     /// authoritative.
     /// </summary>
     Task<ShareLinkDto> SetScopesAsync(Guid tenantId, IReadOnlyList<string> scopes, CancellationToken ct = default);
+
+    /// <summary>
+    /// The appearance an anonymous share viewer renders the tenant's data with: the owner's
+    /// display preferences, narrowed by <see cref="UserDisplayPreferences.ToPresentationOnly"/>.
+    /// All-null when the tenant has no owner or the owner saved nothing, which leaves the viewer
+    /// on the frontend's own defaults.
+    /// </summary>
+    Task<UserDisplayPreferences> GetSharedAppearanceAsync(Guid tenantId, CancellationToken ct = default);
 }
 
 /// <inheritdoc />
@@ -187,6 +196,27 @@ public sealed class ShareLinkService : IShareLinkService
         _publicAccessCache.Evict(tenantId);
 
         return ToDto(tenant, member);
+    }
+
+    /// <inheritdoc />
+    public async Task<UserDisplayPreferences> GetSharedAppearanceAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        // The longest-standing owner, so a tenant with several owners renders one settled way
+        // instead of changing appearance as the membership list shifts. System subjects are
+        // excluded: the Public subject the share itself runs as never carries an owner role, and
+        // a service account's blank preferences would silently win over a person's.
+        var ownerPreferences = await _dbContext.TenantMembers.AsNoTracking()
+            .Where(m => m.TenantId == tenantId
+                && m.RevokedAt == null
+                && !m.Subject!.IsSystemSubject
+                && m.Subject.IsActive
+                && m.MemberRoles.Any(mr => mr.TenantRole!.Slug == RoleSeeds.Owner))
+            .OrderBy(m => m.SysCreatedAt)
+            .ThenBy(m => m.Id)
+            .Select(m => m.Subject!.Preferences)
+            .FirstOrDefaultAsync(ct);
+
+        return UserDisplayPreferences.Deserialize(ownerPreferences).ToPresentationOnly();
     }
 
     private Task<TenantMemberEntity?> GetPublicMemberAsync(Guid tenantId, CancellationToken ct) =>

--- a/src/API/Nocturne.API/Services/Identity/TenantOwnerResolver.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantOwnerResolver.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Contracts.Identity;
-using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Extensions;
 
@@ -28,8 +27,7 @@ public class TenantOwnerResolver : ITenantOwnerResolver
             tenantId, cancellationToken);
 
         var ownerSubjectId = await context.TenantMembers.AsNoTracking()
-            .Where(tm => tm.TenantId == tenantId
-                && tm.MemberRoles.Any(mr => mr.TenantRole.Slug == RoleSeeds.Owner))
+            .OwnersOf(tenantId)
             .Select(tm => tm.SubjectId)
             .FirstOrDefaultAsync(cancellationToken);
 

--- a/src/Core/Nocturne.Core.Models/Configuration/UserDisplayPreferences.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UserDisplayPreferences.cs
@@ -143,6 +143,28 @@ public class UserDisplayPreferences
         }
     }
 
+    /// <summary>
+    /// A copy carrying only the fields that describe how data is drawn, for disclosure to a
+    /// viewer who is not the owner (the anonymous public share). The projection names every
+    /// field it copies, so a preference added later is withheld until someone decides it is
+    /// presentation rather than a fact about the owner.
+    /// <para>
+    /// Two fields fail that test. <see cref="DashboardTopWidgets"/>: which widgets an owner pins
+    /// says what they treat and track. <see cref="NightModeSchedule"/>: it reveals roughly when
+    /// they sleep, to a stranger who may only have been handed a link — and when a viewer's own
+    /// screen dims is theirs to decide, not the owner's.
+    /// </para>
+    /// </summary>
+    public UserDisplayPreferences ToPresentationOnly() => new()
+    {
+        GlucoseUnits = GlucoseUnits,
+        TimeFormat = TimeFormat,
+        RegionFormat = RegionFormat,
+        ColorTheme = ColorTheme,
+        Prediction = Prediction,
+        Chart = Chart,
+    };
+
     /// <summary>Glucose units: "mg/dl" or "mmol".</summary>
     [JsonPropertyName("glucoseUnits")]
     public string? GlucoseUnits { get; set; }

--- a/src/Core/Nocturne.Core.Models/Configuration/UserDisplayPreferences.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UserDisplayPreferences.cs
@@ -145,14 +145,15 @@ public class UserDisplayPreferences
 
     /// <summary>
     /// A copy carrying only the fields that describe how data is drawn, for disclosure to a
-    /// viewer who is not the owner (the anonymous public share). The projection names every
-    /// field it copies, so a preference added later is withheld until someone decides it is
-    /// presentation rather than a fact about the owner.
+    /// viewer who is not the owner (the anonymous public share). Each top-level field is named
+    /// individually, so one added later is withheld until someone decides it is presentation
+    /// rather than a fact about the owner. <see cref="Prediction"/> and <see cref="Chart"/> are
+    /// carried whole and carry no such guarantee: a field added inside either is disclosed on
+    /// the next build. Their contents are pinned by a test instead.
     /// <para>
-    /// Two fields fail that test. <see cref="DashboardTopWidgets"/>: which widgets an owner pins
-    /// says what they treat and track. <see cref="NightModeSchedule"/>: it reveals roughly when
-    /// they sleep, to a stranger who may only have been handed a link — and when a viewer's own
-    /// screen dims is theirs to decide, not the owner's.
+    /// <see cref="DashboardTopWidgets"/> is withheld: the widgets an owner pins say what they
+    /// treat and track. <see cref="NightModeSchedule"/> is withheld: it reports when the owner
+    /// sleeps, and when a viewer's own screen dims is the viewer's setting.
     /// </para>
     /// </summary>
     public UserDisplayPreferences ToPresentationOnly() => new()

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/TenantOwnerFilter.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/TenantOwnerFilter.cs
@@ -1,0 +1,29 @@
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// The one predicate for "the people who own this tenant".
+/// </summary>
+/// <remarks>
+/// Holding the owner role is not enough on its own. A revoked membership has been removed from the
+/// tenant, a deactivated subject cannot sign in, and the Public subject a share link runs as is a
+/// system row with no person behind it — a caller that reaches for "the owner" to notify them, or
+/// to read a setting of theirs, means none of those. Ordered by join time so a tenant with several
+/// owners resolves the same one on every call.
+/// </remarks>
+public static class TenantOwnerFilter
+{
+    /// <summary>The tenant's owning memberships, longest-standing first.</summary>
+    public static IQueryable<TenantMemberEntity> OwnersOf(
+        this IQueryable<TenantMemberEntity> members, Guid tenantId) =>
+        members
+            .Where(m => m.TenantId == tenantId
+                && m.RevokedAt == null
+                && !m.Subject!.IsSystemSubject
+                && m.Subject.IsActive
+                && m.MemberRoles.Any(mr => mr.TenantRole!.Slug == RoleSeeds.Owner))
+            .OrderBy(m => m.SysCreatedAt)
+            .ThenBy(m => m.Id);
+}

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -81,8 +81,12 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
   );
 
   // Display preferences for SSR, in the same precedence the browser applies them
-  // (backend blob over the mirrored cookie) so the markup matches hydration.
-  const serverPrefs = await resolveServerPreferences(locals);
+  // (backend blob over the mirrored cookie) so the markup matches hydration. Together with the
+  // scopes because on a share host both are API round-trips and neither reads the other.
+  const [serverPrefs, effectivePermissions] = await Promise.all([
+    resolveServerPreferences(locals),
+    resolveEffectivePermissions(locals),
+  ]);
   const cookiePrefs = parsePrefsCookie(cookies.get(PREFS_COOKIE_NAME));
   const displayPreferences = [
     hasStoredPreferences(serverPrefs) ? serverPrefs : null,
@@ -100,7 +104,7 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
     user: locals.user,
     isAuthenticated: locals.isAuthenticated,
     isShareHost: locals.isShareHost,
-    effectivePermissions: await resolveEffectivePermissions(locals),
+    effectivePermissions,
     isPlatformAdmin: locals.isPlatformAdmin,
     isPlatformAccessGrant: locals.isPlatformAccessGrant ?? false,
     tenantSlug,

--- a/src/Web/packages/app/src/routes/+layout.server.ts
+++ b/src/Web/packages/app/src/routes/+layout.server.ts
@@ -1,4 +1,5 @@
 import type { LayoutServerLoad } from "./$types";
+import type { UserDisplayPreferences } from "$lib/api";
 import { getOriginalHost } from "$lib/server/request-host";
 import {
   classifyHost,
@@ -33,6 +34,28 @@ async function resolveEffectivePermissions(locals: App.Locals): Promise<string[]
 }
 
 /**
+ * The saved display preferences this viewer's page is rendered with. A signed-in member has
+ * their own. A public share viewer has no account to have any, so the link owner's presentation
+ * settings stand in: a share link should show its recipient the data the way its sender reads
+ * it — their units, their clock, their colours — rather than the frontend's defaults. Only
+ * presentation crosses; the owner's display language does not, because adopting it would rewrite
+ * the viewer's own base-domain-wide language cookie. A refused call leaves the viewer on the
+ * defaults instead of failing the page.
+ */
+async function resolveServerPreferences(
+  locals: App.Locals
+): Promise<UserDisplayPreferences | null> {
+  if (locals.isAuthenticated) return locals.user?.preferences ?? null;
+  if (!locals.isShareHost) return null;
+
+  try {
+    return await locals.apiClient.shareAppearance.getShareAppearance();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Root layout server load function.
  * Provides session data to all routes.
  * Auth gating is handled by route group layouts.
@@ -59,7 +82,7 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
 
   // Display preferences for SSR, in the same precedence the browser applies them
   // (backend blob over the mirrored cookie) so the markup matches hydration.
-  const serverPrefs = locals.isAuthenticated ? locals.user?.preferences : null;
+  const serverPrefs = await resolveServerPreferences(locals);
   const cookiePrefs = parsePrefsCookie(cookies.get(PREFS_COOKIE_NAME));
   const displayPreferences = [
     hasStoredPreferences(serverPrefs) ? serverPrefs : null,
@@ -73,8 +96,10 @@ export const load: LayoutServerLoad = async ({ locals, request, cookies }) => {
   return {
     displayPreferences,
     displayLanguage,
+    serverPreferences: serverPrefs,
     user: locals.user,
     isAuthenticated: locals.isAuthenticated,
+    isShareHost: locals.isShareHost,
     effectivePermissions: await resolveEffectivePermissions(locals),
     isPlatformAdmin: locals.isPlatformAdmin,
     isPlatformAccessGrant: locals.isPlatformAccessGrant ?? false,

--- a/src/Web/packages/app/src/routes/+layout.ts
+++ b/src/Web/packages/app/src/routes/+layout.ts
@@ -29,8 +29,14 @@ export const load: LayoutLoad = async ({ url, data }) => {
     // Registering the backend write-through here keeps the store free of server-remote imports,
     // and the cookie domain must be registered before anything below writes a cookie.
     if (browser) {
-        registerPreferenceCookieDomain(data?.baseDomain)
-        registerPreferencesWriteThrough((prefs) => updateDisplayPreferences(prefs))
+        // Neither is registered on a share host. The preference cookie spans the base domain,
+        // and the appearance rendered there is the link owner's rather than the viewer's, so a
+        // widened write would push it onto the viewer's own tenant; and the viewer is anonymous,
+        // so there is no account behind the link to write through to.
+        if (!data?.isShareHost) {
+            registerPreferenceCookieDomain(data?.baseDomain)
+            registerPreferencesWriteThrough((prefs) => updateDisplayPreferences(prefs))
+        }
     }
 
     if (queryLocale && isSupportedLocale(queryLocale)) {
@@ -49,9 +55,11 @@ export const load: LayoutLoad = async ({ url, data }) => {
         }
     }
 
-    if (browser && data?.isAuthenticated) {
+    if (browser && (data?.isAuthenticated || data?.isShareHost)) {
         // Server preferences win across devices; an empty server blob seeds from local once.
-        reconcilePreferences(data?.user?.preferences)
+        // On a share host they are the link owner's, and hydrating them here is what keeps the
+        // client from replacing the server-rendered view with this browser's defaults.
+        reconcilePreferences(data?.serverPreferences)
     }
 
     // WUCHALE-DISABLED: wuchale temporarily disabled — locale dynamic load skipped.

--- a/src/Web/packages/app/src/routes/layout-load.test.ts
+++ b/src/Web/packages/app/src/routes/layout-load.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$app/environment", () => ({ browser: true, building: false, dev: false }));
+
+const registerPreferenceCookieDomain = vi.fn();
+const registerPreferencesWriteThrough = vi.fn();
+const reconcilePreferences = vi.fn();
+
+vi.mock("$lib/stores/appearance-store.svelte", () => ({
+  registerPreferenceCookieDomain: (...args: unknown[]) =>
+    registerPreferenceCookieDomain(...args),
+  registerPreferencesWriteThrough: (...args: unknown[]) =>
+    registerPreferencesWriteThrough(...args),
+  reconcilePreferences: (...args: unknown[]) => reconcilePreferences(...args),
+  preferredLanguage: { current: "en" },
+  isSupportedLocale: (locale: string) => locale === "en",
+  setLanguage: vi.fn(),
+}));
+
+vi.mock("$lib/api/user-preferences.remote", () => ({ updateDisplayPreferences: vi.fn() }));
+
+const { load } = await import("./+layout");
+
+type LoadEvent = Parameters<typeof load>[0];
+
+function runLoad(data: Record<string, unknown>) {
+  return load({
+    url: new URL("https://example.test/"),
+    data,
+  } as unknown as LoadEvent);
+}
+
+/**
+ * The universal layout load's wiring of the preference store. A share host is a sibling of every
+ * tenant host under one base domain, so what it is allowed to persist is the whole question.
+ */
+describe("root layout universal load", () => {
+  beforeEach(() => {
+    registerPreferenceCookieDomain.mockClear();
+    registerPreferencesWriteThrough.mockClear();
+    reconcilePreferences.mockClear();
+  });
+
+  it("hydrates a share viewer from the link owner's preferences", async () => {
+    await runLoad({
+      isShareHost: true,
+      isAuthenticated: false,
+      baseDomain: "nocturne.run",
+      serverPreferences: { glucoseUnits: "mmol" },
+    });
+
+    expect(reconcilePreferences).toHaveBeenCalledWith({ glucoseUnits: "mmol" });
+  });
+
+  it("never widens the preference cookie or writes back from a share host", async () => {
+    await runLoad({
+      isShareHost: true,
+      isAuthenticated: false,
+      baseDomain: "nocturne.run",
+      serverPreferences: { glucoseUnits: "mmol" },
+    });
+
+    expect(registerPreferenceCookieDomain).not.toHaveBeenCalled();
+    expect(registerPreferencesWriteThrough).not.toHaveBeenCalled();
+  });
+
+  it("keeps both registered for a signed-in member", async () => {
+    await runLoad({
+      isShareHost: false,
+      isAuthenticated: true,
+      baseDomain: "nocturne.run",
+      user: { preferences: { glucoseUnits: "mg/dl" } },
+      serverPreferences: { glucoseUnits: "mg/dl" },
+    });
+
+    expect(registerPreferenceCookieDomain).toHaveBeenCalledWith("nocturne.run");
+    expect(registerPreferencesWriteThrough).toHaveBeenCalled();
+    expect(reconcilePreferences).toHaveBeenCalledWith({ glucoseUnits: "mg/dl" });
+  });
+});

--- a/src/Web/packages/app/src/routes/layout-server-load.test.ts
+++ b/src/Web/packages/app/src/routes/layout-server-load.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Cookies } from "@sveltejs/kit";
+import type { UserDisplayPreferences } from "$lib/api";
 import { load } from "./+layout.server";
 
 /**
- * The root layout's load, exercised for the one decision it makes on its own: which viewers get
- * their granted scopes resolved. The UI offers surfaces from those scopes, so a viewer resolved
- * to nothing silently loses navigation while every unit test around the filters stays green.
+ * The root layout's load, exercised for the two decisions it makes on its own: which viewers get
+ * their granted scopes resolved, and which saved preferences the page is drawn with. The UI
+ * offers surfaces from those scopes, so a viewer resolved to nothing silently loses navigation
+ * while every unit test around the filters stays green; and a share viewer left without the
+ * owner's preferences reads their glucose in units the owner never chose.
  */
 
 type LoadEvent = Parameters<typeof load>[0];
@@ -18,20 +21,32 @@ interface Situation {
   resolved?: string[];
   isShareHost?: boolean;
   isGuestSession?: boolean;
+  /** The share link owner's presentation settings; a thrown value stands for a refused call. */
+  ownerAppearance?: UserDisplayPreferences | Error;
+  /** A signed-in member's own saved preferences. */
+  memberPreferences?: UserDisplayPreferences;
 }
 
 /** The page data the load returned. */
-type LoadedData = { effectivePermissions: string[] };
+type LoadedData = {
+  effectivePermissions: string[];
+  displayPreferences: UserDisplayPreferences[];
+  serverPreferences: UserDisplayPreferences | null;
+};
 
 function runLoad(situation: Situation) {
   const getMyPermissions = vi.fn(async () => {
     if (situation.reported instanceof Error) throw situation.reported;
     return situation.reported ?? [];
   });
+  const getShareAppearance = vi.fn(async () => {
+    if (situation.ownerAppearance instanceof Error) throw situation.ownerAppearance;
+    return situation.ownerAppearance ?? {};
+  });
 
   const locals = {
-    user: null,
-    isAuthenticated: false,
+    user: situation.memberPreferences ? { preferences: situation.memberPreferences } : null,
+    isAuthenticated: situation.memberPreferences !== undefined,
     isPlatformAdmin: false,
     isShareHost: situation.isShareHost ?? false,
     isGuestSession: situation.isGuestSession ?? false,
@@ -39,6 +54,7 @@ function runLoad(situation: Situation) {
     apiClient: {
       status: { getStatus: async () => ({ tenantSlug: null }) },
       myPermissions: { getMyPermissions },
+      shareAppearance: { getShareAppearance },
     },
   };
 
@@ -55,7 +71,7 @@ function runLoad(situation: Situation) {
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the load reads three fields of the request event; the rest of SvelteKit's ServerLoadEvent is not reachable from here
   const data = load(event as unknown as LoadEvent) as unknown as Promise<LoadedData>;
-  return { data, getMyPermissions };
+  return { data, getMyPermissions, getShareAppearance };
 }
 
 async function permissions(situation: Situation): Promise<string[]> {
@@ -122,5 +138,46 @@ describe("root layout load", () => {
 
     await expect(data).resolves.toMatchObject({ effectivePermissions: [] });
     expect(getMyPermissions).not.toHaveBeenCalled();
+  });
+
+  it("draws a share host with the link owner's units and clock", async () => {
+    const { data } = runLoad({
+      host: SHARE_HOST,
+      isShareHost: true,
+      ownerAppearance: { glucoseUnits: "mmol", timeFormat: "24", colorTheme: "trio" },
+    });
+
+    const loaded = await data;
+    expect(loaded.displayPreferences[0]).toMatchObject({
+      glucoseUnits: "mmol",
+      timeFormat: "24",
+      colorTheme: "trio",
+    });
+    // The client hydrates from this, so SSR and the browser have to agree on one source.
+    expect(loaded.serverPreferences).toMatchObject({ glucoseUnits: "mmol" });
+  });
+
+  it("leaves a share on the frontend defaults when the appearance call is refused", async () => {
+    const { data } = runLoad({
+      host: SHARE_HOST,
+      isShareHost: true,
+      ownerAppearance: new Error("404"),
+    });
+
+    const loaded = await data;
+    expect(loaded.displayPreferences).toEqual([]);
+    expect(loaded.serverPreferences).toBeNull();
+  });
+
+  it("never asks for a share owner's appearance on a tenant host", async () => {
+    const { data, getShareAppearance } = runLoad({
+      host: TENANT_HOST,
+      memberPreferences: { glucoseUnits: "mg/dl" },
+    });
+
+    await expect(data).resolves.toMatchObject({
+      serverPreferences: { glucoseUnits: "mg/dl" },
+    });
+    expect(getShareAppearance).not.toHaveBeenCalled();
   });
 });

--- a/src/Web/packages/app/src/routes/layout-server-load.test.ts
+++ b/src/Web/packages/app/src/routes/layout-server-load.test.ts
@@ -180,4 +180,14 @@ describe("root layout load", () => {
     });
     expect(getShareAppearance).not.toHaveBeenCalled();
   });
+
+  it("asks for no owner's appearance on behalf of an anonymous tenant-host visitor", async () => {
+    const { data, getShareAppearance } = runLoad({
+      host: TENANT_HOST,
+      ownerAppearance: { glucoseUnits: "mmol" },
+    });
+
+    await expect(data).resolves.toMatchObject({ serverPreferences: null });
+    expect(getShareAppearance).not.toHaveBeenCalled();
+  });
 });

--- a/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/ControllerAuthorizationCoverageTests.cs
@@ -57,6 +57,12 @@ public class ControllerAuthorizationCoverageTests
             // the share subject is unauthenticated, so [Authorize] would 401 every public share.
             ["Nocturne.API.Controllers.V4.Identity.MyPermissionsController"] = "returns the caller's own grant; fallback rejects an empty trie",
 
+            // The appearance the share renders with, for the anonymous share subject [Authorize]
+            // would 401. It answers only when the request arrived over a share token, and only
+            // with presentation fields — no identity, and nothing the viewer's own page does not
+            // already display.
+            ["Nocturne.API.Controllers.V4.Identity.ShareAppearanceController"] = "presentation-only, share-host-only; fallback rejects an empty trie",
+
             // ── V4 tracker reads ─────────────────────────────────────────────────────────────
             // GET definitions/instances lean on the fallback policy: a bare unauthenticated request
             // on a tenant subdomain has an empty trie and is rejected, so a private tenant exposes

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareAppearanceControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareAppearanceControllerTests.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Nocturne.API.Controllers.V4.Identity;
+using Nocturne.API.Extensions;
+using Nocturne.API.Services.Auth;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.Identity;
+
+/// <summary>
+/// The share appearance endpoint is reachable without credentials, so two things have to hold:
+/// it answers only on a share host, and what it answers with is presentation, never identity.
+/// </summary>
+public sealed class ShareAppearanceControllerTests
+{
+    private readonly Mock<IShareLinkService> _service = new();
+
+    private ShareAppearanceController BuildController(bool onShareHost)
+    {
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.SetupGet(t => t.TenantId).Returns(Guid.NewGuid());
+
+        var httpContext = new DefaultHttpContext();
+        if (onShareHost)
+            httpContext.SetShareAccess();
+
+        return new ShareAppearanceController(_service.Object, tenantAccessor.Object)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+
+    [Fact]
+    public async Task GetShareAppearance_off_a_share_host_is_not_found_and_reads_nothing()
+    {
+        var controller = BuildController(onShareHost: false);
+
+        var result = await controller.GetShareAppearance(CancellationToken.None);
+
+        result.Result.Should().BeOfType<NotFoundResult>();
+        _service.Verify(
+            s => s.GetSharedAppearanceAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetShareAppearance_on_a_share_host_returns_the_owners_presentation_settings()
+    {
+        _service
+            .Setup(s => s.GetSharedAppearanceAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserDisplayPreferences { GlucoseUnits = "mmol", TimeFormat = "24" });
+        var controller = BuildController(onShareHost: true);
+
+        var result = await controller.GetShareAppearance(CancellationToken.None);
+
+        var value = result.Result.Should().BeOfType<OkObjectResult>().Subject
+            .Value.Should().BeOfType<UserDisplayPreferences>().Subject;
+        value.GlucoseUnits.Should().Be("mmol");
+        value.TimeFormat.Should().Be("24");
+    }
+
+    /// <summary>
+    /// The disclosure boundary, pinned by shape rather than by one response: an anonymous viewer
+    /// reads how the data is drawn and nothing about who owns it. Adding a field to the
+    /// presentation projection fails here until it is weighed.
+    /// </summary>
+    [Fact]
+    public void The_response_carries_presentation_fields_only()
+    {
+        var everythingSet = new UserDisplayPreferences
+        {
+            GlucoseUnits = "mmol",
+            TimeFormat = "24",
+            RegionFormat = "en-GB",
+            ColorTheme = "trio",
+            NightModeSchedule = true,
+            Prediction = new PredictionPreferences { Enabled = true },
+            Chart = new ChartPreferences { ShowPoints = true },
+            DashboardTopWidgets = [WidgetId.Tdd],
+        };
+
+        var disclosed = PropertyNames(typeof(UserDisplayPreferences))
+            .Where(name => typeof(UserDisplayPreferences).GetProperty(name)!
+                .GetValue(everythingSet.ToPresentationOnly()) is not null);
+
+        disclosed.Should().BeEquivalentTo(
+            "GlucoseUnits", "TimeFormat", "RegionFormat", "ColorTheme", "Prediction", "Chart");
+    }
+
+    private static IEnumerable<string> PropertyNames(Type type) =>
+        type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+            .Select(p => p.Name);
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareAppearanceControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Identity/ShareAppearanceControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -84,15 +85,32 @@ public sealed class ShareAppearanceControllerTests
             DashboardTopWidgets = [WidgetId.Tdd],
         };
 
-        var disclosed = PropertyNames(typeof(UserDisplayPreferences))
-            .Where(name => typeof(UserDisplayPreferences).GetProperty(name)!
-                .GetValue(everythingSet.ToPresentationOnly()) is not null);
+        var disclosed = everythingSet.ToPresentationOnly();
 
-        disclosed.Should().BeEquivalentTo(
+        SetPropertyNames(disclosed).Should().BeEquivalentTo(
             "GlucoseUnits", "TimeFormat", "RegionFormat", "ColorTheme", "Prediction", "Chart");
+
+        // Both are carried whole rather than field by field, so the projection cannot withhold a
+        // field added inside them: everything these two types declare is disclosed. Pinning the
+        // declarations is what makes adding one a decision rather than a default.
+        PropertyNames(typeof(PredictionPreferences)).Should().BeEquivalentTo(
+            "Enabled", "Minutes", "DisplayMode");
+        PropertyNames(typeof(ChartPreferences)).Should().BeEquivalentTo(
+            "LineColorMode", "LineColor", "PointColorMode", "PointColor", "ShowPoints",
+            "AreaMode", "AreaOpacity", "AlwaysShowPatterns", "Lookback");
     }
 
     private static IEnumerable<string> PropertyNames(Type type) =>
-        type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(p => p.Name);
+
+    /// <summary>
+    /// The names of the properties carrying a value. Every display preference is nullable, so
+    /// applied to a projection of an all-set instance this is exactly what the projection let
+    /// through.
+    /// </summary>
+    private static IEnumerable<string> SetPropertyNames(UserDisplayPreferences preferences) =>
+        typeof(UserDisplayPreferences)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetValue(preferences) is not null)
             .Select(p => p.Name);
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
@@ -272,6 +272,59 @@ public sealed class ShareLinkServiceTests : IDisposable
         await _db.SaveChangesAsync();
     }
 
+    /// <summary>
+    /// Adds a second owner of the tenant, joining <paramref name="joinedAfter"/> the seeded one.
+    /// </summary>
+    private async Task AddOwnerAsync(
+        UserDisplayPreferences preferences,
+        DateTime joinedAfter,
+        bool isSystemSubject = false,
+        bool isActiveSubject = true)
+    {
+        var subjectId = Guid.NewGuid();
+        _db.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = $"Owner {subjectId:N}",
+            IsActive = isActiveSubject,
+            IsSystemSubject = isSystemSubject,
+            Preferences = preferences.Serialize(),
+        });
+
+        var member = new TenantMemberEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TenantId,
+            SubjectId = subjectId,
+        };
+        _db.TenantMembers.Add(member);
+        _db.TenantMemberRoles.Add(new TenantMemberRoleEntity
+        {
+            Id = Guid.NewGuid(),
+            TenantMemberId = member.Id,
+            TenantRoleId = await _db.TenantRoles
+                .Where(r => r.TenantId == TenantId && r.Slug == RoleSeeds.Owner)
+                .Select(r => r.Id)
+                .FirstAsync(),
+        });
+        await _db.SaveChangesAsync();
+
+        // The context stamps SysCreatedAt on insert, so the join time can only be set afterwards.
+        member.SysCreatedAt = joinedAfter;
+        await _db.SaveChangesAsync();
+    }
+
+    /// <summary>Backdates the seeded owner's membership so later arrivals sort after it.</summary>
+    private async Task<DateTime> BackdateTheSeededOwnerAsync()
+    {
+        var joined = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var member = await _db.TenantMembers
+            .FirstAsync(m => m.SubjectId == TestDatabaseSeeder.TestSubjectId);
+        member.SysCreatedAt = joined;
+        await _db.SaveChangesAsync();
+        return joined;
+    }
+
     [Fact]
     public async Task SharedAppearance_is_the_owners_presentation_settings()
     {
@@ -338,4 +391,48 @@ public sealed class ShareLinkServiceTests : IDisposable
 
         appearance.GlucoseUnits.Should().BeNull();
     }
+
+    [Fact]
+    public async Task SharedAppearance_settles_on_the_longest_standing_of_several_owners()
+    {
+        var seededJoined = await BackdateTheSeededOwnerAsync();
+        await GiveTheOwnerPreferencesAsync(new UserDisplayPreferences { GlucoseUnits = "mmol" });
+        await AddOwnerAsync(
+            new UserDisplayPreferences { GlucoseUnits = "mg/dl" }, seededJoined.AddYears(1));
+
+        var appearance = await _service.GetSharedAppearanceAsync(TenantId);
+
+        appearance.GlucoseUnits.Should().Be("mmol", "a later co-owner does not restyle the link");
+    }
+
+    [Fact]
+    public async Task SharedAppearance_ignores_a_system_subject_holding_the_owner_role()
+    {
+        var seededJoined = await BackdateTheSeededOwnerAsync();
+        await GiveTheOwnerPreferencesAsync(new UserDisplayPreferences { GlucoseUnits = "mmol" });
+        await AddOwnerAsync(
+            new UserDisplayPreferences { GlucoseUnits = "mg/dl" },
+            seededJoined.AddYears(-1),
+            isSystemSubject: true);
+
+        var appearance = await _service.GetSharedAppearanceAsync(TenantId);
+
+        appearance.GlucoseUnits.Should().Be("mmol", "no person is behind a system subject");
+    }
+
+    [Fact]
+    public async Task SharedAppearance_ignores_an_owner_whose_subject_is_deactivated()
+    {
+        var seededJoined = await BackdateTheSeededOwnerAsync();
+        await GiveTheOwnerPreferencesAsync(new UserDisplayPreferences { GlucoseUnits = "mmol" });
+        await AddOwnerAsync(
+            new UserDisplayPreferences { GlucoseUnits = "mg/dl" },
+            seededJoined.AddYears(-1),
+            isActiveSubject: false);
+
+        var appearance = await _service.GetSharedAppearanceAsync(TenantId);
+
+        appearance.GlucoseUnits.Should().Be("mmol", "a deactivated subject cannot sign in either");
+    }
+
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
@@ -11,6 +11,7 @@ using Nocturne.API.Multitenancy;
 using Nocturne.API.Services.Auth;
 using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Security;
@@ -261,5 +262,80 @@ public sealed class ShareLinkServiceTests : IDisposable
 
         dto.Enabled.Should().BeFalse();
         (await _db.Tenants.AsNoTracking().FirstAsync(t => t.Id == TenantId)).ShareToken.Should().BeNull();
+    }
+
+    /// <summary>Stores display preferences against the seeded owner subject.</summary>
+    private async Task GiveTheOwnerPreferencesAsync(UserDisplayPreferences preferences)
+    {
+        var owner = await _db.Subjects.FirstAsync(s => s.Id == TestDatabaseSeeder.TestSubjectId);
+        owner.Preferences = preferences.Serialize();
+        await _db.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task SharedAppearance_is_the_owners_presentation_settings()
+    {
+        await GiveTheOwnerPreferencesAsync(new UserDisplayPreferences
+        {
+            GlucoseUnits = "mmol",
+            TimeFormat = "24",
+            RegionFormat = "en-GB",
+            ColorTheme = "trio",
+            Chart = new ChartPreferences { LineColorMode = "threshold", Lookback = 6 },
+            Prediction = new PredictionPreferences { Enabled = true, Minutes = 45 },
+        });
+
+        var appearance = await _service.GetSharedAppearanceAsync(TenantId);
+
+        appearance.GlucoseUnits.Should().Be("mmol");
+        appearance.TimeFormat.Should().Be("24");
+        appearance.RegionFormat.Should().Be("en-GB");
+        appearance.ColorTheme.Should().Be("trio");
+        appearance.Chart!.LineColorMode.Should().Be("threshold");
+        appearance.Chart.Lookback.Should().Be(6);
+        appearance.Prediction!.Minutes.Should().Be(45);
+    }
+
+    [Fact]
+    public async Task SharedAppearance_withholds_what_the_owner_does_rather_than_how_it_looks()
+    {
+        await GiveTheOwnerPreferencesAsync(new UserDisplayPreferences
+        {
+            GlucoseUnits = "mmol",
+            DashboardTopWidgets = [WidgetId.Tdd, WidgetId.Meals],
+            NightModeSchedule = true,
+        });
+
+        var appearance = await _service.GetSharedAppearanceAsync(TenantId);
+
+        appearance.GlucoseUnits.Should().Be("mmol");
+        appearance.DashboardTopWidgets.Should().BeNull(
+            "the widgets an owner pins describe what they track, not how it looks");
+        appearance.NightModeSchedule.Should().BeNull(
+            "it tells a stranger holding the link roughly when the owner sleeps");
+    }
+
+    [Fact]
+    public async Task SharedAppearance_is_empty_when_the_tenant_has_no_owner_left()
+    {
+        await GiveTheOwnerPreferencesAsync(new UserDisplayPreferences { GlucoseUnits = "mmol" });
+
+        var owner = await _db.TenantMembers.FirstAsync(m => m.SubjectId == TestDatabaseSeeder.TestSubjectId);
+        owner.RevokedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        var appearance = await _service.GetSharedAppearanceAsync(TenantId);
+
+        appearance.GlucoseUnits.Should().BeNull("a revoked member no longer speaks for the tenant");
+    }
+
+    [Fact]
+    public async Task SharedAppearance_ignores_another_tenants_owner()
+    {
+        await GiveTheOwnerPreferencesAsync(new UserDisplayPreferences { GlucoseUnits = "mmol" });
+
+        var appearance = await _service.GetSharedAppearanceAsync(Guid.NewGuid());
+
+        appearance.GlucoseUnits.Should().BeNull();
     }
 }


### PR DESCRIPTION
Fixes #675.

## Problem

A public share link (`{token}.share.{base-domain}`) always rendered in mg/dL, the default theme and 12-hour time. The root layout only passed a signed-in member's preferences to the appearance store; a share visitor is unauthenticated by design, and `GET /api/v4/user/preferences` is `[Authorize]`, so the store fell through to module defaults.

## Change

- **`GET /api/v4/share/appearance`** (`ShareAppearanceController`, modelled on `MyPermissionsController`): fallback-policy gated plus an explicit `IsShareAccess()` guard that answers 404 off a share host, so no member or token can read another member's settings through it. It returns the tenant owner's `UserDisplayPreferences` narrowed by `ToPresentationOnly()`: glucose units, time format, region format, colour theme, prediction display and chart style. Withheld: dashboard widgets (what the owner tracks), night-mode schedule (when the owner sleeps), language, and no identity fields exist on the type. The nested `Prediction`/`Chart` types are carried whole and their declared members are pinned by test.
- **Owner resolution**: the share link is tenant-level (a `Public` system subject), so "owner" is the longest-standing active, non-revoked, non-system member holding the owner role. That predicate is one new `TenantOwnerFilter.OwnersOf(tenantId)` extension, also adopted by `TenantOwnerResolver`, which could previously return a revoked or deactivated owner and picked non-deterministically on a multi-owner tenant. Its four callers already handle null with a warning.
- **Web**: `+layout.server.ts` resolves the owner's preferences on a share host (in parallel with the permissions read) and hands one `serverPreferences` value down; `+layout.ts` reconciles from it on a share host too, but never widens the preferences cookie to the base domain there and never writes through to the backend. Without that, the owner's units would have been written into the viewer's own cookie and changed the viewer's own tenant view.
- Degradation: no owner, an owner who saved nothing, or a refused call leaves today's defaults.

## Tests

Backend: `ShareAppearanceControllerTests` (presentation-only shape incl. nested members; 404 off a share host reads nothing), `ShareLinkServiceTests` (owner's fields returned; widgets and night mode withheld; other tenant's owner ignored; oldest of several owners wins; system-subject and deactivated owners ignored). Web: `layout-server-load.test.ts` (share host hydrates owner units/clock; refused call leaves defaults; tenant hosts, authenticated or anonymous, never ask) and `layout-load.test.ts` (share viewer reconciles; cookie never widened, no write-through). Unit `Nocturne.API.Tests` 6450/0/5; Core.Models 839; app vitest baseline unchanged. Two Fable hostile review rounds; mutations killed include dropping the tenant predicate, returning 200 off a share host, newest owner, dropped system/inactive filters, a field added to `ChartPreferences`, registering the cookie domain on a share host, and skipping reconcile.

Follow-ups filed: #1196 (per-link settings on the Public subject), #1195 (the seven remaining inline owner queries).
