### PR TITLE
fix(connectors): retry Glooko, MyLife and Tandem logins on transient failures only

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoAuthTokenProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoAuthTokenProvider.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Glooko.Configurations;
@@ -17,157 +18,186 @@ namespace Nocturne.Connectors.Glooko.Services;
 ///     Note: Glooko returns a session cookie rather than a bearer token,
 ///     but we represent it as a token for consistency.
 /// </summary>
-public class GlookoAuthTokenProvider : AuthTokenProviderBase<GlookoConnectorConfiguration>
+public class GlookoAuthTokenProvider(
+    HttpClient httpClient,
+    IConnectorTokenCache tokenCache,
+    IConnectorServerResolver<GlookoConnectorConfiguration> serverResolver,
+    ITenantAccessor tenantAccessor,
+    ILogger<GlookoAuthTokenProvider> logger,
+    IRetryDelayStrategy retryDelayStrategy)
+    : AuthTokenProviderBase<GlookoConnectorConfiguration>(httpClient, tokenCache, serverResolver, tenantAccessor, logger)
 {
-    public GlookoAuthTokenProvider(
-        HttpClient httpClient,
-        IConnectorTokenCache tokenCache,
-        IConnectorServerResolver<GlookoConnectorConfiguration> serverResolver,
-        ITenantAccessor tenantAccessor,
-        ILogger<GlookoAuthTokenProvider> logger)
-        : base(httpClient, tokenCache, serverResolver, tenantAccessor, logger)
-    {
-    }
+    private readonly IRetryDelayStrategy _retryDelayStrategy =
+        retryDelayStrategy ?? throw new ArgumentNullException(nameof(retryDelayStrategy));
 
     protected override string ConnectorName => "Glooko";
 
     protected override async Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
         GlookoConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        try
+        var maxRetries = LoginAttempts(config);
+        IReadOnlyDictionary<string, string>? metadata = null;
+
+        var sessionCookie = await ExecuteWithRetryAsync<string>(
+            async attempt =>
+            {
+                _logger.LogInformation(
+                    "Authenticating with Glooko server: {Server} (v3={UseV3}, attempt {Attempt}/{MaxRetries})",
+                    config.Server, config.UseV3Api, attempt + 1, maxRetries);
+
+                var (cookie, sessionMetadata, shouldRetry) = await SignInAsync(config, cancellationToken);
+                if (cookie == null)
+                    return (null, shouldRetry);
+
+                metadata = sessionMetadata;
+                return (cookie, false);
+            },
+            _retryDelayStrategy,
+            maxRetries,
+            "Glooko authentication",
+            cancellationToken);
+
+        if (string.IsNullOrEmpty(sessionCookie))
+            return (null, DateTime.MinValue, null);
+
+        _logger.LogInformation("Glooko authentication successful");
+        return (sessionCookie, DateTime.UtcNow.Add(GlookoConstants.SessionLifetime), metadata);
+    }
+
+    /// <summary>
+    ///     Performs one sign-in attempt, returning the session cookie and the metadata cached with it,
+    ///     or null plus whether the failure is worth another attempt.
+    /// </summary>
+    private async Task<(string? SessionCookie, IReadOnlyDictionary<string, string>? Metadata, bool ShouldRetry)> SignInAsync(
+        GlookoConnectorConfiguration config, CancellationToken cancellationToken)
+    {
+        var baseUrl = GlookoConstants.ResolveBaseUrl(config.Server);
+        var webOrigin = GlookoConstants.ResolveWebOrigin(config.Server);
+
+        string signInPath;
+        string loginJson;
+
+        if (config.UseV3Api)
         {
-            _logger.LogInformation("Authenticating with Glooko server: {Server} (v3={UseV3})",
-                config.Server, config.UseV3Api);
-
-            var baseUrl = GlookoConstants.ResolveBaseUrl(config.Server);
-            var webOrigin = GlookoConstants.ResolveWebOrigin(config.Server);
-
-            string signInPath;
-            string loginJson;
-
-            if (config.UseV3Api)
+            signInPath = GlookoConstants.V3SignInPath;
+            var loginData = new
             {
-                signInPath = GlookoConstants.V3SignInPath;
-                var loginData = new
+                user = new
                 {
-                    user = new
-                    {
-                        email = config.Email,
-                        password = config.Password
-                    }
-                };
-                loginJson = JsonSerializer.Serialize(loginData);
-            }
-            else
-            {
-                signInPath = GlookoConstants.SignInPath;
-                var loginData = new
-                {
-                    userLogin = new
-                    {
-                        email = config.Email,
-                        password = config.Password
-                    },
-                    deviceInformation = GlookoConstants.DeviceInformation
-                };
-                loginJson = JsonSerializer.Serialize(loginData);
-            }
-
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}{signInPath}")
-            {
-                Content = new StringContent(loginJson, Encoding.UTF8, "application/json")
+                    email = config.Email,
+                    password = config.Password
+                }
             };
-
-            GlookoHttpHelper.ApplyStandardHeaders(request, webOrigin);
-
-            var response = await _httpClient.SendAsync(request, cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                var errorContent = await GlookoHttpHelper.ReadResponseAsync(response, cancellationToken);
-                _logger.LogError("Glooko authentication failed: {StatusCode} - {Error}",
-                    response.StatusCode, errorContent);
-                return (null, DateTime.MinValue, null);
-            }
-
-            // Extract session cookie from response headers
-            string? sessionCookie = null;
-            if (response.Headers.TryGetValues("Set-Cookie", out var cookies))
-                foreach (var cookie in cookies)
-                    if (cookie.StartsWith($"{GlookoConstants.SessionCookieName}="))
-                    {
-                        sessionCookie = cookie.Split(';')[0];
-                        _logger.LogInformation("Session cookie extracted successfully");
-                        break;
-                    }
-
-            // Parse user data from sign-in response (V2 only — V3 sign-in returns { success, two_fa_required })
-            var responseJson = await GlookoHttpHelper.ReadResponseAsync(response, cancellationToken);
-            GlookoUserData? userData = null;
-            if (!config.UseV3Api)
-            {
-                try
-                {
-                    userData = JsonSerializer.Deserialize<GlookoUserData>(responseJson);
-                    if (userData?.GlookoCode != null)
-                        _logger.LogInformation(
-                            "User data parsed successfully. Glooko code: {GlookoCode}",
-                            userData.GlookoCode);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning("Could not parse user data: {Message}", ex.Message);
-                }
-            }
-
-            if (!string.IsNullOrEmpty(sessionCookie))
-            {
-                // V3 sign-in doesn't return user data — fetch it from /api/v3/session/users
-                if (config.UseV3Api)
-                {
-                    try
-                    {
-                        var v3User = await FetchV3UserDataAsync(baseUrl, webOrigin, sessionCookie, cancellationToken);
-                        if (v3User != null)
-                        {
-                            userData = new GlookoUserData { User = new GlookoUserLogin { GlookoCode = v3User.GlookoCode } };
-                            _logger.LogInformation(
-                                "V3 user profile loaded. Glooko code: {GlookoCode}, MeterUnits: {Units}",
-                                v3User.GlookoCode, v3User.MeterUnits);
-                        }
-                        else
-                        {
-                            _logger.LogWarning("V3 sign-in succeeded but failed to fetch user profile");
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to fetch V3 user profile after sign-in");
-                    }
-                }
-
-                _logger.LogInformation("Glooko authentication successful");
-
-                var metadata = new Dictionary<string, string>();
-                if (!string.IsNullOrEmpty(sessionCookie))
-                    metadata["SessionCookie"] = sessionCookie;
-                if (userData != null)
-                {
-                    var userDataJson = JsonSerializer.Serialize(userData);
-                    metadata["UserData"] = userDataJson;
-                }
-
-                return (sessionCookie, DateTime.UtcNow.Add(GlookoConstants.SessionLifetime), metadata);
-            }
-
-            _logger.LogError("Failed to extract session cookie from Glooko response");
-            return (null, DateTime.MinValue, null);
+            loginJson = JsonSerializer.Serialize(loginData);
         }
-        catch (Exception ex)
+        else
         {
-            _logger.LogError(ex, "Glooko authentication error: {Message}", ex.Message);
-            return (null, DateTime.MinValue, null);
+            signInPath = GlookoConstants.SignInPath;
+            var loginData = new
+            {
+                userLogin = new
+                {
+                    email = config.Email,
+                    password = config.Password
+                },
+                deviceInformation = GlookoConstants.DeviceInformation
+            };
+            loginJson = JsonSerializer.Serialize(loginData);
         }
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}{signInPath}")
+        {
+            Content = new StringContent(loginJson, Encoding.UTF8, "application/json")
+        };
+
+        GlookoHttpHelper.ApplyStandardHeaders(request, webOrigin);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            // Read through the Glooko helper rather than the base class's reader: Glooko returns
+            // gzip bodies the HTTP layer has not decompressed, so the raw bytes are unreadable.
+            var errorContent = await GlookoHttpHelper.ReadResponseAsync(response, cancellationToken);
+            var shouldRetry = response.IsRetryableError();
+            if (shouldRetry)
+                _logger.LogWarning("Glooko authentication failed with retryable error: {StatusCode} - {Error}",
+                    response.StatusCode, errorContent);
+            else
+                _logger.LogError("Glooko authentication failed with non-retryable error: {StatusCode} - {Error}",
+                    response.StatusCode, errorContent);
+
+            return (null, null, shouldRetry);
+        }
+
+        // Extract session cookie from response headers
+        string? sessionCookie = null;
+        if (response.Headers.TryGetValues("Set-Cookie", out var cookies))
+            foreach (var cookie in cookies)
+                if (cookie.StartsWith($"{GlookoConstants.SessionCookieName}="))
+                {
+                    sessionCookie = cookie.Split(';')[0];
+                    _logger.LogInformation("Session cookie extracted successfully");
+                    break;
+                }
+
+        // Parse user data from sign-in response (V2 only — V3 sign-in returns { success, two_fa_required })
+        var responseJson = await GlookoHttpHelper.ReadResponseAsync(response, cancellationToken);
+        GlookoUserData? userData = null;
+        if (!config.UseV3Api)
+        {
+            try
+            {
+                userData = JsonSerializer.Deserialize<GlookoUserData>(responseJson);
+                if (userData?.GlookoCode != null)
+                    _logger.LogInformation(
+                        "User data parsed successfully. Glooko code: {GlookoCode}",
+                        userData.GlookoCode);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Could not parse user data: {Message}", ex.Message);
+            }
+        }
+
+        if (string.IsNullOrEmpty(sessionCookie))
+        {
+            // A success status with no session cookie is Glooko declining the sign-in in the body
+            // rather than in the status line (V3 answers { success, two_fa_required }); the same
+            // request cannot produce a cookie on a second attempt.
+            _logger.LogError("Failed to extract session cookie from Glooko response");
+            return (null, null, false);
+        }
+
+        // V3 sign-in doesn't return user data — fetch it from /api/v3/session/users
+        if (config.UseV3Api)
+        {
+            try
+            {
+                var v3User = await FetchV3UserDataAsync(baseUrl, webOrigin, sessionCookie, cancellationToken);
+                if (v3User != null)
+                {
+                    userData = new GlookoUserData { User = new GlookoUserLogin { GlookoCode = v3User.GlookoCode } };
+                    _logger.LogInformation(
+                        "V3 user profile loaded. Glooko code: {GlookoCode}, MeterUnits: {Units}",
+                        v3User.GlookoCode, v3User.MeterUnits);
+                }
+                else
+                {
+                    _logger.LogWarning("V3 sign-in succeeded but failed to fetch user profile");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to fetch V3 user profile after sign-in");
+            }
+        }
+
+        var metadata = new Dictionary<string, string> { ["SessionCookie"] = sessionCookie };
+        if (userData != null)
+            metadata["UserData"] = JsonSerializer.Serialize(userData);
+
+        return (sessionCookie, metadata, false);
     }
 
     /// <summary>

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeAuthTokenProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeAuthTokenProvider.cs
@@ -58,13 +58,18 @@ public class MyLifeAuthTokenProvider(
     ///     token or null plus whether the failure is worth another attempt.
     /// </summary>
     /// <remarks>
-    ///     MyLife has no status line to classify: <see cref="MyLifeSoapClient"/> flattens every failed
-    ///     SOAP call to an empty response, so a step that returned nothing could be a 5xx and is
-    ///     retried. The one credential verdict it does expose is a Login that answers with a result
-    ///     carrying no auth token — that is MyLife rejecting the username/password, and it is not
-    ///     retried. A rejected auth token arrives as an <see cref="HttpRequestException"/> carrying
-    ///     HTTP 401, which is classified like any other status; a transport failure carries no status
-    ///     and reaches the base class, which retries it.
+    ///     Only a failed status or a transport failure can buy another attempt. Every non-2xx leaves
+    ///     <see cref="MyLifeSoapClient"/> as an <see cref="HttpRequestException"/> carrying the status,
+    ///     which is classified by the shared
+    ///     <see cref="HttpResponseExtensions.IsRetryableStatusCode"/>; a transport failure carries no
+    ///     status and reaches the base class, which retries it.
+    ///     <para>
+    ///     Everything else here is a 2xx that did not carry what the next step needs — an unknown
+    ///     username, a login MyLife declined, an account with no matching patient. Asking again
+    ///     produces the same answer, so none of them retries. MyLife declines a login by returning a
+    ///     <see cref="MyLifeLoginResult"/> with no <see cref="MyLifeLoginResult.AuthToken"/> rather
+    ///     than by failing the request.
+    ///     </para>
     ///     <para>
     ///     Every step logs which one failed, because a null token surfaces downstream only as the
     ///     generic "MyLife authentication failed". Messages are intentionally free of credentials/PII.
@@ -82,7 +87,7 @@ public class MyLifeAuthTokenProvider(
             if (location == null)
             {
                 _logger.LogWarning("MyLife auth failed at user-location lookup (GetUser20 returned no result)");
-                return (null, true);
+                return (null, false);
             }
 
             var serviceUrl = config.ServiceUrl;
@@ -108,7 +113,7 @@ public class MyLifeAuthTokenProvider(
                 _logger.LogWarning(
                     "MyLife auth failed at login: no response (appVersion {AppVersion}, appPlatform {AppPlatform})",
                     config.AppVersion, config.AppPlatform);
-                return (null, true);
+                return (null, false);
             }
 
             if (string.IsNullOrWhiteSpace(login.AuthToken))
@@ -127,7 +132,7 @@ public class MyLifeAuthTokenProvider(
             if (patients.Count == 0)
             {
                 _logger.LogWarning("MyLife auth failed: patient list was empty");
-                return (null, true);
+                return (null, false);
             }
 
             var patient = ResolvePatient(patients, config.PatientId);
@@ -154,6 +159,13 @@ public class MyLifeAuthTokenProvider(
         catch (HttpRequestException ex) when (ex.StatusCode is { } status && !HttpResponseExtensions.IsRetryableStatusCode(status))
         {
             _logger.LogError("MyLife auth failed with non-retryable HTTP {StatusCode}", (int)status);
+            return (null, false);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // A member-supplied ServiceUrl the SOAP client refuses to send to; no request was made
+            // and the next attempt would build the same URL.
+            _logger.LogError(ex, "MyLife auth failed: service URL is unusable");
             return (null, false);
         }
     }

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeAuthTokenProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeAuthTokenProvider.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.MyLife.Configurations;
@@ -14,11 +15,15 @@ public class MyLifeAuthTokenProvider(
     ITenantAccessor tenantAccessor,
     MyLifeSoapClient soapClient,
     IMyLifeSessionCache sessionCache,
-    ILogger<MyLifeAuthTokenProvider> logger)
+    ILogger<MyLifeAuthTokenProvider> logger,
+    IRetryDelayStrategy retryDelayStrategy)
     : AuthTokenProviderBase<MyLifeConnectorConfiguration>(httpClient, tokenCache, serverResolver, tenantAccessor, logger)
 {
     private readonly IMyLifeSessionCache _sessionCache = sessionCache;
     private readonly MyLifeSoapClient _soapClient = soapClient;
+
+    private readonly IRetryDelayStrategy _retryDelayStrategy =
+        retryDelayStrategy ?? throw new ArgumentNullException(nameof(retryDelayStrategy));
 
     protected override int TokenLifetimeBufferMinutes => 60;
 
@@ -27,86 +32,130 @@ public class MyLifeAuthTokenProvider(
     protected override async Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)> AcquireTokenAsync(
         MyLifeConnectorConfiguration config, CancellationToken cancellationToken)
     {
-        // Each step below fails by returning a null token (the base class records the connector as
-        // unhealthy). Log which step failed so the cause is diagnosable — without this every failure
-        // surfaces only as the generic "MyLife authentication failed" downstream. Messages are
-        // intentionally free of credentials/PII.
-        var location = await _soapClient.GetUserLocationAsync(
-            config.Username,
-            cancellationToken
-        );
-        if (location == null)
-        {
-            _logger.LogWarning("MyLife auth failed at user-location lookup (GetUser20 returned no result)");
+        var maxRetries = LoginAttempts(config);
+
+        var authToken = await ExecuteWithRetryAsync<string>(
+            async attempt =>
+            {
+                _logger.LogInformation(
+                    "Authenticating with MyLife (attempt {Attempt}/{MaxRetries})", attempt + 1, maxRetries);
+
+                return await SignInAsync(config, cancellationToken);
+            },
+            _retryDelayStrategy,
+            maxRetries,
+            "MyLife authentication",
+            cancellationToken);
+
+        if (string.IsNullOrEmpty(authToken))
             return (null, DateTime.MinValue, null);
-        }
 
-        var serviceUrl = config.ServiceUrl;
-        if (string.IsNullOrWhiteSpace(serviceUrl))
-            serviceUrl = location.Country20?.ServiceUrl ?? location.Country20?.RestServiceUrl ?? string.Empty;
+        return (authToken, DateTime.UtcNow.AddHours(24), null);
+    }
 
-        if (string.IsNullOrWhiteSpace(serviceUrl))
+    /// <summary>
+    ///     Performs one MyLife sign-in attempt and caches the resulting session, returning the auth
+    ///     token or null plus whether the failure is worth another attempt.
+    /// </summary>
+    /// <remarks>
+    ///     MyLife has no status line to classify: <see cref="MyLifeSoapClient"/> flattens every failed
+    ///     SOAP call to an empty response, so a step that returned nothing could be a 5xx and is
+    ///     retried. The one credential verdict it does expose is a Login that answers with a result
+    ///     carrying no auth token — that is MyLife rejecting the username/password, and it is not
+    ///     retried. A rejected auth token arrives as an <see cref="HttpRequestException"/> carrying
+    ///     HTTP 401, which is classified like any other status; a transport failure carries no status
+    ///     and reaches the base class, which retries it.
+    ///     <para>
+    ///     Every step logs which one failed, because a null token surfaces downstream only as the
+    ///     generic "MyLife authentication failed". Messages are intentionally free of credentials/PII.
+    ///     </para>
+    /// </remarks>
+    private async Task<(string? Token, bool ShouldRetry)> SignInAsync(
+        MyLifeConnectorConfiguration config, CancellationToken cancellationToken)
+    {
+        try
         {
-            _logger.LogWarning("MyLife auth failed: no service URL resolved from user location");
-            return (null, DateTime.MinValue, null);
-        }
+            var location = await _soapClient.GetUserLocationAsync(
+                config.Username,
+                cancellationToken
+            );
+            if (location == null)
+            {
+                _logger.LogWarning("MyLife auth failed at user-location lookup (GetUser20 returned no result)");
+                return (null, true);
+            }
 
-        var login = await _soapClient.LoginAsync(
-            serviceUrl,
-            config.AppPlatform,
-            config.AppVersion,
-            config.Username,
-            config.Password,
-            cancellationToken
-        );
-        if (login == null)
+            var serviceUrl = config.ServiceUrl;
+            if (string.IsNullOrWhiteSpace(serviceUrl))
+                serviceUrl = location.Country20?.ServiceUrl ?? location.Country20?.RestServiceUrl ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(serviceUrl))
+            {
+                _logger.LogWarning("MyLife auth failed: no service URL resolved from user location");
+                return (null, false);
+            }
+
+            var login = await _soapClient.LoginAsync(
+                serviceUrl,
+                config.AppPlatform,
+                config.AppVersion,
+                config.Username,
+                config.Password,
+                cancellationToken
+            );
+            if (login == null)
+            {
+                _logger.LogWarning(
+                    "MyLife auth failed at login: no response (appVersion {AppVersion}, appPlatform {AppPlatform})",
+                    config.AppVersion, config.AppPlatform);
+                return (null, true);
+            }
+
+            if (string.IsNullOrWhiteSpace(login.AuthToken))
+            {
+                _logger.LogWarning(
+                    "MyLife auth failed: login returned no auth token (check credentials; appVersion {AppVersion})",
+                    config.AppVersion);
+                return (null, false);
+            }
+
+            var patients = await _soapClient.SyncPatientListAsync(
+                serviceUrl,
+                login.AuthToken,
+                cancellationToken
+            );
+            if (patients.Count == 0)
+            {
+                _logger.LogWarning("MyLife auth failed: patient list was empty");
+                return (null, true);
+            }
+
+            var patient = ResolvePatient(patients, config.PatientId);
+            if (patient == null)
+            {
+                _logger.LogWarning(
+                    "MyLife auth failed: configured patient not found among {Count} patient(s)",
+                    patients.Count);
+                return (null, false);
+            }
+
+            var restServiceUrl = location.Country20?.RestServiceUrl ?? string.Empty;
+
+            _sessionCache.Set(_tenantAccessor.TenantId, new MyLifeSession(
+                serviceUrl,
+                restServiceUrl,
+                login.AuthToken,
+                login.UserId ?? string.Empty,
+                patient.OnlinePatientId ?? string.Empty
+            ));
+
+            return (login.AuthToken, false);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode is { } status && !HttpResponseExtensions.IsRetryableStatusCode(status))
         {
-            _logger.LogWarning(
-                "MyLife auth failed at login: no response (appVersion {AppVersion}, appPlatform {AppPlatform})",
-                config.AppVersion, config.AppPlatform);
-            return (null, DateTime.MinValue, null);
+            _logger.LogError("MyLife auth failed with non-retryable HTTP {StatusCode}", (int)status);
+            return (null, false);
         }
-
-        if (string.IsNullOrWhiteSpace(login.AuthToken))
-        {
-            _logger.LogWarning(
-                "MyLife auth failed: login returned no auth token (check credentials; appVersion {AppVersion})",
-                config.AppVersion);
-            return (null, DateTime.MinValue, null);
-        }
-
-        var patients = await _soapClient.SyncPatientListAsync(
-            serviceUrl,
-            login.AuthToken,
-            cancellationToken
-        );
-        if (patients.Count == 0)
-        {
-            _logger.LogWarning("MyLife auth failed: patient list was empty");
-            return (null, DateTime.MinValue, null);
-        }
-
-        var patient = ResolvePatient(patients, config.PatientId);
-        if (patient == null)
-        {
-            _logger.LogWarning(
-                "MyLife auth failed: configured patient not found among {Count} patient(s)",
-                patients.Count);
-            return (null, DateTime.MinValue, null);
-        }
-
-        var restServiceUrl = location.Country20?.RestServiceUrl ?? string.Empty;
-
-        _sessionCache.Set(_tenantAccessor.TenantId, new MyLifeSession(
-            serviceUrl,
-            restServiceUrl,
-            login.AuthToken,
-            login.UserId ?? string.Empty,
-            patient.OnlinePatientId ?? string.Empty
-        ));
-
-        var expiresAt = DateTime.UtcNow.AddHours(24);
-        return (login.AuthToken, expiresAt, null);
     }
 
     private static MyLifePatient? ResolvePatient(

--- a/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeSoapClient.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Services/MyLifeSoapClient.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Security;
 using System.Text;
 using System.Text.Json;
@@ -184,7 +183,8 @@ public class MyLifeSoapClient(HttpClient httpClient, ILogger<MyLifeSoapClient> l
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
         {
             logger.LogError("SOAP request rejected: URL must use HTTPS. Got scheme {Scheme}", Uri.TryCreate(url, UriKind.Absolute, out var rejected) ? rejected.Scheme : "invalid");
-            return string.Empty;
+            throw new InvalidOperationException(
+                $"MyLife service URL for {action} is unusable; it must be an absolute HTTPS URL");
         }
 
         using var request = new HttpRequestMessage(HttpMethod.Post, uri);
@@ -198,14 +198,13 @@ public class MyLifeSoapClient(HttpClient httpClient, ILogger<MyLifeSoapClient> l
 
         logger.LogWarning("MyLife SOAP request failed {StatusCode}", response.StatusCode);
 
-        // Every other status is indistinguishable from "this call returned nothing" to the caller,
-        // which is what the empty string means. A rejected auth token has to be told apart from
-        // that so the caller can drop it.
-        if (response.StatusCode == HttpStatusCode.Unauthorized)
-            throw new HttpRequestException(
-                $"MyLife rejected the {action} request as unauthorized", null, response.StatusCode);
-
-        return string.Empty;
+        // An empty return means "this call returned nothing", which cannot express why. Callers have
+        // to tell a rejected token, a refused request and a sick server apart — to drop the token, to
+        // stop asking, or to try again — so every failed status leaves as an exception carrying it.
+        throw new HttpRequestException(
+            $"MyLife rejected the {action} request with HTTP {(int)response.StatusCode}",
+            null,
+            response.StatusCode);
     }
 
     private string? ExtractSoapResult(string xml, string elementName)

--- a/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemAuthTokenProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.Tandem/Services/TandemAuthTokenProvider.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using System.Web;
 using Microsoft.Extensions.Logging;
+using Nocturne.Connectors.Core.Extensions;
 using Nocturne.Connectors.Core.Interfaces;
 using Nocturne.Connectors.Core.Services;
 using Nocturne.Connectors.Tandem.Configurations;
@@ -20,9 +21,13 @@ public class TandemAuthTokenProvider(
     IConnectorTokenCache tokenCache,
     IConnectorServerResolver<TandemConnectorConfiguration> serverResolver,
     ITenantAccessor tenantAccessor,
-    ILogger<TandemAuthTokenProvider> logger)
+    ILogger<TandemAuthTokenProvider> logger,
+    IRetryDelayStrategy retryDelayStrategy)
     : AuthTokenProviderBase<TandemConnectorConfiguration>(httpClient, tokenCache, serverResolver, tenantAccessor, logger)
 {
+    private readonly IRetryDelayStrategy _retryDelayStrategy =
+        retryDelayStrategy ?? throw new ArgumentNullException(nameof(retryDelayStrategy));
+
     /// <summary>Metadata key under which the resolved pumper id is cached alongside the token.</summary>
     public const string PumperIdKey = "PumperId";
 
@@ -38,9 +43,51 @@ public class TandemAuthTokenProvider(
         AcquireTokenAsync(TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
         var region = TandemConstants.ForRegion(config.Region);
+        var maxRetries = LoginAttempts(config);
+        var expiresAt = DateTime.MinValue;
+        IReadOnlyDictionary<string, string>? metadata = null;
 
+        var accessToken = await ExecuteWithRetryAsync<string>(
+            async attempt =>
+            {
+                _logger.LogInformation(
+                    "Authenticating with Tandem Source (region {Region}, attempt {Attempt}/{MaxRetries})",
+                    region == TandemConstants.Eu ? "EU" : "US", attempt + 1, maxRetries);
+
+                var signIn = await SignInAsync(region, config, cancellationToken);
+                if (signIn.Token == null)
+                    return (null, signIn.ShouldRetry);
+
+                expiresAt = signIn.ExpiresAt;
+                metadata = signIn.Metadata;
+                return (signIn.Token, false);
+            },
+            _retryDelayStrategy,
+            maxRetries,
+            "Tandem Source authentication",
+            cancellationToken);
+
+        if (string.IsNullOrEmpty(accessToken))
+            return (null, DateTime.MinValue, null);
+
+        _logger.LogInformation(
+            "Tandem Source authentication successful (region {Region}), token expires at {ExpiresAt}",
+            region == TandemConstants.Eu ? "EU" : "US", expiresAt);
+
+        return (accessToken, expiresAt, metadata);
+    }
+
+    /// <summary>
+    ///     Runs one full OIDC sign-in, returning the access token plus what to cache with it, or null
+    ///     plus whether the failure is worth another attempt.
+    /// </summary>
+    private async Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata, bool ShouldRetry)>
+        SignInAsync(
+            TandemConstants.RegionUrls region, TandemConnectorConfiguration config,
+            CancellationToken cancellationToken)
+    {
         // One cookie jar per login attempt, matching tconnectsync's fresh requests.Session.
-        using var client = OutboundHttpClient.CreateIsolated(followRedirects: true);
+        using var client = CreateLoginClient();
         client.DefaultRequestHeaders.UserAgent.ParseAdd(TandemConstants.UserAgent);
 
         try
@@ -48,26 +95,27 @@ public class TandemAuthTokenProvider(
             // 1. Prime the SSO session, then post credentials to the login API.
             await client.GetAsync(TandemConstants.LoginPageUrl, cancellationToken);
 
-            if (!await LoginAsync(client, region, config, cancellationToken))
-                return (null, DateTime.MinValue, null);
+            var login = await LoginAsync(client, region, config, cancellationToken);
+            if (!login.Succeeded)
+                return (null, DateTime.MinValue, null, login.ShouldRetry);
 
             // 2. PKCE authorize → authorization code.
             var (verifier, challenge) = GeneratePkcePair();
-            var code = await AuthorizeAsync(client, region, challenge, cancellationToken);
+            var (code, authorizeShouldRetry) = await AuthorizeAsync(client, region, challenge, cancellationToken);
             if (code == null)
-                return (null, DateTime.MinValue, null);
+                return (null, DateTime.MinValue, null, authorizeShouldRetry);
 
             // 3. Exchange the code for tokens.
-            var tokens = await ExchangeCodeAsync(client, region, code, verifier, cancellationToken);
+            var (tokens, exchangeShouldRetry) = await ExchangeCodeAsync(client, region, code, verifier, cancellationToken);
             if (tokens?.AccessToken == null || tokens.IdToken == null)
-                return (null, DateTime.MinValue, null);
+                return (null, DateTime.MinValue, null, exchangeShouldRetry);
 
             // 4. Extract pumper/account ids from the id_token claims.
             var (pumperId, accountId) = ExtractIds(tokens.IdToken);
             if (pumperId == null)
             {
                 _logger.LogError("Tandem id_token did not contain a pumperId claim");
-                return (null, DateTime.MinValue, null);
+                return (null, DateTime.MinValue, null, false);
             }
 
             var metadata = new Dictionary<string, string> { [PumperIdKey] = pumperId };
@@ -75,25 +123,23 @@ public class TandemAuthTokenProvider(
                 metadata[AccountIdKey] = accountId;
 
             var expiresAt = DateTime.UtcNow.AddSeconds(tokens.ExpiresIn > 0 ? tokens.ExpiresIn : 3600);
-            _logger.LogInformation(
-                "Tandem Source authentication successful (region {Region}), token expires at {ExpiresAt}",
-                region == TandemConstants.Eu ? "EU" : "US", expiresAt);
 
-            return (tokens.AccessToken, expiresAt, metadata);
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogError(ex, "HTTP error during Tandem Source authentication");
-            return (null, DateTime.MinValue, null);
+            return (tokens.AccessToken, expiresAt, metadata, false);
         }
         catch (JsonException ex)
         {
             _logger.LogError(ex, "Failed to parse Tandem Source authentication response");
-            return (null, DateTime.MinValue, null);
+            return (null, DateTime.MinValue, null, false);
         }
     }
 
-    private async Task<bool> LoginAsync(
+    /// <summary>
+    ///     Creates the cookie-jar-per-attempt client the sign-in walks its redirect chain on.
+    ///     Overridden in tests to supply a fake transport.
+    /// </summary>
+    protected virtual HttpClient CreateLoginClient() => OutboundHttpClient.CreateIsolated(followRedirects: true);
+
+    private async Task<(bool Succeeded, bool ShouldRetry)> LoginAsync(
         HttpClient client, TandemConstants.RegionUrls region,
         TandemConnectorConfiguration config, CancellationToken cancellationToken)
     {
@@ -108,7 +154,7 @@ public class TandemAuthTokenProvider(
         {
             _logger.LogError(
                 "Tandem Source login failed with HTTP {StatusCode}", (int)response.StatusCode);
-            return false;
+            return (false, response.IsRetryableError());
         }
 
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
@@ -116,14 +162,16 @@ public class TandemAuthTokenProvider(
         var status = doc.RootElement.TryGetProperty("status", out var s) ? s.GetString() : null;
         if (!string.Equals(status, "SUCCESS", StringComparison.OrdinalIgnoreCase))
         {
+            // Tandem answers a rejected credential with HTTP 200 and a non-SUCCESS status in the
+            // body, so this — not the status line — is the sign that retrying cannot help.
             _logger.LogError("Tandem Source login did not return SUCCESS (status: {Status})", status);
-            return false;
+            return (false, false);
         }
 
-        return true;
+        return (true, false);
     }
 
-    private async Task<string?> AuthorizeAsync(
+    private async Task<(string? Code, bool ShouldRetry)> AuthorizeAsync(
         HttpClient client, TandemConstants.RegionUrls region, string codeChallenge,
         CancellationToken cancellationToken)
     {
@@ -144,22 +192,25 @@ public class TandemAuthTokenProvider(
         {
             _logger.LogError(
                 "Tandem Source authorize step failed with HTTP {StatusCode}", (int)response.StatusCode);
-            return null;
+            return (null, response.IsRetryableError());
         }
 
         // After following redirects, the authorization code is in the final request URL's query.
         var finalUri = response.RequestMessage?.RequestUri;
         if (finalUri == null)
-            return null;
+            return (null, false);
 
         var code = HttpUtility.ParseQueryString(finalUri.Query)["code"];
         if (string.IsNullOrEmpty(code))
+        {
             _logger.LogError("Tandem Source authorize step returned no code in redirect URL");
+            return (null, false);
+        }
 
-        return string.IsNullOrEmpty(code) ? null : code;
+        return (code, false);
     }
 
-    private async Task<TandemTokenResponse?> ExchangeCodeAsync(
+    private async Task<(TandemTokenResponse? Tokens, bool ShouldRetry)> ExchangeCodeAsync(
         HttpClient client, TandemConstants.RegionUrls region, string code, string codeVerifier,
         CancellationToken cancellationToken)
     {
@@ -178,12 +229,14 @@ public class TandemAuthTokenProvider(
         {
             _logger.LogError(
                 "Tandem Source token exchange failed with HTTP {StatusCode}", (int)response.StatusCode);
-            return null;
+            return (null, response.IsRetryableError());
         }
 
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
-        return await JsonSerializer.DeserializeAsync<TandemTokenResponse>(
+        var tokens = await JsonSerializer.DeserializeAsync<TandemTokenResponse>(
             stream, cancellationToken: cancellationToken);
+
+        return (tokens, false);
     }
 
     /// <summary>

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoAuthTokenProviderRetryTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoAuthTokenProviderRetryTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+///     Glooko sign-in runs on the shared login retry loop, so a configured
+///     <see cref="Nocturne.Connectors.Core.Models.BaseConnectorConfiguration.MaxRetryAttempts"/>
+///     buys another attempt for a transport failure — and none at all for a rejected credential,
+///     which is what would otherwise walk a tenant into vendor-side lockout.
+/// </summary>
+public class GlookoAuthTokenProviderRetryTests
+{
+    [Fact]
+    public async Task GetValidTokenAsync_RetriesTransportFailure_AndSucceedsOnSecondAttempt()
+    {
+        var handler = new ScriptedHandler(
+            _ => throw new HttpRequestException("connection reset"),
+            _ => SignInSuccess());
+
+        var token = await AuthenticateAsync(handler);
+
+        token.Should().Be($"{GlookoConstants.SessionCookieName}=session-abc");
+        handler.CallCount.Should().Be(2, "a transport failure is worth exactly one more attempt");
+    }
+
+    [Fact]
+    public async Task GetValidTokenAsync_DoesNotRetry_WhenGlookoRejectsTheCredentials()
+    {
+        var handler = new ScriptedHandler(
+            _ => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent("{\"error\":\"Invalid Email or password.\"}")
+            });
+
+        var token = await AuthenticateAsync(handler);
+
+        token.Should().BeNull();
+        handler.CallCount.Should().Be(1, "retrying a rejected credential cannot help and risks lockout");
+    }
+
+    private static async Task<string?> AuthenticateAsync(ScriptedHandler handler)
+    {
+        using var httpClient = new HttpClient(handler);
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+        tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+
+        var retryDelay = new Mock<IRetryDelayStrategy>();
+        retryDelay.Setup(r => r.ApplyRetryDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
+
+        var provider = new GlookoAuthTokenProvider(
+            httpClient,
+            new ConnectorTokenCache(),
+            new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
+            tenantAccessor.Object,
+            NullLogger<GlookoAuthTokenProvider>.Instance,
+            retryDelay.Object);
+
+        // V2 sign-in returns the user data inline, so one request is a whole login attempt.
+        var config = new GlookoConnectorConfiguration
+        {
+            Email = "someone@example.com",
+            Password = "hunter2",
+            UseV3Api = false,
+            MaxRetryAttempts = 3
+        };
+
+        return await provider.GetValidTokenAsync(config, CancellationToken.None);
+    }
+
+    private static HttpResponseMessage SignInSuccess()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"userLogin\":{\"glookoCode\":\"blue-duke-4165\"}}")
+        };
+        response.Headers.TryAddWithoutValidation(
+            "Set-Cookie", $"{GlookoConstants.SessionCookieName}=session-abc; Path=/; HttpOnly");
+        return response;
+    }
+
+    /// <summary>Answers each request from the next step of a script, and counts the requests.</summary>
+    private sealed class ScriptedHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] steps)
+        : HttpMessageHandler
+    {
+        private int _callCount;
+        public int CallCount => _callCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var index = Interlocked.Increment(ref _callCount) - 1;
+            var step = steps[Math.Min(index, steps.Length - 1)];
+            return Task.FromResult(step(request));
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoAuthTokenProviderRetryTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoAuthTokenProviderRetryTests.cs
@@ -47,7 +47,49 @@ public class GlookoAuthTokenProviderRetryTests
         handler.CallCount.Should().Be(1, "retrying a rejected credential cannot help and risks lockout");
     }
 
-    private static async Task<string?> AuthenticateAsync(ScriptedHandler handler)
+    /// <summary>
+    ///     V3 declines a sign-in in the body — 200 with { success, two_fa_required } and no
+    ///     Set-Cookie — so the status line alone would read it as a success worth retrying.
+    /// </summary>
+    [Fact]
+    public async Task GetValidTokenAsync_DoesNotRetry_WhenV3SignInReturnsNoSessionCookie()
+    {
+        var handler = new ScriptedHandler(
+            _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"success\":false,\"two_fa_required\":false}")
+            });
+
+        var token = await AuthenticateAsync(handler, useV3Api: true);
+
+        token.Should().BeNull();
+        handler.CallCount.Should().Be(1, "a sign-in Glooko declined in the body cannot succeed on a retry");
+    }
+
+    /// <summary>
+    ///     The configured MaxRetryAttempts is what the login loop spends, so a tenant lowering or
+    ///     raising it changes how many times the connector authenticates.
+    /// </summary>
+    [Theory]
+    [InlineData(2)]
+    [InlineData(5)]
+    public async Task GetValidTokenAsync_SpendsExactlyMaxRetryAttempts_OnAPersistentRetryableError(
+        int maxRetryAttempts)
+    {
+        var handler = new ScriptedHandler(
+            _ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent("upstream unavailable")
+            });
+
+        var token = await AuthenticateAsync(handler, maxRetryAttempts: maxRetryAttempts);
+
+        token.Should().BeNull();
+        handler.CallCount.Should().Be(maxRetryAttempts, "the configured attempt budget is what gets spent");
+    }
+
+    private static async Task<string?> AuthenticateAsync(
+        ScriptedHandler handler, bool useV3Api = false, int maxRetryAttempts = 3)
     {
         using var httpClient = new HttpClient(handler);
 
@@ -71,8 +113,8 @@ public class GlookoAuthTokenProviderRetryTests
         {
             Email = "someone@example.com",
             Password = "hunter2",
-            UseV3Api = false,
-            MaxRetryAttempts = 3
+            UseV3Api = useV3Api,
+            MaxRetryAttempts = maxRetryAttempts
         };
 
         return await provider.GetValidTokenAsync(config, CancellationToken.None);

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceReauthTests.cs
@@ -202,7 +202,8 @@ public class GlookoConnectorServiceReauthTests
                 new ConnectorTokenCache(),
                 new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
                 new FakeTenantAccessor(),
-                NullLogger<GlookoAuthTokenProvider>.Instance)
+                NullLogger<GlookoAuthTokenProvider>.Instance,
+                Mock.Of<IRetryDelayStrategy>())
         {
             _codes = new Queue<string>(codes);
         }

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceStateIsolationTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoConnectorServiceStateIsolationTests.cs
@@ -229,7 +229,8 @@ public class GlookoConnectorServiceStateIsolationTests
                 new ConnectorTokenCache(),
                 new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
                 new AmbientTenantAccessor(),
-                NullLogger<GlookoAuthTokenProvider>.Instance)
+                NullLogger<GlookoAuthTokenProvider>.Instance,
+                Mock.Of<IRetryDelayStrategy>())
         {
         }
 

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
@@ -126,7 +126,7 @@ internal sealed class StaticGlookoTokenProvider : GlookoAuthTokenProvider
             new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
             new FakeTenantAccessor(),
             NullLogger<GlookoAuthTokenProvider>.Instance,
-                Mock.Of<IRetryDelayStrategy>())
+            Mock.Of<IRetryDelayStrategy>())
     {
     }
 

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoSyncHarness.cs
@@ -125,7 +125,8 @@ internal sealed class StaticGlookoTokenProvider : GlookoAuthTokenProvider
             new ConnectorTokenCache(),
             new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
             new FakeTenantAccessor(),
-            NullLogger<GlookoAuthTokenProvider>.Instance)
+            NullLogger<GlookoAuthTokenProvider>.Instance,
+                Mock.Of<IRetryDelayStrategy>())
     {
     }
 

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeAuthTokenProviderRetryTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeAuthTokenProviderRetryTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.MyLife.Configurations;
+using Nocturne.Connectors.MyLife.Configurations.Constants;
+using Nocturne.Connectors.MyLife.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.Connectors.MyLife.Tests.Services;
+
+/// <summary>
+///     MyLife sign-in runs on the shared login retry loop. One login attempt is three SOAP calls, so
+///     attempts are counted by the GetUser20 call that opens each one.
+/// </summary>
+public class MyLifeAuthTokenProviderRetryTests
+{
+    [Fact]
+    public async Task GetValidTokenAsync_RetriesTransportFailure_AndSucceedsOnSecondAttempt()
+    {
+        var handler = new SoapHandler
+        {
+            FailFirstUserLocationWith = new HttpRequestException("connection reset")
+        };
+
+        var token = await AuthenticateAsync(handler);
+
+        token.Should().Be("auth-token-1");
+        handler.LoginAttempts.Should().Be(2, "a transport failure is worth exactly one more attempt");
+    }
+
+    [Fact]
+    public async Task GetValidTokenAsync_DoesNotRetry_WhenMyLifeAnswersLoginWith401()
+    {
+        var handler = new SoapHandler { LoginStatus = HttpStatusCode.Unauthorized };
+
+        var token = await AuthenticateAsync(handler);
+
+        token.Should().BeNull();
+        handler.LoginAttempts.Should().Be(1, "a 401 is a rejection, and retrying it risks lockout");
+    }
+
+    /// <summary>
+    ///     MyLife's own bad-credentials answer: HTTP 200 carrying a LoginResult with no auth token.
+    /// </summary>
+    [Fact]
+    public async Task GetValidTokenAsync_DoesNotRetry_WhenLoginReturnsNoAuthToken()
+    {
+        var handler = new SoapHandler { LoginResultJson = "{}" };
+
+        var token = await AuthenticateAsync(handler);
+
+        token.Should().BeNull();
+        handler.LoginAttempts.Should().Be(1, "a login answered without a token is a rejected credential");
+    }
+
+    private static async Task<string?> AuthenticateAsync(SoapHandler handler)
+    {
+        using var httpClient = new HttpClient(handler);
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+        tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+
+        var retryDelay = new Mock<IRetryDelayStrategy>();
+        retryDelay.Setup(r => r.ApplyRetryDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
+
+        var provider = new MyLifeAuthTokenProvider(
+            httpClient,
+            new ConnectorTokenCache(),
+            new ConnectorServerResolver<MyLifeConnectorConfiguration>(null, null, null),
+            tenantAccessor.Object,
+            new MyLifeSoapClient(httpClient, NullLogger<MyLifeSoapClient>.Instance),
+            new MyLifeSessionCache(),
+            NullLogger<MyLifeAuthTokenProvider>.Instance,
+            retryDelay.Object);
+
+        var config = new MyLifeConnectorConfiguration
+        {
+            Username = "someone@example.com",
+            Password = "hunter2",
+            MaxRetryAttempts = 3
+        };
+
+        return await provider.GetValidTokenAsync(config, CancellationToken.None);
+    }
+
+    /// <summary>Answers the three SOAP calls of a MyLife login, with per-test failure injection.</summary>
+    private sealed class SoapHandler : HttpMessageHandler
+    {
+        private const string ServiceUrl = "https://svc.mylife-software.net";
+
+        public HttpRequestException? FailFirstUserLocationWith { get; init; }
+        public HttpStatusCode LoginStatus { get; init; } = HttpStatusCode.OK;
+        public string LoginResultJson { get; init; } = "{\"AuthToken\":\"auth-token-1\",\"UserId\":\"u1\"}";
+
+        /// <summary>Each login attempt opens with a GetUser20 call, so these count attempts.</summary>
+        public int LoginAttempts { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var action = request.Headers.TryGetValues("SOAPAction", out var values)
+                ? values.FirstOrDefault()
+                : null;
+
+            if (action == MyLifeConstants.SoapActions.GetUser20)
+            {
+                LoginAttempts++;
+                if (FailFirstUserLocationWith != null && LoginAttempts == 1)
+                    throw FailFirstUserLocationWith;
+
+                return Task.FromResult(Envelope(
+                    HttpStatusCode.OK,
+                    "GetUser20Result",
+                    $"{{\"Country20\":{{\"ServiceUrl\":\"{ServiceUrl}\"}}}}"));
+            }
+
+            if (action == MyLifeConstants.SoapActions.Login)
+                return Task.FromResult(LoginStatus == HttpStatusCode.OK
+                    ? Envelope(HttpStatusCode.OK, "LoginResult", LoginResultJson)
+                    : new HttpResponseMessage(LoginStatus) { Content = new StringContent(string.Empty) });
+
+            if (action == MyLifeConstants.SoapActions.SyncPatientList)
+                return Task.FromResult(Envelope(
+                    HttpStatusCode.OK, "SyncPatientListResult", "[{\"OnlinePatientId\":\"p1\"}]"));
+
+            throw new InvalidOperationException($"Unexpected SOAP action: {action}");
+        }
+
+        private static HttpResponseMessage Envelope(HttpStatusCode status, string element, string payload)
+        {
+            var xml =
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                "<s:Body>" +
+                $"<{element}>{System.Security.SecurityElement.Escape(payload)}</{element}>" +
+                "</s:Body>" +
+                "</s:Envelope>";
+
+            return new HttpResponseMessage(status) { Content = new StringContent(xml) };
+        }
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeAuthTokenProviderRetryTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeAuthTokenProviderRetryTests.cs
@@ -57,7 +57,51 @@ public class MyLifeAuthTokenProviderRetryTests
         handler.LoginAttempts.Should().Be(1, "a login answered without a token is a rejected credential");
     }
 
-    private static async Task<string?> AuthenticateAsync(SoapHandler handler)
+    [Fact]
+    public async Task GetValidTokenAsync_DoesNotRetry_WhenMyLifeAnswersLoginWith403()
+    {
+        var handler = new SoapHandler { LoginStatus = HttpStatusCode.Forbidden };
+
+        var token = await AuthenticateAsync(handler);
+
+        token.Should().BeNull();
+        handler.LoginAttempts.Should().Be(1, "a refused request is not transient");
+    }
+
+    /// <summary>
+    ///     A member-supplied ServiceUrl the SOAP client refuses to send to: no request is made, so
+    ///     nothing about a second attempt could differ.
+    /// </summary>
+    [Fact]
+    public async Task GetValidTokenAsync_DoesNotRetry_WhenServiceUrlIsUnusable()
+    {
+        var handler = new SoapHandler();
+
+        var token = await AuthenticateAsync(handler, serviceUrl: "http://insecure.example.com");
+
+        token.Should().BeNull();
+        handler.LoginAttempts.Should().Be(1, "an unusable service URL is a config fault, not a transient one");
+    }
+
+    /// <summary>
+    ///     The configured MaxRetryAttempts is what the login loop spends.
+    /// </summary>
+    [Theory]
+    [InlineData(2)]
+    [InlineData(4)]
+    public async Task GetValidTokenAsync_SpendsExactlyMaxRetryAttempts_OnAPersistentRetryableError(
+        int maxRetryAttempts)
+    {
+        var handler = new SoapHandler { LoginStatus = HttpStatusCode.ServiceUnavailable };
+
+        var token = await AuthenticateAsync(handler, maxRetryAttempts: maxRetryAttempts);
+
+        token.Should().BeNull();
+        handler.LoginAttempts.Should().Be(maxRetryAttempts, "the configured attempt budget is what gets spent");
+    }
+
+    private static async Task<string?> AuthenticateAsync(
+        SoapHandler handler, string serviceUrl = "", int maxRetryAttempts = 3)
     {
         using var httpClient = new HttpClient(handler);
 
@@ -82,7 +126,8 @@ public class MyLifeAuthTokenProviderRetryTests
         {
             Username = "someone@example.com",
             Password = "hunter2",
-            MaxRetryAttempts = 3
+            ServiceUrl = serviceUrl,
+            MaxRetryAttempts = maxRetryAttempts
         };
 
         return await provider.GetValidTokenAsync(config, CancellationToken.None);

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeSyncHarness.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Services/MyLifeSyncHarness.cs
@@ -41,7 +41,8 @@ internal static class MyLifeSyncHarness
             tenantAccessor.Object,
             soapClient,
             sessionCache,
-            NullLogger<MyLifeAuthTokenProvider>.Instance);
+            NullLogger<MyLifeAuthTokenProvider>.Instance,
+            Mock.Of<IRetryDelayStrategy>());
         var syncService = syncServiceFactory?.Invoke(soapClient)
             ?? new MyLifeSyncService(soapClient, NullLogger<MyLifeSyncService>.Instance);
 

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemAuthTokenProviderRetryTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemAuthTokenProviderRetryTests.cs
@@ -59,7 +59,25 @@ public class TandemAuthTokenProviderRetryTests
         handler.LoginCalls.Should().Be(1, "a non-SUCCESS login body is a rejected credential");
     }
 
-    private static async Task<string?> AuthenticateAsync(TandemLoginHandler handler)
+    /// <summary>
+    ///     The configured MaxRetryAttempts is what the login loop spends.
+    /// </summary>
+    [Theory]
+    [InlineData(2)]
+    [InlineData(4)]
+    public async Task GetValidTokenAsync_SpendsExactlyMaxRetryAttempts_OnAPersistentRetryableError(
+        int maxRetryAttempts)
+    {
+        var handler = new TandemLoginHandler { LoginStatus = HttpStatusCode.ServiceUnavailable };
+
+        var token = await AuthenticateAsync(handler, maxRetryAttempts);
+
+        token.Should().BeNull();
+        handler.LoginCalls.Should().Be(maxRetryAttempts, "the configured attempt budget is what gets spent");
+    }
+
+    private static async Task<string?> AuthenticateAsync(
+        TandemLoginHandler handler, int maxRetryAttempts = 3)
     {
         using var httpClient = new HttpClient();
 
@@ -84,7 +102,7 @@ public class TandemAuthTokenProviderRetryTests
             Email = "someone@example.com",
             Password = "hunter2",
             Region = "US",
-            MaxRetryAttempts = 3
+            MaxRetryAttempts = maxRetryAttempts
         };
 
         return await provider.GetValidTokenAsync(config, CancellationToken.None);

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemAuthTokenProviderRetryTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemAuthTokenProviderRetryTests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Tandem.Configurations;
+using Nocturne.Connectors.Tandem.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.Connectors.Tandem.Tests.Services;
+
+/// <summary>
+///     Tandem's OIDC sign-in runs on the shared login retry loop, so a configured
+///     <see cref="Nocturne.Connectors.Core.Models.BaseConnectorConfiguration.MaxRetryAttempts"/>
+///     buys another attempt for a transport failure — and none at all for a rejected credential.
+/// </summary>
+public class TandemAuthTokenProviderRetryTests
+{
+    [Fact]
+    public async Task GetValidTokenAsync_RetriesTransportFailure_AndSucceedsOnSecondAttempt()
+    {
+        var handler = new TandemLoginHandler
+        {
+            FailFirstLoginWith = new HttpRequestException("connection reset")
+        };
+
+        var token = await AuthenticateAsync(handler);
+
+        token.Should().Be("access-token-1");
+        handler.LoginCalls.Should().Be(2, "a transport failure is worth exactly one more attempt");
+    }
+
+    [Fact]
+    public async Task GetValidTokenAsync_DoesNotRetry_WhenTandemRejectsTheCredentialsWith401()
+    {
+        var handler = new TandemLoginHandler { LoginStatus = HttpStatusCode.Unauthorized };
+
+        var token = await AuthenticateAsync(handler);
+
+        token.Should().BeNull();
+        handler.LoginCalls.Should().Be(1, "retrying a rejected credential cannot help and risks lockout");
+    }
+
+    /// <summary>
+    ///     Tandem's own bad-credentials answer: HTTP 200 carrying a non-SUCCESS status in the body.
+    /// </summary>
+    [Fact]
+    public async Task GetValidTokenAsync_DoesNotRetry_WhenLoginStatusIsNotSuccess()
+    {
+        var handler = new TandemLoginHandler { LoginBodyStatus = "INVALID_CREDENTIALS" };
+
+        var token = await AuthenticateAsync(handler);
+
+        token.Should().BeNull();
+        handler.LoginCalls.Should().Be(1, "a non-SUCCESS login body is a rejected credential");
+    }
+
+    private static async Task<string?> AuthenticateAsync(TandemLoginHandler handler)
+    {
+        using var httpClient = new HttpClient();
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+        tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+
+        var retryDelay = new Mock<IRetryDelayStrategy>();
+        retryDelay.Setup(r => r.ApplyRetryDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
+
+        using var provider = new FakeTransportTandemAuthTokenProvider(
+            handler,
+            httpClient,
+            new ConnectorTokenCache(),
+            new ConnectorServerResolver<TandemConnectorConfiguration>(null, null, null),
+            tenantAccessor.Object,
+            NullLogger<TandemAuthTokenProvider>.Instance,
+            retryDelay.Object);
+
+        var config = new TandemConnectorConfiguration
+        {
+            Email = "someone@example.com",
+            Password = "hunter2",
+            Region = "US",
+            MaxRetryAttempts = 3
+        };
+
+        return await provider.GetValidTokenAsync(config, CancellationToken.None);
+    }
+
+    /// <summary>Runs the real sign-in flow over a fake transport instead of the network.</summary>
+    private sealed class FakeTransportTandemAuthTokenProvider(
+        HttpMessageHandler transport,
+        HttpClient httpClient,
+        IConnectorTokenCache tokenCache,
+        IConnectorServerResolver<TandemConnectorConfiguration> serverResolver,
+        ITenantAccessor tenantAccessor,
+        ILogger<TandemAuthTokenProvider> logger,
+        IRetryDelayStrategy retryDelayStrategy)
+        : TandemAuthTokenProvider(httpClient, tokenCache, serverResolver, tenantAccessor, logger, retryDelayStrategy)
+    {
+        // disposeHandler: false — the sign-in disposes its client per attempt, and the handler has to
+        // outlive that to answer (and count) the next one.
+        protected override HttpClient CreateLoginClient() => new(transport, disposeHandler: false);
+    }
+
+    /// <summary>Answers the four requests of a Tandem OIDC login, with per-test failure injection.</summary>
+    private sealed class TandemLoginHandler : HttpMessageHandler
+    {
+        private static readonly TandemConstants.RegionUrls Region = TandemConstants.Us;
+
+        public HttpRequestException? FailFirstLoginWith { get; init; }
+        public HttpStatusCode LoginStatus { get; init; } = HttpStatusCode.OK;
+        public string LoginBodyStatus { get; init; } = "SUCCESS";
+
+        public int LoginCalls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.ToString();
+
+            if (url == TandemConstants.LoginPageUrl)
+                return Task.FromResult(Ok(string.Empty));
+
+            if (url == Region.LoginApiUrl)
+            {
+                LoginCalls++;
+                if (FailFirstLoginWith != null && LoginCalls == 1)
+                    throw FailFirstLoginWith;
+
+                if (LoginStatus != HttpStatusCode.OK)
+                    return Task.FromResult(new HttpResponseMessage(LoginStatus)
+                    {
+                        Content = new StringContent("{\"message\":\"unauthorized\"}")
+                    });
+
+                return Task.FromResult(Ok($"{{\"status\":\"{LoginBodyStatus}\"}}"));
+            }
+
+            if (url.StartsWith(Region.AuthorizationEndpoint, StringComparison.Ordinal))
+            {
+                var response = Ok(string.Empty);
+                // The authorization code is read off the URL the redirect chain landed on.
+                response.RequestMessage = new HttpRequestMessage(
+                    HttpMethod.Get, $"{Region.RedirectUri}?code=authorization-code-1");
+                return Task.FromResult(response);
+            }
+
+            if (url == Region.TokenEndpoint)
+                return Task.FromResult(Ok(
+                    "{\"access_token\":\"access-token-1\"," +
+                    $"\"id_token\":\"{IdToken()}\"," +
+                    "\"expires_in\":3600}"));
+
+            throw new InvalidOperationException($"Unexpected Tandem request: {url}");
+        }
+
+        private static HttpResponseMessage Ok(string body) =>
+            new(HttpStatusCode.OK) { Content = new StringContent(body) };
+
+        private static string IdToken() =>
+            $"{Base64Url("{\"alg\":\"RS256\"}")}.{Base64Url("{\"pumperId\":\"pumper-1\",\"accountId\":\"account-1\"}")}.signature";
+
+        private static string Base64Url(string json) =>
+            Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
+                .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+}

--- a/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Tandem.Tests/Services/TandemE2eSyncTests.cs
@@ -627,7 +627,8 @@ public class TandemE2eSyncTests
         new ConnectorTokenCache(),
         new ConnectorServerResolver<TandemConnectorConfiguration>(null, null, null),
         new FakeTenantAccessor(),
-        NullLogger<TandemAuthTokenProvider>.Instance)
+        NullLogger<TandemAuthTokenProvider>.Instance,
+        Mock.Of<IRetryDelayStrategy>())
     {
         protected override Task<(string? Token, DateTime ExpiresAt, IReadOnlyDictionary<string, string>? Metadata)>
             AcquireTokenAsync(TandemConnectorConfiguration config, CancellationToken cancellationToken) =>


### PR DESCRIPTION
Closes #790.

## The change

`BaseConnectorConfiguration.MaxRetryAttempts` governed login retries for seven connectors and was inert for Glooko, MyLife and Tandem, which made exactly one login attempt whatever the user configured. All three now acquire credentials through the existing `AuthTokenProviderBase.ExecuteWithRetryAsync` with `LoginAttempts(config)`, under one policy: a credential rejection is never retried; only a transport failure or a status the shared `IsRetryableStatusCode` classifies as transient (408, 429, 5xx) buys another attempt. That does not raise vendor-lockout risk, because a wrong password is tried once.

- **Glooko**: a non-retryable status fails after one request, and so does a 2xx with no session cookie, which is how V3 declines a sign-in in the body. Error bodies are read through the gzip-aware Glooko helper while the verdict comes from the shared classifier.
- **MyLife** (SOAP): the SOAP client used to throw only for 401 and flatten every other non-2xx to an empty response, which the new retry would have treated as transient. It now throws with the status for every non-2xx, and throws when the configured service URL cannot be used and nothing was sent. An unknown username, a declined login, and an account with no matching patient are 2xx answers that cannot change on a retry and are not retried.
- **Tandem**: the existing retry at `TandemConnectorService` wrapped a data fetch, not login. The OIDC walk now runs under the retry with a fresh cookie jar per attempt; a 200 whose body status is not `SUCCESS` is a rejected credential.

## Behaviour delta beyond login

Because the MyLife SOAP client now throws for every non-2xx, a month fetch that Nightscout answers with a 5xx fails that sync run (recorded as an error, remaining months and pump settings skipped for that run, refetched next run since the window is recomputed from stored data) where it used to be skipped silently. The 401 token-invalidation check is unchanged and covered.

## Tests

Per provider: a transport failure then success gives two attempts; a credential rejection gives one; a persistent 503 spends exactly the configured `MaxRetryAttempts` (theories at non-default values, so hard-coding the count fails). Glooko's V3 cookieless 2xx and MyLife's 403, bad URL and token-less login are pinned. Mutations killed by a named test: unwrapping Tandem, retrying Glooko's rejection, retrying MyLife's 401 or token-less login, hard-coding the attempt count in all three, and reverting the SOAP client to 401-only.

Related follow-ups found in review: #1222 (four of the seven other providers retry a rejected login), #1224 (the backoff is uncapped and uncancellable, so the 3-minute per-tenant sync timeout caps real login attempts at two).
