### PR TITLE
fix(bot): fit the alert card's button value inside Telegram's 64-byte callback budget

### DIFF
--- a/src/Web/packages/bot/src/alerts/deliver.test.ts
+++ b/src/Web/packages/bot/src/alerts/deliver.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Chat } from "chat";
 import { AlertDeliveryHandler } from "./deliver.js";
 import type { AlertDispatchEvent, BotApiClient } from "../types.js";
+import { cardButtons } from "../cards/card-buttons.test-utils.js";
+import { encodeActionValue } from "../lib/action-value.js";
 
 vi.mock("../lib/logger.js", () => ({
   createLogger: () => ({
@@ -12,25 +14,13 @@ vi.mock("../lib/logger.js", () => ({
   }),
 }));
 
+const buttonValue = (node: unknown, id: string) =>
+  cardButtons(node).find((b) => b.id === id)?.value;
+
 const ADAPTERS_WITH_DM = ["discord", "slack", "telegram", "whatsapp", "resend"];
 
 const TENANT = "11111111-1111-1111-1111-111111111111";
 const EXCURSION = "33333333-3333-3333-3333-333333333333";
-
-/** Card elements nest through `children`, which holds arrays as well as elements. */
-function buttonValue(node: unknown, id: string): string | undefined {
-  if (Array.isArray(node)) {
-    for (const child of node) {
-      const found = buttonValue(child, id);
-      if (found !== undefined) return found;
-    }
-    return undefined;
-  }
-  if (node === null || typeof node !== "object") return undefined;
-  const el = node as { props?: Record<string, unknown>; children?: unknown };
-  if (el.props?.id === id) return el.props.value as string;
-  return buttonValue(el.children, id);
-}
 
 function createBot(options: { adaptersWithDm?: string[] } = {}) {
   const withDm = options.adaptersWithDm ?? ADAPTERS_WITH_DM;
@@ -194,29 +184,21 @@ describe("AlertDeliveryHandler adapter routing", () => {
 });
 
 describe("AlertDeliveryHandler card actions", () => {
-  it("addresses the acknowledge button at the excursion, not just the tenant", async () => {
-    const bits = createBot();
-    const apiBits = createApi();
+  it.each(["ack_alert", "mute_30"])(
+    "addresses the %s button at the tenant and the excursion",
+    async (id) => {
+      const bits = createBot();
+      const apiBits = createApi();
 
-    await new AlertDeliveryHandler(bits.bot, apiBits.api).deliver(
-      createEvent("discord_dm", "123456789012345678"),
-    );
+      await new AlertDeliveryHandler(bits.bot, apiBits.api).deliver(
+        createEvent("discord_dm", "123456789012345678"),
+      );
 
-    expect(buttonValue(bits.post.mock.calls[0]?.[0], "ack_alert")).toBe(
-      `${TENANT}:${EXCURSION}`,
-    );
-  });
-
-  it("leaves the mute button addressing the tenant alone", async () => {
-    const bits = createBot();
-    const apiBits = createApi();
-
-    await new AlertDeliveryHandler(bits.bot, apiBits.api).deliver(
-      createEvent("discord_dm", "123456789012345678"),
-    );
-
-    expect(buttonValue(bits.post.mock.calls[0]?.[0], "mute_30")).toBe(TENANT);
-  });
+      expect(buttonValue(bits.post.mock.calls[0]?.[0], id)).toBe(
+        encodeActionValue({ tenantId: TENANT, excursionId: EXCURSION }),
+      );
+    },
+  );
 });
 
 describe("AlertDeliveryHandler outcome reporting", () => {

--- a/src/Web/packages/bot/src/cards/alert.test.ts
+++ b/src/Web/packages/bot/src/cards/alert.test.ts
@@ -4,7 +4,7 @@ import { cardButtons } from "./card-buttons.test-utils.js";
 import { decodeActionValue, encodeTenantKey } from "../lib/action-value.js";
 import type { AlertPayload } from "../types.js";
 
-const TENANT = "11111111-1111-1111-1111-111111111111";
+const TENANT = "018f2a1b-3c4d-7000-8000-a1b2c3d4e5f6";
 const EXCURSION = "33333333-3333-3333-3333-333333333333";
 
 /**
@@ -45,6 +45,7 @@ describe("AlertCard button values", () => {
       expect(decodeActionValue(value)).toEqual({
         tenantKey: encodeTenantKey(TENANT),
         excursionId: EXCURSION,
+        unreadableExcursion: false,
       });
     }
   });

--- a/src/Web/packages/bot/src/cards/alert.test.ts
+++ b/src/Web/packages/bot/src/cards/alert.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { AlertCard } from "./alert.js";
+import { cardButtons } from "./card-buttons.test-utils.js";
+import { decodeActionValue, encodeTenantKey } from "../lib/action-value.js";
+import type { AlertPayload } from "../types.js";
+
+const TENANT = "11111111-1111-1111-1111-111111111111";
+const EXCURSION = "33333333-3333-3333-3333-333333333333";
+
+/**
+ * Mirrors `encodeTelegramCallbackData` in `@chat-adapter/telegram`
+ * (`dist/index.js`), which the package does not export: it prefixes `chat:` to
+ * `JSON.stringify({ a: actionId, v: value })` and throws above 64 bytes, failing
+ * the whole delivery.
+ */
+const TELEGRAM_CALLBACK_DATA_LIMIT_BYTES = 64;
+const telegramCallbackBytes = (actionId: string, value: string) =>
+  Buffer.byteLength(`chat:${JSON.stringify({ a: actionId, v: value })}`, "utf8");
+
+const payload = {
+  tenantId: TENANT,
+  excursionId: EXCURSION,
+  ruleName: "Urgent low",
+  subjectName: "Alex",
+  glucoseValue: 54,
+  trend: "SingleDown",
+  trendRate: -1.4,
+  readingTimestamp: "2026-01-01T00:00:00.000Z",
+} as AlertPayload;
+
+const buttons = () => cardButtons(AlertCard({ payload }));
+
+describe("AlertCard button values", () => {
+  it("puts every button inside Telegram's callback_data budget", () => {
+    expect(buttons()).not.toHaveLength(0);
+    for (const { id, value } of buttons()) {
+      expect(telegramCallbackBytes(id, value ?? "")).toBeLessThanOrEqual(
+        TELEGRAM_CALLBACK_DATA_LIMIT_BYTES,
+      );
+    }
+  });
+
+  it("addresses every button at the tenant and the excursion", () => {
+    for (const { value } of buttons()) {
+      expect(decodeActionValue(value)).toEqual({
+        tenantKey: encodeTenantKey(TENANT),
+        excursionId: EXCURSION,
+      });
+    }
+  });
+});

--- a/src/Web/packages/bot/src/cards/alert.tsx
+++ b/src/Web/packages/bot/src/cards/alert.tsx
@@ -13,7 +13,7 @@ export function AlertCard(props: {
       ? formatGlucose(payload.glucoseValue, unit)
       : "N/A";
   const arrow = payload.trend ? trendArrow(payload.trend) : "";
-  const acknowledgeTarget = encodeActionValue({
+  const target = encodeActionValue({
     tenantId: payload.tenantId,
     excursionId: payload.excursionId,
   });
@@ -34,10 +34,10 @@ export function AlertCard(props: {
         )}
       </Fields>
       <Actions>
-        <Button id="ack_alert" value={acknowledgeTarget} style="primary">
+        <Button id="ack_alert" value={target} style="primary">
           Acknowledge
         </Button>
-        <Button id="mute_30" value={payload.tenantId}>
+        <Button id="mute_30" value={target}>
           Mute 30 min
         </Button>
       </Actions>

--- a/src/Web/packages/bot/src/cards/card-buttons.test-utils.ts
+++ b/src/Web/packages/bot/src/cards/card-buttons.test-utils.ts
@@ -1,0 +1,18 @@
+export interface CardButton {
+  id: string;
+  value: string | undefined;
+}
+
+/** Card elements nest through `children`, which holds arrays as well as elements. */
+export function cardButtons(node: unknown, found: CardButton[] = []): CardButton[] {
+  if (Array.isArray(node)) {
+    for (const child of node) cardButtons(child, found);
+    return found;
+  }
+  if (node === null || typeof node !== "object") return found;
+  const el = node as { props?: Record<string, unknown>; children?: unknown };
+  if (typeof el.props?.id === "string") {
+    found.push({ id: el.props.id, value: el.props.value as string | undefined });
+  }
+  return cardButtons(el.children, found);
+}

--- a/src/Web/packages/bot/src/commands/alerts.test.ts
+++ b/src/Web/packages/bot/src/commands/alerts.test.ts
@@ -3,7 +3,7 @@ import type { ActionEvent, Chat } from "chat";
 import { registerAlertCommands } from "./alerts.js";
 import { runWithContext, type BotRequestContext } from "../lib/request-context.js";
 import type { BotApiClient, DirectoryCandidate } from "../types.js";
-import { encodeActionValue } from "../lib/action-value.js";
+import { encodeActionValue, encodeTenantKey } from "../lib/action-value.js";
 
 vi.mock("../lib/logger.js", () => ({
   createLogger: () => ({
@@ -20,6 +20,12 @@ const EXCURSION = "33333333-3333-3333-3333-333333333333";
 
 const HOME = candidate(HOME_TENANT, "home-clinic", "home");
 const WORK = candidate(WORK_TENANT, "work-clinic", "work");
+
+/** Two tenant ids whose trailing bytes — and so whose button-value keys — are identical. */
+const TWIN_TENANT_A = "11111111-1111-7000-8000-000000000001";
+const TWIN_TENANT_B = "22222222-2222-7000-8000-000000000001";
+const TWIN_A = candidate(TWIN_TENANT_A, "twin-a-clinic", "twin-a");
+const TWIN_B = candidate(TWIN_TENANT_B, "twin-b-clinic", "twin-b");
 
 /** The value the alert card puts on its buttons: the tenant and the excursion. */
 const cardValue = (tenantId: string, excursionId: string) =>
@@ -144,7 +150,7 @@ describe("ack_alert action", () => {
     expect(post).toHaveBeenCalledExactlyOnceWith("All alerts acknowledged.");
   });
 
-  it("acknowledges the excursion named by a card posted before the budget fix", async () => {
+  it("acknowledges the excursion named by a two-UUID value", async () => {
     const ctx = createContext([HOME, WORK]);
     const { event } = createActionEvent(`${WORK_TENANT}:${EXCURSION}`);
 
@@ -267,6 +273,42 @@ describe("ack_alert action", () => {
     );
     expect(ctx.scopedApiFactory).not.toHaveBeenCalled();
     expect(post).not.toHaveBeenCalled();
+  });
+
+  it("refuses when two linked tenants answer to the same key", async () => {
+    expect(encodeTenantKey(TWIN_TENANT_A)).toBe(encodeTenantKey(TWIN_TENANT_B));
+    const ctx = createContext([TWIN_A, TWIN_B]);
+    const { event, post, postEphemeral } = createActionEvent(
+      cardValue(TWIN_TENANT_A, EXCURSION),
+    );
+
+    await runWithContext(ctx.context, () => handler(event));
+
+    expect(postEphemeral).toHaveBeenCalledExactlyOnceWith(
+      event.user,
+      "You have multiple linked Nocturne accounts: `twin-a` (TWIN-A), `twin-b` (TWIN-B). Set a default in Settings → Integrations → Discord, or use the matching slash command with a label.",
+      { fallbackToDM: true },
+    );
+    expect(ctx.scopedApiFactory).not.toHaveBeenCalled();
+    expect(ctx.ambientAcknowledge).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges nothing when it cannot read which excursion the value names", async () => {
+    const ctx = createContext([HOME, WORK]);
+    const { event, post } = createActionEvent(
+      `${encodeTenantKey(WORK_TENANT)}:nonsense`,
+    );
+
+    await runWithContext(ctx.context, () => handler(event));
+
+    const alerts = ctx.alertsBySlug.get("work-clinic");
+    expect(alerts?.acknowledge).toBeUndefined();
+    expect(alerts?.acknowledgeExcursion).toBeUndefined();
+    expect(ctx.ambientAcknowledge).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledExactlyOnceWith(
+      "Couldn't tell which alert this button is for. Nothing was acknowledged.",
+    );
   });
 
   it("reports a failure without retrying against another tenant", async () => {

--- a/src/Web/packages/bot/src/commands/alerts.test.ts
+++ b/src/Web/packages/bot/src/commands/alerts.test.ts
@@ -294,22 +294,25 @@ describe("ack_alert action", () => {
     expect(post).not.toHaveBeenCalled();
   });
 
-  it("acknowledges nothing when it cannot read which excursion the value names", async () => {
-    const ctx = createContext([HOME, WORK]);
-    const { event, post } = createActionEvent(
-      `${encodeTenantKey(WORK_TENANT)}:nonsense`,
-    );
+  it.each(["nonsense", "*".repeat(22), "", ":"])(
+    "acknowledges nothing when the excursion segment is %p",
+    async (segment) => {
+      const ctx = createContext([HOME, WORK]);
+      const { event, post } = createActionEvent(
+        `${encodeTenantKey(WORK_TENANT)}:${segment}`,
+      );
 
-    await runWithContext(ctx.context, () => handler(event));
+      await runWithContext(ctx.context, () => handler(event));
 
-    const alerts = ctx.alertsBySlug.get("work-clinic");
-    expect(alerts?.acknowledge).toBeUndefined();
-    expect(alerts?.acknowledgeExcursion).toBeUndefined();
-    expect(ctx.ambientAcknowledge).not.toHaveBeenCalled();
-    expect(post).toHaveBeenCalledExactlyOnceWith(
-      "Couldn't tell which alert this button is for. Nothing was acknowledged.",
-    );
-  });
+      const alerts = ctx.alertsBySlug.get("work-clinic");
+      expect(alerts?.acknowledge).toBeUndefined();
+      expect(alerts?.acknowledgeExcursion).toBeUndefined();
+      expect(ctx.ambientAcknowledge).not.toHaveBeenCalled();
+      expect(post).toHaveBeenCalledExactlyOnceWith(
+        "Couldn't tell which alert this button is for. Nothing was acknowledged.",
+      );
+    },
+  );
 
   it("reports a failure without retrying against another tenant", async () => {
     const ctx = createContext([HOME, WORK]);

--- a/src/Web/packages/bot/src/commands/alerts.test.ts
+++ b/src/Web/packages/bot/src/commands/alerts.test.ts
@@ -3,6 +3,7 @@ import type { ActionEvent, Chat } from "chat";
 import { registerAlertCommands } from "./alerts.js";
 import { runWithContext, type BotRequestContext } from "../lib/request-context.js";
 import type { BotApiClient, DirectoryCandidate } from "../types.js";
+import { encodeActionValue } from "../lib/action-value.js";
 
 vi.mock("../lib/logger.js", () => ({
   createLogger: () => ({
@@ -22,7 +23,7 @@ const WORK = candidate(WORK_TENANT, "work-clinic", "work");
 
 /** The value the alert card puts on its buttons: the tenant and the excursion. */
 const cardValue = (tenantId: string, excursionId: string) =>
-  `${tenantId}:${excursionId}`;
+  encodeActionValue({ tenantId, excursionId });
 
 function candidate(
   tenantId: string,
@@ -141,6 +142,18 @@ describe("ack_alert action", () => {
     });
     expect(alerts.acknowledgeExcursion).not.toHaveBeenCalled();
     expect(post).toHaveBeenCalledExactlyOnceWith("All alerts acknowledged.");
+  });
+
+  it("acknowledges the excursion named by a card posted before the budget fix", async () => {
+    const ctx = createContext([HOME, WORK]);
+    const { event } = createActionEvent(`${WORK_TENANT}:${EXCURSION}`);
+
+    await runWithContext(ctx.context, () => handler(event));
+
+    expect(ctx.scopedApiFactory).toHaveBeenCalledExactlyOnceWith("work-clinic");
+    expect(
+      ctx.alertsBySlug.get("work-clinic")!.acknowledgeExcursion,
+    ).toHaveBeenCalledExactlyOnceWith(EXCURSION, { acknowledgedBy: "Sam Tester" });
   });
 
   it("acknowledges through the client scoped to the alert's tenant", async () => {

--- a/src/Web/packages/bot/src/commands/alerts.ts
+++ b/src/Web/packages/bot/src/commands/alerts.ts
@@ -9,12 +9,19 @@ const logger = createLogger();
 export function registerAlertCommands(bot: Chat) {
   bot.onAction("ack_alert", async (event) => {
     await requireLinkForAction(event, async () => {
-      const { excursionId } = decodeActionValue(event.value);
+      const { excursionId, unreadableExcursion } = decodeActionValue(event.value);
+      if (unreadableExcursion) {
+        await event.thread?.post(
+          "Couldn't tell which alert this button is for. Nothing was acknowledged.",
+        );
+        return;
+      }
+
       try {
         const api = getApi();
         const acknowledgedBy = event.user.fullName ?? "Unknown";
 
-        // Cards already in chat history carry only a tenant; their button still has to work.
+        // A value that names no excursion at all addresses the whole tenant.
         if (!excursionId) {
           await api.alerts.acknowledge({ acknowledgedBy });
           await event.thread?.post("All alerts acknowledged.");

--- a/src/Web/packages/bot/src/lib/action-value.test.ts
+++ b/src/Web/packages/bot/src/lib/action-value.test.ts
@@ -5,9 +5,16 @@ import {
   encodeTenantKey,
 } from "./action-value.js";
 
-const TENANT = "11111111-1111-1111-1111-111111111111";
-const OTHER_TENANT = "22222222-2222-2222-2222-222222222222";
+const TENANT = "018f2a1b-3c4d-7000-8000-a1b2c3d4e5f6";
 const EXCURSION = "33333333-3333-3333-3333-333333333333";
+
+/**
+ * UUIDv7 ids minted in the same millisecond: identical for their leading 48
+ * timestamp bits, and — the pair below — for their trailing three bytes too.
+ * Only rand_b in between tells them apart.
+ */
+const SAME_MS_A = "018f2a1b-3c4d-7000-8000-aaaa00000001";
+const SAME_MS_B = "018f2a1b-3c4d-7000-8000-bbbb00000001";
 
 describe("card button values", () => {
   it("round-trips a tenant and an excursion", () => {
@@ -19,6 +26,7 @@ describe("card button values", () => {
     expect(decodeActionValue(value)).toEqual({
       tenantKey: encodeTenantKey(TENANT),
       excursionId: EXCURSION,
+      unreadableExcursion: false,
     });
   });
 
@@ -32,27 +40,29 @@ describe("card button values", () => {
     expect(decodeActionValue(value).excursionId).toBe(excursionId);
   });
 
-  it("names different tenants differently", () => {
-    expect(encodeTenantKey(TENANT)).not.toBe(encodeTenantKey(OTHER_TENANT));
+  it("names two tenants minted in the same millisecond differently", () => {
+    expect(encodeTenantKey(SAME_MS_A)).not.toBe(encodeTenantKey(SAME_MS_B));
   });
 
   it("names a tenant the same however the value spelled it", () => {
-    const legacy = decodeActionValue(`${TENANT.toUpperCase()}:${EXCURSION}`);
+    const value = `${TENANT.toUpperCase()}:${EXCURSION}`;
 
-    expect(legacy.tenantKey).toBe(encodeTenantKey(TENANT));
+    expect(decodeActionValue(value).tenantKey).toBe(encodeTenantKey(TENANT));
   });
 
   it("reads a single segment as a tenant with no excursion", () => {
     expect(decodeActionValue(TENANT)).toEqual({
       tenantKey: encodeTenantKey(TENANT),
       excursionId: null,
+      unreadableExcursion: false,
     });
   });
 
-  it("reads the pre-budget compound value", () => {
+  it("reads a value carrying two full UUIDs", () => {
     expect(decodeActionValue(`${TENANT}:${EXCURSION}`)).toEqual({
       tenantKey: encodeTenantKey(TENANT),
       excursionId: EXCURSION,
+      unreadableExcursion: false,
     });
   });
 
@@ -60,6 +70,7 @@ describe("card button values", () => {
     expect(decodeActionValue(value)).toEqual({
       tenantKey: null,
       excursionId: null,
+      unreadableExcursion: false,
     });
   });
 
@@ -67,13 +78,23 @@ describe("card button values", () => {
     expect(decodeActionValue(`:${EXCURSION}`)).toEqual({
       tenantKey: null,
       excursionId: null,
+      unreadableExcursion: false,
     });
   });
 
-  it("drops a second segment that is no excursion id", () => {
+  it("marks a second segment that is no excursion id unreadable", () => {
     expect(decodeActionValue(`${encodeTenantKey(TENANT)}:nonsense`)).toEqual({
       tenantKey: encodeTenantKey(TENANT),
       excursionId: null,
+      unreadableExcursion: true,
+    });
+  });
+
+  it("reads a trailing separator as naming no excursion", () => {
+    expect(decodeActionValue(`${encodeTenantKey(TENANT)}:`)).toEqual({
+      tenantKey: encodeTenantKey(TENANT),
+      excursionId: null,
+      unreadableExcursion: false,
     });
   });
 

--- a/src/Web/packages/bot/src/lib/action-value.test.ts
+++ b/src/Web/packages/bot/src/lib/action-value.test.ts
@@ -82,16 +82,21 @@ describe("card button values", () => {
     });
   });
 
-  it("marks a second segment that is no excursion id unreadable", () => {
-    expect(decodeActionValue(`${encodeTenantKey(TENANT)}:nonsense`)).toEqual({
-      tenantKey: encodeTenantKey(TENANT),
-      excursionId: null,
-      unreadableExcursion: true,
-    });
-  });
+  it.each(["nonsense", "*".repeat(22), "", ":"])(
+    "marks the second segment %p unreadable",
+    (segment) => {
+      const value = `${encodeTenantKey(TENANT)}:${segment}`;
 
-  it("reads a trailing separator as naming no excursion", () => {
-    expect(decodeActionValue(`${encodeTenantKey(TENANT)}:`)).toEqual({
+      expect(decodeActionValue(value)).toEqual({
+        tenantKey: encodeTenantKey(TENANT),
+        excursionId: null,
+        unreadableExcursion: true,
+      });
+    },
+  );
+
+  it("addresses only a tenant when the value carries no separator", () => {
+    expect(decodeActionValue(encodeTenantKey(TENANT))).toEqual({
       tenantKey: encodeTenantKey(TENANT),
       excursionId: null,
       unreadableExcursion: false,

--- a/src/Web/packages/bot/src/lib/action-value.test.ts
+++ b/src/Web/packages/bot/src/lib/action-value.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { encodeActionValue, decodeActionValue } from "./action-value.js";
+import {
+  encodeActionValue,
+  decodeActionValue,
+  encodeTenantKey,
+} from "./action-value.js";
 
 const TENANT = "11111111-1111-1111-1111-111111111111";
+const OTHER_TENANT = "22222222-2222-2222-2222-222222222222";
 const EXCURSION = "33333333-3333-3333-3333-333333333333";
 
 describe("card button values", () => {
@@ -11,31 +16,68 @@ describe("card button values", () => {
       excursionId: EXCURSION,
     });
 
-    expect(value).toBe(`${TENANT}:${EXCURSION}`);
     expect(decodeActionValue(value)).toEqual({
-      tenantId: TENANT,
+      tenantKey: encodeTenantKey(TENANT),
       excursionId: EXCURSION,
     });
   });
 
+  it.each([
+    "018f2a1b-0000-7000-8000-000000000000",
+    "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    "00000000-0000-0000-0000-000000000000",
+  ])("round-trips the excursion %s exactly", (excursionId) => {
+    const value = encodeActionValue({ tenantId: TENANT, excursionId });
+
+    expect(decodeActionValue(value).excursionId).toBe(excursionId);
+  });
+
+  it("names different tenants differently", () => {
+    expect(encodeTenantKey(TENANT)).not.toBe(encodeTenantKey(OTHER_TENANT));
+  });
+
+  it("names a tenant the same however the value spelled it", () => {
+    const legacy = decodeActionValue(`${TENANT.toUpperCase()}:${EXCURSION}`);
+
+    expect(legacy.tenantKey).toBe(encodeTenantKey(TENANT));
+  });
+
   it("reads a single segment as a tenant with no excursion", () => {
     expect(decodeActionValue(TENANT)).toEqual({
-      tenantId: TENANT,
+      tenantKey: encodeTenantKey(TENANT),
       excursionId: null,
+    });
+  });
+
+  it("reads the pre-budget compound value", () => {
+    expect(decodeActionValue(`${TENANT}:${EXCURSION}`)).toEqual({
+      tenantKey: encodeTenantKey(TENANT),
+      excursionId: EXCURSION,
     });
   });
 
   it.each([undefined, null, ""])("yields neither id for %p", (value) => {
     expect(decodeActionValue(value)).toEqual({
-      tenantId: null,
+      tenantKey: null,
       excursionId: null,
     });
   });
 
   it("drops an excursion that names no tenant", () => {
     expect(decodeActionValue(`:${EXCURSION}`)).toEqual({
-      tenantId: null,
+      tenantKey: null,
       excursionId: null,
     });
+  });
+
+  it("drops a second segment that is no excursion id", () => {
+    expect(decodeActionValue(`${encodeTenantKey(TENANT)}:nonsense`)).toEqual({
+      tenantKey: encodeTenantKey(TENANT),
+      excursionId: null,
+    });
+  });
+
+  it("keeps an unrecognised tenant segment so it matches no candidate", () => {
+    expect(decodeActionValue("nonsense").tenantKey).toBe("nonsense");
   });
 });

--- a/src/Web/packages/bot/src/lib/action-value.ts
+++ b/src/Web/packages/bot/src/lib/action-value.ts
@@ -1,23 +1,70 @@
 /**
  * Encoding for the `value` a card button round-trips back to its handler.
  *
- * A card addresses one tenant and, when the button acts on a single alert, one
- * excursion. Both are UUIDs, so a colon separates them unambiguously.
+ * A card addresses one tenant and the excursion its buttons act on. Both are
+ * UUIDs, and both together do not fit: Telegram caps `callback_data` at 64
+ * bytes, and `encodeTelegramCallbackData` in `@chat-adapter/telegram` spends
+ * `chat:{"a":"<actionId>","v":"<value>"}` on the envelope — 20 bytes plus the
+ * action id, leaving 35 for the value under `ack_alert`, the longest id an alert
+ * card carries. Two 36-character UUIDs need 73, and 32 raw bytes cannot be
+ * encoded into 35 printable ones either, so a tighter encoding alone is not
+ * enough. Over the limit the adapter throws and the whole delivery is marked
+ * failed, so the budget binds every adapter, not just Telegram.
+ *
+ * The excursion therefore travels as the base64url of its 16 raw bytes (22
+ * chars, lossless — the handler acknowledges it by id), and the tenant as a
+ * prefix of the same encoding, long enough only to pick one of the tapping
+ * user's own linked tenants out of a handful of server-generated UUIDs.
+ * 8 + 1 + 22 = 31 bytes, 60 with the `ack_alert` envelope.
  */
 const SEPARATOR = ":";
+const TENANT_KEY_CHARS = 8;
+
+const UUID = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
+const PACKED_UUID = /^[A-Za-z0-9_-]{22}$/;
+
+const packUuid = (uuid: string) =>
+  Buffer.from(uuid.replace(/-/g, ""), "hex").toString("base64url");
+
+const unpackUuid = (packed: string) => {
+  const hex = Buffer.from(packed, "base64url").toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
+};
+
+/** Reads either encoding, so buttons on cards posted before the budget fix still work. */
+const readUuid = (segment: string | undefined): string | null => {
+  if (!segment) return null;
+  if (UUID.test(segment)) return segment;
+  return PACKED_UUID.test(segment) ? unpackUuid(segment) : null;
+};
 
 export interface ActionTarget {
-  /** Tenant the card was posted for, or null if the value names none. */
-  tenantId: string | null;
+  /**
+   * Names the tenant the card was posted for, or null if the value names none.
+   * Opaque: match it against a candidate with {@link encodeTenantKey} rather
+   * than treating it as an id.
+   */
+  tenantKey: string | null;
   /** Excursion the button acts on, or null if the value addresses only a tenant. */
   excursionId: string | null;
+}
+
+/** The key a tenant id is named by inside a card button value. */
+export function encodeTenantKey(tenantId: string): string {
+  return packUuid(tenantId).slice(0, TENANT_KEY_CHARS);
 }
 
 export function encodeActionValue(target: {
   tenantId: string;
   excursionId: string;
 }): string {
-  return `${target.tenantId}${SEPARATOR}${target.excursionId}`;
+  return `${encodeTenantKey(target.tenantId)}${SEPARATOR}${packUuid(target.excursionId)}`;
 }
 
 /**
@@ -26,7 +73,10 @@ export function encodeActionValue(target: {
  * segment is empty yields neither.
  */
 export function decodeActionValue(value: string | null | undefined): ActionTarget {
-  const [tenantId, excursionId] = (value ?? "").split(SEPARATOR);
-  if (!tenantId) return { tenantId: null, excursionId: null };
-  return { tenantId, excursionId: excursionId || null };
+  const [tenant, excursion] = (value ?? "").split(SEPARATOR);
+  if (!tenant) return { tenantKey: null, excursionId: null };
+  return {
+    tenantKey: UUID.test(tenant) ? encodeTenantKey(tenant) : tenant,
+    excursionId: readUuid(excursion),
+  };
 }

--- a/src/Web/packages/bot/src/lib/action-value.ts
+++ b/src/Web/packages/bot/src/lib/action-value.ts
@@ -77,17 +77,20 @@ export function encodeActionValue(target: {
 }
 
 /**
- * A value with no second segment addresses only a tenant. An excursion is
- * meaningless without the tenant to resolve it against, so a value whose first
- * segment is empty yields neither.
+ * A value carrying no separator at all addresses only a tenant; a separator is
+ * an attempt to name an excursion, and one that does not decode — including an
+ * empty one — is unreadable rather than absent. An excursion is meaningless
+ * without the tenant to resolve it against, so a value whose first segment is
+ * empty yields neither.
  */
 export function decodeActionValue(value: string | null | undefined): ActionTarget {
-  const [tenant, excursion] = (value ?? "").split(SEPARATOR);
+  const raw = value ?? "";
+  const [tenant, excursion] = raw.split(SEPARATOR);
   if (!tenant) return { tenantKey: null, excursionId: null, unreadableExcursion: false };
-  const excursionId = excursion ? readUuid(excursion) : null;
+  const excursionId = readUuid(excursion ?? "");
   return {
     tenantKey: UUID.test(tenant) ? encodeTenantKey(tenant) : tenant,
     excursionId,
-    unreadableExcursion: Boolean(excursion) && excursionId === null,
+    unreadableExcursion: raw.includes(SEPARATOR) && excursionId === null,
   };
 }

--- a/src/Web/packages/bot/src/lib/action-value.ts
+++ b/src/Web/packages/bot/src/lib/action-value.ts
@@ -12,10 +12,14 @@
  * failed, so the budget binds every adapter, not just Telegram.
  *
  * The excursion therefore travels as the base64url of its 16 raw bytes (22
- * chars, lossless — the handler acknowledges it by id), and the tenant as a
- * prefix of the same encoding, long enough only to pick one of the tapping
- * user's own linked tenants out of a handful of server-generated UUIDs.
- * 8 + 1 + 22 = 31 bytes, 60 with the `ack_alert` envelope.
+ * chars, lossless — the handler acknowledges it by id), and the tenant as the
+ * *last* 8 characters of the same encoding. The slice has to come off the tail:
+ * a tenant id is a UUIDv7 whose leading 48 bits are its creation millisecond,
+ * so tenants provisioned concurrently share their head outright, while the
+ * trailing bytes are rand_b and are random. Those 8 characters name one of the
+ * tapping user's own linked tenants; a key matching two of them is refused by
+ * {@link pickCandidate} rather than guessed. 8 + 1 + 22 = 31 bytes, 60 with the
+ * `ack_alert` envelope.
  */
 const SEPARATOR = ":";
 const TENANT_KEY_CHARS = 8;
@@ -37,9 +41,8 @@ const unpackUuid = (packed: string) => {
   ].join("-");
 };
 
-/** Reads either encoding, so buttons on cards posted before the budget fix still work. */
-const readUuid = (segment: string | undefined): string | null => {
-  if (!segment) return null;
+/** Reads an excursion segment written either as a full UUID or as its packed form. */
+const readUuid = (segment: string): string | null => {
   if (UUID.test(segment)) return segment;
   return PACKED_UUID.test(segment) ? unpackUuid(segment) : null;
 };
@@ -51,13 +54,19 @@ export interface ActionTarget {
    * than treating it as an id.
    */
   tenantKey: string | null;
-  /** Excursion the button acts on, or null if the value addresses only a tenant. */
+  /** Excursion the button acts on, or null if the value names none or names one that cannot be read. */
   excursionId: string | null;
+  /**
+   * The value names an excursion that does not decode. The action has to fail:
+   * widening to every alert of the tenant would silence more than the card is
+   * about.
+   */
+  unreadableExcursion: boolean;
 }
 
 /** The key a tenant id is named by inside a card button value. */
 export function encodeTenantKey(tenantId: string): string {
-  return packUuid(tenantId).slice(0, TENANT_KEY_CHARS);
+  return packUuid(tenantId).slice(-TENANT_KEY_CHARS);
 }
 
 export function encodeActionValue(target: {
@@ -74,9 +83,11 @@ export function encodeActionValue(target: {
  */
 export function decodeActionValue(value: string | null | undefined): ActionTarget {
   const [tenant, excursion] = (value ?? "").split(SEPARATOR);
-  if (!tenant) return { tenantKey: null, excursionId: null };
+  if (!tenant) return { tenantKey: null, excursionId: null, unreadableExcursion: false };
+  const excursionId = excursion ? readUuid(excursion) : null;
   return {
     tenantKey: UUID.test(tenant) ? encodeTenantKey(tenant) : tenant,
-    excursionId: readUuid(excursion),
+    excursionId,
+    unreadableExcursion: Boolean(excursion) && excursionId === null,
   };
 }

--- a/src/Web/packages/bot/src/lib/require-link.ts
+++ b/src/Web/packages/bot/src/lib/require-link.ts
@@ -1,6 +1,6 @@
 import type { ActionEvent, SlashCommandEvent } from "chat";
 import { getUnscopedApi, runWithResolvedLink, type ResolvedLink } from "./request-context.js";
-import { decodeActionValue } from "./action-value.js";
+import { decodeActionValue, encodeTenantKey } from "./action-value.js";
 import type { DirectoryCandidate } from "../types.js";
 
 interface LinkResolutionInput {
@@ -9,7 +9,7 @@ interface LinkResolutionInput {
   /** Label typed as a command argument. Actions carry no text, so null. */
   labelArg: string | null;
   /** Tenant the invocation is already bound to (from a card button's value). Wins over labelArg. */
-  tenantId: string | null;
+  tenantKey: string | null;
   /** Appended to the ambiguity message to tell the user how to pick. */
   disambiguationHint: string;
 }
@@ -112,7 +112,7 @@ async function withResolvedLink<T>(
     return null;
   }
 
-  const picked = pickCandidate(candidates, input.labelArg, input.tenantId);
+  const picked = pickCandidate(candidates, input.labelArg, input.tenantKey);
   const availableLabels = candidates.map((c) => `\`${c.label}\``).join(", ");
 
   if (picked === "ambiguous") {
@@ -188,7 +188,7 @@ export async function requireLink<T>(
       platform: event.adapter.name,
       platformUserId: event.user.userId,
       labelArg: event.text?.trim().toLowerCase() || null,
-      tenantId: null,
+      tenantKey: null,
       disambiguationHint: `Use \`${event.command} <label>\` to pick one, or set a default in Settings → Integrations → Discord.`,
     },
     (message) =>
@@ -224,7 +224,7 @@ export async function requireLinkForAction<T>(
       platform: event.adapter.name,
       platformUserId: event.user.userId,
       labelArg: null,
-      tenantId: decodeActionValue(event.value).tenantId,
+      tenantKey: decodeActionValue(event.value).tenantKey,
       disambiguationHint:
         "Set a default in Settings → Integrations → Discord, or use the matching slash command with a label.",
     },
@@ -237,8 +237,8 @@ export async function requireLinkForAction<T>(
 
 /**
  * Selects a single DirectoryCandidate from a non-empty list, preferring a bound
- * `tenantId`, then an explicit `labelArg`, then the sole default link. Returns
- * "tenant-not-linked" if `tenantId` names a tenant the user has no link to,
+ * `tenantKey`, then an explicit `labelArg`, then the sole default link. Returns
+ * "tenant-not-linked" if `tenantKey` names a tenant the user has no link to,
  * "ambiguous" if no disambiguation is possible, or "not-found" if the label arg
  * doesn't match any candidate.
  *
@@ -247,14 +247,13 @@ export async function requireLinkForAction<T>(
 function pickCandidate(
   candidates: DirectoryCandidate[],
   labelArg: string | null,
-  tenantId: string | null,
+  tenantKey: string | null,
 ): DirectoryCandidate | "ambiguous" | "not-found" | "tenant-not-linked" {
   // A bound tenant is authoritative: acting on a different one would silently
   // hit the wrong patient's data.
-  if (tenantId) {
-    const wanted = tenantId.toLowerCase();
+  if (tenantKey) {
     return (
-      candidates.find((c) => c.tenantId.toLowerCase() === wanted) ??
+      candidates.find((c) => encodeTenantKey(c.tenantId) === tenantKey) ??
       "tenant-not-linked"
     );
   }

--- a/src/Web/packages/bot/src/lib/require-link.ts
+++ b/src/Web/packages/bot/src/lib/require-link.ts
@@ -239,8 +239,9 @@ export async function requireLinkForAction<T>(
  * Selects a single DirectoryCandidate from a non-empty list, preferring a bound
  * `tenantKey`, then an explicit `labelArg`, then the sole default link. Returns
  * "tenant-not-linked" if `tenantKey` names a tenant the user has no link to,
- * "ambiguous" if no disambiguation is possible, or "not-found" if the label arg
- * doesn't match any candidate.
+ * "ambiguous" if no disambiguation is possible — including a `tenantKey` two of
+ * the candidates answer to — or "not-found" if the label arg doesn't match any
+ * candidate.
  *
  * Pure function — no side effects, easy to reason about.
  */
@@ -250,12 +251,14 @@ function pickCandidate(
   tenantKey: string | null,
 ): DirectoryCandidate | "ambiguous" | "not-found" | "tenant-not-linked" {
   // A bound tenant is authoritative: acting on a different one would silently
-  // hit the wrong patient's data.
+  // hit the wrong patient's data. The key names a tenant rather than being one,
+  // so two candidates can answer to it; that is a refusal, not a coin toss.
   if (tenantKey) {
-    return (
-      candidates.find((c) => encodeTenantKey(c.tenantId) === tenantKey) ??
-      "tenant-not-linked"
+    const matched = candidates.filter(
+      (c) => encodeTenantKey(c.tenantId) === tenantKey,
     );
+    if (matched.length === 1) return matched[0]!;
+    return matched.length === 0 ? "tenant-not-linked" : "ambiguous";
   }
 
   // Single candidate: always return it, ignoring any label arg the user typed.

--- a/src/Web/packages/bot/tsconfig.json
+++ b/src/Web/packages/bot/tsconfig.json
@@ -20,5 +20,5 @@
     "jsxImportSource": "chat"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-utils.ts"]
 }


### PR DESCRIPTION
Closes #1177.

## The defect

`@chat-adapter/telegram` enforces Telegram's 64-byte `callback_data` limit. The alert card's button value was `tenantId:excursionId`, two UUIDs, which puts the encoded payload at 102 bytes. The adapter threw, `deliver.ts` caught it and marked the delivery failed, so no alert card has ever reached Telegram. Discord's 100-byte limit hid the problem there.

## The change

Two UUIDs cannot fit under any encoding, and neither a delivery id nor an excursion id can be resolved to its tenant server-side: those rows are RLS-scoped and the app role is `NOBYPASSRLS`. The value therefore carries an 8-character tenant key plus the excursion id packed to 22 base64url characters. One encoding for every adapter.

| Action | Envelope bytes |
|---|---|
| `ack_alert` | 60 |
| `mute_30` | 58 |

The tenant key is the last 8 base64url characters of the packed tenant UUID. Tenant ids are UUIDv7, whose leading 48 bits are the creation millisecond, so a head slice would collide for tenants provisioned in the same millisecond; the tail is `rand_b`. The key is only ever compared against the tapping user's own linked tenants; a key matching two of them is refused with the existing multiple-accounts reply rather than guessed.

Legacy values still decode: a full tenant UUID as the first segment is normalised through the same key derivation, so cards already posted to Discord and Slack keep working.

A value with a separator whose second segment does not decode, including an empty one, now declines ("Couldn't tell which alert this button is for. Nothing was acknowledged.") instead of falling through to the tenant-wide acknowledge. Only a value with no separator at all, the pre-#1183 bare-tenant card, addresses the whole tenant.

## Tests

The budget test renders `AlertCard` and checks every button against the adapter's envelope byte for byte (the encoder is not exported; the replication is compared against `dist/index.js`). It fails on the old encoding at 102 bytes. Mutations each killed by a named test: head-slice key, 4-character key, first-match-wins on ambiguity, legacy decode dropped, unreadable segment falling through to tenant-wide ack.
