### PR TITLE
feat(support): give the inactive-tenant page a redirect-only account portal

### DIFF
--- a/src/API/Nocturne.API/Configuration/OperatorConfiguration.cs
+++ b/src/API/Nocturne.API/Configuration/OperatorConfiguration.cs
@@ -33,6 +33,23 @@ public class OperatorConfiguration
 public class OperatorSupportConfiguration
 {
     public OperatorSupportChannelConfiguration? AccountBilling { get; set; }
+
+    public OperatorAccountPortalConfiguration? AccountPortal { get; set; }
+}
+
+/// <summary>
+/// A page the operator hosts for managing the account. Only ever opened in a browser, so it has
+/// no mode: an operator whose <see cref="OperatorSupportConfiguration.AccountBilling"/> is an API
+/// endpoint still has somewhere to send a visitor.
+/// </summary>
+public class OperatorAccountPortalConfiguration
+{
+    public string Url { get; set; } = "";
+
+    /// <summary>
+    /// Optional button/link text. Falls back to "Contact {Operator.Name}".
+    /// </summary>
+    public string? Label { get; set; }
 }
 
 public class OperatorSupportChannelConfiguration

--- a/src/API/Nocturne.API/Controllers/V4/Platform/SupportController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Platform/SupportController.cs
@@ -161,7 +161,7 @@ public class SupportController(
 
     /// <summary>
     /// Returns operator support configuration for the frontend.
-    /// When no operator is configured, accountBilling is null and the default GitHub flow applies.
+    /// When no operator is configured, both channels are null and the default GitHub flow applies.
     /// </summary>
     /// <remarks>
     /// Anonymous because the hosts that most need the operator's address — an inactive tenant's,
@@ -175,6 +175,8 @@ public class SupportController(
     {
         var config = operatorOptions.Value;
         var ab = config.Support.AccountBilling;
+        var portal = config.Support.AccountPortal;
+        var operatorLabel = config.Name is not null ? $"Contact {config.Name}" : null;
 
         return Ok(new SupportConfigResponse
         {
@@ -183,7 +185,14 @@ public class SupportController(
                 {
                     Mode = ab.Mode == OperatorSupportMode.Redirect ? "redirect" : "api",
                     Url = ab.Url,
-                    Label = ab.Label ?? (config.Name is not null ? $"Contact {config.Name}" : null),
+                    Label = ab.Label ?? operatorLabel,
+                }
+                : null,
+            AccountPortal = portal is not null && !string.IsNullOrWhiteSpace(portal.Url)
+                ? new AccountPortalConfig
+                {
+                    Url = portal.Url,
+                    Label = portal.Label ?? operatorLabel,
                 }
                 : null,
         });

--- a/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
+++ b/src/API/Nocturne.API/Extensions/ServiceRegistrationExtensions.cs
@@ -342,7 +342,13 @@ public static class ServiceRegistrationExtensions
                 if (config.Support.AccountBilling is { } ab)
                     return !string.IsNullOrWhiteSpace(ab.Url);
                 return true;
-            }, "Operator:Support:AccountBilling:Url is required when AccountBilling is configured");
+            }, "Operator:Support:AccountBilling:Url is required when AccountBilling is configured")
+            .Validate(config =>
+            {
+                if (config.Support.AccountPortal is { } portal)
+                    return !string.IsNullOrWhiteSpace(portal.Url);
+                return true;
+            }, "Operator:Support:AccountPortal:Url is required when AccountPortal is configured");
 
         services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
         services.AddScoped<ITenantOwnerResolver, TenantOwnerResolver>();

--- a/src/API/Nocturne.API/Services/GitHubIssueService.cs
+++ b/src/API/Nocturne.API/Services/GitHubIssueService.cs
@@ -52,11 +52,18 @@ public record FallbackUrlResponse
 public class SupportConfigResponse
 {
     public SupportChannelConfig? AccountBilling { get; set; }
+    public AccountPortalConfig? AccountPortal { get; set; }
 }
 
 public class SupportChannelConfig
 {
     public string Mode { get; set; } = "";
+    public string Url { get; set; } = "";
+    public string? Label { get; set; }
+}
+
+public class AccountPortalConfig
+{
     public string Url { get; set; } = "";
     public string? Label { get; set; }
 }

--- a/src/API/Nocturne.API/appsettings.example.json
+++ b/src/API/Nocturne.API/appsettings.example.json
@@ -69,7 +69,8 @@
     "SlugValidationWebhookUrl": null,
     "UsernameValidationWebhookUrl": null,
     "Support": {
-      "AccountBilling": null
+      "AccountBilling": null,
+      "AccountPortal": null
     }
   },
 

--- a/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/+page.server.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/+page.server.ts
@@ -4,5 +4,5 @@ import { resolveBillingLink } from "./billing-link";
 export const load: PageServerLoad = async ({ locals }) => {
   const config = await locals.apiClient.support.getSupportConfig().catch(() => null);
 
-  return { billingLink: resolveBillingLink(config?.accountBilling) };
+  return { billingLink: resolveBillingLink(config) };
 };

--- a/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.test.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.test.ts
@@ -5,29 +5,68 @@ describe("resolveBillingLink", () => {
   it("links the operator's billing page in redirect mode", () => {
     expect(
       resolveBillingLink({
-        mode: "redirect",
-        url: "https://nocturne.run/account",
-        label: "Manage your subscription",
+        accountBilling: {
+          mode: "redirect",
+          url: "https://nocturne.run/account",
+          label: "Manage your subscription",
+        },
       })
     ).toEqual({ url: "https://nocturne.run/account", label: "Manage your subscription" });
   });
 
-  it("offers no link in api mode", () => {
+  it("offers no link in api mode without a portal", () => {
     // The hosted deployment configures api mode against a POST-only issue-intake endpoint, so a
     // link here would send a lapsed customer to a route with no GET.
     expect(
-      resolveBillingLink({ mode: "api", url: "https://nocturne.run/api/support" })
+      resolveBillingLink({
+        accountBilling: { mode: "api", url: "https://nocturne.run/api/support" },
+      })
     ).toBeNull();
+  });
+
+  it("links the portal in api mode", () => {
+    expect(
+      resolveBillingLink({
+        accountBilling: { mode: "api", url: "https://nocturne.run/api/support" },
+        accountPortal: { url: "https://nocturne.run/account", label: "Manage your subscription" },
+      })
+    ).toEqual({ url: "https://nocturne.run/account", label: "Manage your subscription" });
+  });
+
+  it("prefers the portal over a redirect billing channel", () => {
+    expect(
+      resolveBillingLink({
+        accountBilling: { mode: "redirect", url: "https://example.test/issues", label: "Issues" },
+        accountPortal: { url: "https://example.test/portal", label: "Portal" },
+      })
+    ).toEqual({ url: "https://example.test/portal", label: "Portal" });
+  });
+
+  it("falls through a portal with no url", () => {
+    expect(
+      resolveBillingLink({
+        accountBilling: { mode: "redirect", url: "https://example.test/account" },
+        accountPortal: { url: "" },
+      })
+    ).toEqual({ url: "https://example.test/account", label: null });
   });
 
   it("offers no link when the operator configured none", () => {
     expect(resolveBillingLink(null)).toBeNull();
     expect(resolveBillingLink(undefined)).toBeNull();
-    expect(resolveBillingLink({ mode: "redirect", url: "" })).toBeNull();
+    expect(resolveBillingLink({})).toBeNull();
+    expect(resolveBillingLink({ accountBilling: { mode: "redirect", url: "" } })).toBeNull();
   });
 
   it("carries a redirect with no label, which the page names itself", () => {
-    expect(resolveBillingLink({ mode: "redirect", url: "https://example.test" }))
-      .toEqual({ url: "https://example.test", label: null });
+    expect(
+      resolveBillingLink({ accountBilling: { mode: "redirect", url: "https://example.test" } })
+    ).toEqual({ url: "https://example.test", label: null });
+  });
+
+  it("carries a portal with no label, which the page names itself", () => {
+    expect(
+      resolveBillingLink({ accountPortal: { url: "https://example.test/portal" } })
+    ).toEqual({ url: "https://example.test/portal", label: null });
   });
 });

--- a/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.ts
+++ b/src/Web/packages/app/src/routes/(unauthenticated)/tenant/inactive/billing-link.ts
@@ -1,15 +1,19 @@
-import type { SupportChannelConfig } from "$api/generated/nocturne-api-client";
+import type { SupportConfigResponse } from "$api/generated/nocturne-api-client";
 
 /**
- * The operator's billing address as a link, or null when there is nothing to link to.
+ * The operator's account address as a link, or null when there is nothing to link to.
  *
- * Api mode is an issue-intake endpoint the app POSTs to, not a page: rendering it as an href
- * would send the visitor to a route with no GET.
+ * Api-mode accountBilling is an issue-intake endpoint the app POSTs to, not a page: rendering it
+ * as an href would send the visitor to a route with no GET. accountPortal is always a page.
  */
 export function resolveBillingLink(
-  config: SupportChannelConfig | null | undefined
+  config: SupportConfigResponse | null | undefined
 ): { url: string; label: string | null } | null {
-  if (config?.mode !== "redirect" || !config.url) return null;
+  const portal = config?.accountPortal;
+  if (portal?.url) return { url: portal.url, label: portal.label ?? null };
 
-  return { url: config.url, label: config.label ?? null };
+  const billing = config?.accountBilling;
+  if (billing?.mode !== "redirect" || !billing.url) return null;
+
+  return { url: billing.url, label: billing.label ?? null };
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/SupportConfigTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Platform/SupportConfigTests.cs
@@ -1,0 +1,148 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Nocturne.API.Configuration;
+using Nocturne.API.Controllers.V4.Platform;
+using Nocturne.API.Services;
+
+namespace Nocturne.API.Tests.Controllers.V4.Platform;
+
+/// <summary>
+/// The support config is the only operator address a browser can read on a host with no session,
+/// so the two channels it carries have to survive each other's absence.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SupportConfigTests
+{
+    private static SupportConfigResponse Read(OperatorConfiguration config)
+    {
+        var githubService = new GitHubIssueService(
+            Mock.Of<IHttpClientFactory>(),
+            Options.Create(new GitHubIssueOptions()),
+            NullLogger<GitHubIssueService>.Instance);
+
+        var controller = new SupportController(
+            githubService,
+            Options.Create(new GitHubIssueOptions()),
+            Options.Create(config),
+            NullLogger<SupportController>.Instance);
+
+        return controller.GetSupportConfig().Result.Should().BeOfType<OkObjectResult>()
+            .Subject.Value.Should().BeOfType<SupportConfigResponse>().Subject;
+    }
+
+    [Fact]
+    public void CarriesTheAccountPortalAsAUrlAndLabel()
+    {
+        var response = Read(new OperatorConfiguration
+        {
+            Name = "Nocturne.run",
+            Support = new OperatorSupportConfiguration
+            {
+                AccountPortal = new OperatorAccountPortalConfiguration
+                {
+                    Url = "https://nocturne.run/billing/account",
+                    Label = "Manage your subscription",
+                },
+            },
+        });
+
+        response.AccountPortal.Should().NotBeNull();
+        response.AccountPortal!.Url.Should().Be("https://nocturne.run/billing/account");
+        response.AccountPortal.Label.Should().Be("Manage your subscription");
+    }
+
+    [Fact]
+    public void GivesBothChannelsTheSameLabelFallback()
+    {
+        var response = Read(new OperatorConfiguration
+        {
+            Name = "Nocturne.run",
+            Support = new OperatorSupportConfiguration
+            {
+                AccountBilling = new OperatorSupportChannelConfiguration
+                {
+                    Mode = OperatorSupportMode.Api,
+                    Url = "https://nocturne.run/billing/support/issues",
+                },
+                AccountPortal = new OperatorAccountPortalConfiguration
+                {
+                    Url = "https://nocturne.run/billing/account",
+                },
+            },
+        });
+
+        response.AccountPortal!.Label.Should().Be("Contact Nocturne.run");
+        response.AccountBilling!.Label.Should().Be(response.AccountPortal.Label);
+    }
+
+    [Fact]
+    public void LeavesTheAccountPortalLabelUnsetWhenNoOperatorIsNamed()
+    {
+        var response = Read(new OperatorConfiguration
+        {
+            Support = new OperatorSupportConfiguration
+            {
+                AccountPortal = new OperatorAccountPortalConfiguration
+                {
+                    Url = "https://example.test/account",
+                },
+            },
+        });
+
+        response.AccountPortal!.Label.Should().BeNull();
+    }
+
+    [Fact]
+    public void OmitsAnAccountPortalWithNoUrl()
+    {
+        var response = Read(new OperatorConfiguration
+        {
+            Name = "Nocturne.run",
+            Support = new OperatorSupportConfiguration
+            {
+                AccountPortal = new OperatorAccountPortalConfiguration { Url = "   " },
+            },
+        });
+
+        response.AccountPortal.Should().BeNull();
+    }
+
+    [Fact]
+    public void OmitsAnAccountPortalTheOperatorDidNotConfigure()
+    {
+        var response = Read(new OperatorConfiguration
+        {
+            Name = "Nocturne.run",
+            Support = new OperatorSupportConfiguration
+            {
+                AccountBilling = new OperatorSupportChannelConfiguration
+                {
+                    Mode = OperatorSupportMode.Redirect,
+                    Url = "https://nocturne.run/billing/account",
+                },
+            },
+        });
+
+        response.AccountPortal.Should().BeNull();
+        response.AccountBilling.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void BindsTheAccountPortalFromConfigurationKeys()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Operator:Support:AccountPortal:Url"] = "https://nocturne.run/billing/account",
+                ["Operator:Support:AccountPortal:Label"] = "Manage your subscription",
+            })
+            .Build();
+
+        var bound = config.GetSection(OperatorConfiguration.SectionName).Get<OperatorConfiguration>();
+
+        bound!.Support.AccountPortal!.Url.Should().Be("https://nocturne.run/billing/account");
+        bound.Support.AccountPortal.Label.Should().Be("Manage your subscription");
+    }
+}


### PR DESCRIPTION
Upstream half of ryceg/nocturne-cloud#116. Follows #1184.

## Problem

`/tenant/inactive` links the operator's account page only when `Operator:Support:AccountBilling` is in `Redirect` mode. A hosted operator that runs that channel in `Api` mode has a POST-only issue-intake URL there, so a lapsed customer sees the generic "contact whoever runs this service" copy and no way to reach the portal where the account is actually managed.

## Change

- `Operator:Support:AccountPortal:{Url,Label}`: a second channel that is only ever a page, so it has no `Mode`. Validated at startup the same way as `AccountBilling:Url`, and listed in `appsettings.example.json`.
- `GET /api/v4/support/config` returns `accountPortal: {url, label} | null` alongside `accountBilling`. The `"Contact {Operator.Name}"` label fallback is computed once and shared by both channels; `accountBilling` output is unchanged. The endpoint stays anonymous and still carries operator configuration only.
- `/tenant/inactive` prefers the portal, then a redirect-mode billing channel, then nothing. Page markup untouched.

The settings support page still switches on `accountBilling.mode` alone, so a signed-in api-mode customer gets the intake form where a locked-out one now gets a link. Left as is here; worth its own decision.

## Tests

`SupportConfigTests` (6: binds the literal config keys, url+label, label fallback shared with billing, no operator name, blank url omitted). `billing-link.test.ts` 4 → 8 (portal in api mode, portal beats redirect billing, blank portal url falls through, unlabelled portal). Nocturne.API.Tests 6518 → 6524, 0 failures; app vitest 1090 pass. Mutation-checked in review: preference order swapped and portal label ignored each fail a test.

https://claude.ai/code/session_01Axfap77xErW7daWoGUPtF4
