### PR TITLE
fix(analytics): derive the CGM cadence from the readings instead of assuming five minutes

### DIFF
--- a/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
+++ b/src/API/Nocturne.API/Services/Analytics/StatisticsService.cs
@@ -1484,11 +1484,35 @@ public class StatisticsService : IStatisticsService
     }
 
     /// <summary>
-    /// The gap credited to the final reading of a series whose entries show no gap of their own:
-    /// a lone reading, or several stamped at the same instant. The readings before it in such a
-    /// series cover no elapsed time and are credited none.
+    /// The cadence assumed of a series whose entries show no interval of their own: a lone
+    /// reading, or several stamped at the same instant. In <see cref="ReadingMinutes"/> it is what
+    /// the final reading of such a series stands for, the readings before it covering no elapsed
+    /// time; in <see cref="AssessDataQuality"/> it is the coverage that reading is credited.
     /// </summary>
     private const double DefaultCadenceMinutes = 5;
+
+    /// <summary>
+    /// The minutes from each reading to the next, in series order; empty for a series of one.
+    /// </summary>
+    private static double[] ReadingIntervals(IList<SensorGlucose> sortedEntries)
+    {
+        var intervals = new double[Math.Max(sortedEntries.Count - 1, 0)];
+        for (var i = 1; i < sortedEntries.Count; i++)
+            intervals[i - 1] = (sortedEntries[i].Mills - sortedEntries[i - 1].Mills) / 60000.0;
+
+        return intervals;
+    }
+
+    /// <summary>
+    /// The cadence the series reports about itself: the median of its intervals, which a sensor
+    /// outage or a warmup cannot drag the way it would a mean. Intervals of no elapsed time are
+    /// excluded, and a series with none left falls back to <see cref="DefaultCadenceMinutes"/>.
+    /// </summary>
+    private static double SeriesCadenceMinutes(IEnumerable<double> intervals)
+    {
+        var elapsed = intervals.Where(interval => interval > 0).Order().ToList();
+        return elapsed.Count == 0 ? DefaultCadenceMinutes : GlucoseStatistics.Median(elapsed);
+    }
 
     /// <summary>
     /// The minutes each reading stands for: the gap to the next reading, capped at twice the
@@ -1497,15 +1521,12 @@ public class StatisticsService : IStatisticsService
     /// </summary>
     private static double[] ReadingMinutes(IList<SensorGlucose> sortedEntries)
     {
+        var intervals = ReadingIntervals(sortedEntries);
+        var cadence = SeriesCadenceMinutes(intervals);
+
         var minutes = new double[sortedEntries.Count];
-        for (var i = 1; i < sortedEntries.Count; i++)
-            minutes[i - 1] = (sortedEntries[i].Mills - sortedEntries[i - 1].Mills) / 60000.0;
-
-        var gaps = minutes.Take(sortedEntries.Count - 1).Where(g => g > 0).Order().ToList();
-        var cadence = gaps.Count == 0 ? DefaultCadenceMinutes : GlucoseStatistics.Median(gaps);
-
-        for (var i = 0; i < sortedEntries.Count - 1; i++)
-            minutes[i] = Math.Min(minutes[i], cadence * 2);
+        for (var i = 0; i < intervals.Length; i++)
+            minutes[i] = Math.Min(intervals[i], cadence * 2);
         minutes[^1] = cadence;
 
         return minutes;
@@ -2725,8 +2746,7 @@ public class StatisticsService : IStatisticsService
         IEnumerable<CarbIntake> carbIntakes,
         ExtendedAnalysisConfig? config = null,
         DateTime? startDate = null,
-        DateTime? endDate = null,
-        int updateIntervalMinutes = 5
+        DateTime? endDate = null
     )
     {
         config ??= new ExtendedAnalysisConfig();
@@ -2756,7 +2776,7 @@ public class StatisticsService : IStatisticsService
         var basicStats = CalculateBasicStats(glucoseValues);
         var timeInRange = CalculateTimeInRange(sortedEntries, config.Thresholds);
         var glycemicVariability = CalculateGlycemicVariability(glucoseValues, sortedEntries);
-        var dataQuality = AssessDataQuality(sortedEntries, startDate, endDate, updateIntervalMinutes);
+        var dataQuality = AssessDataQuality(sortedEntries, startDate, endDate);
 
         var timeStart = sortedEntries.FirstOrDefault()?.Mills ?? 0;
         var timeEnd = sortedEntries.LastOrDefault()?.Mills ?? 0;
@@ -2784,65 +2804,80 @@ public class StatisticsService : IStatisticsService
         };
     }
 
+    /// <summary>
+    /// A stretch longer than three cadences is a gap: two readings the sensor owed are absent.
+    /// </summary>
+    private const double GapCadences = 3;
+
     private DataQuality AssessDataQuality(
         IList<SensorGlucose> entries,
         DateTime? reportStart = null,
-        DateTime? reportEnd = null,
-        int updateIntervalMinutes = 5)
+        DateTime? reportEnd = null)
     {
         var totalReadings = entries.Count;
         var gaps = new List<DataGap>();
+        var missingReadings = 0;
+        double coveredMinutes = 0;
+        double streamSpanMinutes = 0;
 
-        if (entries.Count > 1)
+        // Cadence belongs to a sensor, not to a report: a window spanning a switch from a
+        // one-minute sensor to a five-minute one holds two of them. Streams are told apart on the
+        // identity CanonicalGlucoseStream.Select selects on.
+        foreach (var stream in entries.GroupBy(CanonicalGlucoseStream.StreamKey, StringComparer.Ordinal))
         {
-            for (int i = 1; i < entries.Count; i++)
-            {
-                var prevTime = entries[i - 1].Mills;
-                var currentTime = entries[i].Mills;
-                var gapMinutes = (currentTime - prevTime) / (1000.0 * 60);
+            var readings = stream.ToList();
+            var intervals = ReadingIntervals(readings);
+            var cadence = SeriesCadenceMinutes(intervals);
 
-                if (gapMinutes > 15)
+            coveredMinutes += readings.Count * cadence;
+            streamSpanMinutes += intervals.Sum();
+
+            for (int i = 0; i < intervals.Length; i++)
+            {
+                if (intervals[i] <= cadence * GapCadences)
+                    continue;
+
+                gaps.Add(new DataGap
                 {
-                    gaps.Add(new DataGap
-                    {
-                        Start = prevTime,
-                        End = currentTime,
-                        Duration = gapMinutes,
-                    });
-                }
+                    Start = readings[i].Mills,
+                    End = readings[i + 1].Mills,
+                    Duration = intervals[i],
+                });
+
+                // A gap spanning n cadences is missing n - 1 readings: the one that closed it
+                // arrived.
+                missingReadings += (int)(intervals[i] / cadence) - 1;
             }
         }
 
         var longestGap = gaps.Any() ? gaps.Max(g => g.Duration) : 0;
         var averageGap = gaps.Any() ? gaps.Average(g => g.Duration) : 0;
 
-        // CgmActivePercent: actual readings vs expected readings over report period
+        // CgmActivePercent: minutes the sensors covered, each reading standing for one cadence of
+        // its own stream, against the report period.
         var effectiveStart = reportStart ?? (entries.Count > 0 ? entries[0].Timestamp : DateTime.UtcNow);
         var effectiveEnd = reportEnd ?? (entries.Count > 0 ? entries[^1].Timestamp : DateTime.UtcNow);
         var reportSpanMinutes = (effectiveEnd - effectiveStart).TotalMinutes;
-        var expectedReadings = reportSpanMinutes / updateIntervalMinutes;
-        var cgmActivePercent = expectedReadings > 0
-            ? Math.Min(totalReadings / expectedReadings * 100.0, 100.0)
+        var cgmActivePercent = reportSpanMinutes > 0
+            ? Math.Min(coveredMinutes / reportSpanMinutes * 100.0, 100.0)
             : 0;
 
-        // DataCompleteness: time coverage within the data range (first->last reading)
-        var dataSpanMinutes = entries.Count > 1
-            ? (entries[^1].Mills - entries[0].Mills) / (1000.0 * 60)
-            : 0;
+        // DataCompleteness: time coverage within each stream's own range (first->last reading)
         var totalGapMinutes = gaps.Sum(g => g.Duration);
-        var dataCompleteness = dataSpanMinutes > 0
-            ? ((dataSpanMinutes - totalGapMinutes) / dataSpanMinutes) * 100.0
+        var dataCompleteness = streamSpanMinutes > 0
+            ? ((streamSpanMinutes - totalGapMinutes) / streamSpanMinutes) * 100.0
             : 0;
 
         return new DataQuality
         {
             TotalReadings = totalReadings,
-            MissingReadings = gaps.Sum(g => (int)(g.Duration / updateIntervalMinutes)),
+            MissingReadings = missingReadings,
             DataCompleteness = dataCompleteness,
             CgmActivePercent = cgmActivePercent,
             GapAnalysis = new GapAnalysis
             {
-                Gaps = gaps,
+                // Collected a stream at a time, so put them back in the order they happened.
+                Gaps = gaps.OrderBy(g => g.Start).ToList(),
                 LongestGap = longestGap,
                 AverageGap = averageGap,
             },

--- a/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Analytics/IStatisticsService.cs
@@ -306,8 +306,7 @@ public interface IStatisticsService
         IEnumerable<CarbIntake> carbIntakes,
         ExtendedAnalysisConfig? config = null,
         DateTime? startDate = null,
-        DateTime? endDate = null,
-        int updateIntervalMinutes = 5
+        DateTime? endDate = null
     );
 
     // Site Change Analysis

--- a/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Analytics/StatisticsServiceTests.cs
@@ -947,20 +947,31 @@ public class StatisticsServiceTests
 
     #region CGM Active Percent Tests
 
+    private static SensorGlucose[] AtCadence(
+        DateTime start,
+        double cadenceMinutes,
+        int count,
+        Guid? patientDeviceId = null
+    ) =>
+        Enumerable
+            .Range(0, count)
+            .Select(i => new SensorGlucose
+            {
+                Mgdl = 120,
+                Timestamp = start.AddMinutes(i * cadenceMinutes),
+                PatientDeviceId = patientDeviceId,
+            })
+            .ToArray();
+
     [Fact]
     public void AnalyzeGlucoseData_HalfCoverage_Returns50PercentCgmActive()
     {
-        // 144 readings over 24 hours with 5-min interval = 50% (expected 288)
+        // 144 five-minute readings cover twelve hours of a twenty-four hour report.
         var start = DateTime.UtcNow.AddDays(-1);
-        var entries = Enumerable.Range(0, 144).Select(i => new SensorGlucose
-        {
-            Mgdl = 120,
-            Timestamp = start.AddMinutes(i * 10),
-        });
 
         var result = _statisticsService.AnalyzeGlucoseData(
-            entries, Array.Empty<Bolus>(), Array.Empty<CarbIntake>(),
-            startDate: start, endDate: start.AddDays(1), updateIntervalMinutes: 5);
+            AtCadence(start, 5, 144), Array.Empty<Bolus>(), Array.Empty<CarbIntake>(),
+            startDate: start, endDate: start.AddDays(1));
 
         result.DataQuality.CgmActivePercent.Should().BeApproximately(50.0, 1.0);
     }
@@ -969,49 +980,100 @@ public class StatisticsServiceTests
     public void AnalyzeGlucoseData_FullCoverage_Returns100PercentCgmActive()
     {
         var start = DateTime.UtcNow.AddDays(-1);
-        var entries = Enumerable.Range(0, 288).Select(i => new SensorGlucose
-        {
-            Mgdl = 120,
-            Timestamp = start.AddMinutes(i * 5),
-        });
 
         var result = _statisticsService.AnalyzeGlucoseData(
-            entries, Array.Empty<Bolus>(), Array.Empty<CarbIntake>(),
-            startDate: start, endDate: start.AddDays(1), updateIntervalMinutes: 5);
+            AtCadence(start, 5, 288), Array.Empty<Bolus>(), Array.Empty<CarbIntake>(),
+            startDate: start, endDate: start.AddDays(1));
 
         result.DataQuality.CgmActivePercent.Should().Be(100.0);
     }
 
-    [Fact]
-    public void AnalyzeGlucoseData_Libre1MinInterval_CalculatesCorrectly()
+    [Theory]
+    [InlineData(1, 60, 100.0)]
+    [InlineData(1, 30, 50.0)]
+    [InlineData(5, 12, 100.0)]
+    [InlineData(10, 6, 100.0)]
+    [InlineData(15, 4, 100.0)]
+    [InlineData(15, 2, 50.0)]
+    public void AnalyzeGlucoseData_ScoresCoverageAgainstTheSeriesOwnCadence(
+        int cadenceMinutes,
+        int readingCount,
+        double expectedPercent
+    )
     {
-        // 720 readings over 24 hours with 1-min interval = 50% (expected 1440)
+        var start = DateTime.UtcNow.AddHours(-1);
+
+        var result = _statisticsService.AnalyzeGlucoseData(
+            AtCadence(start, cadenceMinutes, readingCount),
+            Array.Empty<Bolus>(),
+            Array.Empty<CarbIntake>(),
+            startDate: start,
+            endDate: start.AddHours(1));
+
+        result.DataQuality.CgmActivePercent.Should().BeApproximately(expectedPercent, 1.0);
+    }
+
+    [Fact]
+    public void AnalyzeGlucoseData_HoleInAFiveMinuteSeries_CountsTheReadingsItOwed()
+    {
+        var start = DateTime.UtcNow.AddHours(-2);
+        var entries = AtCadence(start, 5, 7).Concat(AtCadence(start.AddMinutes(60), 5, 7));
+
+        var result = _statisticsService.AnalyzeGlucoseData(
+            entries, Array.Empty<Bolus>(), Array.Empty<CarbIntake>());
+
+        result.DataQuality.GapAnalysis.Gaps.Should().HaveCount(1);
+        result.DataQuality.GapAnalysis.LongestGap.Should().Be(30);
+        result.DataQuality.MissingReadings.Should().Be(5);
+    }
+
+    [Theory]
+    [InlineData(30, 0, 0)]
+    [InlineData(40, 0, 0)]
+    [InlineData(50, 1, 2)]
+    [InlineData(60, 1, 3)]
+    public void AnalyzeGlucoseData_GapThresholdFollowsTheCadence(
+        double holeMinutes,
+        int expectedGaps,
+        int expectedMissing
+    )
+    {
+        // A fifteen-minute sensor: one interval missed is jitter, three are a gap.
+        var start = DateTime.UtcNow.AddHours(-4);
+        var entries = AtCadence(start, 15, 6)
+            .Concat(AtCadence(start.AddMinutes(75 + holeMinutes), 15, 6));
+
+        var result = _statisticsService.AnalyzeGlucoseData(
+            entries, Array.Empty<Bolus>(), Array.Empty<CarbIntake>());
+
+        result.DataQuality.GapAnalysis.Gaps.Should().HaveCount(expectedGaps);
+        result.DataQuality.MissingReadings.Should().Be(expectedMissing);
+    }
+
+    [Fact]
+    public void AnalyzeGlucoseData_SensorSwitchMidReport_ScoresEachStreamAtItsOwnCadence()
+    {
+        // Twelve hours of a one-minute Libre, then twelve of a five-minute Dexcom.
         var start = DateTime.UtcNow.AddDays(-1);
-        var entries = Enumerable.Range(0, 720).Select(i => new SensorGlucose
-        {
-            Mgdl = 120,
-            Timestamp = start.AddMinutes(i * 2),
-        });
+        var entries = AtCadence(start, 1, 720, Guid.NewGuid())
+            .Concat(AtCadence(start.AddHours(12), 5, 144, Guid.NewGuid()));
 
         var result = _statisticsService.AnalyzeGlucoseData(
             entries, Array.Empty<Bolus>(), Array.Empty<CarbIntake>(),
-            startDate: start, endDate: start.AddDays(1), updateIntervalMinutes: 1);
+            startDate: start, endDate: start.AddDays(1));
 
-        result.DataQuality.CgmActivePercent.Should().BeApproximately(50.0, 1.0);
+        result.DataQuality.CgmActivePercent.Should().BeApproximately(100.0, 1.0);
+        result.DataQuality.DataCompleteness.Should().BeApproximately(100.0, 1.0);
+        result.DataQuality.GapAnalysis.Gaps.Should().BeEmpty();
     }
 
     [Fact]
     public void AnalyzeGlucoseData_NoReportPeriod_InfersFromEntries()
     {
         var start = DateTime.UtcNow.AddHours(-12);
-        var entries = Enumerable.Range(0, 144).Select(i => new SensorGlucose
-        {
-            Mgdl = 120,
-            Timestamp = start.AddMinutes(i * 5),
-        });
 
         var result = _statisticsService.AnalyzeGlucoseData(
-            entries, Array.Empty<Bolus>(), Array.Empty<CarbIntake>());
+            AtCadence(start, 5, 144), Array.Empty<Bolus>(), Array.Empty<CarbIntake>());
 
         result.DataQuality.CgmActivePercent.Should().BeApproximately(100.0, 2.0);
     }


### PR DESCRIPTION
Closes #1208.

## The change

`AnalyzeGlucoseData` and `AssessDataQuality` took `int updateIntervalMinutes = 5` that no caller passed, so expected readings, missing readings and `CgmActivePercent` assumed a five-minute sensor everywhere. The parameter is deleted from both signatures and the contract. The cadence is derived from the readings themselves, reusing the median-gap computation #1215 added for time-in-range: the inline calculation in `ReadingMinutes` is now `ReadingIntervals` + `SeriesCadenceMinutes`, called from both places.

The issue's "500% CGM-active" was wrong in one detail: the percentage is clamped at 100, so a one-minute sensor reported a flat 100 whatever its coverage. The observable symptom was the other way: a 15-minute sensor at full coverage read 33%, and the clamp hid real loss on faster sensors.

Cadence belongs to a sensor, not a report, so `AssessDataQuality` groups readings by the stream key `CanonicalGlucoseStream` already uses and derives cadence, gaps and missing readings per stream. A day that switches from a one-minute Libre to a five-minute Dexcom scores 100% with no gaps; a single median over the merged readings gave 60% and a "gap" per Dexcom reading, which would have tripped the executive summary's data-quality warning. `CgmActivePercent` is Σ(readings × stream cadence) over the report span, algebraically the old `readings / (span / cadence)` for one stream, so every existing pin is unchanged. A gap is an interval longer than three cadences (the old fixed `> 15 minutes` was three missed readings on a five-minute sensor, so it scales), and a gap spanning n cadences is missing n − 1 readings; the old count included the reading that closed it.

Stated limitations: a series sparse enough that its median interval is itself a gap saturates at 100, the same premise #1215 accepted; two sensors worn concurrently in the same window over-count and the clamp hides it, as before, and the AID endpoint still hands un-canonicalised readings in.

## Tests

`StatisticsServiceTests`: a cadence theory over 1/5/10/15-minute sensors at full and half coverage, a 30-minute hole in a five-minute series owing five readings, a gap-threshold theory with 30/40/50/60-minute holes on a 15-minute series, and the sensor-switch day. Seven cases redden with the production change reverted. Mutations killed by a named test: `GapCadences` 3 → 2 and 3 → 4, median → mean, the − 1 removed, the stream grouping collapsed to one key. `AnalyzeGlucoseData_Libre1MinInterval_CalculatesCorrectly` is deleted: it named the parameter and its arrangement used two-minute spacing; the theory supersedes its one assertion. Statistics filter: 251 passed.
