### PR TITLE
refactor(cache): read the processing-status clock through TimeProvider, and ban the statics there

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -118,6 +118,7 @@
     <!-- Roslyn Code Analysis packages (for source generators) -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <!-- Windows Widget packages -->
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -184,8 +184,8 @@ public static class ServiceRegistrationExtensions
     )
     {
         // Every service that takes TimeProvider by constructor resolves it from here. Without this
-        // it resolves only because some framework extension the host calls registers it in passing,
-        // which would make the alerting and cache subsystems depend on that call staying put.
+        // it resolves only because AddAuthentication TryAdds the same instance in passing, which
+        // would make the alerting and cache subsystems depend on that call staying put.
         services.TryAddSingleton(TimeProvider.System);
 
         services.AddScoped<IStatusService, StatusService>();

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -183,9 +183,10 @@ public static class ServiceRegistrationExtensions
         IConfiguration configuration
     )
     {
-        // Every service that takes TimeProvider by constructor resolves it from here. Without this
-        // it resolves only because AddAuthentication TryAdds the same instance in passing, which
-        // would make the alerting and cache subsystems depend on that call staying put.
+        // The clock every constructor-injected TimeProvider resolves to, stated here rather than
+        // left to AddAuthentication, which TryAdds the same instance in passing. In this host
+        // AddNocturneMemoryCache has already TryAdded it, so this is the registration for hosts
+        // that do not add the cache.
         services.TryAddSingleton(TimeProvider.System);
 
         services.AddScoped<IStatusService, StatusService>();

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -1,5 +1,6 @@
 using System.Threading.RateLimiting;
 using Fido2NetLib;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nocturne.API.Authorization;
 using Nocturne.API.Configuration;
 using Nocturne.API.Services;
@@ -182,6 +183,11 @@ public static class ServiceRegistrationExtensions
         IConfiguration configuration
     )
     {
+        // Every service that takes TimeProvider by constructor resolves it from here. Without this
+        // it resolves only because some framework extension the host calls registers it in passing,
+        // which would make the alerting and cache subsystems depend on that call staying put.
+        services.TryAddSingleton(TimeProvider.System);
+
         services.AddScoped<IStatusService, StatusService>();
         services.AddScoped<IVersionService, VersionService>();
         services.AddSingleton<IXmlDocumentationService, XmlDocumentationService>();

--- a/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutCircuitBreaker.cs
+++ b/src/Connectors/Nocturne.Connectors.Nightscout/Services/WriteBack/NightscoutCircuitBreaker.cs
@@ -7,10 +7,8 @@ namespace Nocturne.Connectors.Nightscout.Services.WriteBack;
 /// Registered as singleton — all fields must be thread-safe.
 /// </summary>
 /// <param name="timeProvider">
-/// Clock used for the recovery window. Defaults to <see cref="TimeProvider.System"/>
-/// when not supplied, so DI registration and tests both work unchanged. Nothing
-/// registers a <see cref="TimeProvider"/> in the container today; if something ever
-/// does, this singleton will start resolving it instead of the default.
+/// Clock used for the recovery window. The container supplies
+/// <see cref="TimeProvider.System"/>, so the default applies only to direct construction.
 /// </param>
 public class NightscoutCircuitBreaker(TimeProvider? timeProvider = null)
 {

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/BannedSymbols.txt
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/BannedSymbols.txt
@@ -1,0 +1,4 @@
+P:System.DateTime.UtcNow;Inject TimeProvider and read GetUtcNow().UtcDateTime.
+P:System.DateTime.Now;Inject TimeProvider; GetLocalNow().LocalDateTime only where local time is genuinely intended.
+P:System.DateTimeOffset.UtcNow;Inject TimeProvider and read GetUtcNow().
+P:System.DateTimeOffset.Now;Inject TimeProvider; GetLocalNow() only where local time is genuinely intended.

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/BannedSymbols.txt
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/BannedSymbols.txt
@@ -1,4 +1,13 @@
 P:System.DateTime.UtcNow;Inject TimeProvider and read GetUtcNow().UtcDateTime.
 P:System.DateTime.Now;Inject TimeProvider; GetLocalNow().LocalDateTime only where local time is genuinely intended.
+P:System.DateTime.Today;Inject TimeProvider; GetLocalNow().Date only where local time is genuinely intended.
 P:System.DateTimeOffset.UtcNow;Inject TimeProvider and read GetUtcNow().
 P:System.DateTimeOffset.Now;Inject TimeProvider; GetLocalNow() only where local time is genuinely intended.
+T:System.Threading.Timer;Use TimeProvider.CreateTimer so the interval is drivable from a test.
+M:System.Threading.Tasks.Task.Delay(System.Int32);Use the TimeProvider overload: Task.Delay(delay, timeProvider, cancellationToken).
+M:System.Threading.Tasks.Task.Delay(System.Int32,System.Threading.CancellationToken);Use the TimeProvider overload: Task.Delay(delay, timeProvider, cancellationToken).
+M:System.Threading.Tasks.Task.Delay(System.TimeSpan);Use the TimeProvider overload: Task.Delay(delay, timeProvider, cancellationToken).
+M:System.Threading.Tasks.Task.Delay(System.TimeSpan,System.Threading.CancellationToken);Use the TimeProvider overload: Task.Delay(delay, timeProvider, cancellationToken).
+M:System.Threading.CancellationTokenSource.CancelAfter(System.TimeSpan);Construct with new CancellationTokenSource(delay, timeProvider) so the deadline is drivable from a test.
+M:System.Threading.CancellationTokenSource.CancelAfter(System.Int32);Construct with new CancellationTokenSource(delay, timeProvider) so the deadline is drivable from a test.
+M:System.Threading.Thread.Sleep(System.Int32);Blocking sleep; await Task.Delay(delay, timeProvider, cancellationToken) instead.

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Infrastructure.Cache.Abstractions;
 using Nocturne.Infrastructure.Cache.Configuration;
@@ -34,11 +33,6 @@ public static class ServiceCollectionExtensions
 
         // Register in-memory cache service
         services.AddSingleton<ICacheService, MemoryCacheService>();
-
-        // No registration in this tree owns the clock — it is only ever reached incidentally,
-        // through whichever framework extension the host happened to call. TryAdd so this
-        // assembly's services resolve one either way, without displacing a host-supplied clock.
-        services.TryAddSingleton(TimeProvider.System);
 
         // Register processing status service (in-memory)
         services.AddSingleton<IProcessingStatusService, MemoryProcessingStatusService>();

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Extensions/ServiceCollectionExtensions.cs
@@ -36,8 +36,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ICacheService, MemoryCacheService>();
 
         // MemoryProcessingStatusService takes TimeProvider, so a caller adding this to a bare
-        // collection would otherwise fail to resolve it. TryAdd, so a host that supplies its own
-        // clock (the API composition root registers one explicitly) still wins.
+        // collection would otherwise fail to resolve it. TryAdd is first-wins: a host that wants a
+        // different clock must register it before calling this.
         services.TryAddSingleton(TimeProvider.System);
 
         // Register processing status service (in-memory)

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Infrastructure.Cache.Abstractions;
 using Nocturne.Infrastructure.Cache.Configuration;
@@ -33,6 +34,11 @@ public static class ServiceCollectionExtensions
 
         // Register in-memory cache service
         services.AddSingleton<ICacheService, MemoryCacheService>();
+
+        // No registration in this tree owns the clock — it is only ever reached incidentally,
+        // through whichever framework extension the host happened to call. TryAdd so this
+        // assembly's services resolve one either way, without displacing a host-supplied clock.
+        services.TryAddSingleton(TimeProvider.System);
 
         // Register processing status service (in-memory)
         services.AddSingleton<IProcessingStatusService, MemoryProcessingStatusService>();

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Infrastructure.Cache.Abstractions;
 using Nocturne.Infrastructure.Cache.Configuration;
@@ -33,6 +34,11 @@ public static class ServiceCollectionExtensions
 
         // Register in-memory cache service
         services.AddSingleton<ICacheService, MemoryCacheService>();
+
+        // MemoryProcessingStatusService takes TimeProvider, so a caller adding this to a bare
+        // collection would otherwise fail to resolve it. TryAdd, so a host that supplies its own
+        // clock (the API composition root registers one explicitly) still wins.
+        services.TryAddSingleton(TimeProvider.System);
 
         // Register processing status service (in-memory)
         services.AddSingleton<IProcessingStatusService, MemoryProcessingStatusService>();

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Nocturne.Infrastructure.Cache.csproj
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Nocturne.Infrastructure.Cache.csproj
@@ -3,11 +3,19 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <!-- This project reads the clock only through an injected TimeProvider; BannedSymbols.txt
+             holds it there. Scoped to this project until the rest of the tree follows. -->
+        <WarningsAsErrors>$(WarningsAsErrors);RS0030</WarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <AdditionalFiles Include="BannedSymbols.txt"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\Core\Nocturne.Core.Models\Nocturne.Core.Models.csproj"/>

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/MemoryProcessingStatusService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/MemoryProcessingStatusService.cs
@@ -12,23 +12,30 @@ namespace Nocturne.Infrastructure.Cache.Services;
 public class MemoryProcessingStatusService : IProcessingStatusService
 {
     private readonly ILogger<MemoryProcessingStatusService> _logger;
+    private readonly TimeProvider _timeProvider;
     private readonly ConcurrentDictionary<string, ProcessingStatus> _statusCache;
-    private readonly Timer _cleanupTimer;
+    private readonly ITimer _cleanupTimer;
     private readonly TimeSpan _defaultTtl = CacheConstants.DefaultTtl.ProcessingStatus;
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
 
-    public MemoryProcessingStatusService(ILogger<MemoryProcessingStatusService> logger)
+    public MemoryProcessingStatusService(
+        ILogger<MemoryProcessingStatusService> logger,
+        TimeProvider timeProvider
+    )
     {
         _logger = logger;
+        _timeProvider = timeProvider;
         _statusCache = new ConcurrentDictionary<string, ProcessingStatus>();
 
-        // Setup cleanup timer to remove expired entries every 5 minutes
-        _cleanupTimer = new Timer(
+        _cleanupTimer = _timeProvider.CreateTimer(
             CleanupExpiredEntries,
             null,
             CacheConstants.CleanupIntervals.StatusCleanup,
             CacheConstants.CleanupIntervals.StatusCleanup
         );
     }
+
+    private DateTime UtcNow => _timeProvider.GetUtcNow().UtcDateTime;
 
     /// <inheritdoc />
     public Task<ProcessingStatus?> GetStatusAsync(
@@ -41,7 +48,7 @@ public class MemoryProcessingStatusService : IProcessingStatusService
             if (_statusCache.TryGetValue(correlationId, out var status))
             {
                 // Check if expired
-                if (status.StartedAt.Add(_defaultTtl) < DateTime.UtcNow)
+                if (status.StartedAt.Add(_defaultTtl) < UtcNow)
                 {
                     _statusCache.TryRemove(correlationId, out _);
                     return Task.FromResult<ProcessingStatus?>(null);
@@ -112,7 +119,7 @@ public class MemoryProcessingStatusService : IProcessingStatusService
             }
 
             status.Status = CacheConstants.ProcessingStatus.Completed;
-            status.CompletedAt = DateTime.UtcNow;
+            status.CompletedAt = UtcNow;
             status.Progress = 100;
             if (results != null)
             {
@@ -156,7 +163,7 @@ public class MemoryProcessingStatusService : IProcessingStatusService
             }
 
             status.Status = CacheConstants.ProcessingStatus.Failed;
-            status.CompletedAt = DateTime.UtcNow;
+            status.CompletedAt = UtcNow;
             status.Errors = errors.ToList();
 
             await UpdateStatusAsync(correlationId, status, cancellationToken);
@@ -193,7 +200,7 @@ public class MemoryProcessingStatusService : IProcessingStatusService
                 Progress = 0,
                 ProcessedCount = 0,
                 TotalCount = totalCount,
-                StartedAt = DateTime.UtcNow,
+                StartedAt = UtcNow,
             };
 
             _statusCache.AddOrUpdate(correlationId, status, (key, existing) => status);
@@ -273,10 +280,13 @@ public class MemoryProcessingStatusService : IProcessingStatusService
     {
         try
         {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(timeout);
+            using var timeoutCts = new CancellationTokenSource(timeout, _timeProvider);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                timeoutCts.Token
+            );
 
-            var startTime = DateTime.UtcNow;
+            var startTimestamp = _timeProvider.GetTimestamp();
             while (!cts.Token.IsCancellationRequested)
             {
                 var status = await GetStatusAsync(correlationId, cts.Token);
@@ -289,15 +299,14 @@ public class MemoryProcessingStatusService : IProcessingStatusService
                     _logger.LogDebug(
                         "Processing completed for correlation ID: {CorrelationId} after {ElapsedTime}ms",
                         correlationId,
-                        (DateTime.UtcNow - startTime).TotalMilliseconds
+                        _timeProvider.GetElapsedTime(startTimestamp).TotalMilliseconds
                     );
                     return status;
                 }
 
-                // Wait 1 second before checking again
                 try
                 {
-                    await Task.Delay(1000, cts.Token);
+                    await Task.Delay(PollInterval, _timeProvider, cts.Token);
                 }
                 catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
                 {
@@ -330,7 +339,7 @@ public class MemoryProcessingStatusService : IProcessingStatusService
     {
         try
         {
-            var cutoffTime = DateTime.UtcNow.Subtract(_defaultTtl);
+            var cutoffTime = UtcNow.Subtract(_defaultTtl);
             var expiredKeys = _statusCache
                 .Where(kvp => kvp.Value.StartedAt < cutoffTime)
                 .Select(kvp => kvp.Key)

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/MemoryProcessingStatusService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/MemoryProcessingStatusService.cs
@@ -10,7 +10,7 @@ namespace Nocturne.Infrastructure.Cache.Services;
 /// Tracks async processing status in process memory. State is per-node and does not survive a
 /// restart, so a correlation ID minted by one node is unknown to any other.
 /// </summary>
-public class MemoryProcessingStatusService : IProcessingStatusService
+public class MemoryProcessingStatusService : IProcessingStatusService, IDisposable
 {
     private readonly ILogger<MemoryProcessingStatusService> _logger;
     private readonly TimeProvider _timeProvider;

--- a/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/MemoryProcessingStatusService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Cache/Services/MemoryProcessingStatusService.cs
@@ -7,7 +7,8 @@ using Nocturne.Infrastructure.Cache.Constants;
 namespace Nocturne.Infrastructure.Cache.Services;
 
 /// <summary>
-/// In-memory implementation of processing status service for development and testing
+/// Tracks async processing status in process memory. State is per-node and does not survive a
+/// restart, so a correlation ID minted by one node is unknown to any other.
 /// </summary>
 public class MemoryProcessingStatusService : IProcessingStatusService
 {

--- a/tests/Unit/Nocturne.API.Tests/Infrastructure/HostClockRegistrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Infrastructure/HostClockRegistrationTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.API.Extensions;
+using Xunit;
+
+namespace Nocturne.API.Tests.Infrastructure;
+
+/// <summary>
+/// Pins that the composition root owns the clock. Services across alerting, auth and the
+/// processing-status cache take <see cref="TimeProvider"/> by constructor; before this
+/// registration existed they resolved one only because some framework extension the host
+/// called registered it in passing, so dropping that call would have broken them at runtime
+/// with nothing in the tree to point at.
+/// </summary>
+public class HostClockRegistrationTests : IClassFixture<AuthenticationTestFactory>
+{
+    private readonly AuthenticationTestFactory _factory;
+
+    public HostClockRegistrationTests(AuthenticationTestFactory factory) => _factory = factory;
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void BuiltHost_Resolves_TheSystemClock()
+    {
+        _factory.Services.GetRequiredService<TimeProvider>().Should().BeSameAs(TimeProvider.System);
+    }
+
+    /// <summary>
+    /// Asserted against <see cref="ServiceRegistrationExtensions.AddApiCoreServices"/> on its own,
+    /// because the host-level check above passes on the incidental registration too and so cannot
+    /// fail if this one is removed.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ApiCoreServices_Registers_TheSystemClock()
+    {
+        var services = new ServiceCollection();
+        services.AddApiCoreServices(new ConfigurationBuilder().Build());
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<TimeProvider>().Should().BeSameAs(TimeProvider.System);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Infrastructure/HostClockRegistrationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Infrastructure/HostClockRegistrationTests.cs
@@ -9,28 +9,17 @@ namespace Nocturne.API.Tests.Infrastructure;
 /// <summary>
 /// Pins that the composition root owns the clock. Services across alerting, auth and the
 /// processing-status cache take <see cref="TimeProvider"/> by constructor; before this
-/// registration existed they resolved one only because some framework extension the host
-/// called registered it in passing, so dropping that call would have broken them at runtime
-/// with nothing in the tree to point at.
+/// registration existed they resolved one only because <c>AddAuthentication</c> happens to
+/// <c>TryAdd</c> the same instance, so moving that call would have broken them at runtime with
+/// nothing in the tree to point at.
 /// </summary>
-public class HostClockRegistrationTests : IClassFixture<AuthenticationTestFactory>
+/// <remarks>
+/// Asserted against <see cref="ServiceRegistrationExtensions.AddApiCoreServices"/> rather than a
+/// built host: the host resolves <see cref="TimeProvider.System"/> either way, so a host-level
+/// check cannot fail if this registration is removed.
+/// </remarks>
+public class HostClockRegistrationTests
 {
-    private readonly AuthenticationTestFactory _factory;
-
-    public HostClockRegistrationTests(AuthenticationTestFactory factory) => _factory = factory;
-
-    [Fact]
-    [Trait("Category", "Unit")]
-    public void BuiltHost_Resolves_TheSystemClock()
-    {
-        _factory.Services.GetRequiredService<TimeProvider>().Should().BeSameAs(TimeProvider.System);
-    }
-
-    /// <summary>
-    /// Asserted against <see cref="ServiceRegistrationExtensions.AddApiCoreServices"/> on its own,
-    /// because the host-level check above passes on the incidental registration too and so cannot
-    /// fail if this one is removed.
-    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
     public void ApiCoreServices_Registers_TheSystemClock()

--- a/tests/Unit/Nocturne.Infrastructure.Cache.Tests/MemoryCacheServiceTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Cache.Tests/MemoryCacheServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Nocturne.Core.Contracts.Infrastructure;
 using Nocturne.Infrastructure.Cache.Abstractions;
 using Nocturne.Infrastructure.Cache.Extensions;
 using Xunit;
@@ -177,6 +178,18 @@ public class MemoryCacheServiceTests : IDisposable
             Assert.NotNull(stored);
             Assert.Equal($"Updated {testData.Value}", stored.Value);
         }
+    }
+
+    /// <summary>
+    /// Everything this collection holds comes from <c>AddNocturneMemoryCache</c>, so a consumer
+    /// that is not the API host resolves the same way. The processing-status service takes
+    /// <see cref="TimeProvider"/>, which nothing here would otherwise register.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Cache")]
+    public void ProcessingStatusService_Should_ResolveWithoutAHostSuppliedClock()
+    {
+        Assert.NotNull(_serviceProvider.GetRequiredService<IProcessingStatusService>());
     }
 
     public void Dispose()

--- a/tests/Unit/Nocturne.Infrastructure.Cache.Tests/MemoryProcessingStatusServiceTimeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Cache.Tests/MemoryProcessingStatusServiceTimeTests.cs
@@ -9,13 +9,17 @@ namespace Nocturne.Infrastructure.Cache.Tests;
 
 /// <summary>
 /// The processing-status TTL, the background sweep and the completion poll are all clock-driven,
-/// on intervals (an hour, five minutes, a ten-minute timeout) no test can wait out. Driving them
-/// from <see cref="FakeTimeProvider"/> asserts each boundary at the exact tick instead.
+/// on intervals (an hour, five minutes, and a long poll up to five more) no test can wait out.
+/// Driving them from <see cref="FakeTimeProvider"/> asserts each boundary at the exact tick instead.
 /// </summary>
 public class MemoryProcessingStatusServiceTimeTests
 {
     private static readonly TimeSpan Ttl = CacheConstants.DefaultTtl.ProcessingStatus;
     private static readonly DateTimeOffset Origin = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    // The longest wait a caller can actually ask for: ProcessingController rejects
+    // timeoutSeconds above 300.
+    private static readonly TimeSpan MaxLongPoll = TimeSpan.FromSeconds(300);
 
     private static (MemoryProcessingStatusService Service, FakeTimeProvider Time, CapturingLogger Log) Build()
     {
@@ -89,9 +93,26 @@ public class MemoryProcessingStatusServiceTimeTests
         var (service, time, _) = Build();
         await service.InitializeAsync("run", 1, TestContext.Current.CancellationToken);
 
-        var wait = service.WaitForCompletionAsync("run", TimeSpan.FromMinutes(10), TestContext.Current.CancellationToken);
-        time.Advance(TimeSpan.FromMinutes(10));
+        var wait = service.WaitForCompletionAsync("run", MaxLongPoll, TestContext.Current.CancellationToken);
+        time.Advance(MaxLongPoll);
 
+        var result = await wait.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Cache")]
+    public async Task WaitForCompletion_Should_EndWhenTheCallerCancels()
+    {
+        var (service, _, _) = Build();
+        await service.InitializeAsync("run", 1, TestContext.Current.CancellationToken);
+
+        using var caller = new CancellationTokenSource();
+        var wait = service.WaitForCompletionAsync("run", MaxLongPoll, caller.Token);
+        await caller.CancelAsync();
+
+        // The clock never moves, so only the caller's token can end this wait.
         var result = await wait.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
@@ -104,7 +125,7 @@ public class MemoryProcessingStatusServiceTimeTests
         var (service, time, _) = Build();
         await service.InitializeAsync("run", 1, TestContext.Current.CancellationToken);
 
-        var wait = service.WaitForCompletionAsync("run", TimeSpan.FromMinutes(10), TestContext.Current.CancellationToken);
+        var wait = service.WaitForCompletionAsync("run", MaxLongPoll, TestContext.Current.CancellationToken);
         await service.MarkCompletedAsync("run", null, TestContext.Current.CancellationToken);
         time.Advance(TimeSpan.FromSeconds(1));
 

--- a/tests/Unit/Nocturne.Infrastructure.Cache.Tests/MemoryProcessingStatusServiceTimeTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Cache.Tests/MemoryProcessingStatusServiceTimeTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Nocturne.Infrastructure.Cache.Constants;
+using Nocturne.Infrastructure.Cache.Services;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Cache.Tests;
+
+/// <summary>
+/// The processing-status TTL, the background sweep and the completion poll are all clock-driven,
+/// on intervals (an hour, five minutes, a ten-minute timeout) no test can wait out. Driving them
+/// from <see cref="FakeTimeProvider"/> asserts each boundary at the exact tick instead.
+/// </summary>
+public class MemoryProcessingStatusServiceTimeTests
+{
+    private static readonly TimeSpan Ttl = CacheConstants.DefaultTtl.ProcessingStatus;
+    private static readonly DateTimeOffset Origin = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static (MemoryProcessingStatusService Service, FakeTimeProvider Time, CapturingLogger Log) Build()
+    {
+        var time = new FakeTimeProvider(Origin);
+        var log = new CapturingLogger();
+        return (new MemoryProcessingStatusService(log, time), time, log);
+    }
+
+    [Fact]
+    [Trait("Category", "Cache")]
+    public async Task GetStatus_Should_SurviveTheExactTtlInstant()
+    {
+        var (service, time, _) = Build();
+        await service.InitializeAsync("run", 1, TestContext.Current.CancellationToken);
+
+        time.Advance(Ttl);
+
+        var status = await service.GetStatusAsync("run", TestContext.Current.CancellationToken);
+
+        status.Should().NotBeNull("an entry expires strictly after StartedAt + TTL, not on it");
+    }
+
+    [Fact]
+    [Trait("Category", "Cache")]
+    public async Task GetStatus_Should_ExpireOneTickPastTheTtl()
+    {
+        var (service, time, _) = Build();
+        await service.InitializeAsync("run", 1, TestContext.Current.CancellationToken);
+
+        time.Advance(Ttl + TimeSpan.FromTicks(1));
+
+        var status = await service.GetStatusAsync("run", TestContext.Current.CancellationToken);
+
+        status.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Cache")]
+    public async Task Timestamps_Should_ComeFromTheInjectedClock()
+    {
+        var (service, time, _) = Build();
+        await service.InitializeAsync("run", 1, TestContext.Current.CancellationToken);
+
+        time.Advance(TimeSpan.FromMinutes(3));
+        await service.MarkCompletedAsync("run", null, TestContext.Current.CancellationToken);
+
+        var status = await service.GetStatusAsync("run", TestContext.Current.CancellationToken);
+
+        status!.StartedAt.Should().Be(Origin.UtcDateTime);
+        status.StartedAt.Kind.Should().Be(DateTimeKind.Utc);
+        status.CompletedAt.Should().Be(Origin.UtcDateTime.AddMinutes(3));
+    }
+
+    [Fact]
+    [Trait("Category", "Cache")]
+    public async Task CleanupSweep_Should_RunOnTheInjectedClock()
+    {
+        var (service, time, log) = Build();
+        await service.InitializeAsync("run", 1, TestContext.Current.CancellationToken);
+
+        // Past the TTL, so the next sweep tick has something to drop.
+        time.Advance(Ttl + CacheConstants.CleanupIntervals.StatusCleanup);
+
+        log.Messages.Should().Contain(m => m.Contains("Cleaned up 1 expired processing status entries"));
+    }
+
+    [Fact]
+    [Trait("Category", "Cache")]
+    public async Task WaitForCompletion_Should_TimeOutOnTheInjectedClock()
+    {
+        var (service, time, _) = Build();
+        await service.InitializeAsync("run", 1, TestContext.Current.CancellationToken);
+
+        var wait = service.WaitForCompletionAsync("run", TimeSpan.FromMinutes(10), TestContext.Current.CancellationToken);
+        time.Advance(TimeSpan.FromMinutes(10));
+
+        var result = await wait.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Cache")]
+    public async Task WaitForCompletion_Should_ReturnAsSoonAsTheRunCompletes()
+    {
+        var (service, time, _) = Build();
+        await service.InitializeAsync("run", 1, TestContext.Current.CancellationToken);
+
+        var wait = service.WaitForCompletionAsync("run", TimeSpan.FromMinutes(10), TestContext.Current.CancellationToken);
+        await service.MarkCompletedAsync("run", null, TestContext.Current.CancellationToken);
+        time.Advance(TimeSpan.FromSeconds(1));
+
+        var result = await wait.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        result!.Status.Should().Be(CacheConstants.ProcessingStatus.Completed);
+    }
+
+    private sealed class CapturingLogger : ILogger<MemoryProcessingStatusService>
+    {
+        private readonly List<string> _messages = [];
+
+        public IReadOnlyList<string> Messages
+        {
+            get
+            {
+                lock (_messages) return _messages.ToList();
+            }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
+        {
+            lock (_messages) _messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Infrastructure.Cache.Tests/Nocturne.Infrastructure.Cache.Tests.csproj
+++ b/tests/Unit/Nocturne.Infrastructure.Cache.Tests/Nocturne.Infrastructure.Cache.Tests.csproj
@@ -18,6 +18,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing"/>
         <PackageReference Include="FluentAssertions"/>
         <PackageReference Include="Moq"/>
     </ItemGroup>


### PR DESCRIPTION
First increment of #993 (incremental TimeProvider migration).

## Subsystem

`Nocturne.Infrastructure.Cache`. All seven static-clock reads in the project were in `MemoryProcessingStatusService`, the only registered `IProcessingStatusService`, behind the V1 entries upload and the V4 tenant-admin processing endpoints. It held three behaviours no test could reach: a one-hour TTL, a five-minute sweep timer, and a long-poll wait with a caller-supplied timeout.

Rejected for this round: `Connectors.Core` (7 sites, but `BaseConnectorService` fans out to 19 connectors and one is in open PR #1123), `Infrastructure.Data` (160 sites, overlaps #1139), `Services.Demo` (17 sites, no test project).

## Change

- `MemoryProcessingStatusService` takes `TimeProvider`. Reads go through `GetUtcNow().UtcDateTime` (same `Kind`); the sweep uses `TimeProvider.CreateTimer`; the wait uses `new CancellationTokenSource(timeout, timeProvider)` linked to the caller's token and `Task.Delay(interval, timeProvider, ct)`; the elapsed-time debug log is monotonic. The service now declares `IDisposable`, so the container disposes the sweep timer it previously leaked.
- `BannedApiAnalyzers` on the project with a `BannedSymbols.txt` (13 entries: the four static clock properties, `DateTime.Today`, `System.Threading.Timer`, the `Task.Delay` overloads without a `TimeProvider`, `CancelAfter`, `Thread.Sleep`), RS0030 as an error in that project only. Re-adding any of them fails the build.
- `TimeProvider.System` is registered explicitly: in `AddNocturneMemoryCache` so the library is self-contained, and in the API composition root (`AddApiCoreServices`) for hosts that do not add the cache. Nothing in `src/` registered it before; `AlertOrchestrator` and the auth handlers resolved it only because `AddAuthentication` TryAdds it in passing. `TryAdd` is first-wins and the comments say so.
- The class doc no longer calls the service "for development and testing" (it serves production; state is per-node). A now-false comment in `NightscoutCircuitBreaker` is corrected.

No behaviour change. There were no `DateTime.Now` sites in this project. `src/Directory.Build.props` exists and is the home for a tree-wide ban once more projects are clean.

## Tests

`MemoryProcessingStatusServiceTimeTests` (FakeTimeProvider): TTL survives the exact instant and expires after it, the sweep runs on the injected clock, a long poll times out on the injected clock at the controller's 300 s cap, and a cancelled caller ends the wait before the timeout. `MemoryCacheServiceTests` resolves `IProcessingStatusService` from a bare collection. `HostClockRegistrationTests` asserts `AddApiCoreServices` registers the clock. Cache tests 10/0; Unit `Nocturne.API.Tests` 6441/0/5. Two hostile review rounds; mutations killed: TTL `<` to `<=`, infinite sweep period, infinite timeout, caller token dropped from the link, library registration removed, composition-root registration removed, each banned construct re-added.

The seeder and demo generators' `DateTime.Now` sites (server-local "today" on a multi-tenant host) are recorded on #993 for the subsystem that owns them.
