### PR TITLE
feat(dashboard): empty state before the first glucose reading

### DIFF
--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { getStatus as getConnectorStatuses } from "$api/generated/connectorStatus.generated.remote";
-  import { getServicesOverview } from "$api/generated/services.generated.remote";
   import FirstReadingEmptyState from "./FirstReadingEmptyState.svelte";
   import type { ConnectorStatusDto } from "$lib/api/generated/nocturne-api-client";
 
@@ -11,21 +10,30 @@
      * reading.
      */
     chart: Snippet;
+    /**
+     * Whether the realtime store's initial load has settled. Until it has, the
+     * decision is held in loading so the empty state can never flash ahead of
+     * the recent-history fetch resolving.
+     */
+    recentHistoryReady: boolean;
+    /**
+     * Whether the realtime store's initial, undated most-recent fetch returned
+     * any entries. This is the authoritative "has data recently" signal for an
+     * uploader-only instance, which carries no managed-connector count.
+     */
+    hasRecentHistory: boolean;
   }
 
-  let { chart }: Props = $props();
+  let { chart, recentHistoryReady, hasRecentHistory }: Props = $props();
 
   const connectorStatusesQuery = getConnectorStatuses();
-  const servicesQuery = getServicesOverview();
 
   const connectors = $derived<ConnectorStatusDto[]>(
     connectorStatusesQuery.current ?? []
   );
-  const services = $derived(servicesQuery.current);
 
   const loading = $derived(
-    connectorStatusesQuery.current === undefined ||
-      servicesQuery.current === undefined
+    connectorStatusesQuery.current === undefined || !recentHistoryReady
   );
 
   const configuredConnectors = $derived(
@@ -33,15 +41,17 @@
   );
 
   /**
-   * "Never had a reading" is a lifetime signal, so it is read from record
-   * counts rather than the health flag: a connector can be healthy and synced
-   * yet have imported nothing, which is exactly the state the empty state
-   * exists for. Any source or connector with a lifetime count means readings
-   * have arrived before, even if none fall inside the chart's current window.
+   * Whether a reading has ever arrived. Read from the realtime store's recent
+   * history and each connector's lifetime import count — never the connector
+   * health flag, which reports a freshly synced connector that fetched nothing
+   * as healthy. Note the two counts differ:
+   * <c>ConnectorStatusDto.totalEntries</c> is genuinely lifetime, whereas the
+   * data-source count from the services overview is a trailing 30-day window,
+   * so it is not used here — the realtime recent-history fetch covers an
+   * uploader-only instance instead.
    */
   const hasEverReceivedReading = $derived(
-    connectors.some((c) => (c.totalEntries ?? 0) > 0) ||
-      (services?.activeDataSources ?? []).some((s) => (s.totalEntries ?? 0) > 0)
+    hasRecentHistory || connectors.some((c) => (c.totalEntries ?? 0) > 0)
   );
 
   const showEmptyState = $derived(!loading && !hasEverReceivedReading);

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte
@@ -3,8 +3,13 @@
   import FirstReadingEmptyStateLoader from "./FirstReadingEmptyStateLoader.svelte";
 
   interface Props {
-    /** The real glucose chart. This component owns the only instance of it. */
-    chart: Snippet;
+    /**
+     * The real glucose chart. This component owns the only instance of it. The
+     * boolean argument is whether the chart is currently shown (not hidden
+     * behind the empty state), so the caller can gate a coach mark on it — a
+     * mark attached to a hidden element positions against a zero rect.
+     */
+    chart: Snippet<[boolean]>;
     /**
      * Whether the instance already has data on hand (server-loaded glucose or a
      * realtime value/history). When true the chart shows and the empty-state
@@ -28,7 +33,7 @@
 </script>
 
 <div hidden={chartHidden} aria-hidden={chartHidden}>
-  {@render chart()}
+  {@render chart(!chartHidden)}
 </div>
 
 <!--

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte
@@ -1,71 +1,44 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
-  import { getStatus as getConnectorStatuses } from "$api/generated/connectorStatus.generated.remote";
-  import FirstReadingEmptyState from "./FirstReadingEmptyState.svelte";
-  import type { ConnectorStatusDto } from "$lib/api/generated/nocturne-api-client";
+  import FirstReadingEmptyStateLoader from "./FirstReadingEmptyStateLoader.svelte";
 
   interface Props {
-    /**
-     * The real glucose chart, rendered once the instance has ever had a
-     * reading.
-     */
+    /** The real glucose chart. This component owns the only instance of it. */
     chart: Snippet;
     /**
-     * Whether the realtime store's initial load has settled. Until it has, the
-     * decision is held in loading so the empty state can never flash ahead of
-     * the recent-history fetch resolving.
+     * Whether the instance already has data on hand (server-loaded glucose or a
+     * realtime value/history). When true the chart shows and the empty-state
+     * check is skipped entirely, so a populated dashboard fires no status
+     * query.
      */
+    bypass: boolean;
+    /** Passed through to the empty-state loader; see its docs. */
     recentHistoryReady: boolean;
-    /**
-     * Whether the realtime store's initial, undated most-recent fetch returned
-     * any entries. This is the authoritative "has data recently" signal for an
-     * uploader-only instance, which carries no managed-connector count.
-     */
+    /** Passed through to the empty-state loader; see its docs. */
     hasRecentHistory: boolean;
   }
 
-  let { chart, recentHistoryReady, hasRecentHistory }: Props = $props();
+  let { chart, bypass, recentHistoryReady, hasRecentHistory }: Props = $props();
 
-  const connectorStatusesQuery = getConnectorStatuses();
+  let emptyStateShown = $state(false);
 
-  const connectors = $derived<ConnectorStatusDto[]>(
-    connectorStatusesQuery.current ?? []
-  );
-
-  const loading = $derived(
-    connectorStatusesQuery.current === undefined || !recentHistoryReady
-  );
-
-  const configuredConnectors = $derived(
-    connectors.filter((c) => c.hasDatabaseConfig || c.isEnabled)
-  );
-
-  /**
-   * Whether a reading has ever arrived. Read from the realtime store's recent
-   * history and each connector's lifetime import count — never the connector
-   * health flag, which reports a freshly synced connector that fetched nothing
-   * as healthy. Note the two counts differ:
-   * <c>ConnectorStatusDto.totalEntries</c> is genuinely lifetime, whereas the
-   * data-source count from the services overview is a trailing 30-day window,
-   * so it is not used here — the realtime recent-history fetch covers an
-   * uploader-only instance instead.
-   */
-  const hasEverReceivedReading = $derived(
-    hasRecentHistory || connectors.some((c) => (c.totalEntries ?? 0) > 0)
-  );
-
-  const showEmptyState = $derived(!loading && !hasEverReceivedReading);
+  // The chart is rendered once, here, so it is never destroyed and remounted as
+  // the empty state comes and goes; it is only hidden behind the empty state.
+  const chartHidden = $derived(!bypass && emptyStateShown);
 </script>
 
-<!--
-  The chart stays mounted so its hydratable queries keep their tracking
-  context; it is only hidden while the empty state is shown, mirroring
-  ResourceGuard.
--->
-<div hidden={showEmptyState} aria-hidden={showEmptyState}>
+<div hidden={chartHidden} aria-hidden={chartHidden}>
   {@render chart()}
 </div>
 
-{#if showEmptyState}
-  <FirstReadingEmptyState connectors={configuredConnectors} />
+<!--
+  The loader owns the connector-status query, so keeping it unmounted while the
+  instance already has data is what spares a populated dashboard that query.
+-->
+{#if !bypass}
+  <FirstReadingEmptyStateLoader
+    {recentHistoryReady}
+    {hasRecentHistory}
+    onResolve={(show) => (emptyStateShown = show)}
+  />
 {/if}

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { getStatus as getConnectorStatuses } from "$api/generated/connectorStatus.generated.remote";
+  import { getServicesOverview } from "$api/generated/services.generated.remote";
+  import FirstReadingEmptyState from "./FirstReadingEmptyState.svelte";
+  import type { ConnectorStatusDto } from "$lib/api/generated/nocturne-api-client";
+
+  interface Props {
+    /**
+     * The real glucose chart, rendered once the instance has ever had a
+     * reading.
+     */
+    chart: Snippet;
+  }
+
+  let { chart }: Props = $props();
+
+  const connectorStatusesQuery = getConnectorStatuses();
+  const servicesQuery = getServicesOverview();
+
+  const connectors = $derived<ConnectorStatusDto[]>(
+    connectorStatusesQuery.current ?? []
+  );
+  const services = $derived(servicesQuery.current);
+
+  const loading = $derived(
+    connectorStatusesQuery.current === undefined ||
+      servicesQuery.current === undefined
+  );
+
+  const configuredConnectors = $derived(
+    connectors.filter((c) => c.hasDatabaseConfig || c.isEnabled)
+  );
+
+  /**
+   * "Never had a reading" is a lifetime signal, so it is read from record
+   * counts rather than the health flag: a connector can be healthy and synced
+   * yet have imported nothing, which is exactly the state the empty state
+   * exists for. Any source or connector with a lifetime count means readings
+   * have arrived before, even if none fall inside the chart's current window.
+   */
+  const hasEverReceivedReading = $derived(
+    connectors.some((c) => (c.totalEntries ?? 0) > 0) ||
+      (services?.activeDataSources ?? []).some((s) => (s.totalEntries ?? 0) > 0)
+  );
+
+  const showEmptyState = $derived(!loading && !hasEverReceivedReading);
+</script>
+
+<!--
+  The chart stays mounted so its hydratable queries keep their tracking
+  context; it is only hidden while the empty state is shown, mirroring
+  ResourceGuard.
+-->
+<div hidden={showEmptyState} aria-hidden={showEmptyState}>
+  {@render chart()}
+</div>
+
+{#if showEmptyState}
+  <FirstReadingEmptyState connectors={configuredConnectors} />
+{/if}

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte.test.ts
@@ -5,6 +5,7 @@ import { createRawSnippet } from "svelte";
 import { remoteQuery } from "$lib/test-stubs/remote-resource";
 import type { ConnectorStatusDto } from "$lib/api/generated/nocturne-api-client";
 import FirstReadingChartArea from "./FirstReadingChartArea.svelte";
+import CoachHarness from "./FirstReadingCoachHarness.test.svelte";
 
 const state = vi.hoisted(() => {
   const connectors: ConnectorStatusDto[] = [];
@@ -73,5 +74,43 @@ describe("FirstReadingChartArea", () => {
     await expect
       .element(page.getByTestId("first-reading-empty-state"))
       .not.toBeInTheDocument();
+  });
+
+  it("does not mark the chart coach-eligible while the empty state is shown", async () => {
+    state.connectors = [
+      {
+        id: "dexcom",
+        name: "Dexcom Share",
+        hasDatabaseConfig: true,
+        totalEntries: 0,
+      },
+    ];
+
+    render(CoachHarness, {
+      bypass: false,
+      recentHistoryReady: true,
+      hasRecentHistory: false,
+    });
+
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .toBeVisible();
+    await expect
+      .element(page.getByTestId("coach-eligible"))
+      .toHaveTextContent("no");
+  });
+
+  it("marks the chart coach-eligible when the chart is shown", async () => {
+    state.connectors = [];
+
+    render(CoachHarness, {
+      bypass: true,
+      recentHistoryReady: false,
+      hasRecentHistory: false,
+    });
+
+    await expect
+      .element(page.getByTestId("coach-eligible"))
+      .toHaveTextContent("yes");
   });
 });

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte.test.ts
@@ -20,7 +20,23 @@ const chart = createRawSnippet(() => ({
 }));
 
 describe("FirstReadingChartArea", () => {
-  it("shows the empty state when no reading has ever arrived", async () => {
+  it("shows the chart and no empty state when data is already present", async () => {
+    state.connectors = [];
+
+    render(FirstReadingChartArea, {
+      chart,
+      bypass: true,
+      recentHistoryReady: false,
+      hasRecentHistory: false,
+    });
+
+    await expect.element(page.getByText("CHART SHOWN")).toBeVisible();
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .not.toBeInTheDocument();
+  });
+
+  it("hides the chart behind the empty state for an instance that never had a reading", async () => {
     state.connectors = [
       {
         id: "dexcom",
@@ -32,6 +48,7 @@ describe("FirstReadingChartArea", () => {
 
     render(FirstReadingChartArea, {
       chart,
+      bypass: false,
       recentHistoryReady: true,
       hasRecentHistory: false,
     });
@@ -42,50 +59,14 @@ describe("FirstReadingChartArea", () => {
     await expect.element(page.getByText("CHART SHOWN")).not.toBeVisible();
   });
 
-  it("shows the chart when a connector has imported readings before", async () => {
-    state.connectors = [
-      {
-        id: "dexcom",
-        name: "Dexcom Share",
-        hasDatabaseConfig: true,
-        totalEntries: 288,
-      },
-    ];
-
-    render(FirstReadingChartArea, {
-      chart,
-      recentHistoryReady: true,
-      hasRecentHistory: false,
-    });
-
-    await expect.element(page.getByText("CHART SHOWN")).toBeVisible();
-    await expect
-      .element(page.getByTestId("first-reading-empty-state"))
-      .not.toBeInTheDocument();
-  });
-
-  it("shows the chart for a dormant uploader-only instance that has recent history but no connector", async () => {
+  it("shows the chart for a dormant uploader-only instance that has recent history", async () => {
     state.connectors = [];
 
     render(FirstReadingChartArea, {
       chart,
+      bypass: false,
       recentHistoryReady: true,
       hasRecentHistory: true,
-    });
-
-    await expect.element(page.getByText("CHART SHOWN")).toBeVisible();
-    await expect
-      .element(page.getByTestId("first-reading-empty-state"))
-      .not.toBeInTheDocument();
-  });
-
-  it("does not render the empty state while the recent-history load is in flight", async () => {
-    state.connectors = [];
-
-    render(FirstReadingChartArea, {
-      chart,
-      recentHistoryReady: false,
-      hasRecentHistory: false,
     });
 
     await expect.element(page.getByText("CHART SHOWN")).toBeVisible();

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte.test.ts
@@ -3,24 +3,16 @@ import { page } from "vitest/browser";
 import { describe, it, expect, vi } from "vitest";
 import { createRawSnippet } from "svelte";
 import { remoteQuery } from "$lib/test-stubs/remote-resource";
-import type {
-  ConnectorStatusDto,
-  ServicesOverview,
-} from "$lib/api/generated/nocturne-api-client";
+import type { ConnectorStatusDto } from "$lib/api/generated/nocturne-api-client";
 import FirstReadingChartArea from "./FirstReadingChartArea.svelte";
 
 const state = vi.hoisted(() => {
   const connectors: ConnectorStatusDto[] = [];
-  const services: ServicesOverview = { activeDataSources: [] };
-  return { connectors, services };
+  return { connectors };
 });
 
 vi.mock("$api/generated/connectorStatus.generated.remote", () => ({
   getStatus: () => remoteQuery(() => state.connectors),
-}));
-
-vi.mock("$api/generated/services.generated.remote", () => ({
-  getServicesOverview: () => remoteQuery(() => state.services),
 }));
 
 const chart = createRawSnippet(() => ({
@@ -37,9 +29,12 @@ describe("FirstReadingChartArea", () => {
         totalEntries: 0,
       },
     ];
-    state.services = { activeDataSources: [] };
 
-    render(FirstReadingChartArea, { chart });
+    render(FirstReadingChartArea, {
+      chart,
+      recentHistoryReady: true,
+      hasRecentHistory: false,
+    });
 
     await expect
       .element(page.getByTestId("first-reading-empty-state"))
@@ -56,9 +51,12 @@ describe("FirstReadingChartArea", () => {
         totalEntries: 288,
       },
     ];
-    state.services = { activeDataSources: [] };
 
-    render(FirstReadingChartArea, { chart });
+    render(FirstReadingChartArea, {
+      chart,
+      recentHistoryReady: true,
+      hasRecentHistory: false,
+    });
 
     await expect.element(page.getByText("CHART SHOWN")).toBeVisible();
     await expect
@@ -66,13 +64,29 @@ describe("FirstReadingChartArea", () => {
       .not.toBeInTheDocument();
   });
 
-  it("shows the chart when an uploader source has readings but no connector exists", async () => {
+  it("shows the chart for a dormant uploader-only instance that has recent history but no connector", async () => {
     state.connectors = [];
-    state.services = {
-      activeDataSources: [{ id: "xdrip", name: "xDrip", totalEntries: 12 }],
-    };
 
-    render(FirstReadingChartArea, { chart });
+    render(FirstReadingChartArea, {
+      chart,
+      recentHistoryReady: true,
+      hasRecentHistory: true,
+    });
+
+    await expect.element(page.getByText("CHART SHOWN")).toBeVisible();
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .not.toBeInTheDocument();
+  });
+
+  it("does not render the empty state while the recent-history load is in flight", async () => {
+    state.connectors = [];
+
+    render(FirstReadingChartArea, {
+      chart,
+      recentHistoryReady: false,
+      hasRecentHistory: false,
+    });
 
     await expect.element(page.getByText("CHART SHOWN")).toBeVisible();
     await expect

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingChartArea.svelte.test.ts
@@ -1,0 +1,82 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, vi } from "vitest";
+import { createRawSnippet } from "svelte";
+import { remoteQuery } from "$lib/test-stubs/remote-resource";
+import type {
+  ConnectorStatusDto,
+  ServicesOverview,
+} from "$lib/api/generated/nocturne-api-client";
+import FirstReadingChartArea from "./FirstReadingChartArea.svelte";
+
+const state = vi.hoisted(() => {
+  const connectors: ConnectorStatusDto[] = [];
+  const services: ServicesOverview = { activeDataSources: [] };
+  return { connectors, services };
+});
+
+vi.mock("$api/generated/connectorStatus.generated.remote", () => ({
+  getStatus: () => remoteQuery(() => state.connectors),
+}));
+
+vi.mock("$api/generated/services.generated.remote", () => ({
+  getServicesOverview: () => remoteQuery(() => state.services),
+}));
+
+const chart = createRawSnippet(() => ({
+  render: () => "<div>CHART SHOWN</div>",
+}));
+
+describe("FirstReadingChartArea", () => {
+  it("shows the empty state when no reading has ever arrived", async () => {
+    state.connectors = [
+      {
+        id: "dexcom",
+        name: "Dexcom Share",
+        hasDatabaseConfig: true,
+        totalEntries: 0,
+      },
+    ];
+    state.services = { activeDataSources: [] };
+
+    render(FirstReadingChartArea, { chart });
+
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .toBeVisible();
+    await expect.element(page.getByText("CHART SHOWN")).not.toBeVisible();
+  });
+
+  it("shows the chart when a connector has imported readings before", async () => {
+    state.connectors = [
+      {
+        id: "dexcom",
+        name: "Dexcom Share",
+        hasDatabaseConfig: true,
+        totalEntries: 288,
+      },
+    ];
+    state.services = { activeDataSources: [] };
+
+    render(FirstReadingChartArea, { chart });
+
+    await expect.element(page.getByText("CHART SHOWN")).toBeVisible();
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .not.toBeInTheDocument();
+  });
+
+  it("shows the chart when an uploader source has readings but no connector exists", async () => {
+    state.connectors = [];
+    state.services = {
+      activeDataSources: [{ id: "xdrip", name: "xDrip", totalEntries: 12 }],
+    };
+
+    render(FirstReadingChartArea, { chart });
+
+    await expect.element(page.getByText("CHART SHOWN")).toBeVisible();
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .not.toBeInTheDocument();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingCoachHarness.test.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingCoachHarness.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import FirstReadingChartArea from "./FirstReadingChartArea.svelte";
+
+  interface Props {
+    bypass: boolean;
+    recentHistoryReady: boolean;
+    hasRecentHistory: boolean;
+  }
+
+  let { bypass, recentHistoryReady, hasRecentHistory }: Props = $props();
+</script>
+
+<FirstReadingChartArea {bypass} {recentHistoryReady} {hasRecentHistory}>
+  {#snippet chart(chartVisible)}
+    <div>
+      CHART SHOWN
+      <span data-testid="coach-eligible">{chartVisible ? "yes" : "no"}</span>
+    </div>
+  {/snippet}
+</FirstReadingChartArea>

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingEmptyState.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingEmptyState.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    CardDescription,
+  } from "$lib/components/ui/card";
+  import { Button } from "$lib/components/ui/button";
+  import {
+    Loader2,
+    Plug,
+    KeyRound,
+    Download,
+    ArrowRight,
+    Wifi,
+  } from "lucide-svelte";
+  import { resolve } from "$app/paths";
+  import type { ConnectorStatusDto } from "$lib/api/generated/nocturne-api-client";
+
+  interface Props {
+    /**
+     * Connectors that have a configuration but have not yet produced any
+     * reading. The caller passes only configured connectors, and only reaches
+     * this state when every one of them has imported zero records.
+     */
+    connectors?: ConnectorStatusDto[];
+  }
+
+  let { connectors = [] }: Props = $props();
+
+  const hasConnector = $derived(connectors.length > 0);
+
+  /**
+   * A connector has run a sync once it records an attempt or a success. With no
+   * records to show, that is the only thing separating "synced, nothing there
+   * yet" from "hasn't synced yet" — the health flag reports both as healthy.
+   */
+  function hasSynced(connector: ConnectorStatusDto): boolean {
+    return Boolean(connector.lastSyncAttempt || connector.lastSuccessfulSync);
+  }
+
+  const connectorsPath = resolve("/settings/connectors");
+  const uploaderTokenPath = `${resolve("/settings/connectors")}#api-tokens-section`;
+  const migrationPath = resolve("/settings/migration");
+</script>
+
+<Card data-testid="first-reading-empty-state">
+  <CardHeader>
+    <CardTitle class="flex items-center gap-2">
+      <Wifi class="h-5 w-5 text-primary" />
+      Waiting for your first reading
+    </CardTitle>
+    <CardDescription>
+      Your glucose chart will appear here as soon as the first reading arrives.
+    </CardDescription>
+  </CardHeader>
+  <CardContent class="space-y-4">
+    {#if hasConnector}
+      <div class="space-y-3" data-testid="waiting-connectors">
+        {#each connectors as connector (connector.id ?? connector.name)}
+          <div
+            class="flex items-start gap-4 rounded-lg border bg-card p-4"
+            data-testid="waiting-connector"
+          >
+            <div
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10"
+            >
+              <Loader2 class="h-5 w-5 animate-spin text-primary" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <h4 class="font-medium">
+                Waiting for the first sync from {connector.name ??
+                  "your connector"}
+              </h4>
+              {#if hasSynced(connector)}
+                {#if connector.stateMessage}
+                  <p
+                    class="mt-1 text-sm text-muted-foreground"
+                    data-testid="connector-outcome"
+                  >
+                    Last sync: {connector.stateMessage}
+                  </p>
+                {:else}
+                  <p
+                    class="mt-1 text-sm text-muted-foreground"
+                    data-testid="connector-synced-empty"
+                  >
+                    It synced, but no readings have come through yet. New data
+                    can take a little while to appear.
+                  </p>
+                {/if}
+              {:else}
+                <p
+                  class="mt-1 text-sm text-muted-foreground"
+                  data-testid="connector-not-synced"
+                >
+                  It hasn't run its first sync yet. This can take a few minutes.
+                </p>
+              {/if}
+            </div>
+          </div>
+        {/each}
+        <Button variant="outline" href={connectorsPath} class="gap-2">
+          <Plug class="h-4 w-4" />
+          Manage connectors
+          <ArrowRight class="h-4 w-4" />
+        </Button>
+      </div>
+    {:else}
+      <p class="text-sm text-muted-foreground" data-testid="no-connector-intro">
+        No data source is set up yet. Pick whichever matches how you track your
+        glucose.
+      </p>
+      <div class="grid gap-3 @md:grid-cols-3">
+        <a
+          href={connectorsPath}
+          data-testid="path-connector"
+          class="group flex flex-col gap-2 rounded-lg border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-muted/40"
+        >
+          <Plug class="h-5 w-5 text-primary" />
+          <span class="font-medium">Connect a CGM or pump account</span>
+          <span class="text-sm text-muted-foreground">
+            Pull data automatically from services like Dexcom, LibreLink, or
+            Glooko.
+          </span>
+        </a>
+        <!-- eslint-disable svelte/no-navigation-without-resolve -- resolve() covers the route; the #api-tokens-section fragment deep-links to the token section and cannot be expressed through resolve() -->
+        <a
+          href={uploaderTokenPath}
+          data-testid="path-uploader"
+          class="group flex flex-col gap-2 rounded-lg border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-muted/40"
+        >
+          <KeyRound class="h-5 w-5 text-primary" />
+          <span class="font-medium">Set up an uploader app</span>
+          <span class="text-sm text-muted-foreground">
+            Create an API token so an app like xDrip, AAPS, Loop, or Trio can
+            send readings.
+          </span>
+        </a>
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
+        <a
+          href={migrationPath}
+          data-testid="path-migration"
+          class="group flex flex-col gap-2 rounded-lg border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-muted/40"
+        >
+          <Download class="h-5 w-5 text-primary" />
+          <span class="font-medium">Coming from Nightscout?</span>
+          <span class="text-sm text-muted-foreground">
+            Import your existing history from a Nightscout site.
+          </span>
+        </a>
+      </div>
+    {/if}
+  </CardContent>
+</Card>

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingEmptyState.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingEmptyState.svelte.test.ts
@@ -1,0 +1,98 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect } from "vitest";
+import type { ConnectorStatusDto } from "$lib/api/generated/nocturne-api-client";
+import FirstReadingEmptyState from "./FirstReadingEmptyState.svelte";
+
+function connector(
+  overrides: Partial<ConnectorStatusDto> = {}
+): ConnectorStatusDto {
+  return {
+    id: "dexcom",
+    name: "Dexcom Share",
+    hasDatabaseConfig: true,
+    isEnabled: true,
+    totalEntries: 0,
+    ...overrides,
+  };
+}
+
+describe("FirstReadingEmptyState", () => {
+  it("offers the three no-connector paths when nothing is configured", async () => {
+    render(FirstReadingEmptyState, { connectors: [] });
+
+    await expect
+      .element(page.getByTestId("path-connector"))
+      .toHaveAttribute("href", "/settings/connectors");
+    await expect
+      .element(page.getByTestId("path-uploader"))
+      .toHaveAttribute("href", "/settings/connectors#api-tokens-section");
+    await expect
+      .element(page.getByTestId("path-migration"))
+      .toHaveAttribute("href", "/settings/migration");
+  });
+
+  it("names the connector and links to the connector page when one is configured", async () => {
+    render(FirstReadingEmptyState, { connectors: [connector()] });
+
+    await expect
+      .element(page.getByText("Waiting for the first sync from Dexcom Share"))
+      .toBeVisible();
+    // The no-connector paths must not appear when a connector is waiting.
+    await expect
+      .element(page.getByTestId("path-migration"))
+      .not.toBeInTheDocument();
+  });
+
+  it("says a sync has not run yet when there is no sync attempt", async () => {
+    render(FirstReadingEmptyState, {
+      connectors: [
+        connector({
+          lastSyncAttempt: undefined,
+          lastSuccessfulSync: undefined,
+        }),
+      ],
+    });
+
+    await expect
+      .element(page.getByTestId("connector-not-synced"))
+      .toBeVisible();
+    await expect
+      .element(page.getByTestId("connector-synced-empty"))
+      .not.toBeInTheDocument();
+  });
+
+  it("distinguishes a completed sync that fetched zero records", async () => {
+    render(FirstReadingEmptyState, {
+      connectors: [
+        connector({
+          lastSuccessfulSync: new Date(),
+          lastSyncAttempt: new Date(),
+          totalEntries: 0,
+        }),
+      ],
+    });
+
+    await expect
+      .element(page.getByTestId("connector-synced-empty"))
+      .toBeVisible();
+    await expect
+      .element(page.getByTestId("connector-not-synced"))
+      .not.toBeInTheDocument();
+  });
+
+  it("surfaces the last attempt's outcome when the connector reports one", async () => {
+    render(FirstReadingEmptyState, {
+      connectors: [
+        connector({
+          lastSyncAttempt: new Date(),
+          stateMessage: "Authentication failed",
+        }),
+      ],
+    });
+
+    await expect
+      .element(page.getByTestId("connector-outcome"))
+      .toHaveTextContent("Authentication failed");
+  });
+});

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingEmptyStateLoader.svelte
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingEmptyStateLoader.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import { getStatus as getConnectorStatuses } from "$api/generated/connectorStatus.generated.remote";
+  import FirstReadingEmptyState from "./FirstReadingEmptyState.svelte";
+  import type { ConnectorStatusDto } from "$lib/api/generated/nocturne-api-client";
+
+  interface Props {
+    /**
+     * Whether the realtime store's initial load has settled. Until it has, the
+     * decision is held in loading so the empty state can never flash ahead of
+     * the recent-history fetch resolving.
+     */
+    recentHistoryReady: boolean;
+    /**
+     * Whether the realtime store's initial, undated most-recent fetch returned
+     * any entries. This is the authoritative "has data recently" signal for an
+     * uploader-only instance, which carries no managed-connector count.
+     */
+    hasRecentHistory: boolean;
+    /** Reports whether the resolved decision is to show the empty state. */
+    onResolve?: (showEmptyState: boolean) => void;
+  }
+
+  let { recentHistoryReady, hasRecentHistory, onResolve }: Props = $props();
+
+  const connectorStatusesQuery = getConnectorStatuses();
+
+  const connectors = $derived<ConnectorStatusDto[]>(
+    connectorStatusesQuery.current ?? []
+  );
+
+  // A failed call (e.g. a 403 for a member without the settings scope) resolves
+  // the gate with no connector count rather than hanging it in loading forever:
+  // on error `.current` never leaves undefined, so `.error` is what settles it.
+  const statusSettled = $derived(
+    connectorStatusesQuery.current !== undefined ||
+      connectorStatusesQuery.error != null
+  );
+
+  const loading = $derived(!statusSettled || !recentHistoryReady);
+
+  const configuredConnectors = $derived(
+    connectors.filter((c) => c.hasDatabaseConfig || c.isEnabled)
+  );
+
+  /**
+   * Whether a reading has ever arrived. Read from the realtime store's recent
+   * history and each connector's lifetime import count — never the connector
+   * health flag, which reports a freshly synced connector that fetched nothing
+   * as healthy. Note the two counts differ:
+   * <c>ConnectorStatusDto.totalEntries</c> is genuinely lifetime, whereas the
+   * data-source count from the services overview is a trailing 30-day window,
+   * so it is not used here — the realtime recent-history fetch covers an
+   * uploader-only instance instead.
+   */
+  const hasEverReceivedReading = $derived(
+    hasRecentHistory || connectors.some((c) => (c.totalEntries ?? 0) > 0)
+  );
+
+  const showEmpty = $derived(!loading && !hasEverReceivedReading);
+
+  $effect(() => {
+    onResolve?.(showEmpty);
+  });
+</script>
+
+{#if showEmpty}
+  <FirstReadingEmptyState connectors={configuredConnectors} />
+{/if}

--- a/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingEmptyStateLoader.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/first-reading/FirstReadingEmptyStateLoader.svelte.test.ts
@@ -1,0 +1,108 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, vi } from "vitest";
+import { remoteQuery, remoteQueryError } from "$lib/test-stubs/remote-resource";
+import type { ConnectorStatusDto } from "$lib/api/generated/nocturne-api-client";
+import FirstReadingEmptyStateLoader from "./FirstReadingEmptyStateLoader.svelte";
+
+const state = vi.hoisted(() => {
+  const value: {
+    mode: "value" | "error";
+    connectors: ConnectorStatusDto[];
+    error: unknown;
+  } = { mode: "value", connectors: [], error: undefined };
+  return value;
+});
+
+vi.mock("$api/generated/connectorStatus.generated.remote", () => ({
+  getStatus: () =>
+    state.mode === "error"
+      ? remoteQueryError(state.error)
+      : remoteQuery(() => state.connectors),
+}));
+
+describe("FirstReadingEmptyStateLoader", () => {
+  it("shows the empty state when no reading has ever arrived", async () => {
+    state.mode = "value";
+    state.connectors = [
+      {
+        id: "dexcom",
+        name: "Dexcom Share",
+        hasDatabaseConfig: true,
+        totalEntries: 0,
+      },
+    ];
+
+    render(FirstReadingEmptyStateLoader, {
+      recentHistoryReady: true,
+      hasRecentHistory: false,
+    });
+
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .toBeVisible();
+  });
+
+  it("does not show the empty state when a connector has imported readings before", async () => {
+    state.mode = "value";
+    state.connectors = [
+      {
+        id: "dexcom",
+        name: "Dexcom Share",
+        hasDatabaseConfig: true,
+        totalEntries: 288,
+      },
+    ];
+
+    render(FirstReadingEmptyStateLoader, {
+      recentHistoryReady: true,
+      hasRecentHistory: false,
+    });
+
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .not.toBeInTheDocument();
+  });
+
+  it("does not show the empty state for a dormant uploader-only instance with recent history", async () => {
+    state.mode = "value";
+    state.connectors = [];
+
+    render(FirstReadingEmptyStateLoader, {
+      recentHistoryReady: true,
+      hasRecentHistory: true,
+    });
+
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .not.toBeInTheDocument();
+  });
+
+  it("does not show the empty state while the recent-history load is in flight", async () => {
+    state.mode = "value";
+    state.connectors = [];
+
+    render(FirstReadingEmptyStateLoader, {
+      recentHistoryReady: false,
+      hasRecentHistory: false,
+    });
+
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .not.toBeInTheDocument();
+  });
+
+  it("resolves and shows the empty state when the connector-status query fails", async () => {
+    state.mode = "error";
+    state.error = { status: 403, message: "Forbidden" };
+
+    render(FirstReadingEmptyStateLoader, {
+      recentHistoryReady: true,
+      hasRecentHistory: false,
+    });
+
+    await expect
+      .element(page.getByTestId("first-reading-empty-state"))
+      .toBeVisible();
+  });
+});

--- a/src/Web/packages/app/src/lib/test-stubs/app-paths.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/app-paths.ts
@@ -1,0 +1,23 @@
+/**
+ * `$app/paths` for the browser test environment. The standalone vitest config
+ * has only the Svelte plugin, not SvelteKit's, so this module is aliased in to
+ * stand in for the framework's. `resolve` echoes the route id it is given,
+ * which is what the app deployed at the root would resolve to.
+ */
+export const base = "";
+export const assets = "";
+
+export function resolve(pathname: string): string {
+  return pathname;
+}
+
+export function resolveRoute(
+  id: string,
+  params?: Record<string, string>
+): string {
+  if (!params) return id;
+  return Object.entries(params).reduce(
+    (acc, [key, value]) => acc.replace(`[${key}]`, value),
+    id
+  );
+}

--- a/src/Web/packages/app/src/lib/test-stubs/remote-resource.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/remote-resource.ts
@@ -95,6 +95,13 @@ class QueryResource<T> implements RemoteQueryStub<T> {
     this.#promise = Promise.resolve();
   }
 
+  settleError(error: unknown) {
+    this.#read = null;
+    this.#loading = false;
+    this.#error = error;
+    this.#promise = Promise.resolve();
+  }
+
   #overridden(read: () => T): T {
     return this.#overrides.reduce<T>((value, apply) => apply(value), read());
   }
@@ -185,6 +192,20 @@ export function createQueryResource<T>(
 export function remoteQuery<T>(read: () => T): RemoteQueryStub<T> {
   const resource = new QueryResource<T>(async () => read());
   resource.settle(read);
+  return resource;
+}
+
+/**
+ * A query resource that is already settled into an error, for a test standing
+ * in for a remote module whose call rejected (e.g. a 403). `current` stays
+ * undefined and `error` holds the reason, synchronously, so a component reads
+ * the failed state on its first render rather than hanging on a pending fetch.
+ */
+export function remoteQueryError<T>(error: unknown): RemoteQueryStub<T> {
+  const resource = new QueryResource<T>(async () => {
+    throw error;
+  });
+  resource.settleError(error);
   return resource;
 }
 

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
@@ -90,14 +90,16 @@
       {/if}
 
       {#if isMainEnabled(WidgetId.GlucoseChart)}
-        {#snippet glucoseChart()}
+        {#snippet glucoseChart(chartVisible)}
           <div
-            {@attach coachmark({
-              key: "quick-tour.chart",
-              title: "Interactive chart",
-              description:
-                "Drag to pan, pinch or scroll to zoom. Tap any point to see the exact reading and time.",
-            })}
+            {@attach chartVisible
+              ? coachmark({
+                  key: "quick-tour.chart",
+                  title: "Interactive chart",
+                  description:
+                    "Drag to pan, pinch or scroll to zoom. Tap any point to see the exact reading and time.",
+                })
+              : undefined}
           >
             <GlucoseChartCard
               showPredictions={isMainEnabled(WidgetId.Predictions) &&

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
@@ -12,11 +12,27 @@
   import { isWidgetEnabled } from "$lib/types/dashboard-widgets";
   import { coachmark } from "@nocturne/coach";
   import TenantsOverview from "$lib/components/tenants/TenantsOverview.svelte";
+  import FirstReadingChartArea from "$lib/components/dashboard/first-reading/FirstReadingChartArea.svelte";
+  import { tryGetRealtimeStore } from "$lib/stores/realtime-store.svelte";
   import type { PageData } from "./$types";
 
   const { data }: { data: PageData } = $props();
 
   const settingsStore = getSettingsStore();
+  const realtimeStore = tryGetRealtimeStore();
+
+  // Whether the current chart window (server-loaded recent data, or anything the
+  // realtime feed has delivered this session) holds any glucose. When it does the
+  // chart renders directly; only an empty window pays for the first-reading check.
+  const hasInitialGlucose = $derived(
+    (data.initialChartData?.glucoseData?.length ?? 0) > 0
+  );
+  const hasWindowData = $derived(
+    hasInitialGlucose ||
+      (realtimeStore
+        ? realtimeStore.currentBG > 0 || realtimeStore.entries.length > 0
+        : false)
+  );
 
   // Get widgets array from settings (for main section visibility)
   const widgets = $derived(settingsStore.features?.widgets);
@@ -29,7 +45,9 @@
   const topWidgets = $derived(dashboardTopWidgets.current);
 
   // Get focusHours setting for chart default time range
-  const focusHours = $derived(settingsStore.features?.display?.focusHours ?? 12);
+  const focusHours = $derived(
+    settingsStore.features?.display?.focusHours ?? 12
+  );
 
   // Algorithm prediction settings - controls whether predictions are calculated
   const predictionEnabled = $derived(
@@ -40,58 +58,66 @@
 {#if data.tenantless}
   <TenantsOverview />
 {:else}
-<div class="@container p-3 @md:p-6 space-y-3 @md:space-y-6">
-  <div
-    {@attach coachmark({
-      key: "quick-tour.current-bg",
-      title: "Your glucose, live",
-      description:
-        "This updates in real-time as new readings arrive from your CGM.",
-    })}
-  >
-    <CurrentBGDisplay />
-  </div>
+  <div class="@container p-3 @md:p-6 space-y-3 @md:space-y-6">
+    <div
+      {@attach coachmark({
+        key: "quick-tour.current-bg",
+        title: "Your glucose, live",
+        description:
+          "This updates in real-time as new readings arrive from your CGM.",
+      })}
+    >
+      <CurrentBGDisplay />
+    </div>
 
-  <div class="flex flex-col-reverse @md:flex-col gap-3 @md:gap-6">
-    {#if isMainEnabled(WidgetId.Statistics)}
-      <div
-        {@attach coachmark({
-          key: "quick-tour.widgets",
-          title: "Customizable widgets",
-          description:
-            "Reorder or swap these in Settings \u2192 Appearance. You can choose from over a dozen stats.",
-        })}
-      >
-        <WidgetGrid widgets={topWidgets} maxWidgets={3} />
-      </div>
+    <div class="flex flex-col-reverse @md:flex-col gap-3 @md:gap-6">
+      {#if isMainEnabled(WidgetId.Statistics)}
+        <div
+          {@attach coachmark({
+            key: "quick-tour.widgets",
+            title: "Customizable widgets",
+            description:
+              "Reorder or swap these in Settings \u2192 Appearance. You can choose from over a dozen stats.",
+          })}
+        >
+          <WidgetGrid widgets={topWidgets} maxWidgets={3} />
+        </div>
+      {/if}
+
+      {#if isMainEnabled(WidgetId.GlucoseChart)}
+        {#snippet glucoseChart()}
+          <GlucoseChartCard
+            showPredictions={isMainEnabled(WidgetId.Predictions) &&
+              predictionEnabled}
+            defaultFocusHours={focusHours}
+            initialChartData={data.initialChartData}
+            streamedHistoricalData={data.streamed?.historicalChartData}
+          />
+        {/snippet}
+
+        {#if hasWindowData}
+          <div
+            {@attach coachmark({
+              key: "quick-tour.chart",
+              title: "Interactive chart",
+              description:
+                "Drag to pan, pinch or scroll to zoom. Tap any point to see the exact reading and time.",
+            })}
+          >
+            {@render glucoseChart()}
+          </div>
+        {:else}
+          <FirstReadingChartArea chart={glucoseChart} />
+        {/if}
+      {/if}
+    </div>
+
+    {#if isMainEnabled(WidgetId.DailyStats)}
+      <RecentEntriesCard />
     {/if}
 
-    {#if isMainEnabled(WidgetId.GlucoseChart)}
-      <div
-        {@attach coachmark({
-          key: "quick-tour.chart",
-          title: "Interactive chart",
-          description:
-            "Drag to pan, pinch or scroll to zoom. Tap any point to see the exact reading and time.",
-        })}
-      >
-        <GlucoseChartCard
-          showPredictions={isMainEnabled(WidgetId.Predictions) &&
-            predictionEnabled}
-          defaultFocusHours={focusHours}
-          initialChartData={data.initialChartData}
-          streamedHistoricalData={data.streamed?.historicalChartData}
-        />
-      </div>
+    {#if isMainEnabled(WidgetId.Treatments)}
+      <RecentTreatmentsCard />
     {/if}
   </div>
-
-  {#if isMainEnabled(WidgetId.DailyStats)}
-    <RecentEntriesCard />
-  {/if}
-
-  {#if isMainEnabled(WidgetId.Treatments)}
-    <RecentTreatmentsCard />
-  {/if}
-</div>
 {/if}

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
@@ -21,17 +21,22 @@
   const settingsStore = getSettingsStore();
   const realtimeStore = tryGetRealtimeStore();
 
-  // Whether the current chart window (server-loaded recent data, or anything the
-  // realtime feed has delivered this session) holds any glucose. When it does the
-  // chart renders directly; only an empty window pays for the first-reading check.
+  // Whether we already know this instance has data: server-loaded recent glucose,
+  // or anything the realtime feed has surfaced (a live value, or its initial
+  // undated most-recent fetch). When it does, the chart renders directly and the
+  // first-reading check never runs; only an instance with nothing on hand pays
+  // for it.
   const hasInitialGlucose = $derived(
     (data.initialChartData?.glucoseData?.length ?? 0) > 0
   );
-  const hasWindowData = $derived(
+  const hasRecentHistory = $derived(
+    realtimeStore?.entries.length ? true : false
+  );
+  const recentHistoryReady = $derived(realtimeStore?.isReady ?? true);
+  const hasDataNow = $derived(
     hasInitialGlucose ||
-      (realtimeStore
-        ? realtimeStore.currentBG > 0 || realtimeStore.entries.length > 0
-        : false)
+      hasRecentHistory ||
+      (realtimeStore ? realtimeStore.currentBG > 0 : false)
   );
 
   // Get widgets array from settings (for main section visibility)
@@ -95,7 +100,7 @@
           />
         {/snippet}
 
-        {#if hasWindowData}
+        {#if hasDataNow}
           <div
             {@attach coachmark({
               key: "quick-tour.chart",
@@ -107,7 +112,11 @@
             {@render glucoseChart()}
           </div>
         {:else}
-          <FirstReadingChartArea chart={glucoseChart} />
+          <FirstReadingChartArea
+            chart={glucoseChart}
+            {recentHistoryReady}
+            {hasRecentHistory}
+          />
         {/if}
       {/if}
     </div>

--- a/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+page.svelte
@@ -91,16 +91,6 @@
 
       {#if isMainEnabled(WidgetId.GlucoseChart)}
         {#snippet glucoseChart()}
-          <GlucoseChartCard
-            showPredictions={isMainEnabled(WidgetId.Predictions) &&
-              predictionEnabled}
-            defaultFocusHours={focusHours}
-            initialChartData={data.initialChartData}
-            streamedHistoricalData={data.streamed?.historicalChartData}
-          />
-        {/snippet}
-
-        {#if hasDataNow}
           <div
             {@attach coachmark({
               key: "quick-tour.chart",
@@ -109,15 +99,22 @@
                 "Drag to pan, pinch or scroll to zoom. Tap any point to see the exact reading and time.",
             })}
           >
-            {@render glucoseChart()}
+            <GlucoseChartCard
+              showPredictions={isMainEnabled(WidgetId.Predictions) &&
+                predictionEnabled}
+              defaultFocusHours={focusHours}
+              initialChartData={data.initialChartData}
+              streamedHistoricalData={data.streamed?.historicalChartData}
+            />
           </div>
-        {:else}
-          <FirstReadingChartArea
-            chart={glucoseChart}
-            {recentHistoryReady}
-            {hasRecentHistory}
-          />
-        {/if}
+        {/snippet}
+
+        <FirstReadingChartArea
+          chart={glucoseChart}
+          bypass={hasDataNow}
+          {recentHistoryReady}
+          {hasRecentHistory}
+        />
       {/if}
     </div>
 

--- a/src/Web/packages/app/vitest.browser.config.ts
+++ b/src/Web/packages/app/vitest.browser.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
         "./src/lib/test-stubs/app-navigation.ts",
         import.meta.url
       ).pathname,
+      "$app/paths": new URL(
+        "./src/lib/test-stubs/app-paths.ts",
+        import.meta.url
+      ).pathname,
       "$app/server": new URL(
         "./src/lib/test-stubs/app-server.ts",
         import.meta.url


### PR DESCRIPTION
Closes #1180.

## What
A fresh instance has zero readings, so the dashboard drew an empty chart with no guidance. This replaces the chart area with a first-reading empty state while the instance has never received a reading, and reverts to the chart as soon as one arrives.

- **Connector configured:** "Waiting for the first sync from {connector}", the last attempt's outcome, and a link to the connector page. It distinguishes "synced but no records yet" from "not synced yet" using record counts, not the health flag.
- **No connector:** three paths — connect a CGM or pump account, set up an uploader app (deep link to API token creation), or import from Nightscout.
- Once the first reading arrives (server data or the realtime feed), the chart returns.

## How
"Has ever received a reading" is decided from two signals: the realtime store's initial, undated most-recent fetch (the authoritative recent-history signal for an uploader-only instance, which carries no managed-connector count) and the genuinely lifetime `ConnectorStatusDto.totalEntries` connector import count. It deliberately does NOT use the services-overview data-source count, which is a trailing 30-day window and would misread a dormant instance as new. The decision is held in a loading state until the realtime initial fetch has settled, so the empty state can never flash ahead of it. A failed connector-status query (e.g. a 403 for a member without the settings scope) resolves the gate rather than wedging it in loading.

`last_reading_at` is the natural lifetime signal but is not exposed on any web-reachable endpoint, and record counts are what's needed for the connector "synced vs not synced" distinction anyway, so no new API surface was added.

The chart has a single owner (`FirstReadingChartArea`) that renders it once and only hides it behind the empty state, so flipping to "has data" does not remount the chart. The connector-status query lives in a child mounted only when the instance has no data on hand, so a populated dashboard fires no status query, and an active instance viewing an empty time window still shows the chart. The `quick-tour.chart` coach mark is attached only while the chart is actually shown, so a brand-new instance skips that tour step instead of pointing a popover at a hidden element.

## Tests
- `FirstReadingEmptyState`: connector-configured vs no-connector; synced-but-empty vs not-synced-yet; the three no-connector paths and their hrefs.
- `FirstReadingEmptyStateLoader`: never-had-a-reading shows the empty state; a lifetime connector count or recent history does not; the load-in-flight state does not; a failed connector-status query resolves and shows the empty state.
- `FirstReadingChartArea`: data present shows the chart with no query; never-had-a-reading hides the chart behind the empty state; a dormant uploader with recent history shows the chart; the chart coach mark is eligible only when the chart is shown.
- Adds a `$app/paths` stub, a `remoteQueryError` helper, and a coach harness for the browser test env.

No dotnet build required; web-only change.
