### PR TITLE
refactor: one widget catalogue behind the defaults, the API and the picker

### DIFF
--- a/src/API/Nocturne.API/Controllers/MetadataController.cs
+++ b/src/API/Nocturne.API/Controllers/MetadataController.cs
@@ -25,7 +25,8 @@ namespace Nocturne.API.Controllers;
 /// configuration shapes, OAuth scope lists). It is excluded from the interactive API explorer via
 /// <see cref="ApiExplorerSettingsAttribute"/> with <c>IgnoreApi = true</c>.
 ///
-/// None of the endpoints here perform real business logic — they return empty/stub responses.
+/// Most answer with a constant, usually an enum's values, but not all: widget definitions serve the
+/// widget catalogue and multitenancy answers from configuration and the resolved tenant.
 /// All endpoints are permitted during initial setup (<see cref="AllowDuringSetupAttribute"/>).
 /// </remarks>
 [ApiController]

--- a/src/API/Nocturne.API/Controllers/MetadataController.cs
+++ b/src/API/Nocturne.API/Controllers/MetadataController.cs
@@ -20,13 +20,15 @@ namespace Nocturne.API.Controllers;
 /// Metadata controller that exposes type definitions for NSwag and the frontend client generation pipeline.
 /// </summary>
 /// <remarks>
-/// This controller exists solely to ensure NSwag generates TypeScript types for models that are not
-/// otherwise reachable through regular API endpoints (e.g., WebSocket event envelopes, connector
-/// configuration shapes, OAuth scope lists). It is excluded from the interactive API explorer via
-/// <see cref="ApiExplorerSettingsAttribute"/> with <c>IgnoreApi = true</c>.
+/// Most of these endpoints exist only to pull types into the generated client that no other endpoint
+/// reaches — WebSocket event envelopes, connector configuration shapes, OAuth scope lists — and
+/// answer with a constant, usually an enum's values. Two serve real data: widget definitions return
+/// the widget catalogue, and multitenancy answers from configuration and the resolved tenant.
 ///
-/// Most answer with a constant, usually an enum's values, but not all: widget definitions serve the
-/// widget catalogue and multitenancy answers from configuration and the resolved tenant.
+/// The class hides itself from the interactive API explorer with
+/// <see cref="ApiExplorerSettingsAttribute"/>, so an endpoint a client actually calls has to
+/// override that with <c>IgnoreApi = false</c> to reach the OpenAPI document at all; widget
+/// definitions, alert condition types, auth error codes and TOTP setup failures do.
 /// All endpoints are permitted during initial setup (<see cref="AllowDuringSetupAttribute"/>).
 /// </remarks>
 [ApiController]

--- a/src/API/Nocturne.API/Controllers/MetadataController.cs
+++ b/src/API/Nocturne.API/Controllers/MetadataController.cs
@@ -167,13 +167,14 @@ public class MetadataController : ControllerBase
     /// <returns>Widget definitions metadata</returns>
     [HttpGet("widget-definitions")]
     [RemoteQuery]
+    [ApiExplorerSettings(IgnoreApi = false)]
     [ProducesResponseType(typeof(WidgetDefinitionsMetadata), 200)]
     public ActionResult<WidgetDefinitionsMetadata> GetWidgetDefinitions()
     {
         return Ok(
             new WidgetDefinitionsMetadata
             {
-                Definitions = GetAllWidgetDefinitions(),
+                Definitions = [.. WidgetCatalog.All],
                 AvailablePlacements = Enum.GetValues<WidgetPlacement>(),
                 AvailableSizes = Enum.GetValues<WidgetSize>(),
                 AvailableUICategories = Enum.GetValues<WidgetUICategory>(),
@@ -286,172 +287,6 @@ public class MetadataController : ControllerBase
             }
         );
     }
-
-    private static WidgetDefinition[] GetAllWidgetDefinitions() =>
-    [
-        // Top widgets (widget grid above the chart)
-        new()
-        {
-            Id = WidgetId.BgDelta,
-            Name = "BG Delta",
-            Description = "Blood glucose change with connection status and last updated time",
-            DefaultEnabled = true,
-            Icon = "TrendingUp",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.LastUpdated,
-            Name = "Last Updated",
-            Description = "Time since last glucose reading with device info",
-            DefaultEnabled = true,
-            Icon = "Clock",
-            UICategory = WidgetUICategory.Device,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.ConnectionStatus,
-            Name = "Connection Status",
-            Description = "Real-time data connection status",
-            DefaultEnabled = true,
-            Icon = "Wifi",
-            UICategory = WidgetUICategory.Status,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.Meals,
-            Name = "Recent Meals",
-            Description = "Recent meal entries and carb intake",
-            DefaultEnabled = false,
-            Icon = "UtensilsCrossed",
-            UICategory = WidgetUICategory.Meals,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.Trackers,
-            Name = "Trackers",
-            Description = "Active tracker status and progress",
-            DefaultEnabled = false,
-            Icon = "ListChecks",
-            UICategory = WidgetUICategory.Status,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.TirChart,
-            Name = "Time in Range",
-            Description = "Stacked chart showing time in glucose ranges",
-            DefaultEnabled = false,
-            Icon = "BarChart3",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.DailySummary,
-            Name = "Daily Summary",
-            Description = "Today's glucose statistics overview",
-            DefaultEnabled = false,
-            Icon = "CalendarDays",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.Clock,
-            Name = "Clock",
-            Description = "Current time and date display",
-            DefaultEnabled = false,
-            Icon = "Clock",
-            UICategory = WidgetUICategory.Status,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.Tdd,
-            Name = "Total Daily Dose",
-            Description = "Today's insulin with basal/bolus breakdown",
-            DefaultEnabled = true,
-            Icon = "PieChart",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Top,
-        },
-        // Main sections (larger dashboard components)
-        new()
-        {
-            Id = WidgetId.GlucoseChart,
-            Name = "Glucose Chart",
-            Description = "Main glucose trend chart with treatments",
-            DefaultEnabled = true,
-            Icon = "LineChart",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.Statistics,
-            Name = "Statistics",
-            Description = "BG statistics cards",
-            DefaultEnabled = true,
-            Icon = "BarChart2",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.Predictions,
-            Name = "Predictions",
-            Description = "Glucose prediction lines on chart",
-            DefaultEnabled = true,
-            Icon = "TrendingUp",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.DailyStats,
-            Name = "Daily Stats",
-            Description = "Recent entries card",
-            DefaultEnabled = true,
-            Icon = "CalendarDays",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.Treatments,
-            Name = "Treatments",
-            Description = "Recent treatments card",
-            DefaultEnabled = true,
-            Icon = "Syringe",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.Agp,
-            Name = "AGP",
-            Description = "Ambulatory glucose profile",
-            DefaultEnabled = false,
-            Icon = "Activity",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.BatteryStatus,
-            Name = "Battery Status",
-            Description = "Device battery status",
-            DefaultEnabled = true,
-            Icon = "Battery",
-            UICategory = WidgetUICategory.Device,
-            Placement = WidgetPlacement.Main,
-        },
-    ];
 }
 
 /// <summary>

--- a/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
@@ -229,7 +229,7 @@ public class FeatureSettings
     /// Dashboard widget configurations. Array position determines display order within each category.
     /// </summary>
     [JsonPropertyName("widgets")]
-    public List<WidgetConfig> Widgets { get; set; } = GetDefaultWidgets();
+    public List<WidgetConfig> Widgets { get; set; } = WidgetCatalog.Defaults();
 
     /// <summary>
     /// Legacy Nightscout plugin toggles, carried for schema compatibility and empty by default.
@@ -249,26 +249,6 @@ public class FeatureSettings
     /// </summary>
     [JsonPropertyName("trackerPills")]
     public TrackerPillsSettings TrackerPills { get; set; } = new();
-
-    private static List<WidgetConfig> GetDefaultWidgets() =>
-    [
-        // Top widgets (widget grid)
-        new() { Id = WidgetId.BgDelta, Enabled = true, Placement = WidgetPlacement.Top },
-        new() { Id = WidgetId.LastUpdated, Enabled = true, Placement = WidgetPlacement.Top },
-        new() { Id = WidgetId.ConnectionStatus, Enabled = true, Placement = WidgetPlacement.Top },
-        new() { Id = WidgetId.Meals, Enabled = false, Placement = WidgetPlacement.Top },
-        new() { Id = WidgetId.Trackers, Enabled = false, Placement = WidgetPlacement.Top },
-        new() { Id = WidgetId.TirChart, Enabled = false, Placement = WidgetPlacement.Top },
-        new() { Id = WidgetId.DailySummary, Enabled = false, Placement = WidgetPlacement.Top },
-        // Main sections
-        new() { Id = WidgetId.GlucoseChart, Enabled = true, Placement = WidgetPlacement.Main },
-        new() { Id = WidgetId.Statistics, Enabled = true, Placement = WidgetPlacement.Main },
-        new() { Id = WidgetId.Predictions, Enabled = true, Placement = WidgetPlacement.Main },
-        new() { Id = WidgetId.DailyStats, Enabled = true, Placement = WidgetPlacement.Main },
-        new() { Id = WidgetId.Treatments, Enabled = true, Placement = WidgetPlacement.Main },
-        new() { Id = WidgetId.Agp, Enabled = false, Placement = WidgetPlacement.Main },
-        new() { Id = WidgetId.BatteryStatus, Enabled = true, Placement = WidgetPlacement.Main },
-    ];
 }
 
 /// <summary>
@@ -320,6 +300,201 @@ public enum WidgetId
     DailyStats,
     Agp,
     BatteryStatus
+}
+
+/// <summary>
+/// The one description of every dashboard widget: what it is called, where it sits, and whether a
+/// fresh tenant gets it. <see cref="FeatureSettings.Widgets"/> and the widget metadata endpoint both
+/// read from here, so adding a widget means adding a <see cref="WidgetId"/> and a row below.
+/// </summary>
+public static class WidgetCatalog
+{
+    /// <summary>
+    /// Every <see cref="WidgetId"/>, including the ones nothing renders — stored settings still
+    /// carry them, and <see cref="WidgetDefinition.Renderable"/> is what tells them apart.
+    /// </summary>
+    public static IReadOnlyList<WidgetDefinition> All { get; } =
+    [
+        // Top widgets (widget grid above the chart)
+        new()
+        {
+            Id = WidgetId.BgDelta,
+            Name = "BG Delta",
+            Description = "Blood glucose change with connection status and last updated time",
+            DefaultEnabled = true,
+            Icon = "TrendingUp",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Top,
+        },
+        new()
+        {
+            Id = WidgetId.LastUpdated,
+            Name = "Last Updated",
+            Description = "Time since last glucose reading with device info",
+            DefaultEnabled = true,
+            Icon = "Clock",
+            UICategory = WidgetUICategory.Device,
+            Placement = WidgetPlacement.Top,
+        },
+        new()
+        {
+            Id = WidgetId.ConnectionStatus,
+            Name = "Connection Status",
+            Description = "Real-time data connection status",
+            DefaultEnabled = true,
+            Icon = "Wifi",
+            UICategory = WidgetUICategory.Status,
+            Placement = WidgetPlacement.Top,
+        },
+        new()
+        {
+            Id = WidgetId.Meals,
+            Name = "Recent Meals",
+            Description = "Recent meal entries and carb intake",
+            DefaultEnabled = false,
+            Icon = "UtensilsCrossed",
+            UICategory = WidgetUICategory.Meals,
+            Placement = WidgetPlacement.Top,
+        },
+        new()
+        {
+            Id = WidgetId.Trackers,
+            Name = "Trackers",
+            Description = "Active tracker status and progress",
+            DefaultEnabled = false,
+            Icon = "ListChecks",
+            UICategory = WidgetUICategory.Status,
+            Placement = WidgetPlacement.Top,
+        },
+        new()
+        {
+            Id = WidgetId.TirChart,
+            Name = "Time in Range",
+            Description = "Stacked chart showing time in glucose ranges",
+            DefaultEnabled = false,
+            Icon = "BarChart3",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Top,
+        },
+        new()
+        {
+            Id = WidgetId.DailySummary,
+            Name = "Daily Summary",
+            Description = "Today's glucose statistics overview",
+            DefaultEnabled = false,
+            Icon = "CalendarDays",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Top,
+        },
+        new()
+        {
+            Id = WidgetId.Clock,
+            Name = "Clock",
+            Description = "Current time and date display",
+            DefaultEnabled = false,
+            Icon = "Clock",
+            UICategory = WidgetUICategory.Status,
+            Placement = WidgetPlacement.Top,
+        },
+        new()
+        {
+            Id = WidgetId.Tdd,
+            Name = "Total Daily Dose",
+            Description = "Today's insulin with basal/bolus breakdown",
+            DefaultEnabled = false,
+            Icon = "PieChart",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Top,
+        },
+        // Main sections (larger dashboard components)
+        new()
+        {
+            Id = WidgetId.GlucoseChart,
+            Name = "Glucose Chart",
+            Description = "Main glucose trend chart with treatments",
+            DefaultEnabled = true,
+            Icon = "LineChart",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Main,
+        },
+        new()
+        {
+            Id = WidgetId.Statistics,
+            Name = "Statistics",
+            Description = "BG statistics cards",
+            DefaultEnabled = true,
+            Icon = "BarChart2",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Main,
+        },
+        new()
+        {
+            Id = WidgetId.Predictions,
+            Name = "Predictions",
+            Description = "Glucose prediction lines on chart",
+            DefaultEnabled = true,
+            Icon = "TrendingUp",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Main,
+        },
+        new()
+        {
+            Id = WidgetId.DailyStats,
+            Name = "Daily Stats",
+            Description = "Recent entries card",
+            DefaultEnabled = true,
+            Icon = "CalendarDays",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Main,
+        },
+        new()
+        {
+            Id = WidgetId.Treatments,
+            Name = "Treatments",
+            Description = "Recent treatments card",
+            DefaultEnabled = true,
+            Icon = "Syringe",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Main,
+        },
+        new()
+        {
+            Id = WidgetId.Agp,
+            Name = "AGP",
+            Description = "Ambulatory glucose profile",
+            DefaultEnabled = false,
+            Renderable = false,
+            Icon = "Activity",
+            UICategory = WidgetUICategory.Glucose,
+            Placement = WidgetPlacement.Main,
+        },
+        new()
+        {
+            Id = WidgetId.BatteryStatus,
+            Name = "Battery Status",
+            Description = "Device battery status",
+            DefaultEnabled = false,
+            Renderable = false,
+            Icon = "Battery",
+            UICategory = WidgetUICategory.Device,
+            Placement = WidgetPlacement.Main,
+        },
+    ];
+
+    /// <summary>
+    /// The widget configuration a tenant starts with: one entry per renderable widget, at its
+    /// catalogued placement and default.
+    /// </summary>
+    public static List<WidgetConfig> Defaults() =>
+        [
+            .. All.Where(d => d.Renderable)
+                .Select(d => new WidgetConfig
+                {
+                    Id = d.Id,
+                    Enabled = d.DefaultEnabled,
+                    Placement = d.Placement,
+                }),
+        ];
 }
 
 /// <summary>
@@ -379,6 +554,14 @@ public class WidgetDefinition
 
     [JsonPropertyName("defaultEnabled")]
     public bool DefaultEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Whether a dashboard surface exists for this widget. Ids kept only so that stored settings
+    /// naming them still deserialise are catalogued with <c>false</c>: they get no default and are
+    /// not offered.
+    /// </summary>
+    [JsonPropertyName("renderable")]
+    public bool Renderable { get; set; } = true;
 
     /// <summary>
     /// Icon name (e.g., "TrendingUp", "Clock") - frontend maps to actual icon component

--- a/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
+++ b/src/Core/Nocturne.Core.Models/Configuration/UISettingsConfiguration.cs
@@ -315,171 +315,97 @@ public static class WidgetCatalog
     /// </summary>
     public static IReadOnlyList<WidgetDefinition> All { get; } =
     [
-        // Top widgets (widget grid above the chart)
-        new()
-        {
-            Id = WidgetId.BgDelta,
-            Name = "BG Delta",
-            Description = "Blood glucose change with connection status and last updated time",
-            DefaultEnabled = true,
-            Icon = "TrendingUp",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.LastUpdated,
-            Name = "Last Updated",
-            Description = "Time since last glucose reading with device info",
-            DefaultEnabled = true,
-            Icon = "Clock",
-            UICategory = WidgetUICategory.Device,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.ConnectionStatus,
-            Name = "Connection Status",
-            Description = "Real-time data connection status",
-            DefaultEnabled = true,
-            Icon = "Wifi",
-            UICategory = WidgetUICategory.Status,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.Meals,
-            Name = "Recent Meals",
-            Description = "Recent meal entries and carb intake",
-            DefaultEnabled = false,
-            Icon = "UtensilsCrossed",
-            UICategory = WidgetUICategory.Meals,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.Trackers,
-            Name = "Trackers",
-            Description = "Active tracker status and progress",
-            DefaultEnabled = false,
-            Icon = "ListChecks",
-            UICategory = WidgetUICategory.Status,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.TirChart,
-            Name = "Time in Range",
-            Description = "Stacked chart showing time in glucose ranges",
-            DefaultEnabled = false,
-            Icon = "BarChart3",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.DailySummary,
-            Name = "Daily Summary",
-            Description = "Today's glucose statistics overview",
-            DefaultEnabled = false,
-            Icon = "CalendarDays",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.Clock,
-            Name = "Clock",
-            Description = "Current time and date display",
-            DefaultEnabled = false,
-            Icon = "Clock",
-            UICategory = WidgetUICategory.Status,
-            Placement = WidgetPlacement.Top,
-        },
-        new()
-        {
-            Id = WidgetId.Tdd,
-            Name = "Total Daily Dose",
-            Description = "Today's insulin with basal/bolus breakdown",
-            DefaultEnabled = false,
-            Icon = "PieChart",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Top,
-        },
-        // Main sections (larger dashboard components)
-        new()
-        {
-            Id = WidgetId.GlucoseChart,
-            Name = "Glucose Chart",
-            Description = "Main glucose trend chart with treatments",
-            DefaultEnabled = true,
-            Icon = "LineChart",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.Statistics,
-            Name = "Statistics",
-            Description = "BG statistics cards",
-            DefaultEnabled = true,
-            Icon = "BarChart2",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.Predictions,
-            Name = "Predictions",
-            Description = "Glucose prediction lines on chart",
-            DefaultEnabled = true,
-            Icon = "TrendingUp",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.DailyStats,
-            Name = "Daily Stats",
-            Description = "Recent entries card",
-            DefaultEnabled = true,
-            Icon = "CalendarDays",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.Treatments,
-            Name = "Treatments",
-            Description = "Recent treatments card",
-            DefaultEnabled = true,
-            Icon = "Syringe",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.Agp,
-            Name = "AGP",
-            Description = "Ambulatory glucose profile",
-            DefaultEnabled = false,
-            Renderable = false,
-            Icon = "Activity",
-            UICategory = WidgetUICategory.Glucose,
-            Placement = WidgetPlacement.Main,
-        },
-        new()
-        {
-            Id = WidgetId.BatteryStatus,
-            Name = "Battery Status",
-            Description = "Device battery status",
-            DefaultEnabled = false,
-            Renderable = false,
-            Icon = "Battery",
-            UICategory = WidgetUICategory.Device,
-            Placement = WidgetPlacement.Main,
-        },
+        Top(WidgetId.BgDelta, "BG Delta",
+            "Blood glucose change with connection status and last updated time",
+            "TrendingUp", WidgetUICategory.Glucose, on: true),
+        Top(WidgetId.LastUpdated, "Last Updated",
+            "Time since last glucose reading with device info",
+            "Clock", WidgetUICategory.Device, on: true),
+        Top(WidgetId.ConnectionStatus, "Connection Status",
+            "Real-time data connection status",
+            "Wifi", WidgetUICategory.Status, on: true),
+        Top(WidgetId.Meals, "Recent Meals",
+            "Recent meal entries and carb intake",
+            "UtensilsCrossed", WidgetUICategory.Meals),
+        Top(WidgetId.Trackers, "Trackers",
+            "Active tracker status and progress",
+            "ListChecks", WidgetUICategory.Status),
+        Top(WidgetId.TirChart, "Time in Range",
+            "Stacked chart showing time in glucose ranges",
+            "BarChart3", WidgetUICategory.Glucose),
+        Top(WidgetId.DailySummary, "Daily Summary",
+            "Today's glucose statistics overview",
+            "CalendarDays", WidgetUICategory.Glucose),
+        Top(WidgetId.Clock, "Clock",
+            "Current time and date display",
+            "Clock", WidgetUICategory.Status),
+        Top(WidgetId.Tdd, "Total Daily Dose",
+            "Today's insulin with basal/bolus breakdown",
+            "PieChart", WidgetUICategory.Glucose),
+        Main(WidgetId.GlucoseChart, "Glucose Chart",
+            "Main glucose trend chart with treatments",
+            "LineChart", WidgetUICategory.Glucose, on: true),
+        Main(WidgetId.Statistics, "Statistics",
+            "BG statistics cards",
+            "BarChart2", WidgetUICategory.Glucose, on: true),
+        Main(WidgetId.Predictions, "Predictions",
+            "Glucose prediction lines on chart",
+            "TrendingUp", WidgetUICategory.Glucose, on: true),
+        Main(WidgetId.DailyStats, "Daily Stats",
+            "Recent entries card",
+            "CalendarDays", WidgetUICategory.Glucose, on: true),
+        Main(WidgetId.Treatments, "Treatments",
+            "Recent treatments card",
+            "Syringe", WidgetUICategory.Glucose, on: true),
+        Main(WidgetId.Agp, "AGP",
+            "Ambulatory glucose profile",
+            "Activity", WidgetUICategory.Glucose, renderable: false),
+        Main(WidgetId.BatteryStatus, "Battery Status",
+            "Device battery status",
+            "Battery", WidgetUICategory.Device, renderable: false),
     ];
+
+    private static WidgetDefinition Top(
+        WidgetId id,
+        string name,
+        string description,
+        string icon,
+        WidgetUICategory category,
+        bool on = false,
+        bool renderable = true
+    ) => Row(id, WidgetPlacement.Top, name, description, icon, category, on, renderable);
+
+    private static WidgetDefinition Main(
+        WidgetId id,
+        string name,
+        string description,
+        string icon,
+        WidgetUICategory category,
+        bool on = false,
+        bool renderable = true
+    ) => Row(id, WidgetPlacement.Main, name, description, icon, category, on, renderable);
+
+    private static WidgetDefinition Row(
+        WidgetId id,
+        WidgetPlacement placement,
+        string name,
+        string description,
+        string icon,
+        WidgetUICategory category,
+        bool on,
+        bool renderable
+    ) =>
+        new()
+        {
+            Id = id,
+            Placement = placement,
+            Name = name,
+            Description = description,
+            Icon = icon,
+            UICategory = category,
+            DefaultEnabled = on,
+            Renderable = renderable,
+        };
 
     /// <summary>
     /// The widget configuration a tenant starts with: one entry per renderable widget, at its
@@ -544,16 +470,16 @@ public enum WidgetUICategory
 public class WidgetDefinition
 {
     [JsonPropertyName("id")]
-    public WidgetId Id { get; set; }
+    public WidgetId Id { get; init; }
 
     [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
 
     [JsonPropertyName("description")]
-    public string Description { get; set; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
 
     [JsonPropertyName("defaultEnabled")]
-    public bool DefaultEnabled { get; set; } = true;
+    public bool DefaultEnabled { get; init; } = true;
 
     /// <summary>
     /// Whether a dashboard surface exists for this widget. Ids kept only so that stored settings
@@ -561,25 +487,25 @@ public class WidgetDefinition
     /// not offered.
     /// </summary>
     [JsonPropertyName("renderable")]
-    public bool Renderable { get; set; } = true;
+    public bool Renderable { get; init; } = true;
 
     /// <summary>
     /// Icon name (e.g., "TrendingUp", "Clock") - frontend maps to actual icon component
     /// </summary>
     [JsonPropertyName("icon")]
-    public string Icon { get; set; } = string.Empty;
+    public string Icon { get; init; } = string.Empty;
 
     /// <summary>
     /// UI category for grouping in settings
     /// </summary>
     [JsonPropertyName("uiCategory")]
-    public WidgetUICategory UICategory { get; set; }
+    public WidgetUICategory UICategory { get; init; }
 
     /// <summary>
     /// Where the widget is displayed (top grid or main section)
     /// </summary>
     [JsonPropertyName("placement")]
-    public WidgetPlacement Placement { get; set; }
+    public WidgetPlacement Placement { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Nocturne.Services.Demo/Services/DemoSettingsGenerator.cs
+++ b/src/Services/Nocturne.Services.Demo/Services/DemoSettingsGenerator.cs
@@ -119,19 +119,7 @@ public class DemoSettingsGenerator
                 ShowRawBG = false,
                 FocusHours = 3,
             },
-            Widgets = new List<WidgetConfig>
-            {
-                // Top widgets
-                new() { Id = WidgetId.BgDelta, Enabled = true, Placement = WidgetPlacement.Top },
-                new() { Id = WidgetId.LastUpdated, Enabled = true, Placement = WidgetPlacement.Top },
-                new() { Id = WidgetId.ConnectionStatus, Enabled = true, Placement = WidgetPlacement.Top },
-                // Main sections
-                new() { Id = WidgetId.GlucoseChart, Enabled = true, Placement = WidgetPlacement.Main },
-                new() { Id = WidgetId.Statistics, Enabled = true, Placement = WidgetPlacement.Main },
-                new() { Id = WidgetId.Predictions, Enabled = true, Placement = WidgetPlacement.Main },
-                new() { Id = WidgetId.DailyStats, Enabled = true, Placement = WidgetPlacement.Main },
-                new() { Id = WidgetId.Treatments, Enabled = true, Placement = WidgetPlacement.Main },
-            },
+            Widgets = WidgetCatalog.Defaults(),
             Plugins = new Dictionary<string, PluginSettings>
             {
                 {

--- a/src/Services/Nocturne.Services.Demo/Services/DemoSettingsGenerator.cs
+++ b/src/Services/Nocturne.Services.Demo/Services/DemoSettingsGenerator.cs
@@ -110,15 +110,6 @@ public class DemoSettingsGenerator
     {
         return new FeatureSettings
         {
-            Display = new DisplaySettings
-            {
-                NightMode = false,
-                Theme = "system",
-                TimeFormat = "12",
-                Units = "mg/dl",
-                ShowRawBG = false,
-                FocusHours = 3,
-            },
             Widgets = WidgetCatalog.Defaults(),
             Plugins = new Dictionary<string, PluginSettings>
             {

--- a/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
@@ -1,7 +1,7 @@
 /**
- * `WidgetId` also carries ids for the dashboard's main sections, which are not
- * grid widgets, so this — not the enum — is the set the grid renders and the
- * settings picker offers.
+ * What this build can render. Names, descriptions and placement come from the
+ * backend widget catalogue; the picker offers that catalogue's top widgets
+ * narrowed to the ids below.
  */
 
 import { WidgetId } from "$lib/api/generated/nocturne-api-client";
@@ -25,13 +25,9 @@ const TOP_WIDGET_LOADERS = {
 /** A widget id the grid can actually render. */
 export type TopWidgetId = keyof typeof TOP_WIDGET_LOADERS;
 
-function isTopWidgetId(id: string): id is TopWidgetId {
+export function isTopWidgetId(id: string): id is TopWidgetId {
   return Object.hasOwn(TOP_WIDGET_LOADERS, id);
 }
-
-/** Every widget offerable in settings, in the order the picker lists them. */
-export const TOP_WIDGET_IDS: TopWidgetId[] =
-  Object.keys(TOP_WIDGET_LOADERS).filter(isTopWidgetId);
 
 export const DEFAULT_TOP_WIDGETS: TopWidgetId[] = [
   WidgetId.BgDelta,

--- a/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
@@ -30,7 +30,7 @@ export function isTopWidgetId(id: string): id is TopWidgetId {
 }
 
 /** What the picker falls back to offering when the catalogue cannot be fetched. */
-export const RENDERABLE_TOP_WIDGETS: TopWidgetId[] =
+export const LOADABLE_TOP_WIDGETS: TopWidgetId[] =
   Object.keys(TOP_WIDGET_LOADERS).filter(isTopWidgetId);
 
 export const DEFAULT_TOP_WIDGETS: TopWidgetId[] = [

--- a/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
@@ -29,6 +29,10 @@ export function isTopWidgetId(id: string): id is TopWidgetId {
   return Object.hasOwn(TOP_WIDGET_LOADERS, id);
 }
 
+/** What the picker falls back to offering when the catalogue cannot be fetched. */
+export const RENDERABLE_TOP_WIDGETS: TopWidgetId[] =
+  Object.keys(TOP_WIDGET_LOADERS).filter(isTopWidgetId);
+
 export const DEFAULT_TOP_WIDGETS: TopWidgetId[] = [
   WidgetId.BgDelta,
   WidgetId.TirChart,

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
@@ -8,10 +8,16 @@
   } from "$lib/components/ui/card";
   import { Badge } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
-  import type { WidgetId } from "$lib/api/generated/nocturne-api-client";
+  import { Skeleton } from "$lib/components/ui/skeleton";
+  import {
+    WidgetPlacement,
+    type WidgetDefinition,
+    type WidgetId,
+  } from "$lib/api/generated/nocturne-api-client";
+  import { getWidgetDefinitions } from "$api/generated/metadatas.generated.remote";
   import {
     DEFAULT_TOP_WIDGETS,
-    TOP_WIDGET_IDS,
+    isTopWidgetId,
     knownTopWidgets,
     type TopWidgetId,
   } from "$lib/components/dashboard/widget-registry";
@@ -35,21 +41,25 @@
   let draggedIndex: number | null = $state(null);
   let dragOverIndex: number | null = $state(null);
 
+  const definitions = getWidgetDefinitions();
+
+  const catalogue = $derived(
+    (definitions.current?.definitions ?? []).filter(
+      (d): d is WidgetDefinition & { id: TopWidgetId } =>
+        d.placement === WidgetPlacement.Top &&
+        d.renderable !== false &&
+        isTopWidgetId(d.id ?? "")
+    )
+  );
+  const widgetNames = $derived(
+    new Map(catalogue.map((d) => [d.id, d.name ?? ""]))
+  );
+
   const selectedWidgets = $derived(knownTopWidgets(value));
   const availableWidgets = $derived(
-    TOP_WIDGET_IDS.filter((id) => !selectedWidgets.includes(id))
+    catalogue.filter((d) => !selectedWidgets.includes(d.id))
   );
   const canAddMore = $derived(selectedWidgets.length < maxWidgets);
-
-  function getWidgetName(id: TopWidgetId): string {
-    // Convert camelCase to Title Case
-    return id
-      .replace(/([A-Z])/g, ' $1')
-      .trim()
-      .split(' ')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-  }
 
   function handleDragStart(event: DragEvent, index: number) {
     draggedIndex = index;
@@ -113,87 +123,95 @@
     </CardDescription>
   </CardHeader>
   <CardContent class="space-y-4 @container">
-    <!-- Selected widgets (draggable) -->
-    <div class="space-y-2">
-      <span class="text-sm font-medium">Active Widgets</span>
+    {#if !definitions.current}
+      <Skeleton class="h-14 w-full" />
+      <Skeleton class="h-14 w-full" />
+      <Skeleton class="h-14 w-full" />
+    {:else}
+      <!-- Selected widgets (draggable) -->
       <div class="space-y-2">
-        {#each selectedWidgets as widgetId, index (widgetId)}
-          {@const Icon = WIDGET_ICONS[widgetId]}
-          <div
-            class="flex items-center gap-2 p-3 rounded-lg border bg-card transition-all
-              {dragOverIndex === index
-              ? 'border-primary bg-accent'
-              : 'border-border'}
-              {draggedIndex === index ? 'opacity-50' : ''}"
-            draggable="true"
-            ondragstart={(e) => handleDragStart(e, index)}
-            ondragover={(e) => handleDragOver(e, index)}
-            ondragleave={handleDragLeave}
-            ondrop={(e) => handleDrop(e, index)}
-            ondragend={handleDragEnd}
-            role="listitem"
-          >
-            <GripVertical class="h-4 w-4 text-muted-foreground cursor-grab" />
-            <Badge variant="outline" class="w-6 h-6 p-0 justify-center">
-              {index + 1}
-            </Badge>
-            <Icon class="h-4 w-4 text-muted-foreground" />
-            <div class="flex-1 min-w-0">
-              <div class="font-medium text-sm">{getWidgetName(widgetId)}</div>
-            </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              class="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
-              onclick={() => removeWidget(index)}
-            >
-              <X class="h-4 w-4" />
-            </Button>
-          </div>
-        {/each}
-
-        {#if selectedWidgets.length === 0}
-          <div
-            class="text-center py-8 text-muted-foreground border border-dashed rounded-lg"
-          >
-            <p class="text-sm">No widgets selected</p>
-            <p class="text-xs">Add widgets from the list below</p>
-          </div>
-        {/if}
-      </div>
-    </div>
-
-    <!-- Available widgets to add -->
-    {#if availableWidgets.length > 0}
-      <div class="space-y-2">
-        <span class="text-sm font-medium text-muted-foreground">
-          Available Widgets {#if !canAddMore}(max {maxWidgets} reached){/if}
-        </span>
-        <div class="grid grid-cols-1 @sm:grid-cols-2 gap-2">
-          {#each availableWidgets as widgetId (widgetId)}
+        <span class="text-sm font-medium">Active Widgets</span>
+        <div class="space-y-2">
+          {#each selectedWidgets as widgetId, index (widgetId)}
             {@const Icon = WIDGET_ICONS[widgetId]}
-            <button
-              type="button"
-              class="flex items-center gap-2 p-2 rounded-lg border border-dashed text-left transition-colors
-                {canAddMore
-                ? 'hover:border-primary hover:bg-accent cursor-pointer'
-                : 'opacity-50 cursor-not-allowed'}"
-              onclick={() => addWidget(widgetId)}
-              disabled={!canAddMore}
+            <div
+              class="flex items-center gap-2 p-3 rounded-lg border bg-card transition-all
+              {dragOverIndex === index
+                ? 'border-primary bg-accent'
+                : 'border-border'}
+              {draggedIndex === index ? 'opacity-50' : ''}"
+              draggable="true"
+              ondragstart={(e) => handleDragStart(e, index)}
+              ondragover={(e) => handleDragOver(e, index)}
+              ondragleave={handleDragLeave}
+              ondrop={(e) => handleDrop(e, index)}
+              ondragend={handleDragEnd}
+              role="listitem"
             >
-              <Plus class="h-4 w-4 text-muted-foreground" />
+              <GripVertical class="h-4 w-4 text-muted-foreground cursor-grab" />
+              <Badge variant="outline" class="w-6 h-6 p-0 justify-center">
+                {index + 1}
+              </Badge>
               <Icon class="h-4 w-4 text-muted-foreground" />
               <div class="flex-1 min-w-0">
-                <div class="font-medium text-sm">{getWidgetName(widgetId)}</div>
+                <div class="font-medium text-sm">
+                  {widgetNames.get(widgetId)}
+                </div>
               </div>
-            </button>
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-8 w-8 p-0 text-muted-foreground hover:text-destructive"
+                onclick={() => removeWidget(index)}
+              >
+                <X class="h-4 w-4" />
+              </Button>
+            </div>
           {/each}
+
+          {#if selectedWidgets.length === 0}
+            <div
+              class="text-center py-8 text-muted-foreground border border-dashed rounded-lg"
+            >
+              <p class="text-sm">No widgets selected</p>
+              <p class="text-xs">Add widgets from the list below</p>
+            </div>
+          {/if}
         </div>
       </div>
-    {/if}
 
-    <p class="text-xs text-muted-foreground">
-      Changes are saved automatically when you leave this page.
-    </p>
+      <!-- Available widgets to add -->
+      {#if availableWidgets.length > 0}
+        <div class="space-y-2">
+          <span class="text-sm font-medium text-muted-foreground">
+            Available Widgets {#if !canAddMore}(max {maxWidgets} reached){/if}
+          </span>
+          <div class="grid grid-cols-1 @sm:grid-cols-2 gap-2">
+            {#each availableWidgets as widget (widget.id)}
+              {@const Icon = WIDGET_ICONS[widget.id]}
+              <button
+                type="button"
+                class="flex items-center gap-2 p-2 rounded-lg border border-dashed text-left transition-colors
+                {canAddMore
+                  ? 'hover:border-primary hover:bg-accent cursor-pointer'
+                  : 'opacity-50 cursor-not-allowed'}"
+                onclick={() => addWidget(widget.id)}
+                disabled={!canAddMore}
+              >
+                <Plus class="h-4 w-4 text-muted-foreground" />
+                <Icon class="h-4 w-4 text-muted-foreground" />
+                <div class="flex-1 min-w-0">
+                  <div class="font-medium text-sm">{widget.name}</div>
+                </div>
+              </button>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
+      <p class="text-xs text-muted-foreground">
+        Changes are saved automatically when you leave this page.
+      </p>
+    {/if}
   </CardContent>
 </Card>

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
@@ -16,7 +16,7 @@
   import { getWidgetDefinitions } from "$api/generated/metadatas.generated.remote";
   import {
     DEFAULT_TOP_WIDGETS,
-    RENDERABLE_TOP_WIDGETS,
+    LOADABLE_TOP_WIDGETS,
     isTopWidgetId,
     knownTopWidgets,
     type TopWidgetId,
@@ -43,7 +43,7 @@
 
   const definitions = getWidgetDefinitions();
 
-  const unnamed = $derived(definitions.error !== undefined);
+  const unnamed = $derived(definitions.error !== undefined && definitions.current === undefined);
   const loading = $derived(!definitions.current && !unnamed);
 
   /**
@@ -53,7 +53,7 @@
    */
   const offered: { id: TopWidgetId; name: string }[] = $derived(
     unnamed
-      ? RENDERABLE_TOP_WIDGETS.map((id) => ({ id, name: id }))
+      ? LOADABLE_TOP_WIDGETS.map((id) => ({ id, name: id }))
       : (definitions.current?.definitions ?? []).flatMap((d) => {
           const id = d.id ?? "";
           return d.placement === WidgetPlacement.Top &&

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte
@@ -11,12 +11,12 @@
   import { Skeleton } from "$lib/components/ui/skeleton";
   import {
     WidgetPlacement,
-    type WidgetDefinition,
     type WidgetId,
   } from "$lib/api/generated/nocturne-api-client";
   import { getWidgetDefinitions } from "$api/generated/metadatas.generated.remote";
   import {
     DEFAULT_TOP_WIDGETS,
+    RENDERABLE_TOP_WIDGETS,
     isTopWidgetId,
     knownTopWidgets,
     type TopWidgetId,
@@ -43,21 +43,31 @@
 
   const definitions = getWidgetDefinitions();
 
-  const catalogue = $derived(
-    (definitions.current?.definitions ?? []).filter(
-      (d): d is WidgetDefinition & { id: TopWidgetId } =>
-        d.placement === WidgetPlacement.Top &&
-        d.renderable !== false &&
-        isTopWidgetId(d.id ?? "")
-    )
+  const unnamed = $derived(definitions.error !== undefined);
+  const loading = $derived(!definitions.current && !unnamed);
+
+  /**
+   * The top widgets this build can render, named by the catalogue. Ids stand in
+   * for names when the catalogue cannot be fetched, so a selection can still be
+   * reordered and saved.
+   */
+  const offered: { id: TopWidgetId; name: string }[] = $derived(
+    unnamed
+      ? RENDERABLE_TOP_WIDGETS.map((id) => ({ id, name: id }))
+      : (definitions.current?.definitions ?? []).flatMap((d) => {
+          const id = d.id ?? "";
+          return d.placement === WidgetPlacement.Top &&
+            d.renderable !== false &&
+            isTopWidgetId(id)
+            ? [{ id, name: d.name || id }]
+            : [];
+        })
   );
-  const widgetNames = $derived(
-    new Map(catalogue.map((d) => [d.id, d.name ?? ""]))
-  );
+  const widgetNames = $derived(new Map(offered.map((w) => [w.id, w.name])));
 
   const selectedWidgets = $derived(knownTopWidgets(value));
   const availableWidgets = $derived(
-    catalogue.filter((d) => !selectedWidgets.includes(d.id))
+    offered.filter((w) => !selectedWidgets.includes(w.id))
   );
   const canAddMore = $derived(selectedWidgets.length < maxWidgets);
 
@@ -123,11 +133,17 @@
     </CardDescription>
   </CardHeader>
   <CardContent class="space-y-4 @container">
-    {#if !definitions.current}
+    {#if loading}
       <Skeleton class="h-14 w-full" />
       <Skeleton class="h-14 w-full" />
       <Skeleton class="h-14 w-full" />
     {:else}
+      {#if unnamed}
+        <p class="text-sm text-muted-foreground">
+          Widget names could not be loaded, so widgets are listed by their
+          internal id. Choosing and reordering them still works.
+        </p>
+      {/if}
       <!-- Selected widgets (draggable) -->
       <div class="space-y-2">
         <span class="text-sm font-medium">Active Widgets</span>
@@ -155,7 +171,7 @@
               <Icon class="h-4 w-4 text-muted-foreground" />
               <div class="flex-1 min-w-0">
                 <div class="font-medium text-sm">
-                  {widgetNames.get(widgetId)}
+                  {widgetNames.get(widgetId) ?? widgetId}
                 </div>
               </div>
               <Button

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte.test.ts
@@ -1,22 +1,27 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   WidgetId,
   WidgetPlacement,
 } from "$lib/api/generated/nocturne-api-client";
 import type { TopWidgetId } from "$lib/components/dashboard/widget-registry";
 
-const top = (id: string, name: string) => ({
+const top = (id: string, name: string, renderable = true) => ({
   id,
   name,
   placement: WidgetPlacement.Top,
-  renderable: true,
+  renderable,
 });
 
-// The catalogue the picker reads: the top widgets it can render, plus a main
-// section, a retired id, and a top widget from a server newer than this build.
-const definitions = [
+const main = (id: string, name: string, renderable = true) => ({
+  id,
+  name,
+  placement: WidgetPlacement.Main,
+  renderable,
+});
+
+const CATALOGUE = [
   top(WidgetId.BgDelta, "BG Delta"),
   top(WidgetId.LastUpdated, "Last Updated"),
   top(WidgetId.ConnectionStatus, "Connection Status"),
@@ -26,23 +31,27 @@ const definitions = [
   top(WidgetId.DailySummary, "Daily Summary"),
   top(WidgetId.Clock, "Clock"),
   top(WidgetId.Tdd, "Total Daily Dose"),
+  // Not offerable: a top widget this build has no loader for, a main section,
+  // and a top widget the server has marked unrenderable.
   top("Sparklines", "Sparklines"),
-  {
-    id: WidgetId.GlucoseChart,
-    name: "Glucose Chart",
-    placement: WidgetPlacement.Main,
-    renderable: true,
-  },
-  {
-    id: WidgetId.BatteryStatus,
-    name: "Battery Status",
-    placement: WidgetPlacement.Main,
-    renderable: false,
-  },
+  main(WidgetId.GlucoseChart, "Glucose Chart"),
+  main(WidgetId.BatteryStatus, "Battery Status", false),
 ];
 
+// The picker reads `.current` and `.error`; both stay writable so a test can
+// stand the query up loaded, degraded or failed.
+let current: { definitions: unknown[] } | undefined;
+let error: unknown;
+
 vi.mock("$api/generated/metadatas.generated.remote", () => ({
-  getWidgetDefinitions: () => ({ current: { definitions } }),
+  getWidgetDefinitions: () => ({
+    get current() {
+      return current;
+    },
+    get error() {
+      return error;
+    },
+  }),
 }));
 
 import DashboardWidgetConfigurator from "./DashboardWidgetConfigurator.svelte";
@@ -60,13 +69,34 @@ const OFFERED = [
 ];
 
 describe("DashboardWidgetConfigurator", () => {
-  it("offers the catalogue's top widgets the grid has a loader for, under their catalogue names", async () => {
+  beforeEach(() => {
+    current = { definitions: CATALOGUE };
+    error = undefined;
+  });
+
+  it("offers the catalogue's top widgets the grid can render, under their catalogue names", async () => {
     render(DashboardWidgetConfigurator, { props: { value: [] } });
 
     for (const name of OFFERED) {
       await expect.element(page.getByRole("button", { name })).toBeVisible();
     }
     expect(page.getByRole("button").elements()).toHaveLength(OFFERED.length);
+  });
+
+  it("does not offer a top widget the server marks unrenderable", async () => {
+    current = {
+      definitions: [
+        top(WidgetId.BgDelta, "BG Delta"),
+        top(WidgetId.Clock, "Clock", false),
+      ],
+    };
+
+    render(DashboardWidgetConfigurator, { props: { value: [] } });
+
+    await expect
+      .element(page.getByRole("button", { name: "BG Delta" }))
+      .toBeVisible();
+    expect(page.getByRole("button").elements()).toHaveLength(1);
   });
 
   it("ignores a stored widget id the grid cannot render", async () => {
@@ -93,5 +123,41 @@ describe("DashboardWidgetConfigurator", () => {
       WidgetId.Tdd,
       WidgetId.Clock,
     ]);
+  });
+
+  it("labels an active widget the catalogue does not name with its id", async () => {
+    current = { definitions: CATALOGUE.filter((d) => d.id !== WidgetId.Meals) };
+
+    render(DashboardWidgetConfigurator, {
+      props: { value: [WidgetId.Meals] },
+    });
+
+    expect(page.getByRole("listitem").elements()).toHaveLength(1);
+    await expect
+      .element(page.getByText(WidgetId.Meals, { exact: true }))
+      .toBeVisible();
+  });
+
+  it("degrades to ids when the catalogue cannot be fetched", async () => {
+    current = undefined;
+    error = new Error("boom");
+
+    render(DashboardWidgetConfigurator, {
+      props: { value: [WidgetId.BgDelta] },
+    });
+
+    await expect
+      .element(page.getByText(/Widget names could not be loaded/))
+      .toBeVisible();
+    expect(page.getByRole("listitem").elements()).toHaveLength(1);
+    await expect
+      .element(page.getByText(WidgetId.BgDelta, { exact: true }))
+      .toBeVisible();
+    await expect
+      .element(page.getByRole("button", { name: WidgetId.TirChart }))
+      .toBeVisible();
+    await expect
+      .element(page.getByText("Time in Range", { exact: true }))
+      .not.toBeInTheDocument();
   });
 });

--- a/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/settings/DashboardWidgetConfigurator.svelte.test.ts
@@ -1,28 +1,66 @@
 import { render } from "vitest-browser-svelte";
 import { page } from "vitest/browser";
-import { describe, it, expect } from "vitest";
-import DashboardWidgetConfigurator from "./DashboardWidgetConfigurator.svelte";
-import { WidgetId } from "$lib/api/generated/nocturne-api-client";
+import { describe, it, expect, vi } from "vitest";
+import {
+  WidgetId,
+  WidgetPlacement,
+} from "$lib/api/generated/nocturne-api-client";
 import type { TopWidgetId } from "$lib/components/dashboard/widget-registry";
 
-/**
- * Spelled out rather than derived from the registry: the point of the test is
- * that the picker cannot drift from the widgets the grid can render.
- */
+const top = (id: string, name: string) => ({
+  id,
+  name,
+  placement: WidgetPlacement.Top,
+  renderable: true,
+});
+
+// The catalogue the picker reads: the top widgets it can render, plus a main
+// section, a retired id, and a top widget from a server newer than this build.
+const definitions = [
+  top(WidgetId.BgDelta, "BG Delta"),
+  top(WidgetId.LastUpdated, "Last Updated"),
+  top(WidgetId.ConnectionStatus, "Connection Status"),
+  top(WidgetId.Meals, "Recent Meals"),
+  top(WidgetId.Trackers, "Trackers"),
+  top(WidgetId.TirChart, "Time in Range"),
+  top(WidgetId.DailySummary, "Daily Summary"),
+  top(WidgetId.Clock, "Clock"),
+  top(WidgetId.Tdd, "Total Daily Dose"),
+  top("Sparklines", "Sparklines"),
+  {
+    id: WidgetId.GlucoseChart,
+    name: "Glucose Chart",
+    placement: WidgetPlacement.Main,
+    renderable: true,
+  },
+  {
+    id: WidgetId.BatteryStatus,
+    name: "Battery Status",
+    placement: WidgetPlacement.Main,
+    renderable: false,
+  },
+];
+
+vi.mock("$api/generated/metadatas.generated.remote", () => ({
+  getWidgetDefinitions: () => ({ current: { definitions } }),
+}));
+
+import DashboardWidgetConfigurator from "./DashboardWidgetConfigurator.svelte";
+
 const OFFERED = [
-  "Bg Delta",
+  "BG Delta",
   "Last Updated",
   "Connection Status",
-  "Meals",
+  "Recent Meals",
   "Trackers",
-  "Tir Chart",
+  "Time in Range",
   "Daily Summary",
   "Clock",
-  "Tdd",
+  "Total Daily Dose",
 ];
 
 describe("DashboardWidgetConfigurator", () => {
-  it("offers exactly the widgets the grid has a loader for", async () => {
+  it("offers the catalogue's top widgets the grid has a loader for, under their catalogue names", async () => {
     render(DashboardWidgetConfigurator, { props: { value: [] } });
 
     for (const name of OFFERED) {
@@ -44,6 +82,9 @@ describe("DashboardWidgetConfigurator", () => {
     await expect
       .element(page.getByText("Glucose Chart", { exact: true }))
       .not.toBeInTheDocument();
+    await expect
+      .element(page.getByText("Total Daily Dose", { exact: true }))
+      .toBeVisible();
 
     await page.getByRole("button", { name: "Clock" }).click();
 

--- a/tests/Unit/Nocturne.Core.Models.Tests/Configuration/WidgetCatalogTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Configuration/WidgetCatalogTests.cs
@@ -14,6 +14,47 @@ public class WidgetCatalogTests
         WidgetCatalog.All.Select(d => d.Id).Should().BeEquivalentTo(Enum.GetValues<WidgetId>());
     }
 
+    // The drift this catalogue replaced was three tables disagreeing about names and defaults, so
+    // both are pinned per id: changing one is a deliberate edit here, never a silent divergence.
+    [Theory]
+    [InlineData(WidgetId.BgDelta, "BG Delta", true, WidgetPlacement.Top, true)]
+    [InlineData(WidgetId.LastUpdated, "Last Updated", true, WidgetPlacement.Top, true)]
+    [InlineData(WidgetId.ConnectionStatus, "Connection Status", true, WidgetPlacement.Top, true)]
+    [InlineData(WidgetId.Meals, "Recent Meals", false, WidgetPlacement.Top, true)]
+    [InlineData(WidgetId.Trackers, "Trackers", false, WidgetPlacement.Top, true)]
+    [InlineData(WidgetId.TirChart, "Time in Range", false, WidgetPlacement.Top, true)]
+    [InlineData(WidgetId.DailySummary, "Daily Summary", false, WidgetPlacement.Top, true)]
+    [InlineData(WidgetId.Clock, "Clock", false, WidgetPlacement.Top, true)]
+    [InlineData(WidgetId.Tdd, "Total Daily Dose", false, WidgetPlacement.Top, true)]
+    [InlineData(WidgetId.GlucoseChart, "Glucose Chart", true, WidgetPlacement.Main, true)]
+    [InlineData(WidgetId.Statistics, "Statistics", true, WidgetPlacement.Main, true)]
+    [InlineData(WidgetId.Predictions, "Predictions", true, WidgetPlacement.Main, true)]
+    [InlineData(WidgetId.DailyStats, "Daily Stats", true, WidgetPlacement.Main, true)]
+    [InlineData(WidgetId.Treatments, "Treatments", true, WidgetPlacement.Main, true)]
+    [InlineData(WidgetId.Agp, "AGP", false, WidgetPlacement.Main, false)]
+    [InlineData(WidgetId.BatteryStatus, "Battery Status", false, WidgetPlacement.Main, false)]
+    public void Catalogue_row_is_pinned(
+        WidgetId id,
+        string name,
+        bool defaultEnabled,
+        WidgetPlacement placement,
+        bool renderable
+    )
+    {
+        WidgetCatalog
+            .All.Single(d => d.Id == id)
+            .Should()
+            .BeEquivalentTo(
+                new
+                {
+                    Name = name,
+                    DefaultEnabled = defaultEnabled,
+                    Placement = placement,
+                    Renderable = renderable,
+                }
+            );
+    }
+
     [Fact]
     public void Catalogue_rows_are_fully_described()
     {

--- a/tests/Unit/Nocturne.Core.Models.Tests/Configuration/WidgetCatalogTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Configuration/WidgetCatalogTests.cs
@@ -14,8 +14,7 @@ public class WidgetCatalogTests
         WidgetCatalog.All.Select(d => d.Id).Should().BeEquivalentTo(Enum.GetValues<WidgetId>());
     }
 
-    // The drift this catalogue replaced was three tables disagreeing about names and defaults, so
-    // both are pinned per id: changing one is a deliberate edit here, never a silent divergence.
+    // Name and default are pinned per id: changing one is a deliberate edit here, never a silent divergence.
     [Theory]
     [InlineData(WidgetId.BgDelta, "BG Delta", true, WidgetPlacement.Top, true)]
     [InlineData(WidgetId.LastUpdated, "Last Updated", true, WidgetPlacement.Top, true)]

--- a/tests/Unit/Nocturne.Core.Models.Tests/Configuration/WidgetCatalogTests.cs
+++ b/tests/Unit/Nocturne.Core.Models.Tests/Configuration/WidgetCatalogTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using FluentAssertions;
+using Nocturne.Core.Models.Configuration;
+using Xunit;
+
+namespace Nocturne.Core.Models.Tests.Configuration;
+
+[Trait("Category", "Unit")]
+public class WidgetCatalogTests
+{
+    [Fact]
+    public void Catalogue_covers_every_widget_id_exactly_once()
+    {
+        WidgetCatalog.All.Select(d => d.Id).Should().BeEquivalentTo(Enum.GetValues<WidgetId>());
+    }
+
+    [Fact]
+    public void Catalogue_rows_are_fully_described()
+    {
+        WidgetCatalog
+            .All.Should()
+            .OnlyContain(d =>
+                d.Name.Length > 0 && d.Description.Length > 0 && d.Icon.Length > 0
+            );
+    }
+
+    [Fact]
+    public void Defaults_are_one_entry_per_renderable_widget()
+    {
+        var expected = WidgetCatalog.All.Where(d => d.Renderable).ToList();
+
+        WidgetCatalog
+            .Defaults()
+            .Should()
+            .BeEquivalentTo(
+                expected.Select(d => new
+                {
+                    d.Id,
+                    Enabled = d.DefaultEnabled,
+                    d.Placement,
+                }),
+                o => o.WithStrictOrdering()
+            );
+    }
+
+    [Fact]
+    public void Defaults_omit_the_widgets_nothing_renders()
+    {
+        WidgetCatalog
+            .Defaults()
+            .Should()
+            .NotContain(w => w.Id == WidgetId.Agp || w.Id == WidgetId.BatteryStatus);
+    }
+
+    [Fact]
+    public void Fresh_feature_settings_use_the_catalogue_defaults()
+    {
+        new FeatureSettings().Widgets.Should().BeEquivalentTo(WidgetCatalog.Defaults());
+    }
+
+    [Fact]
+    public void Stored_settings_naming_an_unrendered_widget_still_deserialise()
+    {
+        const string json = """
+            {
+              "widgets": [
+                { "id": "Agp", "enabled": true, "placement": "Main" },
+                { "id": "BatteryStatus", "enabled": true, "placement": "Main" }
+              ]
+            }
+            """;
+
+        var settings = JsonSerializer.Deserialize<FeatureSettings>(json)!;
+
+        settings.Widgets.Select(w => w.Id).Should().Equal(WidgetId.Agp, WidgetId.BatteryStatus);
+    }
+}


### PR DESCRIPTION
Closes #1188.

## The change

The widget catalogue (which `WidgetId`s are top-grid or main, their names, descriptions, icon keys and defaults) was written three times on the backend and two of the copies disagreed: `MetadataController` advertised nine top widgets, `UISettingsConfiguration.GetDefaultWidgets` seven (no `Clock`, no `Tdd`), and `DemoSettingsGenerator` three. The frontend read none of them and derived labels from the enum name with a regex ("Bg Delta", "Tir Chart").

- One `WidgetCatalog` next to `WidgetId`, one row per member built through `Top(...)`/`Main(...)` factories so placement is unforgeable. `FeatureSettings.Widgets` defaults, the `widget-definitions` endpoint and the demo generator all derive from it. The 167-line controller table and the two hand lists are gone; the demo generator's verbatim restatement of `DisplaySettings` defaults is gone too.
- `WidgetDefinition` gains an additive `renderable` field; `Agp` and `BatteryStatus` have no dashboard surface and are marked unrenderable and dropped from the defaults. Stored configs naming them still deserialise and are ignored, as before.
- The picker reads names and placement from `GET metadata/widget-definitions`, intersected with the local loader map for renderability. The regex is deleted. An active widget the catalogue does not name is labelled by its id; if the query fails, the picker says so in plain language and lists widgets by id, still fully usable.
- The endpoint was not in the OpenAPI document (class-level `IgnoreApi = true`); it now opts back in like its siblings, so it lands in the generated client and every SDK. The controller remarks were false in two places and are rewritten.

## Wire deltas

Reviewed field by field against the old controller table: all sixteen rows are identical in name, description, icon, category and placement. `Tdd` and `BatteryStatus` change `defaultEnabled` true→false. `renderable` is new. `WidgetConfig` defaults gain `Clock` and `Tdd` (top, disabled) and lose `Agp` and `BatteryStatus`. The generated TypeScript client and `openapi.json` were regenerated and are byte-identical apart from the new field and endpoint. Note #1209: the top-grid rows in `FeatureSettings.Widgets` gate nothing today, so the default changes are advertised, not enforced.

## Tests

A theory pins name, default, placement and renderability for every id, and every enum member must appear in the catalogue exactly once. Picker tests cover the API names, the unrenderable and unknown-id filters, the id fallback and the failed-query state. Mutations killed by a named test: removing a catalogue row, ignoring `renderable` in the defaults, renaming `Tdd`, flipping a default, dropping the picker's renderable filter, dropping the id fallback, never reading the query error.
