### PR TITLE
test: build in-memory SQLite arrangements through the shared factory

### DIFF
--- a/tests/Shared/Nocturne.Tests.Shared/Infrastructure/TestDbContextFactory.cs
+++ b/tests/Shared/Nocturne.Tests.Shared/Infrastructure/TestDbContextFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.InMemory.Storage.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 
@@ -27,8 +28,8 @@ public static class TestDbContextFactory
     }
 
     /// <summary>
-    /// Creates an empty SQLite-backed schema. Use when the test seeds its own tenant rows,
-    /// for example because it needs several tenants or a non-default slug.
+    /// Creates an empty SQLite-backed schema with no tenant seeded; contexts it creates carry
+    /// <see cref="Guid.Empty"/> as their tenant id. Use when the test seeds its own rows, or none.
     /// </summary>
     public static SqliteTestDatabase CreateSqlite() => new(tenantId: null, tenantSlug: null);
 
@@ -94,6 +95,18 @@ public sealed class SqliteTestDatabase : IDisposable
     public NocturneDbContext CreateContext() => CreateContext(TenantId);
 
     public NocturneDbContext CreateContext(Guid tenantId) => new(Options) { TenantId = tenantId };
+
+    /// <summary>
+    /// Registers this database the way the request pipeline resolves it: <see cref="ContextFactory"/>
+    /// as the context pool, plus one scoped <see cref="NocturneDbContext"/> per service scope, every
+    /// one of them over the same connection.
+    /// </summary>
+    public IServiceCollection AddToServices(IServiceCollection services)
+    {
+        services.AddSingleton(ContextFactory);
+        services.AddScoped(_ => CreateContext());
+        return services;
+    }
 
     /// <summary>Adds a further tenant row, for tests that assert one tenant cannot reach another's.</summary>
     public SqliteTestDatabase SeedTenant(Guid tenantId, string slug)

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthDeviceCodeServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthDeviceCodeServiceTests.cs
@@ -1,5 +1,3 @@
-using System.Data.Common;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -7,6 +5,7 @@ using Nocturne.API.Services.Auth;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Authorization;
@@ -19,8 +18,7 @@ namespace Nocturne.API.Tests.Authorization;
 [Trait("Category", "OAuth")]
 public class OAuthDeviceCodeServiceTests : IDisposable
 {
-    private readonly DbConnection _connection;
-    private readonly DbContextOptions<NocturneDbContext> _contextOptions;
+    private readonly SqliteTestDatabase _db;
     private readonly Mock<IJwtService> _mockJwtService;
     private readonly Mock<IOAuthClientService> _mockClientService;
     private readonly Mock<IOAuthGrantService> _mockGrantService;
@@ -38,17 +36,7 @@ public class OAuthDeviceCodeServiceTests : IDisposable
 
     public OAuthDeviceCodeServiceTests()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
-
-        _contextOptions = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseSqlite(_connection)
-            .Options;
-
-        using var dbContext = new NocturneDbContext(_contextOptions);
-        dbContext.Database.EnsureCreated();
-        dbContext.Tenants.Add(new TenantEntity { Id = _testTenantId, Slug = "test" });
-        dbContext.SaveChanges();
+        _db = TestDbContextFactory.CreateSqliteWithTenant(_testTenantId);
 
         _mockJwtService = new Mock<IJwtService>();
         _mockClientService = new Mock<IOAuthClientService>();
@@ -60,7 +48,7 @@ public class OAuthDeviceCodeServiceTests : IDisposable
 
     public void Dispose()
     {
-        _connection.Dispose();
+        _db.Dispose();
     }
 
     private void SetupDefaultMocks()
@@ -109,10 +97,7 @@ public class OAuthDeviceCodeServiceTests : IDisposable
         );
     }
 
-    private NocturneDbContext CreateDbContext()
-    {
-        return new NocturneDbContext(_contextOptions) { TenantId = _testTenantId };
-    }
+    private NocturneDbContext CreateDbContext() => _db.CreateContext();
 
     /// <summary>
     /// Seed a SubjectEntity so FK constraints are satisfied.
@@ -449,8 +434,7 @@ public class OAuthDeviceCodeServiceTests : IDisposable
 [Trait("Category", "OAuth")]
 public class OAuthDeviceCodeExchangeTests : IDisposable
 {
-    private readonly DbConnection _connection;
-    private readonly DbContextOptions<NocturneDbContext> _contextOptions;
+    private readonly SqliteTestDatabase _db;
     private readonly Mock<IJwtService> _mockJwtService;
     private readonly Mock<ISubjectService> _mockSubjectService;
     private readonly Mock<IOAuthGrantService> _mockGrantService;
@@ -471,17 +455,7 @@ public class OAuthDeviceCodeExchangeTests : IDisposable
 
     public OAuthDeviceCodeExchangeTests()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
-
-        _contextOptions = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseSqlite(_connection)
-            .Options;
-
-        using var dbContext = new NocturneDbContext(_contextOptions);
-        dbContext.Database.EnsureCreated();
-        dbContext.Tenants.Add(new TenantEntity { Id = _testTenantId, Slug = "test" });
-        dbContext.SaveChanges();
+        _db = TestDbContextFactory.CreateSqliteWithTenant(_testTenantId);
 
         _mockJwtService = new Mock<IJwtService>();
         _mockSubjectService = new Mock<ISubjectService>();
@@ -493,7 +467,7 @@ public class OAuthDeviceCodeExchangeTests : IDisposable
 
     public void Dispose()
     {
-        _connection.Dispose();
+        _db.Dispose();
     }
 
     private void SetupDefaultMocks()
@@ -542,10 +516,7 @@ public class OAuthDeviceCodeExchangeTests : IDisposable
         );
     }
 
-    private NocturneDbContext CreateDbContext()
-    {
-        return new NocturneDbContext(_contextOptions) { TenantId = _testTenantId };
-    }
+    private NocturneDbContext CreateDbContext() => _db.CreateContext();
 
     /// <summary>
     /// Seed a SubjectEntity so FK constraints are satisfied.

--- a/tests/Unit/Nocturne.API.Tests/Authorization/OAuthTokenServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/OAuthTokenServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -7,6 +6,7 @@ using Nocturne.API.Services.Auth;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Authorization;
@@ -19,8 +19,7 @@ namespace Nocturne.API.Tests.Authorization;
 [Trait("Category", "OAuth")]
 public class OAuthTokenServiceTests : IDisposable
 {
-    private readonly DbConnection _connection;
-    private readonly DbContextOptions<NocturneDbContext> _contextOptions;
+    private readonly SqliteTestDatabase _db;
     private readonly Mock<IJwtService> _mockJwtService;
     private readonly Mock<ISubjectService> _mockSubjectService;
     private readonly Mock<IOAuthGrantService> _mockGrantService;
@@ -47,17 +46,7 @@ public class OAuthTokenServiceTests : IDisposable
 
     public OAuthTokenServiceTests()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
-
-        _contextOptions = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseSqlite(_connection)
-            .Options;
-
-        using var dbContext = new NocturneDbContext(_contextOptions);
-        dbContext.Database.EnsureCreated();
-        dbContext.Tenants.Add(new TenantEntity { Id = _testTenantId, Slug = "test" });
-        dbContext.SaveChanges();
+        _db = TestDbContextFactory.CreateSqliteWithTenant(_testTenantId);
 
         _mockJwtService = new Mock<IJwtService>();
         _mockSubjectService = new Mock<ISubjectService>();
@@ -70,7 +59,7 @@ public class OAuthTokenServiceTests : IDisposable
 
     public void Dispose()
     {
-        _connection.Dispose();
+        _db.Dispose();
     }
 
     private void SetupDefaultMocks()
@@ -134,10 +123,7 @@ public class OAuthTokenServiceTests : IDisposable
         );
     }
 
-    private NocturneDbContext CreateDbContext()
-    {
-        return new NocturneDbContext(_contextOptions) { TenantId = _testTenantId };
-    }
+    private NocturneDbContext CreateDbContext() => _db.CreateContext();
 
     /// <summary>
     /// Seed a SubjectEntity so FK constraints are satisfied.

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/DndWindowsControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Monitoring/DndWindowsControllerTests.cs
@@ -1,8 +1,6 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Nocturne.API.Controllers.V4.Monitoring;
 using Nocturne.Core.Models.Alerts;
 using Nocturne.Infrastructure.Data;
@@ -194,20 +192,14 @@ public class DndWindowsControllerTests
         // Sqlite rather than InMemory: the PK collision must surface as the relational
         // DbUpdateException the controller catches (InMemory throws a raw
         // ArgumentException for duplicate keys).
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseSqlite(connection)
-            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
-            .Options;
+        using var sqlite = TestDbContextFactory.CreateSqlite();
         var id = Guid.NewGuid();
 
         // Seed the id under another tenant. The tenant query filter (and RLS in prod)
         // hides it from the idempotency lookup, so the insert hits the global PK.
         var otherTenant = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
-        await using (var other = new NocturneDbContext(options) { TenantId = otherTenant })
+        await using (var other = sqlite.CreateContext(otherTenant))
         {
-            await other.Database.EnsureCreatedAsync();
             // dnd_windows.tenant_id is FK'd to tenants; seed both tenant rows.
             other.Tenants.Add(new TenantEntity { Id = Tenant, Slug = "a", DisplayName = "a" });
             other.Tenants.Add(new TenantEntity { Id = otherTenant, Slug = "b", DisplayName = "b" });
@@ -223,14 +215,14 @@ public class DndWindowsControllerTests
         }
 
         var controller = new DndWindowsController(
-            new TestTenantDbContextFactory(new NocturneDbContext(options) { TenantId = Tenant }));
+            new TestTenantDbContextFactory(sqlite.CreateContext(Tenant)));
 
         var result = await controller.Create(Request(id, DndScope.Lows), CancellationToken.None);
 
         result.Result.Should().BeOfType<ConflictObjectResult>();
 
         // The other tenant's window is untouched.
-        await using var db = new NocturneDbContext(options) { TenantId = otherTenant };
+        await using var db = sqlite.CreateContext(otherTenant);
         var stored = await db.DndWindows.SingleAsync(w => w.Id == id);
         stored.TenantId.Should().Be(otherTenant);
         stored.Source.Should().Be("other-tenant");

--- a/tests/Unit/Nocturne.API.Tests/Middleware/AuthHandlerPriorityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/AuthHandlerPriorityTests.cs
@@ -1,8 +1,6 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -16,6 +14,7 @@ using Nocturne.API.Services.Auth;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Models.Configuration;
 using Nocturne.Infrastructure.Data;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 using Nocturne.API.Extensions;
 
@@ -96,7 +95,8 @@ public class AuthHandlerPriorityTests
             Mock.Of<IDbContextFactory<Nocturne.Infrastructure.Data.NocturneDbContext>>(),
             NullLogger<PublicAccessCacheService>.Instance);
 
-        var scopeFactory = CreateScopeFactoryWithDb();
+        using var db = TestDbContextFactory.CreateSqlite();
+        var scopeFactory = CreateScopeFactoryWithDb(db);
 
         var middleware = new AuthenticationMiddleware(
             next: _ => Task.CompletedTask,
@@ -213,24 +213,10 @@ public class AuthHandlerPriorityTests
     /// Creates a real IServiceScopeFactory backed by SQLite in-memory so the middleware
     /// can resolve NocturneDbContext when looking up platform admin flags.
     /// </summary>
-    private static IServiceScopeFactory CreateScopeFactoryWithDb()
-    {
-        var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-
-        var services = new ServiceCollection();
-        services.AddDbContext<NocturneDbContext>(options =>
-            options.UseSqlite(connection)
-                .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
-        var sp = services.BuildServiceProvider();
-
-        // Ensure schema is created
-        using var scope = sp.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<NocturneDbContext>();
-        db.Database.EnsureCreated();
-
-        return sp.GetRequiredService<IServiceScopeFactory>();
-    }
+    private static IServiceScopeFactory CreateScopeFactoryWithDb(SqliteTestDatabase db) =>
+        db.AddToServices(new ServiceCollection())
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
 
     private sealed class StubAuthHandler(int priority, string name, AuthResult result)
         : IAuthHandler

--- a/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeFilterPipelineTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeFilterPipelineTests.cs
@@ -5,15 +5,13 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.API.Attributes;
 using Nocturne.API.Middleware;
 using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Models.Authorization;
-using Nocturne.Infrastructure.Data;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Middleware;
@@ -258,14 +256,11 @@ public class MemberScopeFilterPipelineTests
     private static async Task<IReadOnlySet<string>> ResolveScopesForRoleAsync(
         string roleSlug, AuthType authType, params string[] credentialScopes)
     {
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+        using var db = TestDbContextFactory.CreateSqlite();
 
         var subjectId = Guid.CreateVersion7();
-        using (var seed = new NocturneDbContext(options))
+        using (var seed = db.CreateContext())
         {
-            seed.Database.EnsureCreated();
             TestDatabaseSeeder.Seed(seed);
 
             seed.Subjects.Add(new Nocturne.Infrastructure.Data.Entities.SubjectEntity
@@ -302,7 +297,7 @@ public class MemberScopeFilterPipelineTests
         }
 
         var services = new ServiceCollection();
-        services.AddScoped(_ => new NocturneDbContext(options));
+        services.AddScoped(_ => db.CreateContext());
         using var provider = services.BuildServiceProvider();
 
         var httpContext = new DefaultHttpContext { RequestServices = provider };

--- a/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Middleware/MemberScopeMiddlewareTests.cs
@@ -1,13 +1,11 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Nocturne.API.Middleware;
 using Nocturne.API.Tests.Infrastructure;
 using Nocturne.Core.Models.Authorization;
-using Nocturne.Infrastructure.Data;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 using Nocturne.API.Extensions;
 
@@ -23,18 +21,7 @@ public class MemberScopeMiddlewareTests
     {
         // An owner's api-secret grant scoped to glucose.read only. The owner's "*" membership must
         // not widen it back to superuser.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-        var subjectId = SeedMemberWithRole(options, OwnerPermissions);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.GlucoseRead], AuthType.ApiKey);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(OwnerPermissions, [Scope.GlucoseRead], AuthType.ApiKey);
 
         // Assert: should NOT have superuser wildcard
         var grantedScopes = context.GetGrantedScopes();
@@ -54,18 +41,7 @@ public class MemberScopeMiddlewareTests
     {
         // An owner's full-access api-secret — what every uploader configured by the tenant owner
         // carries. Nothing is stripped, so DELETE (RequireScope("*")) keeps working.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-        var subjectId = SeedMemberWithRole(options, OwnerPermissions);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.FullAccess], AuthType.ApiKey);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(OwnerPermissions, [Scope.FullAccess], AuthType.ApiKey);
 
         // Assert: full access normalizes to all scopes
         var grantedScopes = context.GetGrantedScopes();
@@ -128,18 +104,8 @@ public class MemberScopeMiddlewareTests
     [Fact]
     public async Task ApiKey_WithMultipleScopes_GrantsOnlyThoseScopes()
     {
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-        var subjectId = SeedMemberWithRole(options, OwnerPermissions);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.GlucoseRead, Scope.TreatmentsReadWrite], AuthType.ApiKey);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            OwnerPermissions, [Scope.GlucoseRead, Scope.TreatmentsReadWrite], AuthType.ApiKey);
 
         // Assert
         var grantedScopes = context.GetGrantedScopes();
@@ -160,43 +126,22 @@ public class MemberScopeMiddlewareTests
     public async Task TenantMemberWithWildcardRole_GetsSuperuserPermissionTrie()
     {
         // Arrange — a tenant owner whose membership role grants "*", but whose session token
-        // carries no permissions. Session tokens are minted from the subject's GLOBAL roles,
+        // carries no scopes. Session tokens are minted from the subject's GLOBAL roles,
         // which are empty for a normal owner (their access comes from tenant membership), so
         // AuthenticationMiddleware leaves an empty PermissionTrie. The superuser branch must
         // rebuild it, or HasPermissions-gated endpoints (the legacy v1 API, e.g. the realtime
         // /api/v1/entries probe) would 403 for the owner on their own tenant.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+        using var db = TestDbContextFactory.CreateSqlite();
 
-        using (var seed = new NocturneDbContext(options))
+        // Seeds the default tenant with TestSubjectId as owner (the "*" wildcard role).
+        using (var seed = db.CreateContext())
         {
-            seed.Database.EnsureCreated();
-            // Seeds the default tenant with TestSubjectId as owner (the "*" wildcard role).
             TestDatabaseSeeder.Seed(seed);
         }
 
-        var services = new ServiceCollection();
-        services.AddScoped(_ => new NocturneDbContext(options));
-        using var provider = services.BuildServiceProvider();
-
-        var context = new DefaultHttpContext { RequestServices = provider };
-        context.Items["AuthContext"] = new AuthContext
-        {
-            IsAuthenticated = true,
-            AuthType = AuthType.SessionCookie,
-            SubjectId = TestDatabaseSeeder.TestSubjectId,
-            TenantId = TestDatabaseSeeder.TenantId,
-            Permissions = [], // session JWT carries no permissions
-        };
-        // As AuthenticationMiddleware would set it for a token with no permissions.
-        context.Items["PermissionTrie"] = new PermissionTrie();
-        context.Items["GrantedScopes"] = (IReadOnlySet<string>)new HashSet<string>();
-
-        var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-
         // Act
-        await middleware.InvokeAsync(context);
+        var context = await ResolveAsync(
+            db, TestDatabaseSeeder.TestSubjectId, [], AuthType.SessionCookie);
 
         // Assert — a non-empty wildcard trie so the HasPermissions policy succeeds.
         var permissionTrie = context.GetPermissionTrie();
@@ -214,19 +159,8 @@ public class MemberScopeMiddlewareTests
         // A tenant owner who authorized a third-party app for glucose.read only. The owner's
         // membership grants "*", but the access token is the consent boundary: widening to
         // superuser here would hand the app write/delete on every resource.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Owner]);
-
-        var (context, provider) = BuildMemberContext(options, subjectId, [Scope.GlucoseRead]);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Owner], [Scope.GlucoseRead]);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().Contain(Scope.GlucoseRead);
@@ -247,19 +181,8 @@ public class MemberScopeMiddlewareTests
     {
         // The same owner consenting to full access keeps superuser: the credential's own scope
         // list is what bounds it, and "*" bounds nothing.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Owner]);
-
-        var (context, provider) = BuildMemberContext(options, subjectId, [Scope.FullAccess]);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Owner], [Scope.FullAccess]);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().Contain("*");
@@ -274,20 +197,8 @@ public class MemberScopeMiddlewareTests
     {
         // Same token, presented as a bearer/?token= direct grant instead of an OAuth JWT. It must
         // resolve to the same narrow scopes it does in the api-secret header (AuthType.ApiKey).
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Owner]);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.GlucoseRead], AuthType.DirectGrant);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Owner], [Scope.GlucoseRead], AuthType.DirectGrant);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().BeEquivalentTo([Scope.GlucoseRead]);
@@ -300,19 +211,8 @@ public class MemberScopeMiddlewareTests
         // capability scopes, and the caretaker seed role grants the matching permission atoms,
         // so the scope intersection must keep them (they'd otherwise 403 on
         // POST /api/v4/client-devices).
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Caretaker]);
-
-        var (context, provider) = BuildMemberContext(options, subjectId, CompanionTokenScopes);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Caretaker], CompanionTokenScopes);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().Contain(Scope.DeviceNotify);
@@ -330,22 +230,12 @@ public class MemberScopeMiddlewareTests
         // The scopes are member-personal (the member's own client devices, not patient data), so
         // the middleware must grant them from the token alone — otherwise every pre-existing
         // tenant's members 403 on the client-devices API forever.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
         var staleCaretakerPermissions = RoleSeeds
             .Permissions[RoleSeeds.Caretaker]
             .Where(p => !Scope.MemberPersonalScopes.Contains(p))
             .ToList();
-        var subjectId = SeedMemberWithRole(options, staleCaretakerPermissions);
 
-        var (context, provider) = BuildMemberContext(options, subjectId, CompanionTokenScopes);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(staleCaretakerPermissions, CompanionTokenScopes);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().Contain(Scope.DeviceNotify);
@@ -361,19 +251,8 @@ public class MemberScopeMiddlewareTests
     {
         // The Denied seed role grants nothing. Device scopes must not bypass that: alert
         // actuations reveal patient state, so a member with no permissions at all gets none.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Denied]);
-
-        var (context, provider) = BuildMemberContext(options, subjectId, CompanionTokenScopes);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Denied], CompanionTokenScopes);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().BeEmpty();
@@ -392,19 +271,8 @@ public class MemberScopeMiddlewareTests
         // set 403ed the whole scope-gated surface for every non-owner. Every administration gate
         // (MemberInviteController, RoleController, ShareLinkController, GuestLinkController,
         // AuditController) reads GrantedScopes through Scope.Satisfies.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Admin]);
-
-        var (context, provider) = BuildMemberContext(options, subjectId, [], authType);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Admin], [], authType);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().NotBeEmpty();
@@ -433,20 +301,10 @@ public class MemberScopeMiddlewareTests
         // an outbound protocol list identical for every user of that provider, not a Nocturne data
         // grant. Normalize drops all three, so treating them as a ceiling resolved the member to
         // nothing.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Caretaker]);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, ["openid", "profile", "email"], AuthType.OidcToken);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Caretaker],
+            ["openid", "profile", "email"],
+            AuthType.OidcToken);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().Contain(Scope.GlucoseRead);
@@ -461,19 +319,8 @@ public class MemberScopeMiddlewareTests
     {
         // The trie drives the HasPermissions policy on v1/v2/v3. An empty resolved scope set left it
         // empty for every non-owner web-app user.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Caretaker]);
-
-        var (context, provider) = BuildMemberContext(options, subjectId, [], AuthType.SessionCookie);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Caretaker], [], AuthType.SessionCookie);
 
         var permissionTrie = context.GetPermissionTrie();
         permissionTrie.Should().NotBeNull();
@@ -488,19 +335,8 @@ public class MemberScopeMiddlewareTests
     public async Task UnscopedCredential_WithDeniedRole_ResolvesToNothing()
     {
         // An unscoped credential removes the ceiling, not the membership check.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Denied]);
-
-        var (context, provider) = BuildMemberContext(options, subjectId, [], AuthType.SessionCookie);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Denied], [], AuthType.SessionCookie);
 
         context.Items.Should().ContainKey("GrantedScopes",
             "the middleware has to resolve a scope set, not leave the request unscoped");
@@ -517,20 +353,8 @@ public class MemberScopeMiddlewareTests
         // An OAuth access token, a direct grant and an api-secret header all carry a consent
         // boundary, so an Admin membership must not widen past the scopes the credential presents
         // — administration included, since no client can request an administration atom.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Admin]);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.GlucoseReadWrite], authType);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Admin], [Scope.GlucoseReadWrite], authType);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().BeEquivalentTo([Scope.GlucoseReadWrite]);
@@ -544,20 +368,10 @@ public class MemberScopeMiddlewareTests
         // A read-only app authorized by a Caretaker: the member holds treatments.readwrite and the
         // token grants treatments.read. SatisfiesScope answers false for the readwrite requirement
         // and normalization adds no read counterpart, so this resolved to NEITHER scope.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Caretaker]);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.TreatmentsRead], AuthType.OAuthAccessToken);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Caretaker],
+            [Scope.TreatmentsRead],
+            AuthType.OAuthAccessToken);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().BeEquivalentTo([Scope.TreatmentsRead]);
@@ -574,20 +388,8 @@ public class MemberScopeMiddlewareTests
         // A guest link carries its own read-only scopes and never reaches the membership lookup.
         // Membership must not widen it even when the guest code was activated by a subject who is
         // also an Admin member of the tenant.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Admin]);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.GlucoseRead], AuthType.Guest);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Admin], [Scope.GlucoseRead], AuthType.Guest);
 
         (context.GetGrantedScopes())
             .Should().BeEquivalentTo([Scope.GlucoseRead]);
@@ -627,20 +429,8 @@ public class MemberScopeMiddlewareTests
         // token arrives in the api-secret header (ApiKey) or as Authorization: Bearer / ?token=
         // (DirectGrant). Before this, the header path returned the grant verbatim and the write
         // went through.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Viewer]);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.TreatmentsReadWrite], authType);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Viewer], [Scope.TreatmentsReadWrite], authType);
 
         // The Viewer's own scopes (glucose.read, reports.read) are not in the grant either, so the
         // intersection is empty.
@@ -661,20 +451,8 @@ public class MemberScopeMiddlewareTests
         // full-access grant they minted resolves the same way: the delete endpoints
         // (RequireScope("*") on DELETE /api/v1|v3/treatments/{id} and friends) stay closed to them.
         // Writes — every uploader's actual traffic — are untouched.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(
-            options, RoleSeeds.Permissions[RoleSeeds.Admin]);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.FullAccess], authType);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[RoleSeeds.Admin], [Scope.FullAccess], authType);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().NotContain(Scope.FullAccess);
@@ -700,8 +478,10 @@ public class MemberScopeMiddlewareTests
                      RoleSeeds.Permissions[RoleSeeds.Viewer],
                  })
         {
-            var headerScopes = await ResolveAsync(rolePermissions, grantScopes, AuthType.ApiKey);
-            var bearerScopes = await ResolveAsync(rolePermissions, grantScopes, AuthType.DirectGrant);
+            var headerScopes = (await ResolveAsync(rolePermissions, grantScopes, AuthType.ApiKey))
+                .GetGrantedScopes();
+            var bearerScopes = (await ResolveAsync(rolePermissions, grantScopes, AuthType.DirectGrant))
+                .GetGrantedScopes();
 
             headerScopes.Should().BeEquivalentTo(
                 bearerScopes,
@@ -724,19 +504,8 @@ public class MemberScopeMiddlewareTests
         //
         // No such grant exists in production today (every direct grant is owner-held), so this is
         // latent rather than a live regression, but minting a key as a Caretaker would hit it.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-
-        var subjectId = SeedMemberWithRole(options, RoleSeeds.Permissions[roleSlug]);
-
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, [Scope.FullAccess], AuthType.ApiKey);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            RoleSeeds.Permissions[roleSlug], [Scope.FullAccess], AuthType.ApiKey);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().NotContain(Scope.GlucoseReadWrite);
@@ -756,19 +525,9 @@ public class MemberScopeMiddlewareTests
         // Normalize([health.readwrite]) against the subject who saved the connector secrets.
         // That subject is a tenant member, so the grant is now intersected — the eight
         // health.readwrite scopes every field uploader writes with must survive.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-        var subjectId = SeedMemberWithRole(options, OwnerPermissions);
-
         var migratedGrantScopes = Scope.Normalize([Scope.HealthReadWrite]).ToList();
-        var (context, provider) = BuildMemberContext(
-            options, subjectId, migratedGrantScopes, AuthType.ApiKey);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+
+        var context = await ResolveAsync(OwnerPermissions, migratedGrantScopes, AuthType.ApiKey);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().Contain(Scope.HealthReadWriteExpansion);
@@ -793,23 +552,15 @@ public class MemberScopeMiddlewareTests
         // builds is empty, and PolicyNames.HasPermissions — class-level on every V1/V2/V3
         // controller — succeeds only on a non-empty trie. Scopes alone passing is not enough to
         // keep the legacy uploader surface reachable.
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
+        using var db = TestDbContextFactory.CreateSqlite();
 
-        using (var seed = new NocturneDbContext(options))
+        using (var seed = db.CreateContext())
         {
-            seed.Database.EnsureCreated();
             TestDatabaseSeeder.Seed(seed);
         }
 
-        var (context, provider) = BuildMemberContext(
-            options, Guid.CreateVersion7(), [Scope.TreatmentsReadWrite], AuthType.ApiKey);
-        using (provider)
-        {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+        var context = await ResolveAsync(
+            db, Guid.CreateVersion7(), [Scope.TreatmentsReadWrite], AuthType.ApiKey);
 
         var grantedScopes = context.GetGrantedScopes();
         grantedScopes.Should().Contain(Scope.TreatmentsReadWrite);
@@ -823,25 +574,52 @@ public class MemberScopeMiddlewareTests
     }
 
     /// <summary>
-    /// Seeds a member holding <paramref name="rolePermissions"/>, runs the middleware for a
-    /// credential carrying <paramref name="grantScopes"/>, and returns the resolved scopes.
+    /// Seeds a member holding <paramref name="rolePermissions"/> on a database of its own, then
+    /// runs the middleware for a credential carrying <paramref name="tokenScopes"/>.
     /// </summary>
-    private static async Task<IReadOnlySet<string>> ResolveAsync(
-        List<string> rolePermissions, List<string> grantScopes, AuthType authType)
+    private static async Task<DefaultHttpContext> ResolveAsync(
+        List<string> rolePermissions,
+        List<string> tokenScopes,
+        AuthType authType = AuthType.OAuthAccessToken)
     {
-        using var connection = new SqliteConnection("DataSource=:memory:");
-        connection.Open();
-        var options = new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options;
-        var subjectId = SeedMemberWithRole(options, rolePermissions);
+        using var db = TestDbContextFactory.CreateSqlite();
+        var subjectId = SeedMemberWithRole(db, rolePermissions);
+        return await ResolveAsync(db, subjectId, tokenScopes, authType);
+    }
 
-        var (context, provider) = BuildMemberContext(options, subjectId, grantScopes, authType);
-        using (provider)
+    /// <summary>
+    /// Runs the middleware over <paramref name="db"/> for a request authenticated as
+    /// <paramref name="authType"/> whose credential carries <paramref name="tokenScopes"/>, as
+    /// AuthenticationMiddleware would leave it, and returns the request it resolved. The service provider is disposed before returning, so the
+    /// caller asserts on <c>HttpContext.Items</c> alone.
+    /// </summary>
+    private static async Task<DefaultHttpContext> ResolveAsync(
+        SqliteTestDatabase db,
+        Guid subjectId,
+        List<string> tokenScopes,
+        AuthType authType)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => db.CreateContext());
+        using var provider = services.BuildServiceProvider();
+
+        var context = new DefaultHttpContext { RequestServices = provider };
+        context.Items["AuthContext"] = new AuthContext
         {
-            var middleware = new MemberScopeMiddleware(_ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
-            await middleware.InvokeAsync(context);
-        }
+            IsAuthenticated = true,
+            AuthType = authType,
+            SubjectId = subjectId,
+            TenantId = TestDatabaseSeeder.TenantId,
+            Scopes = tokenScopes,
+        };
+        context.Items["GrantedScopes"] = Scope.Normalize(tokenScopes);
+        context.Items["PermissionTrie"] = new PermissionTrie();
 
-        return (context.GetGrantedScopes())!;
+        var middleware = new MemberScopeMiddleware(
+            _ => Task.CompletedTask, NullLogger<MemberScopeMiddleware>.Instance);
+        await middleware.InvokeAsync(context);
+
+        return context;
     }
 
     /// <summary>The owner seed role's permissions (the "*" wildcard).</summary>
@@ -860,11 +638,10 @@ public class MemberScopeMiddlewareTests
     /// permission atoms. Returns the member's subject id.
     /// </summary>
     private static Guid SeedMemberWithRole(
-        DbContextOptions<NocturneDbContext> options, List<string> rolePermissions)
+        SqliteTestDatabase db, List<string> rolePermissions)
     {
         var subjectId = Guid.CreateVersion7();
-        using var seed = new NocturneDbContext(options);
-        seed.Database.EnsureCreated();
+        using var seed = db.CreateContext();
         TestDatabaseSeeder.Seed(seed);
 
         seed.Subjects.Add(new Nocturne.Infrastructure.Data.Entities.SubjectEntity
@@ -902,35 +679,6 @@ public class MemberScopeMiddlewareTests
         });
         seed.SaveChanges();
         return subjectId;
-    }
-
-    /// <summary>
-    /// Builds an HTTP context for an OAuth-token member request whose token carries the given
-    /// scopes, as AuthenticationMiddleware would leave it. The caller disposes the provider.
-    /// </summary>
-    private static (DefaultHttpContext context, ServiceProvider provider) BuildMemberContext(
-        DbContextOptions<NocturneDbContext> options,
-        Guid subjectId,
-        List<string> tokenScopes,
-        AuthType authType = AuthType.OAuthAccessToken)
-    {
-        var services = new ServiceCollection();
-        services.AddScoped(_ => new NocturneDbContext(options));
-        var provider = services.BuildServiceProvider();
-
-        var context = new DefaultHttpContext { RequestServices = provider };
-        context.Items["AuthContext"] = new AuthContext
-        {
-            IsAuthenticated = true,
-            AuthType = authType,
-            SubjectId = subjectId,
-            TenantId = TestDatabaseSeeder.TenantId,
-            Scopes = tokenScopes,
-        };
-        context.Items["GrantedScopes"] = Scope.Normalize(tokenScopes);
-        context.Items["PermissionTrie"] = new PermissionTrie();
-
-        return (context, provider);
     }
 
     private (MemberScopeMiddleware middleware, DefaultHttpContext context) Build(AuthContext authContext)

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareApexTests.cs
@@ -1,8 +1,6 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,6 +9,7 @@ using Nocturne.API.Multitenancy;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Multitenancy;
@@ -25,33 +24,25 @@ namespace Nocturne.API.Tests.Multitenancy;
 /// </summary>
 public sealed class TenantResolutionMiddlewareApexTests : IDisposable
 {
-    private readonly SqliteConnection _connection;
+    private readonly SqliteTestDatabase _db;
     private readonly ServiceProvider _root;
     private const string BaseDomain = "nocturne.theconen.de";
 
     public TenantResolutionMiddlewareApexTests()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        _db = TestDbContextFactory.CreateSqlite();
 
         var services = new ServiceCollection();
-        services.AddDbContextFactory<NocturneDbContext>(o => o
-            .UseSqlite(_connection)
-            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
-        services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext());
+        _db.AddToServices(services);
         services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
         services.AddMemoryCache();
         _root = services.BuildServiceProvider();
-
-        using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
-        seed.Database.EnsureCreated();
-        seed.SaveChanges();
     }
 
     public void Dispose()
     {
         _root.Dispose();
-        _connection.Dispose();
+        _db.Dispose();
     }
 
     private TenantResolutionMiddleware Build(RequestDelegate next) => new(

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareInactiveTenantTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareInactiveTenantTests.cs
@@ -1,17 +1,14 @@
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Nocturne.API.Multitenancy;
 using Nocturne.Core.Contracts.Multitenancy;
-using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Multitenancy;
@@ -26,27 +23,22 @@ namespace Nocturne.API.Tests.Multitenancy;
 [Trait("Category", "Unit")]
 public sealed class TenantResolutionMiddlewareInactiveTenantTests : IDisposable
 {
-    private readonly SqliteConnection _connection;
+    private readonly SqliteTestDatabase _db;
     private readonly ServiceProvider _root;
     private const string BaseDomain = "nocturne.example";
     private const string Slug = "lapsed";
 
     public TenantResolutionMiddlewareInactiveTenantTests()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        _db = TestDbContextFactory.CreateSqlite();
 
         var services = new ServiceCollection();
-        services.AddDbContextFactory<NocturneDbContext>(o => o
-            .UseSqlite(_connection)
-            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
-        services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext());
+        _db.AddToServices(services);
         services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
         services.AddMemoryCache();
         _root = services.BuildServiceProvider();
 
-        using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
-        seed.Database.EnsureCreated();
+        using var seed = _db.CreateContext();
         seed.Tenants.Add(new TenantEntity
         {
             Id = Guid.CreateVersion7(),
@@ -60,7 +52,7 @@ public sealed class TenantResolutionMiddlewareInactiveTenantTests : IDisposable
     public void Dispose()
     {
         _root.Dispose();
-        _connection.Dispose();
+        _db.Dispose();
     }
 
     private TenantResolutionMiddleware Build(RequestDelegate next) => new(

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareShareTokenTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareShareTokenTests.cs
@@ -1,9 +1,7 @@
 using System.Linq;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,6 +13,7 @@ using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Security;
 using Nocturne.Infrastructure.Data.Services;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Multitenancy;
@@ -27,7 +26,7 @@ namespace Nocturne.API.Tests.Multitenancy;
 /// </summary>
 public sealed class TenantResolutionMiddlewareShareTokenTests : IDisposable
 {
-    private readonly SqliteConnection _connection;
+    private readonly SqliteTestDatabase _db;
     private readonly ServiceProvider _root;
     private readonly Guid _tenantId = Guid.CreateVersion7();
     private const string Slug = "acme";
@@ -36,14 +35,10 @@ public sealed class TenantResolutionMiddlewareShareTokenTests : IDisposable
 
     public TenantResolutionMiddlewareShareTokenTests()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        _db = TestDbContextFactory.CreateSqlite();
 
         var services = new ServiceCollection();
-        services.AddDbContextFactory<NocturneDbContext>(o => o
-            .UseSqlite(_connection)
-            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
-        services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext());
+        _db.AddToServices(services);
         services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
         services.AddScoped<ICategoryReadContext, CategoryReadContext>();
         services.AddMemoryCache();
@@ -51,8 +46,7 @@ public sealed class TenantResolutionMiddlewareShareTokenTests : IDisposable
         services.AddSingleton<ShareTokenCacheService>();
         _root = services.BuildServiceProvider();
 
-        using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
-        seed.Database.EnsureCreated();
+        using var seed = _db.CreateContext();
         seed.Tenants.Add(new TenantEntity
         {
             Id = _tenantId,
@@ -68,7 +62,7 @@ public sealed class TenantResolutionMiddlewareShareTokenTests : IDisposable
     public void Dispose()
     {
         _root.Dispose();
-        _connection.Dispose();
+        _db.Dispose();
     }
 
     private TenantResolutionMiddleware Build(RequestDelegate next) => new(

--- a/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareTenantPinTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Multitenancy/TenantResolutionMiddlewareTenantPinTests.cs
@@ -1,8 +1,5 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,6 +8,7 @@ using Nocturne.API.Multitenancy;
 using Nocturne.Core.Contracts.Multitenancy;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Multitenancy;
@@ -25,7 +23,7 @@ namespace Nocturne.API.Tests.Multitenancy;
 /// </summary>
 public sealed class TenantResolutionMiddlewareTenantPinTests : IDisposable
 {
-    private readonly SqliteConnection _connection;
+    private readonly SqliteTestDatabase _db;
     private readonly ServiceProvider _root;
     private readonly Guid _tenantId = Guid.CreateVersion7();
     private const string Slug = "acme";
@@ -33,22 +31,17 @@ public sealed class TenantResolutionMiddlewareTenantPinTests : IDisposable
 
     public TenantResolutionMiddlewareTenantPinTests()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        _db = TestDbContextFactory.CreateSqlite();
 
         var services = new ServiceCollection();
-        services.AddDbContextFactory<NocturneDbContext>(o => o
-            .UseSqlite(_connection)
-            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
-        // Mirror production: a scoped context obtained from the (pooled) factory, shared by every
-        // service injected within the request scope.
-        services.AddScoped(sp => sp.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext());
+        // Mirror production: one scoped context shared by every service injected within the
+        // request scope.
+        _db.AddToServices(services);
         services.AddScoped<ITenantAccessor, HttpContextTenantAccessor>();
         services.AddMemoryCache();
         _root = services.BuildServiceProvider();
 
-        using var seed = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>().CreateDbContext();
-        seed.Database.EnsureCreated();
+        using var seed = _db.CreateContext();
         seed.Tenants.Add(new TenantEntity { Id = _tenantId, Slug = Slug, DisplayName = "Acme" });
         seed.SaveChanges();
     }
@@ -56,7 +49,7 @@ public sealed class TenantResolutionMiddlewareTenantPinTests : IDisposable
     public void Dispose()
     {
         _root.Dispose();
-        _connection.Dispose();
+        _db.Dispose();
     }
 
     private TenantResolutionMiddleware Build(RequestDelegate next) => new(

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/ShareTokenCacheServiceTests.cs
@@ -1,43 +1,30 @@
 using System.Linq;
 using FluentAssertions;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.DependencyInjection;
 using Nocturne.API.Services.Auth;
 using Nocturne.Infrastructure.Data;
 using Nocturne.Infrastructure.Data.Entities;
 using Nocturne.Infrastructure.Data.Security;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.API.Tests.Services.Auth;
 
 public sealed class ShareTokenCacheServiceTests : IDisposable
 {
-    private readonly SqliteConnection _connection;
-    private readonly ServiceProvider _root;
+    private readonly SqliteTestDatabase _db;
     private readonly IDbContextFactory<NocturneDbContext> _factory;
-    private readonly IMemoryCache _cache;
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
     private readonly Guid _tenantId = Guid.CreateVersion7();
     private const string Token = "k7m2q9x4r3wt";
 
     public ShareTokenCacheServiceTests()
     {
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
-
-        var services = new ServiceCollection();
-        services.AddDbContextFactory<NocturneDbContext>(o => o
-            .UseSqlite(_connection)
-            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning)));
-        services.AddMemoryCache();
-        _root = services.BuildServiceProvider();
-        _factory = _root.GetRequiredService<IDbContextFactory<NocturneDbContext>>();
-        _cache = _root.GetRequiredService<IMemoryCache>();
+        _db = TestDbContextFactory.CreateSqlite();
+        _factory = _db.ContextFactory;
 
         using var seed = _factory.CreateDbContext();
-        seed.Database.EnsureCreated();
         seed.Tenants.Add(new TenantEntity
         {
             Id = _tenantId,
@@ -50,8 +37,8 @@ public sealed class ShareTokenCacheServiceTests : IDisposable
 
     public void Dispose()
     {
-        _root.Dispose();
-        _connection.Dispose();
+        _cache.Dispose();
+        _db.Dispose();
     }
 
     private ShareTokenCacheService Service() =>

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalReadVisibilityTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/V4/TempBasalReadVisibilityTests.cs
@@ -1,6 +1,4 @@
-using System.Data.Common;
 using FluentAssertions;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -23,30 +21,14 @@ namespace Nocturne.Infrastructure.Data.Tests.Repositories.V4;
 public class TempBasalReadVisibilityTests : IDisposable
 {
     private static readonly Guid TestTenantId = Guid.Parse("00000000-0000-0000-0000-000000000001");
-    private readonly DbConnection _connection;
+    private readonly SqliteTestDatabase _db;
     private readonly NocturneDbContext _context;
     private readonly TempBasalRepository _repo;
 
     public TempBasalReadVisibilityTests()
     {
-        _connection = new SqliteConnection("Filename=:memory:");
-        _connection.Open();
-
-        var contextOptions = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseSqlite(_connection)
-            .EnableSensitiveDataLogging()
-            .Options;
-
-        using (var seedContext = new NocturneDbContext(contextOptions))
-        {
-            seedContext.TenantId = TestTenantId;
-            seedContext.Database.EnsureCreated();
-            seedContext.Tenants.Add(new TenantEntity { Id = TestTenantId, Slug = "test" });
-            seedContext.SaveChanges();
-        }
-
-        _context = new NocturneDbContext(contextOptions);
-        _context.TenantId = TestTenantId;
+        _db = TestDbContextFactory.CreateSqliteWithTenant(TestTenantId);
+        _context = _db.CreateContext();
 
         _repo = new TempBasalRepository(
             new TestTenantDbContextFactory(_context),
@@ -58,7 +40,7 @@ public class TempBasalReadVisibilityTests : IDisposable
     public void Dispose()
     {
         _context.Dispose();
-        _connection.Dispose();
+        _db.Dispose();
         GC.SuppressFinalize(this);
     }
 

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/UpdateTimestampsTests.cs
@@ -1,8 +1,7 @@
-using System.Data.Common;
 using FluentAssertions;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
 using Xunit;
 
 namespace Nocturne.Infrastructure.Data.Tests;
@@ -23,7 +22,7 @@ public class UpdateTimestampsTests : IDisposable
     // A clearly-stale sentinel so a freshly-stamped utcNow value is unambiguously newer.
     private static readonly DateTime Stale = new(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-    private readonly List<DbConnection> _connections = [];
+    private readonly List<SqliteTestDatabase> _databases = [];
 
     [Fact]
     public async Task SystemTimestamped_StampsBothOnInsert_AndBumpsUpdatedOnModify()
@@ -338,31 +337,22 @@ public class UpdateTimestampsTests : IDisposable
     /// </summary>
     private DbContextOptions<NocturneDbContext> NewStore(params Guid[] tenantIds)
     {
-        var connection = new SqliteConnection("Filename=:memory:");
-        connection.Open();
-        _connections.Add(connection);
+        var db = TestDbContextFactory.CreateSqlite();
+        _databases.Add(db);
 
-        var options = new DbContextOptionsBuilder<NocturneDbContext>()
-            .UseSqlite(connection)
-            .EnableSensitiveDataLogging()
-            .Options;
-
-        using var seed = new NocturneDbContext(options);
-        seed.Database.EnsureCreated();
         foreach (var tenantId in tenantIds)
         {
-            seed.Tenants.Add(new TenantEntity { Id = tenantId, Slug = $"t{tenantId:N}"[..12] });
+            db.SeedTenant(tenantId, $"t{tenantId:N}"[..12]);
         }
-        seed.SaveChanges();
 
-        return options;
+        return db.Options;
     }
 
     public void Dispose()
     {
-        foreach (var connection in _connections)
+        foreach (var db in _databases)
         {
-            connection.Dispose();
+            db.Dispose();
         }
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
## The change

Thirty-six hand-rolled in-memory SQLite arrangements across thirteen test files (open a `:memory:` connection, build `DbContextOptions`, `EnsureCreated`, seed a tenant, track the connection for disposal) now go through `TestDbContextFactory.CreateSqlite()` / `CreateSqliteWithTenant()` from `tests/Shared`, which already did all of that. One widening: `SqliteTestDatabase.AddToServices(IServiceCollection)` registers the context factory and a scoped `NocturneDbContext` over the one connection, replacing the five copies of that DI pair in the tenant-resolution and auth-handler suites.

`MemberScopeMiddlewareTests` was the bulk of it: 23 connections because every test and both helpers opened their own. It now has one `ResolveAsync` helper (and a `(db, subjectId, …)` overload for the two tests that seed differently). No assertion, test name or seeded role/scope changed; the old helper's connection and provider leak in `AuthHandlerPriorityTests` goes away as a side effect.

Deliberately left: `SqliteWebAppFactoryBase` (host-lifetime connection exposed to configuration), four suites that pass a connection string without opening it (they only want the relational model), and three Data suites whose schema comes from a derived `DbContext`.

Net: 14 files, +182/−562.

## Tests

`Nocturne.Infrastructure.Data.Tests` 941 passed and `Nocturne.API.Tests` 6563 passed / 5 skipped, identical before and after. Per-file check that no context's tenant id changed (the query filter closes over it, so a `Guid.Empty` where a real id used to be would read nothing and pass vacuously): none did. Flipping the seeded permission in the collapsed helper reddens 16 of 33 `MemberScopeMiddlewareTests`, including every negative-scope assertion, so the arrangement still reaches the database.

Touches `TenantResolutionMiddlewareApexTests`, which #1225 also edits; whichever lands second rebases.
