### PR TITLE
fix(auth): resolve tenant owners through OwnersOf at every site

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -1053,8 +1053,7 @@ public class PasskeyController : ControllerBase
             await using var ownerCtx = await _dbContextFactory.CreateTenantPinnedContextAsync(
                 tenant.Id, HttpContext.RequestAborted);
             var ownerIds = await ownerCtx.TenantMembers
-                .Where(tm => tm.TenantId == tenant.Id
-                    && tm.MemberRoles.Any(mr => mr.TenantRole.Slug == Core.Models.Authorization.RoleSeeds.Owner))
+                .OwnersOf(tenant.Id)
                 .Select(tm => tm.SubjectId)
                 .ToListAsync();
 

--- a/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAdminController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAdminController.cs
@@ -1097,7 +1097,7 @@ public class DevAdminController : ControllerBase
             .ToListAsync(ct);
         var candidates = DevTenantMemberSelection.Candidates(members);
         var owner = candidates.Count > 0
-            ? DevTenantMemberSelection.PickOwnerOrFirst(candidates)
+            ? DevTenantMemberSelection.PickOwnerOrFirst(candidates, tenant.Id)
             : null;
 
         var seeded = await sampleDataService.SeedAsync(
@@ -1145,7 +1145,7 @@ public class DevAdminController : ControllerBase
 
         var target = request?.SubjectId is { } subjectId
             ? candidates.FirstOrDefault(m => m.SubjectId == subjectId)
-            : DevTenantMemberSelection.PickOwnerOrFirst(candidates);
+            : DevTenantMemberSelection.PickOwnerOrFirst(candidates, tenant.Id);
         if (target is null)
             return NotFound(new { error = $"Subject {request?.SubjectId} is not a member of '{tenant.Slug}'" });
 

--- a/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAuthController.cs
@@ -203,7 +203,7 @@ public class DevAuthController : ControllerBase
         }
         else
         {
-            member = DevTenantMemberSelection.PickOwnerOrFirst(candidates);
+            member = DevTenantMemberSelection.PickOwnerOrFirst(candidates, tenant.Id);
         }
 
         var session = await _sessionService.IssueSessionAsync(

--- a/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/AccessRequestController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/PlatformAdmin/AccessRequestController.cs
@@ -6,7 +6,7 @@ using Nocturne.API.Authorization;
 using Nocturne.Core.Contracts.Notifications;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models;
-using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.API.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.API.Extensions;
@@ -99,10 +99,8 @@ public class AccessRequestController(
 
             await tenantService.AddMemberAsync(tenantId, subjectId, request.RoleIds, request.DirectPermissions, ct: ct);
 
-            // Find owners by looking at members with the owner role slug
             var ownerIds = await dbContext.TenantMembers
-                .Where(tm => tm.TenantId == tenantId
-                    && tm.MemberRoles.Any(mr => mr.TenantRole.Slug == RoleSeeds.Owner))
+                .OwnersOf(tenantId)
                 .Select(tm => tm.SubjectId)
                 .ToListAsync(ct);
 
@@ -141,8 +139,7 @@ public class AccessRequestController(
         if (denyTenantContext != null)
         {
             var ownerIds = await dbContext.TenantMembers
-                .Where(tm => tm.TenantId == denyTenantContext.TenantId
-                    && tm.MemberRoles.Any(mr => mr.TenantRole.Slug == RoleSeeds.Owner))
+                .OwnersOf(denyTenantContext.TenantId)
                 .Select(tm => tm.SubjectId)
                 .ToListAsync(ct);
 

--- a/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Extensions;
@@ -99,9 +98,8 @@ public class PlatformAdminBootstrapService
     }
 
     /// <summary>
-    /// The subject holding the owner role on the oldest tenant that has one, or
-    /// <see langword="null"/> when no tenant does. Tenants without an owner are skipped, matching
-    /// the ordered membership scan this replaces.
+    /// The owner of the oldest tenant that has one, or <see langword="null"/> when no tenant
+    /// does. Tenants without an owner are skipped.
     /// </summary>
     private static async Task<Guid?> FindOldestTenantOwnerAsync(
         NocturneDbContext db, CancellationToken cancellationToken)
@@ -117,8 +115,7 @@ public class PlatformAdminBootstrapService
             await db.PinTenantAsync(tenantId, cancellationToken);
 
             var ownerSubjectId = await db.TenantMembers
-                .Where(tm => tm.TenantId == tenantId
-                    && tm.MemberRoles.Any(mr => mr.TenantRole!.Slug == RoleSeeds.Owner))
+                .OwnersOf(tenantId)
                 .Select(tm => tm.SubjectId)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -141,7 +138,7 @@ public class PlatformAdminBootstrapService
     /// <para>
     /// The caller names the subject, but this method re-derives whether that subject is
     /// eligible rather than taking its word: the instance must still be a single-tenant
-    /// install and the subject must hold that tenant's <c>owner</c> role. A privilege grant
+    /// install and the subject must be an owner of that tenant. A privilege grant
     /// shouldn't depend on every present and future call site having checked setup state
     /// first, and the setup OIDC callback in particular is reachable anonymously.
     /// </para>
@@ -175,11 +172,8 @@ public class PlatformAdminBootstrapService
         await db.PinTenantAsync(tenantIds[0], cancellationToken);
 
         var isTenantOwner = await db.TenantMembers
-            .AnyAsync(
-                tm => tm.TenantId == tenantIds[0]
-                    && tm.SubjectId == subjectId
-                    && tm.MemberRoles.Any(mr => mr.TenantRole!.Slug == RoleSeeds.Owner),
-                cancellationToken);
+            .OwnersOf(tenantIds[0])
+            .AnyAsync(tm => tm.SubjectId == subjectId, cancellationToken);
 
         if (!isTenantOwner)
         {

--- a/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
+++ b/src/API/Nocturne.API/Services/Auth/PlatformAdminBootstrapService.cs
@@ -98,8 +98,7 @@ public class PlatformAdminBootstrapService
     }
 
     /// <summary>
-    /// The owner of the oldest tenant that has one, or <see langword="null"/> when no tenant
-    /// does. Tenants without an owner are skipped.
+    /// The owner of the oldest tenant that has one, or <see langword="null"/> when no tenant does.
     /// </summary>
     private static async Task<Guid?> FindOldestTenantOwnerAsync(
         NocturneDbContext db, CancellationToken cancellationToken)

--- a/src/API/Nocturne.API/Services/DevOnly/DevTenantMemberSelection.cs
+++ b/src/API/Nocturne.API/Services/DevOnly/DevTenantMemberSelection.cs
@@ -1,5 +1,5 @@
-using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.DevOnly;
 
@@ -17,9 +17,8 @@ public static class DevTenantMemberSelection
             .Where(m => m.Subject is { IsActive: true, IsSystemSubject: false })
             .ToList();
 
-    /// <summary>The first owner-role member, else the first candidate.</summary>
-    public static TenantMemberEntity PickOwnerOrFirst(List<TenantMemberEntity> candidates) =>
-        candidates.FirstOrDefault(m => m.MemberRoles.Any(mr =>
-            mr.TenantRole.Slug == RoleSeeds.Owner))
+    /// <summary>The tenant's longest-standing owner, else the first candidate.</summary>
+    public static TenantMemberEntity PickOwnerOrFirst(List<TenantMemberEntity> candidates, Guid tenantId) =>
+        candidates.AsQueryable().OwnersOf(tenantId).FirstOrDefault()
         ?? candidates[0];
 }

--- a/src/API/Nocturne.API/Services/Identity/TenantService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantService.cs
@@ -348,20 +348,13 @@ public partial class TenantService : ITenantService
         if (member.Subject?.IsSystemSubject == true)
             return new MemberRemovalResult(false, "Cannot remove system subject memberships");
 
-        var isOwner = await context.TenantMemberRoles
-            .AnyAsync(mr => mr.TenantMemberId == member.Id
-                && mr.TenantRole!.Slug == RoleSeeds.Owner, ct);
+        var ownerIds = await context.TenantMembers
+            .OwnersOf(tenantId)
+            .Select(m => m.Id)
+            .ToListAsync(ct);
 
-        if (isOwner)
-        {
-            var ownerCount = await context.TenantMemberRoles
-                .CountAsync(mr => mr.TenantRole!.TenantId == tenantId
-                    && mr.TenantRole.Slug == RoleSeeds.Owner
-                    && mr.TenantMember!.RevokedAt == null, ct);
-
-            if (ownerCount <= 1)
-                return new MemberRemovalResult(false, "Cannot remove the last owner of a tenant");
-        }
+        if (ownerIds.Count == 1 && ownerIds[0] == member.Id)
+            return new MemberRemovalResult(false, "Cannot remove the last owner of a tenant");
 
         // Chat identity directory rows are global and carry no membership join, so a link left
         // behind here would keep answering bot commands for this tenant. It goes in the same

--- a/src/API/Nocturne.API/Services/Identity/TenantService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantService.cs
@@ -352,8 +352,7 @@ public partial class TenantService : ITenantService
             .AnyAsync(mr => mr.TenantMemberId == member.Id
                 && mr.TenantRole!.Slug == RoleSeeds.Owner, ct);
 
-        // A deactivated owner can be reactivated; a removed membership cannot be brought back, so
-        // the guard holds even when the departing owner is one the rest of the system ignores.
+        // A deactivated or system-subject peer is not a remaining owner.
         if (isOwner && !await context.TenantMembers.OwnersOf(tenantId).AnyAsync(m => m.Id != member.Id, ct))
             return new MemberRemovalResult(false, "Cannot remove the last owner of a tenant");
 

--- a/src/API/Nocturne.API/Services/Identity/TenantService.cs
+++ b/src/API/Nocturne.API/Services/Identity/TenantService.cs
@@ -348,12 +348,13 @@ public partial class TenantService : ITenantService
         if (member.Subject?.IsSystemSubject == true)
             return new MemberRemovalResult(false, "Cannot remove system subject memberships");
 
-        var ownerIds = await context.TenantMembers
-            .OwnersOf(tenantId)
-            .Select(m => m.Id)
-            .ToListAsync(ct);
+        var isOwner = await context.TenantMemberRoles
+            .AnyAsync(mr => mr.TenantMemberId == member.Id
+                && mr.TenantRole!.Slug == RoleSeeds.Owner, ct);
 
-        if (ownerIds.Count == 1 && ownerIds[0] == member.Id)
+        // A deactivated owner can be reactivated; a removed membership cannot be brought back, so
+        // the guard holds even when the departing owner is one the rest of the system ignores.
+        if (isOwner && !await context.TenantMembers.OwnersOf(tenantId).AnyAsync(m => m.Id != member.Id, ct))
             return new MemberRemovalResult(false, "Cannot remove the last owner of a tenant");
 
         // Chat identity directory rows are global and carry no membership join, so a link left

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -645,6 +645,39 @@ public class PasskeyControllerTests : IDisposable
     }
 
     /// <summary>
+    /// Only owners who still stand are told a stranger is at the door: a revoked membership is off
+    /// the tenant, a deactivated subject cannot sign in to act, and the Public subject is a share
+    /// with nobody behind it.
+    /// </summary>
+    [Fact]
+    public async Task AccessRequestComplete_NotifiesTheStandingOwnersOnly()
+    {
+        await AllowAccessRequestsAsync();
+        var owner = await SeedOwnerAsync("owner");
+        await SeedOwnerAsync("revoked", revokedAt: DateTime.UtcNow);
+        await SeedOwnerAsync("deactivated", isActive: false);
+        await SeedOwnerAsync("public", isSystemSubject: true);
+        var requestorId = await SeedPendingAccessRequestAsync("Sam Smith");
+        StubRegistrationChallengeMintedFor(requestorId);
+
+        var notifications = new Mock<IInAppNotificationService>();
+        var result = await _controller.AccessRequestComplete(
+            new AccessRequestCompleteRequest
+            {
+                DisplayName = "Sam Smith",
+                AttestationResponseJson = "{}",
+                ChallengeToken = "challenge-for-sam",
+            },
+            notifications.Object);
+
+        Assert.IsType<OkResult>(result);
+        notifications.Invocations
+            .Where(i => i.Method.Name == nameof(IInAppNotificationService.CreateNotificationAsync))
+            .Select(i => (string)i.Arguments[0]!)
+            .Should().Equal(owner.ToString());
+    }
+
+    /// <summary>
     /// Subjects are global; membership is what scopes them. A credential-less member of another
     /// tenant is that tenant's locked-out account, not an abandoned enrolment here, so an invite
     /// naming their username enrols a fresh subject and leaves theirs untouched.
@@ -1067,6 +1100,68 @@ public class PasskeyControllerTests : IDisposable
         });
         await _dbContext.SaveChangesAsync();
         return subjectId;
+    }
+
+    /// <summary>Adds a membership on this tenant carrying the owner role.</summary>
+    private async Task<Guid> SeedOwnerAsync(
+        string username,
+        DateTime? revokedAt = null,
+        bool isActive = true,
+        bool isSystemSubject = false)
+    {
+        await EnsureTenantAsync(_tenantId);
+
+        var ownerRoleId = await EnsureOwnerRoleAsync();
+        var subjectId = Guid.CreateVersion7();
+        var memberId = Guid.CreateVersion7();
+
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = username,
+            Username = username,
+            IsActive = isActive,
+            IsSystemSubject = isSystemSubject,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = memberId,
+            TenantId = _tenantId,
+            SubjectId = subjectId,
+            RevokedAt = revokedAt,
+        });
+        _dbContext.TenantMemberRoles.Add(new TenantMemberRoleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantMemberId = memberId,
+            TenantRoleId = ownerRoleId,
+        });
+        await _dbContext.SaveChangesAsync();
+        return subjectId;
+    }
+
+    private async Task<Guid> EnsureOwnerRoleAsync()
+    {
+        var existing = await _dbContext.TenantRoles
+            .Where(r => r.TenantId == _tenantId && r.Slug == RoleSeeds.Owner)
+            .Select(r => (Guid?)r.Id)
+            .FirstOrDefaultAsync();
+
+        if (existing is { } id)
+            return id;
+
+        var roleId = Guid.CreateVersion7();
+        _dbContext.TenantRoles.Add(new TenantRoleEntity
+        {
+            Id = roleId,
+            TenantId = _tenantId,
+            Name = "Owner",
+            Slug = RoleSeeds.Owner,
+            Permissions = [Scope.FullAccess],
+            IsSystem = true,
+        });
+        await _dbContext.SaveChangesAsync();
+        return roleId;
     }
 
     private async Task AllowAccessRequestsAsync()

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Services.Auth;
 using Nocturne.API.Services.Identity;
+using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Contracts.Notifications;
@@ -644,11 +645,6 @@ public class PasskeyControllerTests : IDisposable
             Times.Once);
     }
 
-    /// <summary>
-    /// Only owners who still stand are told a stranger is at the door: a revoked membership is off
-    /// the tenant, a deactivated subject cannot sign in to act, and the Public subject is a share
-    /// with nobody behind it.
-    /// </summary>
     [Fact]
     public async Task AccessRequestComplete_NotifiesTheStandingOwnersOnly()
     {
@@ -1102,7 +1098,6 @@ public class PasskeyControllerTests : IDisposable
         return subjectId;
     }
 
-    /// <summary>Adds a membership on this tenant carrying the owner role.</summary>
     private async Task<Guid> SeedOwnerAsync(
         string username,
         DateTime? revokedAt = null,
@@ -1110,58 +1105,9 @@ public class PasskeyControllerTests : IDisposable
         bool isSystemSubject = false)
     {
         await EnsureTenantAsync(_tenantId);
-
-        var ownerRoleId = await EnsureOwnerRoleAsync();
-        var subjectId = Guid.CreateVersion7();
-        var memberId = Guid.CreateVersion7();
-
-        _dbContext.Subjects.Add(new SubjectEntity
-        {
-            Id = subjectId,
-            Name = username,
-            Username = username,
-            IsActive = isActive,
-            IsSystemSubject = isSystemSubject,
-        });
-        _dbContext.TenantMembers.Add(new TenantMemberEntity
-        {
-            Id = memberId,
-            TenantId = _tenantId,
-            SubjectId = subjectId,
-            RevokedAt = revokedAt,
-        });
-        _dbContext.TenantMemberRoles.Add(new TenantMemberRoleEntity
-        {
-            Id = Guid.CreateVersion7(),
-            TenantMemberId = memberId,
-            TenantRoleId = ownerRoleId,
-        });
-        await _dbContext.SaveChangesAsync();
-        return subjectId;
-    }
-
-    private async Task<Guid> EnsureOwnerRoleAsync()
-    {
-        var existing = await _dbContext.TenantRoles
-            .Where(r => r.TenantId == _tenantId && r.Slug == RoleSeeds.Owner)
-            .Select(r => (Guid?)r.Id)
-            .FirstOrDefaultAsync();
-
-        if (existing is { } id)
-            return id;
-
-        var roleId = Guid.CreateVersion7();
-        _dbContext.TenantRoles.Add(new TenantRoleEntity
-        {
-            Id = roleId,
-            TenantId = _tenantId,
-            Name = "Owner",
-            Slug = RoleSeeds.Owner,
-            Permissions = [Scope.FullAccess],
-            IsSystem = true,
-        });
-        await _dbContext.SaveChangesAsync();
-        return roleId;
+        return await TestDatabaseSeeder.SeedMemberAsync(
+            _dbContext, _tenantId, name: username,
+            isActive: isActive, isSystemSubject: isSystemSubject, revokedAt: revokedAt);
     }
 
     private async Task AllowAccessRequestsAsync()

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/PlatformAdmin/AccessRequestControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/PlatformAdmin/AccessRequestControllerTests.cs
@@ -1,0 +1,166 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Controllers.V4.PlatformAdmin;
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Notifications;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
+using Nocturne.Tests.Shared.Mocks;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers.V4.PlatformAdmin;
+
+/// <summary>
+/// Which owners the approve and deny paths archive the pending-request notification for.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class AccessRequestControllerTests : IDisposable
+{
+    private readonly SqliteTestDatabase _db;
+    private readonly NocturneDbContext _dbContext;
+    private readonly Mock<IInAppNotificationService> _notifications = new();
+    private readonly Mock<ITenantService> _tenantService = new();
+    private readonly AccessRequestController _controller;
+
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly Guid _ownerRoleId = Guid.CreateVersion7();
+
+    public AccessRequestControllerTests()
+    {
+        _db = TestDbContextFactory.CreateSqlite();
+        _dbContext = _db.CreateContext(_tenantId);
+
+        var roleService = new Mock<ITenantRoleService>();
+        roleService
+            .Setup(s => s.ValidateRoleGrantAsync(
+                It.IsAny<Guid>(), It.IsAny<List<Guid>>(), It.IsAny<IReadOnlySet<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RoleGrantValidation.Valid);
+
+        _controller = new AccessRequestController(
+            _dbContext,
+            Mock.Of<ISubjectService>(),
+            _tenantService.Object,
+            roleService.Object,
+            MockTenantAccessor.Create(_tenantId).Object,
+            _notifications.Object,
+            NullLogger<AccessRequestController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+
+        _dbContext.Tenants.Add(new TenantEntity
+        {
+            Id = _tenantId,
+            Slug = "test",
+            DisplayName = "Test",
+        });
+        _dbContext.TenantRoles.Add(new TenantRoleEntity
+        {
+            Id = _ownerRoleId,
+            TenantId = _tenantId,
+            Name = "Owner",
+            Slug = RoleSeeds.Owner,
+            Permissions = [Scope.FullAccess],
+            IsSystem = true,
+        });
+        _dbContext.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _db.Dispose();
+    }
+
+    [Fact]
+    public async Task Approve_archivesForTheStandingOwnerOnly()
+    {
+        var owner = SeedOwner();
+        var revoked = SeedOwner(revokedAt: DateTime.UtcNow);
+        var deactivated = SeedOwner(isActive: false);
+        var requestorId = SeedPendingRequest();
+
+        var result = await _controller.Approve(
+            requestorId,
+            new ApproveAccessRequestRequest { RoleIds = [_ownerRoleId] },
+            CancellationToken.None);
+
+        Assert.IsType<OkResult>(result);
+        ArchivedFor(owner, NotificationArchiveReason.Completed, Times.Once());
+        ArchivedFor(revoked, NotificationArchiveReason.Completed, Times.Never());
+        ArchivedFor(deactivated, NotificationArchiveReason.Completed, Times.Never());
+    }
+
+    [Fact]
+    public async Task Deny_archivesForTheStandingOwnerOnly()
+    {
+        var owner = SeedOwner();
+        var revoked = SeedOwner(revokedAt: DateTime.UtcNow);
+        var system = SeedOwner(isSystemSubject: true);
+        var requestorId = SeedPendingRequest();
+
+        var result = await _controller.Deny(requestorId, CancellationToken.None);
+
+        Assert.IsType<OkResult>(result);
+        ArchivedFor(owner, NotificationArchiveReason.Dismissed, Times.Once());
+        ArchivedFor(revoked, NotificationArchiveReason.Dismissed, Times.Never());
+        ArchivedFor(system, NotificationArchiveReason.Dismissed, Times.Never());
+    }
+
+    private void ArchivedFor(Guid subjectId, NotificationArchiveReason reason, Times times) =>
+        _notifications.Verify(
+            s => s.ArchiveBySourceAsync(
+                subjectId.ToString(), "passkey.anonymous_login_request", It.IsAny<string>(),
+                reason, It.IsAny<CancellationToken>()),
+            times);
+
+    private Guid SeedOwner(
+        DateTime? revokedAt = null, bool isActive = true, bool isSystemSubject = false)
+    {
+        var subjectId = Guid.CreateVersion7();
+        var memberId = Guid.CreateVersion7();
+
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = "Owner",
+            IsActive = isActive,
+            IsSystemSubject = isSystemSubject,
+        });
+        _dbContext.TenantMembers.Add(new TenantMemberEntity
+        {
+            Id = memberId,
+            TenantId = _tenantId,
+            SubjectId = subjectId,
+            RevokedAt = revokedAt,
+        });
+        _dbContext.TenantMemberRoles.Add(new TenantMemberRoleEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantMemberId = memberId,
+            TenantRoleId = _ownerRoleId,
+        });
+        _dbContext.SaveChanges();
+        return subjectId;
+    }
+
+    private Guid SeedPendingRequest()
+    {
+        var subjectId = Guid.CreateVersion7();
+        _dbContext.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = "Requestor",
+            IsActive = false,
+            ApprovalStatus = "Pending",
+        });
+        _dbContext.SaveChanges();
+        return subjectId;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/PlatformAdmin/AccessRequestControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/PlatformAdmin/AccessRequestControllerTests.cs
@@ -4,9 +4,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Nocturne.API.Controllers.V4.PlatformAdmin;
+using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Contracts.Notifications;
-using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Tests.Shared.Infrastructure;
@@ -24,11 +24,9 @@ public sealed class AccessRequestControllerTests : IDisposable
     private readonly SqliteTestDatabase _db;
     private readonly NocturneDbContext _dbContext;
     private readonly Mock<IInAppNotificationService> _notifications = new();
-    private readonly Mock<ITenantService> _tenantService = new();
     private readonly AccessRequestController _controller;
 
     private readonly Guid _tenantId = Guid.CreateVersion7();
-    private readonly Guid _ownerRoleId = Guid.CreateVersion7();
 
     public AccessRequestControllerTests()
     {
@@ -45,7 +43,7 @@ public sealed class AccessRequestControllerTests : IDisposable
         _controller = new AccessRequestController(
             _dbContext,
             Mock.Of<ISubjectService>(),
-            _tenantService.Object,
+            Mock.Of<ITenantService>(),
             roleService.Object,
             MockTenantAccessor.Create(_tenantId).Object,
             _notifications.Object,
@@ -60,15 +58,6 @@ public sealed class AccessRequestControllerTests : IDisposable
             Slug = "test",
             DisplayName = "Test",
         });
-        _dbContext.TenantRoles.Add(new TenantRoleEntity
-        {
-            Id = _ownerRoleId,
-            TenantId = _tenantId,
-            Name = "Owner",
-            Slug = RoleSeeds.Owner,
-            Permissions = [Scope.FullAccess],
-            IsSystem = true,
-        });
         _dbContext.SaveChanges();
     }
 
@@ -81,14 +70,14 @@ public sealed class AccessRequestControllerTests : IDisposable
     [Fact]
     public async Task Approve_archivesForTheStandingOwnerOnly()
     {
-        var owner = SeedOwner();
-        var revoked = SeedOwner(revokedAt: DateTime.UtcNow);
-        var deactivated = SeedOwner(isActive: false);
-        var requestorId = SeedPendingRequest();
+        var owner = await SeedOwnerAsync();
+        var revoked = await SeedOwnerAsync(revokedAt: DateTime.UtcNow);
+        var deactivated = await SeedOwnerAsync(isActive: false);
+        var requestorId = await SeedPendingRequestAsync();
 
         var result = await _controller.Approve(
             requestorId,
-            new ApproveAccessRequestRequest { RoleIds = [_ownerRoleId] },
+            new ApproveAccessRequestRequest { DirectPermissions = ["api:*:read"] },
             CancellationToken.None);
 
         Assert.IsType<OkResult>(result);
@@ -100,10 +89,10 @@ public sealed class AccessRequestControllerTests : IDisposable
     [Fact]
     public async Task Deny_archivesForTheStandingOwnerOnly()
     {
-        var owner = SeedOwner();
-        var revoked = SeedOwner(revokedAt: DateTime.UtcNow);
-        var system = SeedOwner(isSystemSubject: true);
-        var requestorId = SeedPendingRequest();
+        var owner = await SeedOwnerAsync();
+        var revoked = await SeedOwnerAsync(revokedAt: DateTime.UtcNow);
+        var system = await SeedOwnerAsync(isSystemSubject: true);
+        var requestorId = await SeedPendingRequestAsync();
 
         var result = await _controller.Deny(requestorId, CancellationToken.None);
 
@@ -120,37 +109,13 @@ public sealed class AccessRequestControllerTests : IDisposable
                 reason, It.IsAny<CancellationToken>()),
             times);
 
-    private Guid SeedOwner(
-        DateTime? revokedAt = null, bool isActive = true, bool isSystemSubject = false)
-    {
-        var subjectId = Guid.CreateVersion7();
-        var memberId = Guid.CreateVersion7();
+    private Task<Guid> SeedOwnerAsync(
+        DateTime? revokedAt = null, bool isActive = true, bool isSystemSubject = false) =>
+        TestDatabaseSeeder.SeedMemberAsync(
+            _dbContext, _tenantId,
+            isActive: isActive, isSystemSubject: isSystemSubject, revokedAt: revokedAt);
 
-        _dbContext.Subjects.Add(new SubjectEntity
-        {
-            Id = subjectId,
-            Name = "Owner",
-            IsActive = isActive,
-            IsSystemSubject = isSystemSubject,
-        });
-        _dbContext.TenantMembers.Add(new TenantMemberEntity
-        {
-            Id = memberId,
-            TenantId = _tenantId,
-            SubjectId = subjectId,
-            RevokedAt = revokedAt,
-        });
-        _dbContext.TenantMemberRoles.Add(new TenantMemberRoleEntity
-        {
-            Id = Guid.CreateVersion7(),
-            TenantMemberId = memberId,
-            TenantRoleId = _ownerRoleId,
-        });
-        _dbContext.SaveChanges();
-        return subjectId;
-    }
-
-    private Guid SeedPendingRequest()
+    private async Task<Guid> SeedPendingRequestAsync()
     {
         var subjectId = Guid.CreateVersion7();
         _dbContext.Subjects.Add(new SubjectEntity
@@ -160,7 +125,7 @@ public sealed class AccessRequestControllerTests : IDisposable
             IsActive = false,
             ApprovalStatus = "Pending",
         });
-        _dbContext.SaveChanges();
+        await _dbContext.SaveChangesAsync();
         return subjectId;
     }
 }

--- a/tests/Unit/Nocturne.API.Tests/Infrastructure/TestDatabaseSeeder.cs
+++ b/tests/Unit/Nocturne.API.Tests/Infrastructure/TestDatabaseSeeder.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.EntityFrameworkCore;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
@@ -145,6 +146,89 @@ public static class TestDatabaseSeeder
         });
 
         db.SaveChanges();
+    }
+
+    /// <summary>
+    /// Adds a subject and its membership of <paramref name="tenantId"/>, carrying
+    /// <paramref name="roleSlug"/> unless that is <see langword="null"/>. The tenant's role row is
+    /// created on first use. Returns the subject id.
+    /// </summary>
+    public static async Task<Guid> SeedMemberAsync(
+        NocturneDbContext db,
+        Guid tenantId,
+        string? roleSlug = RoleSeeds.Owner,
+        string? name = null,
+        bool isActive = true,
+        bool isSystemSubject = false,
+        DateTime? revokedAt = null,
+        DateTime? joinedAt = null,
+        string? preferences = null)
+    {
+        var roleId = roleSlug == null ? (Guid?)null : await EnsureRoleAsync(db, tenantId, roleSlug);
+        var subjectId = Guid.CreateVersion7();
+        var member = new TenantMemberEntity
+        {
+            Id = Guid.CreateVersion7(),
+            TenantId = tenantId,
+            SubjectId = subjectId,
+            RevokedAt = revokedAt,
+        };
+
+        db.Subjects.Add(new SubjectEntity
+        {
+            Id = subjectId,
+            Name = name ?? (isSystemSubject ? "Public" : $"Member {subjectId:N}"),
+            Username = name,
+            IsActive = isActive,
+            IsSystemSubject = isSystemSubject,
+            Preferences = preferences,
+        });
+        db.TenantMembers.Add(member);
+
+        if (roleId is { } id)
+        {
+            db.TenantMemberRoles.Add(new TenantMemberRoleEntity
+            {
+                Id = Guid.CreateVersion7(),
+                TenantMemberId = member.Id,
+                TenantRoleId = id,
+            });
+        }
+
+        await db.SaveChangesAsync();
+
+        if (joinedAt is { } joined)
+        {
+            // The context stamps SysCreatedAt on insert, so the join time can only be set afterwards.
+            member.SysCreatedAt = joined;
+            await db.SaveChangesAsync();
+        }
+
+        return subjectId;
+    }
+
+    private static async Task<Guid> EnsureRoleAsync(NocturneDbContext db, Guid tenantId, string roleSlug)
+    {
+        var existing = await db.TenantRoles
+            .Where(r => r.TenantId == tenantId && r.Slug == roleSlug)
+            .Select(r => (Guid?)r.Id)
+            .FirstOrDefaultAsync();
+
+        if (existing is { } id)
+            return id;
+
+        var roleId = Guid.CreateVersion7();
+        db.TenantRoles.Add(new TenantRoleEntity
+        {
+            Id = roleId,
+            TenantId = tenantId,
+            Name = RoleSeeds.DisplayNames[roleSlug],
+            Slug = roleSlug,
+            Permissions = RoleSeeds.Permissions[roleSlug],
+            IsSystem = true,
+        });
+        await db.SaveChangesAsync();
+        return roleId;
     }
 
     public static string Sha1Hex(string input)

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
@@ -97,6 +97,68 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
         (await _db.Subjects.AsNoTracking().AnyAsync(s => s.IsPlatformAdmin)).Should().BeFalse();
     }
 
+    [Fact]
+    public async Task ATenantWhoseOnlyOwnerIsRevokedIsSkippedForTheNextOldest()
+    {
+        var revoked = await AddTenantAsync(
+            "revoked-oldest", new DateTime(2019, 1, 1), RoleSeeds.Owner, revoked: true);
+        var owner = await AddTenantWithOwnerAsync("owned", new DateTime(2020, 1, 1));
+
+        await BootstrapAsync();
+
+        (await IsPlatformAdminAsync(revoked)).Should().BeFalse();
+        (await IsPlatformAdminAsync(owner)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ATenantWhoseOnlyOwnerIsDeactivatedIsSkippedForTheNextOldest()
+    {
+        var deactivated = await AddTenantAsync(
+            "deactivated-oldest", new DateTime(2019, 1, 1), RoleSeeds.Owner, subjectIsActive: false);
+        var owner = await AddTenantWithOwnerAsync("owned", new DateTime(2020, 1, 1));
+
+        await BootstrapAsync();
+
+        (await IsPlatformAdminAsync(deactivated)).Should().BeFalse();
+        (await IsPlatformAdminAsync(owner)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TheFirstOwnerOfTheSoleTenantIsGrantedOnSetupCompletion()
+    {
+        var owner = await AddTenantWithOwnerAsync("only", new DateTime(2020, 1, 1));
+
+        (await EnsureFirstOwnerAsync(owner)).Should().BeTrue();
+        (await IsPlatformAdminAsync(owner)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ARevokedOwnerOfTheSoleTenantIsNotGrantedOnSetupCompletion()
+    {
+        var revoked = await AddTenantAsync(
+            "only", new DateTime(2020, 1, 1), RoleSeeds.Owner, revoked: true);
+
+        (await EnsureFirstOwnerAsync(revoked)).Should().BeFalse();
+        (await IsPlatformAdminAsync(revoked)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ADeactivatedOwnerOfTheSoleTenantIsNotGrantedOnSetupCompletion()
+    {
+        var deactivated = await AddTenantAsync(
+            "only", new DateTime(2020, 1, 1), RoleSeeds.Owner, subjectIsActive: false);
+
+        (await EnsureFirstOwnerAsync(deactivated)).Should().BeFalse();
+        (await IsPlatformAdminAsync(deactivated)).Should().BeFalse();
+    }
+
+    private Task<bool> EnsureFirstOwnerAsync(Guid subjectId) =>
+        new PlatformAdminBootstrapService(
+            _sqlite.ContextFactory,
+            Options.Create(new PlatformOptions { AdminSubjectIds = [] }),
+            NullLogger<PlatformAdminBootstrapService>.Instance)
+            .EnsureFirstOwnerIsPlatformAdminAsync(subjectId, CancellationToken.None);
+
     private Task BootstrapAsync(List<Guid>? adminSubjectIds = null) =>
         new PlatformAdminBootstrapService(
             _sqlite.ContextFactory,
@@ -110,14 +172,15 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
             .Select(s => s.IsPlatformAdmin)
             .SingleAsync();
 
-    private async Task<Guid> AddSubjectAsync(string name, bool isPlatformAdmin = false)
+    private async Task<Guid> AddSubjectAsync(
+        string name, bool isPlatformAdmin = false, bool isActive = true)
     {
         var subject = new SubjectEntity
         {
             Id = Guid.CreateVersion7(),
             Name = name,
             Username = name,
-            IsActive = true,
+            IsActive = isActive,
             IsPlatformAdmin = isPlatformAdmin,
         };
         _db.Subjects.Add(subject);
@@ -134,10 +197,15 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
     private async Task<Guid> AddTenantWithoutOwnerAsync(string slug, DateTime createdAt) =>
         await AddTenantAsync(slug, createdAt, RoleSeeds.Viewer);
 
-    private async Task<Guid> AddTenantAsync(string slug, DateTime createdAt, string roleSlug)
+    private async Task<Guid> AddTenantAsync(
+        string slug,
+        DateTime createdAt,
+        string roleSlug,
+        bool revoked = false,
+        bool subjectIsActive = true)
     {
         var tenantId = Guid.CreateVersion7();
-        var subjectId = await AddSubjectAsync($"{slug}-member");
+        var subjectId = await AddSubjectAsync($"{slug}-member", isActive: subjectIsActive);
         var roleId = Guid.CreateVersion7();
         var memberId = Guid.CreateVersion7();
 
@@ -163,6 +231,7 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
             Id = memberId,
             TenantId = tenantId,
             SubjectId = subjectId,
+            RevokedAt = revoked ? createdAt : null,
         });
         _db.TenantMemberRoles.Add(new TenantMemberRoleEntity
         {

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Services.Auth;
+using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
@@ -172,15 +173,14 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
             .Select(s => s.IsPlatformAdmin)
             .SingleAsync();
 
-    private async Task<Guid> AddSubjectAsync(
-        string name, bool isPlatformAdmin = false, bool isActive = true)
+    private async Task<Guid> AddSubjectAsync(string name, bool isPlatformAdmin = false)
     {
         var subject = new SubjectEntity
         {
             Id = Guid.CreateVersion7(),
             Name = name,
             Username = name,
-            IsActive = isActive,
+            IsActive = true,
             IsPlatformAdmin = isPlatformAdmin,
         };
         _db.Subjects.Add(subject);
@@ -205,10 +205,6 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
         bool subjectIsActive = true)
     {
         var tenantId = Guid.CreateVersion7();
-        var subjectId = await AddSubjectAsync($"{slug}-member", isActive: subjectIsActive);
-        var roleId = Guid.CreateVersion7();
-        var memberId = Guid.CreateVersion7();
-
         _db.Tenants.Add(new TenantEntity
         {
             Id = tenantId,
@@ -217,29 +213,14 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
             IsActive = true,
             SysCreatedAt = createdAt,
         });
-        _db.TenantRoles.Add(new TenantRoleEntity
-        {
-            Id = roleId,
-            TenantId = tenantId,
-            Name = roleSlug,
-            Slug = roleSlug,
-            Permissions = [],
-            IsSystem = true,
-        });
-        _db.TenantMembers.Add(new TenantMemberEntity
-        {
-            Id = memberId,
-            TenantId = tenantId,
-            SubjectId = subjectId,
-            RevokedAt = revoked ? createdAt : null,
-        });
-        _db.TenantMemberRoles.Add(new TenantMemberRoleEntity
-        {
-            Id = Guid.CreateVersion7(),
-            TenantMemberId = memberId,
-            TenantRoleId = roleId,
-        });
         await _db.SaveChangesAsync();
+
+        var subjectId = await TestDatabaseSeeder.SeedMemberAsync(
+            _db, tenantId, roleSlug,
+            name: $"{slug}-member",
+            isActive: subjectIsActive,
+            revokedAt: revoked ? createdAt : null);
+
         _db.ChangeTracker.Clear();
         return subjectId;
     }

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/PlatformAdminBootstrapServiceTests.cs
@@ -99,19 +99,6 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ATenantWhoseOnlyOwnerIsRevokedIsSkippedForTheNextOldest()
-    {
-        var revoked = await AddTenantAsync(
-            "revoked-oldest", new DateTime(2019, 1, 1), RoleSeeds.Owner, revoked: true);
-        var owner = await AddTenantWithOwnerAsync("owned", new DateTime(2020, 1, 1));
-
-        await BootstrapAsync();
-
-        (await IsPlatformAdminAsync(revoked)).Should().BeFalse();
-        (await IsPlatformAdminAsync(owner)).Should().BeTrue();
-    }
-
-    [Fact]
     public async Task ATenantWhoseOnlyOwnerIsDeactivatedIsSkippedForTheNextOldest()
     {
         var deactivated = await AddTenantAsync(
@@ -131,16 +118,6 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
 
         (await EnsureFirstOwnerAsync(owner)).Should().BeTrue();
         (await IsPlatformAdminAsync(owner)).Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task ARevokedOwnerOfTheSoleTenantIsNotGrantedOnSetupCompletion()
-    {
-        var revoked = await AddTenantAsync(
-            "only", new DateTime(2020, 1, 1), RoleSeeds.Owner, revoked: true);
-
-        (await EnsureFirstOwnerAsync(revoked)).Should().BeFalse();
-        (await IsPlatformAdminAsync(revoked)).Should().BeFalse();
     }
 
     [Fact]
@@ -201,7 +178,6 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
         string slug,
         DateTime createdAt,
         string roleSlug,
-        bool revoked = false,
         bool subjectIsActive = true)
     {
         var tenantId = Guid.CreateVersion7();
@@ -218,8 +194,7 @@ public class PlatformAdminBootstrapServiceTests : IDisposable
         var subjectId = await TestDatabaseSeeder.SeedMemberAsync(
             _db, tenantId, roleSlug,
             name: $"{slug}-member",
-            isActive: subjectIsActive,
-            revokedAt: revoked ? createdAt : null);
+            isActive: subjectIsActive);
 
         _db.ChangeTracker.Clear();
         return subjectId;

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareLinkServiceTests.cs
@@ -275,44 +275,17 @@ public sealed class ShareLinkServiceTests : IDisposable
     /// <summary>
     /// Adds a second owner of the tenant, joining <paramref name="joinedAfter"/> the seeded one.
     /// </summary>
-    private async Task AddOwnerAsync(
+    private Task AddOwnerAsync(
         UserDisplayPreferences preferences,
         DateTime joinedAfter,
         bool isSystemSubject = false,
-        bool isActiveSubject = true)
-    {
-        var subjectId = Guid.NewGuid();
-        _db.Subjects.Add(new SubjectEntity
-        {
-            Id = subjectId,
-            Name = $"Owner {subjectId:N}",
-            IsActive = isActiveSubject,
-            IsSystemSubject = isSystemSubject,
-            Preferences = preferences.Serialize(),
-        });
-
-        var member = new TenantMemberEntity
-        {
-            Id = Guid.NewGuid(),
-            TenantId = TenantId,
-            SubjectId = subjectId,
-        };
-        _db.TenantMembers.Add(member);
-        _db.TenantMemberRoles.Add(new TenantMemberRoleEntity
-        {
-            Id = Guid.NewGuid(),
-            TenantMemberId = member.Id,
-            TenantRoleId = await _db.TenantRoles
-                .Where(r => r.TenantId == TenantId && r.Slug == RoleSeeds.Owner)
-                .Select(r => r.Id)
-                .FirstAsync(),
-        });
-        await _db.SaveChangesAsync();
-
-        // The context stamps SysCreatedAt on insert, so the join time can only be set afterwards.
-        member.SysCreatedAt = joinedAfter;
-        await _db.SaveChangesAsync();
-    }
+        bool isActiveSubject = true) =>
+        TestDatabaseSeeder.SeedMemberAsync(
+            _db, TenantId,
+            isActive: isActiveSubject,
+            isSystemSubject: isSystemSubject,
+            joinedAt: joinedAfter,
+            preferences: preferences.Serialize());
 
     /// <summary>Backdates the seeded owner's membership so later arrivals sort after it.</summary>
     private async Task<DateTime> BackdateTheSeededOwnerAsync()

--- a/tests/Unit/Nocturne.API.Tests/Services/DevOnly/DevTenantMemberSelectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/DevOnly/DevTenantMemberSelectionTests.cs
@@ -26,16 +26,6 @@ public sealed class DevTenantMemberSelectionTests
     }
 
     [Fact]
-    public void PickOwnerOrFirst_skipsAnOwnerOfAnotherTenant()
-    {
-        var elsewhere = Member(isOwner: true, tenantId: Guid.CreateVersion7());
-        var plainMember = Member();
-
-        DevTenantMemberSelection.PickOwnerOrFirst([elsewhere, plainMember], TenantId)
-            .Should().BeSameAs(elsewhere, "the first candidate is the fallback when no owner stands");
-    }
-
-    [Fact]
     public void PickOwnerOrFirst_takesTheOldestOwner()
     {
         var newer = Member(isOwner: true, createdAt: new DateTime(2024, 1, 1));
@@ -60,11 +50,10 @@ public sealed class DevTenantMemberSelectionTests
         bool isActive = true,
         bool isSystemSubject = false,
         DateTime? revokedAt = null,
-        DateTime? createdAt = null,
-        Guid? tenantId = null) => new()
+        DateTime? createdAt = null) => new()
     {
         Id = Guid.CreateVersion7(),
-        TenantId = tenantId ?? TenantId,
+        TenantId = TenantId,
         SubjectId = Guid.CreateVersion7(),
         RevokedAt = revokedAt,
         SysCreatedAt = createdAt ?? DateTime.UtcNow,
@@ -85,7 +74,7 @@ public sealed class DevTenantMemberSelectionTests
                     TenantRole = new TenantRoleEntity
                     {
                         Id = OwnerRoleId,
-                        TenantId = tenantId ?? TenantId,
+                        TenantId = TenantId,
                         Name = "Owner",
                         Slug = RoleSeeds.Owner,
                         Permissions = [Scope.FullAccess],

--- a/tests/Unit/Nocturne.API.Tests/Services/DevOnly/DevTenantMemberSelectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/DevOnly/DevTenantMemberSelectionTests.cs
@@ -35,7 +35,6 @@ public sealed class DevTenantMemberSelectionTests
             .Should().BeSameAs(elsewhere, "the first candidate is the fallback when no owner stands");
     }
 
-    /// <summary>Several owners resolve to the longest-standing one on every call.</summary>
     [Fact]
     public void PickOwnerOrFirst_takesTheOldestOwner()
     {

--- a/tests/Unit/Nocturne.API.Tests/Services/DevOnly/DevTenantMemberSelectionTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/DevOnly/DevTenantMemberSelectionTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Nocturne.API.Services.DevOnly;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.DevOnly;
+
+/// <summary>
+/// Which member the dev-only endpoints act on when the caller named nobody.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class DevTenantMemberSelectionTests
+{
+    private static readonly Guid TenantId = Guid.CreateVersion7();
+    private static readonly Guid OwnerRoleId = Guid.CreateVersion7();
+
+    [Fact]
+    public void PickOwnerOrFirst_skipsARevokedOwner()
+    {
+        var revoked = Member(isOwner: true, revokedAt: DateTime.UtcNow);
+        var owner = Member(isOwner: true);
+
+        DevTenantMemberSelection.PickOwnerOrFirst([revoked, owner], TenantId)
+            .Should().BeSameAs(owner);
+    }
+
+    [Fact]
+    public void PickOwnerOrFirst_skipsAnOwnerOfAnotherTenant()
+    {
+        var elsewhere = Member(isOwner: true, tenantId: Guid.CreateVersion7());
+        var plainMember = Member();
+
+        DevTenantMemberSelection.PickOwnerOrFirst([elsewhere, plainMember], TenantId)
+            .Should().BeSameAs(elsewhere, "the first candidate is the fallback when no owner stands");
+    }
+
+    /// <summary>Several owners resolve to the longest-standing one on every call.</summary>
+    [Fact]
+    public void PickOwnerOrFirst_takesTheOldestOwner()
+    {
+        var newer = Member(isOwner: true, createdAt: new DateTime(2024, 1, 1));
+        var older = Member(isOwner: true, createdAt: new DateTime(2020, 1, 1));
+
+        DevTenantMemberSelection.PickOwnerOrFirst([newer, older], TenantId)
+            .Should().BeSameAs(older);
+    }
+
+    [Fact]
+    public void Candidates_dropsDeactivatedAndSystemSubjects()
+    {
+        var usable = Member();
+
+        DevTenantMemberSelection.Candidates(
+            [Member(isActive: false), Member(isSystemSubject: true), usable])
+            .Should().Equal(usable);
+    }
+
+    private static TenantMemberEntity Member(
+        bool isOwner = false,
+        bool isActive = true,
+        bool isSystemSubject = false,
+        DateTime? revokedAt = null,
+        DateTime? createdAt = null,
+        Guid? tenantId = null) => new()
+    {
+        Id = Guid.CreateVersion7(),
+        TenantId = tenantId ?? TenantId,
+        SubjectId = Guid.CreateVersion7(),
+        RevokedAt = revokedAt,
+        SysCreatedAt = createdAt ?? DateTime.UtcNow,
+        Subject = new SubjectEntity
+        {
+            Id = Guid.CreateVersion7(),
+            Name = "Member",
+            IsActive = isActive,
+            IsSystemSubject = isSystemSubject,
+        },
+        MemberRoles = isOwner
+            ?
+            [
+                new TenantMemberRoleEntity
+                {
+                    Id = Guid.CreateVersion7(),
+                    TenantRoleId = OwnerRoleId,
+                    TenantRole = new TenantRoleEntity
+                    {
+                        Id = OwnerRoleId,
+                        TenantId = tenantId ?? TenantId,
+                        Name = "Owner",
+                        Slug = RoleSeeds.Owner,
+                        Permissions = [Scope.FullAccess],
+                        IsSystem = true,
+                    },
+                },
+            ]
+            : [],
+    };
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantServiceRemoveMemberTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantServiceRemoveMemberTests.cs
@@ -67,7 +67,10 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
         Mock.Of<ILogger<TenantService>>());
 
     /// <summary>Adds a membership, optionally carrying the owner role or being a system subject.</summary>
-    private Guid SeedMember(bool isOwner = false, bool isSystemSubject = false)
+    private Guid SeedMember(
+        bool isOwner = false,
+        bool isSystemSubject = false,
+        bool isActive = true)
     {
         var subjectId = Guid.CreateVersion7();
         using var db = Context();
@@ -76,6 +79,7 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
         {
             Id = subjectId,
             Name = isSystemSubject ? "Public" : "Member",
+            IsActive = isActive,
             IsSystemSubject = isSystemSubject,
         });
 
@@ -138,6 +142,42 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
         result.Ok.Should().BeTrue();
         await using var db = Context();
         (await db.TenantMembers.AnyAsync(m => m.SubjectId == firstOwner)).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The Public subject's membership is the share's storage, so an owner role on it is not a
+    /// person who could administer the tenant once the only one who can is gone.
+    /// </summary>
+    [Fact]
+    public async Task RemoveMemberAsync_refusesTheLastOwnerWhoseOnlyPeerIsASystemSubject()
+    {
+        var owner = SeedMember(isOwner: true);
+        SeedMember(isOwner: true, isSystemSubject: true);
+
+        var result = await Service().RemoveMemberAsync(_tenantId, owner);
+
+        result.Ok.Should().BeFalse();
+        result.ErrorDescription.Should().Be("Cannot remove the last owner of a tenant");
+        await using var db = Context();
+        (await db.TenantMembers.AnyAsync(m => m.SubjectId == owner)).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A deactivated owner cannot sign in, so it is not the second owner that would let the only
+    /// one who can go.
+    /// </summary>
+    [Fact]
+    public async Task RemoveMemberAsync_refusesTheLastOwnerWhoseOnlyPeerIsDeactivated()
+    {
+        var owner = SeedMember(isOwner: true);
+        SeedMember(isOwner: true, isActive: false);
+
+        var result = await Service().RemoveMemberAsync(_tenantId, owner);
+
+        result.Ok.Should().BeFalse();
+        result.ErrorDescription.Should().Be("Cannot remove the last owner of a tenant");
+        await using var db = Context();
+        (await db.TenantMembers.AnyAsync(m => m.SubjectId == owner)).Should().BeTrue();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantServiceRemoveMemberTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantServiceRemoveMemberTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Nocturne.API.Services.Chat;
 using Nocturne.API.Services.Identity;
+using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
@@ -30,7 +31,6 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
 {
     private readonly SqliteTestDatabase _db;
     private readonly Guid _tenantId = Guid.CreateVersion7();
-    private readonly Guid _ownerRoleId = Guid.CreateVersion7();
 
     public TenantServiceRemoveMemberTests()
     {
@@ -38,15 +38,6 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
 
         using var db = Context();
         db.Tenants.Add(new TenantEntity { Id = _tenantId, Slug = "test", DisplayName = "Test" });
-        db.TenantRoles.Add(new TenantRoleEntity
-        {
-            Id = _ownerRoleId,
-            TenantId = _tenantId,
-            Name = "Owner",
-            Slug = RoleSeeds.Owner,
-            Permissions = [Scope.FullAccess],
-            IsSystem = true,
-        });
         db.SaveChanges();
     }
 
@@ -67,48 +58,19 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
         Mock.Of<ILogger<TenantService>>());
 
     /// <summary>Adds a membership, optionally carrying the owner role or being a system subject.</summary>
-    private Guid SeedMember(
-        bool isOwner = false,
-        bool isSystemSubject = false,
-        bool isActive = true)
+    private async Task<Guid> SeedMemberAsync(
+        bool isOwner = false, bool isSystemSubject = false, bool isActive = true)
     {
-        var subjectId = Guid.CreateVersion7();
-        using var db = Context();
-
-        db.Subjects.Add(new SubjectEntity
-        {
-            Id = subjectId,
-            Name = isSystemSubject ? "Public" : "Member",
-            IsActive = isActive,
-            IsSystemSubject = isSystemSubject,
-        });
-
-        var member = new TenantMemberEntity
-        {
-            Id = Guid.CreateVersion7(),
-            TenantId = _tenantId,
-            SubjectId = subjectId,
-        };
-        db.TenantMembers.Add(member);
-
-        if (isOwner)
-        {
-            db.TenantMemberRoles.Add(new TenantMemberRoleEntity
-            {
-                Id = Guid.CreateVersion7(),
-                TenantMemberId = member.Id,
-                TenantRoleId = _ownerRoleId,
-            });
-        }
-
-        db.SaveChanges();
-        return subjectId;
+        await using var db = Context();
+        return await TestDatabaseSeeder.SeedMemberAsync(
+            db, _tenantId, isOwner ? RoleSeeds.Owner : null,
+            isActive: isActive, isSystemSubject: isSystemSubject);
     }
 
     [Fact]
     public async Task RemoveMemberAsync_removesAnOrdinaryMember()
     {
-        var subjectId = SeedMember();
+        var subjectId = await SeedMemberAsync();
 
         var result = await Service().RemoveMemberAsync(_tenantId, subjectId);
 
@@ -120,7 +82,7 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
     [Fact]
     public async Task RemoveMemberAsync_refusesTheLastOwner()
     {
-        var ownerSubjectId = SeedMember(isOwner: true);
+        var ownerSubjectId = await SeedMemberAsync(isOwner: true);
 
         var result = await Service().RemoveMemberAsync(_tenantId, ownerSubjectId);
 
@@ -134,8 +96,8 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
     [Fact]
     public async Task RemoveMemberAsync_removesAnOwnerWhenAnotherRemains()
     {
-        var firstOwner = SeedMember(isOwner: true);
-        SeedMember(isOwner: true);
+        var firstOwner = await SeedMemberAsync(isOwner: true);
+        await SeedMemberAsync(isOwner: true);
 
         var result = await Service().RemoveMemberAsync(_tenantId, firstOwner);
 
@@ -144,15 +106,11 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
         (await db.TenantMembers.AnyAsync(m => m.SubjectId == firstOwner)).Should().BeFalse();
     }
 
-    /// <summary>
-    /// The Public subject's membership is the share's storage, so an owner role on it is not a
-    /// person who could administer the tenant once the only one who can is gone.
-    /// </summary>
     [Fact]
     public async Task RemoveMemberAsync_refusesTheLastOwnerWhoseOnlyPeerIsASystemSubject()
     {
-        var owner = SeedMember(isOwner: true);
-        SeedMember(isOwner: true, isSystemSubject: true);
+        var owner = await SeedMemberAsync(isOwner: true);
+        await SeedMemberAsync(isOwner: true, isSystemSubject: true);
 
         var result = await Service().RemoveMemberAsync(_tenantId, owner);
 
@@ -162,15 +120,25 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
         (await db.TenantMembers.AnyAsync(m => m.SubjectId == owner)).Should().BeTrue();
     }
 
-    /// <summary>
-    /// A deactivated owner cannot sign in, so it is not the second owner that would let the only
-    /// one who can go.
-    /// </summary>
     [Fact]
     public async Task RemoveMemberAsync_refusesTheLastOwnerWhoseOnlyPeerIsDeactivated()
     {
-        var owner = SeedMember(isOwner: true);
-        SeedMember(isOwner: true, isActive: false);
+        var owner = await SeedMemberAsync(isOwner: true);
+        await SeedMemberAsync(isOwner: true, isActive: false);
+
+        var result = await Service().RemoveMemberAsync(_tenantId, owner);
+
+        result.Ok.Should().BeFalse();
+        result.ErrorDescription.Should().Be("Cannot remove the last owner of a tenant");
+        await using var db = Context();
+        (await db.TenantMembers.AnyAsync(m => m.SubjectId == owner)).Should().BeTrue();
+    }
+
+    /// <summary>A deactivated subject can be reactivated; a removed membership cannot come back.</summary>
+    [Fact]
+    public async Task RemoveMemberAsync_refusesADeactivatedSoleOwner()
+    {
+        var owner = await SeedMemberAsync(isOwner: true, isActive: false);
 
         var result = await Service().RemoveMemberAsync(_tenantId, owner);
 
@@ -183,7 +151,7 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
     [Fact]
     public async Task RemoveMemberAsync_refusesASystemSubject()
     {
-        var publicSubjectId = SeedMember(isSystemSubject: true);
+        var publicSubjectId = await SeedMemberAsync(isSystemSubject: true);
 
         var result = await Service().RemoveMemberAsync(_tenantId, publicSubjectId);
 
@@ -242,9 +210,9 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
     [Fact]
     public async Task RemoveMemberAsync_removesTheMembersChatLinkForThisTenantOnly()
     {
-        var subjectId = SeedMember();
+        var subjectId = await SeedMemberAsync();
         var otherTenantId = Guid.CreateVersion7();
-        var otherSubjectId = SeedMember();
+        var otherSubjectId = await SeedMemberAsync();
 
         await using (var db = Context())
         {

--- a/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantServiceRemoveMemberTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Identity/TenantServiceRemoveMemberTests.cs
@@ -134,20 +134,6 @@ public sealed class TenantServiceRemoveMemberTests : IDisposable
         (await db.TenantMembers.AnyAsync(m => m.SubjectId == owner)).Should().BeTrue();
     }
 
-    /// <summary>A deactivated subject can be reactivated; a removed membership cannot come back.</summary>
-    [Fact]
-    public async Task RemoveMemberAsync_refusesADeactivatedSoleOwner()
-    {
-        var owner = await SeedMemberAsync(isOwner: true, isActive: false);
-
-        var result = await Service().RemoveMemberAsync(_tenantId, owner);
-
-        result.Ok.Should().BeFalse();
-        result.ErrorDescription.Should().Be("Cannot remove the last owner of a tenant");
-        await using var db = Context();
-        (await db.TenantMembers.AnyAsync(m => m.SubjectId == owner)).Should().BeTrue();
-    }
-
     [Fact]
     public async Task RemoveMemberAsync_refusesASystemSubject()
     {


### PR DESCRIPTION
Closes #1195.

## The change

"The owner of this tenant" was an inline role-only membership predicate at seven sites. All of them now use `TenantOwnerFilter.OwnersOf(tenantId)`, the one predicate that also requires an active, non-system subject and orders by longest-standing membership.

| Site | Before |
|---|---|
| `PlatformAdminBootstrapService.FindOldestTenantOwnerAsync` | unordered `FirstOrDefaultAsync` on role |
| `PlatformAdminBootstrapService.EnsureFirstOwnerIsPlatformAdminAsync` | `AnyAsync` on role + subject |
| `AccessRequestController.Approve` / `.Deny` | `ToListAsync` on role |
| `PasskeyController.AccessRequestComplete` | `ToListAsync` on role |
| `DevTenantMemberSelection.PickOwnerOrFirst` | in-memory role scan over fetch order |
| `TenantService.RemoveMemberAsync` last-owner guard | owner-role row count |

## Behaviour deltas

- At the notify (PasskeyController), archive (AccessRequestController) and promote (PlatformAdminBootstrapService) sites, a deactivated or system subject no longer counts as an owner. Revoked memberships were already excluded everywhere by the global `RevokedAt == null` query filter, so that clause is not a reachable change (see #1201: nothing ever writes it).
- `RemoveMemberAsync`: a deactivated or system-subject peer no longer keeps the last-owner guard open. Removing the only standing owner while such a peer exists is now refused; previously the role count read 2 and allowed it, leaving the tenant without a usable owner. Every other cell of the truth table is unchanged.
- `FindOldestTenantOwnerAsync` and `PickOwnerOrFirst` are deterministic (oldest membership) where they previously took database order.
- An owner deactivated between an access request and its decision keeps an un-archived notification, since the archive now targets standing owners only. Inherent to the requested rule.

Three other `RoleSeeds.Owner` sites are role-row lookups or a DTO check over an already-filtered list, not membership predicates, and are left alone.

## Tests

One shared `TestDatabaseSeeder.SeedMemberAsync` replaces five hand-rolled owner seeders (including the pre-existing one in `ShareLinkServiceTests`). Reverting `OwnersOf` to a role-only filter fails nine named tests, at least one per touched site; reverting all seven production sites fails the same nine. Four tests that pinned no delta were deleted after hostile review.
