### PR TITLE
fix(multitenancy): a demo tenant no longer ends single-tenant mode at the apex

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAuthController.cs
@@ -11,6 +11,7 @@ using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Controllers.V4.DevOnly;
 
@@ -162,8 +163,8 @@ public class DevAuthController : ControllerBase
         else
         {
             // Apex request with no explicit slug: unambiguous only when a single
-            // tenant exists.
-            var tenants = await _db.Tenants.AsNoTracking().Take(2).ToListAsync(ct);
+            // tenant exists. Counted the way the apex counts it, demo excluded.
+            var tenants = await _db.Tenants.AsNoTracking().ExcludeDemo().Take(2).ToListAsync(ct);
             if (tenants.Count != 1)
                 return (BadRequest(new
                 {

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using Nocturne.API.Services.Auth;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Extensions;
 using Nocturne.API.Extensions;
 
 namespace Nocturne.API.Multitenancy;
@@ -460,21 +461,28 @@ public class TenantResolutionMiddleware
     }
 
     /// <summary>
-    /// Checks whether any tenant exists at all (used to distinguish "no tenants
-    /// yet" from "tenant not found" on the apex domain).
+    /// Checks whether any tenant a caller could be served exists at all (used to distinguish
+    /// "no tenants yet" from "tenant not found" on the apex domain).
     /// </summary>
     private async Task<bool> AnyTenantExistsAsync(IServiceProvider services)
     {
         var factory = services.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
         await using var context = await factory.CreateDbContextAsync();
-        return await context.Tenants.AsNoTracking().AnyAsync();
+        return await context.Tenants.AsNoTracking().ExcludeDemo().AnyAsync();
     }
 
     /// <summary>
-    /// Returns the sole active tenant if exactly one exists, enabling single-tenant
+    /// Returns the sole active non-demo tenant if exactly one exists, enabling single-tenant
     /// mode where the apex domain auto-resolves without a subdomain.
-    /// Returns null when zero or multiple tenants exist.
+    /// Returns null when zero or multiple such tenants exist.
     /// </summary>
+    /// <remarks>
+    /// A demo tenant is an ordinary active tenant, so counting it would take an operator's
+    /// single-tenant install out of single-tenant mode the moment the demo is provisioned. It
+    /// is excluded instead, which also means a demo-only instance's apex resolves nothing
+    /// rather than quietly becoming a public demo: the demo is reached on its own host, the
+    /// same as on a multi-tenant install.
+    /// </remarks>
     private async Task<TenantContext?> GetSoleTenantAsync(IServiceProvider services)
     {
         var cacheKey = SoleTenantCacheKey;
@@ -486,6 +494,7 @@ public class TenantResolutionMiddleware
         await using var context = await factory.CreateDbContextAsync();
 
         var tenants = await context.Tenants.AsNoTracking()
+            .ExcludeDemo()
             .Where(t => t.IsActive)
             .OrderBy(t => t.Id)
             .Take(2)

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -477,11 +477,8 @@ public class TenantResolutionMiddleware
     /// Returns null when zero or multiple such tenants exist.
     /// </summary>
     /// <remarks>
-    /// A demo tenant is an ordinary active tenant, so counting it would take an operator's
-    /// single-tenant install out of single-tenant mode the moment the demo is provisioned. It
-    /// is excluded instead, which also means a demo-only instance's apex resolves nothing
-    /// rather than quietly becoming a public demo: the demo is reached on its own host, the
-    /// same as on a multi-tenant install.
+    /// A demo tenant is an ordinary active tenant, so it would otherwise be counted here; see
+    /// <see cref="DemoExclusionFilter"/>.
     /// </remarks>
     private async Task<TenantContext?> GetSoleTenantAsync(IServiceProvider services)
     {

--- a/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
+++ b/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
@@ -9,6 +9,7 @@ using Nocturne.Core.Contracts.Auth;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Infrastructure.Data.Extensions;
 
 namespace Nocturne.API.Services.Docs;
 
@@ -274,6 +275,7 @@ public sealed class ScalarAuthProvider
         {
             var soleTenants = await db.Set<TenantEntity>()
                 .AsNoTracking()
+                .ExcludeDemo()
                 .Where(t => t.IsActive)
                 .OrderBy(t => t.Id)
                 .Take(2)

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DemoExclusionFilter.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DemoExclusionFilter.cs
@@ -6,11 +6,12 @@ namespace Nocturne.Infrastructure.Data.Extensions;
 /// The one predicate for "the rows that belong to a real operator rather than the demo".
 /// </summary>
 /// <remarks>
-/// First-run setup and the platform-admin grant that follows it decide what to do from counts and
-/// orderings over tenants and subjects. The demo contributes one of each, and neither can ever
-/// become an operator's: a demo tenant has no owner to adopt it, and a demo subject is one anyone
-/// can obtain a session for. Left in, the demo tenant reads as a tenant awaiting its first owner
-/// and the demo subject reads as the account that owner is enrolling.
+/// First-run setup, the platform-admin grant that follows it, and apex tenant resolution decide
+/// what to do from counts and orderings over tenants and subjects. The demo contributes one of
+/// each, and neither can ever become an operator's: a demo tenant has no owner to adopt it, and a
+/// demo subject is one anyone can obtain a session for. Left in, the demo tenant reads as a tenant
+/// awaiting its first owner, the demo subject reads as the account that owner is enrolling, and
+/// the operator's own single-tenant install stops being single-tenant the moment a demo appears.
 /// </remarks>
 public static class DemoExclusionFilter
 {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DemoExclusionFilter.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/DemoExclusionFilter.cs
@@ -12,6 +12,10 @@ namespace Nocturne.Infrastructure.Data.Extensions;
 /// demo subject is one anyone can obtain a session for. Left in, the demo tenant reads as a tenant
 /// awaiting its first owner, the demo subject reads as the account that owner is enrolling, and
 /// the operator's own single-tenant install stops being single-tenant the moment a demo appears.
+/// <para>
+/// A demo-only instance therefore resolves no tenant on its apex: the demo is reached on its own
+/// host, never adopted by the front door.
+/// </para>
 /// </remarks>
 public static class DemoExclusionFilter
 {

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
@@ -60,16 +60,16 @@ public sealed class TenantResolutionMiddlewareApexTests : IDisposable
         Options.Create(new BaseDomainOptions { BaseDomain = BaseDomain }),
         _root.GetRequiredService<IMemoryCache>());
 
-    private Guid SeedTenant(string slug, bool isDemo = false)
+    private Guid SeedTenant(string slug, bool isDemo = false, Guid? id = null)
     {
-        var id = Guid.CreateVersion7();
+        var tenantId = id ?? Guid.CreateVersion7();
         using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
         seed.Tenants.Add(new TenantEntity
         {
-            Id = id, Slug = slug, DisplayName = slug, IsActive = true, IsDemo = isDemo,
+            Id = tenantId, Slug = slug, DisplayName = slug, IsActive = true, IsDemo = isDemo,
         });
         seed.SaveChanges();
-        return id;
+        return tenantId;
     }
 
     // Host == BaseDomain → apex, no subdomain.
@@ -123,6 +123,9 @@ public sealed class TenantResolutionMiddlewareApexTests : IDisposable
     [Fact]
     public async Task Apex_status_with_multiple_tenants_stays_tenantless()
     {
+        // The demo takes the lowest id so it orders first: a demo dropped after the two-row
+        // limit rather than before it would leave one row here and serve alpha from the apex.
+        SeedTenant("demo", isDemo: true, id: new Guid("00000000-0000-7000-8000-000000000001"));
         SeedTenant("alpha");
         SeedTenant("beta");
         using var scope = _root.CreateScope();

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
@@ -60,11 +60,14 @@ public sealed class TenantResolutionMiddlewareApexTests : IDisposable
         Options.Create(new BaseDomainOptions { BaseDomain = BaseDomain }),
         _root.GetRequiredService<IMemoryCache>());
 
-    private Guid SeedTenant(string slug)
+    private Guid SeedTenant(string slug, bool isDemo = false)
     {
         var id = Guid.CreateVersion7();
         using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
-        seed.Tenants.Add(new TenantEntity { Id = id, Slug = slug, DisplayName = slug, IsActive = true });
+        seed.Tenants.Add(new TenantEntity
+        {
+            Id = id, Slug = slug, DisplayName = slug, IsActive = true, IsDemo = isDemo,
+        });
         seed.SaveChanges();
         return id;
     }
@@ -175,6 +178,51 @@ public sealed class TenantResolutionMiddlewareApexTests : IDisposable
         read.Should().BeTrue();
         created.Should().BeFalse();
         createCtx.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task Apex_keeps_resolving_the_operators_tenant_once_a_demo_is_provisioned()
+    {
+        var tenantId = SeedTenant("theconen");
+        SeedTenant("demo", isDemo: true);
+        using var scope = _root.CreateScope();
+        var accessor = scope.ServiceProvider.GetRequiredService<ITenantAccessor>();
+
+        var served = false;
+        var pageCtx = ApexRequest(scope, "/api/v4/entries");
+        await Build(_ => { served = true; return Task.CompletedTask; }).InvokeAsync(pageCtx);
+
+        var statusTenant = Guid.Empty;
+        var statusCtx = ApexRequest(scope, "/api/v4/status");
+        await Build(_ => { statusTenant = accessor.TenantId; return Task.CompletedTask; }).InvokeAsync(statusCtx);
+
+        // Turning the demo on is a second active tenant, which would otherwise end single-tenant
+        // mode: every apex page 404s and status stops naming the operator's tenant.
+        served.Should().BeTrue();
+        pageCtx.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        accessor.TenantId.Should().Be(tenantId);
+        statusTenant.Should().Be(tenantId);
+    }
+
+    [Fact]
+    public async Task Apex_with_only_a_demo_tenant_answers_as_a_fresh_install()
+    {
+        SeedTenant("demo", isDemo: true);
+        using var scope = _root.CreateScope();
+
+        var served = false;
+        var pageCtx = ApexRequest(scope, "/api/v4/entries");
+        await Build(_ => { served = true; return Task.CompletedTask; }).InvokeAsync(pageCtx);
+
+        var statusCtx = ApexRequest(scope, "/api/v4/status");
+        await Build(_ => Task.CompletedTask).InvokeAsync(statusCtx);
+
+        // The demo is served on its own host, never adopted by the apex — so an instance holding
+        // only a demo has no tenant to resolve, and answers 503 so the frontend goes to /setup
+        // rather than the 404 that would strand an operator with nowhere to create one.
+        served.Should().BeFalse();
+        pageCtx.Response.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        scope.ServiceProvider.GetRequiredService<ITenantAccessor>().IsResolved.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Unit/Nocturne.API.Tests/Services/Docs/ScalarAuthProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Docs/ScalarAuthProviderTests.cs
@@ -328,12 +328,19 @@ public class ScalarAuthProviderTests : IDisposable
     [Fact]
     public async Task TryPrepareAsync_ResolvesTheSoleTenant_OnTheConfiguredApex()
     {
+        // The demo sits beside the operator's tenant on a stock install. Counted here, it would
+        // either take the apex out of single-tenant mode or make the front door serve the demo
+        // account's bearer token.
+        _fixture.SeedTenant("demo", isDemo: true, withDemoMember: true);
         _fixture.SeedTenant("rhys", isDemo: false, withDemoMember: false);
         var context = DocsTenantFixture.BuildContext(BaseDomain);
 
         await _fixture.BuildProvider().TryPrepareAsync(context);
 
-        Auth(context)!.RedirectUri.Should().Be($"https://{BaseDomain}/scalar");
+        var auth = Auth(context);
+        auth.Should().NotBeNull("a demo beside it does not end single-tenant mode");
+        auth!.RedirectUri.Should().Be($"https://{BaseDomain}/scalar");
+        auth.BearerToken.Should().BeNull("only the demo's own host may carry its token");
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #1160.

## The defect

`TenantResolutionMiddleware.GetSoleTenantAsync` decided single-tenant mode by counting active tenants. A demo tenant is an active tenant, so provisioning one on a single-tenant install made the count two: every apex page answered a bare 404, and apex `/api/v4/status` stopped naming the operator's tenant. Nothing linked the symptom to the demo toggle.

## The decision

Demo tenants do not count toward "sole tenant". The existing `DemoExclusionFilter.ExcludeDemo()` from #1164 is applied to the sole-tenant query and to `AnyTenantExistsAsync` (without the latter a demo-only apex still hit the multi-tenant 404 arm), and to the two other apex sole-tenant lookups that had the same unfiltered query: `ScalarAuthProvider` and the dev-only `DevAuthController`. The rationale lives once, on the filter.

On a demo-only instance the apex now answers as a fresh install (503 `setup_required`, then the setup wizard's `no_tenant_exists`), and creating the real tenant makes it sole. The demo stays reachable on its own host, which is the only shape the compose, Portainer and Helm bundles and the demo service itself use.

Cache eviction needed no change: provisioning, status toggles and deletion of a demo already go through `EvictTenant`, which removes the sole-tenant key.

## Tests

Real plus demo resolves the real tenant at the apex; demo-only answers as a fresh install; a demo seeded with the lowest id beside two real tenants stays tenantless, so filtering after the `Take(2)` would fail; the Scalar apex lookup ignores a demo and hands out no bearer token. Mutations dropping either exclusion, filtering after the limit, or dropping the Scalar exclusion each fail a named test.
