### PR TITLE
refactor(multitenancy): one query for the apex's sole tenant

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAuthController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/DevOnly/DevAuthController.cs
@@ -162,15 +162,12 @@ public class DevAuthController : ControllerBase
         }
         else
         {
-            // Apex request with no explicit slug: unambiguous only when a single
-            // tenant exists. Counted the way the apex counts it, demo excluded.
-            var tenants = await _db.Tenants.AsNoTracking().ExcludeDemo().Take(2).ToListAsync(ct);
-            if (tenants.Count != 1)
+            tenant = await _db.Tenants.SoleTenantAsync(ct);
+            if (tenant is null)
                 return (BadRequest(new
                 {
                     error = "Tenant could not be resolved from the host. Pass ?tenant=<slug>.",
                 }), null);
-            tenant = tenants[0];
         }
 
         // tenant_members/tenant_roles carry no RLS policies today, but set the

--- a/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
+++ b/src/API/Nocturne.API/Multitenancy/TenantResolutionMiddleware.cs
@@ -472,9 +472,9 @@ public class TenantResolutionMiddleware
     }
 
     /// <summary>
-    /// Returns the sole active non-demo tenant if exactly one exists, enabling single-tenant
-    /// mode where the apex domain auto-resolves without a subdomain.
-    /// Returns null when zero or multiple such tenants exist.
+    /// Returns the install's <see cref="SoleTenantQuery.SoleTenantAsync">sole servable tenant</see>,
+    /// enabling single-tenant mode where the apex domain auto-resolves without a subdomain, or null
+    /// when there is none or several.
     /// </summary>
     /// <remarks>
     /// A demo tenant is an ordinary active tenant, so it would otherwise be counted here; see
@@ -490,17 +490,11 @@ public class TenantResolutionMiddleware
         var factory = services.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
         await using var context = await factory.CreateDbContextAsync();
 
-        var tenants = await context.Tenants.AsNoTracking()
-            .ExcludeDemo()
-            .Where(t => t.IsActive)
-            .OrderBy(t => t.Id)
-            .Take(2)
-            .ToListAsync();
+        var tenant = await context.Tenants.SoleTenantAsync();
 
-        if (tenants.Count != 1)
+        if (tenant is null)
             return null;
 
-        var tenant = tenants[0];
         var tenantContext = new TenantContext(tenant.Id, tenant.Slug, tenant.DisplayName, tenant.IsActive, tenant.IsDemo);
         _cache.Set(cacheKey, tenantContext, CacheDuration);
         return tenantContext;

--- a/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
+++ b/src/API/Nocturne.API/Services/Docs/ScalarAuthProvider.cs
@@ -273,18 +273,10 @@ public sealed class ScalarAuthProvider
         TenantEntity? tenant;
         if (slug is null)
         {
-            var soleTenants = await db.Set<TenantEntity>()
-                .AsNoTracking()
-                .ExcludeDemo()
-                .Where(t => t.IsActive)
-                .OrderBy(t => t.Id)
-                .Take(2)
-                .ToListAsync(ct);
+            tenant = await db.Set<TenantEntity>().SoleTenantAsync(ct);
 
-            if (soleTenants.Count != 1)
+            if (tenant is null)
                 return null;
-
-            tenant = soleTenants[0];
         }
         else
         {

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SoleTenantQuery.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Extensions/SoleTenantQuery.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.Infrastructure.Data.Extensions;
+
+/// <summary>
+/// The one reading of "this install has exactly one tenant, so the apex domain serves it".
+/// </summary>
+/// <remarks>
+/// Tenant resolution, the Scalar docs resolver and the dev-only session login answer the same
+/// question at the apex and must answer it identically, or the front door serves one tenant for
+/// requests and another for docs. An inactive tenant is not served and the demo is never the
+/// operator's (<see cref="DemoExclusionFilter"/>), so neither counts. First-run setup and the
+/// platform-admin grant ask a different question, whether this is a fresh install, which an
+/// inactive tenant still answers, so they count tenants themselves.
+/// </remarks>
+public static class SoleTenantQuery
+{
+    /// <summary>
+    /// The install's only servable tenant, or <see langword="null"/> when none or several exist.
+    /// </summary>
+    public static async Task<TenantEntity?> SoleTenantAsync(
+        this DbSet<TenantEntity> tenants, CancellationToken ct = default)
+    {
+        var candidates = await tenants.AsNoTracking().ExcludeDemo().Where(t => t.IsActive).Take(2).ToListAsync(ct);
+        return candidates.Count == 1 ? candidates[0] : null;
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
@@ -60,13 +60,13 @@ public sealed class TenantResolutionMiddlewareApexTests : IDisposable
         Options.Create(new BaseDomainOptions { BaseDomain = BaseDomain }),
         _root.GetRequiredService<IMemoryCache>());
 
-    private Guid SeedTenant(string slug, bool isDemo = false, Guid? id = null)
+    private Guid SeedTenant(string slug, bool isDemo = false, Guid? id = null, bool isActive = true)
     {
         var tenantId = id ?? Guid.CreateVersion7();
         using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
         seed.Tenants.Add(new TenantEntity
         {
-            Id = tenantId, Slug = slug, DisplayName = slug, IsActive = true, IsDemo = isDemo,
+            Id = tenantId, Slug = slug, DisplayName = slug, IsActive = isActive, IsDemo = isDemo,
         });
         seed.SaveChanges();
         return tenantId;
@@ -225,6 +225,21 @@ public sealed class TenantResolutionMiddlewareApexTests : IDisposable
         // rather than the 404 that would strand an operator with nowhere to create one.
         served.Should().BeFalse();
         pageCtx.Response.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        scope.ServiceProvider.GetRequiredService<ITenantAccessor>().IsResolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Apex_with_a_single_inactive_tenant_does_not_resolve_it()
+    {
+        SeedTenant("paused", isActive: false);
+        using var scope = _root.CreateScope();
+
+        var served = false;
+        var ctx = ApexRequest(scope, "/api/v4/entries");
+        await Build(_ => { served = true; return Task.CompletedTask; }).InvokeAsync(ctx);
+
+        served.Should().BeFalse();
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
         scope.ServiceProvider.GetRequiredService<ITenantAccessor>().IsResolved.Should().BeFalse();
     }
 


### PR DESCRIPTION
Follow-up to #1221.

## The change

Tenant resolution, the Scalar docs resolver and the dev-only session login each hand-wrote "exactly one active non-demo tenant" at the apex, and the copies had drifted: the dev login never filtered on `IsActive`, so it would resolve a deactivated tenant at an apex the middleware refused to serve. The three now call `SoleTenantQuery.SoleTenantAsync` on the `DbSet`, which also owns the `AsNoTracking` each caller repeated. The `OrderBy` the copies carried is dropped: only the count matters, and the single survivor is the same row in any order.

First-run setup and the platform-admin bootstrap keep their own counts on purpose. They ask whether this is a fresh install, and an inactive tenant still answers that; adopting the helper there would invite a second tenant or decline the grant on an install whose only tenant was deactivated, and setup needs the zero/one/many split a nullable return collapses.

## Tests

The middleware and Scalar demo-exclusion cases from #1221 cover two call sites; deleting `ExcludeDemo` from the helper reddens both, and `Take(2)` → `Take(1)` reddens the multi-tenant apex cases. The `IsActive` clause had no apex test now that it lives in one place, so `Apex_with_a_single_inactive_tenant_does_not_resolve_it` pins it. Filtered API unit run: 243 passed.
