### PR TITLE
refactor(v4): fold BasalInjection's Create/Update onto the CRUD base hooks

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Base/V4CrudControllerBase.cs
@@ -87,8 +87,8 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
-        if (await OnBeforeCreateAsync(model, request, ct) is { } error)
-            return error;
+        if (await OnBeforeCreateAsync(model, request, ct) is { } result)
+            return result;
 
         var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
         created = await OnAfterCreateAsync(created, ct);
@@ -161,8 +161,8 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
         if (model.Timestamp == default)
             return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
-        if (await OnBeforeUpdateAsync(model, request, existing, ct) is { } error)
-            return error;
+        if (await OnBeforeUpdateAsync(model, request, existing, ct) is { } result)
+            return result;
 
         try
         {
@@ -281,7 +281,12 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// <param name="model">The mapped record.</param>
     /// <param name="request">The inbound request, for the fields the domain model does not carry.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>A problem result rejecting the request, or <c>null</c> to persist.</returns>
+    /// <returns>
+    /// <c>null</c> to persist, or a result that is returned to the caller verbatim in place of the
+    /// write. That is usually a problem rejecting the request, but it may equally be a success
+    /// result standing in for the create — an idempotent upsert answering with the record it
+    /// already holds, say.
+    /// </returns>
     protected virtual Task<ObjectResult?> OnBeforeCreateAsync(TModel model, TCreateRequest request, CancellationToken ct)
         => Task.FromResult<ObjectResult?>(null);
 
@@ -293,7 +298,11 @@ public abstract class V4CrudControllerBase<TModel, TCreateRequest, TUpdateReques
     /// <param name="request">The inbound request, for the fields the domain model does not carry.</param>
     /// <param name="existing">The stored record this update replaces.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>A problem result rejecting the request, or <c>null</c> to persist.</returns>
+    /// <returns>
+    /// <c>null</c> to persist, or a result that is returned to the caller verbatim in place of the
+    /// write. That is usually a problem rejecting the request, but it may equally be a success
+    /// result standing in for the update.
+    /// </returns>
     protected virtual Task<ObjectResult?> OnBeforeUpdateAsync(TModel model, TUpdateRequest request, TModel existing, CancellationToken ct)
         => Task.FromResult<ObjectResult?>(null);
 

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -152,7 +152,7 @@ public class BasalInjectionController(
         if (string.IsNullOrEmpty(dataSource) || string.IsNullOrEmpty(syncIdentifier))
             return BadRequest("dataSource and syncIdentifier are required");
 
-        var deleted = await ((IBasalInjectionRepository)Repository).DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, WriteOrigin.Live, ct);
+        var deleted = await Repository.DeleteBySyncIdentifierAsync(dataSource, syncIdentifier, WriteOrigin.Live, ct);
         return deleted > 0 ? NoContent() : NotFound();
     }
 

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -61,8 +61,7 @@ public class BasalInjectionController(
             return unitsOrTsProblem;
 
         // Idempotent upsert: a record already stored under this (DataSource, SyncIdentifier) is
-        // returned as a 200 instead of the create the caller asked for, so the hook short-circuits
-        // with a success result rather than a rejection.
+        // returned as a 200 instead of the create the caller asked for.
         if (!string.IsNullOrEmpty(request.DataSource) && !string.IsNullOrEmpty(request.SyncIdentifier)
             && await Repository.FindBySyncIdentifierAsync(request.DataSource, request.SyncIdentifier, ct) is { } existingBySync)
         {
@@ -157,9 +156,11 @@ public class BasalInjectionController(
     }
 
     /// <summary>
-    /// The rules the CRUD base does not already enforce: the unset-timestamp guard is the base's,
-    /// on every single and bulk write path alike.
+    /// Enforces the two rules every basal injection write shares: <see cref="BasalInjection.Units"/>
+    /// must be in (0, 500], and <see cref="BasalInjection.Timestamp"/> must be no more than five
+    /// minutes in the future.
     /// </summary>
+    /// <returns>A <c>400 Bad Request</c> problem naming the rule broken, or <c>null</c> when both hold.</returns>
     private ObjectResult? ValidateUnitsAndFutureTolerance(double units, DateTimeOffset timestamp)
     {
         if (units <= 0 || units > UnitsHardCeiling)
@@ -173,9 +174,9 @@ public class BasalInjectionController(
 
     /// <summary>
     /// Resolves the referenced <see cref="PatientInsulin"/> onto
-    /// <see cref="BasalInjection.InsulinContext"/>, or leaves it <c>null</c> when the request omits
-    /// the reference — not an error, but uploader parity with <see cref="BolusController"/> for
-    /// clients that know nothing about the patient's insulin catalog.
+    /// <see cref="BasalInjection.InsulinContext"/>, or leaves it as the mapper left it — unset —
+    /// when the request omits the reference. That is not an error, but uploader parity with
+    /// <see cref="BolusController"/> for clients that know nothing about the patient's insulin catalog.
     /// </summary>
     /// <param name="model">The mapped injection, enriched in place.</param>
     /// <param name="patientInsulinId">The requested insulin reference, or <c>null</c>.</param>
@@ -188,8 +189,6 @@ public class BasalInjectionController(
     private async Task<ObjectResult?> ApplyInsulinContextAsync(
         BasalInjection model, Guid? patientInsulinId, DateTimeOffset timestamp, CancellationToken ct)
     {
-        model.InsulinContext = null;
-
         if (patientInsulinId is not { } insulinId)
             return null;
 

--- a/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Treatments/BasalInjectionController.cs
@@ -54,60 +54,30 @@ public class BasalInjectionController(
     protected override V4BulkNaming BulkNaming => new("Basal injection", "injection", "injections");
 
     /// <inheritdoc/>
-    public override async Task<ActionResult<BasalInjection>> Create(
-        [FromBody] CreateBasalInjectionRequest request, CancellationToken ct = default)
+    protected override async Task<ObjectResult?> OnBeforeCreateAsync(
+        BasalInjection model, CreateBasalInjectionRequest request, CancellationToken ct)
     {
-        if (ValidateUnitsAndTimestamp(request.Units, request.Timestamp) is { } unitsOrTsProblem)
+        if (ValidateUnitsAndFutureTolerance(request.Units, request.Timestamp) is { } unitsOrTsProblem)
             return unitsOrTsProblem;
 
-        // Idempotent upsert: if a record with this (DataSource, SyncIdentifier) already exists, return it.
-        if (!string.IsNullOrEmpty(request.DataSource) && !string.IsNullOrEmpty(request.SyncIdentifier))
+        // Idempotent upsert: a record already stored under this (DataSource, SyncIdentifier) is
+        // returned as a 200 instead of the create the caller asked for, so the hook short-circuits
+        // with a success result rather than a rejection.
+        if (!string.IsNullOrEmpty(request.DataSource) && !string.IsNullOrEmpty(request.SyncIdentifier)
+            && await Repository.FindBySyncIdentifierAsync(request.DataSource, request.SyncIdentifier, ct) is { } existingBySync)
         {
-            var existingBySync = await Repository.FindBySyncIdentifierAsync(
-                request.DataSource, request.SyncIdentifier, ct);
-            if (existingBySync is not null)
-                return Ok(existingBySync);
+            return Ok(existingBySync);
         }
 
-        var (insulin, insulinProblem) = await ResolveInsulinAsync(request.PatientInsulinId, request.Timestamp, ct);
-        if (insulinProblem is not null)
-            return insulinProblem;
-
-        var model = MapCreateToModel(request);
-        model.InsulinContext = insulin is null ? null : BuildContext(insulin);
-
-        var created = await Repository.CreateAsync(model, WriteOrigin.Live, ct);
-        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        return await ApplyInsulinContextAsync(model, request.PatientInsulinId, request.Timestamp, ct);
     }
 
     /// <inheritdoc/>
-    public override async Task<ActionResult<BasalInjection>> Update(
-        Guid id, [FromBody] UpdateBasalInjectionRequest request, CancellationToken ct = default)
-    {
-        var existing = await Repository.GetByIdAsync(id, ct);
-        if (existing is null)
-            return NotFound();
-
-        if (ValidateUnitsAndTimestamp(request.Units, request.Timestamp) is { } unitsOrTsProblem)
-            return unitsOrTsProblem;
-
-        var (insulin, insulinProblem) = await ResolveInsulinAsync(request.PatientInsulinId, request.Timestamp, ct);
-        if (insulinProblem is not null)
-            return insulinProblem;
-
-        var model = MapUpdateToModel(id, request, existing);
-        model.InsulinContext = insulin is null ? null : BuildContext(insulin);
-
-        try
-        {
-            var updated = await Repository.UpdateAsync(id, model, WriteOrigin.Live, ct);
-            return Ok(updated);
-        }
-        catch (KeyNotFoundException)
-        {
-            return NotFound();
-        }
-    }
+    protected override Task<ObjectResult?> OnBeforeUpdateAsync(
+        BasalInjection model, UpdateBasalInjectionRequest request, BasalInjection existing, CancellationToken ct)
+        => ValidateUnitsAndFutureTolerance(request.Units, request.Timestamp) is { } unitsOrTsProblem
+            ? Task.FromResult<ObjectResult?>(unitsOrTsProblem)
+            : ApplyInsulinContextAsync(model, request.PatientInsulinId, request.Timestamp, ct);
 
     /// <summary>Maps a <see cref="CreateBasalInjectionRequest"/> to a new <see cref="BasalInjection"/>.</summary>
     /// <param name="request">The inbound create request.</param>
@@ -153,16 +123,13 @@ public class BasalInjectionController(
     {
         for (var i = 0; i < models.Count; i++)
         {
-            if (ValidateUnitsAndTimestamp(requests[i].Units, requests[i].Timestamp) is { } unitsOrTsProblem)
+            if (ValidateUnitsAndFutureTolerance(requests[i].Units, requests[i].Timestamp) is { } unitsOrTsProblem)
                 return unitsOrTsProblem;
 
             // Resolved per item: the active-at-injection-time window check depends on each
             // item's timestamp, so a per-insulin cache would skip it.
-            var (insulin, insulinProblem) = await ResolveInsulinAsync(requests[i].PatientInsulinId, requests[i].Timestamp, ct);
-            if (insulinProblem is not null)
+            if (await ApplyInsulinContextAsync(models[i], requests[i].PatientInsulinId, requests[i].Timestamp, ct) is { } insulinProblem)
                 return insulinProblem;
-
-            models[i].InsulinContext = insulin is null ? null : BuildContext(insulin);
         }
 
         return null;
@@ -189,13 +156,14 @@ public class BasalInjectionController(
         return deleted > 0 ? NoContent() : NotFound();
     }
 
-    private ObjectResult? ValidateUnitsAndTimestamp(double units, DateTimeOffset timestamp)
+    /// <summary>
+    /// The rules the CRUD base does not already enforce: the unset-timestamp guard is the base's,
+    /// on every single and bulk write path alike.
+    /// </summary>
+    private ObjectResult? ValidateUnitsAndFutureTolerance(double units, DateTimeOffset timestamp)
     {
         if (units <= 0 || units > UnitsHardCeiling)
             return Problem(detail: "Units must be > 0 and <= 500.", statusCode: 400, title: "Bad Request");
-
-        if (timestamp == default)
-            return Problem(detail: "Timestamp must be set", statusCode: 400, title: "Bad Request");
 
         if (timestamp > DateTimeOffset.UtcNow.AddMinutes(FutureToleranceMinutes))
             return Problem(detail: "Timestamp cannot be more than 5 minutes in the future.", statusCode: 400, title: "Bad Request");
@@ -204,54 +172,53 @@ public class BasalInjectionController(
     }
 
     /// <summary>
-    /// Resolves the referenced <see cref="PatientInsulin"/>, or short-circuits when the request
-    /// omits the reference.
+    /// Resolves the referenced <see cref="PatientInsulin"/> onto
+    /// <see cref="BasalInjection.InsulinContext"/>, or leaves it <c>null</c> when the request omits
+    /// the reference — not an error, but uploader parity with <see cref="BolusController"/> for
+    /// clients that know nothing about the patient's insulin catalog.
     /// </summary>
-    /// <param name="patientInsulinId">
-    /// The requested insulin reference, or <c>null</c>. A <c>null</c> reference is not an error:
-    /// resolution is skipped and both tuple members come back <c>null</c>, leaving the caller to
-    /// store the injection without an insulin context (uploader parity with
-    /// <see cref="BolusController"/>).
-    /// </param>
+    /// <param name="model">The mapped injection, enriched in place.</param>
+    /// <param name="patientInsulinId">The requested insulin reference, or <c>null</c>.</param>
     /// <param name="timestamp">Injection time, checked against the insulin's active window.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>
-    /// The resolved insulin and a <c>null</c> problem on success; a <c>400 Bad Request</c> problem
-    /// when a supplied reference is unknown, is not a basal insulin, or was inactive at
-    /// <paramref name="timestamp"/>.
+    /// <c>null</c> on success; a <c>400 Bad Request</c> problem when a supplied reference is
+    /// unknown, is not a basal insulin, or was inactive at <paramref name="timestamp"/>.
     /// </returns>
-    private async Task<(PatientInsulin? Insulin, ObjectResult? Problem)> ResolveInsulinAsync(
-        Guid? patientInsulinId, DateTimeOffset timestamp, CancellationToken ct)
+    private async Task<ObjectResult?> ApplyInsulinContextAsync(
+        BasalInjection model, Guid? patientInsulinId, DateTimeOffset timestamp, CancellationToken ct)
     {
+        model.InsulinContext = null;
+
         if (patientInsulinId is not { } insulinId)
-            return (null, null);
+            return null;
 
         var insulin = await insulinRepo.GetByIdAsync(insulinId, ct);
         if (insulin is null)
-            return (null, Problem(detail: "PatientInsulin not found.", statusCode: 400, title: "Bad Request"));
+            return Problem(detail: "PatientInsulin not found.", statusCode: 400, title: "Bad Request");
 
         if (insulin.Role != InsulinRole.Basal && insulin.Role != InsulinRole.Both)
-            return (null, Problem(detail: "Referenced insulin is not a basal insulin.", statusCode: 400, title: "Bad Request"));
+            return Problem(detail: "Referenced insulin is not a basal insulin.", statusCode: 400, title: "Bad Request");
 
         var injectionDate = DateOnly.FromDateTime(timestamp.UtcDateTime);
         if ((insulin.StartDate is { } start && start > injectionDate)
             || (insulin.EndDate is { } end && end < injectionDate))
         {
-            return (null, Problem(
+            return Problem(
                 detail: "Referenced insulin was not active at injection time.",
-                statusCode: 400, title: "Bad Request"));
+                statusCode: 400, title: "Bad Request");
         }
 
-        return (insulin, null);
-    }
+        model.InsulinContext = new TreatmentInsulinContext
+        {
+            PatientInsulinId = insulin.Id,
+            InsulinName = insulin.Name,
+            Dia = insulin.Dia,
+            Peak = insulin.Peak,
+            Curve = insulin.Curve,
+            Concentration = insulin.Concentration,
+        };
 
-    private static TreatmentInsulinContext BuildContext(PatientInsulin insulin) => new()
-    {
-        PatientInsulinId = insulin.Id,
-        InsulinName = insulin.Name,
-        Dia = insulin.Dia,
-        Peak = insulin.Peak,
-        Curve = insulin.Curve,
-        Concentration = insulin.Concentration,
-    };
+        return null;
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
@@ -140,6 +140,48 @@ public class BasalInjectionControllerTests
         _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    /// <summary>
+    /// The ceiling is inclusive: 500 units is a legal dose, and only the next representable double
+    /// above it is not. Paired with <see cref="Create_rejects_the_smallest_step_above_the_ceiling"/>
+    /// these straddle the exact comparison, so widening or narrowing it by one step reddens one of them.
+    /// </summary>
+    [Fact]
+    public async Task Create_accepts_units_exactly_at_the_ceiling()
+    {
+        BasalInjection? captured = null;
+        SetupCreatePassthrough(b => captured = b);
+
+        var request = new CreateBasalInjectionRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Units = 500,
+        };
+
+        var result = await CreateController().Create(request);
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+        captured.Should().NotBeNull();
+        captured!.Units.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task Create_rejects_the_smallest_step_above_the_ceiling()
+    {
+        var request = new CreateBasalInjectionRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Units = Math.BitIncrement(500),
+        };
+
+        var result = await CreateController().Create(request);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        objectResult.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Be("Units must be > 0 and <= 500.");
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     [Fact]
     public async Task Create_returns_400_when_timestamp_is_more_than_5_minutes_in_future()
     {
@@ -173,7 +215,6 @@ public class BasalInjectionControllerTests
         var request = new CreateBasalInjectionRequest
         {
             Timestamp = default,
-            PatientInsulinId = Guid.NewGuid(),
             Units = 12,
         };
 

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Treatments/BasalInjectionControllerTests.cs
@@ -144,10 +144,11 @@ public class BasalInjectionControllerTests
     public async Task Create_returns_400_when_timestamp_is_more_than_5_minutes_in_future()
     {
         var controller = CreateController();
+        // No PatientInsulinId: an unresolvable reference would collect its own 400 and pass this
+        // test whatever the future tolerance is.
         var request = new CreateBasalInjectionRequest
         {
             Timestamp = DateTimeOffset.UtcNow.AddMinutes(10),
-            PatientInsulinId = Guid.NewGuid(),
             Units = 12,
         };
 
@@ -155,6 +156,8 @@ public class BasalInjectionControllerTests
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
         objectResult.StatusCode.Should().Be(400);
+        objectResult.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Be("Timestamp cannot be more than 5 minutes in the future.");
         _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -175,6 +178,29 @@ public class BasalInjectionControllerTests
         };
 
         var result = await controller.Create(request);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        objectResult.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Be("Timestamp must be set");
+        _repoMock.Verify(r => r.CreateAsync(It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// A request breaking both rules is answered for the timestamp, not the units: the CRUD base
+    /// runs its unset-timestamp guard before the hook carrying the units rule, which is the order
+    /// the bulk path already reported in.
+    /// </summary>
+    [Fact]
+    public async Task Create_with_both_unset_timestamp_and_bad_units_reports_the_timestamp()
+    {
+        var request = new CreateBasalInjectionRequest
+        {
+            Timestamp = default,
+            Units = 0,
+        };
+
+        var result = await CreateController().Create(request);
 
         var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
         objectResult.StatusCode.Should().Be(400);
@@ -359,43 +385,132 @@ public class BasalInjectionControllerTests
         _insulinRepoMock.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
-    [Fact]
-    public async Task Update_without_PatientInsulinId_clears_InsulinContext()
+    /// <summary>
+    /// Stores an existing injection carrying an insulin context, so an update that drops the
+    /// reference has something to drop.
+    /// </summary>
+    private Guid SetupExistingWithInsulinContext()
     {
         var id = Guid.NewGuid();
-        var existing = new BasalInjection
-        {
-            Id = id,
-            Timestamp = DateTime.UtcNow.AddHours(-2),
-            Units = 10,
-            InsulinContext = new TreatmentInsulinContext
-            {
-                PatientInsulinId = Guid.NewGuid(),
-                InsulinName = "Tresiba",
-            },
-        };
         _repoMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(existing);
+            .ReturnsAsync(new BasalInjection
+            {
+                Id = id,
+                Timestamp = DateTime.UtcNow.AddHours(-2),
+                Units = 10,
+                InsulinContext = new TreatmentInsulinContext
+                {
+                    PatientInsulinId = Guid.NewGuid(),
+                    InsulinName = "Tresiba",
+                },
+            });
+        return id;
+    }
 
-        BasalInjection? captured = null;
+    private void SetupUpdatePassthrough(Guid id, Action<BasalInjection> onUpdate)
+    {
         _repoMock
             .Setup(r => r.UpdateAsync(id, It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, BasalInjection, WriteOrigin, CancellationToken>((_, b, _, _) => captured = b)
+            .Callback<Guid, BasalInjection, WriteOrigin, CancellationToken>((_, b, _, _) => onUpdate(b))
             .ReturnsAsync((Guid _, BasalInjection b, WriteOrigin _, CancellationToken _) => b);
+    }
 
-        var controller = CreateController();
+    private void VerifyNoUpdate() => _repoMock.Verify(
+        r => r.UpdateAsync(It.IsAny<Guid>(), It.IsAny<BasalInjection>(), It.IsAny<WriteOrigin>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+
+    /// <summary>
+    /// <c>InsulinContext</c> is not among the fields an update carries forward from the stored
+    /// record, unlike <c>LegacyId</c> and <c>CreatedAt</c>: dropping the reference drops the snapshot.
+    /// </summary>
+    [Fact]
+    public async Task Update_without_PatientInsulinId_does_not_carry_the_stored_InsulinContext_forward()
+    {
+        var id = SetupExistingWithInsulinContext();
+        BasalInjection? captured = null;
+        SetupUpdatePassthrough(id, b => captured = b);
+
         var request = new UpdateBasalInjectionRequest
         {
             Timestamp = DateTimeOffset.UtcNow,
             Units = 11,
         };
 
-        var result = await controller.Update(id, request);
+        var result = await CreateController().Update(id, request);
 
         result.Result.Should().BeOfType<OkObjectResult>();
         captured.Should().NotBeNull();
         captured!.InsulinContext.Should().BeNull();
         _insulinRepoMock.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1.5)]
+    [InlineData(500.01)]
+    public async Task Update_returns_400_when_units_out_of_range(double units)
+    {
+        var id = SetupExistingWithInsulinContext();
+
+        var request = new UpdateBasalInjectionRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Units = units,
+        };
+
+        var result = await CreateController().Update(id, request);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        objectResult.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Be("Units must be > 0 and <= 500.");
+        VerifyNoUpdate();
+    }
+
+    [Fact]
+    public async Task Update_returns_400_when_timestamp_is_more_than_5_minutes_in_future()
+    {
+        var id = SetupExistingWithInsulinContext();
+
+        // No PatientInsulinId: an unresolvable reference would collect its own 400 and pass this
+        // test whatever the future tolerance is.
+        var request = new UpdateBasalInjectionRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow.AddMinutes(10),
+            Units = 11,
+        };
+
+        var result = await CreateController().Update(id, request);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        objectResult.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Be("Timestamp cannot be more than 5 minutes in the future.");
+        VerifyNoUpdate();
+    }
+
+    [Fact]
+    public async Task Update_returns_400_when_PatientInsulin_not_found()
+    {
+        var id = SetupExistingWithInsulinContext();
+        var insulinId = Guid.NewGuid();
+        _insulinRepoMock.Setup(r => r.GetByIdAsync(insulinId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PatientInsulin?)null);
+
+        var request = new UpdateBasalInjectionRequest
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            PatientInsulinId = insulinId,
+            Units = 11,
+        };
+
+        var result = await CreateController().Update(id, request);
+
+        var objectResult = result.Result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(400);
+        objectResult.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Detail.Should().Be("PatientInsulin not found.");
+        VerifyNoUpdate();
     }
 
     [Fact]


### PR DESCRIPTION
Finishes #1091. Every item the issue lists was already fixed on main by #1129 and #1133; this takes the shape #1091 preferred for item 1 now that #1193 makes it possible.

## The change

`BasalInjectionController` replaced `V4CrudControllerBase.Create` and `Update` wholesale, which is why its single-create path once lacked the base's unset-timestamp guard. With the `OnBeforeCreateAsync`/`OnBeforeUpdateAsync` hooks from #1193 the overrides go: mapping, the timestamp guard and persistence come from the base, and the controller keeps only what is its own.

- `ValidateUnitsAndFutureTolerance` holds the two rules the base does not: units in (0, 500], timestamp at most five minutes ahead. Its default-timestamp branch is gone because the base guards single writes and `V4BulkValidation` guards bulk.
- `ResolveInsulinAsync` and `BuildContext` collapse into one `ApplyInsulinContextAsync` used by create, update and bulk.
- The idempotent `(DataSource, SyncIdentifier)` upsert returns the stored record as a 200 from the create hook. The base hook's contract now says a non-null result is returned to the caller verbatim and may be a success; the locals are renamed from `error` to `result`.
- A redundant repository cast and a dead `InsulinContext = null` write are deleted.

No other V4 controller overrides a write action wholesale any more.

## Behaviour delta

On a request that is both unset-timestamp and out-of-range units, the 400 `detail` is now "Timestamp must be set" where it was the units message. The base guard runs first, which matches the bulk path's order. Pinned by a test.

## Tests

The update path had no validation tests: replacing the whole update hook with `null` kept the suite green. It now fails five. `Create_returns_400_when_timestamp_is_more_than_5_minutes_in_future` carried an unstubbed insulin id and was collecting the insulin 400; fixed and asserting the tolerance message, so a 60× tolerance widening fails. The units ceiling is pinned at exactly 500 and one ULP above. The 5-minute edge is not pinned at tick granularity because the validator reads the wall clock; a `TimeProvider` seam for controllers belongs with #993.

Controller source is net −33 lines.
