### PR TITLE
Add Google Health connector and configurable Year Overview colors

### DIFF
--- a/src/API/Nocturne.API/Controllers/V4/Health/GoogleHealth/GoogleHealthController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Health/GoogleHealth/GoogleHealthController.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.API.Attributes;
+using Nocturne.API.Authorization;
+using Nocturne.API.Extensions;
+using Nocturne.API.Services.Health.GoogleHealth;
+using Nocturne.Core.Models.Authorization;
+using Nocturne.Core.Models.Health;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Infrastructure.Data;
+using OpenApi.Remote.Attributes;
+
+namespace Nocturne.API.Controllers.V4.Health;
+
+[ApiController, Authorize, DenyDemoSubject, RequireScope(Scope.TenantSettings)]
+[Route("api/v4/google-health")]
+[ProducesResponseType(typeof(ProblemDetails), 400)]
+public class GoogleHealthController(IGoogleHealthService service, NocturneDbContext db) : ControllerBase
+{
+    private Guid Subject => HttpContext.GetAuthContext()?.SubjectId ?? throw new UnauthorizedAccessException();
+
+    [HttpGet, RemoteQuery]
+    [ProducesResponseType(typeof(GoogleHealthStatus), 200)]
+    public async Task<ActionResult<GoogleHealthStatus>> GetGoogleHealth(CancellationToken ct) => Ok(await service.StatusAsync(ct));
+
+    [HttpPut("options"), RemoteCommand, RequireScope(Scope.TenantSettings)]
+    [ProducesResponseType(typeof(GoogleHealthStatus), 200)]
+    public Task<ActionResult<GoogleHealthStatus>> SaveGoogleHealth(GoogleHealthOptions input, CancellationToken ct) => Run(async () => await service.SaveAsync(input, Subject, ct), ct);
+
+    [HttpPost("start"), RemoteCommand, RequireScope(Scope.TenantSettings)]
+    [ProducesResponseType(typeof(GoogleHealthAuthorize), 200)]
+    public async Task<ActionResult<GoogleHealthAuthorize>> StartGoogleHealth(CancellationToken ct)
+    {
+        try { return Ok(await service.StartAsync(Subject, ct)); }
+        catch (GoogleHealthException ex) { return Problem(statusCode: 400, detail: ex.Message); }
+    }
+
+    [HttpPost("complete"), RemoteCommand, RequireScope(Scope.TenantSettings)]
+    [ProducesResponseType(typeof(GoogleHealthStatus), 200)]
+    public Task<ActionResult<GoogleHealthStatus>> CompleteGoogleHealth(GoogleHealthCallback input, CancellationToken ct) => Run(async () => await service.CompleteAsync(input, Subject, ct), ct);
+
+    [HttpPost("disconnect"), RemoteCommand, RequireScope(Scope.TenantSettings)]
+    [ProducesResponseType(typeof(GoogleHealthStatus), 200)]
+    public Task<ActionResult<GoogleHealthStatus>> DisconnectGoogleHealth(CancellationToken ct) => Run(async () => await service.DisconnectAsync(Subject, ct), ct);
+
+    [HttpPost("sync"), RemoteCommand, RequireScope(Scope.TenantSettings)]
+    [ProducesResponseType(typeof(GoogleHealthStatus), 200)]
+    [ProducesResponseType(typeof(ProblemDetails), 502)]
+    public Task<ActionResult<GoogleHealthStatus>> SyncGoogleHealth(CancellationToken ct) => Run(async () => await service.QueueSyncAsync(ct), ct);
+
+    [HttpPost("preview"), RemoteCommand, RequireScope(Scope.TenantSettings)]
+    [ProducesResponseType(typeof(GoogleHealthPreview), 200)]
+    public async Task<ActionResult<GoogleHealthPreview>> PreviewGoogleHealth(CancellationToken ct)
+    {
+        try { return Ok(await service.PreviewAsync(Subject, ct)); }
+        catch (GoogleHealthException ex) { return Problem(statusCode: 400, detail: ex.Message); }
+        catch (HttpRequestException) { return Problem(statusCode: 502, detail: "google_unavailable"); }
+    }
+
+    [HttpDelete("readings"), RemoteCommand, RequireScope(Scope.TenantSettings)]
+    [ProducesResponseType(typeof(GoogleHealthStatus), 200)]
+    public Task<ActionResult<GoogleHealthStatus>> PurgeGoogleHealth(CancellationToken ct) => Run(async () => await service.PurgeAsync(Subject, ct), ct);
+
+    [HttpGet("readings"), RemoteQuery]
+    [ProducesResponseType(typeof(List<GoogleHealthReading>), 200)]
+    public async Task<ActionResult<List<GoogleHealthReading>>> GetGoogleHealthReadings(string dataType, int skip = 0, CancellationToken ct = default)
+    {
+        if (!GoogleHealthClient.SupportedTypes.Contains(dataType)) return BadRequest();
+        return Ok(await db.GoogleHealthReadings.AsNoTracking().Where(x => x.DataType == dataType)
+            .OrderByDescending(x => x.Mills).ThenBy(x => x.Id).Skip(Math.Clamp(skip, 0, 10000000)).Take(100)
+            .Select(x => new GoogleHealthReading { DataType = x.DataType, Mills = x.Mills, EndMills = x.EndMills,
+                Value = x.Value, Unit = x.Unit, UtcOffsetMinutes = x.UtcOffsetMinutes }).ToListAsync(ct));
+    }
+
+    private async Task<ActionResult<GoogleHealthStatus>> Run(Func<Task> action, CancellationToken ct)
+    {
+        try { await action(); return Ok(await service.StatusAsync(ct)); }
+        catch (GoogleHealthException ex) { return Problem(statusCode: 400, detail: ex.Message); }
+        catch (HttpRequestException) { return Problem(statusCode: 502, detail: "google_unavailable"); }
+    }
+}

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -12,7 +12,9 @@ using Nocturne.API.Services.Auth;
 using Nocturne.API.Services.BackgroundServices;
 using Nocturne.API.Services.DevOnly;
 using Nocturne.API.Services.Docs;
+using Nocturne.API.Services.Health.GoogleHealth;
 using Nocturne.API.Services.Seeding;
+using Nocturne.Core.Contracts.Health;
 using Nocturne.Core.Models.Authorization;
 using Nocturne.Core.Contracts.Audit;
 using Nocturne.API.Extensions;
@@ -148,6 +150,15 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IAuditContext, AuditContext>();
 builder.Services.AddHostedService<AuditRetentionService>();
 builder.Services.AddHostedService<SoftDeleteCleanupService>();
+builder.Services.AddSingleton<GoogleHealthCoordinator>();
+builder.Services.AddScoped<IGoogleHealthService, GoogleHealthService>();
+builder.Services.AddScoped<IGoogleHealthReadingWriter, GoogleHealthReadingWriter>();
+builder.Services.AddHttpClient<GoogleHealthClient>(client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(45);
+    client.MaxResponseContentBufferSize = 16 * 1024 * 1024;
+}).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false });
+builder.Services.AddHostedService<GoogleHealthWorker>();
 
 // Consumed by the dev-only admin controllers (Development) and the demo admin
 // controller's seed-extras endpoint (demo container, all environments).

--- a/src/API/Nocturne.API/Services/Health/GoogleHealth/GoogleHealthClient.cs
+++ b/src/API/Nocturne.API/Services/Health/GoogleHealth/GoogleHealthClient.cs
@@ -1,0 +1,519 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Health;
+
+namespace Nocturne.API.Services.Health.GoogleHealth;
+
+public sealed class GoogleHealthException(
+    string code,
+    TimeSpan? retryAfter = null,
+    string? stage = null,
+    string? dataType = null,
+    string? providerReason = null,
+    int? providerStatus = null) : Exception(code)
+{
+    public TimeSpan? RetryAfter { get; } = retryAfter;
+    public string? Stage { get; } = stage;
+    public string? DataType { get; } = dataType;
+    public string? ProviderReason { get; } = providerReason;
+    public int? ProviderStatus { get; } = providerStatus;
+}
+
+public sealed class GoogleHealthClient(HttpClient http)
+{
+    // A faulty provider can keep issuing unique cursors that bypass cycle detection.
+    internal const int MaximumHistoryPages = 10_000;
+
+    public const string ActivityScope = "https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly";
+    public const string MetricsScope = "https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly";
+    public const string SleepScope = "https://www.googleapis.com/auth/googlehealth.sleep.readonly";
+    public static readonly GoogleHealthCapability[] Capabilities =
+    [
+        new() { DataType = "steps", Supported = true, Destination = "step-counts" },
+        new() { DataType = "heart-rate", Supported = true, Destination = "heart-rates" },
+        new() { DataType = "weight", Supported = true, Destination = "body-weights" },
+        new() { DataType = "sleep", Supported = true, Destination = "sleep-sessions" }, new() { DataType = "body-fat" },
+        new() { DataType = "distance" }, new() { DataType = "oxygen-saturation" }, new() { DataType = "heart-rate-variability" }
+    ];
+    public static string[] SupportedTypes => Capabilities.Where(c => c.Supported).Select(c => c.DataType).ToArray();
+    public static string ScopeFor(string type) => type switch
+    {
+        "steps" => ActivityScope,
+        "heart-rate" or "weight" or "body-fat" or "oxygen-saturation" or "heart-rate-variability" => MetricsScope,
+        "distance" => ActivityScope,
+        "sleep" => SleepScope,
+        _ => throw new GoogleHealthException("unsupported_type")
+    };
+
+    public async Task<int> CountAsync(string token, string type, DateTimeOffset from, DateTimeOffset to, CancellationToken ct)
+    {
+        var field = type switch
+        {
+            "steps" or "distance" => $"{type.Replace('-', '_')}.interval.start_time",
+            "sleep" => "sleep.interval.start_time",
+            _ => $"{type.Replace('-', '_')}.sample_time.physical_time"
+        };
+        var filter = $"{field} >= \"{from.UtcDateTime:O}\" AND {field} < \"{to.UtcDateTime:O}\"";
+        var pageSize = type == "sleep" ? 25 : 10000;
+        var root = $"https://health.googleapis.com/v4/users/me/dataTypes/{type}/dataPoints:reconcile?pageSize={pageSize}&filter={Uri.EscapeDataString(filter)}";
+        var count = 0;
+        var pageToken = "";
+        var seen = new HashSet<string>();
+        for (var page = 0; page < MaximumHistoryPages; page++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var url = pageToken.Length == 0 ? root : root + "&pageToken=" + Uri.EscapeDataString(pageToken);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using var response = await http.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+                throw await ErrorAsync(response, response.StatusCode switch
+                {
+                    System.Net.HttpStatusCode.Unauthorized => "access_token_rejected",
+                    System.Net.HttpStatusCode.Forbidden => "permission_denied",
+                    System.Net.HttpStatusCode.BadRequest => "invalid_google_request",
+                    System.Net.HttpStatusCode.NotFound => "google_resource_not_found",
+                    _ => "google_unavailable"
+                }, type, ct);
+            try
+            {
+                using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+                if (json.RootElement.TryGetProperty("dataPoints", out var data) && data.ValueKind == JsonValueKind.Array)
+                    count += data.GetArrayLength();
+                pageToken = json.RootElement.TryGetProperty("nextPageToken", out var next) ? next.GetString() ?? "" : "";
+            }
+            catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+            {
+                throw new GoogleHealthException("invalid_google_response", stage: "inventory", dataType: type);
+            }
+            if (pageToken.Length == 0) return count;
+            if (!seen.Add(pageToken)) throw new GoogleHealthException("pagination_failed", stage: "inventory", dataType: type);
+        }
+        throw new GoogleHealthException("history_too_large", stage: "inventory", dataType: type);
+    }
+
+    public async Task<List<SleepSession>> ReadSleepAsync(
+        string token, DateTimeOffset from, DateTimeOffset to, CancellationToken ct,
+        Action<int>? onPageRead = null)
+    {
+        var filter = $"sleep.interval.start_time >= \"{from.UtcDateTime:O}\" AND sleep.interval.start_time < \"{to.UtcDateTime:O}\"";
+        var root = $"https://health.googleapis.com/v4/users/me/dataTypes/sleep/dataPoints:reconcile?pageSize=25&filter={Uri.EscapeDataString(filter)}";
+        var sessions = new List<SleepSession>();
+        var seen = new HashSet<string>();
+        var pageToken = "";
+        for (var page = 0; page < MaximumHistoryPages; page++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var url = pageToken.Length == 0 ? root : root + "&pageToken=" + Uri.EscapeDataString(pageToken);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using var response = await http.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+                throw await ErrorAsync(response, response.StatusCode switch
+                {
+                    System.Net.HttpStatusCode.Unauthorized => "access_token_rejected",
+                    System.Net.HttpStatusCode.Forbidden => "permission_denied",
+                    System.Net.HttpStatusCode.BadRequest => "invalid_google_request",
+                    System.Net.HttpStatusCode.NotFound => "google_resource_not_found",
+                    _ => "google_unavailable"
+                }, "sleep", ct);
+            try
+            {
+                using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+                if (json.RootElement.TryGetProperty("dataPoints", out var data))
+                    foreach (var item in data.EnumerateArray())
+                    {
+                        var session = ParseSleep(item);
+                        if (session.StartMills < from.ToUnixTimeMilliseconds() || session.StartMills >= to.ToUnixTimeMilliseconds())
+                            throw new GoogleHealthException("unexpected_time_range", stage: "data_parse", dataType: "sleep");
+                        sessions.Add(session);
+                    }
+                pageToken = json.RootElement.TryGetProperty("nextPageToken", out var next) ? next.GetString() ?? "" : "";
+                onPageRead?.Invoke(page + 1);
+            }
+            catch (GoogleHealthException) { throw; }
+            catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+            {
+                throw new GoogleHealthException("invalid_google_response", stage: "data_read", dataType: "sleep");
+            }
+            if (pageToken.Length == 0) return sessions;
+            if (!seen.Add(pageToken)) throw new GoogleHealthException("pagination_failed", stage: "data_read", dataType: "sleep");
+        }
+        throw new GoogleHealthException("history_too_large", stage: "data_read", dataType: "sleep");
+    }
+
+    public Task<JsonElement> ExchangeAuthorizationCodeAsync(Dictionary<string, string> form, CancellationToken ct) =>
+        ExchangeAsync(form, "expired_signin", "authorization_code", ct);
+
+    public Task<JsonElement> RefreshAccessTokenAsync(Dictionary<string, string> form, CancellationToken ct) =>
+        ExchangeAsync(form, "reconnect_required", "token_refresh", ct);
+
+    private async Task<JsonElement> ExchangeAsync(
+        Dictionary<string, string> form, string invalidGrantCode, string stage, CancellationToken ct)
+    {
+        using var response = await http.PostAsync("https://oauth2.googleapis.com/token", new FormUrlEncodedContent(form), ct);
+        if (!response.IsSuccessStatusCode)
+            throw await OAuthErrorAsync(response, invalidGrantCode, stage, ct);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+        return json.RootElement.Clone();
+    }
+
+    public async Task<bool> RevokeAsync(string refreshToken, CancellationToken ct)
+    {
+        using var response = await http.PostAsync("https://oauth2.googleapis.com/revoke",
+            new FormUrlEncodedContent(new Dictionary<string, string> { ["token"] = refreshToken }), ct);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<string> AccountKeyAsync(string token, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://openidconnect.googleapis.com/v1/userinfo");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        using var response = await http.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+            throw new GoogleHealthException("reconnect_required", stage: "account_identity", providerStatus: (int)response.StatusCode);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+        if (!json.RootElement.TryGetProperty("sub", out var subjectValue) || subjectValue.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(subjectValue.GetString()))
+            throw new GoogleHealthException("invalid_token_response", stage: "account_identity");
+        var subject = subjectValue.GetString()!;
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(subject)));
+    }
+
+    public async Task<List<GoogleHealthReading>> ReadAsync(
+        string token, string type, DateTimeOffset from, DateTimeOffset to, CancellationToken ct,
+        Action<int>? onPageRead = null)
+    {
+        var field = type == "steps" ? "steps.interval.start_time" : $"{type.Replace('-', '_')}.sample_time.physical_time";
+        var filter = $"{field} >= \"{from.UtcDateTime:O}\" AND {field} < \"{to.UtcDateTime:O}\"";
+        var root = $"https://health.googleapis.com/v4/users/me/dataTypes/{type}/dataPoints:reconcile?pageSize=10000&filter={Uri.EscapeDataString(filter)}";
+        var points = new List<GoogleHealthReading>();
+        var seen = new HashSet<string>();
+        var pageToken = "";
+        for (var page = 0; page < MaximumHistoryPages; page++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var url = pageToken.Length == 0 ? root : root + "&pageToken=" + Uri.EscapeDataString(pageToken);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            using var response = await http.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+                throw await ErrorAsync(response, response.StatusCode switch
+                {
+                    System.Net.HttpStatusCode.Unauthorized => "access_token_rejected",
+                    System.Net.HttpStatusCode.Forbidden => "permission_denied",
+                    System.Net.HttpStatusCode.BadRequest => "invalid_google_request",
+                    System.Net.HttpStatusCode.NotFound => "google_resource_not_found",
+                    _ => "google_unavailable"
+                }, type, ct);
+            try
+            {
+                using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+                if (json.RootElement.TryGetProperty("dataPoints", out var data))
+                    foreach (var item in data.EnumerateArray())
+                    {
+                        var point = Parse(type, item);
+                        if (point.Mills < from.ToUnixTimeMilliseconds() || point.Mills >= to.ToUnixTimeMilliseconds())
+                            throw new GoogleHealthException("unexpected_time_range", stage: "data_parse", dataType: type);
+                        points.Add(point);
+                    }
+                pageToken = json.RootElement.TryGetProperty("nextPageToken", out var next) ? next.GetString() ?? "" : "";
+                onPageRead?.Invoke(page + 1);
+            }
+            catch (GoogleHealthException)
+            {
+                throw;
+            }
+            catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+            {
+                throw new GoogleHealthException("invalid_google_response", stage: "data_read", dataType: type);
+            }
+            if (pageToken.Length == 0) return points;
+            if (!seen.Add(pageToken)) throw new GoogleHealthException("pagination_failed", stage: "data_read", dataType: type);
+        }
+        throw new GoogleHealthException("history_too_large", stage: "data_read", dataType: type);
+    }
+
+    private static async Task<GoogleHealthException> OAuthErrorAsync(
+        HttpResponseMessage response, string invalidGrantCode, string stage, CancellationToken ct)
+    {
+        var code = response.StatusCode == System.Net.HttpStatusCode.TooManyRequests ? "rate_limited" : "google_unavailable";
+        string? providerReason = null;
+        try
+        {
+            using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+            string? rawReason = null;
+            if (json.RootElement.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.String)
+                rawReason = error.GetString();
+            providerReason = SafeProviderReason(rawReason);
+            code = rawReason switch
+            {
+                "invalid_grant" => invalidGrantCode,
+                "invalid_client" => "invalid_client_credentials",
+                "redirect_uri_mismatch" => "invalid_callback",
+                "invalid_scope" => "oauth_scope_configuration",
+                "access_denied" => "permission_denied",
+                "invalid_request" => "oauth_request_invalid",
+                "temporarily_unavailable" or "server_error" => "google_unavailable",
+                _ => code
+            };
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+        }
+        return new GoogleHealthException(code, RetryAfter(response), stage, providerReason: providerReason,
+            providerStatus: (int)response.StatusCode);
+    }
+
+    private static async Task<GoogleHealthException> ErrorAsync(
+        HttpResponseMessage response, string fallback, string dataType, CancellationToken ct)
+    {
+        var code = response.StatusCode == System.Net.HttpStatusCode.TooManyRequests ? "rate_limited" : fallback;
+        string? providerReason = null;
+        try
+        {
+            using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+            if (json.RootElement.TryGetProperty("error", out var error) &&
+                error.TryGetProperty("details", out var details) && details.ValueKind == JsonValueKind.Array)
+            {
+                var reasons = GoogleReasons(details);
+                (code, providerReason) = MapGoogleReason(reasons, code);
+                providerReason = SafeProviderReason(providerReason);
+            }
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+        }
+        return new GoogleHealthException(code, RetryAfter(response), "data_read", dataType, providerReason,
+            (int)response.StatusCode);
+    }
+
+    private static TimeSpan? RetryAfter(HttpResponseMessage response) =>
+        response.Headers.RetryAfter?.Delta ?? (response.Headers.RetryAfter?.Date - DateTimeOffset.UtcNow);
+
+    private static string? SafeProviderReason(string? reason) =>
+        !string.IsNullOrWhiteSpace(reason) && reason.Length <= 100 &&
+        reason.All(character => character is >= 'A' and <= 'Z' or >= '0' and <= '9' or '_' or >= 'a' and <= 'z')
+            ? reason
+            : null;
+
+    private static (string Code, string? Reason) MapGoogleReason(HashSet<string> reasons, string fallback)
+    {
+        string? Find(string reason) => reasons.FirstOrDefault(value => value.Equals(reason, StringComparison.OrdinalIgnoreCase));
+        string? FindPrefix(string prefix) => reasons.FirstOrDefault(value => value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+        var reason = Find("ACCOUNT_NOT_LINKED");
+        if (reason is not null) return ("account_not_linked", reason);
+        reason = Find("API_PRIVATE_PREVIEW_ACCESS_DENIED");
+        if (reason is not null) return ("preview_access_denied", reason);
+        reason = Find("MISSING_OAUTH_SCOPE") ?? Find("DISALLOWED_OAUTH_SCOPES");
+        if (reason is not null) return ("permission_denied", reason);
+        reason = Find("DATA_ACCESS_DENIED") ?? Find("RESOURCE_PERMISSION_DENIED");
+        if (reason is not null) return ("data_access_denied", reason);
+        reason = Find("RESOURCE_NOT_FOUND");
+        if (reason is not null) return ("google_resource_not_found", reason);
+        reason = Find("INVALID_TIME_RANGE");
+        if (reason is not null) return ("invalid_time_range", reason);
+        reason = Find("INVALID_DATA_POINT_FILTER_RESTRICTION_COMPARATOR");
+        if (reason is not null) return ("invalid_filter_operator", reason);
+        reason = FindPrefix("INVALID_DATA_POINT_FILTER") ?? FindPrefix("INVALID_FILTER");
+        if (reason is not null) return ("invalid_google_filter", reason);
+        reason = Find("INVALID_PARENT_DATA_TYPE_COLLECTION_FORMAT") ?? Find("INVALID_PARENT_DATA_TYPE_COLLECTION") ??
+                 Find("INVALID_DATA_TYPE_FORMAT");
+        if (reason is not null) return ("invalid_google_data_type", reason);
+        reason = Find("INVALID_DATA_POINT_DATA_SOURCE_FAMILY");
+        if (reason is not null) return ("invalid_source_family", reason);
+        reason = Find("INTERNAL_ERROR");
+        if (reason is not null) return ("google_unavailable", reason);
+        reason = FindPrefix("INVALID_");
+        return reason is null ? (fallback, null) : ("invalid_google_request", reason);
+    }
+
+    private static HashSet<string> GoogleReasons(JsonElement details)
+    {
+        var reasons = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var detail in details.EnumerateArray())
+        {
+            AddReasons(detail, "reason", reasons);
+            if (!detail.TryGetProperty("metadata", out var metadata) || metadata.ValueKind != JsonValueKind.Object) continue;
+            foreach (var property in metadata.EnumerateObject())
+                if (property.Name.Equals("detailedReasons", StringComparison.OrdinalIgnoreCase) ||
+                    property.Name.Equals("reason", StringComparison.OrdinalIgnoreCase))
+                    AddReasons(property.Value, reasons);
+        }
+        return reasons;
+    }
+
+    private static void AddReasons(JsonElement source, string propertyName, HashSet<string> reasons)
+    {
+        if (source.ValueKind == JsonValueKind.Object && source.TryGetProperty(propertyName, out var value))
+            AddReasons(value, reasons);
+    }
+
+    private static void AddReasons(JsonElement value, HashSet<string> reasons)
+    {
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            foreach (var reason in (value.GetString() ?? "").Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+            {
+                var normalized = reason.Trim().Trim('[', ']', '"', '\'');
+                if (normalized.Length > 0) reasons.Add(normalized);
+            }
+        }
+        else if (value.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var reason in value.EnumerateArray()) AddReasons(reason, reasons);
+        }
+    }
+
+    public static string Key(GoogleHealthReading reading) => Convert.ToHexString(SHA256.HashData(
+        Encoding.UTF8.GetBytes($"{reading.DataType}|{reading.Mills}|{reading.EndMills}")));
+
+    public static SleepSession ParseSleep(JsonElement point)
+    {
+        try
+        {
+            var payload = point.GetProperty("sleep");
+            var interval = payload.GetProperty("interval");
+            var start = DateTimeOffset.Parse(interval.GetProperty("startTime").GetString()!, CultureInfo.InvariantCulture);
+            var end = DateTimeOffset.Parse(interval.GetProperty("endTime").GetString()!, CultureInfo.InvariantCulture);
+            if (end <= start) throw new GoogleHealthException("invalid_google_data", stage: "data_parse", dataType: "sleep");
+
+            var stages = new List<SleepStageInterval>();
+            if (payload.TryGetProperty("stages", out var stageData) && stageData.ValueKind == JsonValueKind.Array)
+            {
+                var ordinal = 0;
+                foreach (var stage in stageData.EnumerateArray())
+                {
+                    var stageStart = DateTimeOffset.Parse(stage.GetProperty("startTime").GetString()!, CultureInfo.InvariantCulture);
+                    var stageEnd = DateTimeOffset.Parse(stage.GetProperty("endTime").GetString()!, CultureInfo.InvariantCulture);
+                    if (stageStart < start || stageEnd > end || stageEnd <= stageStart)
+                        throw new GoogleHealthException("invalid_google_data", stage: "data_parse", dataType: "sleep");
+                    stages.Add(new SleepStageInterval
+                    {
+                        StartTime = stageStart.UtcDateTime,
+                        EndTime = stageEnd.UtcDateTime,
+                        Stage = ParseSleepStage(stage.GetProperty("type").GetString()),
+                        Ordinal = ordinal++
+                    });
+                }
+            }
+
+            JsonElement metadata = default;
+            var hasMetadata = payload.TryGetProperty("metadata", out metadata) && metadata.ValueKind == JsonValueKind.Object;
+            var isNap = hasMetadata && metadata.TryGetProperty("nap", out var nap) && nap.ValueKind == JsonValueKind.True;
+            var manuallyEdited = hasMetadata && metadata.TryGetProperty("manuallyEdited", out var manual) && manual.ValueKind == JsonValueKind.True;
+            var processed = hasMetadata && metadata.TryGetProperty("processed", out var complete) && complete.ValueKind == JsonValueKind.True;
+
+            JsonElement summary = default;
+            var hasSummary = payload.TryGetProperty("summary", out summary) && summary.ValueKind == JsonValueKind.Object;
+            var durationMs = (long)(end - start).TotalMilliseconds;
+            var stagedSleepMs = StageMilliseconds(stages, SleepStageType.Asleep, SleepStageType.Light, SleepStageType.Deep, SleepStageType.Rem);
+            var sleepMinutes = hasSummary ? Minutes(summary, "minutesAsleep") : null;
+            var totalSleepMs = sleepMinutes.HasValue ? sleepMinutes.Value * 60_000 : stagedSleepMs;
+            if (totalSleepMs == 0 && stages.Count == 0) totalSleepMs = durationMs;
+            var stagedAwakeMs = StageMilliseconds(stages, SleepStageType.Awake, SleepStageType.AwakeInBed);
+            var awakeMinutes = hasSummary ? Minutes(summary, "minutesAwake") : null;
+            long? totalAwakeMs = awakeMinutes.HasValue
+                ? awakeMinutes.Value * 60_000
+                : stages.Count > 0 ? stagedAwakeMs : null;
+            var latencyMinutes = hasSummary ? Minutes(summary, "minutesToFallAsleep") : null;
+
+            var externalId = hasMetadata && metadata.TryGetProperty("externalId", out var external) && external.ValueKind == JsonValueKind.String
+                ? external.GetString()
+                : null;
+            var resourceName = point.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String ? name.GetString() : null;
+            var originalId = !string.IsNullOrWhiteSpace(resourceName) ? resourceName : externalId;
+            originalId ??= Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes($"sleep|{start:O}|{end:O}")));
+
+            return new SleepSession
+            {
+                StartTime = start.UtcDateTime,
+                EndTime = end.UtcDateTime,
+                Type = isNap ? SleepSessionType.Nap : SleepSessionType.Overnight,
+                DetectionMethod = manuallyEdited ? SleepDetectionMethod.Manual : processed ? SleepDetectionMethod.AutoFinal : SleepDetectionMethod.AutoTentative,
+                IsMainSleep = !isNap,
+                DurationMs = durationMs,
+                TotalSleepMs = totalSleepMs,
+                TotalAwakeMs = totalAwakeMs,
+                DeepSleepMs = stages.Count > 0 ? StageMilliseconds(stages, SleepStageType.Deep) : null,
+                LightSleepMs = stages.Count > 0 ? StageMilliseconds(stages, SleepStageType.Light) : null,
+                RemSleepMs = stages.Count > 0 ? StageMilliseconds(stages, SleepStageType.Rem) : null,
+                SleepLatencyMs = latencyMinutes.HasValue
+                    ? latencyMinutes.Value * 60_000
+                    : null,
+                Efficiency = durationMs > 0 ? (float)(totalSleepMs * 100d / durationMs) : null,
+                RestlessPeriods = stages.Count > 0 ? stages.Count(stage => stage.Stage == SleepStageType.Restless) : null,
+                Source = SleepSource.Google,
+                SourceApp = "Google Health",
+                OriginalId = originalId,
+                Stages = stages,
+                Metadata = new Dictionary<string, object>
+                {
+                    ["googleSleepType"] = payload.TryGetProperty("type", out var sleepType) ? sleepType.GetString() ?? "SLEEP_TYPE_UNSPECIFIED" : "SLEEP_TYPE_UNSPECIFIED",
+                    ["manuallyEdited"] = manuallyEdited
+                }
+            };
+        }
+        catch (GoogleHealthException) { throw; }
+        catch (Exception ex) when (ex is KeyNotFoundException or FormatException or InvalidOperationException or OverflowException or ArgumentException)
+        {
+            throw new GoogleHealthException("invalid_google_data", stage: "data_parse", dataType: "sleep");
+        }
+    }
+
+    private static SleepStageType ParseSleepStage(string? value) => value switch
+    {
+        "AWAKE" => SleepStageType.Awake,
+        "LIGHT" => SleepStageType.Light,
+        "DEEP" => SleepStageType.Deep,
+        "REM" => SleepStageType.Rem,
+        "ASLEEP" => SleepStageType.Asleep,
+        "RESTLESS" => SleepStageType.Restless,
+        _ => SleepStageType.Unknown
+    };
+
+    private static long StageMilliseconds(IEnumerable<SleepStageInterval> stages, params SleepStageType[] types) =>
+        stages.Where(stage => types.Contains(stage.Stage)).Sum(stage => (long)(stage.EndTime - stage.StartTime).TotalMilliseconds);
+
+    private static long? Minutes(JsonElement summary, string property) =>
+        summary.TryGetProperty(property, out var value) && long.TryParse(value.ToString(), CultureInfo.InvariantCulture, out var minutes) && minutes >= 0
+            ? minutes
+            : null;
+
+    public static GoogleHealthReading Parse(string type, JsonElement point)
+    {
+        try
+        {
+            var payload = point.GetProperty(type == "heart-rate" ? "heartRate" : type);
+            var interval = type == "steps";
+            var time = payload.GetProperty(interval ? "interval" : "sampleTime");
+            var start = DateTimeOffset.Parse(time.GetProperty(interval ? "startTime" : "physicalTime").GetString()!, CultureInfo.InvariantCulture);
+            long? end = interval ? DateTimeOffset.Parse(time.GetProperty("endTime").GetString()!, CultureInfo.InvariantCulture).ToUnixTimeMilliseconds() : null;
+            var valueName = type switch { "steps" => "count", "heart-rate" => "beatsPerMinute", "weight" => "weightGrams", _ => throw new GoogleHealthException("unsupported_type", stage: "data_parse", dataType: type) };
+            var value = decimal.Parse(payload.GetProperty(valueName).ToString(), CultureInfo.InvariantCulture);
+            if (value < 0 || (type != "steps" && value == 0) || (type != "weight" && decimal.Truncate(value) != value) || (end.HasValue && end.Value <= start.ToUnixTimeMilliseconds()))
+                throw new GoogleHealthException("invalid_google_data", stage: "data_parse", dataType: type);
+            int? offset = null;
+            if (time.TryGetProperty(interval ? "startUtcOffset" : "utcOffset", out var offsetValue))
+            {
+                var seconds = decimal.Parse(offsetValue.GetString()!.TrimEnd('s'), CultureInfo.InvariantCulture);
+                if (seconds % 60 != 0 || Math.Abs(seconds) > 50400) throw new GoogleHealthException("invalid_google_data", stage: "data_parse", dataType: type);
+                offset = (int)(seconds / 60);
+            }
+            return new GoogleHealthReading
+            {
+                DataType = type, Mills = start.ToUnixTimeMilliseconds(), EndMills = end, UtcOffsetMinutes = offset,
+                Value = type == "weight" ? value / 1000m : value,
+                Unit = type switch { "weight" => "kg", "heart-rate" => "bpm", _ => "steps" }
+            };
+        }
+        catch (Exception ex) when (ex is KeyNotFoundException or FormatException or InvalidOperationException or OverflowException or ArgumentException)
+        {
+            throw new GoogleHealthException("invalid_google_data", stage: "data_parse", dataType: type);
+        }
+    }
+}

--- a/src/API/Nocturne.API/Services/Health/GoogleHealth/GoogleHealthReadingWriter.cs
+++ b/src/API/Nocturne.API/Services/Health/GoogleHealth/GoogleHealthReadingWriter.cs
@@ -1,0 +1,143 @@
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.Sleep;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Health;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Infrastructure.Data;
+
+namespace Nocturne.API.Services.Health.GoogleHealth;
+
+public sealed class GoogleHealthReadingWriter(
+    IHeartRateService heartRates,
+    IStepCountService stepCounts,
+    IBodyWeightService bodyWeights,
+    ISleepService sleep,
+    NocturneDbContext? db = null) : IGoogleHealthReadingWriter
+{
+    public const string Source = "google-health";
+
+    public async Task WriteAsync(
+        IReadOnlyCollection<GoogleHealthReading> readings,
+        IReadOnlyCollection<SleepSession> sleepSessions,
+        IReadOnlyCollection<string> activeTypes,
+        DateTimeOffset from,
+        DateTimeOffset to,
+        CancellationToken ct)
+    {
+        var heartRateBatch = readings.Where(reading => reading.DataType == "heart-rate").Select(reading => new HeartRate
+        {
+            Mills = reading.Mills,
+            UtcOffset = reading.UtcOffsetMinutes,
+            Bpm = checked((int)reading.Value),
+            Accuracy = 0,
+            Device = "Google Health",
+            EnteredBy = "Google Health",
+            DataSource = Source,
+            SyncIdentifier = GoogleHealthClient.Key(reading)
+        }).ToArray();
+        if (heartRateBatch.Length > 0) await heartRates.CreateHeartRatesAsync(heartRateBatch, ct);
+
+        var stepBatch = readings.Where(reading => reading.DataType == "steps").Select(reading => new StepCount
+        {
+            Mills = reading.Mills,
+            UtcOffset = reading.UtcOffsetMinutes,
+            Metric = checked((int)reading.Value),
+            Source = 0,
+            Device = "Google Health",
+            EnteredBy = "Google Health",
+            DataSource = Source,
+            SyncIdentifier = GoogleHealthClient.Key(reading)
+        }).ToArray();
+        if (stepBatch.Length > 0) await stepCounts.CreateStepCountsAsync(stepBatch, ct);
+
+        var weightBatch = readings.Where(reading => reading.DataType == "weight").Select(reading => new BodyWeight
+        {
+            Mills = reading.Mills,
+            UtcOffset = reading.UtcOffsetMinutes,
+            WeightKg = reading.Value,
+            Device = "Google Health",
+            EnteredBy = "Google Health",
+            DataSource = Source,
+            SyncIdentifier = GoogleHealthClient.Key(reading)
+        }).ToArray();
+        if (weightBatch.Length > 0) await bodyWeights.CreateBodyWeightsAsync(weightBatch, ct);
+
+        foreach (var session in sleepSessions)
+            await sleep.UpsertSessionAsync(session, ct);
+
+        if (db is not null)
+            await ReconcileAsync(readings, sleepSessions, activeTypes, from, to, ct);
+    }
+
+    private async Task ReconcileAsync(
+        IReadOnlyCollection<GoogleHealthReading> readings,
+        IReadOnlyCollection<SleepSession> sleepSessions,
+        IReadOnlyCollection<string> activeTypes,
+        DateTimeOffset from,
+        DateTimeOffset to,
+        CancellationToken ct)
+    {
+        var first = from.UtcDateTime;
+        var last = to.UtcDateTime;
+        var firstMills = from.ToUnixTimeMilliseconds();
+        var lastMills = to.ToUnixTimeMilliseconds();
+        var deletedAt = DateTime.UtcNow;
+        var heartRateIds = Keys(readings, "heart-rate");
+        var stepIds = Keys(readings, "steps");
+        var weightIds = Keys(readings, "weight");
+        var sleepIds = sleepSessions.Select(session => session.OriginalId!).ToArray();
+
+        if (activeTypes.Contains("heart-rate")) await db!.HeartRates
+            .Where(record => record.DataSource == Source && record.Timestamp >= first && record.Timestamp < last &&
+                !heartRateIds.Contains(record.SyncIdentifier!))
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(record => record.DeletedAt, deletedAt)
+                .SetProperty(record => EF.Property<bool>(record, "DeletedByUser"), false), ct);
+        if (activeTypes.Contains("steps")) await db!.StepCounts
+            .Where(record => record.DataSource == Source && record.Timestamp >= first && record.Timestamp < last &&
+                !stepIds.Contains(record.SyncIdentifier!))
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(record => record.DeletedAt, deletedAt)
+                .SetProperty(record => EF.Property<bool>(record, "DeletedByUser"), false), ct);
+        if (activeTypes.Contains("weight")) await db!.BodyWeights
+            .Where(record => record.DataSource == Source && record.Mills >= firstMills && record.Mills < lastMills &&
+                !weightIds.Contains(record.SyncIdentifier!))
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(record => record.DeletedAt, deletedAt)
+                .SetProperty(record => EF.Property<bool>(record, "DeletedByUser"), false), ct);
+        if (activeTypes.Contains("sleep")) await db!.SleepSessions
+            .Where(session => session.Source == SleepSource.Google.ToString() &&
+                session.StartTime >= first && session.StartTime < last &&
+                (session.OriginalId == null || !sleepIds.Contains(session.OriginalId)))
+            .ExecuteDeleteAsync(ct);
+    }
+
+    private static string[] Keys(IEnumerable<GoogleHealthReading> readings, string dataType) =>
+        readings.Where(reading => reading.DataType == dataType).Select(GoogleHealthClient.Key).ToArray();
+
+    public async Task PurgeAsync(CancellationToken ct)
+    {
+        if (db is null) return;
+        var strategy = db.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await db.Database.BeginTransactionAsync(ct);
+            var deletedAt = DateTime.UtcNow;
+            await db.HeartRates.Where(record => record.DataSource == Source)
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(record => record.DeletedAt, deletedAt)
+                    .SetProperty(record => EF.Property<bool>(record, "DeletedByUser"), false), ct);
+            await db.StepCounts.Where(record => record.DataSource == Source)
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(record => record.DeletedAt, deletedAt)
+                    .SetProperty(record => EF.Property<bool>(record, "DeletedByUser"), false), ct);
+            await db.BodyWeights.Where(record => record.DataSource == Source)
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(record => record.DeletedAt, deletedAt)
+                    .SetProperty(record => EF.Property<bool>(record, "DeletedByUser"), false), ct);
+            await db.SleepSessions.Where(session => session.Source == SleepSource.Google.ToString())
+                .ExecuteDeleteAsync(ct);
+            await transaction.CommitAsync(ct);
+        });
+    }
+}

--- a/src/API/Nocturne.API/Services/Health/GoogleHealth/GoogleHealthService.cs
+++ b/src/API/Nocturne.API/Services/Health/GoogleHealth/GoogleHealthService.cs
@@ -1,0 +1,657 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using Nocturne.Core.Models.Health;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+
+namespace Nocturne.API.Services.Health.GoogleHealth;
+
+public sealed class GoogleHealthCoordinator
+{
+    internal sealed record Flow(string State, string Verifier, Guid SubjectId, string Settings, DateTimeOffset Expires);
+    internal sealed record SyncProgress(
+        string Phase,
+        string? DataType,
+        int CompletedDataTypes,
+        int TotalDataTypes,
+        int PagesRead);
+
+    private readonly Channel<Guid> syncRequests = Channel.CreateUnbounded<Guid>(new()
+    {
+        SingleReader = true,
+        SingleWriter = false
+    });
+    private readonly ConcurrentDictionary<Guid, SyncProgress> syncProgress = new();
+    internal ConcurrentDictionary<Guid, Flow> Flows { get; } = new();
+    internal ConcurrentDictionary<Guid, SemaphoreSlim> Locks { get; } = new();
+    public SemaphoreSlim Gate(Guid tenant) => Locks.GetOrAdd(tenant, _ => new SemaphoreSlim(1));
+
+    internal bool Queue(Guid tenant, int totalDataTypes)
+    {
+        if (!syncProgress.TryAdd(tenant, new("queued", null, 0, totalDataTypes, 0))) return false;
+        if (syncRequests.Writer.TryWrite(tenant)) return true;
+        syncProgress.TryRemove(tenant, out _);
+        return false;
+    }
+
+    internal IAsyncEnumerable<Guid> ReadRequestsAsync(CancellationToken ct) =>
+        syncRequests.Reader.ReadAllAsync(ct);
+
+    internal bool StartQueued(Guid tenant) => Update(tenant, current =>
+        current.Phase == "queued" ? current with { Phase = "preparing" } : null);
+
+    internal bool StartScheduled(Guid tenant) =>
+        syncProgress.TryAdd(tenant, new("preparing", null, 0, 0, 0));
+
+    internal void Report(Guid tenant, string phase, string? dataType = null,
+        int? completedDataTypes = null, int? totalDataTypes = null, int? pagesRead = null) =>
+        Update(tenant, current => current with
+        {
+            Phase = phase,
+            DataType = dataType,
+            CompletedDataTypes = completedDataTypes ?? current.CompletedDataTypes,
+            TotalDataTypes = totalDataTypes ?? current.TotalDataTypes,
+            PagesRead = pagesRead ?? current.PagesRead
+        });
+
+    internal SyncProgress? Progress(Guid tenant) =>
+        syncProgress.TryGetValue(tenant, out var progress) ? progress : null;
+
+    internal void Complete(Guid tenant) => syncProgress.TryRemove(tenant, out _);
+
+    private bool Update(Guid tenant, Func<SyncProgress, SyncProgress?> update)
+    {
+        while (syncProgress.TryGetValue(tenant, out var current))
+        {
+            var next = update(current);
+            if (next is null) return false;
+            if (syncProgress.TryUpdate(tenant, next, current)) return true;
+        }
+        return false;
+    }
+}
+
+public sealed class GoogleHealthService(NocturneDbContext db, IDataProtectionProvider protection,
+    GoogleHealthCoordinator coordinator, GoogleHealthClient google,
+    IGoogleHealthReadingWriter? writer = null,
+    ILogger<GoogleHealthService>? logger = null) : IGoogleHealthService
+{
+    private sealed record Token(
+        string RefreshToken,
+        string[] Scopes,
+        string? AccessToken = null,
+        DateTimeOffset? AccessTokenExpiresAt = null);
+    private static readonly TimeSpan AccessTokenSafety = TimeSpan.FromMinutes(1);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+    private IDataProtector Protector => protection.CreateProtector("Nocturne.GoogleHealth.v1", db.TenantId.ToString());
+    private string Protect<T>(T value) => Protector.Protect(JsonSerializer.Serialize(value, Json));
+    private T Unprotect<T>(string value) => JsonSerializer.Deserialize<T>(Protector.Unprotect(value), Json) ?? throw new JsonException();
+    private Task<GoogleHealthConnectionEntity?> Connection(CancellationToken ct) => db.GoogleHealthConnections.SingleOrDefaultAsync(ct);
+
+    private static string RequiredString(JsonElement response, string name, string stage)
+    {
+        if (!response.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(value.GetString()))
+            throw new GoogleHealthException("invalid_token_response", stage: stage);
+        return value.GetString()!;
+    }
+
+    private static int RequiredExpiresIn(JsonElement response, string stage)
+    {
+        if (!response.TryGetProperty("expires_in", out var value) || !value.TryGetInt32(out var seconds) || seconds <= 0)
+            throw new GoogleHealthException("invalid_token_response", stage: stage);
+        return seconds;
+    }
+
+    private static void ValidateTokenType(JsonElement response, string stage)
+    {
+        if (response.TryGetProperty("token_type", out var value) &&
+            (value.ValueKind != JsonValueKind.String ||
+             !string.Equals(value.GetString(), "Bearer", StringComparison.OrdinalIgnoreCase)))
+            throw new GoogleHealthException("invalid_token_response", stage: stage);
+    }
+
+    private static string[] ResponseScopes(JsonElement response, string[] fallback)
+    {
+        if (!response.TryGetProperty("scope", out var value) || value.ValueKind != JsonValueKind.String)
+            return fallback;
+        return (value.GetString() ?? "").Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static string EncodeError(string code, IEnumerable<string>? dataTypes = null)
+    {
+        var types = dataTypes?.Where(type => GoogleHealthClient.SupportedTypes.Contains(type, StringComparer.Ordinal))
+            .Distinct(StringComparer.Ordinal).ToArray() ?? [];
+        return types.Length == 0 ? code : $"{code}:{string.Join(',', types)}";
+    }
+
+    private static (string? Code, string[] DataTypes) DecodeError(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return (null, []);
+        var separator = value.IndexOf(':');
+        if (separator < 0) return (value, []);
+        return (value[..separator], value[(separator + 1)..].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(type => GoogleHealthClient.SupportedTypes.Contains(type, StringComparer.Ordinal))
+            .Distinct(StringComparer.Ordinal).ToArray());
+    }
+
+    private void LogFailure(GoogleHealthException error) => logger?.LogWarning(
+        "Google Health import failed for tenant {TenantId} with code {Code} at stage {Stage} for data type {DataType}; provider status {ProviderStatus}, provider reason {ProviderReason}",
+        db.TenantId, error.Message, error.Stage, error.DataType, error.ProviderStatus, error.ProviderReason);
+
+    private GoogleHealthStatus WithProgress(GoogleHealthStatus status)
+    {
+        var progress = coordinator.Progress(db.TenantId);
+        if (progress is null) return status;
+        status.IsSyncing = true;
+        status.SyncPhase = progress.Phase;
+        status.SyncDataType = progress.DataType;
+        status.SyncCompletedDataTypes = progress.CompletedDataTypes;
+        status.SyncTotalDataTypes = progress.TotalDataTypes;
+        status.SyncPagesRead = progress.PagesRead;
+        status.SyncProgressPercent = progress.Phase switch
+        {
+            "saving" or "integrating" => 95,
+            _ when progress.TotalDataTypes > 0 =>
+                Math.Min(90, progress.CompletedDataTypes * 90 / progress.TotalDataTypes),
+            _ => null
+        };
+        return status;
+    }
+
+    private async Task<Token> RefreshSessionAsync(GoogleHealthOptions settings, Token token, CancellationToken ct)
+    {
+        var response = await google.RefreshAccessTokenAsync(new()
+        {
+            ["grant_type"] = "refresh_token", ["refresh_token"] = token.RefreshToken,
+            ["client_id"] = settings.ClientId, ["client_secret"] = settings.ClientSecret!
+        }, ct);
+        ValidateTokenType(response, "token_refresh");
+        var access = RequiredString(response, "access_token", "token_refresh");
+        var expiresIn = RequiredExpiresIn(response, "token_refresh");
+        var scopes = ResponseScopes(response, token.Scopes);
+        var refresh = token.RefreshToken;
+        if (response.TryGetProperty("refresh_token", out var replacement))
+        {
+            if (replacement.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(replacement.GetString()))
+                throw new GoogleHealthException("invalid_token_response", stage: "token_refresh");
+            refresh = replacement.GetString()!;
+        }
+        return new Token(refresh, scopes, access, DateTimeOffset.UtcNow.AddSeconds(expiresIn));
+    }
+
+    public async Task<GoogleHealthStatus> StatusAsync(CancellationToken ct)
+    {
+        var row = await Connection(ct);
+        if (row is null) return WithProgress(new() { Capabilities = GoogleHealthClient.Capabilities });
+        GoogleHealthOptions settings;
+        try
+        {
+            settings = Unprotect<GoogleHealthOptions>(row.ProtectedSettings);
+            if (settings.DataTypes is null) throw new JsonException();
+        }
+        catch (Exception ex) when (ex is CryptographicException or JsonException or FormatException)
+        {
+            return WithProgress(new()
+            {
+                Capabilities = GoogleHealthClient.Capabilities, Connected = row.ProtectedToken is not null,
+                LastAttempt = row.LastAttempt, LastSync = row.LastSync, NextAttempt = row.NextAttempt,
+                ErrorCode = "stored_google_configuration_unreadable"
+            });
+        }
+        var selectedTypes = settings.DataTypes
+            .Where(type => GoogleHealthClient.SupportedTypes.Contains(type, StringComparer.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        var selectionIsValid = selectedTypes.Length == settings.DataTypes.Length;
+        Token? token;
+        try
+        {
+            token = row.ProtectedToken is null ? null : Unprotect<Token>(row.ProtectedToken);
+            if (token is not null && (string.IsNullOrWhiteSpace(token.RefreshToken) || token.Scopes is null)) throw new JsonException();
+        }
+        catch (Exception ex) when (ex is CryptographicException or JsonException or FormatException)
+        {
+            return WithProgress(new()
+            {
+                Capabilities = GoogleHealthClient.Capabilities, Configured = true, Connected = true,
+                ClientId = settings.ClientId, CallbackUrl = settings.CallbackUrl, HistoryDays = settings.HistoryDays, ImportFrom = settings.ImportFrom,
+                SelectedTypes = selectedTypes, LastAttempt = row.LastAttempt, LastSync = row.LastSync,
+                NextAttempt = row.NextAttempt,
+                ErrorCode = "stored_google_configuration_unreadable"
+            });
+        }
+        var storedError = DecodeError(row.ErrorCode);
+        return WithProgress(new()
+        {
+            Capabilities = GoogleHealthClient.Capabilities, Configured = true, Connected = token is not null, ClientId = settings.ClientId,
+            CallbackUrl = settings.CallbackUrl, HistoryDays = settings.HistoryDays, ImportFrom = settings.ImportFrom,
+            SelectedTypes = selectedTypes, GrantedTypes = GoogleHealthClient.SupportedTypes.Where(t => token?.Scopes.Contains(GoogleHealthClient.ScopeFor(t)) == true).ToArray(),
+            AccessTokenExpiresAt = token?.AccessTokenExpiresAt, LastAttempt = row.LastAttempt, LastSync = row.LastSync,
+            NextAttempt = row.NextAttempt, ErrorCode = selectionIsValid ? storedError.Code : "unsupported_type",
+            ErrorDataTypes = selectionIsValid ? storedError.DataTypes : [], PreviewRequired = settings.PreviewOnly
+        });
+    }
+
+    public static void ValidateOptions(GoogleHealthOptions options)
+    {
+        if (options.DataTypes is null || options.DataTypes.Length > 32 || options.DataTypes.Distinct().Count() != options.DataTypes.Length || options.DataTypes.Except(GoogleHealthClient.SupportedTypes).Any())
+            throw new GoogleHealthException("unsupported_type");
+        if (!options.ClientId.EndsWith(".apps.googleusercontent.com", StringComparison.Ordinal) || options.HistoryDays is < 1 or > 90 ||
+            options.ImportFrom is { } importFrom && (importFrom < new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero) || importFrom > DateTimeOffset.UtcNow.AddDays(1)))
+            throw new GoogleHealthException("invalid_configuration");
+        if (!Uri.TryCreate(options.CallbackUrl, UriKind.Absolute, out var callback) || callback.Scheme != "https" || callback.HostNameType != UriHostNameType.Dns || callback.UserInfo != "" || callback.Query != "" || callback.Fragment != "" || callback.AbsolutePath != "/settings/connectors/google-health/callback")
+            throw new GoogleHealthException("invalid_callback");
+    }
+
+    public async Task SaveAsync(GoogleHealthOptions options, Guid subject, CancellationToken ct)
+    {
+        ValidateOptions(options);
+        var gate = coordinator.Gate(db.TenantId); await gate.WaitAsync(ct);
+        try
+        {
+            var row = await Connection(ct);
+            if (row is null) { row = new() { Id = Guid.CreateVersion7(), SubjectId = subject }; db.GoogleHealthConnections.Add(row); }
+            else
+            {
+                if (row.SubjectId != subject) throw new GoogleHealthException("connection_owner_required");
+                GoogleHealthOptions? prior = null;
+                if (row.ProtectedToken is not null || string.IsNullOrWhiteSpace(options.ClientSecret))
+                    prior = Unprotect<GoogleHealthOptions>(row.ProtectedSettings);
+                if (row.ProtectedToken is not null && prior is not null &&
+                    (options.ClientId != prior.ClientId || options.CallbackUrl != prior.CallbackUrl))
+                    throw new GoogleHealthException("disconnect_first");
+                if (string.IsNullOrWhiteSpace(options.ClientSecret))
+                {
+                    if (options.ClientId == prior?.ClientId) options.ClientSecret = prior.ClientSecret;
+                }
+            }
+            if (string.IsNullOrWhiteSpace(options.ClientSecret)) throw new GoogleHealthException("client_secret_required");
+            row.ProtectedSettings = Protect(options); row.ErrorCode = null; row.NextAttempt = null;
+            coordinator.Flows.TryRemove(db.TenantId, out _);
+            await db.SaveChangesAsync(ct);
+        }
+        finally { gate.Release(); }
+    }
+
+    public async Task<GoogleHealthAuthorize> StartAsync(Guid subject, CancellationToken ct)
+    {
+        var gate = coordinator.Gate(db.TenantId); await gate.WaitAsync(ct);
+        try
+        {
+            var row = await Connection(ct) ?? throw new GoogleHealthException("configure_first");
+            if (row.SubjectId != subject) throw new GoogleHealthException("connection_owner_required");
+            if (row.ProtectedToken is not null) throw new GoogleHealthException("disconnect_first");
+            var settings = Unprotect<GoogleHealthOptions>(row.ProtectedSettings);
+            var verifier = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(48));
+            var state = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+            coordinator.Flows[db.TenantId] = new(state, verifier, subject, row.ProtectedSettings, DateTimeOffset.UtcNow.AddMinutes(10));
+            var parameters = new Dictionary<string, string?>
+            {
+                ["client_id"] = settings.ClientId, ["redirect_uri"] = settings.CallbackUrl,
+                ["response_type"] = "code", ["access_type"] = "offline", ["prompt"] = "consent select_account",
+                ["scope"] = "openid " + string.Join(' ', GoogleHealthClient.SupportedTypes.Select(GoogleHealthClient.ScopeFor).Distinct()),
+                ["state"] = state, ["code_challenge_method"] = "S256",
+                ["code_challenge"] = WebEncoders.Base64UrlEncode(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)))
+            };
+            return new() { Url = QueryHelpers.AddQueryString("https://accounts.google.com/o/oauth2/v2/auth", parameters) };
+        }
+        finally { gate.Release(); }
+    }
+
+    public async Task CompleteAsync(GoogleHealthCallback callback, Guid subject, CancellationToken ct)
+    {
+        var gate = coordinator.Gate(db.TenantId); await gate.WaitAsync(ct);
+        try
+        {
+            if (!coordinator.Flows.TryGetValue(db.TenantId, out var flow) || flow.Expires <= DateTimeOffset.UtcNow || flow.SubjectId != subject || !CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(flow.State), Encoding.UTF8.GetBytes(callback.State)))
+                throw new GoogleHealthException("expired_signin");
+            coordinator.Flows.TryRemove(db.TenantId, out _);
+            var row = await Connection(ct) ?? throw new GoogleHealthException("configure_first");
+            if (row.SubjectId != subject || row.ProtectedSettings != flow.Settings) throw new GoogleHealthException("expired_signin");
+            var settings = Unprotect<GoogleHealthOptions>(row.ProtectedSettings);
+            var response = await google.ExchangeAuthorizationCodeAsync(new()
+            {
+                ["grant_type"] = "authorization_code", ["code"] = callback.Code,
+                ["code_verifier"] = flow.Verifier, ["client_id"] = settings.ClientId,
+                ["client_secret"] = settings.ClientSecret!, ["redirect_uri"] = settings.CallbackUrl
+            }, ct);
+            ValidateTokenType(response, "authorization_code");
+            var access = RequiredString(response, "access_token", "authorization_code");
+            var expiresIn = RequiredExpiresIn(response, "authorization_code");
+            var requestedScopes = GoogleHealthClient.SupportedTypes.Select(GoogleHealthClient.ScopeFor).Append("openid")
+                .Distinct(StringComparer.Ordinal).ToArray();
+            var scopes = ResponseScopes(response, requestedScopes);
+            if (!response.TryGetProperty("refresh_token", out var refreshValue) ||
+                refreshValue.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(refreshValue.GetString()))
+                throw new GoogleHealthException("offline_access_required", stage: "authorization_code");
+            var refresh = refreshValue.GetString()!;
+            var account = await google.AccountKeyAsync(access, ct);
+            if (row.AccountKey is not null && row.AccountKey != account)
+            {
+                await google.RevokeAsync(refresh, ct);
+                throw new GoogleHealthException("account_mismatch");
+            }
+            var now = DateTimeOffset.UtcNow;
+            var missingScopes = GoogleHealthClient.SupportedTypes
+                .Where(type => !scopes.Contains(GoogleHealthClient.ScopeFor(type), StringComparer.Ordinal)).ToArray();
+            row.AccountKey = account;
+            row.ProtectedToken = Protect(new Token(refresh, scopes, access, now.AddSeconds(expiresIn)));
+            row.NextAttempt = null; row.LastAttempt = null;
+            row.ErrorCode = missingScopes.Length == 0 ? null : EncodeError("partial_consent", missingScopes);
+            await db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex) when (ex is GoogleHealthException or HttpRequestException or JsonException or TaskCanceledException)
+        {
+            if (ct.IsCancellationRequested) throw;
+            var error = ex as GoogleHealthException ?? new GoogleHealthException(
+                ex is JsonException ? "invalid_google_response" : "google_unavailable",
+                stage: ex is JsonException ? "token_response" : "network");
+            LogFailure(error);
+            db.ChangeTracker.Clear();
+            var row = await Connection(CancellationToken.None);
+            if (row is not null && row.ProtectedToken is null)
+            {
+                row.LastAttempt = DateTimeOffset.UtcNow;
+                row.NextAttempt = null;
+                row.ErrorCode = EncodeError(error.Message, error.DataType is null ? null : [error.DataType]);
+                await db.SaveChangesAsync(CancellationToken.None);
+            }
+            throw error;
+        }
+        finally { gate.Release(); }
+    }
+
+    public async Task DisconnectAsync(Guid subject, CancellationToken ct)
+    {
+        var gate = coordinator.Gate(db.TenantId); await gate.WaitAsync(ct);
+        try
+        {
+            var row = await Connection(ct);
+            if (row is null) return;
+            if (row.SubjectId != subject) throw new GoogleHealthException("connection_owner_required");
+            Token? token = null;
+            var revokeFailed = false;
+            if (row.ProtectedToken is not null)
+                try { token = Unprotect<Token>(row.ProtectedToken); }
+                catch (Exception ex) when (ex is CryptographicException or JsonException or FormatException) { revokeFailed = true; }
+            row.ProtectedToken = null; row.ErrorCode = revokeFailed ? "revoke_in_google" : null; row.NextAttempt = null;
+            coordinator.Flows.TryRemove(db.TenantId, out _);
+            await db.SaveChangesAsync(ct);
+            if (token is not null)
+            {
+                try { if (!await google.RevokeAsync(token.RefreshToken, ct)) row.ErrorCode = "revoke_in_google"; }
+                catch (HttpRequestException) { row.ErrorCode = "revoke_in_google"; }
+                catch (TaskCanceledException) { row.ErrorCode = "revoke_in_google"; }
+                await db.SaveChangesAsync(CancellationToken.None);
+            }
+        }
+        finally { gate.Release(); }
+    }
+
+    public async Task PurgeAsync(Guid subject, CancellationToken ct)
+    {
+        var gate = coordinator.Gate(db.TenantId); await gate.WaitAsync(ct);
+        try
+        {
+            var row = await Connection(ct);
+            if (row is null) return;
+            if (row.SubjectId != subject) throw new GoogleHealthException("connection_owner_required");
+            if (row.ProtectedToken is not null) throw new GoogleHealthException("disconnect_first");
+            if (writer is not null) await writer.PurgeAsync(ct);
+            var strategy = db.Database.CreateExecutionStrategy();
+            await strategy.ExecuteAsync(async () =>
+            {
+                await using var transaction = await db.Database.BeginTransactionAsync(ct);
+                await db.GoogleHealthReadings.ExecuteDeleteAsync(ct);
+                row.AccountKey = null; row.LastSync = null;
+                await db.SaveChangesAsync(ct); await transaction.CommitAsync(ct);
+            });
+        }
+        finally { gate.Release(); }
+    }
+
+    public async Task<GoogleHealthPreview> PreviewAsync(Guid subject, CancellationToken ct)
+    {
+        var gate = coordinator.Gate(db.TenantId); await gate.WaitAsync(ct);
+        try
+        {
+            var row = await Connection(ct) ?? throw new GoogleHealthException("configure_first");
+            if (row.SubjectId != subject) throw new GoogleHealthException("connection_owner_required");
+            if (row.ProtectedToken is null) throw new GoogleHealthException("configure_first");
+            var settings = Unprotect<GoogleHealthOptions>(row.ProtectedSettings);
+            var token = Unprotect<Token>(row.ProtectedToken);
+            var now = DateTimeOffset.UtcNow;
+            if (string.IsNullOrWhiteSpace(token.AccessToken) || token.AccessTokenExpiresAt is null ||
+                token.AccessTokenExpiresAt <= now.Add(AccessTokenSafety))
+            {
+                token = await RefreshSessionAsync(settings, token, ct);
+                row.ProtectedToken = Protect(token);
+                await db.SaveChangesAsync(ct);
+            }
+            var from = settings.ImportFrom ?? now.AddDays(-settings.HistoryDays);
+            var items = new List<GoogleHealthPreviewItem>();
+            foreach (var capability in GoogleHealthClient.Capabilities)
+            {
+                var type = capability.DataType;
+                var granted = token.Scopes.Contains(GoogleHealthClient.ScopeFor(type), StringComparer.Ordinal);
+                if (!granted)
+                {
+                    items.Add(new() { DataType = type, Granted = false, Supported = capability.Supported });
+                    continue;
+                }
+                try
+                {
+                    var count = await google.CountAsync(token.AccessToken!, type, from, now, ct);
+                    items.Add(new() { DataType = type, Granted = true, Count = count, Supported = capability.Supported });
+                }
+                catch (GoogleHealthException ex)
+                {
+                    items.Add(new() { DataType = type, Granted = true, ErrorCode = ex.Message, Supported = capability.Supported });
+                }
+            }
+            return new() { Items = items.ToArray() };
+        }
+        catch (Exception ex) when (ex is CryptographicException or JsonException or FormatException)
+        {
+            throw new GoogleHealthException("stored_google_configuration_unreadable", stage: "preview");
+        }
+        finally { gate.Release(); }
+    }
+
+    public async Task QueueSyncAsync(CancellationToken ct)
+    {
+        var row = await Connection(ct) ?? throw new GoogleHealthException("configure_first");
+        if (row.ProtectedToken is null) throw new GoogleHealthException("configure_first");
+        GoogleHealthOptions settings;
+        try
+        {
+            settings = Unprotect<GoogleHealthOptions>(row.ProtectedSettings);
+            if (settings.DataTypes is null) throw new JsonException();
+        }
+        catch (Exception ex) when (ex is CryptographicException or JsonException or FormatException)
+        {
+            throw new GoogleHealthException("stored_google_configuration_unreadable", stage: "sync_queue");
+        }
+        if (settings.PreviewOnly) throw new GoogleHealthException("preview_required");
+        if (settings.DataTypes.Length == 0) throw new GoogleHealthException("no_types_selected");
+        coordinator.Queue(db.TenantId, settings.DataTypes.Length);
+    }
+
+    public async Task SyncAsync(bool force, CancellationToken ct)
+    {
+        var gate = coordinator.Gate(db.TenantId);
+        if (force) await gate.WaitAsync(ct);
+        else if (!await gate.WaitAsync(0, ct)) return;
+        var stage = "connection_read";
+        try
+        {
+            var row = await Connection(ct);
+            if (row?.ProtectedToken is null || row.NextAttempt > DateTimeOffset.UtcNow || (!force && row.LastAttempt > DateTimeOffset.UtcNow.AddMinutes(-15))) return;
+            row.LastAttempt = DateTimeOffset.UtcNow;
+            await db.SaveChangesAsync(ct);
+            try
+            {
+                stage = "session_read";
+                GoogleHealthOptions settings;
+                Token token;
+                try
+                {
+                    settings = Unprotect<GoogleHealthOptions>(row.ProtectedSettings);
+                    token = Unprotect<Token>(row.ProtectedToken);
+                    if (settings.DataTypes is null || string.IsNullOrWhiteSpace(token.RefreshToken) || token.Scopes is null)
+                        throw new JsonException();
+                }
+                catch (Exception ex) when (ex is CryptographicException or JsonException or FormatException)
+                {
+                    throw new GoogleHealthException("stored_google_configuration_unreadable", stage: stage);
+                }
+                if (settings.PreviewOnly || settings.DataTypes.Length == 0) return;
+                var now = DateTimeOffset.UtcNow;
+                var access = token.AccessToken ?? "";
+                if (string.IsNullOrWhiteSpace(access) || token.AccessTokenExpiresAt is null ||
+                    token.AccessTokenExpiresAt <= now.Add(AccessTokenSafety))
+                {
+                    stage = "token_refresh";
+                    coordinator.Report(db.TenantId, "refreshing_session");
+                    token = await RefreshSessionAsync(settings, token, ct);
+                    access = token.AccessToken!;
+                    row.ProtectedToken = Protect(token);
+                    await db.SaveChangesAsync(ct);
+                }
+                stage = "scope_validation";
+                var active = settings.DataTypes.Where(t => token.Scopes.Contains(GoogleHealthClient.ScopeFor(t))).ToArray();
+                if (active.Length == 0) throw new GoogleHealthException("permission_denied", stage: "scope_validation");
+                coordinator.Report(db.TenantId, "reading", totalDataTypes: active.Length);
+                var to = DateTimeOffset.UtcNow; var from = settings.ImportFrom ?? to.AddDays(-settings.HistoryDays);
+                async Task<(List<GoogleHealthReading> Readings, List<Nocturne.Core.Models.SleepSession> SleepSessions)> ReadAllAsync()
+                {
+                    var result = new List<GoogleHealthReading>();
+                    var sleepSessions = new List<Nocturne.Core.Models.SleepSession>();
+                    for (var index = 0; index < active.Length; index++)
+                    {
+                        var type = active[index];
+                        coordinator.Report(db.TenantId, "reading", type, index, active.Length, 0);
+                        void PageRead(int pages) => coordinator.Report(db.TenantId, "reading", type, index, active.Length, pages);
+                        if (type == "sleep") sleepSessions.AddRange(await google.ReadSleepAsync(access, from, to, ct, PageRead));
+                        else result.AddRange(await google.ReadAsync(access, type, from, to, ct, PageRead));
+                        coordinator.Report(db.TenantId, "reading", type, index + 1, active.Length);
+                    }
+                    return (result, sleepSessions);
+                }
+                List<GoogleHealthReading> readings;
+                List<Nocturne.Core.Models.SleepSession> sleepSessions;
+                try
+                {
+                    stage = "google_read";
+                    (readings, sleepSessions) = await ReadAllAsync();
+                }
+                catch (GoogleHealthException first) when (first.Message == "access_token_rejected")
+                {
+                    logger?.LogInformation(
+                        "Google Health access token was rejected early for tenant {TenantId}, data type {DataType}; refreshing the session once",
+                        db.TenantId, first.DataType);
+                    stage = "token_refresh";
+                    coordinator.Report(db.TenantId, "refreshing_session");
+                    token = await RefreshSessionAsync(settings, token, ct);
+                    access = token.AccessToken!;
+                    row.ProtectedToken = Protect(token);
+                    await db.SaveChangesAsync(ct);
+                    try
+                    {
+                        stage = "google_read";
+                        (readings, sleepSessions) = await ReadAllAsync();
+                    }
+                    catch (GoogleHealthException second) when (second.Message == "access_token_rejected")
+                    {
+                        throw new GoogleHealthException("reconnect_required", stage: second.Stage,
+                            dataType: second.DataType, providerReason: second.ProviderReason,
+                            providerStatus: second.ProviderStatus);
+                    }
+                }
+                stage = "data_validation";
+                coordinator.Report(db.TenantId, "validating");
+                if (readings.Select(GoogleHealthClient.Key).Distinct().Count() != readings.Count)
+                    throw new GoogleHealthException("duplicate_google_data", stage: "data_validation");
+                if (sleepSessions.Select(session => session.OriginalId).Distinct(StringComparer.Ordinal).Count() != sleepSessions.Count)
+                    throw new GoogleHealthException("duplicate_google_data", stage: "data_validation", dataType: "sleep");
+                // Replace only the completely fetched window, so retries, edits and source deletions cannot double-count steps.
+                var firstMills = from.ToUnixTimeMilliseconds(); var lastMills = to.ToUnixTimeMilliseconds();
+                var replacements = readings.Select(r => new GoogleHealthReadingEntity
+                {
+                    Id = Guid.CreateVersion7(), DataType = r.DataType, SourceKey = GoogleHealthClient.Key(r), Mills = r.Mills,
+                    EndMills = r.EndMills, UtcOffsetMinutes = r.UtcOffsetMinutes, Value = r.Value, Unit = r.Unit
+                }).ToArray();
+                var missingConsent = settings.DataTypes.Except(active, StringComparer.Ordinal).ToArray();
+                var strategy = db.Database.CreateExecutionStrategy();
+                stage = "database_write";
+                coordinator.Report(db.TenantId, "saving");
+                await strategy.ExecuteAsync(async () =>
+                {
+                    foreach (var replacement in replacements)
+                    {
+                        var entry = db.Entry(replacement);
+                        if (entry.State != EntityState.Detached) entry.State = EntityState.Detached;
+                    }
+                    await using var transaction = await db.Database.BeginTransactionAsync(ct);
+                    await db.GoogleHealthReadings.Where(x => active.Contains(x.DataType) && x.Mills >= firstMills && x.Mills < lastMills).ExecuteDeleteAsync(ct);
+                    db.GoogleHealthReadings.AddRange(replacements);
+                    row.LastSync = to; row.NextAttempt = null;
+                    row.ErrorCode = missingConsent.Length > 0
+                        ? EncodeError("partial_consent", missingConsent)
+                        : null;
+                    await db.SaveChangesAsync(ct); await transaction.CommitAsync(ct);
+                });
+                stage = "native_write";
+                coordinator.Report(db.TenantId, "integrating");
+                if (writer is not null) await writer.WriteAsync(readings, sleepSessions, active, from, to, ct);
+                stage = "complete";
+            }
+            catch (Exception ex) when (ex is GoogleHealthException or HttpRequestException or JsonException or TaskCanceledException)
+            {
+                if (ct.IsCancellationRequested) throw;
+                var error = ex as GoogleHealthException ?? new GoogleHealthException(
+                    ex is JsonException ? "invalid_google_response" : "google_unavailable",
+                    stage: ex is JsonException ? "response_parse" : "network");
+                LogFailure(error);
+                db.ChangeTracker.Clear();
+                row = await Connection(ct);
+                if (row is not null)
+                {
+                    row.ErrorCode = EncodeError(error.Message, error.DataType is null ? null : [error.DataType]);
+                    row.NextAttempt = null;
+                    if (error.RetryAfter is { } delay && delay > TimeSpan.Zero)
+                        row.NextAttempt = DateTimeOffset.UtcNow.Add(delay > TimeSpan.FromDays(7) ? TimeSpan.FromDays(7) : delay);
+                    if (error.Message == "reconnect_required") row.ProtectedToken = null;
+                    await db.SaveChangesAsync(ct);
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
+            catch (Exception ex)
+            {
+                var diagnosticId = Guid.NewGuid().ToString("N")[..12];
+                var errorCode = $"internal_sync_{stage}";
+                logger?.LogError(ex,
+                    "Unexpected Google Health import failure for tenant {TenantId}; diagnostic {DiagnosticId}, stage {Stage}, error code {Code}",
+                    db.TenantId, diagnosticId, stage, errorCode);
+                db.ChangeTracker.Clear();
+                row = await Connection(CancellationToken.None);
+                if (row is not null)
+                {
+                    row.ErrorCode = errorCode;
+                    row.NextAttempt = null;
+                    await db.SaveChangesAsync(CancellationToken.None);
+                }
+            }
+        }
+        finally { gate.Release(); }
+    }
+}

--- a/src/API/Nocturne.API/Services/Health/GoogleHealth/GoogleHealthWorker.cs
+++ b/src/API/Nocturne.API/Services/Health/GoogleHealth/GoogleHealthWorker.cs
@@ -1,0 +1,75 @@
+using Nocturne.Core.Contracts.Multitenancy;
+using Nocturne.Core.Contracts.Health;
+
+namespace Nocturne.API.Services.Health.GoogleHealth;
+
+public sealed class GoogleHealthWorker(
+    IServiceScopeFactory scopes,
+    GoogleHealthCoordinator coordinator,
+    ILogger<GoogleHealthWorker> logger) : BackgroundService
+{
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) =>
+        Task.WhenAll(ProcessRequestsAsync(stoppingToken), ProcessScheduleAsync(stoppingToken));
+
+    private async Task ProcessRequestsAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await foreach (var tenantId in coordinator.ReadRequestsAsync(stoppingToken))
+            {
+                if (!coordinator.StartQueued(tenantId)) continue;
+                try
+                {
+                    using var listing = scopes.CreateScope();
+                    var tenant = await listing.ServiceProvider.GetRequiredService<ITenantService>()
+                        .GetByIdAsync(tenantId, stoppingToken);
+                    if (tenant is not { IsActive: true }) continue;
+                    await SyncTenantAsync(tenant.Id, tenant.Slug, tenant.DisplayName, true, stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { return; }
+                catch (Exception) { logger.LogWarning("Queued Google Health sync failed; details are not logged to protect health data and credentials"); }
+                finally { coordinator.Complete(tenantId); }
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { }
+    }
+
+    private async Task ProcessScheduleAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMinutes(1));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                try
+                {
+                    using var listing = scopes.CreateScope();
+                    var tenants = await listing.ServiceProvider.GetRequiredService<ITenantService>().GetAllAsync(stoppingToken);
+                    foreach (var tenant in tenants.Where(t => t.IsActive))
+                    {
+                        if (!coordinator.StartScheduled(tenant.Id)) continue;
+                        try
+                        {
+                            await SyncTenantAsync(tenant.Id, tenant.Slug, tenant.DisplayName, false, stoppingToken);
+                        }
+                        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { return; }
+                        catch (Exception) { logger.LogWarning("Google Health sync failed; details are not logged to protect health data and credentials"); }
+                        finally { coordinator.Complete(tenant.Id); }
+                    }
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { return; }
+                catch (Exception) { logger.LogWarning("Google Health scheduler could not enumerate tenants"); }
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { }
+    }
+
+    private async Task SyncTenantAsync(Guid id, string slug, string displayName, bool force, CancellationToken ct)
+    {
+        using var scope = scopes.CreateScope();
+        scope.ServiceProvider.GetRequiredService<ITenantAccessor>()
+            .SetTenant(new(id, slug, displayName, true, false));
+        await scope.ServiceProvider.GetRequiredService<IGoogleHealthService>()
+            .SyncAsync(force, ct);
+    }
+}

--- a/src/Core/Nocturne.Core.Contracts/Health/IGoogleHealthService.cs
+++ b/src/Core/Nocturne.Core.Contracts/Health/IGoogleHealthService.cs
@@ -1,0 +1,29 @@
+using Nocturne.Core.Models.Health;
+using Nocturne.Core.Models;
+
+namespace Nocturne.Core.Contracts.Health;
+
+public interface IGoogleHealthService
+{
+    Task<GoogleHealthStatus> StatusAsync(CancellationToken ct);
+    Task SaveAsync(GoogleHealthOptions options, Guid subject, CancellationToken ct);
+    Task<GoogleHealthAuthorize> StartAsync(Guid subject, CancellationToken ct);
+    Task CompleteAsync(GoogleHealthCallback callback, Guid subject, CancellationToken ct);
+    Task DisconnectAsync(Guid subject, CancellationToken ct);
+    Task PurgeAsync(Guid subject, CancellationToken ct);
+    Task<GoogleHealthPreview> PreviewAsync(Guid subject, CancellationToken ct);
+    Task QueueSyncAsync(CancellationToken ct);
+    Task SyncAsync(bool force, CancellationToken ct);
+}
+
+public interface IGoogleHealthReadingWriter
+{
+    Task WriteAsync(
+        IReadOnlyCollection<GoogleHealthReading> readings,
+        IReadOnlyCollection<SleepSession> sleepSessions,
+        IReadOnlyCollection<string> activeTypes,
+        DateTimeOffset from,
+        DateTimeOffset to,
+        CancellationToken ct);
+    Task PurgeAsync(CancellationToken ct);
+}

--- a/src/Core/Nocturne.Core.Models/Health/GoogleHealthModels.cs
+++ b/src/Core/Nocturne.Core.Models/Health/GoogleHealthModels.cs
@@ -1,0 +1,79 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Nocturne.Core.Models.Health;
+
+public class GoogleHealthOptions
+{
+    [Required, MaxLength(200)] public string ClientId { get; set; } = "";
+    [MaxLength(500)] public string? ClientSecret { get; set; }
+    [Required, MaxLength(500)] public string CallbackUrl { get; set; } = "";
+    [MaxLength(32)] public string[] DataTypes { get; set; } = [];
+    [Range(1, 90)] public int HistoryDays { get; set; } = 7;
+    public DateTimeOffset? ImportFrom { get; set; }
+    public bool PreviewOnly { get; set; }
+}
+
+public class GoogleHealthStatus
+{
+    public GoogleHealthCapability[] Capabilities { get; set; } = [];
+    public bool Configured { get; set; }
+    public bool Connected { get; set; }
+    public string ClientId { get; set; } = "";
+    public string CallbackUrl { get; set; } = "";
+    public string[] SelectedTypes { get; set; } = [];
+    public string[] GrantedTypes { get; set; } = [];
+    public int HistoryDays { get; set; } = 7;
+    public DateTimeOffset? ImportFrom { get; set; }
+    public DateTimeOffset? AccessTokenExpiresAt { get; set; }
+    public DateTimeOffset? LastAttempt { get; set; }
+    public DateTimeOffset? LastSync { get; set; }
+    public DateTimeOffset? NextAttempt { get; set; }
+    public string? ErrorCode { get; set; }
+    public string[] ErrorDataTypes { get; set; } = [];
+    public bool PreviewRequired { get; set; }
+    public bool IsSyncing { get; set; }
+    public string? SyncPhase { get; set; }
+    public string? SyncDataType { get; set; }
+    public int SyncCompletedDataTypes { get; set; }
+    public int SyncTotalDataTypes { get; set; }
+    public int SyncPagesRead { get; set; }
+    public int? SyncProgressPercent { get; set; }
+}
+
+public class GoogleHealthPreview
+{
+    public GoogleHealthPreviewItem[] Items { get; set; } = [];
+}
+
+public class GoogleHealthPreviewItem
+{
+    public string DataType { get; set; } = "";
+    public bool Granted { get; set; }
+    public int Count { get; set; }
+    public string? ErrorCode { get; set; }
+    public bool Supported { get; set; }
+}
+
+public class GoogleHealthCapability
+{
+    public string DataType { get; set; } = "";
+    public bool Supported { get; set; }
+    public string? Destination { get; set; }
+}
+
+public class GoogleHealthAuthorize { public string Url { get; set; } = ""; }
+public class GoogleHealthCallback
+{
+    [Required, MaxLength(256)] public string State { get; set; } = "";
+    [Required, MaxLength(4096)] public string Code { get; set; } = "";
+}
+
+public class GoogleHealthReading
+{
+    public string DataType { get; set; } = "";
+    public long Mills { get; set; }
+    public long? EndMills { get; set; }
+    public int? UtcOffsetMinutes { get; set; }
+    public decimal Value { get; set; }
+    public string Unit { get; set; } = "";
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/GoogleHealthEntities.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/GoogleHealthEntities.cs
@@ -1,0 +1,80 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace Nocturne.Infrastructure.Data.Entities;
+
+[Table("google_health_connections")]
+[Index(nameof(TenantId), IsUnique = true)]
+public class GoogleHealthConnectionEntity : ITenantScoped
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    [Column("subject_id")]
+    public Guid SubjectId { get; set; }
+
+    [Column("protected_settings")]
+    public string ProtectedSettings { get; set; } = "";
+
+    [Column("protected_token")]
+    public string? ProtectedToken { get; set; }
+
+    [Column("account_key")]
+    [MaxLength(64)]
+    public string? AccountKey { get; set; }
+
+    [Column("last_sync")]
+    public DateTimeOffset? LastSync { get; set; }
+
+    [Column("last_attempt")]
+    public DateTimeOffset? LastAttempt { get; set; }
+
+    [Column("next_attempt")]
+    public DateTimeOffset? NextAttempt { get; set; }
+
+    [Column("error_code")]
+    [MaxLength(80)]
+    public string? ErrorCode { get; set; }
+}
+
+[Table("google_health_readings")]
+[Index(nameof(TenantId), nameof(DataType), nameof(Mills))]
+[Index(nameof(TenantId), nameof(DataType), nameof(SourceKey), IsUnique = true)]
+public class GoogleHealthReadingEntity : ITenantScoped
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Column("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    [Column("data_type")]
+    [MaxLength(32)]
+    public string DataType { get; set; } = "";
+
+    [Column("source_key")]
+    [MaxLength(64)]
+    public string SourceKey { get; set; } = "";
+
+    [Column("mills")]
+    public long Mills { get; set; }
+
+    [Column("end_mills")]
+    public long? EndMills { get; set; }
+
+    [Column("utc_offset_minutes")]
+    public int? UtcOffsetMinutes { get; set; }
+
+    [Column("value")]
+    public decimal Value { get; set; }
+
+    [Column("unit")]
+    [MaxLength(16)]
+    public string Unit { get; set; } = "";
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Entities/IV4TimeSeriesEntity.cs
@@ -10,4 +10,6 @@ namespace Nocturne.Infrastructure.Data.Entities;
 /// the shared base.
 /// </summary>
 /// <remarks><inheritdoc cref="IOriginalIdentified" path="/remarks"/></remarks>
-public interface IV4TimeSeriesEntity : IV4Entity, ISourcedEntity, IObservationTimestamped;
+public interface IV4TimeSeriesEntity : IV4Entity, ISourcedEntity, IObservationTimestamped
+{
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260902165425_AddGoogleHealth.Designer.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260902165425_AddGoogleHealth.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nocturne.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nocturne.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(NocturneDbContext))]
-    partial class NocturneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260902165425_AddGoogleHealth")]
+    partial class AddGoogleHealth
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260902165425_AddGoogleHealth.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Migrations/20260902165425_AddGoogleHealth.cs
@@ -1,0 +1,107 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nocturne.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGoogleHealth : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "google_health_connections",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tenant_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    subject_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    protected_settings = table.Column<string>(type: "text", nullable: false),
+                    protected_token = table.Column<string>(type: "text", nullable: true),
+                    account_key = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    last_sync = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    last_attempt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    next_attempt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    error_code = table.Column<string>(type: "character varying(80)", maxLength: 80, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_google_health_connections", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_google_health_connections_tenants_tenant_id",
+                        column: x => x.tenant_id,
+                        principalTable: "tenants",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "google_health_readings",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tenant_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    data_type = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    source_key = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    mills = table.Column<long>(type: "bigint", nullable: false),
+                    end_mills = table.Column<long>(type: "bigint", nullable: true),
+                    utc_offset_minutes = table.Column<int>(type: "integer", nullable: true),
+                    value = table.Column<decimal>(type: "numeric", nullable: false),
+                    unit = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_google_health_readings", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_google_health_readings_tenants_tenant_id",
+                        column: x => x.tenant_id,
+                        principalTable: "tenants",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_google_health_connections_tenant_id",
+                table: "google_health_connections",
+                column: "tenant_id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_google_health_readings_tenant_id_data_type_mills",
+                table: "google_health_readings",
+                columns: new[] { "tenant_id", "data_type", "mills" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_google_health_readings_tenant_id_data_type_source_key",
+                table: "google_health_readings",
+                columns: new[] { "tenant_id", "data_type", "source_key" },
+                unique: true);
+
+            foreach (var table in new[] { "google_health_connections", "google_health_readings" })
+            {
+                migrationBuilder.Sql($"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;");
+                migrationBuilder.Sql($"ALTER TABLE {table} FORCE ROW LEVEL SECURITY;");
+                migrationBuilder.Sql($"""
+                    CREATE POLICY tenant_isolation ON {table}
+                    USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid
+                        AND COALESCE(current_setting('app.is_share', true), '') <> 'true')
+                    WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid
+                        AND COALESCE(current_setting('app.is_share', true), '') <> 'true');
+                    """);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "google_health_connections");
+
+            migrationBuilder.DropTable(
+                name: "google_health_readings");
+
+        }
+    }
+}

--- a/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/NocturneDbContext.cs
@@ -124,6 +124,9 @@ public class NocturneDbContext : DbContext, IDataProtectionKeyContext
 
     public DbSet<BodyWeightEntity> BodyWeights { get; set; }
 
+    public DbSet<GoogleHealthConnectionEntity> GoogleHealthConnections { get; set; }
+    public DbSet<GoogleHealthReadingEntity> GoogleHealthReadings { get; set; }
+
     public DbSet<DiscrepancyAnalysisEntity> DiscrepancyAnalyses { get; set; }
 
     public DbSet<DiscrepancyDetailEntity> DiscrepancyDetails { get; set; }

--- a/src/Web/packages/app/src/lib/components/connectors/GoogleHealthSourceRow.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/GoogleHealthSourceRow.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { resolve } from "$app/paths";
+  import type { GoogleHealthStatus } from "$lib/api/generated/nocturne-api-client";
+  import DataSourceRow, { type DataSourceStatus } from "$lib/components/settings/DataSourceRow.svelte";
+  import { lastSeen } from "$lib/utils/formatting";
+  import { HeartPulse } from "lucide-svelte";
+
+  let { connection }: { connection: GoogleHealthStatus } = $props();
+  const status = $derived<DataSourceStatus>(
+    !connection.connected ? "offline"
+      : connection.errorCode ? "error"
+      : connection.previewRequired || !connection.selectedTypes?.length ? "configured"
+      : "active"
+  );
+</script>
+
+<DataSourceRow
+  name="Google Health"
+  icon={undefined}
+  {status}
+  statusMessage={connection.errorCode ? "Google Health needs attention. Open the connector for details and recovery options." : undefined}
+  lastSyncAttempt={connection.lastAttempt}
+  lastSuccessfulSync={connection.lastSync}
+  onclick={() => void goto(resolve("/settings/connectors/google-health"))}
+>
+  {#snippet logo()}<HeartPulse class="h-5 w-5" />{/snippet}
+  {#snippet metrics()}
+    <p class="text-sm text-muted-foreground">
+      {#if !connection.connected}
+        Reconnect to resume importing
+      {:else if connection.previewRequired}
+        Review available data and confirm the import selection
+      {:else if !connection.selectedTypes?.length}
+        Choose at least one data type to start importing
+      {:else if connection.lastSync}
+        Last successful sync: {lastSeen(connection.lastSync)}
+      {:else}
+        Waiting for the first successful sync
+      {/if}
+    </p>
+  {/snippet}
+</DataSourceRow>

--- a/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
+++ b/src/Web/packages/app/src/lib/components/connectors/ServerConnectorsCard.svelte
@@ -11,6 +11,7 @@
     AvailableConnector,
     ConnectorCapabilities,
     DataSourceInfo,
+    GoogleHealthStatus,
   } from "$lib/api/generated/nocturne-api-client";
   import {
     Card,
@@ -29,11 +30,14 @@
     Database,
     ExternalLink,
     ChevronRight,
+    HeartPulse,
   } from "lucide-svelte";
   import DataSourceRow from "$lib/components/settings/DataSourceRow.svelte";
+  import GoogleHealthSourceRow from "./GoogleHealthSourceRow.svelte";
   import AppLogo from "$lib/components/ui/AppLogo.svelte";
   import { mapConnectorStatus } from "$lib/utils/connector-display";
   import type { SyncProgressEvent } from "$lib/websocket/types";
+  import { resolve } from "$app/paths";
 
   interface Props {
     availableConnectors: AvailableConnector[];
@@ -48,6 +52,7 @@
     onManualSync: () => void;
     onQuickSync: (connectorId: string) => void;
     onConnectorClick: (connector: ConnectorStatusWithDescription, connectorId?: string) => void;
+    googleHealth: GoogleHealthStatus | null;
   }
 
   let {
@@ -63,6 +68,7 @@
     onManualSync,
     onQuickSync,
     onConnectorClick,
+    googleHealth,
   }: Props = $props();
 
   function getConnectorDataSource(connector: AvailableConnector): DataSourceInfo | null {
@@ -102,7 +108,7 @@
         </CardDescription>
       </div>
       <div class="flex gap-2">
-        {#if connectorStatuses.length > 0}
+        {#if connectorStatuses.length > 0 || googleHealth?.configured || googleHealth?.connected}
           <Button
             variant="outline"
             size="sm"
@@ -138,6 +144,30 @@
   </CardHeader>
   <CardContent>
     <div class="grid gap-3 @xl:grid-cols-2">
+      {#if googleHealth?.connected || googleHealth?.configured}
+        <GoogleHealthSourceRow connection={googleHealth} />
+      {:else}
+      <a
+        href={resolve("/settings/connectors/google-health")}
+        class="group relative flex items-center gap-4 rounded-lg border bg-muted/30 p-4 transition-colors hover:border-primary/50 hover:bg-accent/50"
+      >
+        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+          <HeartPulse class="h-5 w-5 text-primary" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="font-medium">Google Health</span>
+            <Badge variant={googleHealth?.connected ? "default" : "outline"} class="text-xs">
+              {googleHealth?.connected ? "Connected" : googleHealth?.configured ? "Configured" : "Not Configured"}
+            </Badge>
+          </div>
+          <p class="text-sm text-muted-foreground">
+            Import steps, heart rate, weight, and sleep from Google Health
+          </p>
+        </div>
+        <ChevronRight class="h-4 w-4 text-muted-foreground group-hover:text-foreground" />
+      </a>
+      {/if}
       {#each availableConnectors as connector}
         {@const connectorStatusInfo = connectorStatuses.find(
           (cs) => cs.id === connector.id

--- a/src/Web/packages/app/src/lib/components/connectors/google-health-source.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/connectors/google-health-source.svelte.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import type { GoogleHealthStatus } from "$lib/api";
+import { goto } from "$lib/test-stubs/year-overview-runtime.svelte";
+import GoogleHealthSourceRow from "./GoogleHealthSourceRow.svelte";
+import ServerConnectorsCard from "./ServerConnectorsCard.svelte";
+
+const connected: GoogleHealthStatus = {
+  configured: true, connected: true, selectedTypes: ["steps", "sleep"],
+  previewRequired: false, lastSync: new Date("2026-09-06T09:00:00Z"),
+};
+
+describe("Google Health source presentation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("uses the same active styling as other connectors and opens its settings", async () => {
+    render(ServerConnectorsCard, {
+      googleHealth: connected,
+      availableConnectors: [{ id: "dexcom", name: "Dexcom" }],
+      connectorStatuses: [{ id: "dexcom", isEnabled: true, hasDatabaseConfig: true, isHealthy: true, state: "Active" }],
+      connectorCapabilitiesById: {}, syncProgressByConnector: {}, activeDataSources: [],
+      isLoadingConnectorStatuses: false, isManualSyncing: false, quickSyncingById: {},
+      onRefreshStatuses: vi.fn(), onManualSync: vi.fn(), onQuickSync: vi.fn(), onConnectorClick: vi.fn(),
+    });
+    const google = page.getByRole("button", { name: /Google Health/ });
+    const dexcom = page.getByRole("button", { name: /Dexcom/ });
+    await expect.element(google).toHaveTextContent("Active");
+    expect(google.element().className).toBe(dexcom.element().className);
+    expect(google.element().className).toContain("border-green");
+    await expect.element(google).toHaveTextContent("Last successful sync:");
+    await expect.element(google).not.toHaveTextContent("0 records");
+    await google.click();
+    expect(goto).toHaveBeenCalledWith("/settings/connectors/google-health");
+  });
+
+  it.each([
+    { change: { previewRequired: true }, label: "Configured" },
+    { change: { selectedTypes: [] }, label: "Configured" },
+    { change: { errorCode: "google_unavailable" }, label: "Error" },
+    { change: { connected: false }, label: "Offline" },
+  ])("does not show a healthy active status for $label", async ({ change, label }) => {
+    render(GoogleHealthSourceRow, { connection: { ...connected, ...change } });
+    const row = page.getByRole("button", { name: /Google Health/ });
+    await expect.element(row).toHaveTextContent(label);
+    await expect.element(row).not.toHaveTextContent("Active");
+    expect(row.element().className).not.toContain("border-green");
+  });
+
+  it("does not invent an import count or successful sync before the first import", async () => {
+    render(GoogleHealthSourceRow, { connection: { ...connected, lastSync: undefined } });
+    await expect.element(page.getByText("Waiting for the first successful sync")).toBeVisible();
+    await expect.element(page.getByRole("button", { name: /Google Health/ })).not.toHaveTextContent("0 records");
+  });
+
+  it.each([
+    { change: { previewRequired: true }, guidance: "Review available data and confirm the import selection" },
+    { change: { selectedTypes: [] }, guidance: "Choose at least one data type to start importing" },
+  ])("explains the next action for $guidance", async ({ change, guidance }) => {
+    render(GoogleHealthSourceRow, { connection: { ...connected, ...change } });
+    await expect.element(page.getByRole("button", { name: /Google Health/ })).toHaveTextContent(guidance);
+  });
+
+  it("offers a working refresh when Google Health is the only configured connector", async () => {
+    const refresh = vi.fn();
+    render(ServerConnectorsCard, {
+      googleHealth: connected, availableConnectors: [], connectorStatuses: [],
+      connectorCapabilitiesById: {}, syncProgressByConnector: {}, activeDataSources: [],
+      isLoadingConnectorStatuses: false, isManualSyncing: false, quickSyncingById: {},
+      onRefreshStatuses: refresh, onManualSync: vi.fn(), onQuickSync: vi.fn(), onConnectorClick: vi.fn(),
+    });
+    await page.getByRole("button", { name: "Refresh", exact: true }).click();
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+});

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import { Slider } from "bits-ui";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import {
+    colorFocusGradient,
+    resolveColorFocusRange,
+    type ColorFocusRange,
+  } from "$lib/utils/metric-color-focus";
+
+  let {
+    metricLabel,
+    unit,
+    observedMax,
+    cssVar,
+    fixedMax,
+    focusRange = null,
+    onFocusRangeChange,
+  }: {
+    metricLabel: string;
+    unit: string;
+    observedMax: number;
+    cssVar: string;
+    fixedMax?: number;
+    focusRange?: ColorFocusRange | null;
+    onFocusRangeChange: (range: [number, number] | null) => void;
+  } = $props();
+
+  const id = $props.id();
+  const automaticMax = $derived(
+    fixedMax ??
+      (Number.isFinite(observedMax) && observedMax > 0 ? observedMax : 1)
+  );
+  const range = $derived(focusRange ?? ([0, automaticMax] as const));
+  const domainMax = $derived(fixedMax ?? Math.max(automaticMax, range[1], 1));
+  const gradient = $derived(colorFocusGradient(range, domainMax, cssVar));
+  const baseSliderSteps = $derived.by(() => {
+    const step = Math.max(0.1, domainMax / 10_000);
+    const count = Math.min(10_000, Math.floor(domainMax / step));
+    return Array.from({ length: count + 1 }, (_, index) =>
+      Number((index * step).toPrecision(12))
+    );
+  });
+  // Bits UI normalizes supplied values to its steps, including untouched Auto values.
+  const sliderSteps = $derived.by(() =>
+    [...new Set([...baseSliderSteps, range[0], range[1], domainMax])].sort(
+      (left, right) => left - right
+    )
+  );
+  let minimumDraft = $state<number | undefined>();
+  let maximumDraft = $state<number | undefined>();
+  let invalidBound = $state<0 | 1 | null>(null);
+
+  $effect(() => {
+    void metricLabel;
+    minimumDraft = range[0];
+    maximumDraft = range[1];
+    invalidBound = null;
+  });
+
+  function changeSlider(values: number[]) {
+    const next = resolveColorFocusRange(values);
+    if (!next || next[1] > domainMax) return;
+    onFocusRangeChange([next[0], next[1]]);
+  }
+
+  function changeBound(index: 0 | 1, input: HTMLInputElement) {
+    const value = input.valueAsNumber;
+    const next = resolveColorFocusRange(
+      index === 0 ? [value, range[1]] : [range[0], value]
+    );
+    if (
+      !input.value ||
+      !next ||
+      (fixedMax !== undefined && next[1] > fixedMax)
+    ) {
+      invalidBound = index;
+      return;
+    }
+    invalidBound = null;
+    onFocusRangeChange([next[0], next[1]]);
+  }
+
+  function resetRange() {
+    minimumDraft = 0;
+    maximumDraft = automaticMax;
+    invalidBound = null;
+    onFocusRangeChange(null);
+  }
+</script>
+
+<div
+  class="w-full max-w-[420px] min-w-0 text-xs text-muted-foreground color-focus"
+>
+  <div class="print:hidden">
+    <Slider.Root
+      type="multiple"
+      min={0}
+      max={domainMax}
+      step={sliderSteps}
+      autoSort={false}
+      thumbPositioning="exact"
+      bind:value={() => [range[0], range[1]], changeSlider}
+      class="relative flex h-10 w-full touch-none select-none items-center"
+      aria-label="{metricLabel} color focus"
+    >
+      {#snippet children({ thumbItems })}
+        <span
+          class="h-3.5 w-full rounded-sm"
+          style:background={gradient}
+          data-color-focus-track
+        ></span>
+        {#each thumbItems as thumb (thumb.index)}
+          <Slider.Thumb
+            index={thumb.index}
+            aria-label="{metricLabel} {thumb.index === 0
+              ? 'minimum'
+              : 'maximum'} color value"
+            aria-valuetext="{thumb.value} {unit}"
+            class="block size-5 shrink-0 rounded-full border-2 border-foreground bg-background shadow-sm before:absolute before:-inset-3 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring/50"
+          />
+        {/each}
+      {/snippet}
+    </Slider.Root>
+    <div class="mb-2 flex justify-between tabular-nums" aria-hidden="true">
+      <span>0 {unit}</span>
+      <span>{domainMax} {unit}</span>
+    </div>
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-2">
+      <label for="{id}-minimum">Min</label>
+      <Input
+        id="{id}-minimum"
+        type="number"
+        inputmode="decimal"
+        min={0}
+        max={range[1]}
+        step="any"
+        bind:value={minimumDraft}
+        oninput={(event) => changeBound(0, event.currentTarget)}
+        aria-label="{metricLabel} minimum color value"
+        aria-invalid={invalidBound === 0}
+        aria-describedby={invalidBound === 0 ? `${id}-error` : undefined}
+        class="h-8 w-20 px-2 text-xs tabular-nums"
+      />
+      <label for="{id}-maximum">Max</label>
+      <Input
+        id="{id}-maximum"
+        type="number"
+        inputmode="decimal"
+        min={range[0]}
+        max={fixedMax}
+        step="any"
+        bind:value={maximumDraft}
+        oninput={(event) => changeBound(1, event.currentTarget)}
+        aria-label="{metricLabel} maximum color value"
+        aria-invalid={invalidBound === 1}
+        aria-describedby={invalidBound === 1 ? `${id}-error` : undefined}
+        class="h-8 w-20 px-2 text-xs tabular-nums"
+      />
+      <span>{unit}</span>
+      <Button
+        variant="outline"
+        size="sm"
+        class="h-8 px-2 text-xs"
+        aria-label="Reset {metricLabel} color range to automatic"
+        onclick={resetRange}
+      >
+        Auto
+      </Button>
+    </div>
+    {#if invalidBound !== null}
+      <p id="{id}-error" class="mt-2 text-destructive" role="alert">
+        Enter a minimum of 0 or more and a maximum greater than the minimum{fixedMax !==
+        undefined
+          ? `, up to ${fixedMax} ${unit}`
+          : ""}.
+      </p>
+    {/if}
+    <p class="mt-2">Values outside the selected range use the end colors.</p>
+  </div>
+  <div class="hidden print:block">
+    <div class="h-3.5 w-full rounded-sm" style:background={gradient}></div>
+    <div class="mt-1 flex justify-between tabular-nums">
+      <span>0 {unit}</span>
+      <span>{domainMax} {unit}</span>
+    </div>
+    <p class="mt-1">
+      {metricLabel}: color focus {range[0]}–{range[1]}
+      {unit}; values outside use the end colors.
+    </p>
+  </div>
+</div>
+
+<style>
+  .color-focus {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+</style>

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.test-harness.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/ColorFocusRange.test-harness.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { untrack } from "svelte";
+  import type { ColorFocusRange as Range } from "$lib/utils/metric-color-focus";
+  import ColorFocusRange from "./ColorFocusRange.svelte";
+
+  let {
+    initialRange = null,
+    observedMax = 500,
+    fixedMax,
+    metricLabel = "TDD",
+    unit = "U",
+  }: {
+    initialRange?: Range | null;
+    observedMax?: number;
+    fixedMax?: number;
+    metricLabel?: string;
+    unit?: string;
+  } = $props();
+
+  let range = $state<Range | null>(untrack(() => initialRange));
+</script>
+
+<ColorFocusRange
+  {metricLabel}
+  {unit}
+  {observedMax}
+  {fixedMax}
+  cssVar="--primary"
+  focusRange={range}
+  onFocusRangeChange={(next) => (range = next)}
+/>
+<output data-testid="selected-range">{JSON.stringify(range)}</output>

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/GlucoseColorThresholds.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/GlucoseColorThresholds.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import { Slider } from "bits-ui";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import {
+    convertToDisplayUnits,
+    convertFromDisplayUnits,
+    formatGlucoseValue,
+    getUnitLabel,
+    type GlucoseUnits,
+  } from "$lib/utils/formatting";
+  import {
+    DEFAULT_GLUCOSE_COLOR_THRESHOLDS,
+    GLUCOSE_COLOR_MIN,
+    GLUCOSE_COLOR_MAX,
+    resolveGlucoseColorThresholds,
+    type GlucoseColorThresholds,
+  } from "$lib/utils/metric-color-focus";
+
+  let {
+    units,
+    thresholds = DEFAULT_GLUCOSE_COLOR_THRESHOLDS,
+    onThresholdsChange,
+    stops,
+  }: {
+    units: GlucoseUnits;
+    thresholds?: GlucoseColorThresholds;
+    onThresholdsChange: (value: GlucoseColorThresholds | null) => void;
+    stops: ReadonlyArray<{ mgdl: number; color: string }>;
+  } = $props();
+
+  const id = $props.id();
+  const minimum = GLUCOSE_COLOR_MIN;
+  const maximum = GLUCOSE_COLOR_MAX;
+  const labels = ["Very low", "Low", "High", "Very high"] as const;
+  const unitLabel = $derived(getUnitLabel(units));
+  const inputStep = $derived(units === "mmol" ? 0.1 : 1);
+  const gradient = $derived(
+    `linear-gradient(to right in srgb, ${stops
+      .map(
+        (stop) =>
+          `${stop.color} ${((stop.mgdl - minimum) / (maximum - minimum)) * 100}%`
+      )
+      .join(", ")})`
+  );
+  const sliderSteps = $derived.by(() => {
+    const first = Math.ceil(convertToDisplayUnits(minimum, units) / inputStep);
+    const last = Math.floor(convertToDisplayUnits(maximum, units) / inputStep);
+    const values = Array.from({ length: last - first + 1 }, (_, index) =>
+      convertFromDisplayUnits((first + index) * inputStep, units)
+    ).filter((value) => value > minimum && value < maximum);
+    // Bits UI snaps supplied values to its steps, including boundaries not being edited.
+    return [...new Set([...values, ...thresholds])].sort((a, b) => a - b);
+  });
+  let drafts = $state<(number | undefined)[]>([]);
+  let invalidBound = $state<number | null>(null);
+
+  $effect(() => {
+    drafts = thresholds.map((threshold) =>
+      convertToDisplayUnits(threshold, units)
+    );
+    invalidBound = null;
+  });
+
+  function changeSlider(values: number[]) {
+    const next = resolveGlucoseColorThresholds(values);
+    if (next) onThresholdsChange(next);
+  }
+
+  function changeBound(index: number, input: HTMLInputElement) {
+    const value = input.valueAsNumber;
+    if (!input.value || !Number.isFinite(value)) {
+      invalidBound = index;
+      return;
+    }
+    if (value === convertToDisplayUnits(thresholds[index], units)) {
+      invalidBound = null;
+      return;
+    }
+    const candidate = [...thresholds];
+    candidate[index] = convertFromDisplayUnits(value, units);
+    const next = resolveGlucoseColorThresholds(candidate);
+    if (!next) {
+      invalidBound = index;
+      return;
+    }
+    invalidBound = null;
+    onThresholdsChange(next);
+  }
+
+  function resetThresholds() {
+    drafts = DEFAULT_GLUCOSE_COLOR_THRESHOLDS.map((threshold) =>
+      convertToDisplayUnits(threshold, units)
+    );
+    invalidBound = null;
+    onThresholdsChange(null);
+  }
+</script>
+
+<div
+  class="glucose-color-focus w-full max-w-[420px] min-w-0 text-xs text-muted-foreground"
+>
+  <div class="print:hidden">
+    <Slider.Root
+      type="multiple"
+      min={minimum}
+      max={maximum}
+      step={sliderSteps}
+      autoSort={false}
+      thumbPositioning="exact"
+      bind:value={() => [...thresholds], changeSlider}
+      class="relative flex h-10 w-full touch-none select-none items-center"
+      aria-label="Average glucose color boundaries"
+      aria-describedby="{id}-description"
+    >
+      {#snippet children({ thumbItems })}
+        <span
+          class="h-3.5 w-full rounded-sm"
+          style:background={gradient}
+          data-glucose-color-track
+        ></span>
+        {#each thumbItems as thumb (thumb.index)}
+          <Slider.Thumb
+            index={thumb.index}
+            aria-label="Average glucose {labels[thumb.index]} color boundary"
+            aria-valuetext="{formatGlucoseValue(
+              thumb.value,
+              units
+            )} {unitLabel}"
+            class="block size-5 shrink-0 rounded-full border-2 border-foreground bg-background shadow-sm before:absolute before:-inset-3 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-ring/50"
+          />
+        {/each}
+      {/snippet}
+    </Slider.Root>
+    <div class="mb-2 flex justify-between tabular-nums" aria-hidden="true">
+      <span>{formatGlucoseValue(minimum, units)} {unitLabel}</span>
+      <span>{formatGlucoseValue(maximum, units)} {unitLabel}</span>
+    </div>
+    <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
+      {#each labels as label, index}
+        <div class="min-w-0">
+          <label for="{id}-boundary-{index}" class="mb-1 block">{label}</label>
+          <Input
+            id="{id}-boundary-{index}"
+            type="number"
+            inputmode="decimal"
+            min={convertToDisplayUnits(sliderSteps[0], units)}
+            max={convertToDisplayUnits(
+              sliderSteps[sliderSteps.length - 1],
+              units
+            )}
+            step={inputStep}
+            bind:value={drafts[index]}
+            oninput={(event) => changeBound(index, event.currentTarget)}
+            aria-label="Average glucose {label} color boundary"
+            aria-invalid={invalidBound === index}
+            aria-describedby={invalidBound === index
+              ? `${id}-unit ${id}-error`
+              : `${id}-unit`}
+            class="h-8 w-full px-2 text-xs tabular-nums"
+          />
+        </div>
+      {/each}
+    </div>
+    <div class="mt-2 flex items-center justify-between gap-2">
+      <span id="{id}-unit">{unitLabel}</span>
+      <Button
+        variant="outline"
+        size="sm"
+        class="h-8 px-2 text-xs"
+        aria-label="Reset average glucose color boundaries"
+        onclick={resetThresholds}
+      >
+        Reset
+      </Button>
+    </div>
+    {#if invalidBound !== null}
+      <p id="{id}-error" class="mt-2 text-destructive" role="alert">
+        Enter four increasing boundaries within the color scale. Boundaries
+        cannot overlap or use the endpoints.
+      </p>
+    {/if}
+  </div>
+  <div class="hidden print:block">
+    <div class="h-3.5 w-full rounded-sm" style:background={gradient}></div>
+    <div class="mt-1 flex justify-between tabular-nums">
+      <span>{formatGlucoseValue(minimum, units)} {unitLabel}</span>
+      <span>{formatGlucoseValue(maximum, units)} {unitLabel}</span>
+    </div>
+    <p class="mt-2">Average glucose color boundaries:</p>
+    <div class="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 tabular-nums">
+      {#each labels as label, index}
+        <span>
+          {label}: {formatGlucoseValue(thresholds[index], units)}
+          {unitLabel}
+        </span>
+      {/each}
+    </div>
+  </div>
+  <p id="{id}-description" class="mt-2">
+    Color scale only; glucose targets and Time in Range are unchanged.
+  </p>
+</div>
+
+<style>
+  .glucose-color-focus {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+</style>

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/HeatmapLegend.svelte
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/HeatmapLegend.svelte
@@ -1,32 +1,41 @@
 <script lang="ts">
   import * as Select from "$lib/components/ui/select";
-  import { formatGlucoseValue } from "$lib/utils/formatting";
   import type { GlucoseUnits } from "$lib/utils/formatting";
+  import ColorFocusRange from "./ColorFocusRange.svelte";
+  import GlucoseColorThresholds from "./GlucoseColorThresholds.svelte";
+  import type { GlucoseColorThresholds as GlucoseThresholds } from "$lib/utils/metric-color-focus";
 
-  type HeatmapMetric = "avgGlucose" | "tir" | "bolus" | "basal" | "tdd" | "carbs";
+  type HeatmapMetric =
+    | "avgGlucose"
+    | "tir"
+    | "bolus"
+    | "basal"
+    | "tdd"
+    | "carbs";
 
   let {
     selectedMetric = $bindable("avgGlucose"),
     units,
     METRIC_OPTIONS,
     HEATMAP_STOPS,
-    LEGEND_W,
-    LEGEND_THRESHOLDS,
-    legendX,
     METRIC_CSS_VARS,
     getMetricMax,
+    focusRange = null,
+    onFocusRangeChange = () => {},
+    glucoseThresholds,
+    onGlucoseThresholdsChange = () => {},
   } = $props<{
     selectedMetric: HeatmapMetric;
     units: GlucoseUnits;
     METRIC_OPTIONS: { value: HeatmapMetric; label: string }[];
     HEATMAP_STOPS: ReadonlyArray<{ mgdl: number; color: string }>;
-    LEGEND_W: number;
-    LEGEND_THRESHOLDS: number[];
-    legendX: (mgdl: number) => number;
     METRIC_CSS_VARS: Record<Exclude<HeatmapMetric, "avgGlucose">, string>;
     getMetricMax: (metric: HeatmapMetric) => number;
+    focusRange?: readonly [number, number] | null;
+    onFocusRangeChange?: (range: [number, number] | null) => void;
+    glucoseThresholds: GlucoseThresholds;
+    onGlucoseThresholdsChange?: (value: GlucoseThresholds | null) => void;
   }>();
-
 </script>
 
 <div class="mb-6 rounded-lg border border-border bg-card p-3">
@@ -41,7 +50,10 @@
       >
         <Select.Trigger class="w-[150px] h-8 text-xs print:hidden">
           <span class="truncate">
-            {METRIC_OPTIONS.find((o: { value: HeatmapMetric; label: string }) => o.value === selectedMetric)?.label ?? "Avg Glucose"}
+            {METRIC_OPTIONS.find(
+              (o: { value: HeatmapMetric; label: string }) =>
+                o.value === selectedMetric
+            )?.label ?? "Avg Glucose"}
           </span>
         </Select.Trigger>
         <Select.Content>
@@ -52,55 +64,12 @@
           {/each}
         </Select.Content>
       </Select.Root>
-      <svg
-        viewBox="0 0 {LEGEND_W} 48"
-        class="h-12 w-full max-w-[420px] text-muted-foreground"
-        overflow="visible"
-        role="img"
-        aria-label="Glucose color scale legend"
-      >
-        <defs>
-          <linearGradient id="heatmap-grad">
-            {#each HEATMAP_STOPS as heatmapStop}
-              <stop
-                offset="{(legendX(heatmapStop.mgdl) / LEGEND_W) * 100}%"
-                stop-color={heatmapStop.color}
-              />
-            {/each}
-          </linearGradient>
-        </defs>
-
-        <!-- Zone labels -->
-        <text x={legendX(55)} y="10" text-anchor="middle" font-size="10" fill="currentColor">Low</text>
-        <text x={legendX(125)} y="10" text-anchor="middle" font-size="10" fill="currentColor">In Range</text>
-        <text x={legendX(215)} y="10" text-anchor="middle" font-size="10" fill="currentColor">High</text>
-        <text x={legendX(300)} y="10" text-anchor="middle" font-size="10" fill="currentColor">Very High</text>
-
-        <!-- Gradient bar -->
-        <rect x="0" y="14" width={LEGEND_W} height="14" rx="2" fill="url(#heatmap-grad)" />
-
-        <!-- Threshold markers -->
-        {#each LEGEND_THRESHOLDS as threshold}
-          {@const x = legendX(threshold)}
-          <line
-            x1={x}
-            y1={14}
-            x2={x}
-            y2={32}
-            stroke="currentColor"
-            stroke-opacity="0.3"
-          />
-          <text
-            {x}
-            y={44}
-            text-anchor="middle"
-            font-size="10"
-            fill="currentColor"
-          >
-            {formatGlucoseValue(threshold, units)}
-          </text>
-        {/each}
-      </svg>
+      <GlucoseColorThresholds
+        {units}
+        thresholds={glucoseThresholds}
+        stops={HEATMAP_STOPS}
+        onThresholdsChange={onGlucoseThresholdsChange}
+      />
       <div class="flex items-center gap-1.5 text-xs text-muted-foreground">
         <span
           class="inline-block h-3 w-3 rounded-sm"
@@ -110,11 +79,17 @@
       </div>
     </div>
   {:else}
-    <!-- Single-hue legend for other metrics -->
-    {@const metricLabel = METRIC_OPTIONS.find((o: { value: HeatmapMetric; label: string }) => o.value === selectedMetric)?.label ?? ""}
-    {@const metricUnit = selectedMetric === "tir" ? "%" : selectedMetric === "carbs" ? "g" : "U"}
-    {@const metricMax = selectedMetric === "tir" ? 100 : getMetricMax(selectedMetric)}
-    {@const cssVar = METRIC_CSS_VARS[selectedMetric as Exclude<HeatmapMetric, "avgGlucose">]}
+    {@const metricLabel =
+      METRIC_OPTIONS.find(
+        (o: { value: HeatmapMetric; label: string }) =>
+          o.value === selectedMetric
+      )?.label ?? ""}
+    {@const metricUnit =
+      selectedMetric === "tir" ? "%" : selectedMetric === "carbs" ? "g" : "U"}
+    {@const metricMax =
+      selectedMetric === "tir" ? 100 : getMetricMax(selectedMetric)}
+    {@const cssVar =
+      METRIC_CSS_VARS[selectedMetric as Exclude<HeatmapMetric, "avgGlucose">]}
     <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
       <Select.Root
         type="single"
@@ -125,7 +100,10 @@
       >
         <Select.Trigger class="w-[150px] h-8 text-xs print:hidden">
           <span class="truncate">
-            {METRIC_OPTIONS.find((o: { value: HeatmapMetric; label: string }) => o.value === selectedMetric)?.label ?? "Avg Glucose"}
+            {METRIC_OPTIONS.find(
+              (o: { value: HeatmapMetric; label: string }) =>
+                o.value === selectedMetric
+            )?.label ?? "Avg Glucose"}
           </span>
         </Select.Trigger>
         <Select.Content>
@@ -136,33 +114,20 @@
           {/each}
         </Select.Content>
       </Select.Root>
-      <svg
-        viewBox="0 0 {LEGEND_W} 36"
-        class="h-9 w-full max-w-[420px] text-muted-foreground"
-        overflow="visible"
-        role="img"
-        aria-label="{metricLabel} color scale legend"
-      >
-        <defs>
-          <linearGradient id="metric-grad">
-            <stop offset="0%" stop-color="var({cssVar})" stop-opacity="0.15" />
-            <stop offset="100%" stop-color="var({cssVar})" stop-opacity="1" />
-          </linearGradient>
-        </defs>
-        <rect x="0" y="4" width={LEGEND_W} height="14" rx="2" fill="url(#metric-grad)" />
-        <text x="0" y="32" font-size="10" fill="currentColor">0</text>
-        <text x={LEGEND_W} y="32" text-anchor="end" font-size="10" fill="currentColor">
-          {selectedMetric === "tir" ? "100%" : `${Math.round(metricMax)} ${metricUnit}`}
-        </text>
-        {#if selectedMetric === "tir"}
-          <!-- 70% TIR target marker -->
-          {@const targetX = (70 / 100) * LEGEND_W}
-          <line x1={targetX} y1={4} x2={targetX} y2={18} stroke="currentColor" stroke-opacity="0.3" />
-          <text x={targetX} y="32" text-anchor="middle" font-size="10" fill="currentColor">70%</text>
-        {/if}
-      </svg>
+      <ColorFocusRange
+        {metricLabel}
+        unit={metricUnit}
+        observedMax={metricMax}
+        {cssVar}
+        fixedMax={selectedMetric === "tir" ? 100 : undefined}
+        {focusRange}
+        {onFocusRangeChange}
+      />
       <div class="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <span class="inline-block h-3 w-3 rounded-sm" style="background: var(--muted)"></span>
+        <span
+          class="inline-block h-3 w-3 rounded-sm"
+          style="background: var(--muted)"
+        ></span>
         No {metricLabel.toLowerCase()} data
       </div>
     </div>

--- a/src/Web/packages/app/src/lib/components/reports/year-overview/color-focus-range.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/reports/year-overview/color-focus-range.svelte.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page, userEvent } from "vitest/browser";
+import Harness from "./ColorFocusRange.test-harness.svelte";
+
+const minimumInput = (metric = "TDD") =>
+  page.getByRole("spinbutton", { name: `${metric} minimum color value` });
+const maximumInput = (metric = "TDD") =>
+  page.getByRole("spinbutton", { name: `${metric} maximum color value` });
+const minimumSlider = () =>
+  page.getByRole("slider", { name: "TDD minimum color value" });
+const maximumSlider = () =>
+  page.getByRole("slider", { name: "TDD maximum color value" });
+
+describe("year overview color focus", () => {
+  it("reuses base steps when only the focus changes", async () => {
+    const precision = vi.spyOn(Number.prototype, "toPrecision");
+    try {
+      const screen = render(Harness);
+      await expect.element(maximumInput()).toHaveValue(500);
+      const initialConversions = precision.mock.calls.length;
+      expect(initialConversions).toBeGreaterThan(1000);
+
+      await minimumInput().fill("10.25");
+      await maximumInput().fill("70.75");
+      await expect.element(maximumInput()).toHaveValue(70.75);
+      expect(precision.mock.calls.length).toBe(initialConversions);
+
+      await screen.rerender({ observedMax: 800 });
+      await expect
+        .element(maximumSlider())
+        .toHaveAttribute("aria-valuemax", "800");
+      expect(precision.mock.calls.length).toBeGreaterThan(initialConversions);
+      await expect.element(minimumInput()).toHaveValue(10.25);
+      await expect.element(maximumInput()).toHaveValue(70.75);
+    } finally {
+      precision.mockRestore();
+    }
+  });
+
+  it("focuses the legend on exact numeric limits within an outlier-sized axis", async () => {
+    const { container } = render(Harness);
+
+    await minimumInput().fill("10");
+    await maximumInput().fill("70");
+
+    await expect
+      .element(page.getByTestId("selected-range"))
+      .toHaveTextContent("[10,70]");
+    await expect
+      .element(minimumSlider())
+      .toHaveAttribute("aria-valuenow", "10");
+    await expect
+      .element(maximumSlider())
+      .toHaveAttribute("aria-valuenow", "70");
+    await expect
+      .element(maximumSlider())
+      .toHaveAttribute("aria-valuemax", "500");
+    const track = container.querySelector<HTMLElement>(
+      "[data-color-focus-track]"
+    );
+    expect(track?.style.background).toContain("2%");
+    expect(track?.style.background).toMatch(/14(?:\.0+2)?%/);
+  });
+
+  it("allows decimal limits without rounding the selected values", async () => {
+    render(Harness);
+
+    await minimumInput().fill("10.25");
+    await maximumInput().fill("70.75");
+
+    await expect
+      .element(page.getByTestId("selected-range"))
+      .toHaveTextContent("[10.25,70.75]");
+    await expect.element(minimumInput()).toHaveValue(10.25);
+    await expect.element(maximumInput()).toHaveValue(70.75);
+  });
+
+  it.each([12.35, 0.5])(
+    "keeps fractional automatic maximum %s without creating a manual preference",
+    async (observedMax) => {
+      const screen = render(Harness, { observedMax });
+      const { container } = screen;
+
+      await expect.element(maximumInput()).toHaveValue(observedMax);
+      await expect
+        .element(maximumSlider())
+        .toHaveAttribute("aria-valuenow", String(observedMax));
+      await expect
+        .element(page.getByTestId("selected-range"))
+        .toHaveTextContent("null");
+      if (observedMax === 0.5) {
+        expect(
+          container.querySelector<HTMLElement>("[data-color-focus-track]")
+            ?.style.background
+        ).toContain("50%");
+      }
+      await screen.rerender({ observedMax: observedMax + 1 });
+      await expect.element(maximumInput()).toHaveValue(observedMax + 1);
+      await expect
+        .element(page.getByTestId("selected-range"))
+        .toHaveTextContent("null");
+    }
+  );
+
+  it("keeps controls responsive for very large manually entered maxima", async () => {
+    render(Harness);
+
+    await maximumInput().fill("1000000000");
+    await expect
+      .element(maximumSlider())
+      .toHaveAttribute("aria-valuemax", "1000000000");
+    await expect.element(maximumInput()).toHaveValue(1_000_000_000);
+    await page
+      .getByRole("button", { name: "Reset TDD color range to automatic" })
+      .click();
+    await expect.element(maximumInput()).toHaveValue(500);
+    await expect
+      .element(page.getByTestId("selected-range"))
+      .toHaveTextContent("null");
+  });
+
+  it("moves handles by keyboard without crossing or collapsing the range", async () => {
+    render(Harness, { initialRange: [10, 10.2] });
+
+    (minimumSlider().element() as HTMLElement).focus();
+    await userEvent.keyboard("{ArrowRight}");
+    await expect
+      .element(minimumSlider())
+      .toHaveAttribute("aria-valuenow", "10.1");
+    await userEvent.keyboard("{ArrowRight}{End}");
+    await expect
+      .element(minimumSlider())
+      .toHaveAttribute("aria-valuenow", "10.1");
+
+    (maximumSlider().element() as HTMLElement).focus();
+    await userEvent.keyboard("{ArrowLeft}{Home}");
+    await expect
+      .element(maximumSlider())
+      .toHaveAttribute("aria-valuenow", "10.2");
+    await expect
+      .element(page.getByTestId("selected-range"))
+      .toHaveTextContent("[10.1,10.2]");
+  });
+
+  it("drags the upper handle on the color bar at mobile width", async () => {
+    const originalSize = [window.innerWidth, window.innerHeight] as const;
+    await page.viewport(390, 700);
+    try {
+      const { container } = render(Harness, { initialRange: [10, 70] });
+      const track = container.querySelector<HTMLElement>(
+        "[data-color-focus-track]"
+      )!;
+      const bounds = track.getBoundingClientRect();
+      expect(bounds.width).toBeGreaterThan(300);
+      expect(bounds.height).toBeGreaterThan(10);
+
+      await page.screenshot({ path: "test-results/color-focus-mobile.png" });
+      await userEvent.dragAndDrop(maximumSlider(), track, {
+        targetPosition: { x: bounds.width * 0.6, y: bounds.height / 2 },
+      });
+
+      await expect.element(minimumInput()).toHaveValue(10);
+      const maximum = (maximumInput().element() as HTMLInputElement)
+        .valueAsNumber;
+      expect(maximum).toBeGreaterThan(299);
+      expect(maximum).toBeLessThan(301);
+    } finally {
+      await page.viewport(originalSize[0], originalSize[1]);
+    }
+  });
+
+  it.each(["", "-1", "70", "80", "1e309"])(
+    "rejects invalid minimum %j without changing the active colors",
+    async (value) => {
+      render(Harness, { initialRange: [10, 70] });
+
+      await minimumInput().fill(value);
+
+      await expect
+        .element(minimumInput())
+        .toHaveAttribute("aria-invalid", "true");
+      await expect.element(page.getByRole("alert")).toBeVisible();
+      await expect
+        .element(page.getByTestId("selected-range"))
+        .toHaveTextContent("[10,70]");
+      await expect
+        .element(minimumSlider())
+        .toHaveAttribute("aria-valuenow", "10");
+    }
+  );
+
+  it("rejects a TIR maximum above 100 percent", async () => {
+    render(Harness, {
+      metricLabel: "Time in Range",
+      unit: "%",
+      fixedMax: 100,
+      initialRange: [10, 70],
+    });
+
+    await maximumInput("Time in Range").fill("101");
+
+    await expect
+      .element(maximumInput("Time in Range"))
+      .toHaveAttribute("aria-invalid", "true");
+    await expect
+      .element(page.getByRole("alert"))
+      .toHaveTextContent("up to 100 %");
+    await expect
+      .element(page.getByTestId("selected-range"))
+      .toHaveTextContent("[10,70]");
+  });
+
+  it("resets invalid drafts even when the range is already automatic", async () => {
+    render(Harness);
+    await minimumInput().fill("600");
+    await expect.element(page.getByRole("alert")).toBeVisible();
+
+    await page
+      .getByRole("button", { name: "Reset TDD color range to automatic" })
+      .click();
+
+    await expect.element(page.getByRole("alert")).not.toBeInTheDocument();
+    await expect.element(minimumInput()).toHaveValue(0);
+    await expect.element(maximumInput()).toHaveValue(500);
+    await expect
+      .element(page.getByTestId("selected-range"))
+      .toHaveTextContent("null");
+  });
+
+  it("clears an invalid draft when switching metrics with the same automatic maximum", async () => {
+    const screen = render(Harness);
+    await minimumInput().fill("600");
+    await expect.element(page.getByRole("alert")).toBeVisible();
+
+    await screen.rerender({ metricLabel: "Basal" });
+
+    await expect.element(page.getByRole("alert")).not.toBeInTheDocument();
+    await expect.element(minimumInput("Basal")).toHaveValue(0);
+    await expect.element(maximumInput("Basal")).toHaveValue(500);
+  });
+
+  it("preserves manual limits across observed-data changes and restores Auto", async () => {
+    const screen = render(Harness, { initialRange: [10, 70] });
+
+    await screen.rerender({ observedMax: 800 });
+    await expect
+      .element(maximumSlider())
+      .toHaveAttribute("aria-valuemax", "800");
+    await expect.element(minimumInput()).toHaveValue(10);
+    await expect.element(maximumInput()).toHaveValue(70);
+
+    await screen.rerender({ observedMax: 40 });
+    await expect
+      .element(maximumSlider())
+      .toHaveAttribute("aria-valuemax", "70");
+    await expect
+      .element(page.getByTestId("selected-range"))
+      .toHaveTextContent("[10,70]");
+
+    await page
+      .getByRole("button", { name: "Reset TDD color range to automatic" })
+      .click();
+    await expect.element(minimumInput()).toHaveValue(0);
+    await expect.element(maximumInput()).toHaveValue(40);
+    await expect
+      .element(page.getByTestId("selected-range"))
+      .toHaveTextContent("null");
+  });
+});

--- a/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
+++ b/src/Web/packages/app/src/lib/components/settings/DataSourceRow.svelte
@@ -47,6 +47,8 @@
     actions?: Snippet;
     onclick?: () => void;
     subtitle?: string;
+    logo?: Snippet;
+    metrics?: Snippet;
   }
 
   let {
@@ -66,6 +68,8 @@
     actions,
     onclick,
     subtitle,
+    logo,
+    metrics,
   }: Props = $props();
 
   function getIconColors(s: DataSourceStatus): {
@@ -159,7 +163,11 @@
       <div
         class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg {iconColors.bg}"
       >
-        <AppLogo {icon} invertMode />
+        {#if logo}
+          {@render logo()}
+        {:else}
+          <AppLogo {icon} invertMode />
+        {/if}
       </div>
       <div class="min-w-0 flex-1">
         <div class="flex items-center gap-2 flex-wrap">
@@ -251,7 +259,9 @@
         </div>
 
         <!-- Metrics line -->
-        {#if (syncProgress?.phase === "Syncing") && syncProgress.messageType}
+        {#if metrics}
+          {@render metrics()}
+        {:else if (syncProgress?.phase === "Syncing") && syncProgress.messageType}
         <p class="text-sm text-blue-600 dark:text-blue-400">
           {formatSyncMessage(syncProgress.messageType, syncProgress.messageParams)}
         </p>

--- a/src/Web/packages/app/src/lib/components/ui/logo-src.test.ts
+++ b/src/Web/packages/app/src/lib/components/ui/logo-src.test.ts
@@ -37,12 +37,17 @@ describe("resolveLogoSrc", () => {
 		expect(resolveLogoName("carelink")).toBe("medtronic");
 		expect(resolveLogoSrc("carelink")).toBe("/logos/medtronic.jpg");
 	});
+
+	it("uses the generic device mark for OpenAPS", () => {
+		expect(resolveLogoName("openaps")).toBe("device");
+		expect(resolveLogoSrc("openaps")).toBe("/logos/device.svg");
+	});
 });
 
 describe("logo assets", () => {
 	// Regression: carelink, iaps and gluroo had no entry and no file, so each
 	// rendered a 404 broken image in the connectors UI.
-	it.each(["carelink", "iaps", "gluroo"])("ships an asset for %s", (icon) => {
+	it.each(["carelink", "iaps", "gluroo", "openaps"])("ships an asset for %s", (icon) => {
 		expect(existsSync(staticPath(resolveLogoSrc(icon)))).toBe(true);
 	});
 

--- a/src/Web/packages/app/src/lib/components/ui/logo-src.ts
+++ b/src/Web/packages/app/src/lib/components/ui/logo-src.ts
@@ -15,6 +15,7 @@ export const FALLBACK_LOGO = "/logos/device.svg";
  */
 export const logoAliases: Record<string, string> = {
   carelink: "medtronic",
+  openaps: "device",
 };
 
 /**

--- a/src/Web/packages/app/src/lib/connectors/google-health-error.test.ts
+++ b/src/Web/packages/app/src/lib/connectors/google-health-error.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { describeGoogleHealthError } from "./google-health-error";
+
+const known = { reconnect_required: "Reconnect to Google." };
+
+describe("Google Health diagnostics", () => {
+  it("identifies a failed Nocturne session separately from Google consent", () => {
+    const message = describeGoogleHealthError(
+      { status: 401, body: { message: "private upstream response" } },
+      "status",
+      known
+    );
+    expect(message).toContain("Nocturne session is missing or has expired");
+    expect(message).toContain("status/http_401");
+    expect(message).toContain("HTTP 401");
+    expect(message).not.toContain("private upstream response");
+  });
+
+  it("retains a recognized provider code with the failing action", () => {
+    const message = describeGoogleHealthError(
+      { status: 400, body: { message: "reconnect_required" } },
+      "sync",
+      known
+    );
+    expect(message).toContain("Reconnect to Google.");
+    expect(message).toContain("sync/reconnect_required");
+    expect(message).toContain("HTTP 400");
+  });
+
+  it.each([
+    new Error("access_token=private-token client_secret=private-secret"),
+    new TypeError("private health reading"),
+    { status: 502, body: { message: "private provider body" } },
+    { status: 400, body: { message: "toString" } },
+    { status: Infinity, body: { message: "__proto__" } },
+  ])(
+    "never reveals unknown exceptions, provider data or inherited properties",
+    (error) => {
+      const message = describeGoogleHealthError(error, "readings", known);
+      expect(message).toContain("Google Health data could not be retrieved");
+      expect(message).toContain("Technical code: readings/");
+      expect(message).not.toMatch(
+        /private|access_token|client_secret|toString|__proto__|Infinity/
+      );
+    }
+  );
+});

--- a/src/Web/packages/app/src/lib/connectors/google-health-error.ts
+++ b/src/Web/packages/app/src/lib/connectors/google-health-error.ts
@@ -1,0 +1,47 @@
+import { errorMessage, errorStatus } from "$lib/forms/submit-error";
+
+const operations = {
+  status: "The connection status could not be retrieved.",
+  readings: "The available Google Health data could not be retrieved.",
+  save: "The Google settings could not be saved.",
+  signin: "Google sign-in could not be started.",
+  sync: "The Google import could not be completed.",
+  disconnect: "Google could not be disconnected.",
+  purge: "The imported Google data could not be deleted.",
+};
+
+export type GoogleHealthOperation = keyof typeof operations;
+
+export function describeGoogleHealthError(
+  error: unknown,
+  operation: GoogleHealthOperation,
+  knownErrors: Record<string, string>
+): string {
+  const status = errorStatus(error);
+  const http =
+    status !== undefined &&
+    Number.isInteger(status) &&
+    status >= 400 &&
+    status <= 599
+      ? status
+      : undefined;
+  const reason = errorMessage(error);
+  const known = reason !== undefined && Object.hasOwn(knownErrors, reason);
+  const code = known ? reason : http ? `http_${http}` : "page_or_network_error";
+  const explanation = known
+    ? knownErrors[reason]
+    : http === 401
+      ? "Your Nocturne session is missing or has expired. Sign in to Nocturne and reload this page."
+      : http === 403
+        ? "Your Nocturne account cannot access these settings. Use an administrator account with tenant settings permission."
+        : http === 404
+          ? "This feature is missing from the installed version. Check that Nocturne is up to date."
+          : http === 429
+            ? "Too many requests were made. Try again in a few minutes."
+            : http && http >= 500
+              ? "Nocturne could not process the request. Check the server log for this attempt."
+              : "A page or connection error occurred. Reload the page; if this continues, report the technical code.";
+
+  // Only fixed messages and recognized codes may leave the error boundary.
+  return `${operations[operation]} ${explanation} Technical code: ${operation}/${code}${http ? ` · HTTP ${http}` : ""}.`;
+}

--- a/src/Web/packages/app/src/lib/test-stubs/EmptyYearPanel.test-stub.svelte
+++ b/src/Web/packages/app/src/lib/test-stubs/EmptyYearPanel.test-stub.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let {
+    selectedDataSources = $bindable([]),
+  }: { selectedDataSources?: string[] } = $props();
+</script>

--- a/src/Web/packages/app/src/lib/test-stubs/YearHeatmap.test-stub.svelte
+++ b/src/Web/packages/app/src/lib/test-stubs/YearHeatmap.test-stub.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { DailySummaryDay } from "$api/generated/nocturne-api-client";
+
+  let {
+    year,
+    yearData,
+    transformYearData,
+    getCellFill,
+    sentinelElement = $bindable(),
+  }: {
+    year: number;
+    yearData: Map<number, DailySummaryDay[]>;
+    transformYearData: (days: DailySummaryDay[]) => { dateString: string }[];
+    getCellFill: (day: { dateString: string }) => string;
+    sentinelElement?: HTMLDivElement;
+  } = $props();
+</script>
+
+<div bind:this={sentinelElement} data-year={year}>
+  {#each transformYearData(yearData.get(year) ?? []) as day}
+    <span data-testid="cell-{day.dateString}">{getCellFill(day)}</span>
+  {/each}
+</div>

--- a/src/Web/packages/app/src/lib/test-stubs/data-type-labels.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/data-type-labels.ts
@@ -1,0 +1,1 @@
+export const getDataTypeLabel = (key: string) => key;

--- a/src/Web/packages/app/src/lib/test-stubs/effect-aware-query.svelte.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/effect-aware-query.svelte.ts
@@ -1,0 +1,22 @@
+function isInEffect(): boolean {
+  try {
+    $effect.pre(() => {});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function effectAwareQuery<T>(read: () => Promise<T>) {
+  return {
+    run(): Promise<T> {
+      // SvelteKit 2.59.1 detects effects this way; $effect.tracking() misses onMount.
+      if (isInEffect()) {
+        throw new Error(
+          "On the client, .run() can only be called outside render, e.g. in universal `load` functions and event handlers. In render, await the query directly",
+        );
+      }
+      return read();
+    },
+  };
+}

--- a/src/Web/packages/app/src/lib/test-stubs/google-health-app-paths.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/google-health-app-paths.ts
@@ -1,0 +1,3 @@
+export function resolve(path: string): string {
+  return path;
+}

--- a/src/Web/packages/app/src/lib/test-stubs/google-health.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/google-health.ts
@@ -1,0 +1,33 @@
+import { vi } from "vitest";
+import type {
+  GoogleHealthPreview,
+  GoogleHealthStatus,
+  GoogleHealthReading,
+} from "$lib/api";
+import type { getGoogleHealthReadings as queryGoogleHealthReadings } from "$lib/api/generated/googleHealths.generated.remote";
+import { effectAwareQuery } from "./effect-aware-query.svelte";
+
+type ReadingsRequest = Parameters<typeof queryGoogleHealthReadings>[0];
+
+export const googleHealthMocks = {
+  status: vi.fn<() => Promise<GoogleHealthStatus>>(),
+  readings:
+    vi.fn<(request: ReadingsRequest) => Promise<GoogleHealthReading[]>>(),
+  save: vi.fn(),
+  start: vi.fn(),
+  disconnect: vi.fn(),
+  sync: vi.fn(),
+  purge: vi.fn(),
+  preview: vi.fn<() => Promise<GoogleHealthPreview>>(),
+};
+
+export const getGoogleHealth = () =>
+  effectAwareQuery(googleHealthMocks.status);
+export const getGoogleHealthReadings = (request: ReadingsRequest) =>
+  effectAwareQuery(() => googleHealthMocks.readings(request));
+export const saveGoogleHealth = googleHealthMocks.save;
+export const startGoogleHealth = googleHealthMocks.start;
+export const disconnectGoogleHealth = googleHealthMocks.disconnect;
+export const syncGoogleHealth = googleHealthMocks.sync;
+export const purgeGoogleHealth = googleHealthMocks.purge;
+export const previewGoogleHealth = googleHealthMocks.preview;

--- a/src/Web/packages/app/src/lib/test-stubs/year-overview-remote.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/year-overview-remote.ts
@@ -1,0 +1,23 @@
+import { vi } from "vitest";
+import type { DailySummaryDay } from "$api/generated/nocturne-api-client";
+import { effectAwareQuery } from "./effect-aware-query.svelte";
+
+export const yearOverviewMocks = {
+  years:
+    vi.fn<() => Promise<{ years: number[]; availableDataSources: string[] }>>(),
+  days: vi.fn<
+    (request: {
+      year: number;
+      dataSources?: string[];
+    }) => Promise<{ days: DailySummaryDay[] }>
+  >(),
+  gri: vi.fn<() => Promise<{ periods: [] }>>(),
+};
+
+export const getAvailableYears = () =>
+  effectAwareQuery(yearOverviewMocks.years);
+export const getDailySummary = (request: {
+  year: number;
+  dataSources?: string[];
+}) => effectAwareQuery(() => yearOverviewMocks.days(request));
+export const getGriTimeline = () => effectAwareQuery(yearOverviewMocks.gri);

--- a/src/Web/packages/app/src/lib/test-stubs/year-overview-runtime.svelte.ts
+++ b/src/Web/packages/app/src/lib/test-stubs/year-overview-runtime.svelte.ts
@@ -1,0 +1,18 @@
+import { vi } from "vitest";
+
+export const browser = true;
+export const building = false;
+export const goto = vi.fn();
+export const glucoseUnits = $state<{ current: "mg/dl" | "mmol" }>({
+  current: "mg/dl",
+});
+export const timeFormat = { current: "24h" };
+export const regionFormat = { current: "en-US" };
+export const preferredLanguage = { current: "en" };
+export const getDateParamsContext = () => ({});
+export const page = $state({
+  data: {
+    tenantSlug: "synthetic-tenant",
+    user: { subjectId: "synthetic-user" },
+  },
+});

--- a/src/Web/packages/app/src/lib/utils/chart-colors.test.ts
+++ b/src/Web/packages/app/src/lib/utils/chart-colors.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
 
 vi.mock("$app/environment", () => ({ browser: false, dev: false }));
 vi.mock("$app/navigation", () => ({}));
@@ -85,6 +86,12 @@ describe("getGlucoseHeatmapFill", () => {
     expect(getGlucoseHeatmapFill(85)).toBe(
       "color-mix(in srgb, var(--glucose-heatmap-3) 50.00%, var(--glucose-heatmap-4))"
     );
+  });
+
+  it("renders the complete very-low average range in black", () => {
+    const theme = readFileSync(new URL("../../../../ui/src/styles/nocturne-theme.css", import.meta.url), "utf8");
+    expect(theme).toMatch(/--glucose-heatmap-1:\s*#000000;/);
+    expect(theme).toMatch(/--glucose-heatmap-2:\s*#000000;/);
   });
 });
 

--- a/src/Web/packages/app/src/lib/utils/chart-colors.ts
+++ b/src/Web/packages/app/src/lib/utils/chart-colors.ts
@@ -2,7 +2,7 @@
  * Chart color utilities for resolving backend ChartColor enum values to CSS variables
  * ChartColor enum values are kebab-case strings that match CSS custom property names
  */
-import { type ChartColor } from '$lib/api';
+import type { ChartColor } from '$lib/api';
 
 /**
  * Resolve a ChartColor enum value to a CSS variable reference
@@ -133,17 +133,20 @@ export const GLUCOSE_HEATMAP_LEGEND_STOPS: ReadonlyArray<{ mgdl: number; color: 
  * variables: interpolation would have to read their computed values back out of
  * the document and re-read them on every theme change.
  */
-export function getGlucoseHeatmapFill(mgdl: number): string {
-	const upper = GLUCOSE_HEATMAP_STOPS.findIndex(([anchor]) => mgdl <= anchor);
+export function getGlucoseHeatmapFill(
+	mgdl: number,
+	stops = GLUCOSE_HEATMAP_LEGEND_STOPS
+): string {
+	const upper = stops.findIndex(({ mgdl: anchor }) => mgdl <= anchor);
 
 	// Above every anchor (no match) or at/below the first one — clamp to an end stop.
-	if (upper === -1) return `var(${GLUCOSE_HEATMAP_STOPS[GLUCOSE_HEATMAP_STOPS.length - 1][1]})`;
-	if (upper === 0) return `var(${GLUCOSE_HEATMAP_STOPS[0][1]})`;
+	if (upper === -1) return stops[stops.length - 1].color;
+	if (upper === 0) return stops[0].color;
 
-	const [loAnchor, loVar] = GLUCOSE_HEATMAP_STOPS[upper - 1];
-	const [hiAnchor, hiVar] = GLUCOSE_HEATMAP_STOPS[upper];
+	const { mgdl: loAnchor, color: loColor } = stops[upper - 1];
+	const { mgdl: hiAnchor, color: hiColor } = stops[upper];
 	const loShare = ((hiAnchor - mgdl) / (hiAnchor - loAnchor)) * 100;
-	return `color-mix(in srgb, var(${loVar}) ${loShare.toFixed(2)}%, var(${hiVar}))`;
+	return `color-mix(in srgb, ${loColor} ${loShare.toFixed(2)}%, ${hiColor})`;
 }
 
 /**

--- a/src/Web/packages/app/src/lib/utils/metric-color-focus.test.ts
+++ b/src/Web/packages/app/src/lib/utils/metric-color-focus.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import {
+  GLUCOSE_HEATMAP_LEGEND_STOPS,
+  getGlucoseHeatmapFill,
+} from "./chart-colors";
+import {
+  colorFocusGradient,
+  getFocusedIntensityFill,
+  parseColorFocusPreferences,
+  resolveColorFocusRange,
+  resolveGlucoseColorThresholds,
+  glucoseColorFocusStops,
+  type ColorFocusRange,
+} from "./metric-color-focus";
+
+const cssVar = "--chart-bolus";
+const focus = [10, 70] as const satisfies ColorFocusRange;
+
+function colorShare(fill: string): number {
+  const match = fill.match(/var\(--chart-bolus\) ([\d.]+)%/);
+  expect(match).not.toBeNull();
+  return Number(match![1]);
+}
+
+describe("resolveColorFocusRange", () => {
+  it("accepts increasing nonnegative bounds including decimals", () => {
+    expect(resolveColorFocusRange([0, 100])).toEqual([0, 100]);
+    expect(resolveColorFocusRange([10.5, 70.5])).toEqual([10.5, 70.5]);
+  });
+
+  it.each(
+    [
+      null,
+      undefined,
+      "10,70",
+      { min: 10, max: 70 },
+      [],
+      [10],
+      [10, 70, 100],
+      ["10", 70],
+      [10, "70"],
+      [-1, 70],
+      [10, 10],
+      [70, 10],
+      [NaN, 70],
+      [10, Infinity],
+      [-Infinity, 70],
+    ].map((candidate) => ({ candidate }))
+  )("rejects invalid range $candidate", ({ candidate }) => {
+    expect(resolveColorFocusRange(candidate)).toBeNull();
+  });
+});
+
+describe("resolveGlucoseColorThresholds", () => {
+  it("accepts four strictly increasing glucose boundaries", () => {
+    expect(resolveGlucoseColorThresholds([54, 70, 180, 250])).toEqual([
+      54, 70, 180, 250,
+    ]);
+  });
+
+  it.each(
+    [
+      null,
+      [54, 70, 180],
+      [54, 70, 70, 250],
+      [40, 70, 180, 250],
+      [54, 70, 180, 350],
+      [-1, 70, 180, 250],
+      [54, 70, 180, Infinity],
+      [54, "70", 180, 250],
+      [54, 70, 180, 170],
+    ].map((value) => ({ value }))
+  )("rejects invalid boundaries $value", ({ value }) =>
+    expect(resolveGlucoseColorThresholds(value)).toBeNull()
+  );
+});
+
+describe("glucoseColorFocusStops", () => {
+  it("preserves every original color when using the default boundaries", () => {
+    expect(glucoseColorFocusStops([54, 70, 180, 250])).toEqual(
+      GLUCOSE_HEATMAP_LEGEND_STOPS
+    );
+  });
+
+  it("moves palette anchors continuously and uses those same stops for cells", () => {
+    const stops = glucoseColorFocusStops([60, 100, 200, 280]);
+    expect(stops.find((stop) => stop.mgdl === 100)?.color).toBe(
+      "var(--glucose-heatmap-3)"
+    );
+    expect(stops.find((stop) => stop.mgdl === 200)?.color).toBe(
+      "var(--glucose-heatmap-6)"
+    );
+    expect(stops.some((stop) => stop.mgdl === 280)).toBe(true);
+    expect(
+      stops.every(
+        (stop, index) => index === 0 || stop.mgdl > stops[index - 1].mgdl
+      )
+    ).toBe(true);
+    expect(getGlucoseHeatmapFill(100 + (50 / 110) * 100, stops)).toBe(
+      getGlucoseHeatmapFill(120)
+    );
+    expect(getGlucoseHeatmapFill(-1, stops)).toBe("var(--glucose-heatmap-1)");
+    expect(getGlucoseHeatmapFill(500, stops)).toBe("var(--glucose-heatmap-9)");
+    expect(getGlucoseHeatmapFill(120, stops)).not.toBe(
+      getGlucoseHeatmapFill(120)
+    );
+  });
+});
+
+describe("getFocusedIntensityFill", () => {
+  it("clamps outliers to the selected endpoint colors", () => {
+    const low = getFocusedIntensityFill(10, focus, cssVar);
+    const high = getFocusedIntensityFill(70, focus, cssVar);
+
+    expect(getFocusedIntensityFill(0, focus, cssVar)).toBe(low);
+    expect(getFocusedIntensityFill(500, focus, cssVar)).toBe(high);
+    expect(colorShare(low)).toBe(15);
+    expect(colorShare(high)).toBe(100);
+  });
+
+  it("makes 20, 40 and 60 distinguishable despite an observed outlier of 500", () => {
+    const focused = [20, 40, 60].map((value) =>
+      colorShare(getFocusedIntensityFill(value, focus, cssVar))
+    );
+    const fullDomain = [20, 40, 60].map((value) =>
+      colorShare(getFocusedIntensityFill(value, [0, 500], cssVar))
+    );
+
+    expect(focused).toEqual([29, 58, 86]);
+    expect(focused[2] - focused[0]).toBeGreaterThan(
+      fullDomain[2] - fullDomain[0]
+    );
+  });
+
+  it("preserves the default zero-to-maximum scale and theme color", () => {
+    expect(getFocusedIntensityFill(0, [0, 500], cssVar)).toBe(
+      "color-mix(in srgb, var(--chart-bolus) 15%, transparent)"
+    );
+    expect(colorShare(getFocusedIntensityFill(250, [0, 500], cssVar))).toBe(58);
+    expect(colorShare(getFocusedIntensityFill(500, [0, 500], cssVar))).toBe(
+      100
+    );
+  });
+});
+
+describe("colorFocusGradient", () => {
+  it("uses the cell endpoint colors with flat ends outside the selected focus", () => {
+    const low = getFocusedIntensityFill(0, focus, cssVar);
+    const high = getFocusedIntensityFill(500, focus, cssVar);
+    const gradient = colorFocusGradient(focus, 500, cssVar);
+
+    expect(gradient).toContain(`${low} 0%, ${low} 2%`);
+    const highStop = gradient
+      .slice(gradient.indexOf(high) + high.length)
+      .match(/^ ([\d.]+)%/);
+    expect(Number(highStop?.[1])).toBeCloseTo(14);
+    expect(gradient).toContain(`${high} 100%)`);
+    expect(gradient).toMatch(/^linear-gradient\(to right,/);
+  });
+
+  it("keeps the selected maximum in the legend when observed values decrease", () => {
+    const high = getFocusedIntensityFill(70, focus, cssVar);
+
+    expect(colorFocusGradient(focus, 20, cssVar)).toContain(
+      `${high} 100%, ${high} 100%`
+    );
+  });
+});
+
+describe("parseColorFocusPreferences", () => {
+  it("restores independent ranges for supported metrics", () => {
+    const preferences = {
+      avgGlucose: [54, 70, 180, 250],
+      tir: [70, 100],
+      bolus: [10, 70],
+      basal: [0, 20],
+      tdd: [10, 100],
+      carbs: [0, 500],
+    };
+
+    expect(parseColorFocusPreferences(JSON.stringify(preferences))).toEqual(
+      preferences
+    );
+  });
+
+  it.each([null, "", "{", "null", "false", "42", '"text"', "[]"])(
+    "ignores missing or malformed storage %j",
+    (raw) => {
+      expect(parseColorFocusPreferences(raw)).toEqual({});
+    }
+  );
+
+  it("discards invalid and unknown entries without losing valid preferences", () => {
+    expect(
+      parseColorFocusPreferences(
+        JSON.stringify({
+          tir: [70, 101],
+          bolus: [10, 70],
+          basal: [-1, 20],
+          tdd: [100, 10],
+          carbs: ["0", 500],
+          avgGlucose: [70, 180],
+          unknown: [0, 100],
+        })
+      )
+    ).toEqual({ bolus: [10, 70] });
+  });
+});

--- a/src/Web/packages/app/src/lib/utils/metric-color-focus.ts
+++ b/src/Web/packages/app/src/lib/utils/metric-color-focus.ts
@@ -1,0 +1,151 @@
+import {
+  GLUCOSE_HEATMAP_LEGEND_STOPS,
+  getGlucoseHeatmapFill,
+} from "./chart-colors";
+
+export type ColorFocusRange = readonly [number, number];
+export type GlucoseColorThresholds = readonly [number, number, number, number];
+export const DEFAULT_GLUCOSE_COLOR_THRESHOLDS: GlucoseColorThresholds = [
+  54, 70, 180, 250,
+];
+export const GLUCOSE_COLOR_MIN = GLUCOSE_HEATMAP_LEGEND_STOPS[0].mgdl;
+export const GLUCOSE_COLOR_MAX = GLUCOSE_HEATMAP_LEGEND_STOPS.at(-1)!.mgdl;
+
+export const COLOR_FOCUS_METRICS = [
+  "tir",
+  "bolus",
+  "basal",
+  "tdd",
+  "carbs",
+] as const;
+export type ColorFocusMetric = (typeof COLOR_FOCUS_METRICS)[number];
+export type ColorFocusPreferences = Partial<
+  Record<ColorFocusMetric, ColorFocusRange>
+> & { avgGlucose?: GlucoseColorThresholds };
+
+export function resolveGlucoseColorThresholds(
+  candidate: unknown
+): GlucoseColorThresholds | null {
+  if (!Array.isArray(candidate) || candidate.length !== 4) return null;
+  if (
+    !candidate.every(
+      (value) => typeof value === "number" && Number.isFinite(value)
+    )
+  )
+    return null;
+  const [a, b, c, d] = candidate;
+  return a > GLUCOSE_COLOR_MIN &&
+    a < b &&
+    b < c &&
+    c < d &&
+    d < GLUCOSE_COLOR_MAX
+    ? [a, b, c, d]
+    : null;
+}
+
+// Keep the theme's continuous heatmap palette while moving its four color boundaries.
+export function glucoseColorFocusStops(candidate: GlucoseColorThresholds) {
+  const thresholds =
+    resolveGlucoseColorThresholds(candidate) ??
+    DEFAULT_GLUCOSE_COLOR_THRESHOLDS;
+  if (
+    thresholds.every(
+      (value, index) => value === DEFAULT_GLUCOSE_COLOR_THRESHOLDS[index]
+    )
+  )
+    return GLUCOSE_HEATMAP_LEGEND_STOPS;
+  const source = [
+    GLUCOSE_COLOR_MIN,
+    ...DEFAULT_GLUCOSE_COLOR_THRESHOLDS,
+    GLUCOSE_COLOR_MAX,
+  ];
+  const target = [GLUCOSE_COLOR_MIN, ...thresholds, GLUCOSE_COLOR_MAX];
+  // A boundary inside an existing color segment must split that segment in the legend too.
+  const anchors = [
+    ...new Set([
+      ...GLUCOSE_HEATMAP_LEGEND_STOPS.map((stop) => stop.mgdl),
+      ...source,
+    ]),
+  ].sort((a, b) => a - b);
+  return anchors.map((anchor) => {
+    const upper = Math.max(
+      1,
+      source.findIndex((value) => anchor <= value)
+    );
+    const fraction =
+      (anchor - source[upper - 1]) / (source[upper] - source[upper - 1]);
+    return {
+      mgdl: target[upper - 1] + fraction * (target[upper] - target[upper - 1]),
+      color:
+        GLUCOSE_HEATMAP_LEGEND_STOPS.find((stop) => stop.mgdl === anchor)
+          ?.color ?? getGlucoseHeatmapFill(anchor),
+    };
+  });
+}
+
+export function resolveColorFocusRange(
+  candidate: unknown
+): ColorFocusRange | null {
+  if (!Array.isArray(candidate) || candidate.length !== 2) return null;
+  const [min, max] = candidate;
+  return typeof min === "number" &&
+    typeof max === "number" &&
+    Number.isFinite(min) &&
+    Number.isFinite(max) &&
+    min >= 0 &&
+    max > min
+    ? [min, max]
+    : null;
+}
+
+export function parseColorFocusPreferences(
+  raw: string | null
+): ColorFocusPreferences {
+  try {
+    const parsed: unknown = JSON.parse(raw ?? "null");
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      return {};
+    const preferences: ColorFocusPreferences = {};
+    for (const metric of COLOR_FOCUS_METRICS) {
+      const range = resolveColorFocusRange(
+        (parsed as Record<string, unknown>)[metric]
+      );
+      if (range && (metric !== "tir" || range[1] <= 100))
+        preferences[metric] = range;
+    }
+    const glucose = resolveGlucoseColorThresholds(
+      (parsed as Record<string, unknown>).avgGlucose
+    );
+    if (glucose) preferences.avgGlucose = glucose;
+    return preferences;
+  } catch {
+    return {};
+  }
+}
+
+export function getFocusedIntensityFill(
+  value: number,
+  range: ColorFocusRange,
+  cssVar: string
+): string {
+  const [min, max] = resolveColorFocusRange(range) ?? [0, 1];
+  const intensity = Number.isFinite(value)
+    ? Math.max(0, Math.min((value - min) / (max - min), 1))
+    : 0;
+  return `color-mix(in srgb, var(${cssVar}) ${Math.round(15 + intensity * 85)}%, transparent)`;
+}
+
+export function colorFocusGradient(
+  range: ColorFocusRange,
+  domainMax: number,
+  cssVar: string
+): string {
+  const validRange = resolveColorFocusRange(range) ?? [0, 1];
+  const domain = Math.max(
+    Number.isFinite(domainMax) ? domainMax : 1,
+    validRange[1]
+  );
+  const low = getFocusedIntensityFill(validRange[0], validRange, cssVar);
+  const high = getFocusedIntensityFill(validRange[1], validRange, cssVar);
+  return `linear-gradient(to right, ${low} 0%, ${low} ${(validRange[0] / domain) * 100}%, ${high} ${(validRange[1] / domain) * 100}%, ${high} 100%)`;
+}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { browser } from "$app/environment";
+  import { page } from "$app/state";
   import { Loader2, CalendarDays } from "lucide-svelte";
   import { scaleThreshold } from "d3-scale";
   import { Button } from "$lib/components/ui/button";
@@ -19,11 +20,19 @@
     GriTimelinePeriod,
   } from "$api/generated/nocturne-api-client";
   import { formatLongDate, getUnitLabel } from "$lib/utils/formatting";
-  import {
-    GLUCOSE_HEATMAP_LEGEND_STOPS,
-    getGlucoseHeatmapFill,
-  } from "$lib/utils/chart-colors";
+  import { getGlucoseHeatmapFill } from "$lib/utils/chart-colors";
   import { glucoseUnits } from "$lib/stores/appearance-store.svelte";
+  import {
+    getFocusedIntensityFill,
+    parseColorFocusPreferences,
+    resolveColorFocusRange,
+    resolveGlucoseColorThresholds,
+    DEFAULT_GLUCOSE_COLOR_THRESHOLDS,
+    glucoseColorFocusStops,
+    type ColorFocusPreferences,
+    type ColorFocusRange,
+    type GlucoseColorThresholds,
+  } from "$lib/utils/metric-color-focus";
   import { getDateParamsContext } from "$lib/hooks/date-params.svelte";
   import { onMount, untrack, tick } from "svelte";
   import { fade } from "svelte/transition";
@@ -64,6 +73,71 @@
   ];
 
   let selectedMetric = $state<HeatmapMetric>("avgGlucose");
+  let colorFocusPreferences = $state<ColorFocusPreferences>({});
+  let loadedColorFocusKey = $state<string | null>(null);
+  let colorFocusStorageFailed = $state(false);
+  const colorFocusStorageKey = $derived(
+    `nocturne-year-color-focus-v1:${JSON.stringify([page.data.tenantSlug ?? null, page.data.user?.subjectId ?? null])}`
+  );
+  const focusRange = $derived(
+    selectedMetric === "avgGlucose"
+      ? null
+      : (colorFocusPreferences[selectedMetric] ?? null)
+  );
+  const glucoseThresholds = $derived(
+    colorFocusPreferences.avgGlucose ?? DEFAULT_GLUCOSE_COLOR_THRESHOLDS
+  );
+  const glucoseLegendStops = $derived(
+    glucoseColorFocusStops(glucoseThresholds)
+  );
+
+  function saveColorPreferences(next: ColorFocusPreferences) {
+    colorFocusPreferences = next;
+    try {
+      if (loadedColorFocusKey !== colorFocusStorageKey) return;
+      window.localStorage.setItem(colorFocusStorageKey, JSON.stringify(next));
+      colorFocusStorageFailed = false;
+    } catch {
+      colorFocusStorageFailed = true;
+    }
+  }
+
+  function setFocusRange(candidate: ColorFocusRange | null) {
+    if (selectedMetric === "avgGlucose") return;
+    const range = resolveColorFocusRange(candidate);
+    if (
+      candidate !== null &&
+      (!range || (selectedMetric === "tir" && range[1] > 100))
+    )
+      return;
+    const next = { ...colorFocusPreferences };
+    if (range) next[selectedMetric] = range;
+    else delete next[selectedMetric];
+    saveColorPreferences(next);
+  }
+
+  function setGlucoseThresholds(candidate: GlucoseColorThresholds | null) {
+    const thresholds = resolveGlucoseColorThresholds(candidate);
+    if (candidate !== null && !thresholds) return;
+    const next = { ...colorFocusPreferences };
+    if (thresholds) next.avgGlucose = thresholds;
+    else delete next.avgGlucose;
+    saveColorPreferences(next);
+  }
+
+  $effect(() => {
+    const key = colorFocusStorageKey;
+    try {
+      colorFocusPreferences = parseColorFocusPreferences(
+        window.localStorage.getItem(key)
+      );
+      colorFocusStorageFailed = false;
+    } catch {
+      colorFocusPreferences = {};
+      colorFocusStorageFailed = true;
+    }
+    loadedColorFocusKey = key;
+  });
 
   /** All known data types that can appear in counts */
   const ALL_DATA_TYPES = [
@@ -97,18 +171,6 @@
       "var(--glucose-high)",
       "var(--glucose-very-high)",
     ]);
-
-  // Ends of the heatmap ramp, which the legend maps onto its gradient bar.
-  const HEATMAP_MIN = GLUCOSE_HEATMAP_LEGEND_STOPS[0].mgdl;
-  const HEATMAP_MAX =
-    GLUCOSE_HEATMAP_LEGEND_STOPS[GLUCOSE_HEATMAP_LEGEND_STOPS.length - 1].mgdl;
-
-  const LEGEND_W = 420;
-  const LEGEND_THRESHOLDS = [70, 180, 250];
-
-  function legendX(mgdl: number): number {
-    return ((mgdl - HEATMAP_MIN) / (HEATMAP_MAX - HEATMAP_MIN)) * LEGEND_W;
-  }
 
   /** CSS variable names for each metric's hue */
   const METRIC_CSS_VARS: Record<
@@ -148,7 +210,7 @@
             val = day.averageGlucoseMgdl;
             break;
         }
-        if (val != null && val > max) max = val;
+        if (val != null && Number.isFinite(val) && val > max) max = val;
       }
     }
     return max || 1;
@@ -184,36 +246,29 @@
     }
   }
 
-  function getIntensityFill(
-    value: number,
-    maxVal: number,
-    cssVarName: string
-  ): string {
-    const intensity = Math.min(value / maxVal, 1);
-    // Scale from 15% opacity (min visible) to 100%
-    const alpha = 0.15 + intensity * 0.85;
-    return `color-mix(in srgb, var(${cssVarName}) ${Math.round(alpha * 100)}%, transparent)`;
-  }
-
   function getCellFill(data: CalendarDatum | undefined): string {
     if (!data) return "rgb(0 0 0 / 5%)";
 
     if (selectedMetric === "avgGlucose") {
-      if (data.value != null) return getGlucoseHeatmapFill(data.value);
+      if (data.value != null && Number.isFinite(data.value))
+        return getGlucoseHeatmapFill(data.value, glucoseLegendStops);
       if (data.filteredCount > 0) return "var(--muted)";
       return "rgb(0 0 0 / 5%)";
     }
 
     const metricValue = getMetricCellValue(data);
-    if (metricValue == null) {
+    if (metricValue == null || !Number.isFinite(metricValue)) {
       if (data.filteredCount > 0) return "var(--muted)";
       return "rgb(0 0 0 / 5%)";
     }
 
-    const maxVal = metricMaxCached;
     const cssVar =
       METRIC_CSS_VARS[selectedMetric as Exclude<HeatmapMetric, "avgGlucose">];
-    return getIntensityFill(metricValue, maxVal, cssVar);
+    return getFocusedIntensityFill(
+      metricValue,
+      focusRange ?? [0, metricMaxCached],
+      cssVar
+    );
   }
 
   // =========================================================================
@@ -565,13 +620,22 @@
       bind:selectedMetric
       {units}
       {METRIC_OPTIONS}
-      HEATMAP_STOPS={GLUCOSE_HEATMAP_LEGEND_STOPS}
-      {LEGEND_W}
-      {LEGEND_THRESHOLDS}
-      {legendX}
+      HEATMAP_STOPS={glucoseLegendStops}
       {METRIC_CSS_VARS}
       {getMetricMax}
+      {focusRange}
+      onFocusRangeChange={setFocusRange}
+      {glucoseThresholds}
+      onGlucoseThresholdsChange={setGlucoseThresholds}
     />
+    <p
+      class="-mt-4 mb-6 text-xs text-muted-foreground print:hidden"
+      role={colorFocusStorageFailed ? "status" : undefined}
+    >
+      {colorFocusStorageFailed
+        ? "This browser could not save the color settings. Changes apply only until you leave this page."
+        : "Color settings are remembered per metric in this browser."}
+    </p>
 
     <!-- Loading state for metadata -->
     {#if metadataLoading && !metadataLoaded}

--- a/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/year-color-focus.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/reports/year-overview/year-color-focus.svelte.test.ts
@@ -1,0 +1,374 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page, userEvent } from "vitest/browser";
+import type { DailySummaryDay } from "$api/generated/nocturne-api-client";
+import { yearOverviewMocks } from "$lib/test-stubs/year-overview-remote";
+import {
+  page as applicationPage,
+  glucoseUnits,
+} from "$lib/test-stubs/year-overview-runtime.svelte";
+import { getGlucoseHeatmapFill } from "$lib/utils/chart-colors";
+import { glucoseColorFocusStops } from "$lib/utils/metric-color-focus";
+import YearOverviewPage from "./+page.svelte";
+
+const storageKey = (user = "synthetic-user") =>
+  `nocturne-year-color-focus-v1:${JSON.stringify(["synthetic-tenant", user])}`;
+const minimum = (metric = "TDD") =>
+  page.getByRole("spinbutton", { name: `${metric} minimum color value` });
+const maximum = (metric = "TDD") =>
+  page.getByRole("spinbutton", { name: `${metric} maximum color value` });
+const cell = (day: string) => page.getByTestId(`cell-${day}`);
+const observedYears = new Map<number, () => void>();
+const bgInput = (name = "High") =>
+  page.getByRole("spinbutton", {
+    name: `Average glucose ${name} color boundary`,
+    exact: true,
+  });
+const bgSlider = (name = "High") =>
+  page.getByRole("slider", {
+    name: `Average glucose ${name} color boundary`,
+    exact: true,
+  });
+
+function day(date: string, dose: number | null): DailySummaryDay {
+  return {
+    date,
+    averageGlucoseMgdl: 120,
+    totalCount: 1,
+    counts: { Glucose: 1 },
+    totalDailyDose: dose,
+    totalBolusUnits: dose,
+    timeInRangePercent: 75,
+  };
+}
+
+async function selectMetric(name: string) {
+  await page
+    .getByRole("button", {
+      name: /^(Avg Glucose|Time in Range|Bolus|Basal|TDD|Carbs)$/,
+    })
+    .click();
+  await page.getByRole("option", { name, exact: true }).click();
+}
+
+async function setRange(min: number, max: number, metric = "TDD") {
+  await minimum(metric).fill(String(min));
+  await maximum(metric).fill(String(max));
+}
+
+describe("year overview page color focus integration", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    window.localStorage.clear();
+    applicationPage.data.user.subjectId = "synthetic-user";
+    glucoseUnits.current = "mg/dl";
+    observedYears.clear();
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        private observed = new Map<number, () => void>();
+        constructor(private callback: IntersectionObserverCallback) {}
+        observe(target: HTMLElement) {
+          const year = Number(target.dataset.year);
+          const intersect = () => {
+            this.callback(
+              [{ target, isIntersecting: true } as IntersectionObserverEntry],
+              this as unknown as IntersectionObserver
+            );
+          };
+          this.observed.set(year, intersect);
+          observedYears.set(year, intersect);
+        }
+        disconnect() {
+          for (const [year, callback] of this.observed) {
+            if (observedYears.get(year) === callback)
+              observedYears.delete(year);
+          }
+          this.observed.clear();
+        }
+      }
+    );
+    yearOverviewMocks.years.mockResolvedValue({
+      years: [2026],
+      availableDataSources: [],
+    });
+    yearOverviewMocks.days.mockResolvedValue({
+      days: [
+        day("2026-01-01", 20),
+        day("2026-01-02", 40),
+        day("2026-01-03", 60),
+        day("2026-01-04", 500),
+      ],
+    });
+    yearOverviewMocks.gri.mockResolvedValue({ periods: [] });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("remembers independent metric limits across switches and a page remount", async () => {
+    const screen = render(YearOverviewPage);
+    await expect.element(cell("2026-01-04")).toBeInTheDocument();
+    await selectMetric("TDD");
+    await setRange(10, 70);
+    await expect
+      .element(cell("2026-01-02"))
+      .toHaveTextContent("var(--chart-4) 58%");
+
+    await selectMetric("Bolus");
+    await setRange(2, 25, "Bolus");
+    await selectMetric("TDD");
+    await expect.element(minimum()).toHaveValue(10);
+    await expect.element(maximum()).toHaveValue(70);
+    expect(JSON.parse(window.localStorage.getItem(storageKey())!)).toEqual({
+      tdd: [10, 70],
+      bolus: [2, 25],
+    });
+
+    await screen.unmount();
+    render(YearOverviewPage);
+    await selectMetric("TDD");
+    await expect.element(minimum()).toHaveValue(10);
+    await expect.element(maximum()).toHaveValue(70);
+    await selectMetric("Bolus");
+    await expect.element(minimum("Bolus")).toHaveValue(2);
+    await expect.element(maximum("Bolus")).toHaveValue(25);
+    await page
+      .getByRole("button", { name: "Reset Bolus color range to automatic" })
+      .click();
+    expect(JSON.parse(window.localStorage.getItem(storageKey())!)).toEqual({
+      tdd: [10, 70],
+    });
+  });
+
+  it("keeps a saved manual focus when lazy loading introduces a larger outlier", async () => {
+    window.localStorage.setItem(
+      storageKey(),
+      JSON.stringify({ tdd: [10, 70] })
+    );
+    yearOverviewMocks.years.mockResolvedValue({
+      years: [2026, 2025],
+      availableDataSources: [],
+    });
+    const olderYear = Promise.withResolvers<{ days: DailySummaryDay[] }>();
+    yearOverviewMocks.days.mockImplementation(({ year }) =>
+      year === 2026
+        ? Promise.resolve({
+            days: [day("2026-01-01", 40), day("2026-01-02", 70)],
+          })
+        : olderYear.promise
+    );
+    render(YearOverviewPage);
+    await expect.element(cell("2026-01-01")).toBeInTheDocument();
+    await selectMetric("TDD");
+    await expect
+      .element(cell("2026-01-01"))
+      .toHaveTextContent("var(--chart-4) 58%");
+    await vi.waitFor(() => expect(observedYears.has(2025)).toBe(true));
+    observedYears.get(2025)!();
+    await vi.waitFor(() =>
+      expect(yearOverviewMocks.days).toHaveBeenCalledWith({ year: 2025 })
+    );
+    olderYear.resolve({ days: [day("2025-01-01", 1000)] });
+    await expect
+      .element(cell("2025-01-01"))
+      .toHaveTextContent("var(--chart-4) 100%");
+    await expect
+      .element(cell("2026-01-01"))
+      .toHaveTextContent("var(--chart-4) 58%");
+    await expect.element(minimum()).toHaveValue(10);
+    await expect.element(maximum()).toHaveValue(70);
+    await expect
+      .element(page.getByRole("slider", { name: "TDD maximum color value" }))
+      .toHaveAttribute("aria-valuemax", "1000");
+
+    await page
+      .getByRole("button", { name: "Reset TDD color range to automatic" })
+      .click();
+    await expect.element(maximum()).toHaveValue(1000);
+    await expect
+      .element(cell("2026-01-01"))
+      .toHaveTextContent("var(--chart-4) 18%");
+  });
+
+  it("saturates outliers without treating missing readings as zero or changing glucose colors", async () => {
+    yearOverviewMocks.days.mockResolvedValue({
+      days: [
+        day("2026-01-01", null),
+        day("2026-01-02", 0),
+        day("2026-01-03", 10),
+        day("2026-01-04", 70),
+        day("2026-01-05", 500),
+      ],
+    });
+    render(YearOverviewPage);
+    await expect
+      .element(cell("2026-01-01"))
+      .toHaveTextContent(getGlucoseHeatmapFill(120));
+    expect(page.getByRole("slider").elements()).toHaveLength(4);
+    await selectMetric("TDD");
+    await setRange(10, 70);
+    await expect.element(cell("2026-01-01")).toHaveTextContent("var(--muted)");
+    await expect
+      .element(cell("2026-01-02"))
+      .toHaveTextContent("var(--chart-4) 15%");
+    await expect
+      .element(cell("2026-01-03"))
+      .toHaveTextContent("var(--chart-4) 15%");
+    await expect
+      .element(cell("2026-01-04"))
+      .toHaveTextContent("var(--chart-4) 100%");
+    await expect
+      .element(cell("2026-01-05"))
+      .toHaveTextContent("var(--chart-4) 100%");
+
+    await selectMetric("Avg Glucose");
+    expect(page.getByRole("slider").elements()).toHaveLength(4);
+    await expect
+      .element(cell("2026-01-01"))
+      .toHaveTextContent(getGlucoseHeatmapFill(120));
+  });
+
+  it("keeps the control usable and reports when browser storage cannot save", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Blocked", "SecurityError");
+    });
+    render(YearOverviewPage);
+    await expect.element(cell("2026-01-02")).toBeInTheDocument();
+    await selectMetric("TDD");
+    await setRange(10, 70);
+    await expect
+      .element(page.getByRole("status"))
+      .toHaveTextContent("This browser could not save the color settings");
+    await expect
+      .element(cell("2026-01-02"))
+      .toHaveTextContent("var(--chart-4) 58%");
+    await selectMetric("Bolus");
+    await selectMetric("TDD");
+    await expect.element(minimum()).toHaveValue(10);
+    await expect.element(maximum()).toHaveValue(70);
+  });
+
+  it("keeps four BG color boundaries across metric, unit and page changes, then resets only BG", async () => {
+    const screen = render(YearOverviewPage);
+    await expect
+      .element(cell("2026-01-01"))
+      .toHaveTextContent(getGlucoseHeatmapFill(120));
+    expect(page.getByRole("slider").elements()).toHaveLength(4);
+    await bgInput("High").fill("140");
+    const expected = [54, 70, 140, 250] as const;
+    await expect
+      .element(cell("2026-01-01"))
+      .toHaveTextContent(
+        getGlucoseHeatmapFill(120, glucoseColorFocusStops(expected))
+      );
+    const stored = JSON.parse(window.localStorage.getItem(storageKey())!);
+    expect(stored.avgGlucose).toEqual(expected);
+
+    glucoseUnits.current = "mmol";
+    await expect.element(bgInput("High")).toHaveValue(7.8);
+    expect(
+      JSON.parse(window.localStorage.getItem(storageKey())!).avgGlucose
+    ).toEqual(expected);
+    glucoseUnits.current = "mg/dl";
+    await selectMetric("TDD");
+    await setRange(10, 70);
+    await selectMetric("Avg Glucose");
+    await expect.element(bgInput("High")).toHaveValue(140);
+    await screen.unmount();
+    render(YearOverviewPage);
+    await expect.element(bgInput("High")).toHaveValue(140);
+    await page
+      .getByRole("button", { name: "Reset average glucose color boundaries" })
+      .click();
+    await expect.element(bgInput("High")).toHaveValue(180);
+    expect(JSON.parse(window.localStorage.getItem(storageKey())!)).toEqual({
+      tdd: [10, 70],
+    });
+    await expect
+      .element(cell("2026-01-01"))
+      .toHaveTextContent(getGlucoseHeatmapFill(120));
+  });
+
+  it("rejects crossing and empty BG inputs and moves a boundary with the keyboard", async () => {
+    render(YearOverviewPage);
+    await expect.element(bgInput("Low")).toHaveValue(70);
+    for (const invalid of ["", "54", "200", "-1"]) {
+      await bgInput("Low").fill(invalid);
+      await expect
+        .element(bgInput("Low"))
+        .toHaveAttribute("aria-invalid", "true");
+      expect(window.localStorage.getItem(storageKey())).toBeNull();
+    }
+    await bgInput("Low").fill("100");
+    (bgSlider("Low").element() as HTMLElement).focus();
+    await userEvent.keyboard("{ArrowRight}");
+    await expect.element(bgInput("Low")).toHaveValue(101);
+    await userEvent.keyboard("{End}");
+    const saved = JSON.parse(
+      window.localStorage.getItem(storageKey())!
+    ).avgGlucose;
+    expect(saved[1]).toBeLessThan(saved[2]);
+  });
+
+  it("edits BG in mmol and restores canonical mg/dL without changing other boundaries", async () => {
+    glucoseUnits.current = "mmol";
+    render(YearOverviewPage);
+    await expect.element(bgInput("High")).toHaveValue(10);
+    await bgInput("High").fill("8");
+    expect(
+      JSON.parse(window.localStorage.getItem(storageKey())!).avgGlucose
+    ).toEqual([54, 70, 144, 250]);
+    glucoseUnits.current = "mg/dl";
+    await expect.element(bgInput("High")).toHaveValue(144);
+  });
+
+  it("drags a BG boundary on the mobile gradient without overflowing the page", async () => {
+    const originalSize = [window.innerWidth, window.innerHeight] as const;
+    await page.viewport(390, 800);
+    try {
+      const { container } = render(YearOverviewPage);
+      await expect.element(bgInput("High")).toHaveValue(180);
+      const track = container.querySelector<HTMLElement>("[data-glucose-color-track]")!;
+      const bounds = track.getBoundingClientRect();
+      expect(bounds.width).toBeGreaterThan(300);
+      const originalGradient = track.style.background;
+      await userEvent.dragAndDrop(bgSlider("High"), track, {
+        targetPosition: { x: bounds.width * 0.6, y: bounds.height / 2 },
+      });
+      const value = (bgInput("High").element() as HTMLInputElement).valueAsNumber;
+      expect(value).toBeGreaterThan(224);
+      expect(value).toBeLessThan(228);
+      await expect.element(bgInput("Very high")).toHaveValue(250);
+      expect(track.style.background).not.toBe(originalGradient);
+      expect(container.querySelector<HTMLElement>(".glucose-color-focus")!.getBoundingClientRect().right).toBeLessThanOrEqual(390);
+      await page.screenshot({ path: "test-results/bg-color-focus-mobile.png" });
+    } finally {
+      await page.viewport(originalSize[0], originalSize[1]);
+    }
+  });
+
+  it("does not restore another user's saved focus on the same browser", async () => {
+    window.localStorage.setItem(
+      storageKey(),
+      JSON.stringify({ tdd: [10, 70] })
+    );
+    applicationPage.data.user.subjectId = "another-synthetic-user";
+    render(YearOverviewPage);
+    await expect.element(cell("2026-01-04")).toBeInTheDocument();
+    await selectMetric("TDD");
+    await expect.element(minimum()).toHaveValue(0);
+    await expect.element(maximum()).toHaveValue(500);
+    await setRange(20, 60);
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(storageKey("another-synthetic-user"))!
+      )
+    ).toEqual({ tdd: [20, 60] });
+    expect(JSON.parse(window.localStorage.getItem(storageKey())!)).toEqual({
+      tdd: [10, 70],
+    });
+  });
+});

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getStatus as getConnectorStatuses } from "$api/generated/connectorStatus.generated.remote";
+  import { getGoogleHealth } from "$api/generated/googleHealths.generated.remote";
   import {
     getServicesOverview,
     getConnectorCapabilities,
@@ -41,6 +42,7 @@
   } from "lucide-svelte";
   import SettingsPageSkeleton from "$lib/components/settings/SettingsPageSkeleton.svelte";
   import DataSourceRow from "$lib/components/settings/DataSourceRow.svelte";
+  import GoogleHealthSourceRow from "$lib/components/connectors/GoogleHealthSourceRow.svelte";
   import type { DataSourceStatus } from "$lib/components/settings/DataSourceRow.svelte";
   import ConnectedApps from "$lib/components/settings/ConnectedApps.svelte";
   import ClientDevices from "$lib/components/settings/ClientDevices.svelte";
@@ -50,10 +52,14 @@
   import UploaderSetupDialog from "$lib/components/connectors/UploaderSetupDialog.svelte";
   import { createUploaderTokenHandoff } from "./uploader-token-handoff";
   import ConnectorDetailsDialog from "$lib/components/connectors/ConnectorDetailsDialog.svelte";
-  import ManualSyncDialog, { type BatchSyncResult } from "$lib/components/connectors/ManualSyncDialog.svelte";
+  import ManualSyncDialog, {
+    type BatchSyncResult,
+  } from "$lib/components/connectors/ManualSyncDialog.svelte";
   import DemoDataSection from "$lib/components/connectors/DemoDataSection.svelte";
   import UploaderAppsCard from "$lib/components/connectors/UploaderAppsCard.svelte";
-  import ServerConnectorsCard, { type ConnectorStatusWithDescription } from "$lib/components/connectors/ServerConnectorsCard.svelte";
+  import ServerConnectorsCard, {
+    type ConnectorStatusWithDescription,
+  } from "$lib/components/connectors/ServerConnectorsCard.svelte";
   import DataSourceManageDialog from "$lib/components/connectors/DataSourceManageDialog.svelte";
   import { describeSubmitError } from "$lib/forms/submit-error";
   import { resolve } from "$app/paths";
@@ -65,27 +71,29 @@
   import { copyToClipboard } from "$lib/utils";
   import { createTerminalRunTracker } from "./terminal-run-tracker";
 
-  const isPlatformAdmin = $derived((page.data as { isPlatformAdmin?: boolean }).isPlatformAdmin ?? false);
+  const isPlatformAdmin = $derived(
+    (page.data as { isPlatformAdmin?: boolean }).isPlatformAdmin ?? false
+  );
 
   // Queries — fire on the server during SSR; results land in cache for hydration.
   const servicesOverviewQuery = getServicesOverview();
   const connectorStatusesQuery = getConnectorStatuses();
+  const googleHealthQuery = getGoogleHealth();
 
   const servicesOverview = $derived<ServicesOverview | null>(
-    servicesOverviewQuery.current ?? null,
+    servicesOverviewQuery.current ?? null
   );
   const connectorStatuses = $derived<ConnectorStatusDto[]>(
-    connectorStatusesQuery.current ?? [],
+    connectorStatusesQuery.current ?? []
   );
-  const isLoading = $derived(
-    servicesOverviewQuery.current === undefined,
-  );
+  const googleHealth = $derived(googleHealthQuery.current ?? null);
+  const isLoading = $derived(servicesOverviewQuery.current === undefined);
   const isLoadingConnectorStatuses = $derived(
-    connectorStatusesQuery.current === undefined,
+    connectorStatusesQuery.current === undefined
   );
 
   const error = $derived<string | null>(
-    !isLoading && !servicesOverview ? "Failed to load services" : null,
+    !isLoading && !servicesOverview ? "Failed to load services" : null
   );
   let selectedUploader = $state<UploaderApp | null>(null);
   let showSetupDialog = $state(false);
@@ -105,7 +113,9 @@
 
   // Connector heartbeat metrics state
   let selectedConnector = $state<ConnectorStatusWithDescription | null>(null);
-  let selectedConnectorCapabilities = $state<ConnectorCapabilities | null>(null);
+  let selectedConnectorCapabilities = $state<ConnectorCapabilities | null>(
+    null
+  );
   // Capability descriptors per connector, keyed by connector id.
   const connectorCapabilitiesById = $derived.by(() => {
     const overview = servicesOverviewQuery.current;
@@ -184,7 +194,8 @@
   async function refreshAll() {
     await refreshQuietly(
       () => servicesOverviewQuery.refresh(),
-      () => connectorStatusesQuery.refresh()
+      () => connectorStatusesQuery.refresh(),
+      () => googleHealthQuery.refresh()
     );
   }
 
@@ -193,7 +204,10 @@
   }
 
   async function loadConnectorStatuses() {
-    await refreshQuietly(() => connectorStatusesQuery.refresh());
+    await refreshQuietly(
+      () => connectorStatusesQuery.refresh(),
+      () => googleHealthQuery.refresh()
+    );
   }
 
   async function loadConnectorCapabilitiesFor(connectorId?: string) {
@@ -202,7 +216,8 @@
       return;
     }
     try {
-      selectedConnectorCapabilities = await getConnectorCapabilities(connectorId).run();
+      selectedConnectorCapabilities =
+        await getConnectorCapabilities(connectorId).run();
     } catch (e) {
       console.error("Failed to load connector capabilities", e);
       selectedConnectorCapabilities = null;
@@ -229,7 +244,9 @@
     showManualSyncDialog = true;
 
     const startTime = new Date();
-    const connectorsToSync = connectorStatuses.filter((c) => c.isEnabled !== false);
+    const connectorsToSync = connectorStatuses.filter(
+      (c) => c.isEnabled !== false
+    );
     const results: BatchSyncResult["connectorResults"] = [];
     let successes = 0;
 
@@ -247,7 +264,10 @@
         let errorMsg = undefined;
 
         try {
-          const result = await triggerConnectorSync({ id: connectorId, request });
+          const result = await triggerConnectorSync({
+            id: connectorId,
+            request,
+          });
           success = result.success ?? false;
           if (!success) errorMsg = result.message || "Unknown error";
         } catch (e) {
@@ -307,7 +327,10 @@
 
     quickSyncingById = { ...quickSyncingById, [connectorId]: true };
     try {
-      const result = await triggerConnectorSync({ id: connectorId, request: {} });
+      const result = await triggerConnectorSync({
+        id: connectorId,
+        request: {},
+      });
 
       if (result.success) {
         toast.success("Sync started");
@@ -337,22 +360,36 @@
       if (sourceLower === uploaderIdLower) return uploader;
 
       if (uploaderIdLower === "xdrip") {
-        if (sourceLower.includes("xdrip") || deviceLower.includes("xdrip")) return uploader;
+        if (sourceLower.includes("xdrip") || deviceLower.includes("xdrip"))
+          return uploader;
       }
       if (uploaderIdLower === "loop") {
-        if ((sourceLower === "loop" || deviceLower.includes("loop")) && !sourceLower.includes("openaps")) return uploader;
+        if (
+          (sourceLower === "loop" || deviceLower.includes("loop")) &&
+          !sourceLower.includes("openaps")
+        )
+          return uploader;
       }
       if (uploaderIdLower === "aaps") {
-        if (sourceLower.includes("aaps") || sourceLower.includes("androidaps") || deviceLower.includes("aaps") || deviceLower.includes("androidaps")) return uploader;
+        if (
+          sourceLower.includes("aaps") ||
+          sourceLower.includes("androidaps") ||
+          deviceLower.includes("aaps") ||
+          deviceLower.includes("androidaps")
+        )
+          return uploader;
       }
       if (uploaderIdLower === "trio") {
-        if (sourceLower === "trio" || deviceLower.includes("trio")) return uploader;
+        if (sourceLower === "trio" || deviceLower.includes("trio"))
+          return uploader;
       }
       if (uploaderIdLower === "iaps") {
-        if (sourceLower === "iaps" || deviceLower.includes("iaps")) return uploader;
+        if (sourceLower === "iaps" || deviceLower.includes("iaps"))
+          return uploader;
       }
       if (uploaderIdLower === "spike") {
-        if (sourceLower.includes("spike") || deviceLower.includes("spike")) return uploader;
+        if (sourceLower.includes("spike") || deviceLower.includes("spike"))
+          return uploader;
       }
     }
 
@@ -400,11 +437,15 @@
   <!-- Header -->
   <div class="flex items-start justify-between">
     <div class="flex items-center gap-3">
-      <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+      <div
+        class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10"
+      >
         <Wifi class="h-6 w-6 text-primary" />
       </div>
       <div>
-        <h1 class="text-2xl font-bold tracking-tight">Connectors & Connected Apps</h1>
+        <h1 class="text-2xl font-bold tracking-tight">
+          Connectors & Connected Apps
+        </h1>
         <p class="text-muted-foreground">
           Manage data sources, set up new connections, and control app access
         </p>
@@ -435,11 +476,14 @@
     </Card>
   {:else if servicesOverview}
     <!-- Active Data Sources -->
-    <Card {@attach coachmark({
-      key: "setup-connectors.sources",
-      title: "Waiting for data",
-      description: "Once you set up an uploader app or cloud connector below, your data source will appear here automatically.",
-    })}>
+    <Card
+      {@attach coachmark({
+        key: "setup-connectors.sources",
+        title: "Waiting for data",
+        description:
+          "Once you set up an uploader app or cloud connector below, your data source will appear here automatically.",
+      })}
+    >
       <CardHeader>
         <CardTitle class="flex items-center gap-2">
           <Wifi class="h-5 w-5" />
@@ -450,7 +494,7 @@
         </CardDescription>
       </CardHeader>
       <CardContent>
-        {#if !servicesOverview.activeDataSources || servicesOverview.activeDataSources.length === 0}
+        {#if !googleHealth?.connected && !servicesOverview.activeDataSources?.length}
           <div class="text-center py-8 text-muted-foreground">
             <WifiOff class="h-12 w-12 mx-auto mb-4 opacity-50" />
             <p class="font-medium">No data sources detected</p>
@@ -460,7 +504,10 @@
           </div>
         {:else}
           <div class="space-y-3">
-            {#each servicesOverview.activeDataSources as source (source.id)}
+            {#if googleHealth?.connected}
+              <GoogleHealthSourceRow connection={googleHealth} />
+            {/if}
+            {#each servicesOverview.activeDataSources ?? [] as source (source.id)}
               {@const matchingUploader = getMatchingUploader(source)}
               {@const isDemo = isDemoDataSource(source)}
               <DataSourceRow
@@ -470,7 +517,9 @@
                 totalEntries={source.totalEntries}
                 entriesLast24h={source.entriesLast24h}
                 lastSeen={source.lastSeen}
-                subtitle={source.name !== source.deviceId ? source.deviceId : undefined}
+                subtitle={source.name !== source.deviceId
+                  ? source.deviceId
+                  : undefined}
                 onclick={() => openDataSourceDialog(source)}
               >
                 {#snippet badges()}
@@ -504,11 +553,14 @@
     />
 
     <!-- Server-Side Connectors -->
-    <div {@attach coachmark({
-      key: "setup-connectors.server-connectors",
-      title: "Cloud connectors",
-      description: "Pull data directly from Dexcom, LibreLink, or Glooko \u2014 no uploader app needed.",
-    })}>
+    <div
+      {@attach coachmark({
+        key: "setup-connectors.server-connectors",
+        title: "Cloud connectors",
+        description:
+          "Pull data directly from Dexcom, LibreLink, or Glooko \u2014 no uploader app needed.",
+      })}
+    >
       <ServerConnectorsCard
         availableConnectors={servicesOverview.availableConnectors ?? []}
         {connectorStatuses}
@@ -526,6 +578,7 @@
           await loadConnectorCapabilitiesFor(connectorId);
           showConnectorDialog = true;
         }}
+        {googleHealth}
       />
     </div>
 
@@ -574,7 +627,9 @@
               apiTokenPrefillLabel = "";
               apiTokenPrefillScopes = ["health.readwrite"];
               apiTokenCreateOpen = true;
-              document.getElementById("api-tokens-section")?.scrollIntoView({ behavior: "smooth" });
+              document
+                .getElementById("api-tokens-section")
+                ?.scrollIntoView({ behavior: "smooth" });
             }}
           >
             <KeyRound class="mr-1.5 h-4 w-4" />
@@ -691,13 +746,16 @@
           class="flex items-center justify-between rounded-lg border p-4 hover:bg-accent transition-colors"
         >
           <div class="flex items-center gap-3">
-            <div class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-md bg-muted">
+            <div
+              class="flex h-10 w-10 items-center justify-center overflow-hidden rounded-md bg-muted"
+            >
               <AppLogo icon="discord" />
             </div>
             <div>
               <p class="font-medium">Discord</p>
               <p class="text-sm text-muted-foreground">
-                Link a Discord account to receive alerts and use the Nocturne bot
+                Link a Discord account to receive alerts and use the Nocturne
+                bot
               </p>
             </div>
           </div>
@@ -739,7 +797,10 @@
 />
 
 <!-- Demo Data Management Dialog -->
-<DemoDataSection bind:open={showDemoDataDialog} onDeleteComplete={loadServices} />
+<DemoDataSection
+  bind:open={showDemoDataDialog}
+  onDeleteComplete={loadServices}
+/>
 
 <!-- Data Source Management Dialog -->
 <DataSourceManageDialog
@@ -748,9 +809,19 @@
   onDeleteComplete={loadServices}
 />
 
-<ManualSyncDialog bind:open={showManualSyncDialog} {isManualSyncing} {manualSyncResult} syncProgress={isManualSyncing ? activeSyncProgress : null} />
+<ManualSyncDialog
+  bind:open={showManualSyncDialog}
+  {isManualSyncing}
+  {manualSyncResult}
+  syncProgress={isManualSyncing ? activeSyncProgress : null}
+/>
 
 <!-- Connector Details Dialog -->
-<ConnectorDetailsDialog bind:open={showConnectorDialog} {selectedConnector} {selectedConnectorCapabilities} onSyncComplete={loadConnectorStatuses} />
+<ConnectorDetailsDialog
+  bind:open={showConnectorDialog}
+  {selectedConnector}
+  {selectedConnectorCapabilities}
+  onSyncComplete={loadConnectorStatuses}
+/>
 
 <DeduplicationDialog bind:open={showDeduplicationDialog} bind:isDeduplicating />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/google-health/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/google-health/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import GoogleHealth from "./google-health-page.svelte";
+</script>
+
+<GoogleHealth />

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/google-health/callback/+server.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/google-health/callback/+server.ts
@@ -1,0 +1,27 @@
+import { redirect } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = async ({ locals, url, setHeaders }) => {
+  setHeaders({ "cache-control": "no-store", "referrer-policy": "no-referrer" });
+  let outcome =
+    !locals.isAuthenticated || !locals.user
+      ? "no_session"
+      : url.searchParams.has("error")
+        ? "provider_denied"
+        : "failed";
+
+  if (locals.isAuthenticated && locals.user && !url.searchParams.has("error")) {
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    if (code && state) {
+      try {
+        await locals.apiClient.googleHealth.completeGoogleHealth({ code, state });
+        outcome = "connected";
+      } catch {
+        // Authorization codes, tokens and provider errors must never be logged.
+      }
+    }
+  }
+
+  redirect(303, `/settings/connectors/google-health?connection=${outcome}`);
+};

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/google-health/google-health-page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/google-health/google-health-page.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { resolve } from "$app/paths";
+  import { ArrowLeft, HeartPulse, RefreshCw, Unplug } from "lucide-svelte";
+  import type { GoogleHealthPreview, GoogleHealthStatus } from "$lib/api";
+  import { Button } from "$lib/components/ui/button";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Progress } from "$lib/components/ui/progress";
+  import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "$lib/components/ui/card";
+  import { describeGoogleHealthError, type GoogleHealthOperation } from "$lib/connectors/google-health-error";
+  import { getGoogleHealth, saveGoogleHealth, startGoogleHealth, disconnectGoogleHealth, syncGoogleHealth, previewGoogleHealth, purgeGoogleHealth } from "$lib/api/generated/googleHealths.generated.remote";
+
+  let status = $state<GoogleHealthStatus | null>(null), preview = $state<GoogleHealthPreview | null>(null);
+  let clientId = $state(""), clientSecret = $state(""), callbackUrl = $state(""), importFrom = $state("");
+  let selected = $state<string[]>(["steps", "heart-rate", "weight", "sleep"]), busy = $state(true), inventoryBusy = $state(false), message = $state(""), notice = $state("");
+  let statusPolling = false;
+  let operation: GoogleHealthOperation = "status";
+  const labels: Record<string, string> = { steps: "Steps", "heart-rate": "Heart rate", weight: "Weight", sleep: "Sleep", "body-fat": "Body fat", distance: "Distance", "oxygen-saturation": "Oxygen saturation", "heart-rate-variability": "Heart rate variability" };
+  const destinations: Record<string, string> = { "step-counts": "Step history", "heart-rates": "Heart-rate history", "body-weights": "Weight history", "sleep-sessions": "Sleep history" };
+  const errors: Record<string, string> = {
+    configure_first: "Save the Google configuration first.", invalid_configuration: "Check the client ID and import start date.", invalid_callback: "Use an HTTPS URL ending exactly in /settings/connectors/google-health/callback.",
+    invalid_client_credentials: "Google rejected the client ID or secret.", oauth_scope_configuration: "Google rejected a requested Health scope.", oauth_request_invalid: "Google rejected the OAuth request.", invalid_token_response: "Google did not return a usable session.", client_secret_required: "A Google client secret is required.", preview_required: "Review and save the available data types before importing.", no_types_selected: "Select at least one data type before starting an import.",
+    connection_owner_required: "Only the user who created this connection can change it.", disconnect_first: "Disconnect before changing these settings.", account_mismatch: "This is a different Google account. Purge the old import before switching.", expired_signin: "The sign-in attempt expired. Start again.", offline_access_required: "Google did not grant background access. Revoke access and reconnect.", partial_consent: "Not every requested permission was granted.", permission_denied: "Google denied access.", reconnect_required: "Google access expired or was revoked. Reconnect.", rate_limited: "Google's request limit was reached. Nocturne will retry later.", google_unavailable: "Google is temporarily unavailable. Existing data was preserved.",
+    account_not_linked: "This Google account is not linked to Fitbit.", invalid_google_request: "Google rejected the data request.", preview_access_denied: "This account cannot access this API version.", google_resource_not_found: "This data type is unavailable for this account.", data_access_denied: "Google does not permit this data type to be read.", invalid_time_range: "Google rejected this date range. Choose a later start date.", invalid_filter_operator: "Google rejected Nocturne's time filter.", invalid_google_filter: "Google rejected the filter for this data type.", invalid_google_data_type: "Google did not recognise this data type.", invalid_source_family: "Google could not reconcile the sources.", invalid_google_response: "Google returned an incomplete response.", no_google_data: "Google returned no measurements for this date range.", stored_google_configuration_unreadable: "The saved connection cannot be read. Configure it again.", unsupported_type: "The saved selection contains an unsupported type.", revoke_in_google: "Disconnected locally. Revoke the app in Google as well.", history_too_large: "Google exceeded the pagination safety limit. Try a later start date, or report the technical code if this persists.", invalid_google_data: "Google returned an unexpected data format.", duplicate_google_data: "Google returned overlapping measurements.", unexpected_time_range: "Google returned data outside the requested range.", pagination_failed: "Nocturne could not retrieve every page.",
+    internal_sync_connection_read: "Nocturne could not read the saved connection. Check the server log.", internal_sync_session_read: "Nocturne could not process the protected session. Check the server log.", internal_sync_token_refresh: "Refreshing the Google session failed. Check the server log.", internal_sync_scope_validation: "Checking permissions failed. Check the server log.", internal_sync_google_read: "Reading Google Health failed. Check the server log.", internal_sync_data_validation: "Validating Google data failed. Check the server log.", internal_sync_native_write: "Data could not be stored in Nocturne health records. Check the server log.", internal_sync_database_write: "Data could not be stored. Check the server log."
+  };
+  const day = (value?: string | Date | null) => value ? new Date(value).toISOString().slice(0, 10) : "";
+  const options = (previewOnly: boolean) => ({ clientId, clientSecret: clientSecret || null, callbackUrl, dataTypes: selected, historyDays: 7, importFrom: importFrom ? `${importFrom}T00:00:00.000Z` : null, previewOnly });
+  async function loadPreview() {
+    if (inventoryBusy) return;
+    inventoryBusy = true;
+    try { preview = await previewGoogleHealth(); }
+    catch (error) { message = describeGoogleHealthError(error, "readings", errors); }
+    finally { inventoryBusy = false; }
+  }
+  async function refresh(loadInventory = true) {
+    operation = "status"; status = await getGoogleHealth().run(); clientId = status.clientId ?? "";
+    callbackUrl = status.callbackUrl || `${location.origin}/settings/connectors/google-health/callback`;
+    selected = status.configured ? status.selectedTypes ?? [] : selected;
+    importFrom = day(status.importFrom) || day(new Date(Date.now() - (status.historyDays ?? 7) * 86400000));
+    if (status.connected && loadInventory && !status.isSyncing) void loadPreview();
+  }
+  async function run(action: () => Promise<unknown>) { busy = true; message = ""; try { await action(); } catch (error) { message = describeGoogleHealthError(error, operation, errors); } finally { busy = false; } }
+  async function connect() { operation = "save"; await saveGoogleHealth(options(true)); clientSecret = ""; operation = "signin"; const auth = await startGoogleHealth(); if (auth.url) location.assign(auth.url); }
+  async function saveChanges(sync: boolean) {
+    operation = "save";
+    await saveGoogleHealth(options(false));
+    try {
+      if (sync && selected.length > 0) {
+        operation = "sync";
+        status = await syncGoogleHealth();
+        notice = status.isSyncing ? "The import is running in the background. You can leave this page and return later." : status.errorCode ? "" : "Google Health import completed.";
+      }
+    } catch (error) {
+      const failedOperation = operation;
+      // Keep the original sync failure if reloading the saved settings also fails.
+      try { await refresh(); } catch {}
+      operation = failedOperation;
+      throw error;
+    }
+    if (!sync) await refresh();
+  }
+  async function disconnect() { operation = "disconnect"; await disconnectGoogleHealth(); preview = null; await refresh(); }
+  function itemStatus(item: NonNullable<GoogleHealthPreview["items"]>[number]) {
+    if (item.errorCode) return `Read failed (${item.errorCode})`;
+    if (!item.supported) return "Not yet supported by Nocturne";
+    if (!item.granted) return "Permission not granted";
+    if (!status?.previewRequired && status?.selectedTypes?.includes(item.dataType ?? "")) {
+      if (status.errorCode && (!status.errorDataTypes?.length || status.errorDataTypes.includes(item.dataType ?? "")))
+        return "Import needs attention";
+      return item.count > 0 ? "Import enabled" : "Import enabled; no data found";
+    }
+    return item.count > 0 ? "Available to connect" : "Supported, but no data found";
+  }
+  function syncPhase() {
+    if (!status?.isSyncing) return "";
+    if (status.syncPhase === "queued") return "Waiting for the background worker";
+    if (status.syncPhase === "refreshing_session") return "Refreshing the Google session";
+    if (status.syncPhase === "reading") return status.syncDataType ? `Reading ${labels[status.syncDataType] ?? status.syncDataType}` : "Reading Google Health data";
+    if (status.syncPhase === "validating") return "Validating the downloaded data";
+    if (status.syncPhase === "saving") return "Saving the imported measurements";
+    if (status.syncPhase === "integrating") return "Updating Nocturne health records";
+    return "Preparing the import";
+  }
+  async function pollSync() {
+    if (!status?.isSyncing || statusPolling) return;
+    statusPolling = true;
+    try {
+      const updated = await getGoogleHealth().run();
+      const completed = status.isSyncing && !updated.isSyncing;
+      status = updated;
+      if (completed) { notice = updated.errorCode ? "" : "Google Health import completed."; if (!updated.errorCode) void loadPreview(); }
+    } catch (error) { message = describeGoogleHealthError(error, "status", errors); }
+    finally { statusPolling = false; }
+  }
+  onMount(() => {
+    let active = true;
+    const timer = window.setInterval(() => { if (active) void pollSync(); }, 2000);
+    queueMicrotask(() => { if (active) void run(async () => { const outcome = new URLSearchParams(location.search).get("connection"); await refresh(); if (outcome === "failed") message = "Google sign-in failed or was cancelled."; if (outcome === "provider_denied") message = "Google did not grant the requested read access."; if (outcome === "no_session") message = "The Nocturne session was missing after the Google redirect. Sign in and reconnect in the same browser."; }); });
+    return () => { active = false; window.clearInterval(timer); };
+  });
+</script>
+
+<svelte:head><title>Google Health · Connectors & Apps</title></svelte:head>
+<section class="mx-auto max-w-5xl space-y-6 p-6">
+  <a class="inline-flex items-center gap-2 text-sm text-muted-foreground" href={resolve("/settings/connectors")}><ArrowLeft class="h-4 w-4" />Connectors & Apps</a>
+  <header class="flex items-start justify-between gap-4"><div class="flex items-center gap-3"><div class="rounded-lg bg-primary/10 p-3"><HeartPulse class="h-6 w-6 text-primary" /></div><div><h1 class="text-3xl font-semibold">Google Health</h1><p class="text-muted-foreground">Server connector for health and fitness data</p></div></div><Badge variant={status?.connected ? "default" : "outline"}>{status?.connected ? "Connected" : status?.configured ? "Configured" : "Not Configured"}</Badge></header>
+  {#if message}<p role="alert" class="rounded-lg border border-destructive p-4">{message}</p>{/if}
+  {#if notice}<p role="status" class="rounded-lg border border-primary/40 p-4">{notice}</p>{/if}
+  {#if status?.errorCode && !status.isSyncing}<div role="status" class="rounded-lg border p-4"><p>{errors[status.errorCode] ?? "The import could not be completed."}</p><p class="mt-2 text-sm text-muted-foreground">Technical code: <code>{status.errorCode}</code>{status.errorDataTypes?.length ? ` · ${status.errorDataTypes.join(", ")}` : ""}</p></div>{/if}
+  {#if status?.isSyncing}<div role="status" aria-live="polite" class="space-y-3 rounded-lg border border-primary/40 bg-primary/5 p-4"><div><p class="font-medium">Import running in the background</p><p class="text-sm text-muted-foreground">{syncPhase()}</p></div><Progress value={status.syncProgressPercent ?? 0} max={100} aria-label="Google Health import progress" /><div class="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground"><span>{status.syncProgressPercent ?? 0}% complete</span>{#if status.syncTotalDataTypes > 0}<span>{status.syncCompletedDataTypes} of {status.syncTotalDataTypes} data types read</span>{/if}{#if status.syncPagesRead > 0}<span>{status.syncPagesRead} Google {status.syncPagesRead === 1 ? "page" : "pages"} read for this data type</span>{/if}</div><p class="text-sm">You can keep using Nocturne or leave this page. The server will continue the import.</p></div>{/if}
+
+  <Card><CardHeader><CardTitle>Connection</CardTitle><CardDescription>Read-only OAuth connection to the Google Health API</CardDescription></CardHeader><CardContent class="space-y-4">
+    {#if !status}<p>Loading connection status…</p>{:else if !status.connected}
+      {#if !status.configured}<form class="space-y-4" onsubmit={(event) => { event.preventDefault(); void run(connect); }}>
+        <label class="block text-sm font-medium">Google client ID<input class="mt-1 w-full rounded border bg-background p-2" required bind:value={clientId} /></label>
+        <label class="block text-sm font-medium">Client secret<input class="mt-1 w-full rounded border bg-background p-2" type="password" required bind:value={clientSecret} /></label>
+        <label class="block text-sm font-medium">Callback URL<input class="mt-1 w-full rounded border bg-background p-2" type="url" required bind:value={callbackUrl} /></label>
+        <label class="block text-sm font-medium">Import data from<input class="mt-1 block rounded border bg-background p-2" type="date" min="2000-01-01" max={day(new Date())} required bind:value={importFrom} /></label>
+        <p class="text-sm text-muted-foreground">Nocturne retrieves every available page from this date. An early start date can make the first import take longer.</p><Button type="submit" disabled={busy}>Save and connect</Button>
+      </form>{:else}<p>The encrypted Google Cloud configuration is saved.</p><div class="flex gap-2"><Button disabled={busy} onclick={() => void run(async () => { operation = "signin"; const auth = await startGoogleHealth(); if (auth.url) location.assign(auth.url); })}>Sign in with Google</Button><Button variant="outline" disabled={busy} onclick={() => void run(disconnect)}><Unplug class="mr-2 h-4 w-4" />Disconnect</Button></div>
+        <details><summary class="cursor-pointer text-sm font-medium">Edit connection settings</summary><form class="mt-4 space-y-4" onsubmit={(event) => { event.preventDefault(); void run(connect); }}><label class="block text-sm font-medium">Google client ID<input class="mt-1 w-full rounded border bg-background p-2" required bind:value={clientId} /></label><label class="block text-sm font-medium">Client secret<input class="mt-1 w-full rounded border bg-background p-2" type="password" bind:value={clientSecret} placeholder="Leave empty to keep the saved secret" /></label><label class="block text-sm font-medium">Callback URL<input class="mt-1 w-full rounded border bg-background p-2" type="url" required bind:value={callbackUrl} /></label><label class="block text-sm font-medium">Import data from<input class="mt-1 block rounded border bg-background p-2" type="date" min="2000-01-01" max={day(new Date())} required bind:value={importFrom} /></label><Button type="submit" disabled={busy}>Save and reconnect</Button></form></details>{/if}
+    {:else}
+      <p>{status.previewRequired
+        ? "Google Health is connected. Review the available data below, then save your selection to start importing."
+        : !status.selectedTypes?.length ? "Google Health is connected. Imports are paused because no data types are selected."
+        : "Google Health is connected. Automatic sync runs approximately every 15 minutes."}</p>
+      <p class="text-sm text-muted-foreground">Change the import start date and selection below without reconnecting. Disconnect only to change OAuth settings.</p>
+      <div class="flex gap-2"><Button variant="outline" disabled={busy || status.isSyncing || status.previewRequired || !status.selectedTypes?.length} onclick={() => void run(async () => { operation = "sync"; status = await syncGoogleHealth(); notice = status.isSyncing ? "The import is running in the background. You can leave this page and return later." : status.errorCode ? "" : "Google Health import completed."; })}><RefreshCw class="mr-2 h-4 w-4" />Sync now</Button><Button variant="outline" disabled={busy || status.isSyncing} onclick={() => void run(disconnect)}><Unplug class="mr-2 h-4 w-4" />Disconnect</Button></div>
+    {/if}
+  </CardContent></Card>
+
+  {#if status?.connected}<Card><CardHeader><CardTitle>Google Health data</CardTitle><CardDescription>Detected data types and how Nocturne can use them</CardDescription></CardHeader><CardContent class="space-y-4">
+    <form class="space-y-4" onsubmit={(event) => { event.preventDefault(); const sync = (event.submitter as HTMLButtonElement | null)?.value === "sync"; void run(() => saveChanges(sync)); }}>
+      <label class="block text-sm font-medium">Import data from<input class="mt-1 block rounded border bg-background p-2" type="date" min="2000-01-01" max={day(new Date())} required disabled={busy || status.isSyncing} bind:value={importFrom} /></label>
+      <p class="text-sm text-muted-foreground">Choose an earlier date to import older data shared with Google Health. Empty results are not errors. Clear all selections and save to pause imports; previously imported data is kept.</p>
+    {#if preview}<div class="overflow-auto"><table class="w-full text-left text-sm"><thead><tr class="border-b"><th class="p-3">Import</th><th class="p-3">Data type</th><th class="p-3">Found</th><th class="p-3">Nocturne destination</th><th class="p-3">Status</th></tr></thead><tbody>{#each preview.items ?? [] as item (item.dataType)}{@const capability = status.capabilities?.find((entry) => entry.dataType === item.dataType)}<tr class="border-b"><td class="p-3"><input aria-label={`Import ${labels[item.dataType ?? ""] ?? item.dataType}`} type="checkbox" bind:group={selected} value={item.dataType} disabled={busy || status.isSyncing || (!selected.includes(item.dataType ?? "") && (!item.supported || !item.granted || !!item.errorCode))} /></td><td class="p-3 font-medium">{labels[item.dataType ?? ""] ?? item.dataType}</td><td class="p-3">{item.errorCode || !item.granted ? "Unknown" : item.count > 0 ? `Yes (${item.count})` : "No"}</td><td class="p-3">{capability?.destination ? destinations[capability.destination] ?? capability.destination : "No destination yet"}</td><td class="p-3">{itemStatus(item)}</td></tr>{/each}</tbody></table></div>
+    {:else if inventoryBusy}<div class="space-y-2"><p>Scanning the selected history in Google Health…</p><p class="text-sm text-muted-foreground">This runs separately, so the rest of the page remains available.</p></div>{:else}<p>No inventory has been loaded yet.</p>{/if}
+      <div class="flex flex-wrap gap-2"><Button type="submit" disabled={busy || status.isSyncing}>Save import settings</Button><Button type="submit" value="sync" disabled={busy || status.isSyncing || selected.length === 0}>Save selection and import</Button><Button type="button" variant="outline" disabled={busy || inventoryBusy || status.isSyncing} onclick={() => void loadPreview()}><RefreshCw class="mr-2 h-4 w-4" />{inventoryBusy ? "Scanning inventory…" : "Refresh inventory"}</Button></div>
+    </form>
+  </CardContent></Card>{/if}
+
+  <details class="rounded-lg border p-4"><summary class="cursor-pointer font-medium">Google Cloud setup</summary><ol class="mt-3 list-inside list-decimal space-y-2 text-sm"><li>Enable the Google Health API and create an OAuth Web application client.</li><li>Add your account as a test user while the consent screen is in testing.</li><li>Register the callback URL above as an Authorized redirect URI.</li><li>Keep the client secret private.</li></ol><a class="mt-3 inline-block underline" href="https://developers.google.com/health/setup" target="_blank" rel="noreferrer">Google setup documentation</a></details>
+  {#if status?.configured && !status.connected}<Button variant="destructive" disabled={busy} onclick={() => { if (confirm("Permanently delete measurements imported through Google Health? Data in Google is unchanged.")) void run(async () => { operation = "purge"; await purgeGoogleHealth(); await refresh(); }); }}>Delete imported Google Health data</Button>{/if}
+</section>

--- a/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/google-health/google-health-page.svelte.test.ts
+++ b/src/Web/packages/app/src/routes/(authenticated)/settings/connectors/google-health/google-health-page.svelte.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import { page } from "vitest/browser";
+import type { GoogleHealthStatus } from "$lib/api";
+import { googleHealthMocks } from "$lib/test-stubs/google-health";
+import GoogleHealthPage from "./google-health-page.svelte";
+
+function status(overrides: Partial<GoogleHealthStatus> = {}): GoogleHealthStatus {
+  return {
+    configured: false,
+    connected: false,
+    clientId: "",
+    callbackUrl: "",
+    historyDays: 7,
+    selectedTypes: ["steps", "heart-rate", "weight", "sleep"],
+    grantedTypes: [],
+    previewRequired: false,
+    capabilities: [
+      { dataType: "steps", supported: true, destination: "step-counts" },
+      { dataType: "body-fat", supported: false },
+    ],
+    ...overrides,
+  };
+}
+
+describe("Google Health connector page", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    googleHealthMocks.status.mockResolvedValue(status());
+    googleHealthMocks.preview.mockResolvedValue({ items: [] });
+  });
+
+  it("uses the standard connector presentation and an explicit history date", async () => {
+    render(GoogleHealthPage);
+    await expect.element(page.getByRole("heading", { name: "Google Health" })).toBeVisible();
+    await expect.element(page.getByText("Server connector for health and fitness data")).toBeVisible();
+    await expect.element(page.getByLabelText("Import data from")).toBeVisible();
+  });
+
+  it("shows the effective legacy history window when no explicit date is saved", async () => {
+    const expected = new Date(Date.now() - 7 * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    render(GoogleHealthPage);
+
+    await expect.element(page.getByLabelText("Import data from")).toHaveValue(expected);
+  });
+
+  it("shows detected, supported, and unsupported data types", async () => {
+    googleHealthMocks.status.mockResolvedValue(status({ configured: true, connected: true }));
+    googleHealthMocks.preview.mockResolvedValue({ items: [
+      { dataType: "steps", granted: true, count: 42, supported: true },
+      { dataType: "body-fat", granted: true, count: 3, supported: false },
+    ] });
+    render(GoogleHealthPage);
+    await expect.element(page.getByText("Import enabled", { exact: true })).toBeVisible();
+    await expect.element(page.getByText("Not yet supported by Nocturne")).toBeVisible();
+    await expect.element(page.getByText("Step history")).toBeVisible();
+  });
+
+  it("allows problematic selected types to be unchecked and saved without syncing", async () => {
+    googleHealthMocks.status.mockResolvedValue(status({ configured: true, connected: true, selectedTypes: ["steps", "heart-rate", "weight"] }));
+    googleHealthMocks.preview.mockResolvedValue({ items: [
+      { dataType: "steps", granted: true, supported: true, count: 4 },
+      { dataType: "heart-rate", granted: true, supported: true, count: 0 },
+      { dataType: "weight", granted: true, supported: true, count: 0, errorCode: "google_unavailable" },
+    ] });
+    render(GoogleHealthPage);
+    await page.getByRole("checkbox", { name: "Import Heart rate" }).click();
+    await page.getByRole("checkbox", { name: "Import Weight" }).click();
+    await page.getByRole("button", { name: "Save import settings", exact: true }).click();
+    expect(googleHealthMocks.save).toHaveBeenCalledWith(expect.objectContaining({ dataTypes: ["steps"] }));
+    expect(googleHealthMocks.sync).not.toHaveBeenCalled();
+    expect(googleHealthMocks.disconnect).not.toHaveBeenCalled();
+  });
+
+  it("saves an older history date and an empty selection without reconnecting", async () => {
+    googleHealthMocks.status
+      .mockResolvedValueOnce(status({ configured: true, connected: true, selectedTypes: ["heart-rate"], importFrom: new Date("2026-08-29T00:00:00Z") }))
+      .mockResolvedValue(status({ configured: true, connected: true, selectedTypes: [], importFrom: new Date("2020-01-01T00:00:00Z") }));
+    googleHealthMocks.preview.mockResolvedValue({ items: [
+      { dataType: "heart-rate", granted: true, supported: true, count: 0 },
+    ] });
+    render(GoogleHealthPage);
+    await page.getByRole("checkbox", { name: "Import Heart rate" }).click();
+    await page.getByLabelText("Import data from").fill("2020-01-01");
+    await page.getByRole("button", { name: "Save import settings", exact: true }).click();
+    expect(googleHealthMocks.save).toHaveBeenCalledWith(expect.objectContaining({ dataTypes: [], importFrom: "2020-01-01T00:00:00.000Z", clientSecret: null }));
+    expect(googleHealthMocks.sync).not.toHaveBeenCalled();
+    expect(googleHealthMocks.start).not.toHaveBeenCalled();
+    expect(googleHealthMocks.disconnect).not.toHaveBeenCalled();
+    await expect.element(page.getByText("Google Health is connected. Imports are paused because no data types are selected.")).toBeVisible();
+    await expect.element(page.getByRole("button", { name: "Sync now", exact: true })).toBeDisabled();
+  });
+
+  it("allows a supported empty type to be enabled for future measurements", async () => {
+    googleHealthMocks.status.mockResolvedValue(status({ configured: true, connected: true, selectedTypes: ["steps"] }));
+    googleHealthMocks.preview.mockResolvedValue({ items: [
+      { dataType: "heart-rate", granted: true, supported: true, count: 0 },
+    ] });
+    render(GoogleHealthPage);
+    await page.getByRole("checkbox", { name: "Import Heart rate" }).click();
+    await expect.element(page.getByRole("checkbox", { name: "Import Heart rate" })).toBeChecked();
+  });
+
+  it("explains the history safety limit without silently truncating the import", async () => {
+    googleHealthMocks.status.mockResolvedValue(status({ configured: true, connected: true }));
+    googleHealthMocks.preview.mockRejectedValue({ status: 400, body: { message: "history_too_large" } });
+    render(GoogleHealthPage);
+
+    await expect.element(page.getByRole("alert")).toHaveTextContent("Google exceeded the pagination safety limit");
+    await expect.element(page.getByRole("alert")).toHaveTextContent("readings/history_too_large");
+  });
+
+  it("requires preview confirmation before claiming that data is importing", async () => {
+    googleHealthMocks.status.mockResolvedValue(status({ configured: true, connected: true, previewRequired: true }));
+    googleHealthMocks.preview.mockResolvedValue({ items: [
+      { dataType: "steps", granted: true, count: 42, supported: true },
+    ] });
+    render(GoogleHealthPage);
+
+    await expect.element(page.getByText("Review the available data below", { exact: false })).toBeVisible();
+    await expect.element(page.getByText("Available to connect", { exact: true })).toBeVisible();
+    await expect.element(page.getByRole("button", { name: "Sync now" })).toBeDisabled();
+    await expect.element(page.getByRole("button", { name: "Save selection and import" })).toBeEnabled();
+    expect(googleHealthMocks.sync).not.toHaveBeenCalled();
+  });
+
+  it("keeps import status tied to saved selection while checkboxes are edited", async () => {
+    googleHealthMocks.status.mockResolvedValue(status({ configured: true, connected: true, selectedTypes: ["steps"] }));
+    googleHealthMocks.preview.mockResolvedValue({ items: [
+      { dataType: "steps", granted: true, count: 42, supported: true },
+      { dataType: "weight", granted: true, count: 3, supported: true },
+    ] });
+    render(GoogleHealthPage);
+    const steps = page.getByRole("row", { name: /Steps/ });
+    const weight = page.getByRole("row", { name: /Weight/ });
+
+    await expect.element(steps.getByText("Import enabled", { exact: true })).toBeVisible();
+    await expect.element(weight.getByText("Available to connect", { exact: true })).toBeVisible();
+    await page.getByRole("checkbox", { name: "Import Steps" }).click();
+    await page.getByRole("checkbox", { name: "Import Weight" }).click();
+
+    await expect.element(steps.getByText("Import enabled", { exact: true })).toBeVisible();
+    await expect.element(weight.getByText("Available to connect", { exact: true })).toBeVisible();
+    expect(googleHealthMocks.save).not.toHaveBeenCalled();
+  });
+
+  it("shows an import error for the affected saved data type", async () => {
+    googleHealthMocks.status.mockResolvedValue(status({
+      configured: true, connected: true, errorCode: "internal_sync_native_write", errorDataTypes: ["steps"],
+    }));
+    googleHealthMocks.preview.mockResolvedValue({ items: [
+      { dataType: "steps", granted: true, count: 42, supported: true },
+      { dataType: "weight", granted: true, count: 3, supported: true },
+    ] });
+    render(GoogleHealthPage);
+
+    await expect.element(page.getByText("Import needs attention", { exact: true })).toBeVisible();
+    await expect.element(page.getByText("Import enabled", { exact: true })).toBeVisible();
+  });
+
+  it("shows server-side progress while a large import continues in the background", async () => {
+    googleHealthMocks.status.mockResolvedValue(status({
+      configured: true, connected: true, isSyncing: true, syncPhase: "reading", syncDataType: "steps",
+      syncCompletedDataTypes: 1, syncTotalDataTypes: 4, syncPagesRead: 12, syncProgressPercent: 22,
+    }));
+    render(GoogleHealthPage);
+
+    await expect.element(page.getByText("Import running in the background")).toBeVisible();
+    await expect.element(page.getByText("Reading Steps")).toBeVisible();
+    await expect.element(page.getByText("12 Google pages read for this data type")).toBeVisible();
+    await expect.element(page.getByRole("progressbar", { name: "Google Health import progress" })).toHaveAttribute("aria-valuenow", "22");
+    await expect.element(page.getByRole("button", { name: "Sync now" })).toBeDisabled();
+    expect(googleHealthMocks.preview).not.toHaveBeenCalled();
+  });
+});

--- a/src/Web/packages/app/vitest.google-health.config.ts
+++ b/src/Web/packages/app/vitest.google-health.config.ts
@@ -1,0 +1,91 @@
+import { fileURLToPath } from "node:url";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import tailwindcss from "@tailwindcss/vite";
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
+
+const local = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  plugins: [svelte(), tailwindcss()],
+  optimizeDeps: {
+    include: [
+      "lucide-svelte",
+      "d3-scale",
+      "@lucide/svelte/icons/check",
+      "@lucide/svelte/icons/chevron-down",
+      "@lucide/svelte/icons/chevron-up",
+    ],
+  },
+  server: { fs: { strict: false } },
+  resolve: {
+    dedupe: ["svelte"],
+    alias: [
+      {
+        find: /(?:\$lib\/utils\/|\.\/)data-type-labels$/,
+        replacement: local("./src/lib/test-stubs/data-type-labels.ts"),
+      },
+      {
+        find: "$lib/api/generated/googleHealths.generated.remote",
+        replacement: local("./src/lib/test-stubs/google-health.ts"),
+      },
+      {
+        find: "$app/paths",
+        replacement: local("./src/lib/test-stubs/google-health-app-paths.ts"),
+      },
+      {
+        find: /^\$app\/(navigation|environment|state)$/,
+        replacement: local(
+          "./src/lib/test-stubs/year-overview-runtime.svelte.ts"
+        ),
+      },
+      {
+        find: "$api/generated/dataOverviews.generated.remote",
+        replacement: local("./src/lib/test-stubs/year-overview-remote.ts"),
+      },
+      ...[
+        "$lib/stores/appearance-store.svelte",
+        "$lib/hooks/date-params.svelte",
+      ].map((find) => ({
+        find,
+        replacement: local(
+          "./src/lib/test-stubs/year-overview-runtime.svelte.ts"
+        ),
+      })),
+      {
+        find: "$lib/components/reports/year-overview/YearHeatmap.svelte",
+        replacement: local("./src/lib/test-stubs/YearHeatmap.test-stub.svelte"),
+      },
+      ...[
+        "$lib/components/reports/year-overview/YearOverviewFilters.svelte",
+        "$lib/components/reports/year-overview/DayDetailPanel.svelte",
+        "$lib/components/reports/GlycemicRiskIndexChart.svelte",
+      ].map((find) => ({
+        find,
+        replacement: local(
+          "./src/lib/test-stubs/EmptyYearPanel.test-stub.svelte"
+        ),
+      })),
+      { find: "$lib", replacement: local("./src/lib") },
+    ],
+  },
+  test: {
+    include: [
+      "src/**/google-health-page.svelte.test.ts",
+      "src/**/google-health-source.svelte.test.ts",
+      "src/lib/connectors/google-health-error.test.ts",
+      "src/lib/utils/metric-color-focus.test.ts",
+      "src/**/color-focus-range.svelte.test.ts",
+      "src/**/year-color-focus.svelte.test.ts",
+    ],
+    setupFiles: ["vitest-browser-svelte", "./vitest.browser.setup.ts"],
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright({
+        launchOptions: { channel: process.env.NOCTURNE_TEST_BROWSER_CHANNEL },
+      }),
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});

--- a/src/Web/packages/ui/src/styles/nocturne-theme.css
+++ b/src/Web/packages/ui/src/styles/nocturne-theme.css
@@ -14,8 +14,8 @@
      meaning on their own: the hues are spread to keep neighbouring values in the
      70–250 range distinguishable across a calendar grid. Stop-to-mg/dL mapping
      lives with the interpolation in chart-colors.ts. */
-  --glucose-heatmap-1: #2563eb; /* blue-600 */
-  --glucose-heatmap-2: #3b82f6; /* blue-500 */
+  --glucose-heatmap-1: #000000;
+  --glucose-heatmap-2: #000000;
   --glucose-heatmap-3: #06b6d4; /* cyan-500 */
   --glucose-heatmap-4: #10b981; /* emerald-500 */
   --glucose-heatmap-5: #84cc16; /* lime-500 */

--- a/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Authorization/V4WriteScopeGatingTests.cs
@@ -329,6 +329,7 @@ public class V4WriteScopeGatingTests
             // therapy: body_weights has no category scope of its own. The record is patient clinical
             // configuration written from the Patient Record settings form alongside therapy settings.
             ["BodyWeightController"] = Scope.TherapyReadWrite,
+            ["GoogleHealthController"] = Scope.TenantSettings,
 
             // treatments: state_spans is the decomposed form of the legacy treatment events
             // (temporary target, profile switch, exercise, illness, travel) and of the temp-basal

--- a/tests/Unit/Nocturne.API.Tests/Health/GoogleHealth/GoogleHealthTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Health/GoogleHealth/GoogleHealthTests.cs
@@ -1,0 +1,757 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Moq;
+using Nocturne.API.Controllers.V4.Health;
+using Nocturne.API.Services.Health.GoogleHealth;
+using Nocturne.Core.Contracts.Health;
+using Nocturne.Core.Contracts.Sleep;
+using Nocturne.Core.Models;
+using Nocturne.Core.Models.Health;
+using Nocturne.Infrastructure.Data;
+using Nocturne.Infrastructure.Data.Entities;
+using Xunit;
+
+namespace Nocturne.API.Tests.Health.GoogleHealth;
+
+public class GoogleHealthTests
+{
+    [Fact]
+    public void Maps_google_sleep_session_and_stages_to_nocturne_sleep()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+          "name":"users/example/dataTypes/sleep/dataPoints/night-1",
+          "sleep":{
+            "interval":{"startTime":"2026-09-04T22:00:00Z","endTime":"2026-09-05T06:00:00Z"},
+            "type":"STAGES",
+            "stages":[
+              {"startTime":"2026-09-04T22:00:00Z","endTime":"2026-09-05T00:00:00Z","type":"LIGHT"},
+              {"startTime":"2026-09-05T00:00:00Z","endTime":"2026-09-05T02:00:00Z","type":"DEEP"},
+              {"startTime":"2026-09-05T02:00:00Z","endTime":"2026-09-05T04:00:00Z","type":"REM"},
+              {"startTime":"2026-09-05T04:00:00Z","endTime":"2026-09-05T06:00:00Z","type":"AWAKE"}
+            ],
+            "metadata":{"processed":true,"nap":false,"manuallyEdited":false},
+            "summary":{"minutesAsleep":"360","minutesAwake":"120","minutesToFallAsleep":"15"}
+          }
+        }
+        """);
+
+        var session = GoogleHealthClient.ParseSleep(doc.RootElement);
+
+        Assert.Equal(SleepSource.Google, session.Source);
+        Assert.Equal(SleepSessionType.Overnight, session.Type);
+        Assert.Equal(SleepDetectionMethod.AutoFinal, session.DetectionMethod);
+        Assert.Equal(8 * 60 * 60 * 1000, session.DurationMs);
+        Assert.Equal(6 * 60 * 60 * 1000, session.TotalSleepMs);
+        Assert.Equal(2 * 60 * 60 * 1000, session.TotalAwakeMs);
+        Assert.Equal(4, session.Stages!.Count);
+        Assert.Equal(SleepStageType.Deep, session.Stages[1].Stage);
+        Assert.EndsWith("night-1", session.OriginalId);
+    }
+
+    [Fact]
+    public async Task Writes_google_measurements_to_native_nocturne_health_services()
+    {
+        var heartRateService = new Mock<IHeartRateService>();
+        var stepCountService = new Mock<IStepCountService>();
+        var bodyWeightService = new Mock<IBodyWeightService>();
+        var sleepService = new Mock<ISleepService>();
+        HeartRate[] heartRates = [];
+        StepCount[] stepCounts = [];
+        BodyWeight[] bodyWeights = [];
+        SleepSession? sleepSession = null;
+        heartRateService.Setup(service => service.CreateHeartRatesAsync(It.IsAny<IEnumerable<HeartRate>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<HeartRate>, CancellationToken>((items, _) => heartRates = items.ToArray())
+            .ReturnsAsync((IEnumerable<HeartRate> items, CancellationToken _) => items);
+        stepCountService.Setup(service => service.CreateStepCountsAsync(It.IsAny<IEnumerable<StepCount>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<StepCount>, CancellationToken>((items, _) => stepCounts = items.ToArray())
+            .ReturnsAsync((IEnumerable<StepCount> items, CancellationToken _) => items);
+        bodyWeightService.Setup(service => service.CreateBodyWeightsAsync(It.IsAny<IEnumerable<BodyWeight>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<BodyWeight>, CancellationToken>((items, _) => bodyWeights = items.ToArray())
+            .ReturnsAsync((IEnumerable<BodyWeight> items, CancellationToken _) => items);
+        sleepService.Setup(service => service.UpsertSessionAsync(It.IsAny<SleepSession>(), It.IsAny<CancellationToken>()))
+            .Callback<SleepSession, CancellationToken>((item, _) => sleepSession = item)
+            .ReturnsAsync((SleepSession item, CancellationToken _) => item);
+        var writer = new GoogleHealthReadingWriter(
+            heartRateService.Object, stepCountService.Object, bodyWeightService.Object, sleepService.Object);
+        var readings = new[]
+        {
+            new GoogleHealthReading { DataType = "heart-rate", Mills = 1_000, Value = 65, Unit = "bpm" },
+            new GoogleHealthReading { DataType = "steps", Mills = 2_000, EndMills = 3_000, Value = 42, Unit = "steps" },
+            new GoogleHealthReading { DataType = "weight", Mills = 4_000, Value = 72.5m, Unit = "kg" }
+        };
+        var sleep = new SleepSession { OriginalId = "night-1", Source = SleepSource.Google };
+
+        await writer.WriteAsync(
+            readings,
+            [sleep],
+            ["heart-rate", "steps", "weight", "sleep"],
+            DateTimeOffset.FromUnixTimeMilliseconds(0),
+            DateTimeOffset.FromUnixTimeMilliseconds(10_000),
+            default);
+
+        Assert.Equal(65, Assert.Single(heartRates).Bpm);
+        Assert.Equal(42, Assert.Single(stepCounts).Metric);
+        Assert.Equal(72.5m, Assert.Single(bodyWeights).WeightKg);
+        Assert.Equal(GoogleHealthReadingWriter.Source, heartRates[0].DataSource);
+        Assert.False(string.IsNullOrWhiteSpace(heartRates[0].SyncIdentifier));
+        Assert.Same(sleep, sleepSession);
+    }
+
+    [Fact]
+    public async Task Reconciliation_preserves_google_types_that_are_not_active()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:"); await connection.OpenAsync();
+        await using var db = new NocturneDbContext(new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options);
+        await db.Database.EnsureCreatedAsync();
+        var tenant = Guid.NewGuid(); db.TenantId = tenant;
+        db.Tenants.Add(new TenantEntity { Id = tenant, Slug = "synthetic", DisplayName = "Synthetic", IsActive = true });
+        var timestamp = DateTime.UtcNow.AddHours(-1);
+        db.HeartRates.Add(new HeartRateEntity { Id = Guid.CreateVersion7(), Timestamp = timestamp, Bpm = 60, DataSource = GoogleHealthReadingWriter.Source, SyncIdentifier = "old-heart" });
+        db.BodyWeights.Add(new BodyWeightEntity { Id = Guid.CreateVersion7(), Mills = new DateTimeOffset(timestamp).ToUnixTimeMilliseconds(), WeightKg = 70, DataSource = GoogleHealthReadingWriter.Source, SyncIdentifier = "old-weight" });
+        await db.SaveChangesAsync();
+        var writer = new GoogleHealthReadingWriter(
+            Mock.Of<IHeartRateService>(), Mock.Of<IStepCountService>(), Mock.Of<IBodyWeightService>(), Mock.Of<ISleepService>(), db);
+
+        await writer.WriteAsync([], [], ["weight"], DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow, default);
+
+        Assert.Single(await db.HeartRates.AsNoTracking().ToListAsync());
+        Assert.Empty(await db.BodyWeights.AsNoTracking().ToListAsync());
+    }
+
+    [Theory]
+    [InlineData("weight", "{\"weight\":{\"sampleTime\":{\"physicalTime\":\"2026-09-01T10:00:00Z\",\"utcOffset\":\"7200s\"},\"weightGrams\":72500}}", "kg", 72.5)]
+    [InlineData("heart-rate", "{\"heartRate\":{\"sampleTime\":{\"physicalTime\":\"2026-09-01T10:00:00Z\"},\"beatsPerMinute\":\"67\"}}", "bpm", 67)]
+    [InlineData("steps", "{\"steps\":{\"interval\":{\"startTime\":\"2026-09-01T12:00:00+02:00\",\"endTime\":\"2026-09-01T12:01:00+02:00\"},\"count\":\"42\"}}", "steps", 42)]
+    public void Maps_documented_google_types_without_inventing_values(string type, string json, string unit, decimal expected)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var reading = GoogleHealthClient.Parse(type, doc.RootElement);
+        Assert.Equal(expected, reading.Value); Assert.Equal(unit, reading.Unit);
+        Assert.Equal(DateTimeOffset.Parse("2026-09-01T10:00:00Z").ToUnixTimeMilliseconds(), reading.Mills);
+        if (type == "weight") Assert.Equal(120, reading.UtcOffsetMinutes);
+        else Assert.Null(reading.UtcOffsetMinutes);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"heartRate\":{\"sampleTime\":{\"physicalTime\":\"2026-09-01T10:00:00Z\"}}}")]
+    [InlineData("{\"heartRate\":{\"sampleTime\":{\"physicalTime\":\"2026-09-01T10:00:00Z\"},\"beatsPerMinute\":\"-1\"}}")]
+    [InlineData("{\"heartRate\":{\"sampleTime\":{\"physicalTime\":\"2026-09-01T10:00:00Z\"},\"beatsPerMinute\":\"60.5\"}}")]
+    public void Rejects_missing_or_invalid_samples(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        Assert.Throws<GoogleHealthException>(() => GoogleHealthClient.Parse("heart-rate", doc.RootElement));
+    }
+
+    [Theory]
+    [InlineData("http://example.com/settings/connectors/google-health/callback")]
+    [InlineData("https://192.168.2.238/settings/connectors/google-health/callback")]
+    [InlineData("https://example.com/settings/connectors/google-health/callback?x=1")]
+    [InlineData("https://user@example.com/settings/connectors/google-health/callback")]
+    [InlineData("https://example.com/auth/login")]
+    public void Requires_exact_https_callback(string url)
+    {
+        var options = Options(); options.CallbackUrl = url;
+        Assert.Throws<GoogleHealthException>(() => GoogleHealthService.ValidateOptions(options));
+    }
+
+    [Fact]
+    public async Task Follows_pages_and_rejects_repeated_page_tokens()
+    {
+        var calls = 0;
+        var requests = new List<Uri>();
+        var handler = new StubHandler(request =>
+        {
+            requests.Add(request.RequestUri!);
+            return Json(++calls == 1 ? "{\"nextPageToken\":\"second\"}" : "{\"dataPoints\":[]}");
+        });
+        var client = new GoogleHealthClient(new HttpClient(handler));
+        Assert.Empty(await client.ReadAsync("synthetic-token", "weight", DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow, default));
+        Assert.Equal(2, calls);
+        Assert.DoesNotContain("pageToken", requests[0].Query);
+        Assert.Equal("second", QueryHelpers.ParseQuery(requests[1].Query)["pageToken"]);
+        handler.Responder = _ => Json("{\"nextPageToken\":\"repeated\"}");
+        await Assert.ThrowsAsync<GoogleHealthException>(() => client.ReadAsync("synthetic-token", "weight", DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow, default));
+    }
+
+    [Theory]
+    [InlineData("inventory", "weight", "10000")]
+    [InlineData("inventory", "sleep", "25")]
+    [InlineData("read", "weight", "10000")]
+    [InlineData("sleep", "sleep", "25")]
+    public async Task Reads_history_beyond_one_hundred_pages_without_changing_the_time_window(
+        string operation, string type, string pageSize)
+    {
+        var from = DateTimeOffset.Parse("2026-09-01T00:00:00Z");
+        var to = from.AddDays(1);
+        var field = type == "sleep" ? "sleep.interval.start_time" : "weight.sample_time.physical_time";
+        var expectedFilter = $"{field} >= \"{from.UtcDateTime:O}\" AND {field} < \"{to.UtcDateTime:O}\"";
+        var calls = 0;
+        var sample = type == "sleep"
+            ? """{"name":"users/example/dataTypes/sleep/dataPoints/last-night","sleep":{"interval":{"startTime":"2026-09-01T00:00:00Z","endTime":"2026-09-01T08:00:00Z"}}}"""
+            : """{"weight":{"sampleTime":{"physicalTime":"2026-09-01T00:00:00Z"},"weightGrams":72500}}""";
+        using var http = new HttpClient(new StubHandler(request =>
+        {
+            var query = QueryHelpers.ParseQuery(request.RequestUri!.Query);
+            Assert.Equal(expectedFilter, query["filter"].ToString());
+            Assert.Equal(pageSize, query["pageSize"].ToString());
+            Assert.Equal(calls == 0 ? "" : $"page-{calls + 1}",
+                query.TryGetValue("pageToken", out var pageToken) ? pageToken.ToString() : "");
+            Assert.Equal("Bearer", request.Headers.Authorization?.Scheme);
+            Assert.Equal("synthetic-token", request.Headers.Authorization?.Parameter);
+            calls++;
+            return Json(calls < 101
+                ? JsonSerializer.Serialize(new { dataPoints = Array.Empty<object>(), nextPageToken = $"page-{calls + 1}" })
+                : "{\"dataPoints\":[" + sample + "]}");
+        }));
+        var client = new GoogleHealthClient(http);
+
+        switch (operation)
+        {
+            case "inventory":
+                Assert.Equal(1, await client.CountAsync("synthetic-token", type, from, to, default));
+                break;
+            case "read":
+                var reading = Assert.Single(await client.ReadAsync("synthetic-token", type, from, to, default));
+                Assert.Equal(72.5m, reading.Value);
+                Assert.Equal(from.ToUnixTimeMilliseconds(), reading.Mills);
+                break;
+            case "sleep":
+                var session = Assert.Single(await client.ReadSleepAsync("synthetic-token", from, to, default));
+                Assert.EndsWith("last-night", session.OriginalId);
+                Assert.Equal(from.ToUnixTimeMilliseconds(), session.StartMills);
+                break;
+        }
+        Assert.Equal(101, calls);
+    }
+
+    [Theory]
+    [InlineData("inventory", "inventory", "weight", false)]
+    [InlineData("read", "data_read", "weight", false)]
+    [InlineData("sleep", "data_read", "sleep", false)]
+    [InlineData("inventory", "inventory", "weight", true)]
+    [InlineData("read", "data_read", "weight", true)]
+    [InlineData("sleep", "data_read", "sleep", true)]
+    public async Task Limits_unique_page_tokens_but_allows_completion_on_the_last_page(
+        string operation, string stage, string type, bool completesOnLastPage)
+    {
+        var calls = 0;
+        using var http = new HttpClient(new StubHandler(_ =>
+        {
+            calls++;
+            Assert.True(calls <= GoogleHealthClient.MaximumHistoryPages);
+            return Json(completesOnLastPage && calls == GoogleHealthClient.MaximumHistoryPages
+                ? """{"dataPoints":[]}"""
+                : JsonSerializer.Serialize(new { dataPoints = Array.Empty<object>(), nextPageToken = $"page-{calls + 1}" }));
+        }));
+        var client = new GoogleHealthClient(http);
+
+        if (completesOnLastPage)
+        {
+            await ReadHistoryAsync(client, operation, default);
+        }
+        else
+        {
+            var exception = await Assert.ThrowsAsync<GoogleHealthException>(() => ReadHistoryAsync(client, operation, default));
+            Assert.Equal("history_too_large", exception.Message);
+            Assert.Equal(stage, exception.Stage);
+            Assert.Equal(type, exception.DataType);
+        }
+        Assert.Equal(GoogleHealthClient.MaximumHistoryPages, calls);
+    }
+
+    [Theory]
+    [InlineData("inventory", "inventory", "weight")]
+    [InlineData("read", "data_read", "weight")]
+    [InlineData("sleep", "data_read", "sleep")]
+    public async Task Rejects_pagination_cycles_for_each_history_operation(string operation, string stage, string type)
+    {
+        var calls = 0;
+        string[] tokens = ["first", "second", "first"];
+        using var http = new HttpClient(new StubHandler(_ =>
+            Json(JsonSerializer.Serialize(new { nextPageToken = tokens[calls++] }))));
+        var client = new GoogleHealthClient(http);
+
+        var exception = await Assert.ThrowsAsync<GoogleHealthException>(() => ReadHistoryAsync(client, operation, default));
+
+        Assert.Equal("pagination_failed", exception.Message);
+        Assert.Equal(stage, exception.Stage);
+        Assert.Equal(type, exception.DataType);
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
+    public async Task Reports_each_completed_import_page()
+    {
+        var calls = 0;
+        using var http = new HttpClient(new StubHandler(_ =>
+        {
+            calls++;
+            return Json(calls == 1
+                ? """{"dataPoints":[],"nextPageToken":"second"}"""
+                : """{"dataPoints":[]}""");
+        }));
+        var pages = new List<int>();
+        var client = new GoogleHealthClient(http);
+
+        await client.ReadAsync("synthetic-token", "weight", DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow, default, pages.Add);
+
+        Assert.Equal([1, 2], pages);
+    }
+
+    [Fact]
+    public async Task Queues_only_one_manual_import_per_tenant_and_tracks_progress()
+    {
+        var tenant = Guid.NewGuid();
+        var coordinator = new GoogleHealthCoordinator();
+
+        Assert.True(coordinator.Queue(tenant, 4));
+        Assert.False(coordinator.Queue(tenant, 4));
+        await using var requests = coordinator.ReadRequestsAsync(default).GetAsyncEnumerator();
+        Assert.True(await requests.MoveNextAsync());
+        Assert.Equal(tenant, requests.Current);
+        Assert.True(coordinator.StartQueued(tenant));
+        coordinator.Report(tenant, "reading", "steps", 1, 4, 3);
+
+        var progress = Assert.IsType<GoogleHealthCoordinator.SyncProgress>(coordinator.Progress(tenant));
+        Assert.Equal("reading", progress.Phase);
+        Assert.Equal("steps", progress.DataType);
+        Assert.Equal(1, progress.CompletedDataTypes);
+        Assert.Equal(4, progress.TotalDataTypes);
+        Assert.Equal(3, progress.PagesRead);
+
+        coordinator.Complete(tenant);
+        Assert.Null(coordinator.Progress(tenant));
+    }
+
+    [Theory]
+    [InlineData("inventory", true)]
+    [InlineData("read", true)]
+    [InlineData("sleep", true)]
+    [InlineData("inventory", false)]
+    [InlineData("read", false)]
+    [InlineData("sleep", false)]
+    public async Task Stops_history_requests_when_cancelled(string operation, bool cancelBeforeFirstPage)
+    {
+        using var cancellation = new CancellationTokenSource();
+        var calls = 0;
+        using var http = new HttpClient(new StubHandler(_ =>
+        {
+            calls++;
+            if (calls == 3) cancellation.Cancel();
+            return Json(JsonSerializer.Serialize(new { dataPoints = Array.Empty<object>(), nextPageToken = $"page-{calls + 1}" }));
+        }));
+        var client = new GoogleHealthClient(http);
+        if (cancelBeforeFirstPage) cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ReadHistoryAsync(client, operation, cancellation.Token));
+
+        Assert.Equal(cancelBeforeFirstPage ? 0 : 3, calls);
+    }
+
+    [Theory]
+    [InlineData("ACCOUNT_NOT_LINKED", "account_not_linked", true)]
+    [InlineData("INVALID_PAGE_TOKEN", "invalid_google_request", true)]
+    [InlineData("API_PRIVATE_PREVIEW_ACCESS_DENIED", "preview_access_denied", false)]
+    [InlineData("MISSING_OAUTH_SCOPE", "permission_denied", false)]
+    [InlineData("[\"ACCOUNT_NOT_LINKED\"]", "account_not_linked", false)]
+    public async Task Maps_google_error_reasons_without_exposing_response_details(string reason, string expected, bool directReason)
+    {
+        var detail = directReason
+            ? new Dictionary<string, object> { ["reason"] = reason }
+            : new Dictionary<string, object> { ["metadata"] = new { detailedReasons = reason } };
+        var body = JsonSerializer.Serialize(new { error = new { message = "sensitive upstream detail", details = new[] { detail } } });
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        });
+        var client = new GoogleHealthClient(new HttpClient(handler));
+
+        var exception = await Assert.ThrowsAsync<GoogleHealthException>(() => client.ReadAsync(
+            "synthetic-token", "weight", DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow, default));
+
+        Assert.Equal(expected, exception.Message);
+        Assert.Equal("weight", exception.DataType);
+        Assert.Equal("data_read", exception.Stage);
+        Assert.DoesNotContain("sensitive", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("invalid_client", "invalid_client_credentials")]
+    [InlineData("redirect_uri_mismatch", "invalid_callback")]
+    [InlineData("invalid_scope", "oauth_scope_configuration")]
+    [InlineData("invalid_grant", "expired_signin")]
+    public async Task Maps_oauth_exchange_errors_to_actionable_codes(string providerError, string expected)
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(new { error = providerError, error_description = "do not expose" }),
+                Encoding.UTF8, "application/json")
+        });
+        var client = new GoogleHealthClient(new HttpClient(handler));
+
+        var exception = await Assert.ThrowsAsync<GoogleHealthException>(() => client.ExchangeAuthorizationCodeAsync([], default));
+
+        Assert.Equal(expected, exception.Message);
+        Assert.Equal("authorization_code", exception.Stage);
+        Assert.DoesNotContain("expose", exception.Message);
+    }
+
+    [Fact]
+    public async Task Invalid_refresh_grant_requires_reconnection()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("{\"error\":\"invalid_grant\"}", Encoding.UTF8, "application/json")
+        });
+        var client = new GoogleHealthClient(new HttpClient(handler));
+
+        var exception = await Assert.ThrowsAsync<GoogleHealthException>(() => client.RefreshAccessTokenAsync([], default));
+
+        Assert.Equal("reconnect_required", exception.Message);
+        Assert.Equal("token_refresh", exception.Stage);
+    }
+
+    [Fact]
+    public async Task Stores_encrypted_oauth_and_imports_atomically_with_tenant_isolation()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:"); await connection.OpenAsync();
+        await using var db = new NocturneDbContext(new DbContextOptionsBuilder<NocturneDbContext>()
+            .UseSqlite(connection, options => options.ExecutionStrategy(dependencies => new TestRetryingExecutionStrategy(dependencies)))
+            .Options);
+        await db.Database.EnsureCreatedAsync();
+        Assert.True(db.Database.CreateExecutionStrategy().RetriesOnFailure);
+        var tenant = Guid.NewGuid(); var subject = Guid.NewGuid();
+        db.TenantId = tenant;
+        db.Tenants.Add(new TenantEntity { Id = tenant, Slug = "synthetic", DisplayName = "Synthetic", IsActive = true }); await db.SaveChangesAsync();
+        var observation = DateTimeOffset.UtcNow.AddHours(-1).ToString("O");
+        var grams = 72000;
+        var tokenCalls = 0;
+        var dataAuthorizations = new List<string?>();
+        var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri!.AbsolutePath == "/token")
+            {
+                tokenCalls++;
+                return Json($$"""{"access_token":"synthetic-access","refresh_token":"synthetic-refresh","expires_in":3600,"token_type":"Bearer","scope":"openid {{GoogleHealthClient.MetricsScope}}"}""");
+            }
+            if (request.RequestUri.AbsolutePath == "/v1/userinfo") return Json("{\"sub\":\"synthetic-account\"}");
+            if (request.RequestUri.AbsolutePath == "/revoke") return Json("{}");
+            dataAuthorizations.Add(request.Headers.Authorization?.ToString());
+            return Json(JsonSerializer.Serialize(new { dataPoints = new[] { new { weight = new { sampleTime = new { physicalTime = observation }, weightGrams = grams } } } }));
+        });
+        var protection = new EphemeralDataProtectionProvider();
+        var service = new GoogleHealthService(db, protection, new GoogleHealthCoordinator(), new GoogleHealthClient(new HttpClient(handler)));
+        var options = Options(); options.DataTypes = ["steps", "weight"];
+        await service.SaveAsync(options, subject, default);
+        var auth = await service.StartAsync(subject, default);
+        var query = QueryHelpers.ParseQuery(new Uri(auth.Url).Query);
+        Assert.Equal("S256", query["code_challenge_method"]); Assert.Contains("readonly", query["scope"].ToString());
+        var callback = new GoogleHealthCallback { Code = "synthetic-code", State = query["state"].ToString() };
+        await Assert.ThrowsAsync<GoogleHealthException>(() => service.CompleteAsync(callback, Guid.NewGuid(), default));
+        await service.CompleteAsync(callback, subject, default);
+        await Assert.ThrowsAsync<GoogleHealthException>(() => service.CompleteAsync(callback, subject, default));
+        var status = await service.StatusAsync(default);
+        Assert.Equal(["heart-rate", "weight"], status.GrantedTypes); Assert.Equal("partial_consent", status.ErrorCode);
+        Assert.Equal(["steps", "sleep"], status.ErrorDataTypes);
+        Assert.NotNull(status.AccessTokenExpiresAt);
+        var stored = await db.GoogleHealthConnections.SingleAsync();
+        Assert.DoesNotContain("synthetic-secret", stored.ProtectedSettings); Assert.DoesNotContain("synthetic-refresh", stored.ProtectedToken!);
+        await service.SyncAsync(true, default); Assert.Equal(72m, (await db.GoogleHealthReadings.SingleAsync()).Value);
+        Assert.Equal(1, tokenCalls);
+        Assert.All(dataAuthorizations, value => Assert.Equal("Bearer synthetic-access", value));
+        var protector = protection.CreateProtector("Nocturne.GoogleHealth.v1", tenant.ToString());
+        stored.ProtectedToken = protector.Protect(JsonSerializer.Serialize(new
+        {
+            refreshToken = "synthetic-refresh",
+            scopes = new[] { "openid", GoogleHealthClient.MetricsScope }
+        }, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+        await db.SaveChangesAsync();
+        grams = 73000; await service.SyncAsync(true, default);
+        Assert.Equal(2, tokenCalls);
+        Assert.Single(await db.GoogleHealthReadings.ToListAsync()); Assert.Equal(73m, (await db.GoogleHealthReadings.AsNoTracking().SingleAsync()).Value);
+        handler.Responder = _ => new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        await service.SyncAsync(true, default); Assert.Single(await db.GoogleHealthReadings.ToListAsync());
+        handler.Responder = _ => throw new InvalidOperationException("synthetic internal failure");
+        await service.SyncAsync(true, default);
+        Assert.Equal("internal_sync_google_read", (await service.StatusAsync(default)).ErrorCode);
+        handler.Responder = request => request.RequestUri!.AbsolutePath == "/revoke"
+            ? Json("{}")
+            : throw new InvalidOperationException("Unexpected request after import failure");
+        db.TenantId = Guid.NewGuid(); Assert.Empty(await db.GoogleHealthReadings.ToListAsync()); Assert.Empty(await db.GoogleHealthConnections.ToListAsync());
+        db.TenantId = tenant;
+        await service.DisconnectAsync(subject, default);
+        Assert.False((await service.StatusAsync(default)).Connected); Assert.Single(await db.GoogleHealthReadings.ToListAsync());
+        await service.PurgeAsync(subject, default); Assert.Empty(await db.GoogleHealthReadings.ToListAsync());
+
+        handler.Responder = request => request.RequestUri!.AbsolutePath switch
+        {
+            "/token" => Json(JsonSerializer.Serialize(new { access_token = "synthetic-access", refresh_token = "synthetic-refresh", expires_in = 3600, token_type = "Bearer", scope = $"openid {GoogleHealthClient.MetricsScope} {GoogleHealthClient.ActivityScope}" })),
+            "/v1/userinfo" => Json("{\"sub\":\"synthetic-account\"}"),
+            var path when path.Contains("/steps/") => Json(JsonSerializer.Serialize(new { dataPoints = new[] { new { steps = new { interval = new { startTime = observation, endTime = DateTimeOffset.Parse(observation).AddMinutes(1).ToString("O") }, count = "42" } } } })),
+            var path when path.Contains("/heart-rate/") => Json(JsonSerializer.Serialize(new { dataPoints = new[] { new { heartRate = new { sampleTime = new { physicalTime = observation }, beatsPerMinute = "65" } } } })),
+            _ => Json(JsonSerializer.Serialize(new { dataPoints = new[] { new { weight = new { sampleTime = new { physicalTime = observation }, weightGrams = 71000 } } } }))
+        };
+        options.DataTypes = ["steps", "heart-rate", "weight"];
+        await service.SaveAsync(options, subject, default);
+        query = QueryHelpers.ParseQuery(new Uri((await service.StartAsync(subject, default)).Url).Query);
+        await service.CompleteAsync(new() { State = query["state"].ToString(), Code = "synthetic-code" }, subject, default);
+        await service.SyncAsync(true, default);
+        Assert.Equal(3, await db.GoogleHealthReadings.CountAsync());
+        Assert.Equal(42m, (await db.GoogleHealthReadings.SingleAsync(x => x.DataType == "steps")).Value);
+        Assert.Equal(65m, (await db.GoogleHealthReadings.SingleAsync(x => x.DataType == "heart-rate")).Value);
+        Assert.Equal(71m, (await db.GoogleHealthReadings.SingleAsync(x => x.DataType == "weight")).Value);
+        var controller = new GoogleHealthController(service, db);
+        foreach (var type in options.DataTypes)
+            Assert.Single(Assert.IsType<List<GoogleHealthReading>>(Assert.IsType<OkObjectResult>((await controller.GetGoogleHealthReadings(type)).Result).Value));
+    }
+
+    [Fact]
+    public async Task Persists_provider_errors_but_allows_empty_results_and_import_reconfiguration()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:"); await connection.OpenAsync();
+        await using var db = new NocturneDbContext(new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options);
+        await db.Database.EnsureCreatedAsync();
+        var tenant = Guid.NewGuid(); var subject = Guid.NewGuid(); db.TenantId = tenant;
+        db.Tenants.Add(new TenantEntity { Id = tenant, Slug = "synthetic", DisplayName = "Synthetic", IsActive = true });
+        await db.SaveChangesAsync();
+        var handler = new StubHandler(request => request.RequestUri!.AbsolutePath switch
+        {
+            "/token" => Json($$"""{"access_token":"synthetic-access","refresh_token":"synthetic-refresh","expires_in":3600,"token_type":"Bearer","scope":"openid {{GoogleHealthClient.MetricsScope}}"}"""),
+            "/v1/userinfo" => Json("{\"sub\":\"synthetic-account\"}"),
+            _ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"error\":{\"message\":\"do not persist this\",\"details\":[{\"metadata\":{\"detailedReasons\":[\"ACCOUNT_NOT_LINKED\"]}}]}}", Encoding.UTF8, "application/json")
+            }
+        });
+        var service = new GoogleHealthService(db, new EphemeralDataProtectionProvider(), new GoogleHealthCoordinator(),
+            new GoogleHealthClient(new HttpClient(handler)));
+        await service.SaveAsync(Options(), subject, default);
+        var authorization = await service.StartAsync(subject, default);
+        var state = QueryHelpers.ParseQuery(new Uri(authorization.Url).Query)["state"].ToString();
+        await service.CompleteAsync(new() { State = state, Code = "synthetic-code" }, subject, default);
+
+        await service.SyncAsync(true, default);
+
+        var status = await service.StatusAsync(default);
+        Assert.Equal("account_not_linked", status.ErrorCode);
+        Assert.Equal(["weight"], status.ErrorDataTypes);
+        Assert.NotNull(status.LastAttempt);
+        Assert.True(status.Connected);
+        Assert.DoesNotContain("persist", (await db.GoogleHealthConnections.SingleAsync()).ErrorCode);
+
+        handler.Responder = _ => Json("{\"dataPoints\":[]}");
+        await service.SyncAsync(true, default);
+        status = await service.StatusAsync(default);
+        Assert.Null(status.ErrorCode);
+        Assert.Empty(status.ErrorDataTypes);
+        Assert.NotNull(status.LastSync);
+
+        var token = (await db.GoogleHealthConnections.SingleAsync()).ProtectedToken;
+        db.GoogleHealthReadings.Add(new GoogleHealthReadingEntity
+        {
+            Id = Guid.CreateVersion7(), DataType = "weight", SourceKey = "existing-import",
+            Mills = DateTimeOffset.UtcNow.AddDays(-30).ToUnixTimeMilliseconds(), Value = 72m, Unit = "kg"
+        });
+        await db.SaveChangesAsync();
+        var options = Options();
+        options.ClientSecret = null;
+        options.DataTypes = [];
+        options.ImportFrom = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        await service.SaveAsync(options, subject, default);
+        handler.Responder = _ => throw new InvalidOperationException("Paused imports must not call Google");
+        await service.SyncAsync(true, default);
+        status = await service.StatusAsync(default);
+        Assert.True(status.Connected);
+        Assert.Empty(status.SelectedTypes);
+        Assert.Null(status.ErrorCode);
+        Assert.Equal(options.ImportFrom, status.ImportFrom);
+        Assert.Equal(token, (await db.GoogleHealthConnections.SingleAsync()).ProtectedToken);
+        Assert.Equal(72m, (await db.GoogleHealthReadings.SingleAsync()).Value);
+
+        options.DataTypes = ["weight"];
+        await service.SaveAsync(options, subject, default);
+        var readCalls = 0;
+        handler.Responder = request =>
+        {
+            readCalls++;
+            Assert.Contains("2000-01-01", QueryHelpers.ParseQuery(request.RequestUri!.Query)["filter"].ToString());
+            return Json("{\"dataPoints\":[]}");
+        };
+        await service.SyncAsync(true, default);
+        Assert.Equal(1, readCalls);
+        Assert.Null((await service.StatusAsync(default)).ErrorCode);
+    }
+
+    [Fact]
+    public async Task Unreadable_google_configuration_can_be_disconnected_and_reconfigured()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:"); await connection.OpenAsync();
+        await using var db = new NocturneDbContext(new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options);
+        await db.Database.EnsureCreatedAsync();
+        var tenant = Guid.NewGuid(); var subject = Guid.NewGuid(); db.TenantId = tenant;
+        db.Tenants.Add(new TenantEntity { Id = tenant, Slug = "synthetic", DisplayName = "Synthetic", IsActive = true }); await db.SaveChangesAsync();
+        var handler = new StubHandler(request => request.RequestUri!.AbsolutePath switch
+        {
+            "/token" => Json($$"""{"access_token":"synthetic-access","refresh_token":"synthetic-refresh","expires_in":3600,"token_type":"Bearer","scope":"openid {{GoogleHealthClient.MetricsScope}}"}"""),
+            "/v1/userinfo" => Json("{\"sub\":\"synthetic-account\"}"),
+            _ => Json("{}")
+        });
+        var coordinator = new GoogleHealthCoordinator();
+        var original = new GoogleHealthService(db, new EphemeralDataProtectionProvider(), coordinator, new GoogleHealthClient(new HttpClient(handler)));
+        var options = Options();
+        await original.SaveAsync(options, subject, default);
+        var authorization = await original.StartAsync(subject, default);
+        var state = QueryHelpers.ParseQuery(new Uri(authorization.Url).Query)["state"].ToString();
+        await original.CompleteAsync(new() { State = state, Code = "synthetic-code" }, subject, default);
+
+        var recovered = new GoogleHealthService(db, new EphemeralDataProtectionProvider(), coordinator, new GoogleHealthClient(new HttpClient(handler)));
+        var broken = await recovered.StatusAsync(default);
+        Assert.True(broken.Connected); Assert.False(broken.Configured);
+        Assert.Equal("stored_google_configuration_unreadable", broken.ErrorCode);
+
+        await recovered.SyncAsync(true, default);
+        Assert.Equal("stored_google_configuration_unreadable", (await db.GoogleHealthConnections.SingleAsync()).ErrorCode);
+        Assert.True((await recovered.StatusAsync(default)).Connected);
+
+        await recovered.DisconnectAsync(subject, default);
+        Assert.False((await recovered.StatusAsync(default)).Connected);
+        await recovered.SaveAsync(options, subject, default);
+        Assert.True((await recovered.StatusAsync(default)).Configured);
+    }
+
+    [Fact]
+    public async Task Unsupported_stored_type_keeps_status_and_disconnect_available()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:"); await connection.OpenAsync();
+        await using var db = new NocturneDbContext(new DbContextOptionsBuilder<NocturneDbContext>().UseSqlite(connection).Options);
+        await db.Database.EnsureCreatedAsync();
+        var tenant = Guid.NewGuid(); var subject = Guid.NewGuid(); db.TenantId = tenant;
+        db.Tenants.Add(new TenantEntity { Id = tenant, Slug = "synthetic", DisplayName = "Synthetic", IsActive = true }); await db.SaveChangesAsync();
+        var provider = new EphemeralDataProtectionProvider();
+        var service = new GoogleHealthService(db, provider, new GoogleHealthCoordinator(), new GoogleHealthClient(new HttpClient(new StubHandler(_ => Json("{}")))));
+        await service.SaveAsync(Options(), subject, default);
+        var row = await db.GoogleHealthConnections.SingleAsync();
+        var legacy = Options(); legacy.DataTypes = ["weight", "body-fat"];
+        var protector = provider.CreateProtector("Nocturne.GoogleHealth.v1", tenant.ToString());
+        row.ProtectedSettings = protector.Protect(JsonSerializer.Serialize(legacy, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+        await db.SaveChangesAsync();
+
+        var status = await service.StatusAsync(default);
+
+        Assert.True(status.Configured); Assert.False(status.Connected);
+        Assert.Equal(["weight"], status.SelectedTypes);
+        Assert.Equal("unsupported_type", status.ErrorCode);
+        await service.DisconnectAsync(subject, default);
+    }
+
+    [Fact]
+    public void Future_catalog_entries_cannot_be_silently_selected()
+    {
+        var options = Options(); options.DataTypes = ["body-fat"];
+        Assert.Contains(GoogleHealthClient.Capabilities, c => c.DataType == "body-fat" && !c.Supported);
+        Assert.Throws<GoogleHealthException>(() => GoogleHealthService.ValidateOptions(options));
+    }
+
+    [Fact]
+    public async Task Inventory_counts_known_types_without_importing_unsupported_data()
+    {
+        var handler = new StubHandler(_ => Json("""{"dataPoints":[{},{}]}"""));
+        var client = new GoogleHealthClient(new HttpClient(handler));
+
+        var count = await client.CountAsync("token", "body-fat", DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow, default);
+
+        Assert.Equal(2, count);
+        Assert.NotNull(handler.LastRequestUri);
+        Assert.Contains("dataTypes/body-fat/dataPoints:reconcile", handler.LastRequestUri.AbsoluteUri);
+    }
+
+    [Fact]
+    public void Explicit_history_start_accepts_full_history_and_rejects_future_dates()
+    {
+        var options = Options();
+        options.ImportFrom = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        GoogleHealthService.ValidateOptions(options);
+
+        options.ImportFrom = DateTimeOffset.UtcNow.AddDays(2);
+        Assert.Throws<GoogleHealthException>(() => GoogleHealthService.ValidateOptions(options));
+    }
+
+    [Fact]
+    public void Empty_import_selection_is_valid_for_pausing()
+    {
+        var options = Options();
+        options.DataTypes = [];
+        GoogleHealthService.ValidateOptions(options);
+        Assert.True(System.ComponentModel.DataAnnotations.Validator.TryValidateObject(
+            options, new System.ComponentModel.DataAnnotations.ValidationContext(options),
+            new List<System.ComponentModel.DataAnnotations.ValidationResult>(), true));
+    }
+
+    [Fact]
+    public async Task Sync_returns_problem_details_when_google_is_unavailable()
+    {
+        var controller = new GoogleHealthController(new ThrowingGoogleHealthService(), null!);
+
+        var result = await controller.SyncGoogleHealth(default);
+
+        var response = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(502, response.StatusCode);
+        var problem = Assert.IsType<ProblemDetails>(response.Value);
+        Assert.Equal("google_unavailable", problem.Detail);
+    }
+
+    private static Task ReadHistoryAsync(GoogleHealthClient client, string operation, CancellationToken ct)
+    {
+        var from = DateTimeOffset.Parse("2026-09-01T00:00:00Z");
+        var to = from.AddDays(1);
+        return operation switch
+        {
+            "inventory" => client.CountAsync("synthetic-token", "weight", from, to, ct),
+            "read" => client.ReadAsync("synthetic-token", "weight", from, to, ct),
+            "sleep" => client.ReadSleepAsync("synthetic-token", from, to, ct),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation))
+        };
+    }
+
+    private static GoogleHealthOptions Options() => new() { ClientId = "synthetic.apps.googleusercontent.com", ClientSecret = "synthetic-secret", CallbackUrl = "https://example.test:8450/settings/connectors/google-health/callback", DataTypes = ["weight"] };
+    private static HttpResponseMessage Json(string text) => new(HttpStatusCode.OK) { Content = new StringContent(text, Encoding.UTF8, "application/json") };
+    private sealed class ThrowingGoogleHealthService : IGoogleHealthService
+    {
+        public Task<GoogleHealthStatus> StatusAsync(CancellationToken ct) => Task.FromResult(new GoogleHealthStatus());
+        public Task SaveAsync(GoogleHealthOptions options, Guid subject, CancellationToken ct) => Task.CompletedTask;
+        public Task<GoogleHealthAuthorize> StartAsync(Guid subject, CancellationToken ct) => Task.FromResult(new GoogleHealthAuthorize());
+        public Task CompleteAsync(GoogleHealthCallback callback, Guid subject, CancellationToken ct) => Task.CompletedTask;
+        public Task DisconnectAsync(Guid subject, CancellationToken ct) => Task.CompletedTask;
+        public Task PurgeAsync(Guid subject, CancellationToken ct) => Task.CompletedTask;
+        public Task<GoogleHealthPreview> PreviewAsync(Guid subject, CancellationToken ct) => Task.FromResult(new GoogleHealthPreview());
+        public Task QueueSyncAsync(CancellationToken ct) => throw new HttpRequestException("synthetic");
+        public Task SyncAsync(bool force, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public Func<HttpRequestMessage, HttpResponseMessage> Responder { get; set; } = responder;
+        public Uri? LastRequestUri { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            return Task.FromResult(Responder(request));
+        }
+    }
+
+    private sealed class TestRetryingExecutionStrategy(ExecutionStrategyDependencies dependencies)
+        : ExecutionStrategy(dependencies, 1, TimeSpan.Zero)
+    {
+        protected override bool ShouldRetryOn(Exception exception) => false;
+    }
+}


### PR DESCRIPTION
## Summary

This brings the working Nocturne Personal implementation back to upstream as clean, first-party functionality for new users:

1. a native, read-only Google Health connector integrated with Nocturne's existing health histories; and
2. adjustable color focus controls for the Year Overview heatmaps.

The contribution branch is based directly on `nightscout/nocturne:main` at `01644942c08ef27b4915763560a58aa1905951fc`. Fork-only release workflows, Personal synchronization/version files, the fork README, Home Assistant packaging, Copilot configuration, GLP-1/medication code, compatibility shims and unrelated fixes are deliberately excluded.

## Google Health connector

### First-party naming and routes

- Uses the generic `GoogleHealth` service, controller, model, entity and test namespaces.
- Exposes the API at `/api/v4/google-health`.
- Uses `/settings/connectors/google-health/callback` as the OAuth callback.
- Stores connector state in `google_health_connections` and imported source records in `google_health_readings`.
- Contains no legacy Personal route, table, redirect or data migration; this is a clean initial implementation for new users.

### OAuth and security

- Adds a Google OAuth authorization-code flow with PKCE and read-only Health scopes.
- Stores client settings and refresh/access-token material through ASP.NET Core Data Protection rather than plaintext application settings.
- Validates callback state, subject and expiry, and keeps access tenant-scoped.
- Uses tenant query filters and PostgreSQL row-level security for connector state and imported staging records.

### Discovery and user controls

- Presents Google Health as a normal **Settings -> Connectors & Apps -> Server Connectors** entry.
- Shows active/error status in the common data-source presentation.
- Previews every known Google Health data type, whether consent was granted, whether data was found, and whether Nocturne currently has a destination.
- Lets users independently enable or disable supported imports without reconnecting their Google account.
- Lets users choose the historical import start date instead of enforcing a short fixed lookback.
- Supports disconnecting the account separately from explicitly deleting imported Google data.

### Native Nocturne integration

- Imports steps into step history.
- Imports heart rate into heart-rate history.
- Imports weight into body-weight history.
- Imports sleep sessions/stages into sleep history.
- Exposes unsupported-but-detected types in the inventory without pretending that Nocturne can store them.
- Reconciles the selected date range, including removal of source records that Google no longer returns.
- Treats an empty result for a selected period as a valid no-data outcome rather than a connector-wide failure.

### Long-running import behavior

- Follows Google pagination with a 10,000-page safety bound per type and operation.
- Queues manual imports on the server so multi-year history does not hold the browser request open.
- Keeps scheduled synchronization at approximately 15-minute intervals with retry/backoff state.
- Deduplicates queued tenant work and continues safely when the browser leaves the page.
- Reports phase, current data type, completed/total types, pages read and estimated percentage.
- Polls status while an import is running, leaving the rest of the connector page usable.
- Returns stable technical error codes and affected data types for actionable diagnostics.
- Handles host cancellation as a normal background-worker shutdown.

## Year Overview color focus

- Adds two adjustable color bounds for TDD, bolus, basal, carbohydrates and Time in Range.
- Adds four independently adjustable boundaries for average glucose while retaining the semantic glucose color order.
- Supports numeric input, keyboard control and pointer dragging on the gradient.
- Supports mg/dL and mmol/L editing without losing canonical values.
- Saturates values outside the selected focus range to maximize contrast inside it.
- Remembers settings independently per metric, tenant and user in the current browser.
- Provides reset/automatic behavior and validates crossing, empty, non-finite and out-of-range input.
- Makes Very Low average-glucose cells black so they are clearly distinct from Low.
- Changes visualization only; glucose targets, measurements and Time in Range calculations are untouched.

## Additional UI correction

- Maps OpenAPS to the existing generic device mark, avoiding requests for the missing `/logos/openaps.svg` asset.

## Database changes

One clean EF Core migration adds the final tenant-scoped Google connection and health-reading schema, including retry scheduling and row-level-security policies. The large diff is mostly its generated EF model designer snapshot. No legacy Personal or medication tables are created.

## Tests and validation

Included coverage exercises:

- OAuth state, consent, token refresh and protected storage;
- import mapping, pagination, reconciliation, deletion and partial/no-data outcomes;
- background queue progress, retry behavior and shutdown cancellation;
- tenant filters/RLS and V4 write-scope gating;
- connector inventory, selection, diagnostics and progress UI;
- two-bound metric focus and four-bound glucose controls, persistence, units, validation, keyboard and mobile drag behavior;
- OpenAPS logo fallback and glucose color mapping.

The complete implementation passed the Personal merged-branch source checks before extraction: 96 browser tests and the focused .NET regression suite. This upstream branch removes the compatibility layer and consolidates the schema into one initial migration; upstream CI is therefore the authoritative validation for this exact branch. No automated test signs into a real Google account, so real consent/data availability remains an operator acceptance test.

## Review notes

- This is one integration PR because the frontend remote functions are generated from the backend API contract and the database/API/UI changes need to remain coherent.
- No dosing behavior, insulin/IOB calculation, clinical recommendation or write access to Google Health is introduced.
- Existing Personal installations are intentionally not migrated by this upstream contribution; it targets clean new upstream installations.