### PR TITLE
fix(web): keep resolveBillingLink out of the inactive page's server module

### DIFF
--- a/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/+page.server.ts
@@ -1,19 +1,5 @@
-import type { SupportChannelConfig } from "$api/generated/nocturne-api-client";
 import type { PageServerLoad } from "./$types";
-
-/**
- * The operator's billing address as a link, or null when there is nothing to link to.
- *
- * Api mode is an issue-intake endpoint the app POSTs to, not a page: rendering it as an href
- * would send the visitor to a route with no GET.
- */
-export function resolveBillingLink(
-  config: SupportChannelConfig | null | undefined
-): { url: string; label: string | null } | null {
-  if (config?.mode !== "redirect" || !config.url) return null;
-
-  return { url: config.url, label: config.label ?? null };
-}
+import { resolveBillingLink } from "./billing-link";
 
 export const load: PageServerLoad = async ({ locals }) => {
   const config = await locals.apiClient.support.getSupportConfig().catch(() => null);

--- a/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.test.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveBillingLink } from "./+page.server";
+import { resolveBillingLink } from "./billing-link";
 
 describe("resolveBillingLink", () => {
   it("links the operator's billing page in redirect mode", () => {

--- a/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.ts
@@ -1,0 +1,15 @@
+import type { SupportChannelConfig } from "$api/generated/nocturne-api-client";
+
+/**
+ * The operator's billing address as a link, or null when there is nothing to link to.
+ *
+ * Api mode is an issue-intake endpoint the app POSTs to, not a page: rendering it as an href
+ * would send the visitor to a route with no GET.
+ */
+export function resolveBillingLink(
+  config: SupportChannelConfig | null | undefined
+): { url: string; label: string | null } | null {
+  if (config?.mode !== "redirect" || !config.url) return null;
+
+  return { url: config.url, label: config.label ?? null };
+}


### PR DESCRIPTION
## Problem

Every `build-and-push` run since #1184 landed fails, on main and on every open PR:

```
Error: Invalid export 'resolveBillingLink' in src/routes/(unauthenticated)/tenant/inactive/+page.server.ts
(valid exports are load, prerender, csr, ssr, trailingSlash, config, actions, entries, or anything with a '_' prefix)
```

SvelteKit only allows its own names as exports from `+page.server.ts`. #1184 exported the `resolveBillingLink` helper from there so its unit test could import it, which `vite build` rejects. Vitest and `svelte-check` do not enforce this, so the Tests workflow stayed green while the Docker web image build broke.

## Fix

Move the helper into a sibling `billing-link.ts`, the same arrangement as `auth/recovery-error.ts` and `guest/activation-error.ts`. The page server module keeps only `load`, and the test imports from the new module. No behaviour change.

## Verification

- `billing-link.test.ts`: 4/4 pass.
- The `build-and-push` check on this PR is the real reproduction; a local `vite build` of the app was killed for memory before finishing.
