### PR TITLE
refactor(statistics): make the controller's documented policies true of its code

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.RateLimiting;
 using Nocturne.API.Attributes;
 using Nocturne.API.Extensions;
@@ -128,15 +129,17 @@ public class StatisticsController : ControllerBase
     /// <param name="limit">Per collection. An AID pump writes a TempBasal and often an SMB every
     /// ~5 minutes, so anything short of <c>int.MaxValue</c> truncates a multi-month window to its
     /// oldest records and understates every total computed from it.</param>
+    /// <param name="alongside">Reads the caller started before calling, joined into the same
+    /// <see cref="Task.WhenAll(Task[])"/> so a failure here still observes them.</param>
     private async Task<InsulinRecords> FetchInsulinRecordsAsync(
-        DateTime from, DateTime to, int limit, CancellationToken ct = default)
+        DateTime from, DateTime to, int limit, CancellationToken ct = default, params Task[] alongside)
     {
         var manualTask    = _bolusRepository.GetAsync(from, to, null, null, limit, descending: false, kind: BolusKind.Manual, ct: ct);
         var algorithmTask = _bolusRepository.GetAsync(from, to, null, null, limit, descending: false, kind: BolusKind.Algorithm, ct: ct);
         var tempBasalTask = _tempBasalRepository.GetAsync(from, to, null, null, limit, descending: false, ct: ct);
         var injectionTask = _basalInjectionRepository.GetAsync(from, to, null, null, limit, 0, false, ct);
 
-        await Task.WhenAll(manualTask, algorithmTask, tempBasalTask, injectionTask);
+        await Task.WhenAll([manualTask, algorithmTask, tempBasalTask, injectionTask, .. alongside]);
 
         return new InsulinRecords(
             (await manualTask).ToList(),
@@ -366,8 +369,8 @@ public class StatisticsController : ControllerBase
     [RemoteQuery]
     [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
     public async Task<ActionResult<ReportAnalysisResult>> GetRangeAnalytics(
-        [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate,
+        [FromQuery, BindRequired] DateTime startDate,
+        [FromQuery, BindRequired] DateTime endDate,
         [FromQuery] DiabetesPopulation population = DiabetesPopulation.Type1Adult,
         [FromQuery] Guid? patientDeviceId = null,
         CancellationToken cancellationToken = default
@@ -456,8 +459,8 @@ public class StatisticsController : ControllerBase
     [RemoteQuery]
     [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
     public async Task<ActionResult<IEnumerable<WeekdayGlucoseSlot>>> GetWeekdayAverages(
-        [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate,
+        [FromQuery, BindRequired] DateTime startDate,
+        [FromQuery, BindRequired] DateTime endDate,
         CancellationToken cancellationToken = default
     )
     {
@@ -722,7 +725,7 @@ public class StatisticsController : ControllerBase
             var carbTask    = _carbIntakeRepository.GetAsync(from: (DateTime?)startDate, to: (DateTime?)endDate, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
 
             var (filteredBoluses, algorithmBoluses, tempBasals, basalInjections) =
-                await FetchInsulinRecordsAsync(startDate, endDate, int.MaxValue, cancellationToken);
+                await FetchInsulinRecordsAsync(startDate, endDate, int.MaxValue, cancellationToken, glucoseTask, carbTask);
             var filteredEntries = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
             var filteredCarbs   = (await carbTask).ToList();
 
@@ -912,8 +915,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<DailyBasalBolusRatioResponse>> GetDailyBasalBolusRatios(
-        [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate
+        [FromQuery, BindRequired] DateTime startDate,
+        [FromQuery, BindRequired] DateTime endDate
     )
     {
         var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
@@ -950,8 +953,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.GlucoseRead)]
     [RemoteQuery]
     public async Task<ActionResult<PunchCardResponse>> GetPunchCardData(
-        [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate,
+        [FromQuery, BindRequired] DateTime startDate,
+        [FromQuery, BindRequired] DateTime endDate,
         CancellationToken cancellationToken = default
     )
     {
@@ -969,7 +972,7 @@ public class StatisticsController : ControllerBase
         var carbTask       = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken);
 
         var (manualBoluses, algorithmBoluses, tempBasals, basalInjections) =
-            await FetchInsulinRecordsAsync(startDt, endDt, 10_000, cancellationToken);
+            await FetchInsulinRecordsAsync(startDt, endDt, 10_000, cancellationToken, rawGlucoseTask, carbTask);
 
         var rawGlucose  = (await rawGlucoseTask).ToList();
         var glucoseData = (await _canonicalGlucose.SelectAsync(rawGlucose, cancellationToken)).ToList();
@@ -1147,8 +1150,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<InsulinDeliveryStatistics>> GetInsulinDeliveryStatistics(
-        [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate
+        [FromQuery, BindRequired] DateTime startDate,
+        [FromQuery, BindRequired] DateTime endDate
     )
     {
         var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
@@ -1160,7 +1163,7 @@ public class StatisticsController : ControllerBase
         var carbTask = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
 
         var (boluses, algorithmBoluses, tempBasals, basalInjections) =
-            await FetchInsulinRecordsAsync(startDt, endDt, 10000);
+            await FetchInsulinRecordsAsync(startDt, endDt, 10000, default, carbTask);
         var carbs  = await carbTask;
         var rateAt = await _basalRateResolver.BuildResolverAsync(startMs, endMs);
 
@@ -1192,8 +1195,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<BasalAnalysisResponse>> GetBasalAnalysis(
-        [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate
+        [FromQuery, BindRequired] DateTime startDate,
+        [FromQuery, BindRequired] DateTime endDate
     )
     {
         // Force UTC kind to avoid DateTimeOffset throwing when the server's local
@@ -1201,8 +1204,7 @@ public class StatisticsController : ControllerBase
         var startUtc = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
         var endUtc = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
 
-        // Uncapped for the reason given on FetchInsulinRecordsAsync's limit; only two of its four
-        // collections are read here, so the fetch is not shared with it.
+        // Uncapped for the reason given on FetchInsulinRecordsAsync's limit.
         var tempBasalTask = _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false);
         var algoTask      = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
 
@@ -1240,8 +1242,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<HourlyInsulinDeliveryResponse>> GetHourlyInsulinDelivery(
-        [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate
+        [FromQuery, BindRequired] DateTime startDate,
+        [FromQuery, BindRequired] DateTime endDate
     )
     {
         var startUtc = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
@@ -1285,8 +1287,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<AidSystemMetrics>> GetAidSystemMetrics(
-        [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate
+        [FromQuery, BindRequired] DateTime startDate,
+        [FromQuery, BindRequired] DateTime endDate
     )
     {
         var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -24,15 +24,12 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 /// time-in-range, glycemic variability, GMI, GRI, basal/bolus ratios, and AID system metrics.
 /// </summary>
 /// <remarks>
-/// Several computation endpoints accept large payloads and are decorated with
-/// <c>[RequestSizeLimit(ComputeBodyLimitBytes)]</c>.
+/// <c>GET /periods</c> caches for five minutes through <see cref="ICacheService"/>;
+/// <c>GET /range-analytics</c> and <c>GET /weekday-averages</c> carry a 60-second
+/// <see cref="ResponseCacheAttribute"/>. No other action caches.
 ///
-/// <c>GET /periods</c> and <c>GET /basal-analysis</c> fetch data directly from the database
-/// using the injected V4 repositories, apply profile-based scheduled-basal fallback when no
-/// TempBasal records exist, and cache results for 5 minutes to absorb rapid dashboard refreshes.
-///
-/// All repositories use <c>ITenantDbContextFactory</c> so each call creates its own independent
-/// DbContext; independent repository calls within a single request are parallelised with <c>Task.WhenAll</c>.
+/// Repositories create their own DbContext per call from <c>ITenantDbContextFactory</c>, so
+/// independent reads within one request are issued together under <c>Task.WhenAll</c>.
 /// </remarks>
 /// <seealso cref="IStatisticsService"/>
 /// <seealso cref="ISensorGlucoseRepository"/>
@@ -45,10 +42,11 @@ namespace Nocturne.API.Controllers.V4.Analytics;
 [Route("api/v4/[controller]")]
 [Produces("application/json")]
 [BadRequestOnInvalidInput]
+[RequestSizeLimit(StatisticsController.ComputeBodyLimitBytes)]
 public class StatisticsController : ControllerBase
 {
     /// <summary>
-    /// Body ceiling for the actions that compute over a caller-supplied collection. A report
+    /// Body ceiling for every action here that computes over a caller-supplied collection. A report
     /// covering a year posts every reading in the range in one body, so the bound is set by the
     /// longest range a report can ask for rather than by a typical request.
     /// </summary>
@@ -121,6 +119,32 @@ public class StatisticsController : ControllerBase
         _canonicalGlucose = canonicalGlucose;
     }
 
+    private readonly record struct InsulinRecords(
+        List<Bolus> ManualBoluses,
+        List<Bolus> AlgorithmBoluses,
+        List<TempBasal> TempBasals,
+        List<BasalInjection> BasalInjections);
+
+    /// <param name="limit">Per collection. An AID pump writes a TempBasal and often an SMB every
+    /// ~5 minutes, so anything short of <c>int.MaxValue</c> truncates a multi-month window to its
+    /// oldest records and understates every total computed from it.</param>
+    private async Task<InsulinRecords> FetchInsulinRecordsAsync(
+        DateTime from, DateTime to, int limit, CancellationToken ct = default)
+    {
+        var manualTask    = _bolusRepository.GetAsync(from, to, null, null, limit, descending: false, kind: BolusKind.Manual, ct: ct);
+        var algorithmTask = _bolusRepository.GetAsync(from, to, null, null, limit, descending: false, kind: BolusKind.Algorithm, ct: ct);
+        var tempBasalTask = _tempBasalRepository.GetAsync(from, to, null, null, limit, descending: false, ct: ct);
+        var injectionTask = _basalInjectionRepository.GetAsync(from, to, null, null, limit, 0, false, ct);
+
+        await Task.WhenAll(manualTask, algorithmTask, tempBasalTask, injectionTask);
+
+        return new InsulinRecords(
+            (await manualTask).ToList(),
+            (await algorithmTask).ToList(),
+            (await tempBasalTask).ToList(),
+            (await injectionTask).ToList());
+    }
+
     /// <summary>
     /// Calculate basic glucose statistics from provided glucose values
     /// </summary>
@@ -167,7 +191,6 @@ public class StatisticsController : ControllerBase
     [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
-    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<TimeInRangeMetrics> CalculateTimeInRange(
         [FromBody] TimeInRangeRequest request
     )
@@ -187,7 +210,6 @@ public class StatisticsController : ControllerBase
     [HttpPost("glucose-distribution")]
     [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(Scope.ReportsRead)]
-    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<IEnumerable<DistributionDataPoint>> CalculateGlucoseDistribution(
         [FromBody] GlucoseDistributionRequest request
     )
@@ -208,7 +230,6 @@ public class StatisticsController : ControllerBase
     [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
-    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<IEnumerable<AveragedStats>> CalculateAveragedStats(
         [FromBody] SensorGlucose[] entries
     )
@@ -264,7 +285,6 @@ public class StatisticsController : ControllerBase
     [HttpPost("comprehensive-analytics")]
     [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(Scope.ReportsRead)]
-    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<GlucoseAnalytics> AnalyzeGlucoseData(
         [FromBody] GlucoseAnalyticsRequest request
     )
@@ -286,7 +306,6 @@ public class StatisticsController : ControllerBase
     [HttpPost("extended-analytics")]
     [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(Scope.ReportsRead)]
-    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<ExtendedGlucoseAnalytics> AnalyzeGlucoseDataExtended(
         [FromBody] ExtendedGlucoseAnalyticsRequest request
     )
@@ -673,13 +692,11 @@ public class StatisticsController : ControllerBase
             var endTimestamp = endDate;
 
             var glucoseTask = _sensorGlucoseRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
-            var bolusTask   = _bolusRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Manual, ct: cancellationToken);
             var carbTask    = _carbIntakeRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
 
-            await Task.WhenAll(glucoseTask, bolusTask, carbTask);
-
+            var (filteredBoluses, algorithmBoluses, tempBasals, basalInjections) =
+                await FetchInsulinRecordsAsync(startTimestamp, endTimestamp, int.MaxValue, cancellationToken);
             var filteredEntries = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
-            var filteredBoluses = (await bolusTask).ToList();
             var filteredCarbs   = (await carbTask).ToList();
 
             // Calculate analytics if we have sufficient data
@@ -700,14 +717,6 @@ public class StatisticsController : ControllerBase
                     filteredBoluses,
                     filteredCarbs
                 );
-
-                // Fetch TempBasals and algorithm boluses for basal data
-                // Deduplicate by 30s window + rate to eliminate duplicates from multiple connectors
-                // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
-                // which does not support concurrent operations.
-                var tempBasals       = (await _tempBasalRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken)).ToList();
-                var algorithmBoluses = (await _bolusRepository.GetAsync(from: startTimestamp, to: endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken)).ToList();
-                var basalInjections  = (await _basalInjectionRepository.GetAsync(startTimestamp, endTimestamp, null, null, int.MaxValue, 0, false, cancellationToken)).ToList();
 
                 insulinDelivery = _statisticsService.CalculateInsulinDeliveryStatistics(
                     filteredBoluses,
@@ -852,7 +861,6 @@ public class StatisticsController : ControllerBase
     [HttpPost("site-change-impact")]
     [EnableRateLimiting(ServiceRegistrationExtensions.StatisticsComputeRateLimitPolicy)]
     [RequireScope(Scope.ReportsRead)]
-    [RequestSizeLimit(ComputeBodyLimitBytes)]
     public ActionResult<SiteChangeImpactAnalysis> CalculateSiteChangeImpact(
         [FromBody] SiteChangeImpactRequest request
     )
@@ -884,12 +892,8 @@ public class StatisticsController : ControllerBase
         var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
         var endDt = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
 
-        // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
-        // which does not support concurrent operations.
-        var boluses          = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
-        var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false)).ToList();
-        var algorithmBoluses = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
-        var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10000, 0, false)).ToList();
+        var (boluses, algorithmBoluses, tempBasals, basalInjections) =
+            await FetchInsulinRecordsAsync(startDt, endDt, 10000);
 
         var tzId = await _therapySettingsResolver.GetTimezoneAsync();
         var tz = !string.IsNullOrEmpty(tzId)
@@ -934,15 +938,15 @@ public class StatisticsController : ControllerBase
         var startDt = TimeZoneInfo.ConvertTimeToUtc(startLocalDate, tz);
         var endDt = TimeZoneInfo.ConvertTimeToUtc(endLocalDate.AddDays(1).AddTicks(-1), tz);
 
-        // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
-        // which does not support concurrent operations.
-        var rawGlucose       = (await _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, 100_000, descending: false, ct: cancellationToken)).ToList();
-        var glucoseData      = (await _canonicalGlucose.SelectAsync(rawGlucose, cancellationToken)).ToList();
-        var manualBoluses    = (await _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Manual, ct: cancellationToken)).ToList();
-        var carbs            = (await _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken)).ToList();
-        var algorithmBoluses = (await _bolusRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, kind: BolusKind.Algorithm, ct: cancellationToken)).ToList();
-        var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken)).ToList();
-        var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10_000, 0, false, ct: cancellationToken)).ToList();
+        var rawGlucoseTask = _sensorGlucoseRepository.GetAsync(startDt, endDt, null, null, 100_000, descending: false, ct: cancellationToken);
+        var carbTask       = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10_000, descending: false, ct: cancellationToken);
+
+        var (manualBoluses, algorithmBoluses, tempBasals, basalInjections) =
+            await FetchInsulinRecordsAsync(startDt, endDt, 10_000, cancellationToken);
+
+        var rawGlucose  = (await rawGlucoseTask).ToList();
+        var glucoseData = (await _canonicalGlucose.SelectAsync(rawGlucose, cancellationToken)).ToList();
+        var carbs       = (await carbTask).ToList();
 
         // Daily basal totals come from the existing service path so the calendar's "totalBasal"
         // matches what /daily-basal-bolus-ratios would return for the same window.
@@ -1126,14 +1130,12 @@ public class StatisticsController : ControllerBase
         var startMs = new DateTimeOffset(startDt, TimeSpan.Zero).ToUnixTimeMilliseconds();
         var endMs   = new DateTimeOffset(endDt,   TimeSpan.Zero).ToUnixTimeMilliseconds();
 
-        // These reads share the request-scoped NocturneDbContext, which is not safe for
-        // concurrent operations, so they are awaited sequentially rather than via Task.WhenAll.
-        var boluses          = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Manual);
-        var tempBasals       = (await _tempBasalRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false)).ToList();
-        var algorithmBoluses = await _bolusRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false, kind: BolusKind.Algorithm);
-        var carbs            = await _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
-        var basalInjections  = (await _basalInjectionRepository.GetAsync(startDt, endDt, null, null, 10000, 0, false)).ToList();
-        var rateAt           = await _basalRateResolver.BuildResolverAsync(startMs, endMs);
+        var carbTask = _carbIntakeRepository.GetAsync(startDt, endDt, null, null, 10000, descending: false);
+
+        var (boluses, algorithmBoluses, tempBasals, basalInjections) =
+            await FetchInsulinRecordsAsync(startDt, endDt, 10000);
+        var carbs  = await carbTask;
+        var rateAt = await _basalRateResolver.BuildResolverAsync(startMs, endMs);
 
         foreach (var tb in tempBasals)
         {
@@ -1163,22 +1165,17 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<BasalAnalysisResponse>> GetBasalAnalysis(
-        [FromQuery] DateTime? startDate = null,
-        [FromQuery] DateTime? endDate = null
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate
     )
     {
-        if (startDate is null || endDate is null)
-            return Problem(detail: "startDate and endDate are required.", statusCode: 400, title: "Bad Request");
-
         // Force UTC kind to avoid DateTimeOffset throwing when the server's local
         // timezone offset would push DateTime.MinValue/MaxValue out of the valid range.
-        var startUtc = DateTime.SpecifyKind(startDate.Value, DateTimeKind.Utc);
-        var endUtc = DateTime.SpecifyKind(endDate.Value, DateTimeKind.Utc);
+        var startUtc = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+        var endUtc = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
 
-        // Fetch TempBasals and algorithm boluses
-        // Deduplicate by 30s window + rate to eliminate duplicates from multiple connectors
-        // No practical fetch cap — see GetHourlyInsulinDelivery: a 10k cap
-        // silently truncates ~5-minute AID records past ~35 days.
+        // Uncapped for the reason given on FetchInsulinRecordsAsync's limit; only two of its four
+        // collections are read here, so the fetch is not shared with it.
         var tempBasalTask = _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false);
         var algoTask      = _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
 
@@ -1234,26 +1231,15 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<HourlyInsulinDeliveryResponse>> GetHourlyInsulinDelivery(
-        [FromQuery] DateTime? startDate = null,
-        [FromQuery] DateTime? endDate = null
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate
     )
     {
-        if (startDate is null || endDate is null)
-            return Problem(detail: "startDate and endDate are required.", statusCode: 400, title: "Bad Request");
+        var startUtc = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
+        var endUtc = DateTime.SpecifyKind(endDate, DateTimeKind.Utc);
 
-        var startUtc = DateTime.SpecifyKind(startDate.Value, DateTimeKind.Utc);
-        var endUtc = DateTime.SpecifyKind(endDate.Value, DateTimeKind.Utc);
-
-        // No practical fetch cap: AID pumps write a TempBasal (and often an
-        // SMB) every ~5 minutes, so 90 days is ~26k records per type — a
-        // 10k cap would silently truncate to the oldest ~35 days and
-        // understate every average.
-        // Awaited sequentially: these reads share the request-scoped NocturneDbContext,
-        // which does not support concurrent operations.
-        var tempBasals       = (await _tempBasalRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false)).ToList();
-        var boluses          = await _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Manual);
-        var algorithmBoluses = await _bolusRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, descending: false, kind: BolusKind.Algorithm);
-        var basalInjections  = (await _basalInjectionRepository.GetAsync((DateTime?)startUtc, (DateTime?)endUtc, null, null, int.MaxValue, 0, false)).ToList();
+        var (boluses, algorithmBoluses, tempBasals, basalInjections) =
+            await FetchInsulinRecordsAsync(startUtc, endUtc, int.MaxValue);
 
         // Fall back to profile-based scheduled rates when no TempBasals exist,
         // mirroring GetBasalAnalysis: each segment becomes one synthetic

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -146,6 +146,37 @@ public class StatisticsController : ControllerBase
     }
 
     /// <summary>
+    /// Appends one <see cref="TempBasalOrigin.Scheduled"/> TempBasal per profile basal segment
+    /// when the pump reported none, so a tenant with a profile still gets a basal shape. Callers
+    /// distribute each across the user-local hour-of-day buckets it overlaps, weighted by duration.
+    /// </summary>
+    /// <param name="recordedBasal">Basal delivered by a route other than TempBasals; non-empty
+    /// suppresses the fallback, because a profile baseline on top of MDI injections would
+    /// double-count the day's coverage. <c>null</c> where the caller does not read injections.</param>
+    private async Task AddScheduledBasalFallbackAsync(
+        List<TempBasal> tempBasals,
+        DateTime startUtc,
+        DateTime endUtc,
+        IReadOnlyCollection<BasalInjection>? recordedBasal)
+    {
+        if (tempBasals.Count > 0 || recordedBasal is { Count: > 0 }) return;
+        if (!await _therapySettingsResolver.HasDataAsync(HttpContext.RequestAborted)) return;
+
+        var fromMs = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        var toMs = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+        await foreach (var seg in _basalSegments.GetSegmentsAsync(fromMs, toMs, HttpContext.RequestAborted))
+        {
+            tempBasals.Add(new TempBasal
+            {
+                StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.StartMills).UtcDateTime,
+                EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.EndMills).UtcDateTime,
+                Rate = seg.UnitsPerHour,
+                Origin = TempBasalOrigin.Scheduled,
+            });
+        }
+    }
+
+    /// <summary>
     /// Calculate basic glucose statistics from provided glucose values
     /// </summary>
     /// <param name="values">Array of glucose values in mg/dL</param>
@@ -688,14 +719,11 @@ public class StatisticsController : ControllerBase
             var startDate = now.AddDays(-days);
             var endDate = now;
 
-            var startTimestamp = startDate;
-            var endTimestamp = endDate;
-
-            var glucoseTask = _sensorGlucoseRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
-            var carbTask    = _carbIntakeRepository.GetAsync(from: (DateTime?)startTimestamp, to: (DateTime?)endTimestamp, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
+            var glucoseTask = _sensorGlucoseRepository.GetAsync(from: (DateTime?)startDate, to: (DateTime?)endDate, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
+            var carbTask    = _carbIntakeRepository.GetAsync(from: (DateTime?)startDate, to: (DateTime?)endDate, device: null, source: null, limit: int.MaxValue, descending: false, ct: cancellationToken);
 
             var (filteredBoluses, algorithmBoluses, tempBasals, basalInjections) =
-                await FetchInsulinRecordsAsync(startTimestamp, endTimestamp, int.MaxValue, cancellationToken);
+                await FetchInsulinRecordsAsync(startDate, endDate, int.MaxValue, cancellationToken);
             var filteredEntries = (await _canonicalGlucose.SelectAsync((await glucoseTask).ToList(), cancellationToken)).ToList();
             var filteredCarbs   = (await carbTask).ToList();
 
@@ -736,8 +764,8 @@ public class StatisticsController : ControllerBase
                     && hasProfileData
                 )
                 {
-                    var fromMs = new DateTimeOffset(startTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
-                    var toMs = new DateTimeOffset(endTimestamp, TimeSpan.Zero).ToUnixTimeMilliseconds();
+                    var fromMs = new DateTimeOffset(startDate, TimeSpan.Zero).ToUnixTimeMilliseconds();
+                    var toMs = new DateTimeOffset(endDate, TimeSpan.Zero).ToUnixTimeMilliseconds();
                     var profileBasal = Math.Round(
                         await _basalSegments.GetSegmentsAsync(fromMs, toMs, cancellationToken).SumUnitsAsync(cancellationToken)
                         * 100) / 100;
@@ -1184,25 +1212,7 @@ public class StatisticsController : ControllerBase
         var tempBasals       = (await tempBasalTask).ToList();
         var algorithmBoluses = await algoTask;
 
-        // Fall back to profile-based scheduled rates when no TempBasals exist.
-        // Each segment becomes one synthetic TempBasal; CalculateBasalAnalysis distributes
-        // each across the user-local hour-of-day buckets it overlaps, weighted by duration.
-        var hasTherapyData = await _therapySettingsResolver.HasDataAsync(HttpContext.RequestAborted);
-        if (tempBasals.Count == 0 && hasTherapyData)
-        {
-            var fromMs = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-            var toMs = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-            await foreach (var seg in _basalSegments.GetSegmentsAsync(fromMs, toMs, HttpContext.RequestAborted))
-            {
-                tempBasals.Add(new TempBasal
-                {
-                    StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.StartMills).UtcDateTime,
-                    EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.EndMills).UtcDateTime,
-                    Rate = seg.UnitsPerHour,
-                    Origin = TempBasalOrigin.Scheduled,
-                });
-            }
-        }
+        await AddScheduledBasalFallbackAsync(tempBasals, startUtc, endUtc, recordedBasal: null);
 
         var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: HttpContext.RequestAborted);
         var userTz = string.IsNullOrEmpty(tzId) ? null : TimeZoneHelper.GetTimeZoneInfoFromId(tzId);
@@ -1241,28 +1251,7 @@ public class StatisticsController : ControllerBase
         var (boluses, algorithmBoluses, tempBasals, basalInjections) =
             await FetchInsulinRecordsAsync(startUtc, endUtc, int.MaxValue);
 
-        // Fall back to profile-based scheduled rates when no TempBasals exist,
-        // mirroring GetBasalAnalysis: each segment becomes one synthetic
-        // TempBasal that gets duration-weighted across the hours it overlaps.
-        // Skip the profile fallback when basal injections exist: MDI injections are the
-        // actual basal source, so synthesizing scheduled rates from the profile on top of
-        // them would double-count the day's baseline coverage.
-        var hasTherapyData = await _therapySettingsResolver.HasDataAsync(HttpContext.RequestAborted);
-        if (tempBasals.Count == 0 && basalInjections.Count == 0 && hasTherapyData)
-        {
-            var fromMs = new DateTimeOffset(startUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-            var toMs = new DateTimeOffset(endUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
-            await foreach (var seg in _basalSegments.GetSegmentsAsync(fromMs, toMs, HttpContext.RequestAborted))
-            {
-                tempBasals.Add(new TempBasal
-                {
-                    StartTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.StartMills).UtcDateTime,
-                    EndTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(seg.EndMills).UtcDateTime,
-                    Rate = seg.UnitsPerHour,
-                    Origin = TempBasalOrigin.Scheduled,
-                });
-            }
-        }
+        await AddScheduledBasalFallbackAsync(tempBasals, startUtc, endUtc, basalInjections);
 
         var tzId = await _therapySettingsResolver.GetTimezoneAsync(ct: HttpContext.RequestAborted);
         var userTz = string.IsNullOrEmpty(tzId) ? null : TimeZoneHelper.GetTimeZoneInfoFromId(tzId);

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -147,8 +147,7 @@ public class StatisticsController : ControllerBase
 
     /// <summary>
     /// Appends one <see cref="TempBasalOrigin.Scheduled"/> TempBasal per profile basal segment
-    /// when the pump reported none, so a tenant with a profile still gets a basal shape. Callers
-    /// distribute each across the user-local hour-of-day buckets it overlaps, weighted by duration.
+    /// when the pump reported none.
     /// </summary>
     /// <param name="recordedBasal">Basal delivered by a route other than TempBasals; non-empty
     /// suppresses the fallback, because a profile baseline on top of MDI injections would

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
@@ -20,6 +20,7 @@ namespace Nocturne.API.Tests.Controllers.V4.Analytics;
 /// the API's CPU and the bytes it reads. The sweep pins the rule rather than today's action list,
 /// so a new compute POST that ships without the policy fails here.
 /// </remarks>
+[Trait("Category", "Unit")]
 public class StatisticsComputeLimitTests
 {
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.RateLimiting;
 using Nocturne.API.Controllers.V4.Analytics;
 using Nocturne.API.Extensions;
@@ -68,9 +69,15 @@ public class StatisticsComputeLimitTests
     [Fact]
     public void TheBodyLimit_IsDeclaredOnceOnTheController()
     {
-        typeof(StatisticsController)
-            .GetCustomAttribute<RequestSizeLimitAttribute>()
-            .Should().NotBeNull("the ceiling is a controller-wide convention, not a per-action opt-in");
+        // RequestSizeLimitAttribute keeps its bytes private, so the declaration is read off the metadata.
+        var declared = typeof(StatisticsController)
+            .GetCustomAttributesData()
+            .SingleOrDefault(a => a.AttributeType == typeof(RequestSizeLimitAttribute));
+
+        declared.Should().NotBeNull("the ceiling is a controller-wide convention, not a per-action opt-in");
+        Convert.ToInt64(declared!.ConstructorArguments.Single().Value)
+            .Should().Be(StatisticsController.ComputeBodyLimitBytes,
+                "the attribute has to carry the declared ceiling, not some other number");
 
         var perAction = typeof(StatisticsController)
             .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
@@ -81,6 +88,34 @@ public class StatisticsComputeLimitTests
         perAction.Should().BeEmpty(
             "an action-level copy overrides the controller's and lets the two drift. Copies on: "
             + string.Join(", ", perAction));
+    }
+
+    /// <summary>
+    /// MVC does not reject a <em>missing</em> non-nullable value-type query parameter: it binds
+    /// <c>default</c> and runs the action, so an omitted date silently becomes 0001-01-01 and the
+    /// endpoint answers 200 with an empty report. <c>[BindRequired]</c> is what produces the 400.
+    /// </summary>
+    [Fact]
+    public void EveryRequiredDateOnAGetAction_IsBindRequired()
+    {
+        var dateParams = typeof(StatisticsController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetCustomAttributes<HttpGetAttribute>().Any())
+            .SelectMany(m => m.GetParameters().Select(p => (Action: m.Name, Parameter: p)))
+            .Where(x => x.Parameter.ParameterType == typeof(DateTime))
+            .ToList();
+
+        dateParams.Should().HaveCountGreaterThan(10,
+            "the scan should discover the date-range GETs; zero discoveries would pass while guarding nothing");
+
+        var unguarded = dateParams
+            .Where(x => x.Parameter.GetCustomAttribute<BindRequiredAttribute>() is null)
+            .Select(x => $"{x.Action}.{x.Parameter.Name}")
+            .ToList();
+
+        unguarded.Should().BeEmpty(
+            "an omitted date would bind to DateTime.MinValue and answer 200 over an empty window "
+            + "instead of 400. Unguarded: " + string.Join(", ", unguarded));
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
@@ -64,6 +64,24 @@ public class StatisticsComputeLimitTests
         return context;
     }
 
+    [Fact]
+    public void TheBodyLimit_IsDeclaredOnceOnTheController()
+    {
+        typeof(StatisticsController)
+            .GetCustomAttribute<RequestSizeLimitAttribute>()
+            .Should().NotBeNull("the ceiling is a controller-wide convention, not a per-action opt-in");
+
+        var perAction = typeof(StatisticsController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetCustomAttribute<RequestSizeLimitAttribute>() is not null)
+            .Select(m => m.Name)
+            .ToList();
+
+        perAction.Should().BeEmpty(
+            "an action-level copy overrides the controller's and lets the two drift. Copies on: "
+            + string.Join(", ", perAction));
+    }
+
     /// <summary>
     /// The declared body limit has to cover the largest range a report can ask for: the web client
     /// pages every reading in the range into one <c>site-change-impact</c> post, so a year of
@@ -73,10 +91,6 @@ public class StatisticsComputeLimitTests
     public void TheDeclaredBodyLimit_CoversAYearOfReadings()
     {
         const int readingsPerYear = 365 * 24 * 12;
-
-        ComputePosts()
-            .Count(a => a.GetCustomAttribute<RequestSizeLimitAttribute>() is not null)
-            .Should().BeGreaterThan(0, "the collection-taking posts declare a body ceiling");
 
         (readingsPerYear * (long)SerializedReadingBytes()).Should()
             .BeLessThan(StatisticsController.ComputeBodyLimitBytes,

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
@@ -379,6 +379,116 @@ public class StatisticsControllerTests
                 s.UnitsPerHour)));
     }
 
+    [Fact]
+    public async Task GetHourlyInsulinDelivery_WithBasalInjections_DoesNotSynthesizeScheduledBasal()
+    {
+        var start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        SetupEmptyTreatments();
+        _basalInjectionRepoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<BasalInjection> { new() { Timestamp = start, Units = 22 } });
+        _therapySettingsResolverMock
+            .Setup(r => r.HasDataAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _basalSegmentsMock
+            .Setup(s => s.GetSegmentsAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(AsAsync([new BasalSegment(Mills(start), Mills(start.AddDays(1)), 1.0, 1.0, "Default")]));
+
+        List<TempBasal>? passed = null;
+        _statsServiceMock
+            .Setup(s => s.CalculateHourlyInsulinDelivery(
+                It.IsAny<IEnumerable<TempBasal>>(), It.IsAny<IEnumerable<Bolus>>(),
+                It.IsAny<IEnumerable<Bolus>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<TimeZoneInfo?>(), It.IsAny<IEnumerable<BasalInjection>?>()))
+            .Callback<IEnumerable<TempBasal>, IEnumerable<Bolus>, IEnumerable<Bolus>, DateTime, DateTime, TimeZoneInfo?, IEnumerable<BasalInjection>?>(
+                (tempBasals, _, _, _, _, _, _) => passed = tempBasals.ToList())
+            .Returns(new HourlyInsulinDeliveryResponse());
+
+        await CreateController().GetHourlyInsulinDelivery(start, start.AddDays(1));
+
+        passed.Should().BeEmpty(
+            "MDI injections are already the day's basal, so a profile baseline on top would double-count it");
+        _basalSegmentsMock.Verify(
+            s => s.GetSegmentsAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetInsulinDeliveryStatistics_KeepsManualAndAlgorithmBolusesInTheirOwnArguments()
+    {
+        var start = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        var manual = new List<Bolus> { new() { Timestamp = start, Insulin = 4.5 } };
+        var algorithm = new List<Bolus>
+        {
+            new() { Timestamp = start.AddMinutes(5), Insulin = 0.15 },
+            new() { Timestamp = start.AddMinutes(10), Insulin = 0.2 },
+        };
+
+        SetupEmptyTreatments();
+        SetupBoluses(BolusKind.Manual, manual);
+        SetupBoluses(BolusKind.Algorithm, algorithm);
+
+        List<Bolus>? passedManual = null;
+        List<Bolus>? passedAlgorithm = null;
+        _statsServiceMock
+            .Setup(s => s.CalculateInsulinDeliveryStatistics(
+                It.IsAny<IEnumerable<Bolus>>(), It.IsAny<IEnumerable<Bolus>>(),
+                It.IsAny<IEnumerable<TempBasal>>(), It.IsAny<IEnumerable<CarbIntake>>(),
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<IEnumerable<BasalInjection>?>()))
+            .Callback<IEnumerable<Bolus>, IEnumerable<Bolus>, IEnumerable<TempBasal>, IEnumerable<CarbIntake>, DateTime, DateTime, IEnumerable<BasalInjection>?>(
+                (m, a, _, _, _, _, _) => { passedManual = m.ToList(); passedAlgorithm = a.ToList(); })
+            .Returns(new InsulinDeliveryStatistics());
+
+        await CreateController().GetInsulinDeliveryStatistics(start, start.AddDays(1));
+
+        passedManual.Should().BeEquivalentTo(manual);
+        passedAlgorithm.Should().BeEquivalentTo(algorithm);
+
+        VerifyBolusLimit(BolusKind.Manual, 10000);
+        VerifyBolusLimit(BolusKind.Algorithm, 10000);
+    }
+
+    [Fact]
+    public async Task GetHourlyInsulinDelivery_FetchesUncapped()
+    {
+        var start = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        SetupEmptyTreatments();
+        _statsServiceMock
+            .Setup(s => s.CalculateHourlyInsulinDelivery(
+                It.IsAny<IEnumerable<TempBasal>>(), It.IsAny<IEnumerable<Bolus>>(),
+                It.IsAny<IEnumerable<Bolus>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<TimeZoneInfo?>(), It.IsAny<IEnumerable<BasalInjection>?>()))
+            .Returns(new HourlyInsulinDeliveryResponse());
+
+        await CreateController().GetHourlyInsulinDelivery(start, start.AddDays(90));
+
+        VerifyBolusLimit(BolusKind.Manual, int.MaxValue);
+        VerifyBolusLimit(BolusKind.Algorithm, int.MaxValue);
+    }
+
+    private void SetupBoluses(BolusKind kind, IEnumerable<Bolus> boluses) =>
+        _bolusRepoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), kind,
+                It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(boluses);
+
+    private void VerifyBolusLimit(BolusKind kind, int limit) =>
+        _bolusRepoMock.Verify(r => r.GetAsync(
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+            It.IsAny<string?>(), It.IsAny<string?>(),
+            limit, It.IsAny<int>(), It.IsAny<bool>(),
+            It.IsAny<bool>(), kind,
+            It.IsAny<DateTime?>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()), Times.Once);
+
     private static long Mills(DateTime utc) => new DateTimeOffset(utc, TimeSpan.Zero).ToUnixTimeMilliseconds();
 
     private static async IAsyncEnumerable<BasalSegment> AsAsync(IEnumerable<BasalSegment> segments)

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
@@ -10,6 +10,7 @@ using Nocturne.Core.Contracts.Profiles;
 using Nocturne.Core.Contracts.Profiles.Resolvers;
 using Nocturne.Core.Contracts.V4.Repositories;
 using Nocturne.Core.Models;
+using Nocturne.Core.Models.Basal;
 using Nocturne.Core.Models.V4;
 using Nocturne.Infrastructure.Cache.Abstractions;
 using Xunit;
@@ -28,6 +29,7 @@ public class StatisticsControllerTests
     private readonly Mock<ITargetRangeScheduleRepository> _targetRangeScheduleRepoMock = new();
     private readonly Mock<IBasalInjectionRepository> _basalInjectionRepoMock = new();
     private readonly Mock<IActiveProfileResolver> _activeProfileResolverMock = new();
+    private readonly Mock<IBasalSegmentService> _basalSegmentsMock = new();
 
     private StatisticsController CreateController(ICanonicalGlucoseService? canonicalGlucose = null)
     {
@@ -36,7 +38,7 @@ public class StatisticsControllerTests
             Mock.Of<ICacheService>(),
             Mock.Of<IProfileProjectionService>(),
             Mock.Of<IBasalRateResolver>(),
-            Mock.Of<IBasalSegmentService>(),
+            _basalSegmentsMock.Object,
             _therapySettingsResolverMock.Object,
             _glucoseRepoMock.Object,
             _bolusRepoMock.Object,
@@ -336,6 +338,57 @@ public class StatisticsControllerTests
             new DateTime(2026, 1, 8, 0, 0, 0, DateTimeKind.Utc));
 
         usedTz.Should().Be(TimeZoneInfo.Utc);
+    }
+
+    [Fact]
+    public async Task GetBasalAnalysis_WithNoTempBasals_SynthesizesOneScheduledTempBasalPerProfileSegment()
+    {
+        var start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var segments = new[]
+        {
+            new BasalSegment(Mills(start), Mills(start.AddHours(6)), 0.8, 0.8, "Default"),
+            new BasalSegment(Mills(start.AddHours(6)), Mills(start.AddHours(18)), 1.2, 1.2, "Default"),
+            new BasalSegment(Mills(start.AddHours(18)), Mills(start.AddDays(1)), 0.9, 0.9, "Default"),
+        };
+
+        SetupEmptyTreatments();
+        _therapySettingsResolverMock
+            .Setup(r => r.HasDataAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _basalSegmentsMock
+            .Setup(s => s.GetSegmentsAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(AsAsync(segments));
+
+        List<TempBasal>? synthesized = null;
+        _statsServiceMock
+            .Setup(s => s.CalculateBasalAnalysis(
+                It.IsAny<IEnumerable<TempBasal>>(), It.IsAny<IEnumerable<Bolus>>(),
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<TimeZoneInfo?>()))
+            .Callback<IEnumerable<TempBasal>, IEnumerable<Bolus>, DateTime, DateTime, TimeZoneInfo?>(
+                (tempBasals, _, _, _, _) => synthesized = tempBasals.ToList())
+            .Returns(new BasalAnalysisResponse());
+
+        await CreateController().GetBasalAnalysis(start, start.AddDays(1));
+
+        synthesized.Should().NotBeNull();
+        synthesized!.Should().OnlyContain(t => t.Origin == TempBasalOrigin.Scheduled);
+        synthesized.Select(t => (t.StartTimestamp, t.EndTimestamp, t.Rate)).Should().Equal(
+            segments.Select(s => (
+                DateTimeOffset.FromUnixTimeMilliseconds(s.StartMills).UtcDateTime,
+                (DateTime?)DateTimeOffset.FromUnixTimeMilliseconds(s.EndMills).UtcDateTime,
+                s.UnitsPerHour)));
+    }
+
+    private static long Mills(DateTime utc) => new DateTimeOffset(utc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+    private static async IAsyncEnumerable<BasalSegment> AsAsync(IEnumerable<BasalSegment> segments)
+    {
+        foreach (var segment in segments)
+        {
+            yield return segment;
+        }
+
+        await Task.CompletedTask;
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1097 items 1, 2, 3 and 6. Items 4, 5 and 7 (deleting caller-less endpoints and response fields) are contract decisions and are untouched.

## The change

`StatisticsController` documented three policies its actions did not follow.

- **Five serialised read groups** carried a comment saying the repositories share the request-scoped `DbContext`. They do not: every repository read opens its own context from `ITenantDbContextFactory`, and four sibling actions in the same file already ran their reads under `Task.WhenAll`. The five groups now do too. Four of them fetched the same four insulin collections over one window, so they share one `FetchInsulinRecordsAsync`; any glucose or carb task a caller starts alongside goes into the same `WhenAll` so a helper failure never leaves a task unobserved.
- **The class doc** promised a five-minute cache on two actions. It now states what the code does: `/periods` caches through `ICacheService`, `/range-analytics` and `/weekday-averages` carry a 60-second `ResponseCache`, nothing else caches.
- **`[RequestSizeLimit(ComputeBodyLimitBytes)]`** sat on six of fifteen POSTs. It is now declared once on the controller; a test asserts the declared value and that no action carries a copy.
- **`GetBasalAnalysis` and `GetHourlyInsulinDelivery`** took nullable dates and hand-rolled a 400. MVC does not reject a missing non-nullable value-type query parameter; it binds `0001-01-01` and runs. So every non-nullable `DateTime` query parameter on the eight date-range GETs now carries `[BindRequired]`, and a reflection test with a discovery floor holds that convention. The same defect on five GET actions in four other controllers is #1206.
- The byte-identical profile-segment → scheduled `TempBasal` fallback in those two actions is one helper; two alias variables are gone.

## Behaviour deltas

- Six date-range GETs beyond the two in the issue now answer 400 to an omitted date where they answered 200 over an empty year-1 window. Every in-repo caller supplies both dates; the generated client marks them required to match.
- Nine POSTs that were on Kestrel's 30 MB default now get the 100 MB class limit: `basic-stats`, `glycemic-variability`, `treatment-summary`, `overall-averages`, `gri`, `clinical-assessment`, `data-sufficiency`, `validate/treatment`, `clean/treatments`.
- A sparse `/periods` period issues three extra empty scans; its response is unchanged.
- Concurrent contexts per request rise where reads were serialised: `/periods` 3→6 per period, `/insulin-delivery-stats` 1→4, `/punch-card` 1→6, `/daily-basal-bolus-ratios` 1→5, `/hourly-insulin-delivery` 1→4, against a shared pool of 100.

## Tests

Mutations each killed by a named test: the helper fetching algorithm boluses twice, the hourly site dropping its MDI suppression, `[RequestSizeLimit(1024)]`, a removed `[BindRequired]`, the fallback helper's guard, and a missing class-level attribute. Controller source is net −24 lines.
