### PR TITLE
fix(statistics): count one episode per excursion, and measure time-in-range durations from the readings

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -1024,9 +1024,7 @@ public class StatisticsController : ControllerBase
                 .Select(e => new PunchCardEntry { Mills = e.Mills, Mgdl = e.Mgdl })
                 .ToList();
 
-            // The counts are readings, so they come from the readings. A duration is wall-clock
-            // time at whatever cadence the sensor ran at, so dividing one by a fixed interval
-            // undercounts a one-minute sensor and invents readings across a gap.
+            // The counts are readings, so they come from the readings, not from durations.
             var totalReadings = entries.Count;
             var inRangeCount = (int)Math.Round(inRangePct / 100.0 * totalReadings);
             var lowCount = (int)Math.Round(lowPct / 100.0 * totalReadings);

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -1007,14 +1007,6 @@ public class StatisticsController : ControllerBase
             var lowPct = (pct?.VeryLow ?? 0) + (pct?.Low ?? 0);
             var highPct = (pct?.VeryHigh ?? 0) + (pct?.High ?? 0);
 
-            var dur = tir?.Durations;
-            var totalMinutes = (dur?.VeryLow ?? 0) + (dur?.Low ?? 0)
-                + (dur?.Target ?? 0) + (dur?.High ?? 0) + (dur?.VeryHigh ?? 0);
-            var totalReadings = (int)Math.Round(totalMinutes / 5.0);
-            var inRangeCount = (int)Math.Round(inRangePct / 100.0 * totalReadings);
-            var lowCount = (int)Math.Round(lowPct / 100.0 * totalReadings);
-            var highCount = (int)Math.Round(highPct / 100.0 * totalReadings);
-
             var rangeStats = tir?.RangeStats;
             var avgGlucose = rangeStats?.Target?.Mean ?? rangeStats?.Low?.Mean ?? 0;
 
@@ -1031,6 +1023,14 @@ public class StatisticsController : ControllerBase
                 .OrderBy(e => e.Mills)
                 .Select(e => new PunchCardEntry { Mills = e.Mills, Mgdl = e.Mgdl })
                 .ToList();
+
+            // The counts are readings, so they come from the readings. A duration is wall-clock
+            // time at whatever cadence the sensor ran at, so dividing one by a fixed interval
+            // undercounts a one-minute sensor and invents readings across a gap.
+            var totalReadings = entries.Count;
+            var inRangeCount = (int)Math.Round(inRangePct / 100.0 * totalReadings);
+            var lowCount = (int)Math.Round(lowPct / 100.0 * totalReadings);
+            var highCount = (int)Math.Round(highPct / 100.0 * totalReadings);
 
             var dayStats = new PunchCardDay
             {

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -675,7 +675,7 @@ public class StatisticsService : IStatisticsService
     /// <returns>Basic glucose statistics including mean, median, percentiles, etc.</returns>
     public BasicGlucoseStats CalculateBasicStats(IEnumerable<double> glucoseValues)
     {
-        var values = glucoseValues.Where(v => v > 0 && v < 600).ToList();
+        var values = glucoseValues.Where(IsPlausibleReading).ToList();
 
         if (!values.Any())
         {
@@ -773,8 +773,9 @@ public class StatisticsService : IStatisticsService
         return entries.Where(IsPlausibleReading).Select(entry => entry.Mgdl);
     }
 
-    private static bool IsPlausibleReading(SensorGlucose entry) =>
-        entry.Mgdl > 0 && entry.Mgdl < 600;
+    private static bool IsPlausibleReading(SensorGlucose entry) => IsPlausibleReading(entry.Mgdl);
+
+    private static bool IsPlausibleReading(double mgdl) => mgdl > 0 && mgdl < 600;
 
     #endregion
 
@@ -1360,7 +1361,7 @@ public class StatisticsService : IStatisticsService
         foreach (var entry in entries)
         {
             var value = entry.Mgdl;
-            if (value <= 0 || value >= 600)
+            if (!IsPlausibleReading(value))
                 continue;
 
             var minute =
@@ -1483,8 +1484,9 @@ public class StatisticsService : IStatisticsService
     }
 
     /// <summary>
-    /// The cadence assumed for a series whose entries do not show one: a single reading, or
-    /// several stamped at the same instant.
+    /// The gap credited to the final reading of a series whose entries show no gap of their own:
+    /// a lone reading, or several stamped at the same instant. The readings before it in such a
+    /// series cover no elapsed time and are credited none.
     /// </summary>
     private const double DefaultCadenceMinutes = 5;
 
@@ -2916,7 +2918,7 @@ public class StatisticsService : IStatisticsService
                 Mills = e.Mills,
                 Glucose = e.Mgdl,
             })
-            .Where(e => e.Glucose > 0 && e.Glucose < 600) // Filter invalid readings
+            .Where(e => IsPlausibleReading(e.Glucose))
             .OrderBy(e => e.Mills)
             .ToList();
 

--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -770,8 +770,11 @@ public class StatisticsService : IStatisticsService
     /// <returns>Collection of glucose values in mg/dL</returns>
     public IEnumerable<double> ExtractGlucoseValues(IEnumerable<SensorGlucose> entries)
     {
-        return entries.Select(entry => entry.Mgdl).Where(value => value > 0 && value < 600);
+        return entries.Where(IsPlausibleReading).Select(entry => entry.Mgdl);
     }
+
+    private static bool IsPlausibleReading(SensorGlucose entry) =>
+        entry.Mgdl > 0 && entry.Mgdl < 600;
 
     #endregion
 
@@ -1224,7 +1227,9 @@ public class StatisticsService : IStatisticsService
     {
         thresholds ??= new GlycemicThresholds();
 
-        var entriesList = entries.Where(e => e.Mgdl > 0).OrderBy(e => e.Mills).ToList();
+        // Filtered on the same predicate as the values, so entry i is the reading value i came
+        // from and the minutes derived from the entry timestamps line up with it.
+        var entriesList = entries.Where(IsPlausibleReading).OrderBy(e => e.Mills).ToList();
 
         var glucoseValues = ExtractGlucoseValues(entriesList).ToList();
         var totalReadings = glucoseValues.Count;
@@ -1245,12 +1250,30 @@ public class StatisticsService : IStatisticsService
         // scale rather than read off it.
         var zones = ExcludingZones(thresholds);
         var zoneCounts = new int[zones.ZoneCount];
+        var zoneMinutes = new double[zones.ZoneCount];
         int targetCount = 0, tightTargetCount = 0;
-        foreach (var v in glucoseValues)
+        double targetMinutes = 0, tightTargetMinutes = 0;
+        var readingMinutes = ReadingMinutes(entriesList);
+        for (var i = 0; i < totalReadings; i++)
         {
-            zoneCounts[zones.Classify(v)]++;
-            if (v >= thresholds.TargetBottom && v <= thresholds.TargetTop) targetCount++;
-            if (v >= thresholds.TightTargetBottom && v <= thresholds.TightTargetTop) tightTargetCount++;
+            var v = glucoseValues[i];
+            var minutes = readingMinutes[i];
+
+            var zone = zones.Classify(v);
+            zoneCounts[zone]++;
+            zoneMinutes[zone] += minutes;
+
+            if (v >= thresholds.TargetBottom && v <= thresholds.TargetTop)
+            {
+                targetCount++;
+                targetMinutes += minutes;
+            }
+
+            if (v >= thresholds.TightTargetBottom && v <= thresholds.TightTargetTop)
+            {
+                tightTargetCount++;
+                tightTargetMinutes += minutes;
+            }
         }
 
         var veryLowCount = zoneCounts[(int)ExcludingZone.VeryLow];
@@ -1269,20 +1292,18 @@ public class StatisticsService : IStatisticsService
             VeryHigh = (double)veryHighCount / totalReadings * 100,
         };
 
-        // Calculate durations (assuming 5-minute intervals)
-        const int intervalMinutes = 5;
         var durations = new TimeInRangeDurations
         {
-            VeryLow = (long)veryLowCount * intervalMinutes,
-            Low = (long)lowCount * intervalMinutes,
-            Target = (long)targetCount * intervalMinutes,
-            TightTarget = (long)tightTargetCount * intervalMinutes,
-            High = (long)highCount * intervalMinutes,
-            VeryHigh = (long)veryHighCount * intervalMinutes,
-            AboveRange = (long)(highCount + veryHighCount) * intervalMinutes,
+            VeryLow = zoneMinutes[(int)ExcludingZone.VeryLow],
+            Low = zoneMinutes[(int)ExcludingZone.Low],
+            Target = targetMinutes,
+            TightTarget = tightTargetMinutes,
+            High = zoneMinutes[(int)ExcludingZone.High],
+            VeryHigh = zoneMinutes[(int)ExcludingZone.VeryHigh],
+            AboveRange =
+                zoneMinutes[(int)ExcludingZone.High] + zoneMinutes[(int)ExcludingZone.VeryHigh],
         };
 
-        // Calculate episodes (simplified - consecutive readings in same range)
         var episodes = CalculateEpisodes(glucoseValues, thresholds);
 
         // Calculate per-range detailed statistics
@@ -1397,46 +1418,95 @@ public class StatisticsService : IStatisticsService
         };
     }
 
-    private TimeInRangeEpisodes CalculateEpisodes(
+    /// <summary>
+    /// A run of consecutive readings on the same side of target is one episode, counted against
+    /// the most extreme zone the run reached — so a rise through High into VeryHigh and back is
+    /// one very-high episode, not three. <see cref="ExcludingZone"/> lists the severe zone of each
+    /// side ahead of the milder one, so the most extreme zone of a run is the lowest-numbered.
+    /// </summary>
+    private static TimeInRangeEpisodes CalculateEpisodes(
         IList<double> glucoseValues,
         GlycemicThresholds thresholds
     )
     {
-        var episodes = new TimeInRangeEpisodes();
-
-        if (!glucoseValues.Any())
-            return episodes;
-
         var zones = ExcludingZones(thresholds);
         var episodeCounts = new int[zones.ZoneCount];
-        var lastZone = -1;
         var aboveRange = 0;
+        var side = 0;
+        var extreme = (int)ExcludingZone.Target;
 
         foreach (var value in glucoseValues)
         {
             var zone = zones.Classify(value);
+            var zoneSide = Side(zone);
 
-            if (zone != lastZone && zone != (int)ExcludingZone.Target)
-                episodeCounts[zone]++;
-
-            // One excursion above range may cross between High and VeryHigh any number of
-            // times; it is one excursion, so it is counted on entry only.
-            if (IsAboveRange(zone) && !IsAboveRange(lastZone))
-                aboveRange++;
-
-            lastZone = zone;
+            if (zoneSide != side)
+            {
+                CloseEpisode();
+                side = zoneSide;
+                extreme = zone;
+            }
+            else if (zone < extreme)
+            {
+                extreme = zone;
+            }
         }
 
-        episodes.VeryLow = episodeCounts[(int)ExcludingZone.VeryLow];
-        episodes.Low = episodeCounts[(int)ExcludingZone.Low];
-        episodes.High = episodeCounts[(int)ExcludingZone.High];
-        episodes.VeryHigh = episodeCounts[(int)ExcludingZone.VeryHigh];
-        episodes.AboveRange = aboveRange;
+        CloseEpisode();
 
-        return episodes;
+        return new TimeInRangeEpisodes
+        {
+            VeryLow = episodeCounts[(int)ExcludingZone.VeryLow],
+            Low = episodeCounts[(int)ExcludingZone.Low],
+            High = episodeCounts[(int)ExcludingZone.High],
+            VeryHigh = episodeCounts[(int)ExcludingZone.VeryHigh],
+            AboveRange = aboveRange,
+        };
 
-        static bool IsAboveRange(int zone) =>
-            zone is (int)ExcludingZone.High or (int)ExcludingZone.VeryHigh;
+        void CloseEpisode()
+        {
+            if (side == 0)
+                return;
+
+            episodeCounts[extreme]++;
+            if (side > 0)
+                aboveRange++;
+        }
+
+        static int Side(int zone) =>
+            zone switch
+            {
+                (int)ExcludingZone.VeryLow or (int)ExcludingZone.Low => -1,
+                (int)ExcludingZone.VeryHigh or (int)ExcludingZone.High => 1,
+                _ => 0,
+            };
+    }
+
+    /// <summary>
+    /// The cadence assumed for a series whose entries do not show one: a single reading, or
+    /// several stamped at the same instant.
+    /// </summary>
+    private const double DefaultCadenceMinutes = 5;
+
+    /// <summary>
+    /// The minutes each reading stands for: the gap to the next reading, capped at twice the
+    /// series' median gap so that a stretch the sensor did not cover is not credited to the zone
+    /// the last reading before it happened to be in. The final reading stands for one median gap.
+    /// </summary>
+    private static double[] ReadingMinutes(IList<SensorGlucose> sortedEntries)
+    {
+        var minutes = new double[sortedEntries.Count];
+        for (var i = 1; i < sortedEntries.Count; i++)
+            minutes[i - 1] = (sortedEntries[i].Mills - sortedEntries[i - 1].Mills) / 60000.0;
+
+        var gaps = minutes.Take(sortedEntries.Count - 1).Where(g => g > 0).Order().ToList();
+        var cadence = gaps.Count == 0 ? DefaultCadenceMinutes : GlucoseStatistics.Median(gaps);
+
+        for (var i = 0; i < sortedEntries.Count - 1; i++)
+            minutes[i] = Math.Min(minutes[i], cadence * 2);
+        minutes[^1] = cadence;
+
+        return minutes;
     }
 
     #endregion

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -336,7 +336,9 @@ public class ExtendedTimeInRangePercentages
 /// <summary>
 /// Time in range durations (in minutes), measured from the gaps between the readings themselves
 /// rather than assuming a cadence, so a one-minute sensor and a five-minute one both report the
-/// time they actually covered. A gap the sensor did not cover counts as one reading interval.
+/// time they actually covered. A gap the sensor did not cover counts as one extra median gap.
+/// <see cref="TimeInRangePercentages"/> counts readings while these sum time, so the two diverge
+/// on a series with gaps or a cadence that varies.
 /// </summary>
 public class TimeInRangeDurations
 {
@@ -406,7 +408,8 @@ public class TimeInRangeEpisodes
 
     /// <summary>
     /// Number of excursions above range, which is <see cref="High"/> plus <see cref="VeryHigh"/>:
-    /// every excursion above target is counted once, against whichever of the two it reached.
+    /// every excursion above target is counted once, against the more extreme of the two it
+    /// reached.
     /// </summary>
     public int AboveRange { get; set; }
 }

--- a/src/Core/Nocturne.Core.Models/StatisticsModels.cs
+++ b/src/Core/Nocturne.Core.Models/StatisticsModels.cs
@@ -334,7 +334,9 @@ public class ExtendedTimeInRangePercentages
 }
 
 /// <summary>
-/// Time in range durations (in minutes)
+/// Time in range durations (in minutes), measured from the gaps between the readings themselves
+/// rather than assuming a cadence, so a one-minute sensor and a five-minute one both report the
+/// time they actually covered. A gap the sensor did not cover counts as one reading interval.
 /// </summary>
 public class TimeInRangeDurations
 {
@@ -376,7 +378,9 @@ public class TimeInRangeDurations
 }
 
 /// <summary>
-/// Time in range episodes
+/// Time in range episodes. A run of consecutive readings on the same side of target is one
+/// episode, counted against the most extreme zone the run reached: a rise from high into very
+/// high and back is one very-high episode, not a high one and a very-high one.
 /// </summary>
 public class TimeInRangeEpisodes
 {
@@ -401,9 +405,8 @@ public class TimeInRangeEpisodes
     public int VeryHigh { get; set; }
 
     /// <summary>
-    /// Number of excursions above range. A run of consecutive readings in <see cref="High"/> or
-    /// <see cref="VeryHigh"/> is one excursion however often it crosses between the two, so this
-    /// is at most, and usually less than, the sum of those counts.
+    /// Number of excursions above range, which is <see cref="High"/> plus <see cref="VeryHigh"/>:
+    /// every excursion above target is counted once, against whichever of the two it reached.
     /// </summary>
     public int AboveRange { get; set; }
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsControllerTests.cs
@@ -399,4 +399,51 @@ public class StatisticsControllerTests
         capturedFrom.Should().Be(new DateTime(2026, 5, 31, 22, 0, 0, DateTimeKind.Utc));
         capturedTo.Should().Be(new DateTime(2026, 6, 2, 21, 59, 59, 999, DateTimeKind.Utc).AddTicks(9999));
     }
+
+    [Fact]
+    public async Task GetPunchCardData_CountsTheReadingsThemselvesRatherThanDividingDurations()
+    {
+        // A one-minute sensor: 60 readings covering 60 minutes, which the old count of
+        // duration-minutes over a five-minute interval would have reported as 12 readings.
+        var dayStart = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var readings = Enumerable
+            .Range(0, 60)
+            .Select(i => new SensorGlucose { Timestamp = dayStart.AddMinutes(i), Mgdl = 100 })
+            .ToArray();
+
+        _glucoseRepoMock
+            .Setup(r => r.GetAsync(
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>(), It.IsAny<Guid?>()))
+            .ReturnsAsync(readings);
+        SetupEmptyTreatments();
+        _statsServiceMock
+            .Setup(s => s.CalculateTimeInRange(
+                It.IsAny<IEnumerable<SensorGlucose>>(),
+                It.IsAny<GlycemicThresholds?>()))
+            .Returns(new TimeInRangeMetrics
+            {
+                Percentages = new TimeInRangePercentages { Target = 100 },
+                Durations = new TimeInRangeDurations { Target = 60 },
+                RangeStats = new TimeInRangeDetailedStats
+                {
+                    Target = new PeriodMetrics { PeriodName = "In Range", Mean = 100 },
+                },
+            });
+
+        var result = await CreateController().GetPunchCardData(dayStart, dayStart.AddDays(1));
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<PunchCardResponse>().Subject;
+        var month = payload.Months.Should().ContainSingle().Subject;
+        var day = month.Days.Should().ContainSingle(d => d.Date == "2026-06-01").Subject;
+
+        day.TotalReadings.Should().Be(60);
+        day.InRangeCount.Should().Be(60);
+        month.TotalReadings.Should().Be(60);
+        month.Summary!.TotalReadings.Should().Be(60);
+    }
 }

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/GlucoseStatisticsCharacterisationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/GlucoseStatisticsCharacterisationTests.cs
@@ -316,9 +316,11 @@ public class GlucoseStatisticsCharacterisationTests
         result.Durations.High.Should().Be(10);
         result.Durations.VeryHigh.Should().Be(5);
 
+        // The ascending edges are one excursion below target and one above, each counted against
+        // the most extreme zone it reached.
         result.Episodes.VeryLow.Should().Be(1);
-        result.Episodes.Low.Should().Be(1);
-        result.Episodes.High.Should().Be(1);
+        result.Episodes.Low.Should().Be(0);
+        result.Episodes.High.Should().Be(0);
         result.Episodes.VeryHigh.Should().Be(1);
     }
 

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceClinicalAccuracyTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceClinicalAccuracyTests.cs
@@ -280,8 +280,12 @@ public class StatisticsServiceClinicalAccuracyTests
     [Fact]
     public void CalculateTimeInRange_DurationsShouldMatchReadingCount()
     {
-        // 20 entries * 5 min interval = 100 minutes total
-        var entries = Enumerable.Range(0, 20).Select(_ => new SensorGlucose { Mgdl = 120 }).ToArray();
+        // 20 entries five minutes apart = 100 minutes total
+        var start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entries = Enumerable
+            .Range(0, 20)
+            .Select(i => new SensorGlucose { Mgdl = 120, Timestamp = start.AddMinutes(i * 5) })
+            .ToArray();
 
         var result = _sut.CalculateTimeInRange(entries);
 
@@ -1319,35 +1323,29 @@ public class StatisticsServiceClinicalAccuracyTests
     #region Edge Case: Episode Counting Across Severity Boundaries
 
     /// <summary>
-    /// When glucose drops from target → severe low → low → target,
-    /// the current implementation counts this as 1 severe low episode + 1 low episode.
-    /// Clinically this is a single continuous hypoglycemic event.
+    /// A drop from target through severe low, recovering through low, is one continuous
+    /// hypoglycemic event and is reported as one episode, against the severe zone it reached.
     /// </summary>
     [Fact]
-    public void TimeInRange_Episodes_VeryLowToLowTransition_CountsSeparateEpisodes()
+    public void TimeInRange_Episodes_VeryLowToLowTransition_CountsOneEpisode()
     {
         var entries = new[]
         {
             new SensorGlucose { Mgdl = 120 }, // target
             new SensorGlucose { Mgdl = 45 },  // severe low — episode starts
             new SensorGlucose { Mgdl = 45 },  // severe low — continues
-            new SensorGlucose { Mgdl = 60 },  // low — this is a DIFFERENT range, counts as new episode
+            new SensorGlucose { Mgdl = 60 },  // low — recovering, still the same event
             new SensorGlucose { Mgdl = 60 },  // low — continues
-            new SensorGlucose { Mgdl = 120 }, // back to target
+            new SensorGlucose { Mgdl = 120 }, // back to target — event ends
         };
 
         var result = _sut.CalculateTimeInRange(entries);
 
-        // Current behavior: counts separate episodes for severity transitions
-        // This means one continuous hypo event gets counted as 2 episodes
         result.Episodes.VeryLow.Should().Be(1);
-        result.Episodes.Low.Should().Be(1);
+        result.Episodes.Low.Should().Be(0);
 
-        // Total hypo "episodes" reported = 2, but clinically it was 1 event
         var totalHypoEpisodes = result.Episodes.VeryLow + result.Episodes.Low;
-        totalHypoEpisodes.Should().Be(2,
-            "current implementation counts severity transitions as separate episodes — " +
-            "consider whether a single continuous hypo event should be counted as 1 episode");
+        totalHypoEpisodes.Should().Be(1, "one continuous hypo event is one episode");
     }
 
     #endregion

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
@@ -384,6 +384,22 @@ public class StatisticsServiceTests
         result.Durations.Target.Should().Be(10);
     }
 
+    [Fact]
+    public void CalculateTimeInRange_Durations_CreditReadingsStampedAtTheSameInstantWithOneInterval()
+    {
+        // Readings sharing a timestamp cover no time between them, so only the last is credited.
+        var at = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entries = Enumerable
+            .Range(0, 4)
+            .Select(_ => new SensorGlucose { Mgdl = 100, Timestamp = at })
+            .ToArray();
+
+        var result = _statisticsService.CalculateTimeInRange(entries);
+
+        result.Durations.Target.Should().Be(5);
+        result.Percentages.Target.Should().Be(100);
+    }
+
     private static SensorGlucose[] Sequence(params int[] mgdl) => Sequence(5, mgdl);
 
     private static SensorGlucose[] Sequence(double cadenceMinutes, params int[] mgdl)

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
@@ -286,33 +286,114 @@ public class StatisticsServiceTests
         result.Durations.VeryHigh.Should().Be(5);
         result.Durations.Low.Should().Be(5);
         result.Durations.AboveRange.Should().Be(15);
-        // The zone counters see 200 then 300 as one High and one VeryHigh episode; above range
-        // it is a single excursion, and the later 200 the second.
-        result.Episodes.High.Should().Be(2);
+        // 200 then 300 is one excursion, counted against the very-high zone it reached; the
+        // later 200 is a second, counted against high.
+        result.Episodes.High.Should().Be(1);
         result.Episodes.VeryHigh.Should().Be(1);
         result.Episodes.Low.Should().Be(1);
         result.Episodes.AboveRange.Should().Be(2);
     }
 
     [Fact]
-    public void CalculateTimeInRange_AboveRangeEpisodes_CountAnExcursionOnceHoweverOftenItCrossesVeryHigh()
+    public void CalculateTimeInRange_Episodes_CountAnExcursionOnceAgainstTheMostExtremeZoneItReached()
     {
-        // High, VeryHigh, High, Target, High: the zone counters report three High episodes.
-        var result = _statisticsService.CalculateTimeInRange(Sequence(190, 260, 190, 100, 190));
+        // High, VeryHigh, High, Target, High.
+        var result = _statisticsService.CalculateTimeInRange(Sequence(180, 260, 190, 100, 190));
 
-        result.Episodes.High.Should().Be(3);
+        result.Episodes.High.Should().Be(1);
         result.Episodes.VeryHigh.Should().Be(1);
         result.Episodes.AboveRange.Should().Be(2);
     }
 
-    private static SensorGlucose[] Sequence(params int[] mgdl)
+    [Fact]
+    public void CalculateTimeInRange_Episodes_CountAHypoThatDeepensAndRecoversOnce()
     {
-        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        // Low, VeryLow, Low: one excursion below target, at its worst very low.
+        var result = _statisticsService.CalculateTimeInRange(Sequence(65, 45, 65, 100));
+
+        result.Episodes.VeryLow.Should().Be(1);
+        result.Episodes.Low.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalculateTimeInRange_Episodes_CountAReturnToTargetAsTheEndOfTheExcursion()
+    {
+        // High, Target, High: two excursions, because target separates them.
+        var result = _statisticsService.CalculateTimeInRange(Sequence(200, 100, 200));
+
+        result.Episodes.High.Should().Be(2);
+        result.Episodes.AboveRange.Should().Be(2);
+    }
+
+    [Fact]
+    public void CalculateTimeInRange_Episodes_CountACrossingFromHighStraightToLowOnEachSide()
+    {
+        // No target reading separates them, but they are excursions on opposite sides.
+        var result = _statisticsService.CalculateTimeInRange(Sequence(200, 60));
+
+        result.Episodes.High.Should().Be(1);
+        result.Episodes.Low.Should().Be(1);
+        result.Episodes.AboveRange.Should().Be(1);
+    }
+
+    [Fact]
+    public void CalculateTimeInRange_Episodes_CountNoneWhenTheReadingsNeverLeaveTarget()
+    {
+        var result = _statisticsService.CalculateTimeInRange(Sequence(100, 120, 140, 110));
+
+        result.Episodes.VeryLow.Should().Be(0);
+        result.Episodes.Low.Should().Be(0);
+        result.Episodes.High.Should().Be(0);
+        result.Episodes.VeryHigh.Should().Be(0);
+        result.Episodes.AboveRange.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalculateTimeInRange_Durations_FollowTheSensorsOwnCadence()
+    {
+        int[] values = [200, 300, 100, 60, 200, 100];
+
+        var fiveMinute = _statisticsService.CalculateTimeInRange(Sequence(5, values));
+        var oneMinute = _statisticsService.CalculateTimeInRange(Sequence(1, values));
+
+        oneMinute.Durations.High.Should().Be(fiveMinute.Durations.High / 5).And.Be(2);
+        oneMinute.Durations.VeryHigh.Should().Be(fiveMinute.Durations.VeryHigh / 5).And.Be(1);
+        oneMinute.Durations.Low.Should().Be(fiveMinute.Durations.Low / 5).And.Be(1);
+        oneMinute.Durations.Target.Should().Be(fiveMinute.Durations.Target / 5).And.Be(2);
+        oneMinute.Durations.AboveRange.Should().Be(fiveMinute.Durations.AboveRange / 5).And.Be(3);
+    }
+
+    [Fact]
+    public void CalculateTimeInRange_Durations_CreditAGapWithOneIntervalOnly()
+    {
+        // Five-minute readings, then a two-hour gap the sensor did not cover, then two more.
+        var start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entries = new[]
+        {
+            new SensorGlucose { Mgdl = 200, Timestamp = start },
+            new SensorGlucose { Mgdl = 200, Timestamp = start.AddMinutes(5) },
+            new SensorGlucose { Mgdl = 200, Timestamp = start.AddMinutes(10) },
+            new SensorGlucose { Mgdl = 100, Timestamp = start.AddMinutes(130) },
+            new SensorGlucose { Mgdl = 100, Timestamp = start.AddMinutes(135) },
+        };
+
+        var result = _statisticsService.CalculateTimeInRange(entries);
+
+        // The reading before the gap is credited two intervals, not the 120 minutes it spans.
+        result.Durations.High.Should().Be(20);
+        result.Durations.Target.Should().Be(10);
+    }
+
+    private static SensorGlucose[] Sequence(params int[] mgdl) => Sequence(5, mgdl);
+
+    private static SensorGlucose[] Sequence(double cadenceMinutes, params int[] mgdl)
+    {
+        var start = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
         return mgdl
             .Select((value, i) => new SensorGlucose
             {
                 Mgdl = value,
-                Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(now + i).UtcDateTime,
+                Timestamp = start.AddMinutes(i * cadenceMinutes),
             })
             .ToArray();
     }


### PR DESCRIPTION
Closes #1134.

## The change

`StatisticsService.CalculateTimeInRange` computed two clinical numbers on simplifications its own comments admitted.

**Episodes.** The counter incremented a zone on every transition into it, so one excursion 180→260→190 mg/dL scored three episodes (High 2, VeryHigh 1). A run of consecutive readings on the same side of target is now one episode, attributed to the most extreme zone the run reached; a return to target or a crossing to the other side ends it. `AboveRange` is exactly `High + VeryHigh`. Verified on the review side against ten further sequences (start or end out of target, alternating, direct High→Low crossings, 200 random series).

**Durations.** A constant five minutes per reading reported every duration five times too long on a one-minute sensor and credited a sensor outage to the zone before it. Durations are now derived from the readings' own timestamps: each reading stands for the gap to the next, capped at twice the series' median gap, the final reading for one median gap. This fixes every consumer at once, including the two call paths that had no cadence to thread through. No signature changes.

**Punch card / calendar.** `GetPunchCardData` derived reading counts from durations divided by five, which the cadence fix would have made wrong; it now counts the readings.

The `> 0 && < 600` plausibility bound existed as four literal copies; it is one `IsPlausibleReading`.

## Behaviour deltas

- Percentages count readings; durations sum time. They diverge on a series with gaps or a varying cadence. The DTO doc says so; the executive summary shows both.
- A uniformly sparse series is credited its own gaps in full: two readings three hours apart are each credited three hours, since the median gap is three hours. A lone high before a three-hour silence reports three hours above range where it reported five minutes. Only a gap long relative to the series' own median is capped.
- Readings stamped at the same instant are credited no time except the last; percentages still count each.
- Four existing tests asserted the old counts and were corrected; one had documented the bug in its own name.

## Tests

Mutations each killed by a named test: additive per-transition episodes, flat five-minute cadence, dropping the cap, crediting the last reading zero, side check by zone equality, punch-card `Count - 1`. A year of five-minute readings runs in about 70 ms, the same order as the sort the method already did.
