### PR TITLE
feat(account): prompt an owner with one way in to add a backup, and show recovery-code status

### DIFF
--- a/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
+++ b/src/API/Nocturne.API/Controllers/Authentication/PasskeyController.cs
@@ -717,6 +717,7 @@ public class PasskeyController : ControllerBase
 
         var credentials = await _passkeyService.GetCredentialsAsync(auth.SubjectId.Value);
         var primaryFactorCount = await _subjectService.CountPrimaryAuthFactorsAsync(auth.SubjectId.Value);
+        var hasSingleSignInMethod = await _subjectService.HasSingleSignInMethodAsync(auth.SubjectId.Value);
 
         return Ok(new PasskeyCredentialListResponse
         {
@@ -728,6 +729,7 @@ public class PasskeyController : ControllerBase
                 LastUsedAt = c.LastUsedAt,
             }).ToList(),
             PrimaryAuthFactorCount = primaryFactorCount,
+            HasSingleSignInMethod = hasSingleSignInMethod,
         });
     }
 
@@ -771,7 +773,7 @@ public class PasskeyController : ControllerBase
     /// </summary>
     [HttpPost("recovery/regenerate")]
     [DenyDemoSubject]
-    [RemoteCommand(Invalidates = ["GetRecoveryStatus"])]
+    [RemoteCommand(Invalidates = ["GetRecoveryStatus", "ListCredentials"])]
     [ProducesResponseType(typeof(RecoveryRegenerateResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<RecoveryRegenerateResponse>> RegenerateRecoveryCodes()
@@ -1361,6 +1363,12 @@ public class PasskeyCredentialListResponse
 {
     public List<PasskeyCredentialDto> Credentials { get; set; } = new();
     public int PrimaryAuthFactorCount { get; set; }
+
+    /// <summary>
+    /// True when this account can be signed into exactly one way, with no unused recovery codes
+    /// behind it.
+    /// </summary>
+    public bool HasSingleSignInMethod { get; set; }
 }
 
 /// <summary>

--- a/src/API/Nocturne.API/Services/Auth/SubjectService.cs
+++ b/src/API/Nocturne.API/Services/Auth/SubjectService.cs
@@ -21,6 +21,7 @@ public class SubjectService : ISubjectService
 {
     private readonly NocturneDbContext _dbContext;
     private readonly IAuthAuditService _auditService;
+    private readonly IRecoveryCodeService _recoveryCodeService;
     private readonly ILogger<SubjectService> _logger;
 
     /// <summary>
@@ -28,11 +29,18 @@ public class SubjectService : ISubjectService
     /// </summary>
     /// <param name="dbContext">The EF Core database context for subject and role entity access.</param>
     /// <param name="auditService">Service for recording audit events on authentication actions.</param>
+    /// <param name="recoveryCodeService">Service for counting the subject's unused recovery codes.</param>
     /// <param name="logger">The logger instance.</param>
-    public SubjectService(NocturneDbContext dbContext, IAuthAuditService auditService, ILogger<SubjectService> logger)
+    public SubjectService(
+        NocturneDbContext dbContext,
+        IAuthAuditService auditService,
+        IRecoveryCodeService recoveryCodeService,
+        ILogger<SubjectService> logger
+    )
     {
         _dbContext = dbContext;
         _auditService = auditService;
+        _recoveryCodeService = recoveryCodeService;
         _logger = logger;
     }
 
@@ -797,6 +805,17 @@ public class SubjectService : ISubjectService
         var passkeys = await _dbContext.PasskeyCredentials.CountAsync(p => p.SubjectId == subjectId);
         var oidc = await _dbContext.SubjectOidcIdentities.CountAsync(i => i.SubjectId == subjectId);
         return passkeys + oidc;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HasSingleSignInMethodAsync(Guid subjectId)
+    {
+        if (await CountPrimaryAuthFactorsAsync(subjectId) != 1)
+        {
+            return false;
+        }
+
+        return await _recoveryCodeService.GetRemainingCountAsync(subjectId) == 0;
     }
 
     /// <inheritdoc />

--- a/src/Core/Nocturne.Core.Contracts/Auth/ISubjectService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Auth/ISubjectService.cs
@@ -89,6 +89,13 @@ public interface ISubjectService
     /// <param name="subjectId">Subject identifier.</param>
     Task<int> CountPrimaryAuthFactorsAsync(Guid subjectId);
 
+    /// <summary>
+    /// Returns whether the subject can sign in exactly one way — a single primary factor with no
+    /// unused recovery codes behind it — so that losing that one credential locks the account out.
+    /// </summary>
+    /// <param name="subjectId">Subject identifier.</param>
+    Task<bool> HasSingleSignInMethodAsync(Guid subjectId);
+
     /// <summary>Updates the last-used timestamp on an OIDC identity to track recent activity.</summary>
     /// <param name="identityId">The OIDC identity ID to update.</param>
     Task UpdateOidcIdentityLastUsedAsync(Guid identityId);

--- a/src/Web/packages/app/src/lib/components/layout/BackupSignInPrompt.svelte
+++ b/src/Web/packages/app/src/lib/components/layout/BackupSignInPrompt.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { KeyRound, X } from "lucide-svelte";
+  import { Button } from "$lib/components/ui/button";
+  import { listCredentials } from "$lib/api/generated/passkeys.generated.remote";
+  import {
+    getAll,
+    updateStatus,
+  } from "$lib/api/generated/coachMarks.generated.remote";
+
+  // Persisted with the coach marks, so the dismissal is stored per subject per
+  // tenant rather than per browser.
+  const MARK_KEY = "account.backup-sign-in";
+
+  const credentialsQuery = listCredentials();
+  const marksQuery = getAll();
+
+  const hasSingleSignInMethod = $derived(
+    credentialsQuery.current?.hasSingleSignInMethod === true
+  );
+  const dismissed = $derived(
+    marksQuery.current?.some(
+      (mark) => mark.markKey === MARK_KEY && mark.status === "dismissed"
+    ) === true
+  );
+
+  async function dismiss() {
+    try {
+      await updateStatus({ key: MARK_KEY, request: { status: "dismissed" } });
+    } catch (err) {
+      console.error("Failed to dismiss the backup sign-in prompt:", err);
+    }
+  }
+</script>
+
+{#if hasSingleSignInMethod && !dismissed}
+  <div
+    class="sticky top-0 z-50 flex items-start justify-between gap-4 border-b border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200"
+  >
+    <div class="flex items-start gap-2">
+      <KeyRound class="mt-0.5 h-4 w-4 shrink-0" />
+      <div class="space-y-0.5">
+        <p class="font-medium">Add a backup way to sign in</p>
+        <p>
+          There is one way into this account. Add a second passkey, link a
+          sign-in method, or save recovery codes &mdash; one-time codes you can
+          type in if you lose your device.
+        </p>
+      </div>
+    </div>
+    <div class="flex shrink-0 items-center gap-1">
+      <Button size="sm" variant="outline" href="/settings/account">
+        Account settings
+      </Button>
+      <Button size="sm" variant="ghost" aria-label="Dismiss" onclick={dismiss}>
+        <X class="h-3 w-3" />
+      </Button>
+    </div>
+  </div>
+{/if}

--- a/src/Web/packages/app/src/lib/components/layout/BackupSignInPrompt.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/layout/BackupSignInPrompt.svelte.test.ts
@@ -1,0 +1,74 @@
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { remoteQuery } from "$lib/test-stubs/remote-resource";
+
+let credentials: { hasSingleSignInMethod: boolean };
+let marks: { markKey: string; status: string }[];
+const updateStatus = vi.fn();
+
+vi.mock("$lib/api/generated/passkeys.generated.remote", () => ({
+  listCredentials: () => remoteQuery(() => credentials),
+}));
+
+vi.mock("$lib/api/generated/coachMarks.generated.remote", () => ({
+  getAll: () => remoteQuery(() => marks),
+  updateStatus: (arg: unknown) => updateStatus(arg),
+}));
+
+import BackupSignInPrompt from "./BackupSignInPrompt.svelte";
+
+const heading = () => page.getByText("Add a backup way to sign in");
+
+describe("BackupSignInPrompt", () => {
+  beforeEach(() => {
+    credentials = { hasSingleSignInMethod: true };
+    marks = [];
+    updateStatus.mockReset();
+    updateStatus.mockResolvedValue(undefined);
+  });
+
+  it("prompts when the account has one way in", async () => {
+    render(BackupSignInPrompt);
+
+    await expect.element(heading()).toBeVisible();
+    await expect
+      .element(page.getByRole("link", { name: "Account settings" }))
+      .toBeVisible();
+  });
+
+  it("stays out of the way when the account has another way in", async () => {
+    credentials = { hasSingleSignInMethod: false };
+
+    render(BackupSignInPrompt);
+
+    await expect.element(heading()).not.toBeInTheDocument();
+  });
+
+  it("stays out of the way once the prompt has been dismissed", async () => {
+    marks = [{ markKey: "account.backup-sign-in", status: "dismissed" }];
+
+    render(BackupSignInPrompt);
+
+    await expect.element(heading()).not.toBeInTheDocument();
+  });
+
+  it("ignores another mark's dismissal", async () => {
+    marks = [{ markKey: "quick-tour.chart", status: "dismissed" }];
+
+    render(BackupSignInPrompt);
+
+    await expect.element(heading()).toBeVisible();
+  });
+
+  it("persists the dismissal against the caller's subject", async () => {
+    render(BackupSignInPrompt);
+
+    await page.getByRole("button", { name: "Dismiss" }).click();
+
+    expect(updateStatus).toHaveBeenCalledWith({
+      key: "account.backup-sign-in",
+      request: { status: "dismissed" },
+    });
+  });
+});

--- a/src/Web/packages/app/src/lib/components/layout/index.ts
+++ b/src/Web/packages/app/src/lib/components/layout/index.ts
@@ -6,3 +6,4 @@ export { default as MobileHeader } from "./MobileHeader.svelte";
 export { default as EditorActionBar } from "./EditorActionBar.svelte";
 export { default as UserMenu } from "./UserMenu.svelte";
 export { default as SessionExpiryWarning } from "./SessionExpiryWarning.svelte";
+export { default as BackupSignInPrompt } from "./BackupSignInPrompt.svelte";

--- a/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/+layout.svelte
@@ -19,6 +19,7 @@
   import AlertSurfaces from "$lib/components/alerts/AlertSurfaces.svelte";
   import DemoBanner from "$lib/components/layout/DemoBanner.svelte";
   import GuestBanner from "$lib/components/layout/GuestBanner.svelte";
+  import BackupSignInPrompt from "$lib/components/layout/BackupSignInPrompt.svelte";
   import MembershipRequestAutoSubmit from "$lib/components/members/MembershipRequestAutoSubmit.svelte";
   import { CommandPalette } from "$lib/components/command-palette";
   import { CoachMarkProvider } from "@nocturne/coach";
@@ -215,6 +216,9 @@
       {/if}
       {#if data.isGuestSession && data.guestExpiresAt}
         <GuestBanner expiresAt={data.guestExpiresAt} />
+      {/if}
+      {#if !tenantless && data.user && !data.isGuestSession && !data.isDemo}
+        <BackupSignInPrompt />
       {/if}
       {#if !tenantless}
         <MembershipRequestAutoSubmit

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/account/+page.svelte
@@ -114,6 +114,7 @@
     credentialsQuery.current?.primaryAuthFactorCount ?? 0
   );
   const recoveryStatus = $derived(recoveryQuery.current);
+  const remainingRecoveryCodes = $derived(recoveryStatus?.remainingCodes ?? 0);
   const isSecurityLoading = $derived(credentialsQuery.loading);
   const canRemovePasskey = $derived(primaryAuthFactorCount > 1);
 
@@ -464,25 +465,31 @@
             <div class="flex items-center justify-between">
               <div class="space-y-1">
                 <p class="text-sm font-medium">
-                  {recoveryStatus.remainingCodes} of {recoveryStatus.totalCodes} recovery
-                  codes remaining
+                  {#if remainingRecoveryCodes > 0}
+                    {remainingRecoveryCodes} of {recoveryStatus.totalCodes} recovery
+                    codes remaining
+                  {:else if recoveryStatus.hasCodes}
+                    Every recovery code has been used
+                  {:else}
+                    No recovery codes yet
+                  {/if}
                 </p>
-                <p class="text-xs text-muted-foreground">
-                  Each code can only be used once.
-                </p>
+                {#if remainingRecoveryCodes > 0}
+                  <p class="text-xs text-muted-foreground">
+                    Each code can only be used once.
+                  </p>
+                {/if}
               </div>
               <Badge
-                variant={(recoveryStatus.remainingCodes ?? 0) > 2
+                variant={remainingRecoveryCodes > 2
                   ? "secondary"
                   : "destructive"}
               >
-                {recoveryStatus.remainingCodes} remaining
+                {remainingRecoveryCodes > 0
+                  ? `${remainingRecoveryCodes} remaining`
+                  : "None"}
               </Badge>
             </div>
-          {:else}
-            <p class="text-sm text-muted-foreground">
-              No recovery codes have been generated yet.
-            </p>
           {/if}
 
           <Separator />
@@ -497,7 +504,9 @@
             {:else}
               <RefreshCw class="mr-1.5 h-4 w-4" />
             {/if}
-            Regenerate recovery codes
+            {recoveryStatus?.hasCodes
+              ? "Regenerate recovery codes"
+              : "Generate recovery codes"}
           </Button>
         </Card.Content>
       </Card.Root>

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyControllerTests.cs
@@ -1330,4 +1330,25 @@ public class PasskeyControllerTests : IDisposable
     }
 
     #endregion
+
+    #region ListCredentials reports whether the account has a backup way in
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ListCredentials_CarriesTheSingleSignInMethodVerdict(bool single)
+    {
+        Authenticate();
+        _passkeyService.Setup(s => s.GetCredentialsAsync(_subjectId)).ReturnsAsync([]);
+        _subjectService.Setup(s => s.CountPrimaryAuthFactorsAsync(_subjectId)).ReturnsAsync(1);
+        _subjectService.Setup(s => s.HasSingleSignInMethodAsync(_subjectId)).ReturnsAsync(single);
+
+        var result = await _controller.ListCredentials();
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<PasskeyCredentialListResponse>(okResult.Value);
+        response.HasSingleSignInMethod.Should().Be(single);
+    }
+
+    #endregion
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyInvalidationTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/PasskeyInvalidationTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using FluentAssertions;
+using Nocturne.API.Controllers.Authentication;
+using OpenApi.Remote.Attributes;
+using Xunit;
+
+namespace Nocturne.API.Tests.Controllers;
+
+/// <summary>
+/// Minting recovery codes gives an account a second way in, which
+/// <see cref="PasskeyCredentialListResponse.HasSingleSignInMethod"/> reports from a read of its
+/// own — a hint that lists only the recovery status leaves the backup-sign-in prompt on screen
+/// until the next full load.
+/// </summary>
+[Trait("Category", "Unit")]
+public class PasskeyInvalidationTests
+{
+    [Theory]
+    [InlineData(nameof(PasskeyController.GetRecoveryStatus))]
+    [InlineData(nameof(PasskeyController.ListCredentials))]
+    public void RegeneratingRecoveryCodes_RefreshesTheReadsThatReportThem(string read)
+    {
+        Command(nameof(PasskeyController.RegenerateRecoveryCodes))
+            .Invalidates.Should()
+            .Contain(read);
+    }
+
+    [Theory]
+    [InlineData(nameof(PasskeyController.GetRecoveryStatus))]
+    [InlineData(nameof(PasskeyController.ListCredentials))]
+    public void EveryRefreshedRead_IsAQueryTheCommandCanRefresh(string read)
+    {
+        typeof(PasskeyController).GetMethod(read)!
+            .GetCustomAttribute<RemoteQueryAttribute>().Should().NotBeNull();
+    }
+
+    private static RemoteCommandAttribute Command(string write) =>
+        typeof(PasskeyController).GetMethod(write)!
+            .GetCustomAttribute<RemoteCommandAttribute>()!;
+}

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/SubjectServiceLegacyTokenTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/SubjectServiceLegacyTokenTests.cs
@@ -26,7 +26,12 @@ public class SubjectServiceLegacyTokenTests : IDisposable
     public SubjectServiceLegacyTokenTests()
     {
         _db = TestDbContextFactory.CreateInMemoryContext();
-        _service = new SubjectService(_db, _audit.Object, NullLogger<SubjectService>.Instance);
+        _service = new SubjectService(
+            _db,
+            _audit.Object,
+            Mock.Of<IRecoveryCodeService>(),
+            NullLogger<SubjectService>.Instance
+        );
     }
 
     public void Dispose() => _db.Dispose();

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/SubjectServiceOidcIdentityTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/SubjectServiceOidcIdentityTests.cs
@@ -24,7 +24,12 @@ public class SubjectServiceOidcIdentityTests : IDisposable
     public SubjectServiceOidcIdentityTests()
     {
         _db = TestDbContextFactory.CreateInMemoryContext();
-        _service = new SubjectService(_db, _audit.Object, NullLogger<SubjectService>.Instance);
+        _service = new SubjectService(
+            _db,
+            _audit.Object,
+            Mock.Of<IRecoveryCodeService>(),
+            NullLogger<SubjectService>.Instance
+        );
     }
 
     public void Dispose() => _db.Dispose();

--- a/tests/Unit/Nocturne.API.Tests/Services/Auth/SubjectServiceSignInMethodTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Auth/SubjectServiceSignInMethodTests.cs
@@ -1,0 +1,145 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.API.Services.Auth;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Nocturne.Tests.Shared.Infrastructure;
+using Xunit;
+
+namespace Nocturne.API.Tests.Services.Auth;
+
+/// <summary>
+/// Exercises <see cref="SubjectService.HasSingleSignInMethodAsync"/> — the predicate behind the
+/// "add a backup way to sign in" prompt, widening
+/// <see cref="SubjectService.CountPrimaryAuthFactorsAsync"/> with the recovery-code leg — against
+/// a real EF InMemory DbContext.
+/// </summary>
+public class SubjectServiceSignInMethodTests : IDisposable
+{
+    private readonly NocturneDbContext _db;
+    private readonly SubjectService _service;
+    private readonly Mock<IRecoveryCodeService> _recoveryCodes = new();
+    private readonly Guid _subjectId = Guid.CreateVersion7();
+
+    public SubjectServiceSignInMethodTests()
+    {
+        _db = TestDbContextFactory.CreateInMemoryContext();
+        _service = new SubjectService(
+            _db,
+            Mock.Of<IAuthAuditService>(),
+            _recoveryCodes.Object,
+            NullLogger<SubjectService>.Instance
+        );
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private async Task SeedPasskeysAsync(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            _db.PasskeyCredentials.Add(new PasskeyCredentialEntity
+            {
+                Id = Guid.CreateVersion7(),
+                SubjectId = _subjectId,
+                CredentialId = [(byte)i],
+            });
+        }
+        await _db.SaveChangesAsync();
+    }
+
+    private async Task SeedOidcIdentityAsync()
+    {
+        _db.SubjectOidcIdentities.Add(new SubjectOidcIdentityEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = _subjectId,
+            ProviderId = Guid.CreateVersion7(),
+            OidcSubjectId = "ext-sub",
+            Issuer = "https://issuer.example",
+            LinkedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    private void GiveRecoveryCodes(int unused) =>
+        _recoveryCodes.Setup(s => s.GetRemainingCountAsync(_subjectId)).ReturnsAsync(unused);
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task OnePasskeyAndNoRecoveryCodes_IsASingleMethod()
+    {
+        await SeedPasskeysAsync(1);
+        GiveRecoveryCodes(0);
+
+        (await _service.HasSingleSignInMethodAsync(_subjectId)).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task OnePasskeyWithUnusedRecoveryCodes_IsNotASingleMethod()
+    {
+        await SeedPasskeysAsync(1);
+        GiveRecoveryCodes(8);
+
+        (await _service.HasSingleSignInMethodAsync(_subjectId)).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task TwoPasskeys_IsNotASingleMethod()
+    {
+        await SeedPasskeysAsync(2);
+        GiveRecoveryCodes(0);
+
+        (await _service.HasSingleSignInMethodAsync(_subjectId)).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task OnePasskeyAndOneLinkedIdentity_IsNotASingleMethod()
+    {
+        await SeedPasskeysAsync(1);
+        await SeedOidcIdentityAsync();
+        GiveRecoveryCodes(0);
+
+        (await _service.HasSingleSignInMethodAsync(_subjectId)).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task OneLinkedIdentityAndNoRecoveryCodes_IsASingleMethod()
+    {
+        await SeedOidcIdentityAsync();
+        GiveRecoveryCodes(0);
+
+        (await _service.HasSingleSignInMethodAsync(_subjectId)).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task NoPrimaryFactors_IsNotASingleMethod()
+    {
+        GiveRecoveryCodes(0);
+
+        (await _service.HasSingleSignInMethodAsync(_subjectId)).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AnotherSubjectsPasskey_DoesNotCount()
+    {
+        _db.PasskeyCredentials.Add(new PasskeyCredentialEntity
+        {
+            Id = Guid.CreateVersion7(),
+            SubjectId = Guid.CreateVersion7(),
+            CredentialId = [1],
+        });
+        await _db.SaveChangesAsync();
+        await SeedPasskeysAsync(1);
+        GiveRecoveryCodes(0);
+
+        (await _service.HasSingleSignInMethodAsync(_subjectId)).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Closes #1181 (items 1 and 2; item 3, returning one-time codes from provision-with-owner, is left for after the session handoff in #1178).

## The change

An owner provisioned through the admin API has exactly one credential and no recovery codes, so one lost phone is a lockout, and nothing said so.

- **One predicate, on the backend.** `ISubjectService.HasSingleSignInMethodAsync` widens the existing `CountPrimaryAuthFactorsAsync` (passkeys plus linked identities, already behind the last-factor guards) with a recovery-code leg from `IRecoveryCodeService`, and reaches the browser as one field, `hasSingleSignInMethod`, on the `ListCredentials` response the account page already reads. The frontend does no arithmetic.
- **A dismissable prompt** ("There is one way into this account") in the authenticated layout beside the demo and guest banners, linking to `/settings/account` and naming the three options in plain words. Dismissal is stored through the existing coach-mark store under `account.backup-sign-in`, per subject per tenant, so it survives browsers. Not shown on the tenantless apex, to guests, or to demo subjects.
- **Recovery-code status on the account card.** The API already returned the counts; the card's "none" branch was unreachable, so an owner with no codes read "0 of 8 remaining". It now distinguishes N remaining, every code used, and none generated, and the button says "Generate" when there is nothing to regenerate.
- `RegenerateRecoveryCodes` now also invalidates `ListCredentials`, so generating codes from the account page clears the prompt without a reload.

Net: 12 files, +367/−15 before the review round; see the diff.

## Tests

`SubjectServiceSignInMethodTests` (one passkey → single; passkey plus identity, passkey plus unused codes, zero factors → not single), a `PasskeyControllerTests` theory carrying the verdict on the response, and `PasskeyInvalidationTests` pinning that regenerate refreshes both reads. Mutations killed by a named test: the recovery-code leg dropped, `!= 1` → `> 1`, the response field removed, `ListCredentials` dropped from `Invalidates`. API unit suite 6576 passed. `BackupSignInPrompt.svelte.test.ts` mounts the real component over stubbed remote queries: shown for one method, hidden for more than one, hidden once dismissed, dismissal calls `updateStatus`; collapsing the render gate reddens two. `pnpm check` stays at the repo's 62-error baseline.

Related: #1238 (an identity on a disabled provider still counts as a way in), #1236 (OIDC unlink does not refresh the credential list), #1235 (recovery codes keyed on the JWT secret), #1237 (`SessionExpiryWarning` is never mounted).
