### PR TITLE
fix(data): strip NUL characters from string columns before they reach Postgres

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -2489,12 +2491,15 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
     private void UpdateTimestamps()
     {
         var utcNow = DateTime.UtcNow;
+        // Column types are a relational concept: asking the InMemory provider for one throws.
+        var isRelational = Database.IsRelational();
 
         foreach (var entry in ChangeTracker.Entries())
         {
             var isAdded = entry.State == EntityState.Added;
 
             EnforceTenantOwnership(entry, isAdded);
+            StripNulCharacters(entry, isAdded, isRelational);
 
             // Update timestamps are stamped on insert and on real modifications only. An
             // unchanged tracked row is left alone rather than rewritten on every save, and a row
@@ -2568,6 +2573,63 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
             throw new InvalidOperationException(
                 $"Cannot modify {entry.Entity.GetType().Name} belonging to tenant " +
                 $"{tenantScoped.TenantId} from tenant context {TenantId}.");
+        }
+    }
+
+    /// <summary>
+    /// The string-mapped properties of an entity type, each flagged with whether its column is
+    /// jsonb, so the model metadata is read once per type rather than once per row.
+    /// </summary>
+    private static readonly ConcurrentDictionary<IEntityType, (string Name, bool IsJsonb)[]> StringColumns = new();
+
+    /// <summary>
+    /// The six-character JSON escape for U+0000, matched only where the backslash opening it is
+    /// preceded by an even number of backslashes. An odd count is an escaped backslash followed by
+    /// the literal text u0000, which is a valid jsonb value and must survive.
+    /// </summary>
+    private static readonly Regex JsonNulEscape = new(@"(?<!\\)((?:\\\\)*)\\u0000", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Strips NUL characters out of the string columns of a row about to be written. Legacy
+    /// Nightscout records carry an embedded U+0000 in string fields — a device name from some old
+    /// uploaders — which Mongo and JSON both accept; Postgres rejects the raw byte in a text column
+    /// (22021) and the escape sequence in a jsonb one (22P05), failing the whole insert batch the
+    /// row happens to land in. Runs in the SaveChanges walk, before any interceptor sees the entry,
+    /// so audit snapshots record what is actually persisted.
+    /// </summary>
+    private static void StripNulCharacters(EntityEntry entry, bool isAdded, bool isRelational)
+    {
+        if (!isAdded && entry.State != EntityState.Modified)
+        {
+            return;
+        }
+
+        var columns = StringColumns.GetOrAdd(
+            entry.Metadata,
+            static (entityType, relational) =>
+                [.. entityType.GetProperties()
+                    .Where(p => p.ClrType == typeof(string))
+                    .Select(p => (p.Name, IsJsonb: relational && p.GetColumnType() == "jsonb"))],
+            isRelational);
+
+        foreach (var (name, isJsonb) in columns)
+        {
+            var property = entry.Property(name);
+            if (property.CurrentValue is not string value)
+            {
+                continue;
+            }
+
+            var stripped = value.Contains('\0') ? value.Replace("\0", string.Empty) : value;
+            if (isJsonb && stripped.Contains(@"\u0000", StringComparison.Ordinal))
+            {
+                stripped = JsonNulEscape.Replace(stripped, "$1");
+            }
+
+            if (!string.Equals(stripped, value, StringComparison.Ordinal))
+            {
+                property.CurrentValue = stripped;
+            }
         }
     }
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/NulSanitizationTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/NulSanitizationTests.cs
@@ -1,0 +1,204 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Moq;
+using Nocturne.Core.Contracts.Audit;
+using Nocturne.Infrastructure.Data.Entities.V4;
+using Nocturne.Infrastructure.Data.Interceptors;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.Infrastructure.Data.Tests;
+
+/// <summary>
+/// Covers the NUL stripping in <see cref="NocturneDbContext"/>'s SaveChanges walk. The store is
+/// in-memory SQLite, which accepts a NUL happily: every assertion is on the persisted value, never
+/// on the absence of an exception.
+/// </summary>
+[Trait("Category", "Unit")]
+public class NulSanitizationTests : IDisposable
+{
+    // Spelled as constants so this source file carries no NUL character of its own.
+    private const string NulEscape = @"\u0000";
+    private const string EscapedBackslash = @"\\";
+    private const char Nul = '\0';
+
+    private readonly Guid _tenantId = Guid.CreateVersion7();
+    private readonly PropertyStateRecorder _recorder = new();
+    private readonly SqliteTestDatabase _db;
+
+    public NulSanitizationTests()
+    {
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.Setup(a => a.HttpContext).Returns((HttpContext)null!);
+
+        _db = TestDbContextFactory.CreateSqliteWithTenant(
+            _tenantId, "test", _recorder, new MutationAuditInterceptor(accessor.Object));
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task AddedRow_LosesTheNulInATextColumn()
+    {
+        await using (var ctx = _db.CreateContext())
+        {
+            ctx.MeterGlucose.Add(NewReading(device: "xDrip" + Nul));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var verify = _db.CreateContext();
+        var reading = await verify.MeterGlucose.SingleAsync();
+        reading.Device.Should().Be("xDrip");
+    }
+
+    [Fact]
+    public async Task ModifiedRow_LosesTheNulInATextColumn()
+    {
+        var id = await SeedReadingAsync(device: "meter");
+
+        await using (var ctx = _db.CreateContext())
+        {
+            var reading = await ctx.MeterGlucose.SingleAsync(r => r.Id == id);
+            reading.Device = "iPhone" + Nul;
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var verify = _db.CreateContext();
+        var persisted = await verify.MeterGlucose.SingleAsync();
+        persisted.Device.Should().Be("iPhone");
+    }
+
+    [Fact]
+    public async Task TextColumn_KeepsTheEscapeThatOnlyJsonbRejects()
+    {
+        await using (var ctx = _db.CreateContext())
+        {
+            ctx.MeterGlucose.Add(NewReading(device: "xDrip" + NulEscape));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var verify = _db.CreateContext();
+        var reading = await verify.MeterGlucose.SingleAsync();
+        reading.Device.Should().Be("xDrip" + NulEscape,
+            "in a text column those are six ordinary characters Postgres stores as they are");
+    }
+
+    [Theory]
+    [InlineData(NulEscape, "")]
+    [InlineData(EscapedBackslash + NulEscape, EscapedBackslash)]
+    [InlineData(EscapedBackslash + EscapedBackslash + NulEscape, EscapedBackslash + EscapedBackslash)]
+    [InlineData(EscapedBackslash + "u0000", EscapedBackslash + "u0000")]
+    [InlineData(EscapedBackslash + EscapedBackslash + "u0000", EscapedBackslash + EscapedBackslash + "u0000")]
+    public async Task JsonbColumn_LosesTheNulEscape_AndKeepsTheBackslashRunInFrontOfIt(
+        string fragment, string expected)
+    {
+        await using (var ctx = _db.CreateContext())
+        {
+            var reading = NewReading(device: "xDrip");
+            reading.AdditionalPropertiesJson = $$"""{"a":"x{{fragment}}y"}""";
+            ctx.MeterGlucose.Add(reading);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var verify = _db.CreateContext();
+        var persisted = await verify.MeterGlucose.SingleAsync();
+        persisted.AdditionalPropertiesJson.Should().Be($$"""{"a":"x{{expected}}y"}""");
+    }
+
+    [Fact]
+    public async Task ModifiedRow_LeavesTheColumnsWithNoNulUnmodified()
+    {
+        var id = await SeedReadingAsync(device: "meter", app: "uploader");
+
+        await using var ctx = _db.CreateContext();
+        var reading = await ctx.MeterGlucose.SingleAsync(r => r.Id == id);
+        reading.Device = "iPhone" + Nul;
+        await ctx.SaveChangesAsync();
+
+        _recorder.Properties[nameof(MeterGlucoseEntity.Device)].CurrentValue.Should().Be("iPhone");
+        _recorder.Properties[nameof(MeterGlucoseEntity.App)].IsModified.Should().BeFalse(
+            "a string with no NUL is left alone rather than rewritten");
+    }
+
+    [Fact]
+    public async Task AuditSnapshot_RecordsTheSanitizedValue()
+    {
+        var id = await SeedReadingAsync(device: "meter");
+
+        await using (var ctx = _db.CreateContext())
+        {
+            ctx.AuditContext = new UserAuditContext();
+            var reading = await ctx.MeterGlucose.SingleAsync(r => r.Id == id);
+            reading.Device = "iPhone" + Nul;
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var verify = _db.CreateContext();
+        var log = await verify.MutationAuditLog.SingleAsync(l => l.Action == "update");
+        log.ChangesJson.Should().Contain("iPhone");
+        log.ChangesJson.Should().NotContain(NulEscape,
+            "the walk runs before the interceptor, so the diff holds the persisted value "
+                + "(a NUL would serialize into the audit row's own jsonb column as this escape)");
+    }
+
+    private MeterGlucoseEntity NewReading(string device, string? app = null) => new()
+    {
+        Id = Guid.CreateVersion7(),
+        TenantId = _tenantId,
+        Timestamp = new DateTime(2016, 3, 1, 12, 0, 0, DateTimeKind.Utc),
+        Mgdl = 120,
+        Device = device,
+        App = app,
+    };
+
+    private async Task<Guid> SeedReadingAsync(string device, string? app = null)
+    {
+        await using var ctx = _db.CreateContext();
+        var reading = NewReading(device, app);
+        ctx.MeterGlucose.Add(reading);
+        await ctx.SaveChangesAsync();
+        return reading.Id;
+    }
+
+    /// <summary>
+    /// Captures the change-tracking state of the row under test at the point every SaveChanges
+    /// interceptor sees it: after the DbContext walk, before the statement is generated.
+    /// </summary>
+    private sealed class PropertyStateRecorder : SaveChangesInterceptor
+    {
+        public Dictionary<string, (object? CurrentValue, bool IsModified)> Properties { get; } = [];
+
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            foreach (var entry in eventData.Context!.ChangeTracker.Entries<MeterGlucoseEntity>())
+            {
+                foreach (var property in entry.Properties)
+                {
+                    Properties[property.Metadata.Name] = (property.CurrentValue, property.IsModified);
+                }
+            }
+
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+    }
+
+    private sealed class UserAuditContext : IAuditContext
+    {
+        public Guid? SubjectId => Guid.Empty;
+        public string? SubjectName => "tester";
+        public string? AuthType => "SessionCookie";
+        public string? IpAddress => "127.0.0.1";
+        public Guid? TokenId => null;
+        public string? TraceId => null;
+        public string? Endpoint => "PUT /api/v4/meter-glucose";
+        public bool IsSystem => false;
+    }
+}


### PR DESCRIPTION
Closes #1212.

## The change

Legacy Nightscout records carry an embedded NUL (U+0000) in string fields, in the reported case a `device` name written by an old uploader. Mongo and JSON accept it; Postgres rejects the raw byte in a `text` column (22021) and the six-character escape in a `jsonb` one (22P05). `V4RepositoryBase.BulkWriteAsync` inserts in chunks of 500 inside one transaction, so one 2016-era row failed the 499 rows around it and the run, and because the setup-wizard import, `api/v4/migration` in both modes and the Nightscout connector backfill all crawl backwards from now, everything older than the poisoned row was lost too and every later sync cycle failed the same way.

NUL characters are now stripped from the string columns of every Added or Modified row in `NocturneDbContext.UpdateTimestamps`, the walk over `ChangeTracker.Entries()` that already enforces timestamps and tenant ownership. It runs ahead of every interceptor's `SavingChanges`, so `MutationAuditInterceptor` snapshots record the persisted value, and it needs no registration at the two `AddInterceptors` sites (the issue suggested an interceptor; the existing walk is the DRY seam). For `jsonb` columns the escape `\u0000` is stripped as well, only where the opening backslash is preceded by an even number of backslashes; an odd run is an escaped backslash followed by the text `u0000`, which is a valid value and survives. String properties and their jsonb-ness are cached per entity type; a value with no NUL allocates nothing and is not marked modified. `GetColumnType()` is relational-only and throws on the InMemory provider, so the jsonb flag is gated on `Database.IsRelational()` the same way the `JsonbStringComparer` convention is.

## Tests

`NulSanitizationTests` over in-memory SQLite, which stores a NUL happily, so every assertion is on the persisted value rather than the absence of an exception: a NUL in `device` on an inserted row and on a modified row; a `text` column keeps the literal six-character escape that only jsonb rejects; a jsonb theory over 1–5 backslashes in front of `u0000` (1 → stripped, 2 → kept, 3 → two, 4 → kept, 5 → four); a clean sibling column stays unmodified; the `MutationAuditInterceptor` diff holds the sanitised value. Removing the call from the walk reddens all of them. Mutations killed by a named test: the `isJsonb` guard dropped (regex on every string column), `$1` replaced with an empty string, the regex without its lookbehind, the strip limited to Added rows. `Nocturne.Infrastructure.Data.Tests` 951 passed.

## Not covered here

Audit-log rows are added by the interceptor after the walk, so their own string columns (`SubjectName` from token claims) are not sanitised; and `string[]`/`List<string>` columns (`text[]`, jsonb) can still carry a NUL. None of those hold legacy-import data.
