### PR TITLE
docs(portal): refresh marketing copy, fix hero physics, unbreak portal CI

### DIFF
--- a/.github/workflows/portal-pages.yml
+++ b/.github/workflows/portal-pages.yml
@@ -8,6 +8,10 @@ on:
       - 'src/Web/packages/ui/**'
       - 'src/Web/packages/cms/**'
       - 'src/Web/packages/screenshots/**'
+      # The portal bundles the app's appearance store and OAuth scope constants.
+      - 'src/Web/packages/app/src/lib/stores/**'
+      - 'src/Web/packages/app/src/lib/constants/**'
+      - 'src/Web/packages/app/src/lib/components/dashboard/top-widget-ids.ts'
       - 'src/Web/pnpm-lock.yaml'
       - '.github/workflows/portal-pages.yml'
   workflow_dispatch:

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -4,7 +4,22 @@
 # Copy this file to .env and fill in the required values.
 # Passwords are only used on first database initialization.
 
-# -- Configuration ---------------------------------------------
+# -- Required (set these before first run) ----------------------
+
+# The hostname tenant subdomains hang off, e.g. example.com or nocturne.example.com. At least two labels; not an IP address.
+BASE_DOMAIN=
+# Minimum 12 characters: used for JWT signing and service authentication
+INSTANCE_KEY=
+# Password for nocturne_app: runtime role, cannot bypass Row Level Security
+POSTGRES_APP_PASSWORD=
+# Password for nocturne_migrator: owns the schema, runs EF migrations
+POSTGRES_MIGRATOR_PASSWORD=
+# Used only at first container start to create runtime roles
+POSTGRES_PASSWORD=
+# Password for nocturne_web: bot-framework state, cannot bypass Row Level Security
+POSTGRES_WEB_PASSWORD=
+
+# -- Configuration (defaults work; change if you need to) --------
 
 NOCTURNE_API_IMAGE=ghcr.io/nightscout/nocturne/nocturne-api:latest
 NOCTURNE_WEB_IMAGE=ghcr.io/nightscout/nocturne/nocturne-web:latest
@@ -15,21 +30,6 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 POSTGRES_USERNAME=nocturne
 # Space-separated CIDRs of a CDN in front of this deployment, e.g. Cloudflare's published ranges. Decides whose CF-Connecting-IP header is believed; leave as-is unless a CDN is present, and never set it empty.
 TRUSTED_PROXIES=127.0.0.1/32
-
-# -- Required (set these before first run) ----------------------
-
-# The hostname tenant subdomains hang off, e.g. example.com or nocturne.example.com. At least two labels; not an IP address.
-BASE_DOMAIN=
-# Minimum 12 characters — used for JWT signing and service authentication
-INSTANCE_KEY=
-# Password for nocturne_app — runtime role, cannot bypass Row Level Security
-POSTGRES_APP_PASSWORD=
-# Password for nocturne_migrator — owns the schema, runs EF migrations
-POSTGRES_MIGRATOR_PASSWORD=
-# Used only at first container start to create runtime roles
-POSTGRES_PASSWORD=
-# Password for nocturne_web — bot-framework state, cannot bypass Row Level Security
-POSTGRES_WEB_PASSWORD=
 
 # -- Optional --------------------------------------------------
 

--- a/deploy/portainer/.env.example
+++ b/deploy/portainer/.env.example
@@ -4,7 +4,22 @@
 # Copy this file to .env and fill in the required values.
 # Passwords are only used on first database initialization.
 
-# -- Configuration ---------------------------------------------
+# -- Required (set these before first run) ----------------------
+
+# The hostname tenant subdomains hang off, e.g. example.com or nocturne.example.com. At least two labels; not an IP address.
+BASE_DOMAIN=
+# Minimum 12 characters: used for JWT signing and service authentication
+INSTANCE_KEY=
+# Password for nocturne_app: runtime role, cannot bypass Row Level Security
+POSTGRES_APP_PASSWORD=
+# Password for nocturne_migrator: owns the schema, runs EF migrations
+POSTGRES_MIGRATOR_PASSWORD=
+# Used only at first container start to create runtime roles
+POSTGRES_PASSWORD=
+# Password for nocturne_web: bot-framework state, cannot bypass Row Level Security
+POSTGRES_WEB_PASSWORD=
+
+# -- Configuration (defaults work; change if you need to) --------
 
 NOCTURNE_API_IMAGE=ghcr.io/nightscout/nocturne/nocturne-api:latest
 NOCTURNE_WEB_IMAGE=ghcr.io/nightscout/nocturne/nocturne-web:latest
@@ -15,21 +30,6 @@ OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 POSTGRES_USERNAME=nocturne
 # Space-separated CIDRs of a CDN in front of this deployment, e.g. Cloudflare's published ranges. Decides whose CF-Connecting-IP header is believed; leave as-is unless a CDN is present, and never set it empty.
 TRUSTED_PROXIES=127.0.0.1/32
-
-# -- Required (set these before first run) ----------------------
-
-# The hostname tenant subdomains hang off, e.g. example.com or nocturne.example.com. At least two labels; not an IP address.
-BASE_DOMAIN=
-# Minimum 12 characters — used for JWT signing and service authentication
-INSTANCE_KEY=
-# Password for nocturne_app — runtime role, cannot bypass Row Level Security
-POSTGRES_APP_PASSWORD=
-# Password for nocturne_migrator — owns the schema, runs EF migrations
-POSTGRES_MIGRATOR_PASSWORD=
-# Used only at first container start to create runtime roles
-POSTGRES_PASSWORD=
-# Password for nocturne_web — bot-framework state, cannot bypass Row Level Security
-POSTGRES_WEB_PASSWORD=
 
 # -- Optional --------------------------------------------------
 

--- a/deploy/portainer/templates.json
+++ b/deploy/portainer/templates.json
@@ -30,22 +30,22 @@
         {
           "name": "POSTGRES_MIGRATOR_PASSWORD",
           "label": "Migrator role password",
-          "description": "Password for nocturne_migrator \u2014 owns the schema, runs EF migrations"
+          "description": "Password for nocturne_migrator: owns the schema, runs EF migrations"
         },
         {
           "name": "POSTGRES_APP_PASSWORD",
           "label": "App role password",
-          "description": "Password for nocturne_app \u2014 runtime role, cannot bypass Row Level Security"
+          "description": "Password for nocturne_app: runtime role, cannot bypass Row Level Security"
         },
         {
           "name": "POSTGRES_WEB_PASSWORD",
           "label": "Web role password",
-          "description": "Password for nocturne_web \u2014 bot-framework state, cannot bypass Row Level Security"
+          "description": "Password for nocturne_web: bot-framework state, cannot bypass Row Level Security"
         },
         {
           "name": "INSTANCE_KEY",
           "label": "Instance key",
-          "description": "Minimum 12 characters \u2014 used for JWT signing and service authentication"
+          "description": "Minimum 12 characters: used for JWT signing and service authentication"
         },
         {
           "name": "BASE_DOMAIN",

--- a/scripts/publish-release.cs
+++ b/scripts/publish-release.cs
@@ -230,17 +230,17 @@ static string GenerateEnvExample(EnvVarGroups groups, EnvVarMeta[] metadata)
     sb.AppendLine("# Copy this file to .env and fill in the required values.");
     sb.AppendLine("# Passwords are only used on first database initialization.");
     sb.AppendLine();
-    sb.AppendLine("# -- Configuration ---------------------------------------------");
-    sb.AppendLine();
-    foreach (var (name, value) in groups.Config)
-        AppendVar(name, value);
-    sb.AppendLine();
     sb.AppendLine("# -- Required (set these before first run) ----------------------");
     sb.AppendLine();
     foreach (var (name, _) in groups.RequiredConfig)
         AppendVar(name, "");
     foreach (var (name, _) in groups.Secrets)
         AppendVar(name, "");
+    sb.AppendLine();
+    sb.AppendLine("# -- Configuration (defaults work; change if you need to) --------");
+    sb.AppendLine();
+    foreach (var (name, value) in groups.Config)
+        AppendVar(name, value);
     sb.AppendLine();
     sb.AppendLine("# -- Optional --------------------------------------------------");
     sb.AppendLine();

--- a/src/Aspire/Nocturne.Aspire.Host/Program.cs
+++ b/src/Aspire/Nocturne.Aspire.Host/Program.cs
@@ -100,19 +100,19 @@ class Program
                 secret: true
             ).WithPublishMetadata(
                 "Migrator role password",
-                "Password for nocturne_migrator — owns the schema, runs EF migrations");
+                "Password for nocturne_migrator: owns the schema, runs EF migrations");
             postgresAppPassword = builder.AddParameter(
                 ServiceNames.Parameters.PostgresAppPassword,
                 secret: true
             ).WithPublishMetadata(
                 "App role password",
-                "Password for nocturne_app — runtime role, cannot bypass Row Level Security");
+                "Password for nocturne_app: runtime role, cannot bypass Row Level Security");
             postgresWebPassword = builder.AddParameter(
                 ServiceNames.Parameters.PostgresWebPassword,
                 secret: true
             ).WithPublishMetadata(
                 "Web role password",
-                "Password for nocturne_web — bot-framework state, cannot bypass Row Level Security");
+                "Password for nocturne_web: bot-framework state, cannot bypass Row Level Security");
 
             // Container init lives in docs/postgres/container-init. Only
             // 00-init.sh is mounted into /docker-entrypoint-initdb.d so the
@@ -216,7 +216,7 @@ class Program
         var instanceKey = builder.AddParameter(ServiceNames.Parameters.InstanceKey, secret: true)
             .WithPublishMetadata(
                 "Instance key",
-                "Minimum 12 characters — used for JWT signing and service authentication");
+                "Minimum 12 characters: used for JWT signing and service authentication");
 
         // Discord bot credentials. Optional — only required if Discord bot
         // features are enabled for a deployment. Empty-string defaults let

--- a/src/Web/packages/app/src/lib/components/dashboard/top-widget-ids.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/top-widget-ids.ts
@@ -1,0 +1,49 @@
+/**
+ * The widget ids this build can render in the top grid, without the components
+ * behind them. The appearance store persists a default built from this list and
+ * is imported by the portal, so this module must not reach any widget component:
+ * the loaders live in widget-registry.ts and are typed against these ids.
+ */
+
+import { WidgetId } from "../../api/generated/nocturne-api-client";
+
+export const TOP_WIDGET_IDS = [
+  WidgetId.BgDelta,
+  WidgetId.LastUpdated,
+  WidgetId.ConnectionStatus,
+  WidgetId.Meals,
+  WidgetId.Trackers,
+  WidgetId.TirChart,
+  WidgetId.DailySummary,
+  WidgetId.Clock,
+  WidgetId.Tdd,
+] as const;
+
+/** A widget id the grid can actually render. */
+export type TopWidgetId = (typeof TOP_WIDGET_IDS)[number];
+
+const TOP_WIDGET_ID_SET: ReadonlySet<string> = new Set<string>(TOP_WIDGET_IDS);
+
+export function isTopWidgetId(id: string): id is TopWidgetId {
+  return TOP_WIDGET_ID_SET.has(id);
+}
+
+/** What the picker falls back to offering when the catalogue cannot be fetched. */
+export const LOADABLE_TOP_WIDGETS: TopWidgetId[] = [...TOP_WIDGET_IDS];
+
+export const DEFAULT_TOP_WIDGETS: TopWidgetId[] = [
+  WidgetId.BgDelta,
+  WidgetId.TirChart,
+  WidgetId.Tdd,
+];
+
+/**
+ * Selections persist per user, outlive any one release, and arrive from a
+ * cookie any tenant subdomain can write, so a stored list can name an id this
+ * build has no component for, or no id at all.
+ */
+export function knownTopWidgets(
+  ids: readonly string[] | undefined
+): TopWidgetId[] {
+  return (ids ?? []).filter(isTopWidgetId);
+}

--- a/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
+++ b/src/Web/packages/app/src/lib/components/dashboard/widget-registry.ts
@@ -1,15 +1,26 @@
 /**
  * What this build can render. Names, descriptions and placement come from the
  * backend widget catalogue; the picker offers that catalogue's top widgets
- * narrowed to the ids below.
+ * narrowed to the ids in top-widget-ids.ts, which this map must cover exactly:
+ * an id without a loader, or a loader without an id, fails to compile.
  */
 
 import { WidgetId } from "$lib/api/generated/nocturne-api-client";
 import type { Component } from "svelte";
+import type { TopWidgetId } from "./top-widget-ids";
+
+export {
+  DEFAULT_TOP_WIDGETS,
+  LOADABLE_TOP_WIDGETS,
+  TOP_WIDGET_IDS,
+  isTopWidgetId,
+  knownTopWidgets,
+  type TopWidgetId,
+} from "./top-widget-ids";
 
 type WidgetLoader = () => Promise<{ default: Component }>;
 
-const TOP_WIDGET_LOADERS = {
+const TOP_WIDGET_LOADERS: Record<TopWidgetId, WidgetLoader> = {
   [WidgetId.BgDelta]: () => import("./widgets/BgDeltaWidget.svelte"),
   [WidgetId.LastUpdated]: () => import("./widgets/LastUpdatedWidget.svelte"),
   [WidgetId.ConnectionStatus]: () =>
@@ -20,35 +31,7 @@ const TOP_WIDGET_LOADERS = {
   [WidgetId.DailySummary]: () => import("./widgets/DailySummaryWidget.svelte"),
   [WidgetId.Clock]: () => import("./widgets/ClockWidget.svelte"),
   [WidgetId.Tdd]: () => import("./widgets/TddWidget.svelte"),
-} satisfies Partial<Record<WidgetId, WidgetLoader>>;
-
-/** A widget id the grid can actually render. */
-export type TopWidgetId = keyof typeof TOP_WIDGET_LOADERS;
-
-export function isTopWidgetId(id: string): id is TopWidgetId {
-  return Object.hasOwn(TOP_WIDGET_LOADERS, id);
-}
-
-/** What the picker falls back to offering when the catalogue cannot be fetched. */
-export const LOADABLE_TOP_WIDGETS: TopWidgetId[] =
-  Object.keys(TOP_WIDGET_LOADERS).filter(isTopWidgetId);
-
-export const DEFAULT_TOP_WIDGETS: TopWidgetId[] = [
-  WidgetId.BgDelta,
-  WidgetId.TirChart,
-  WidgetId.Tdd,
-];
-
-/**
- * Selections persist per user, outlive any one release, and arrive from a
- * cookie any tenant subdomain can write, so a stored list can name an id this
- * build has no component for — or no id at all.
- */
-export function knownTopWidgets(
-  ids: readonly string[] | undefined
-): TopWidgetId[] {
-  return (ids ?? []).filter(isTopWidgetId);
-}
+};
 
 const cache = new Map<TopWidgetId, Promise<Component>>();
 

--- a/src/Web/packages/app/src/lib/constants/oauth-scopes.ts
+++ b/src/Web/packages/app/src/lib/constants/oauth-scopes.ts
@@ -35,7 +35,7 @@ export const OAUTH_SCOPE_DESCRIPTIONS: Readonly<Record<string, string>> = {
   [OAuthScope.FullAccess]: "Full access to all data and settings",
   [DEVICE_NOTIFY_SCOPE]: "Send notifications to this device",
   [DEVICE_ACTUATE_SCOPE]:
-    "Use this device's alarms — sound, vibration, flashlight, and full-screen alerts",
+    "Use this device's alarms: sound, vibration, flashlight, and full-screen alerts",
 } as const;
 
 /** Scopes that grant hardware/device actuation and warrant extra emphasis in consent UI. */

--- a/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
+++ b/src/Web/packages/app/src/lib/stores/appearance-store.svelte.ts
@@ -28,7 +28,7 @@ import { PersistedState } from "runed";
 import { setMode, mode, userPrefersMode } from "mode-watcher";
 import supportedLocales from "../../../../../supportedLocales.json";
 import type { WidgetId } from "../api/generated/nocturne-api-client";
-import { DEFAULT_TOP_WIDGETS } from "../components/dashboard/widget-registry";
+import { DEFAULT_TOP_WIDGETS } from "../components/dashboard/top-widget-ids";
 import type { UserDisplayPreferences } from "$lib/api";
 import { weekStartName } from "../components/calendar/calendar-date";
 import { resolveCookieDomain } from "../utils/tenant-host";

--- a/src/Web/packages/app/src/lib/types/dashboard-widgets.ts
+++ b/src/Web/packages/app/src/lib/types/dashboard-widgets.ts
@@ -6,7 +6,7 @@
  */
 
 import { WidgetId, type WidgetConfig } from "$lib/api/generated/nocturne-api-client";
-import type { TopWidgetId } from "$lib/components/dashboard/widget-registry";
+import type { TopWidgetId } from "$lib/components/dashboard/top-widget-ids";
 
 import {
   TrendingUp,

--- a/src/Web/packages/portal/src/content/blog/coming-from-nightscout.svx
+++ b/src/Web/packages/portal/src/content/blog/coming-from-nightscout.svx
@@ -7,7 +7,7 @@ category: nightscout
 tags: []
 summary: Setting up your Nocturne instance to be like Nightscout
 image:
-draft: false
+draft: true
 ---
 <p>Because Nocturne reimplements Nightscout’s API, the good news is that 99% of Nightscout’s features are already baked into Nocturne- they might just be under different names.</p>
 

--- a/src/Web/packages/portal/src/content/docs/alerts/email.svx
+++ b/src/Web/packages/portal/src/content/docs/alerts/email.svx
@@ -11,7 +11,7 @@ title: Email Alerts (Resend)
 
 Nocturne can deliver glucose alerts directly to email using [Resend](https://resend.com),
 an email API provider. Resend's free tier includes 3,000 emails per month and 100 emails
-per day -- more than enough for most alert configurations.
+per day, which is more than enough for most alert configurations.
 
 ## 1. Create a Resend account
 
@@ -23,7 +23,7 @@ per day -- more than enough for most alert configurations.
 1. In the Resend dashboard, go to **Domains**
 2. Click **Add Domain** and enter the domain you want to send from (e.g. `alerts.your-instance.com`)
 3. Add the DNS records Resend provides (typically a few TXT and MX records)
-4. Wait for verification -- this usually takes a few minutes but can take up to 48 hours
+4. Wait for verification. This usually takes a few minutes but can take up to 48 hours
 
 <Callout type="info" title="Free tier sending domain">
   On the free tier you can also send from Resend's shared domain

--- a/src/Web/packages/portal/src/content/docs/authentication/github.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/github.svx
@@ -32,7 +32,7 @@ Replace `your-instance.com` with your actual Nocturne domain.
 ## 2. Generate a client secret
 
 1. On the app page, click **Generate a new client secret**
-2. Copy the **Client ID** and the **Client secret** immediately — the secret is only shown once
+2. Copy the **Client ID** and the **Client secret** immediately; the secret is only shown once
 
 <Callout type="warning" title="Save the secret now">
   GitHub only displays the client secret once. If you lose it, you'll need to
@@ -64,7 +64,7 @@ The GitHub sign-in button will appear on your login page immediately.
 <Callout type="info" title="GitHub as an OIDC provider">
   GitHub doesn't natively implement OpenID Connect discovery, but Nocturne
   handles this automatically. Just use <code>https://github.com</code> as
-  the issuer URL — Nocturne knows how to map GitHub's OAuth endpoints and
+  the issuer URL; Nocturne knows how to map GitHub's OAuth endpoints and
   retrieve user profile information.
 </Callout>
 

--- a/src/Web/packages/portal/src/content/docs/authentication/google.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/google.svx
@@ -53,7 +53,7 @@ https://your-instance.com/api/auth/oidc/callback
 Replace `your-instance.com` with your actual Nocturne domain (e.g. `rhys.nocturne.run`).
 
 6. Click **Create**
-7. Copy the **Client ID** and **Client secret** — you'll need both in the next step
+7. Copy the **Client ID** and **Client secret**; you'll need both in the next step
 
 ## 4. Add the provider in Nocturne
 
@@ -84,7 +84,7 @@ The Google sign-in button will appear on your login page immediately.
 4. You should be redirected back to Nocturne and signed in
 
 <Callout type="tip" title="Multiple tenants">
-  OIDC providers are platform-wide — all tenants on the same Nocturne instance
+  OIDC providers are platform-wide: all tenants on the same Nocturne instance
   share the same provider configuration. You only need to register one callback URL
   in Google Cloud Console regardless of how many tenants you run.
 </Callout>

--- a/src/Web/packages/portal/src/content/docs/authentication/index.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/index.svx
@@ -9,8 +9,8 @@ title: Authentication
 
 # Authentication
 
-Nocturne is passwordless. Every account signs in with a **passkey** — a credential stored
-on a phone, laptop or security key and unlocked with a fingerprint, a face scan or a PIN —
+Nocturne is passwordless. Every account signs in with a **passkey** (a credential stored
+on a phone, laptop or security key and unlocked with a fingerprint, a face scan or a PIN)
 as its primary credential. There are no passwords to set, rotate, or leak. On top of
 passkeys you can optionally offer **social login** through any OIDC provider (OpenID
 Connect, the standard that lets you sign in using an account you already have with Google,
@@ -19,7 +19,7 @@ as fallbacks.
 
 This page is for operators deciding which sign-in methods to offer on their instance.
 If you're building an app or device that talks to the Nocturne API, see
-[Connecting apps](/docs/connecting-apps) instead — that's a separate flow.
+[Connecting apps](/docs/connecting-apps) instead; that's a separate flow.
 
 ## Sign-in methods
 
@@ -35,15 +35,15 @@ For the step-by-step of what signing in actually looks like, see
 
 ### Passkeys
 
-Passkeys are the default and need no configuration — they're always available. A passkey
+Passkeys are the default and need no configuration; they're always available. A passkey
 is bound to the user's device or password manager and unlocked with biometrics or a PIN,
 so there's nothing for you to provision and no shared secret to leak.
 
 The login screen offers two passkey paths:
 
-- **Discoverable login** — the user taps *Sign in with passkey* and picks an account from
+- **Discoverable login**: the user taps *Sign in with passkey* and picks an account from
   the prompt their device shows. No username required.
-- **Username-first** — the user enters their username, then authenticates with the passkey
+- **Username-first**: the user enters their username, then authenticates with the passkey
   registered to that account.
 
 <Callout type="info" title="Browser support">
@@ -61,11 +61,11 @@ guide:
 
 - [Sign in with Google](/docs/authentication/google)
 - [Sign in with GitHub](/docs/authentication/github)
-- [Any other OIDC provider](/docs/authentication/oidc) — Okta, Auth0, Keycloak, Authentik,
+- [Any other OIDC provider](/docs/authentication/oidc): Okta, Auth0, Keycloak, Authentik,
   Microsoft Entra ID, and anything else that speaks OpenID Connect
 
 <Callout type="tip" title="Providers are platform-wide">
-  OIDC providers are configured once for the whole instance — every tenant shares the
+  OIDC providers are configured once for the whole instance; every tenant shares the
   same set. You only register one callback URL with the provider regardless of how many
   tenants you run.
 </Callout>
@@ -75,12 +75,12 @@ guide:
 These are set up by users from their account settings, not methods you enable as an
 operator.
 
-- **Authenticator app (TOTP)** — TOTP stands for time-based one-time password: a
+- **Authenticator app (TOTP)**: TOTP stands for time-based one-time password: a
   six-digit code that changes every thirty seconds. When an account has enrolled an
   authenticator app, signing in with a passkey is followed by a second step asking for the
   current code. It does not apply to OIDC sign-ins, where the provider handles any extra
   steps of its own.
-- **Recovery codes** — one-time backup codes issued when the account is set up, for when
+- **Recovery codes**: one-time backup codes issued when the account is set up, for when
   no passkey is available. The login screen carries a *Use a recovery code* link.
 
 Both are covered in detail on
@@ -88,8 +88,8 @@ Both are covered in detail on
 
 ## What your users see
 
-The login screen leads with the passkey button, and — when membership requests are enabled
-— carries a *Request membership* link at the foot of the card:
+The login screen leads with the passkey button, and, when membership requests are enabled,
+carries a *Request membership* link at the foot of the card:
 
 <Screenshot
   id="sign-in"
@@ -101,13 +101,13 @@ The login screen leads with the passkey button, and — when membership requests
 
 In order:
 
-1. **Sign in with passkey** — the primary button. Triggers a discoverable passkey prompt.
-2. **Sign in with username** — username-first passkey login, for when the discoverable
+1. **Sign in with passkey**: the primary button. Triggers a discoverable passkey prompt.
+2. **Sign in with username**: username-first passkey login, for when the discoverable
    prompt doesn't surface the right account.
-3. **OIDC provider buttons** — one per enabled provider, shown under *Or continue with*.
+3. **OIDC provider buttons**: one per enabled provider, shown under *Or continue with*.
    Only appear when social login is configured.
-4. **Use a recovery code** — a small link for the fallback method.
-5. **Request membership** — a link at the foot of the card for visitors who don't have an
+4. **Use a recovery code**: a small link for the fallback method.
+5. **Request membership**: a link at the foot of the card for visitors who don't have an
    account on this instance yet. See
    [Request membership](/docs/authentication/request-membership).
 
@@ -119,6 +119,6 @@ code follows the passkey.
 | Method | How to enable |
 |--------|---------------|
 | Passkeys | Always on. Nothing to configure. |
-| Social login | Add a provider — see [Google](/docs/authentication/google), [GitHub](/docs/authentication/github), or [generic OIDC](/docs/authentication/oidc). |
+| Social login | Add a provider; see [Google](/docs/authentication/google), [GitHub](/docs/authentication/github), or [generic OIDC](/docs/authentication/oidc). |
 | Authenticator app / recovery codes | Always available. Users set these up from their account settings. |
 | Request membership | On by default. Each instance owner can switch it off under **Settings > Sharing & Privacy**. |

--- a/src/Web/packages/portal/src/content/docs/authentication/oidc.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/oidc.svx
@@ -10,7 +10,7 @@ title: Sign in with any OIDC provider
 # Sign in with any OIDC provider
 
 Nocturne's social login is a generic OpenID Connect client. Any provider that publishes a
-standard discovery document works — Nocturne fetches
+standard discovery document works: Nocturne fetches
 `{issuer}/.well-known/openid-configuration` and wires up the authorization, token, and
 userinfo endpoints automatically. [Google](/docs/authentication/google) and
 [GitHub](/docs/authentication/github) have their own step-by-step guides; this page covers
@@ -25,15 +25,15 @@ https://your-instance.com/api/auth/oidc/callback
 ```
 
 Replace `your-instance.com` with your actual Nocturne domain. This is the same URL for
-every provider — only the credentials differ.
+every provider; only the credentials differ.
 
 ## Two ways to configure providers
 
 Nocturne reads providers from one of two places:
 
-1. **Admin UI (database-backed)** — add and edit providers at runtime from
+1. **Admin UI (database-backed)**: add and edit providers at runtime from
    **Settings > Administration > Identity Providers**. No restart needed. This is the default.
-2. **Operator config (`appsettings` / environment)** — declare providers in configuration.
+2. **Operator config (`appsettings` / environment)**: declare providers in configuration.
    When one or more providers are configured this way, Nocturne **bypasses the database
    entirely and hides the management UI**. Use this for declarative, infrastructure-as-code
    deployments.
@@ -41,7 +41,7 @@ Nocturne reads providers from one of two places:
 <Callout type="info" title="Pick one, not both">
   As soon as <code>Oidc:Providers</code> has at least one entry in configuration, the
   database-backed providers and their management UI are ignored. Manage providers either
-  through the admin UI <em>or</em> through configuration — not a mix.
+  through the admin UI <em>or</em> through configuration, not a mix.
 </Callout>
 
 ### Option A: the admin UI
@@ -60,7 +60,7 @@ The new sign-in button appears on your login page immediately.
 ### Option B: configuration
 
 Declare providers under the `Oidc:Providers` array. Keep the client **secret** out of
-`appsettings.json` — supply it through user-secrets or an environment variable.
+`appsettings.json`; supply it through user-secrets or an environment variable.
 
 ```jsonc
 "Oidc": {
@@ -86,7 +86,7 @@ Supply the secret separately, by index:
 # Local development (user-secrets)
 dotnet user-secrets set "Oidc:Providers:0:ClientSecret" "your-client-secret"
 
-# Production (environment variable — note the double underscores)
+# Production (environment variable; note the double underscores)
 Oidc__Providers__0__ClientSecret=your-client-secret
 ```
 
@@ -129,8 +129,8 @@ When someone signs in through a provider for the first time, Nocturne creates an
 and assigns the provider's **Default Roles** (`readable` unless you change it). Adjust this
 list to control what new users can do before an admin grants them more access.
 
-Providers configured through the admin UI also support **claim mappings** — pairs of
-*(OIDC claim name → Nocturne claim name)* — for providers that emit non-standard claim
+Providers configured through the admin UI also support **claim mappings**, pairs of
+*(OIDC claim name → Nocturne claim name)*, for providers that emit non-standard claim
 names. Most providers need no mapping when they return the standard `email`, `name`, and
 `sub` claims.
 
@@ -138,4 +138,4 @@ names. Most providers need no mapping when they return the standard `email`, `na
 
 - [Sign in with Google](/docs/authentication/google)
 - [Sign in with GitHub](/docs/authentication/github)
-- [Authentication overview](/docs/authentication) — all sign-in methods
+- [Authentication overview](/docs/authentication): all sign-in methods

--- a/src/Web/packages/portal/src/content/docs/authentication/passkeys.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/passkeys.svx
@@ -15,15 +15,15 @@ the two fallbacks that keep an account reachable when the usual device isn't to 
 ## Signing in with a passkey
 
 A **passkey** is a credential kept on your phone, laptop, tablet or hardware security key
-and unlocked the way you already unlock that device — a fingerprint, a face scan, or its
+and unlocked the way you already unlock that device: a fingerprint, a face scan, or its
 PIN. Nothing secret is typed in, and nothing secret is stored on the instance, so there is no
 password to be guessed, reused or leaked.
 
 There are two ways in, both on the sign-in page:
 
-- **Sign in with passkey** — the main button. Your device offers the passkeys it holds for
+- **Sign in with passkey**: the main button. Your device offers the passkeys it holds for
   this instance and you pick one. You don't need to type a username.
-- **Sign in with username** — you type your username first, then unlock the passkey
+- **Sign in with username**: you type your username first, then unlock the passkey
   registered to that account. Use this when the first button doesn't offer the account you
   wanted, which usually means the passkey lives on a different device.
 
@@ -42,7 +42,7 @@ There are two ways in, both on the sign-in page:
 
 ## The authenticator app step
 
-An **authenticator app** — Aegis, 1Password, Google Authenticator and others — shows a
+An **authenticator app** (Aegis, 1Password, Google Authenticator and others) shows a
 six-digit code that changes every thirty seconds. The technical name for this is **TOTP**,
 short for time-based one-time password.
 
@@ -63,7 +63,7 @@ confirm the two are in step:
 
 <Screenshot id="totp-setup" />
 
-Scan the code with the app before leaving the page — it isn't shown again afterwards.
+Scan the code with the app before leaving the page; it isn't shown again afterwards.
 
 ### Signing in afterwards
 
@@ -82,7 +82,7 @@ code from your app. Open the app, read the six digits, type them in.
 
 **Recovery codes** are a short list of one-time codes issued when your account is set up.
 Each one works once and then is spent. They exist for the day the usual device isn't
-available — lost, broken, or simply left at home.
+available: lost, broken, or simply left at home.
 
 To use one, follow the **Use a recovery code** link on the sign-in page and enter
 a code you haven't used yet.

--- a/src/Web/packages/portal/src/content/docs/authentication/request-membership.svx
+++ b/src/Web/packages/portal/src/content/docs/authentication/request-membership.svx
@@ -18,7 +18,7 @@ It is **on by default**, and each instance owner can switch it off.
 ## What the visitor sees
 
 At the foot of the sign-in card there's a **Request membership** link, under the passkey and
-social-login buttons — see the annotated sign-in screen on
+social-login buttons; see the annotated sign-in screen on
 [Authentication](/docs/authentication#what-your-users-see).
 
 Following it opens a short dialog with a message box, so you can say who you are and why you
@@ -26,7 +26,7 @@ are asking, and a **Continue to Sign Up** button:
 
 <Screenshot id="request-membership-dialog" />
 
-A useful note is short and says who you are in terms the owner will recognise — the name
+A useful note is short and says who you are in terms the owner will recognise: the name
 they know you by, and your connection to them. The owner sees the note next to your request
 when they decide, so a blank one is simply harder to say yes to.
 
@@ -37,12 +37,12 @@ when they decide, so a blank one is simply harder to say yes to.
 
 ## What the owner sees
 
-The toggle and the requests themselves both live on **Settings > Sharing & Privacy** — see
+The toggle and the requests themselves both live on **Settings > Sharing & Privacy**; see
 [reviewing requests](/docs/sharing/members#membership-requests) for the owner's side of this,
 including what each role lets the person see and do.
 
 <Callout type="tip" title="Approve deliberately">
   A request tells you what someone says about themselves, and nothing more. If a request is
-  unexpected, or the note doesn't match anyone you know, deny it — someone who genuinely
+  unexpected, or the note doesn't match anyone you know, deny it; someone who genuinely
   needs access can ask again, or you can send them an invite directly.
 </Callout>

--- a/src/Web/packages/portal/src/content/docs/bots/discord.svx
+++ b/src/Web/packages/portal/src/content/docs/bots/discord.svx
@@ -27,11 +27,11 @@ From the application you just created:
 |-------|------------------|
 | **Application ID** | **General Information** tab |
 | **Public Key** | **General Information** tab |
-| **Bot Token** | **Bot** tab — click **Reset Token** and copy the value |
+| **Bot Token** | **Bot** tab: click **Reset Token** and copy the value |
 
 <Callout type="warning" title="Save the bot token now">
   Discord shows the bot token only once when it's generated. If you lose it, reset it again
-  on the <strong>Bot</strong> tab — note that resetting invalidates the previous token.
+  on the <strong>Bot</strong> tab; note that resetting invalidates the previous token.
 </Callout>
 
 ## 3. Configure Nocturne
@@ -83,7 +83,7 @@ Key**. Discord rejects the URL if verification fails.
 ## 5. Register the slash commands
 
 Slash commands (`/bg`, `/glucose`, `/connect`, `/disconnect`, `/status`) are registered with
-Discord once, as a deploy step — not at app startup. Run:
+Discord once, as a deploy step, not at app startup. Run:
 
 ```bash
 DISCORD_APPLICATION_ID=... DISCORD_BOT_TOKEN=... \
@@ -118,9 +118,9 @@ my Discord account** button (**Settings > Integrations > Discord**), enable Disc
 
    Use your root domain (`BASE_DOMAIN`), not a tenant subdomain.
 3. Give the client secret to Nocturne, either:
-   - **Admin UI** — enter it in the **Client Secret** field on the Discord card at
+   - **Admin UI**: enter it in the **Client Secret** field on the Discord card at
      **Settings > Admin > Integrations** (the same card as the bot credentials), or
-   - **Environment** — set `DISCORD_CLIENT_SECRET` and restart Nocturne.
+   - **Environment**: set `DISCORD_CLIENT_SECRET` and restart Nocturne.
 
    The **Application ID** (`DISCORD_APPLICATION_ID`) doubles as the OAuth2 client ID, so no
    separate client ID is needed.

--- a/src/Web/packages/portal/src/content/docs/bots/index.svx
+++ b/src/Web/packages/portal/src/content/docs/bots/index.svx
@@ -16,7 +16,7 @@ from the messaging apps they already use. Four platforms are supported:
 - [Telegram](/docs/bots/telegram)
 - [WhatsApp](/docs/bots/whatsapp)
 
-Email delivery is handled by a separate provider — see [Email Alerts (Resend)](/docs/alerts/email).
+Email delivery is handled by a separate provider; see [Email Alerts (Resend)](/docs/alerts/email).
 
 All four platforms follow the same shape: create an app on the platform, collect its
 credentials, point its webhook at your Nocturne instance, and enter the credentials in
@@ -35,13 +35,13 @@ Once a platform is connected and a user has linked their account, they can:
 | `/status` | Show linked accounts and their status |
 
 The bot can also **deliver alerts**. Add the platform as a delivery channel on an alert rule
-(see **Receiving alerts** below) and excursions are pushed to the linked chat — with
+(see **Receiving alerts** below) and excursions are pushed to the linked chat, with
 **Acknowledge** and **Resolve** actions built into the message.
 
 ## Linking accounts
 
 A chat account has to be linked to a Nocturne account before it can see any glucose data.
-PHI is never stored on the chat platform — every reading is fetched over HTTPS through the
+PHI is never stored on the chat platform; every reading is fetched over HTTPS through the
 Nocturne API at request time, scoped to the linked account.
 
 To link, a user runs `/connect` in the chat app. The bot replies with a one-time
@@ -67,7 +67,7 @@ Every platform's credentials can be supplied two ways. Pick whichever fits your 
 3. Find the platform's card, fill in its fields, turn the **Enabled** switch on, and click **Save**.
 
 Credentials entered here are **encrypted at rest** and stored per-instance. The fields are
-write-only — once saved, a field shows a **Set** badge and the input stays blank; leave it
+write-only: once saved, a field shows a **Set** badge and the input stays blank; leave it
 blank on a later save to keep the existing value.
 
 <Callout type="warning" title="Restart after saving">

--- a/src/Web/packages/portal/src/content/docs/bots/slack.svx
+++ b/src/Web/packages/portal/src/content/docs/bots/slack.svx
@@ -29,7 +29,7 @@ environment-variable workflow that all platforms share, see [Chat Bots](/docs/bo
 
 | Field | Where to find it |
 |-------|------------------|
-| **Bot Token** | **OAuth & Permissions** — the Bot User OAuth Token (`xoxb-…`) |
+| **Bot Token** | **OAuth & Permissions**: the Bot User OAuth Token (`xoxb-…`) |
 | **Signing Secret** | **Basic Information > App Credentials** |
 
 ## 4. Configure Nocturne
@@ -67,10 +67,10 @@ https://your-instance.com/api/v4/webhooks/slack
 
 in each of these places that applies:
 
-- **Slash Commands** — create a `/bg` command (and any others you want) with this Request URL.
-- **Interactivity & Shortcuts** — turn on Interactivity and set the Request URL (needed for
+- **Slash Commands**: create a `/bg` command (and any others you want) with this Request URL.
+- **Interactivity & Shortcuts**: turn on Interactivity and set the Request URL (needed for
   the **Acknowledge** / **Resolve** buttons on alerts).
-- **Event Subscriptions** — if you enable events, set the Request URL here too.
+- **Event Subscriptions**: if you enable events, set the Request URL here too.
 
 <Callout type="info" title="Verify the URL after configuring credentials">
   Slack verifies the Request URL by sending a signed challenge that Nocturne validates with

--- a/src/Web/packages/portal/src/content/docs/bots/whatsapp.svx
+++ b/src/Web/packages/portal/src/content/docs/bots/whatsapp.svx
@@ -27,9 +27,9 @@ WhatsApp messaging runs through Meta's Cloud API.
 | Field | Where to find it |
 |-------|------------------|
 | **Access Token** | **WhatsApp > API Setup** (or a System User token in Business Settings) |
-| **Phone Number ID** | **WhatsApp > API Setup** — the number's ID, not the phone number itself |
+| **Phone Number ID** | **WhatsApp > API Setup**: the number's ID, not the phone number itself |
 | **App Secret** | **App settings > Basic > App Secret** |
-| **Verify Token** | A value *you* choose — any random string (see step 4) |
+| **Verify Token** | A value *you* choose: any random string (see step 4) |
 
 ## 3. Configure Nocturne
 
@@ -87,6 +87,6 @@ Then restart Nocturne. The verify token here must match the one you set in the M
 
 <Callout type="info" title="The 24-hour window">
   Meta only lets a business send free-form messages within 24 hours of the user's last
-  message. Alerts that fire outside that window may require an approved message template —
+  message. Alerts that fire outside that window may require an approved message template;
   see Meta's WhatsApp messaging documentation.
 </Callout>

--- a/src/Web/packages/portal/src/content/docs/configuration.svx
+++ b/src/Web/packages/portal/src/content/docs/configuration.svx
@@ -12,11 +12,11 @@ title: Configuration Guide
 
 Nocturne has two layers of configuration:
 
-- **Environment variables** set the infrastructure — the domain, the database
+- **Environment variables** set the infrastructure: the domain, the database
   connections, secrets, and optional telemetry and chat bots. You set these once,
   before the first start, in your `.env` file (Docker Compose) or the guided form
   (Portainer). This page covers them.
-- **The running app** handles everything per-tenant and per-user — data
+- **The running app** handles everything per-tenant and per-user: data
   connectors, display preferences, sharing, alerts, and sign-in providers. These
   are managed in the Nocturne UI after the instance is up, with no restart. They
   have their own guides, linked under **Beyond environment variables** at the
@@ -35,7 +35,7 @@ so it always matches the current images:
 <CodeBlock code={envExample} maxHeight="440px" />
 
 <Callout type="info" title="This list stays current automatically">
-  The block above is the real <code>.env.example</code> from the release bundle —
+  The block above is the real <code>.env.example</code> from the release bundle;
   there is no separate hand-maintained list to drift out of date. A few optional
   integrations (email alerts, extra OpenTelemetry tuning) read additional
   variables that are documented in their own guides rather than shipped in the
@@ -46,14 +46,14 @@ so it always matches the current images:
 
 These have no default and must be set before the first start:
 
-- **`BASE_DOMAIN`** — the hostname every tenant subdomain hangs off (e.g.
+- **`BASE_DOMAIN`**: the hostname every tenant subdomain hangs off (e.g.
   `example.com`, or `nocturne.example.com` if Nocturne itself lives under a
   subdomain). At least two labels, and not an IP address. Each tenant gets a
   subdomain generated from this.
-- **`INSTANCE_KEY`** — minimum 12 characters. Used for JWT signing and
+- **`INSTANCE_KEY`**: minimum 12 characters. Used for JWT signing and
   service-to-service authentication. Treat it like a password and keep it stable;
   changing it invalidates existing sessions.
-- **The four PostgreSQL passwords** — `POSTGRES_PASSWORD`,
+- **The four PostgreSQL passwords**: `POSTGRES_PASSWORD`,
   `POSTGRES_MIGRATOR_PASSWORD`, `POSTGRES_APP_PASSWORD`, and
   `POSTGRES_WEB_PASSWORD`.
 
@@ -61,7 +61,7 @@ These have no default and must be set before the first start:
   The PostgreSQL passwords are used once, when the database volume is first
   created, to provision the runtime roles. Changing them later does **not** re-key
   an existing database. Use a long random value for <code>INSTANCE_KEY</code> and
-  each password — the install pages include a generator.
+  each password; the install pages include a generator.
 </Callout>
 
 ### Database roles
@@ -72,15 +72,15 @@ can bypass it, so it uses three non-privileged roles instead of one superuser:
 | Role | Password variable | Purpose |
 |------|-------------------|---------|
 | `nocturne_migrator` | `POSTGRES_MIGRATOR_PASSWORD` | Owns the schema, runs migrations |
-| `nocturne_app` | `POSTGRES_APP_PASSWORD` | Runtime API connection — cannot bypass RLS |
-| `nocturne_web` | `POSTGRES_WEB_PASSWORD` | Bot-framework state — cannot bypass RLS |
+| `nocturne_app` | `POSTGRES_APP_PASSWORD` | Runtime API connection; cannot bypass RLS |
+| `nocturne_web` | `POSTGRES_WEB_PASSWORD` | Bot-framework state; cannot bypass RLS |
 
 `POSTGRES_USERNAME` and `POSTGRES_PASSWORD` are the bootstrap superuser the
 bundled Postgres container uses on first start to create those three roles.
 
 Running against a managed database (RDS, Cloud SQL, Supabase, Neon) or an existing
 server instead of the bundled container? See
-[Bring Your Own PostgreSQL](/docs/installation/byo-postgres) — you create the
+[Bring Your Own PostgreSQL](/docs/installation/byo-postgres); you create the
 roles yourself and point Nocturne at them with connection strings.
 
 ### Optional
@@ -94,7 +94,7 @@ roles yourself and point Nocturne at them with connection strings.
 | **Telegram** | `TELEGRAM_*` | The Telegram bot. See [Telegram](/docs/bots/telegram). |
 | **WhatsApp** | `WHATSAPP_*` | The WhatsApp bot. See [WhatsApp](/docs/bots/whatsapp). |
 
-Leave any bot variables blank or commented out if you don't use that platform —
+Leave any bot variables blank or commented out if you don't use that platform;
 nothing here is required for a working install.
 
 ### Image pinning
@@ -108,13 +108,13 @@ updates.
 The rest of Nocturne's configuration lives in the running app, not the
 environment, and can change at any time without a restart:
 
-- **Data connectors** — Dexcom, LibreLinkUp, Glooko, Nightscout, and others are
+- **Data connectors**: Dexcom, LibreLinkUp, Glooko, Nightscout, and others are
   added and authenticated in the Nocturne UI, per tenant, after deployment. No
   Compose changes required.
-- **Display units (mg/dL or mmol/L) and time format** — per-user preferences in
+- **Display units (mg/dL or mmol/L) and time format**: per-user preferences in
   account settings, not server-wide variables.
-- **Sharing and public links** — see [Sharing your data](/docs/sharing).
-- **Email alerts (Resend)** — configured from the admin UI, or optionally via
+- **Sharing and public links**: see [Sharing your data](/docs/sharing).
+- **Email alerts (Resend)**: configured from the admin UI, or optionally via
   environment variables. See [Email Alerts](/docs/alerts/email).
-- **Sign-in providers** — passkeys are always on; Google, GitHub, and generic
+- **Sign-in providers**: passkeys are always on; Google, GitHub, and generic
   OIDC are enabled per instance. See [Authentication](/docs/authentication).

--- a/src/Web/packages/portal/src/content/docs/connecting-apps/device-flow.svx
+++ b/src/Web/packages/portal/src/content/docs/connecting-apps/device-flow.svx
@@ -20,14 +20,14 @@ on a separate device (phone, computer) by entering a short code.
 
 <Callout type="tip" title="Prefer an SDK for API calls?">
   The code below uses raw HTTP requests to show the device flow end to end. Once you
-  have an access token, you don't have to hand-write API calls — official SDKs for
+  have an access token, you don't have to hand-write API calls; official SDKs for
   the V4 API are available in several languages. See <a href="/docs/sdks">SDKs</a>.
 </Callout>
 
 ## 1. Register your app
 
 Before your app can authenticate users, it needs a `client_id`. Nocturne supports
-[Dynamic Client Registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591) —
+[Dynamic Client Registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591):
 your app registers itself by calling a single endpoint.
 
 ```typescript
@@ -47,7 +47,7 @@ const response = await fetch(
 const { client_id } = await response.json();
 ```
 
-Registration is **idempotent per tenant** — if your `software_id` is already registered
+Registration is **idempotent per tenant**: if your `software_id` is already registered
 on that Nocturne instance, you'll get the existing `client_id` back. Store the `client_id`;
 you'll need it for every authorization request.
 
@@ -87,16 +87,16 @@ const {
 
 The response contains everything you need to guide the user through authorization:
 
-- **`user_code`** — a short alphanumeric code like `BCTV-3KMN` the user enters
-- **`verification_uri`** — where the user goes to enter the code
-- **`verification_uri_complete`** — has the code pre-filled (use this for "Open in browser" buttons)
-- **`expires_in`** — how long the code is valid (30 minutes)
-- **`interval`** — minimum polling interval in seconds (5 seconds)
+- **`user_code`**: a short alphanumeric code like `BCTV-3KMN` the user enters
+- **`verification_uri`**: where the user goes to enter the code
+- **`verification_uri_complete`**: has the code pre-filled (use this for "Open in browser" buttons)
+- **`expires_in`**: how long the code is valid (30 minutes)
+- **`interval`**: minimum polling interval in seconds (5 seconds)
 
 ## 3. Display the code to the user
 
 Show the `user_code` prominently in your app. If possible, offer a button that opens
-`verification_uri_complete` in a browser — the code is pre-filled so the user just
+`verification_uri_complete` in a browser; the code is pre-filled so the user just
 needs to sign in and approve.
 
 ## 4. Poll for the token
@@ -194,7 +194,7 @@ const refreshResponse = await fetch(
 );
 
 const { access_token, refresh_token } = await refreshResponse.json();
-// Store BOTH new tokens — the old refresh token is now invalid
+// Store BOTH new tokens; the old refresh token is now invalid
 ```
 
 <Callout type="danger" title="Refresh tokens rotate">
@@ -227,7 +227,7 @@ Scopes control what your app can access. Request only what you need.
 
 <OAuthScopeTable />
 
-A `readwrite` scope always implies `read` — you don't need to request both.
+A `readwrite` scope always implies `read`; you don't need to request both.
 
 <Callout type="info" title="Scope expansion">
   <code>health.read</code> and <code>health.readwrite</code> are convenience aliases.

--- a/src/Web/packages/portal/src/content/docs/connecting-apps/index.svx
+++ b/src/Web/packages/portal/src/content/docs/connecting-apps/index.svx
@@ -13,20 +13,20 @@ This guide walks you through connecting your app to a Nocturne instance using OA
 By the end, you'll have a working integration that can read glucose entries on behalf of a user.
 
 Nocturne uses **OAuth 2.0 Authorization Code with PKCE** (Proof Key for Code Exchange).
-Every client is a public client — there are no client secrets. PKCE replaces the secret,
+Every client is a public client; there are no client secrets. PKCE replaces the secret,
 which makes this flow safe for desktop apps and SPAs. For mobile apps or devices
 with limited input, see the [Device Authorization flow guide](/docs/connecting-apps/device-flow).
 
 <Callout type="tip" title="Prefer an SDK for API calls?">
   The code below uses raw HTTP requests to show the OAuth flow end to end. Once you
-  have an access token, you don't have to hand-write API calls — official SDKs for
+  have an access token, you don't have to hand-write API calls; official SDKs for
   the V4 API are available in several languages. See <a href="/docs/sdks">SDKs</a>.
 </Callout>
 
 ## 1. Register your app
 
 Before your app can authenticate users, it needs a `client_id`. Nocturne supports
-[Dynamic Client Registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591) —
+[Dynamic Client Registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591):
 your app registers itself by calling a single endpoint.
 
 ```typescript
@@ -55,7 +55,7 @@ const registration = await response.json();
 // }
 ```
 
-Registration is **idempotent per tenant** — if your `software_id` is already registered
+Registration is **idempotent per tenant**: if your `software_id` is already registered
 on that Nocturne instance, you'll get the existing `client_id` back. Store the `client_id`;
 you'll need it for every authorization request.
 
@@ -105,7 +105,7 @@ Build the authorization URL and redirect the user's browser to it:
 const codeVerifier = generateCodeVerifier();
 const codeChallenge = await generateCodeChallenge(codeVerifier);
 
-// Store codeVerifier — you'll need it in step 3
+// Store codeVerifier; you'll need it in step 3
 sessionStorage.setItem("pkce_code_verifier", codeVerifier);
 
 const params = new URLSearchParams({
@@ -176,7 +176,7 @@ const tokens = await tokenResponse.json();
   in production.
 </Callout>
 
-The authorization code is single-use — if the exchange fails, you'll get an
+The authorization code is single-use: if the exchange fails, you'll get an
 `invalid_grant` error and the user will need to re-authorize.
 
 ## 4. Make API calls
@@ -238,7 +238,7 @@ const refreshResponse = await fetch(
 );
 
 const newTokens = await refreshResponse.json();
-// Same shape as the original token response —
+// Same shape as the original token response:
 // new access_token AND new refresh_token
 ```
 
@@ -271,7 +271,7 @@ Scopes control what your app can access. Request only what you need.
 
 <OAuthScopeTable />
 
-A `readwrite` scope always implies `read` — you don't need to request both.
+A `readwrite` scope always implies `read`; you don't need to request both.
 
 <Callout type="info" title="Scope expansion">
   <code>health.read</code> and <code>health.readwrite</code> are convenience aliases.

--- a/src/Web/packages/portal/src/content/docs/getting-started.svx
+++ b/src/Web/packages/portal/src/content/docs/getting-started.svx
@@ -16,32 +16,30 @@ Before you begin, make sure you have:
 
 - Docker and Docker Compose installed
 - A server or VPS with at least 1 GB RAM
-- A domain name (recommended) or static IP
+- A domain name with a DNS record pointing at the server
 
-## Step 1: Create your project
+## Step 1: Deploy
 
-```
-mkdir nocturne && cd nocturne
-```
+Follow one of the [installation guides](/docs/installation). The Docker Compose
+guide takes you from an empty directory to a running stack: two files from the
+release page, a handful of values in `.env`, and `docker compose up -d`.
 
-## Step 2: Deploy
+## Step 2: Open your instance
 
-Follow one of our [installation guides](/docs/installation) to set up the Docker Compose stack and configure your environment variables.
-
-## Step 3: Access Your Instance
-
-Once the containers are running, access your Nocturne instance at:
+The bundled proxy obtains a TLS certificate as soon as your DNS points at the
+server, so once the containers are running your instance is at:
 
 ```
-https://your-server-ip:8443
+https://your-domain
 ```
 
-Sign in and you land on the home screen. It stays empty until a device or an app
+where `your-domain` is the `BASE_DOMAIN` you set in `.env`. Sign in and you land
+on the home screen. It stays empty until a device or an app
 starts sending readings:
 
 <Screenshot id="first-run" />
 
-## Step 4: Connect a data source
+## Step 3: Connect a data source
 
 Saying where your readings come from is part of getting started. Every service
 Nocturne can collect readings from, and every phone app that can send readings
@@ -70,5 +68,6 @@ by itself, with nothing left for you to do:
 
 ## Next Steps
 
-- Set up HTTPS with a reverse proxy
-- Configure your CGM app to point to your new instance
+- Point your CGM app or loop system at your new instance: see [Connecting apps](/docs/connecting-apps)
+- Invite followers or create a share link: see [Sharing & privacy](/docs/sharing)
+- Set up your first alarm rule

--- a/src/Web/packages/portal/src/content/docs/installation/reverse-proxy.svx
+++ b/src/Web/packages/portal/src/content/docs/installation/reverse-proxy.svx
@@ -9,8 +9,8 @@ title: Bring your own reverse proxy
 # Bring your own reverse proxy
 
 The Docker Compose bundle ships with Caddy, which obtains and renews TLS
-certificates for you. If you already run a reverse proxy -- nginx, Traefik,
-HAProxy, your own Caddy, a homelab edge -- you can terminate TLS there instead
+certificates for you. If you already run a reverse proxy (nginx, Traefik,
+HAProxy, your own Caddy, a homelab edge) you can terminate TLS there instead
 and forward plain HTTP to Nocturne's gateway.
 
 Nocturne needs three request headers from your proxy to work. Everything else on
@@ -46,14 +46,14 @@ one label deeper again, at `{token}.share.example.com`. Your proxy has to
 terminate all three.
 
 - `BASE_DOMAIN` in `.env` must be a hostname of **at least two labels**, and not
-  an IP address. It does *not* have to be a registrable root domain --
+  an IP address. It does *not* have to be a registrable root domain:
   `nocturne.example.com` is fine, and tenants are then
   `tenant.nocturne.example.com`. An IP address is what to avoid: WebAuthn refuses
   an IP as a relying-party ID, so passkey login stops working, and tenant
   subdomains have nowhere to live.
 - DNS needs an **A** record for the apex and a wildcard **A** record for
   `*.example.com`. A DNS wildcard answers at any depth, so that one record
-  already covers `{token}.share.example.com` -- unless you have also created a
+  already covers `{token}.share.example.com`, unless you have also created a
   real `share.example.com` record, which stops the wildcard applying below it.
 - The certificate is the part that does *not* stretch. An X.509 wildcard matches
   exactly one label, so `*.example.com` covers tenants and nothing deeper: you
@@ -64,7 +64,7 @@ terminate all three.
 <Callout type="tip" title="Wildcards are not the only option">
   A proxy that mints certificates per hostname on first request needs no wildcard
   and no DNS credentials. That is what the bundled Caddy does, and you can do the
-  same &mdash; with one constraint, described under Caddy below.
+  same, with one constraint, described under Caddy below.
 </Callout>
 
 ## The three headers
@@ -85,8 +85,8 @@ three:
 | `X-Forwarded-Host` | The original request host | Used ahead of `Host` when reconstructing the origin. |
 
 <Callout type="danger" title="nginx does not send these by default">
-  nginx's default is <code>proxy_set_header Host $proxy_host</code> -- the literal
-  <code>proxy_pass</code> target, e.g. <code>192.168.1.10:8080</code> -- and it
+  nginx's default is <code>proxy_set_header Host $proxy_host</code> (the literal
+  <code>proxy_pass</code> target, e.g. <code>192.168.1.10:8080</code>) and it
   sends no <code>X-Forwarded-*</code> headers at all. A stock
   <code>proxy_pass</code> with no <code>proxy_set_header</code> lines gets you a
   login page that loads and a login attempt that 403s.
@@ -153,7 +153,7 @@ server {
 
 nginx's `*.example.com` matches at any depth, so the `server_name` above already
 covers share hosts, as does the DNS wildcard. The certificate is the one that
-does not stretch -- it still needs `*.share.example.com` as a second SAN.
+does not stretch; it still needs `*.share.example.com` as a second SAN.
 
 If nginx listens on a non-standard port, use `$http_host` in place of `$host` for
 both host headers so the port survives.
@@ -178,7 +178,7 @@ The dots use the character class `[.]`, which matches a literal dot without
 needing a backslash escape.
 
 `HostRegexp` takes a standard Go regular expression on Traefik v3. Traefik v2's
-named-group form is not an *error* on v3 -- the router loads and reports no
+named-group form is not an *error* on v3: the router loads and reports no
 error, it just silently matches nothing, so every tenant subdomain 404s while the
 apex keeps working:
 
@@ -198,7 +198,7 @@ wildcard will issue.
 Traefik reads these labels over the Docker socket but connects to the container
 itself, so it has to be attached to the bundle's `aspire` network to reach the
 gateway on port 5000. Once it is, it no longer needs the override's published
-port at all -- and dropping `ports` from the override, rather than binding it to
+port at all, and dropping `ports` from the override, rather than binding it to
 loopback, is the safest version of the warning below.
 
 ## Caddy
@@ -225,7 +225,7 @@ Reproducing that in your own Caddy has one constraint. The `ask` endpoint answer
 200 or 404 for a given hostname, which makes it an anonymous tenant-slug oracle,
 so the web container deliberately refuses it on the `/api` path the gateway
 serves. Caddy must therefore reach the API container directly rather than through
-the gateway on port 8080 -- which in practice means running Caddy as a service on
+the gateway on port 8080, which in practice means running Caddy as a service on
 the bundle's compose network:
 
 ```caddyfile
@@ -256,7 +256,7 @@ issuance for arbitrary names.
   <code>&#123;token&#125;.share.example.com</code> host when the token resolves to an
   active share link, so on-demand issuance covers share links. A Caddy
   site-address wildcard matches exactly one label, though, so
-  <code>*.example.com</code> alone never matches a share host — a deployment
+  <code>*.example.com</code> alone never matches a share host; a deployment
   that hands out share links needs a <code>*.share.example.com</code> block
   with the same <code>tls &#123; on_demand &#125;</code> and
   <code>reverse_proxy</code> as the wildcard block above.
@@ -283,7 +283,7 @@ left unread. Declare all of them, or none.
 <Callout type="warning" title="Do not leave port 8080 open to the world">
   A caller that reaches the gateway directly, bypassing your proxy, does get to
   choose its own <code>X-Forwarded-For</code>. Publish the port on the interface
-  your proxy uses rather than all of them &mdash; in the override, change
+  your proxy uses rather than all of them: in the override, change
   <code>"8080:5000"</code> to <code>"127.0.0.1:8080:5000"</code> when the proxy runs
   on the same host.
 </Callout>
@@ -311,7 +311,7 @@ For a 502, nginx's `/var/log/nginx/error.log` is decisive:
 <Callout type="tip" title="Confirming the headers arrive">
   <code>docker compose logs gateway</code> records the host each request arrived
   on. If that shows your upstream address rather than your domain, your proxy is
-  not forwarding <code>Host</code> -- fix that before looking anywhere else.
+  not forwarding <code>Host</code>. Fix that before looking anywhere else.
 </Callout>
 
 ## Next steps

--- a/src/Web/packages/portal/src/content/docs/observability.svx
+++ b/src/Web/packages/portal/src/content/docs/observability.svx
@@ -22,7 +22,7 @@ there is nothing to disable on a default install.
 | **Web** | Server-side traces and logs, plus client-error spans | Node auto-instrumentation (server-side HTTP) and a browser error handler that reports unhandled errors |
 
 Telemetry is **push-based over OTLP**. Nocturne does **not** expose a Prometheus
-`/metrics` scrape endpoint -- see **Using Prometheus and Grafana** below if that
+`/metrics` scrape endpoint; see **Using Prometheus and Grafana** below if that
 is your stack.
 
 <Callout type="info" title="You provide the backend">
@@ -49,7 +49,7 @@ off. The standard OpenTelemetry SDK environment variables apply:
 
 Both the `nocturne-api` and `nocturne-web` services already reference
 `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL` from your `.env`.
-Telemetry is off because the endpoint ships empty -- there is no need to edit
+Telemetry is off because the endpoint ships empty, so there is no need to edit
 the Compose file. To turn it on, set the endpoint in `.env`:
 
 ```bash

--- a/src/Web/packages/portal/src/content/docs/sharing/clock.svx
+++ b/src/Web/packages/portal/src/content/docs/sharing/clock.svx
@@ -9,8 +9,8 @@ title: Clocks
 
 # Clocks
 
-A **clock** turns your glucose into a full-screen display — the number, a trend
-arrow, how much it's changed — that refreshes on its own. It's made for a screen
+A **clock** turns your glucose into a full-screen display (the number, a trend
+arrow, how much it's changed) that refreshes on its own. It's made for a screen
 you read across the room: a bedside clock, a tablet on the kitchen counter, a
 monitor on a desk.
 
@@ -43,7 +43,7 @@ get its address.
 
 That link is **public**: anyone you give it to can open it with no login, on any
 device, and it keeps showing your latest reading. It works **whether or not** you
-have turned on the [public share link](/docs/sharing/public-link) — a clock is its
+have turned on the [public share link](/docs/sharing/public-link); a clock is its
 own, separate thing, and turning public access off does not switch a clock off.
 
 The address ends in a long code, like
@@ -69,7 +69,7 @@ whoever holds it.
       </li>
       <li>
         <strong>The random half is astronomically large.</strong> It has roughly
-        2 &times; 10<sup>22</sup> possible values — a 2 followed by 22 digits — so
+        2 &times; 10<sup>22</sup> possible values (a 2 followed by 22 digits), so
         even someone who knew to the second when you made a clock could not work
         out the rest of its code.
       </li>
@@ -77,14 +77,14 @@ whoever holds it.
     <p>
       To picture that scale,
       <a href="https://everyuuid.com" target="_blank" rel="noopener noreferrer" class="underline">everyuuid.com</a>
-      lets you scroll through every possible UUID — you would never reach the end.
+      lets you scroll through every possible UUID; you would never reach the end.
     </p>
   </div>
 </details>
 
 ## Turning one off
 
-A clock link has no expiry and no password — it works until you delete the clock.
+A clock link has no expiry and no password: it works until you delete the clock.
 Delete it in the **Clock** section and its link stops working right away. Deleting
 and recreating a clock gives it a brand-new code, so the old link can't be reused.
 

--- a/src/Web/packages/portal/src/content/docs/sharing/guest-links.svx
+++ b/src/Web/packages/portal/src/content/docs/sharing/guest-links.svx
@@ -11,7 +11,7 @@ title: Temporary guest links
 
 A guest link gives someone a **read-only view of your data without an account**.
 You create it, hand over the link (or the short code inside it), and it lets them
-look — they can't change anything. It **expires on its own 48 hours after you make
+look; they can't change anything. It **expires on its own 48 hours after you make
 it** and can only be used **once**, so there's nothing to remember to switch off
 afterwards.
 
@@ -24,21 +24,21 @@ currently reaches your data:
 ## Handing one over
 
 Each guest link carries a short code. You can send the whole link, or read the
-code out over the phone — the person enters it on the guest page of your instance:
+code out over the phone. The person enters it on the guest page of your instance:
 
 <Screenshot id="guest-code-entry" />
 
 Once they enter it, the code is spent. That's the point: a link that has already
 been used can't be forwarded on and opened again by somebody else.
 
-You can have **five** active guest links at once — one per person you're sharing
-with — and give each one a label so you can tell them apart.
+You can have **five** active guest links at once (one per person you're sharing
+with) and give each one a label so you can tell them apart.
 
 <Callout type="tip" title="When to use it: a specialist appointment">
   You're seeing your specialist on Tuesday and want them to look at your recent
   data on their own screen. Create a guest link labelled
   <strong>"Dr. Smith"</strong>, send it ahead of the appointment, and forget about
-  it — it stops working on its own two days later. No account to set up
+  it; it stops working on its own two days later. No account to set up
   for a one-off visit, and nothing left switched on afterwards.
 </Callout>
 

--- a/src/Web/packages/portal/src/content/docs/sharing/index.svx
+++ b/src/Web/packages/portal/src/content/docs/sharing/index.svx
@@ -10,7 +10,7 @@ title: Sharing your data
 # Sharing your data
 
 Nocturne gives you a few ways to let someone else see your data, each built for
-a different situation — a one-off clinic visit, an always-on screen at daycare,
+a different situation: a one-off clinic visit, an always-on screen at daycare,
 a person who needs their own ongoing login, or a glucose clock you can leave on
 any screen. This page explains what each one does and when to reach for it; each
 one then has its own page with the step-by-step detail.
@@ -31,10 +31,10 @@ members follow below it:
 
 | Option | Best for | Needs a login? | Expires |
 |--------|----------|----------------|---------|
-| [Temporary guest link](/docs/sharing/guest-links) | A one-off look — a clinic visit | No | After 48 hours, one use |
-| [Public share link](/docs/sharing/public-link) | An always-on screen — a daycare | No | Never (until you turn it off) |
-| [Member account](/docs/sharing/members) | An ongoing helper — a teacher or nurse | Yes | Never (until you remove them) |
-| [Clock](/docs/sharing/clock) | An at-a-glance glucose screen — a bedside clock | No | Never (until you delete it) |
+| [Temporary guest link](/docs/sharing/guest-links) | A one-off look (a clinic visit) | No | After 48 hours, one use |
+| [Public share link](/docs/sharing/public-link) | An always-on screen (a daycare) | No | Never (until you turn it off) |
+| [Member account](/docs/sharing/members) | An ongoing helper (a teacher or nurse) | Yes | Never (until you remove them) |
+| [Clock](/docs/sharing/clock) | An at-a-glance glucose screen (a bedside clock) | No | Never (until you delete it) |
 
 There is also a fifth setting that isn't a way of sharing so much as a way of
 being asked: **membership requests**. Turn it on and visitors can request a
@@ -71,15 +71,15 @@ member account instead of waiting for you to send them an invite. See
 Every option here is reversible, and all but the clock are reversed from
 **Settings > Sharing & Privacy**:
 
-- **Public share link** — switch public access off, or **Regenerate** it. Either
+- **Public share link**: switch public access off, or **Regenerate** it. Either
   one stops the old link working immediately.
-- **Guest link** — revoke it, or simply let it expire. A used code cannot be used
+- **Guest link**: revoke it, or simply let it expire. A used code cannot be used
   a second time.
-- **Member** — change their role to a narrower one, or remove them entirely.
-- **Membership requests** — switch the toggle off, and no one new can ask. It
+- **Member**: change their role to a narrower one, or remove them entirely.
+- **Membership requests**: switch the toggle off, and no one new can ask. It
   doesn't affect anyone you have already approved.
-- **Clock** — turned off separately. Delete it in the **Clock** section and its
+- **Clock**: turned off separately. Delete it in the **Clock** section and its
   link stops working right away.
 
-When in doubt, share the least you can for the shortest time you can — you can
+When in doubt, share the least you can for the shortest time you can; you can
 always grant more later.

--- a/src/Web/packages/portal/src/content/docs/sharing/members.svx
+++ b/src/Web/packages/portal/src/content/docs/sharing/members.svx
@@ -28,7 +28,7 @@ From then on they have access until you change their role or remove them.
 Two things to know about the link:
 
 - **It expires.** By default an invite is good for 7 days. If it lapses before
-  they use it, create another one — nothing is lost.
+  they use it, create another one; nothing is lost.
 - **Treat it as private.** Until it's accepted, whoever opens the link can claim
   that role. Send it directly to the person, not to a group chat.
 
@@ -46,16 +46,16 @@ access:
 | Owner | You. Full control of the account; can't be removed. |
 
 If a role is close but not quite right, you can adjust an individual member's
-**permissions** on top of it — switching a particular kind of access on or off for
+**permissions** on top of it, switching a particular kind of access on or off for
 that one person, without changing what the role means for everyone else.
 
-You can also tick **Only last 24 hours** — when you invite them, or later — to
+You can also tick **Only last 24 hours** (when you invite them, or later) to
 limit that member to recent data, the same way the public link's time window
 works.
 
 <Callout type="tip" title="When to use it: a teacher and a school nurse">
   At school, two people need access for the whole term, and they need different
-  things. Invite the <strong>teacher as a Viewer</strong> — they just need to
+  things. Invite the <strong>teacher as a Viewer</strong>; they just need to
   glance at the current glucose during class. Invite the
   <strong>school nurse as a Caretaker</strong>, so they can also log a treatment
   or manage an alert if they step in. Each has their own login, you can see them
@@ -64,17 +64,17 @@ works.
 
 ## Membership requests
 
-Inviting someone is one direction — you reach out and hand them a link.
+Inviting someone is one direction: you reach out and hand them a link.
 **Membership requests** are the other direction: you let people **ask you** for
 access, and nothing is granted until you approve it.
 
 The toggle lives on **Settings > Sharing & Privacy**. While it's on, your sign-in
 page shows a **Request membership** link. Someone who lands on your instance writes
-a short note saying who they are, presses **Continue to Sign Up**, and signs in —
+a short note saying who they are, presses **Continue to Sign Up**, and signs in,
 which is how the request arrives with a name attached. It **never grants access on
 its own**; it waits for you.
 
-You review requests **in place, on Settings > Sharing & Privacy** — the same page
+You review requests **in place, on Settings > Sharing & Privacy**, the same page
 as the toggle. Each one shows who asked, their note, and when. Tick the roles they
 should have and approve to add them as a member, or deny it. It's the same roles as
 an invite; the only difference is who started the conversation.
@@ -86,7 +86,7 @@ For what the person on the other side sees, and how to word the note, see
   A grandparent asks to keep an eye on your child's glucose. Rather than
   collecting their email and sending an invite, switch membership requests on and
   point them at your instance. They sign in, request access, and you approve them as a
-  <strong>Viewer</strong> when it suits you — or deny it if you change your mind.
+  <strong>Viewer</strong> when it suits you, or deny it if you change your mind.
 </Callout>
 
 ## Removing a member

--- a/src/Web/packages/portal/src/content/docs/sharing/public-link.svx
+++ b/src/Web/packages/portal/src/content/docs/sharing/public-link.svx
@@ -10,7 +10,7 @@ title: Public share link
 # Public share link
 
 Public access turns on a single read-only link that **anyone you give it to can
-open — with no login and no invite**. Because there's no sign-in, treat the link
+open, with no login and no invite**. Because there's no sign-in, treat the link
 itself as the key: anyone who has it can see whatever you've chosen to share.
 
 It is **off until you turn it on**, and you turn it on under
@@ -31,7 +31,7 @@ domain, in the shape `https://<random>.share.<your domain>`.
 
 When you first switch public access on, Nocturne creates the link and shows it to
 you **that one time**. Copy it there and then, and keep it somewhere you can get
-back to — a password manager is ideal. If you lose it, you can't ask Nocturne to
+back to; a password manager is ideal. If you lose it, you can't ask Nocturne to
 show it again; you **Regenerate** to get a new one, which also stops the old one
 working.
 
@@ -83,13 +83,13 @@ chose:
 
 ## Turning it off or replacing it
 
-There's no expiry — the link works until you turn public access off. Two controls
+There's no expiry: the link works until you turn public access off. Two controls
 end it:
 
 - **Switch public access off.** The link stops working immediately.
 - **Regenerate.** Nocturne issues a brand-new link and the old one stops working
   immediately. Use this when a link has spread further than you meant it to, but
-  you still want the daycare (or whoever) to have one — you just have to hand out
+  you still want the daycare (or whoever) to have one; you just have to hand out
   the new address.
 
 <Callout type="warning" title="Anyone with the link can open it">
@@ -100,6 +100,6 @@ end it:
 </Callout>
 
 If only one person needs a look, and only once, a
-[temporary guest link](/docs/sharing/guest-links) is the safer choice — it expires
+[temporary guest link](/docs/sharing/guest-links) is the safer choice; it expires
 on its own. If they need ongoing access, give them their own
 [member account](/docs/sharing/members).

--- a/src/Web/packages/portal/src/content/docs/windows-widget-privacy.svx
+++ b/src/Web/packages/portal/src/content/docs/windows-widget-privacy.svx
@@ -6,7 +6,7 @@ title: Windows Widget Privacy Policy
   import Callout from '@nocturne/cms/components/Callout.svelte';
 </script>
 
-# Nocturne Windows Widget — Privacy Policy
+# Nocturne Windows Widget: Privacy Policy
 
 _Last updated: 21 June 2026_
 
@@ -40,7 +40,7 @@ on your server.
 The widget communicates **directly** between your PC and the Nocturne server you
 enter during setup. There are no intermediary servers. Your diabetes data is
 fetched over the network solely to render the widget and is held only transiently
-in memory for display — it is not written to disk and is not transmitted anywhere
+in memory for display; it is not written to disk and is not transmitted anywhere
 else.
 
 The Nightscout Foundation operates no servers in this flow and receives no data.

--- a/src/Web/packages/portal/src/content/docs/windows-widget.svx
+++ b/src/Web/packages/portal/src/content/docs/windows-widget.svx
@@ -8,7 +8,7 @@ title: Windows 11 Widget
 
 # Nocturne Windows 11 Widget
 
-The Nocturne widget puts your live glucose on the Windows 11 Widgets Board — the
+The Nocturne widget puts your live glucose on the Windows 11 Widgets Board, the
 panel that opens with **Win + W**. It reads from any Nocturne server you have access
 to (hosted or self-hosted) and refreshes on its own.
 
@@ -20,7 +20,7 @@ It comes in three sizes:
 | Medium | Nocturne | Glucose, trend, delta, insulin-on-board and carbs-on-board |
 | Large | Nocturne Dashboard | Everything in Medium, plus short-term predictions and tracker ages |
 
-You can add more than one — for example a Small widget for a quick number and a
+You can add more than one, for example a Small widget for a quick number and a
 Large one for the full picture.
 
 ## Requirements
@@ -30,7 +30,7 @@ Large one for the full picture.
 
 ## Install
 
-The widget installs from the **Microsoft Store** — search for "Nocturne" in the
+The widget installs from the **Microsoft Store**: search for "Nocturne" in the
 Store app, or on the Widgets Board itself. Store installs are signed by Microsoft,
 update automatically, and need no extra setup.
 
@@ -51,7 +51,7 @@ The widget appears showing **Setup Required** until you connect it to your serve
 
 ## Connect to your Nocturne server
 
-The widget signs in with a short code — there are no tokens or passwords to copy.
+The widget signs in with a short code; there are no tokens or passwords to copy.
 
 1. Right-click the widget and choose **Customize**.
 2. Enter your **Nocturne server URL** (for example `https://your-nocturne-server.com`) and click **Connect**.
@@ -59,7 +59,7 @@ The widget signs in with a short code — there are no tokens or passwords to co
    Nocturne if needed, and approve the request.
 4. Once approved, the widget switches to showing your glucose automatically.
 
-The widget asks only for **read-only** access — glucose, treatments (for IOB/COB),
+The widget asks only for **read-only** access: glucose, treatments (for IOB/COB),
 device status, and therapy settings used for display. It can never change anything
 on your server.
 
@@ -70,10 +70,10 @@ on your server.
 
 ## What each size shows
 
-- **Small** — the current glucose value and trend arrow.
-- **Medium** — adds the delta since the previous reading, insulin-on-board (IOB),
+- **Small**: the current glucose value and trend arrow.
+- **Medium**: adds the delta since the previous reading, insulin-on-board (IOB),
   and carbs-on-board (COB).
-- **Large** — adds predicted values at +15 / +30 / +45 / +60 minutes (when your
+- **Large**: adds predicted values at +15 / +30 / +45 / +60 minutes (when your
   server provides predictions) and the ages of your active trackers (such as site
   or sensor), highlighted when one needs attention.
 
@@ -103,7 +103,7 @@ Close and reopen the Widgets Board (Win + W). If it still doesn't appear right a
 installing, sign out of Windows and back in so the board re-scans for new widgets.
 
 **It still says "Setup Required".**
-You haven't connected it yet — follow [Connect to your Nocturne server](#connect-to-your-nocturne-server).
+You haven't connected it yet; follow [Connect to your Nocturne server](#connect-to-your-nocturne-server).
 
 **It shows a connection error or no data.**
 Check that the server URL is correct and reachable from this PC in a browser. If the

--- a/src/Web/packages/portal/src/lib/components/AuroraCanvas.svelte
+++ b/src/Web/packages/portal/src/lib/components/AuroraCanvas.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { onMount } from "svelte";
+    import { auroraTime } from "$lib/utils/aurora-noise";
 
     let {
         height = 880,
@@ -15,7 +16,8 @@
 
     let canvasEl: HTMLCanvasElement;
 
-    // Fragment shader — domain-warped FBM noise into the Nocturne glucose palette
+    // Fragment shader: domain-warped FBM noise into the Nocturne glucose palette.
+    // aurora-noise.ts is a JS port of this chain; keep the two in step.
     const FRAG = `
 precision highp float;
 uniform vec2  u_res;
@@ -101,7 +103,6 @@ void main(){
 
         let raf: number;
         let running = true;
-        const t0 = performance.now();
         const dpr = Math.min(window.devicePixelRatio || 1, 2);
 
         const resize = () => {
@@ -116,7 +117,7 @@ void main(){
 
         const tick = () => {
             if (!running) return;
-            const t = ((performance.now() - t0) / 1000) * speed;
+            const t = auroraTime() * speed;
             gl.uniform2f(uRes, canvas.width, canvas.height);
             gl.uniform1f(uT, t);
             gl.uniform1f(uI, intensity);

--- a/src/Web/packages/portal/src/lib/components/AuroraPool.svelte
+++ b/src/Web/packages/portal/src/lib/components/AuroraPool.svelte
@@ -4,7 +4,7 @@
   }
   let { textBlock = null }: Props = $props();
 
-  import { sampleFlow } from "$lib/utils/aurora-noise";
+  import { auroraTime, sampleSurface } from "$lib/utils/aurora-noise";
 
   // ── Chip definitions ──────────────────────────────────────────────────────
   // hPos: left or right as % of container width. Preserved from the original
@@ -78,21 +78,28 @@
   const INIT_ROTS = [-4, 6, -8, 5, -6, 7, -3, 9, -10] as const;
 
   // ── Physics constants ─────────────────────────────────────────────────────
-  const BOB_FREQ_V = 0.7; // rad/s — vertical bob frequency
-  const BOB_AMP_V = 10; // px/s² force amplitude (vertical)
-  const BOB_FREQ_H = 0.45; // rad/s — horizontal drift frequency
-  const BOB_AMP_H = 2; // px/s² force amplitude (horizontal)
+  // The chips float on the aurora the canvas is drawing. Each frame a chip
+  // samples the shader's brightness field at its own position and gets:
+  //   - a current: it is dragged toward the velocity the pattern is visibly
+  //     moving at under it (optical flow), so it rides the crest passing by;
+  //   - a slide: it slips downhill from bright crests into dark troughs;
+  //   - a tilt: it leans with the slope of the surface it is sitting on.
+  const CURRENT_COUPLING = 1.2; // 1/s: how quickly velocity relaxes to the pattern's flow
+  const CURRENT_MAX = 45; // px/s: optical flow spikes where the field is flat, so cap it
+  const SLIDE_GAIN = 7000; // px/s² per (brightness/px) of slope
+  const TILT_GAIN = 6000; // deg per (brightness/px) of x-slope
+  const TILT_MAX = 14; // deg
+  const TILT_K = 6; // 1/s²: spring toward the surface tilt
   const LINEAR_DAMP = 0.03; // fraction of velocity lost per frame (not per second)
   const ANGULAR_DAMP = 0.07; // same for rotation
   const RESTITUTION = 0.2; // bounciness (0 = dead stop, 1 = perfectly elastic)
   const SPRING_K = 120; // drag spring constant (px/s² per px of offset)
-  const MAX_DT = 0.05; // seconds — cap to prevent tunnelling on hidden tabs
+  const MAX_DT = 0.05; // seconds: cap to prevent tunnelling on hidden tabs
   const ANG_KICK = 2; // deg/s angular impulse added on collision
   const TEXT_PAD = 1; // px padding added around text block collision rect
-  const TIDE_AMP = 250; // px/s² — tidal force amplitude from aurora flow field
-  const TOP_GUARD = 72; // px — keeps chips below the fixed nav header
+  const TOP_GUARD = 72; // px: keeps chips below the fixed nav header
 
-  // ── Physics state (plain JS — NOT $state, no reactivity overhead) ─────────
+  // ── Physics state (plain JS, not $state: no reactivity overhead) ──────────
   interface CS {
     cx: number;
     cy: number; // center position in container-local px
@@ -100,7 +107,6 @@
     vy: number; // velocity px/s
     rot: number;
     rotV: number; // rotation deg, angular velocity deg/s
-    phase: number; // bobbing phase offset (0–2π), unique per chip
     w: number;
     h: number; // measured pixel size (AABB half-extents: w/2, h/2)
     isDragged: boolean;
@@ -109,7 +115,7 @@
   // containerEl is $state so $effect tracks it (triggers after bind:this fires)
   let containerEl: HTMLDivElement | null = $state(null);
 
-  // chipElRefs is plain — populated synchronously by the assignRef action before $effect runs
+  // chipElRefs is plain: populated synchronously by the assignRef action before $effect runs
   const chipElRefs: (HTMLElement | null)[] = Array(CHIP_DEFS.length).fill(null);
 
   const cs: CS[] = CHIP_DEFS.map((_, i) => ({
@@ -119,7 +125,6 @@
     vy: 0,
     rot: INIT_ROTS[i],
     rotV: 0,
-    phase: (i / CHIP_DEFS.length) * Math.PI * 2,
     w: 60,
     h: 30,
     isDragged: false,
@@ -392,7 +397,8 @@
   function tick(now: number) {
     const dt = Math.min((now - lastTime) / 1000, MAX_DT);
     lastTime = now;
-    const t = now / 1000;
+    // Same clock as AuroraCanvas, so the field sampled here is the frame on screen.
+    const t = auroraTime(now);
     const cw = containerEl ? containerEl.offsetWidth : 0;
     const ch = containerEl ? containerEl.offsetHeight : 0;
 
@@ -404,16 +410,23 @@
         // (grabOffset keeps the chip stationary at pickup, no snap)
         c.vx += (pointer.x - grabOffset.x - c.cx) * SPRING_K * dt;
         c.vy += (pointer.y - grabOffset.y - c.cy) * SPRING_K * dt;
-      } else {
-        // Sine-wave bob forces — unique phase per chip so they desync naturally
-        c.vy += Math.sin(t * BOB_FREQ_V + c.phase) * BOB_AMP_V * dt;
-        c.vx += Math.sin(t * BOB_FREQ_H + c.phase * 1.3) * BOB_AMP_H * dt;
-        // Tidal force — flow vector from the same aurora noise field
-        if (cw > 0 && ch > 0) {
-          const flow = sampleFlow(c.cx, c.cy, cw, ch, t);
-          c.vx += (flow.rx - 0.5) * 2 * TIDE_AMP * dt;
-          c.vy += (flow.ry - 0.5) * 2 * TIDE_AMP * dt;
-        }
+      } else if (cw > 0 && ch > 0) {
+        const s = sampleSurface(c.cx, c.cy, cw, ch, t);
+
+        // Current: relax toward the pattern's own velocity under the chip.
+        const mag = Math.hypot(s.flowX, s.flowY);
+        const k = mag > CURRENT_MAX ? CURRENT_MAX / mag : 1;
+        c.vx += (s.flowX * k - c.vx) * CURRENT_COUPLING * dt;
+        c.vy += (s.flowY * k - c.vy) * CURRENT_COUPLING * dt;
+
+        // Slide: downhill, away from the bright crest.
+        c.vx -= s.slopeX * SLIDE_GAIN * dt;
+        c.vy -= s.slopeY * SLIDE_GAIN * dt;
+
+        // Tilt: lean with the surface along the chip's length. A crest to the
+        // right lifts the right end, which is a negative CSS rotation (y is down).
+        const tilt = Math.max(-TILT_MAX, Math.min(TILT_MAX, -s.slopeX * TILT_GAIN));
+        c.rotV += (tilt - c.rot) * TILT_K * dt;
       }
       c.vx *= 1 - LINEAR_DAMP;
       c.vy *= 1 - LINEAR_DAMP;
@@ -465,7 +478,7 @@
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
-  // Physics init — runs once when containerEl is set (bind:this fires on mount)
+  // Physics init: runs once when containerEl is set (bind:this fires on mount)
   $effect(() => {
     if (!containerEl) return;
     measureSizes();
@@ -480,7 +493,7 @@
     };
   });
 
-  // Text rect — re-measures whenever the textBlock prop changes
+  // Text rect: re-measures whenever the textBlock prop changes
   // (parent's bind:this fires after its own mount, after this effect)
   $effect(() => {
     measureTextRect();

--- a/src/Web/packages/portal/src/lib/components/docs/CopyButton.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/CopyButton.svelte
@@ -32,7 +32,7 @@
     type="button"
     onclick={copy}
     class="shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
-    aria-label={copied ? "Copied" : failed ? "Copy failed — select the text and copy it manually" : label}
+    aria-label={copied ? "Copied" : failed ? "Copy failed. Select the text and copy it manually" : label}
 >
     {#if copied}
         <Check class="h-4 w-4 text-green-500" />

--- a/src/Web/packages/portal/src/lib/components/docs/NextSteps.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/NextSteps.svelte
@@ -5,10 +5,25 @@
 
 <div class="mb-8">
     <ul class="list-disc list-inside space-y-2 text-muted-foreground mb-6">
-        <li>Configure your data connectors (Dexcom, LibreLinkUp, Glooko, etc.) via the admin panel</li>
-        <li>Set up a reverse proxy (Nginx, Caddy, Traefik) for HTTPS</li>
-        <li>Point your CGM app or loop system to your new Nocturne instance</li>
-        <li>Watchtower is included and checks for image updates daily — no action required</li>
+        <li>
+            Open <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">https://your-domain</code>
+            and complete first-run setup, which creates the owner account with a
+            <a href="/docs/authentication/passkeys" class="text-primary hover:underline">passkey</a>
+            or a sign-in provider.
+        </li>
+        <li>
+            Connect a data source (Dexcom, LibreLinkUp, CareLink, Glooko, or your existing Nightscout)
+            under <strong>Settings &rsaquo; Connectors &amp; Apps</strong>.
+        </li>
+        <li>
+            Point your CGM app or loop system at your new Nocturne URL. See
+            <a href="/docs/connecting-apps" class="text-primary hover:underline">Connecting apps</a>.
+        </li>
+        <li>
+            Invite the people who follow you, or create a
+            <a href="/docs/sharing" class="text-primary hover:underline">share link</a>.
+        </li>
+        <li>Watchtower is included and checks for image updates daily; no action required.</li>
     </ul>
 
     <div class="flex gap-4 not-prose">

--- a/src/Web/packages/portal/src/lib/components/docs/OAuthScopeTable.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/OAuthScopeTable.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     // The scope list and descriptions are the single source of truth shared with the
-    // OAuth consent screen — derived from the backend OAuthScope enum (NSwag-generated),
+    // OAuth consent screen, derived from the backend OAuthScope enum (NSwag-generated),
     // so this table can never drift from the scopes the API actually accepts. Adding a
     // backend scope regenerates the enum; OAUTH_SCOPE_DESCRIPTIONS is typed
     // Record<OAuthScope, string>, so the build fails until the new scope gets a description.

--- a/src/Web/packages/portal/src/lib/components/docs/PasswordGenerator.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/PasswordGenerator.svelte
@@ -36,7 +36,7 @@
 
     let refreshKey = $state(0);
     // Derived so password regenerates whenever length or refreshKey changes.
-    // The generatePassword call reads neither reactive state nor props directly —
+    // The generatePassword call reads neither reactive state nor props directly,
     // refreshKey and length are the only tracked dependencies here.
     let password = $derived.by(() => {
         // Track both dependencies explicitly.
@@ -74,6 +74,6 @@
     </div>
 
     <p class="mt-1.5 text-xs text-muted-foreground">
-        Generated locally in your browser — never sent anywhere.
+        Generated locally in your browser and never sent anywhere.
     </p>
 </div>

--- a/src/Web/packages/portal/src/lib/components/docs/PlatformAdminNote.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/PlatformAdminNote.svelte
@@ -8,7 +8,7 @@
 <Callout type="info" title="Can't see the Administration section?">
     Administration is only visible to a <strong>platform admin</strong>. That is a
     separate permission from a tenant's <strong>owner</strong> role, so being the owner
-    of your instance is not enough on its own — opening
+    of your instance is not enough on its own; opening
     <code>/settings/admin</code> without it sends you back to <strong>Settings</strong>.
     On a new install the permission goes to the owner of the first tenant, granted when
     that owner finishes setting up their passkey or sign-in provider.

--- a/src/Web/packages/portal/src/lib/components/docs/SdkList.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/SdkList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     // Renders the supported-SDK table. The rows come from SDKS, which is derived
-    // from sdk/<lang>/config.yaml at build time — adding or removing an SDK there
+    // from sdk/<lang>/config.yaml at build time; adding or removing an SDK there
     // updates this table with no edit here.
     import { SDKS } from "$lib/sdk/sdks";
 </script>

--- a/src/Web/packages/portal/src/lib/components/docs/SupportNocturne.svelte
+++ b/src/Web/packages/portal/src/lib/components/docs/SupportNocturne.svelte
@@ -19,7 +19,7 @@
         {
             amount: "US$20",
             name: "Sustainer",
-            desc: "Adds test hardware — pumps, CGM transmitters, and phones the connectors are verified against.",
+            desc: "Adds test hardware: pumps, CGM transmitters, and phones the connectors are verified against.",
             href: LINKS.subscribe20,
             featured: true,
         },

--- a/src/Web/packages/portal/src/lib/components/features/AlarmsDemo.svelte
+++ b/src/Web/packages/portal/src/lib/components/features/AlarmsDemo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    // Stripped-down replay demo — real playback engine + chart, synthetic data,
+    // Stripped-down replay demo: real playback engine + chart, synthetic data,
     // no API calls. Wire to the real ReplayPanel once the portal auth story is done.
 
     import { onDestroy } from "svelte";
@@ -35,7 +35,7 @@
     const BASE_MS = new Date("2026-03-15T22:00:00").getTime();
     const SPAN_MS = 8 * 3600_000;
 
-    // Synthetic rules — each has a single leaf condition for the sidebar.
+    // Synthetic rules; each has a single leaf condition for the sidebar.
     // BG first crosses 180 at 4.2875 h (interpolated from waypoints [4.1,162]→[4.35,186]).
     // Sustained 30-min alarm fires 0.5 h later at 4.7875 h.
     const R1_FIRED_MS    = BASE_MS + 2.25   * 3600_000;
@@ -180,8 +180,8 @@
             const resolved = r.resolvedMs != null && r.resolvedMs <= currentMs;
             const active   = fired && !resolved;
             // Leaf truth:
-            //   threshold — true while BG is currently below 70
-            //   sustained — true once BG has been above 180 for 30 min (i.e. past fire time)
+            //   threshold: true while BG is currently below 70
+            //   sustained: true once BG has been above 180 for 30 min (i.e. past fire time)
             //                but the inner condition (BG > 180) must still hold
             const leafTrue = disabled ? false
                 : r.leaf.kind === "threshold"
@@ -374,11 +374,11 @@
                 </div>
             </div>
 
-            <!-- Events log — fixed height so new entries scroll in without shifting layout -->
+            <!-- Events log: fixed height so new entries scroll in without shifting layout -->
             <div class="h-24 shrink-0 overflow-y-auto mx-3 mt-2 mb-3 rounded-md border divide-y text-sm">
                 {#if firedEvents.length === 0}
                     <div class="flex items-center justify-center h-full text-xs text-muted-foreground/50 px-3 py-4">
-                        No events yet — playhead at start of window.
+                        No events yet; playhead at start of window.
                     </div>
                 {:else}
                     {#each firedEvents as ev (`${ev.kind}-${ev.tMs}`)}

--- a/src/Web/packages/portal/src/lib/components/features/AuthDemo.svelte
+++ b/src/Web/packages/portal/src/lib/components/features/AuthDemo.svelte
@@ -17,7 +17,7 @@
         <div class="font-mono text-[13px] tracking-[0.06em] uppercase text-glucose-in-range font-bold mb-1.5">
             Sign in to your Nocturne
         </div>
-        <div class="text-[14px] text-muted-foreground">No password to forget, leak, or remember.</div>
+        <div class="text-[14px] text-muted-foreground">No password to forget, leak, or reset.</div>
     </div>
 
     <!-- Passkey CTA -->
@@ -53,11 +53,12 @@
             </svg>
             GitHub
         </button>
-        <button type="button" class="oauth-btn" style="background:#000; color:#fff; border:1px solid oklch(1 0 0 / 10%)" tabindex="-1">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+        <button type="button" class="oauth-btn" style="background:oklch(0.22 0.03 261); color:#fff; border:1px solid oklch(1 0 0 / 14%)" tabindex="-1">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="9"/>
+                <circle cx="12" cy="12" r="3.5"/>
             </svg>
-            Apple
+            OpenID
         </button>
     </div>
 

--- a/src/Web/packages/portal/src/lib/components/features/ConnectorsDemo.svelte
+++ b/src/Web/packages/portal/src/lib/components/features/ConnectorsDemo.svelte
@@ -1,158 +1,9 @@
 <script lang="ts">
   import { Search, Check, Clock } from "@lucide/svelte";
 
-  interface Connector {
-    file: string;
-    name: string;
-    kind: string;
-    aliases?: string[];
-    comingSoon?: true;
-    issue?: number;
-  }
+  import { CONNECTORS, type Connector } from "$lib/data/connectors";
 
-  const CONNECTORS: Connector[] = [
-    {
-      file: "dexcom.png",
-      name: "Dexcom",
-      kind: "CGM",
-      aliases: ["Clarity", "g6", "g7"],
-    },
-    {
-      file: "libre.png",
-      name: "FreeStyle Libre",
-      kind: "CGM",
-      aliases: ["Libre", "FSL", "Abbott"],
-    },
-    { file: "glooko.png", name: "Glooko", kind: "Cloud" },
-    { file: "medtronic.jpg", name: "Medtronic", kind: "Pump" },
-    {
-      file: "omnipod.png",
-      name: "Omnipod",
-      kind: "Pump",
-      aliases: ["Insulet", "DASH", "5"],
-    },
-    { file: "loop.png", name: "Loop", kind: "Looping" },
-    { file: "trio.jpg", name: "Trio", kind: "Looping" },
-    {
-      file: "aaps.png",
-      name: "AndroidAPS",
-      kind: "Looping",
-      aliases: ["AAPS", "android"],
-    },
-    {
-      file: "xdrip.jpg",
-      name: "xDrip+",
-      kind: "App",
-      aliases: ["xDrip", "android"],
-    },
-    { file: "mylife.png", name: "myLife", kind: "Pump" },
-    {
-      file: "myfitnesspal.jpg",
-      name: "MyFitnessPal",
-      kind: "Food",
-      aliases: ["MFP"],
-    },
-    { file: "tidepool.jpg", name: "Tidepool", kind: "Cloud" },
-    { file: "sugarmate.png", name: "Sugarmate", kind: "App" },
-    { file: "spike.png", name: "Spike", kind: "App" },
-    { file: "juggluco.png", name: "Juggluco", kind: "App" },
-    { file: "glucotracker.png", name: "GlucoTracker", kind: "App" },
-    {
-      file: "nightscout.png",
-      name: "Nightscout",
-      kind: "Legacy",
-      aliases: ["NS"],
-    },
-    { file: "discord.png", name: "Discord", kind: "Notify" },
-    { file: "slack.png", name: "Slack", kind: "Notify" },
-    { file: "telegram.png", name: "Telegram", kind: "Notify" },
-    {
-      file: "home-assistant.png",
-      name: "Home Assistant",
-      kind: "Smart Home",
-      aliases: ["HA", "smart home"],
-    },
-    // Coming soon
-    {
-      file: "tandem.png",
-      name: "Tandem",
-      kind: "Pump",
-      aliases: ["TConnect"],
-      comingSoon: true,
-      issue: 72,
-    },
-    {
-      file: "medtrum.jpg",
-      name: "Medtrum",
-      kind: "CGM",
-      comingSoon: true,
-      issue: 106,
-    },
-    {
-      file: "n8n.png",
-      name: "n8n",
-      kind: "Cloud",
-      comingSoon: true,
-      issue: 112,
-    },
-    {
-      file: "twilio.png",
-      name: "Twilio / SMS",
-      kind: "Messaging",
-      aliases: ["SMS", "Twilio"],
-      comingSoon: true,
-      issue: 137,
-    },
-    {
-      file: "oura.png",
-      name: "Oura",
-      kind: "App",
-      aliases: ["Oura Ring"],
-      comingSoon: true,
-      issue: 151,
-    },
-    {
-      file: "whatsapp.png",
-      name: "WhatsApp",
-      kind: "Messaging",
-      aliases: ["WA"],
-      comingSoon: true,
-      issue: 177,
-    },
-    {
-      file: "imessage.jpg",
-      name: "iMessage",
-      kind: "Messaging",
-      aliases: ["Apple Messages", "iMsg", "ios"],
-      comingSoon: true,
-      issue: 178,
-    },
-    {
-      file: "google-chat.png",
-      name: "Google Chat",
-      kind: "Messaging",
-      aliases: ["GChat"],
-      comingSoon: true,
-      issue: 179,
-    },
-    {
-      file: "teams.png",
-      name: "MS Teams",
-      kind: "Messaging",
-      aliases: ["Teams", "Microsoft Teams"],
-      comingSoon: true,
-      issue: 180,
-    },
-    {
-      file: "email.jpg",
-      name: "Email",
-      kind: "Notify",
-      comingSoon: true,
-      issue: 181,
-    },
-  ];
-
-  const TYPE_TARGETS = ["Dexcom", "Libre", "Loop", "Omnipod", "xDrip"];
+  const TYPE_TARGETS = ["Dexcom", "Libre", "Loop", "Tandem", "xDrip"];
 
   interface Props {
     height?: number;
@@ -231,7 +82,7 @@
     <Search class="size-5 text-muted-foreground shrink-0" />
     <input
       class="flex-1 bg-transparent border-none outline-none text-[17px] text-foreground font-medium placeholder:text-muted-foreground/60 min-h-7 w-0"
-      placeholder="Find your device or app…"
+      placeholder="Find your device or app"
       aria-label="Search connectors"
       bind:value={query}
       onfocus={() => (userTyping = true)}

--- a/src/Web/packages/portal/src/lib/components/features/FeaturePillars.svelte
+++ b/src/Web/packages/portal/src/lib/components/features/FeaturePillars.svelte
@@ -4,6 +4,7 @@
     import ConnectorsDemo from "./ConnectorsDemo.svelte";
     import AlarmsDemo from "./AlarmsDemo.svelte";
     import AuthDemo from "./AuthDemo.svelte";
+    import { PILLARS } from "$lib/data/pillars";
 
     interface Props {
         /** Pass a button/link component for the CTAs, or use default anchors */
@@ -11,44 +12,6 @@
     }
     let { demoHeight = 400 }: Props = $props();
 
-    const PILLARS = [
-        {
-            n: 1,
-            eyebrow: "Reports",
-            title: "Every report you actually use.",
-            accent: "Built in.",
-            body: "Time in Range. AGP. Day calendars. Meal impact. Pump activity. GLP-1 tracking. A dozen reports your endo asks for — already on the dashboard.",
-            bullets: ["12+ built-in reports", "Print, share, or schedule by email", "Drill from any chart into the raw data"],
-            color: "oklch(0.6 0.118 184.704)",
-        },
-        {
-            n: 2,
-            eyebrow: "Connectors",
-            title: "Plays nice with your gear.",
-            accent: "Right out of the box.",
-            body: "22 devices and services already wired in. Dexcom, Libre, Omnipod, Tandem, Loop, Trio, xDrip, Nightscout, Home Assistant. If your stuff is on the list, it's on Nocturne.",
-            bullets: ["Just sign in to your CGM — no fiddling", "Two-way bridge with Nightscout", "New connector every release"],
-            color: "oklch(0.72 0.16 150)",
-        },
-        {
-            n: 3,
-            eyebrow: "Alarms",
-            title: "Tell Nocturne what to do.",
-            accent: "It will.",
-            body: "Build alarms that fit your life. \"When my BG dips below 70, call my wife and flash the bedroom lights.\" Drag-and-drop rules, no scripts required.",
-            bullets: ["When-this-then-that recipes", "Send to phone, watch, Discord, Slack, Home Assistant", "Snooze, escalate, or skip when asleep"],
-            color: "oklch(0.646 0.222 41.116)",
-        },
-        {
-            n: 4,
-            eyebrow: "Sign in",
-            title: "No password to lose.",
-            accent: "Or to leak.",
-            body: "Sign in with a passkey on your phone, or with Google, Apple, or GitHub. Your health data stays on your server — Nocturne never sees it.",
-            bullets: ["Passkeys on every modern device", "Google · Apple · GitHub · Microsoft", "Self-hosted: nothing leaves your machine"],
-            color: "oklch(0.65 0.18 270)",
-        },
-    ] as const;
 </script>
 
 <section class="max-w-[1200px] mx-auto px-6 border-t border-border overflow-x-clip">
@@ -56,7 +19,7 @@
     <div class="pt-20 pb-14">
         <div class="font-mono text-[11px] tracking-[0.14em] uppercase text-muted-foreground mb-4">What it can do</div>
         <h2 class="text-[clamp(1.6rem,3.5vw,2.5rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">
-            Four things Nocturne is <em class="text-glucose-in-range">really good at.</em>
+            Four things Nocturne is <em class="text-glucose-in-range">good at.</em>
         </h2>
     </div>
 
@@ -126,7 +89,7 @@
     <div class="border-t border-border py-12 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
         <div>
             <div class="text-[1.2rem] font-bold text-foreground">See it all running together</div>
-            <div class="text-[0.9375rem] text-muted-foreground mt-1">Open the demo, or run your own copy in 5 minutes.</div>
+            <div class="text-[0.9375rem] text-muted-foreground mt-1">Open the demo, or run your own copy in a few minutes.</div>
         </div>
         <div class="flex flex-wrap gap-3 shrink-0">
             <a

--- a/src/Web/packages/portal/src/lib/components/features/ReportsDemo.svelte
+++ b/src/Web/packages/portal/src/lib/components/features/ReportsDemo.svelte
@@ -1,22 +1,40 @@
 <script lang="ts">
     import { Check } from "@lucide/svelte";
+    import { REPORTS } from "$lib/data/reports";
 
-    const REPORTS = [
-        { name: "Ambulatory Glucose Profile", short: "AGP",   kind: "agp" },
-        { name: "Time in Range",              short: "TIR",   kind: "tir" },
-        { name: "Glycemia Risk Index",        short: "GRI",   kind: "gri" },
-        { name: "Day Calendar",               short: "Day",   kind: "calendar" },
-        { name: "Hourly Patterns",            short: "Hourly",kind: "heatmap" },
-        { name: "Meal Impact",                short: "Meals", kind: "meals" },
-        { name: "Sensor Lifecycle",           short: "CAGE",  kind: "lifecycle" },
-        { name: "Pump Activity",              short: "Pump",  kind: "pump" },
-        { name: "Insulin on Board",           short: "IOB",   kind: "iob" },
-        { name: "Weekly Summary",             short: "Week",  kind: "weekly" },
-        { name: "Treatment Log",              short: "Log",   kind: "log" },
-        { name: "GLP-1 Tracking",             short: "GLP-1", kind: "glp1" },
-    ] as const;
+    // Palette shared by every preview: the app's glucose range colours plus a neutral ink ramp.
+    const IN_RANGE = "oklch(0.6 0.118 184.704)";
+    const LOW = "oklch(0.646 0.222 41.116)";
+    const VERY_LOW = "oklch(0.577 0.245 27.325)";
+    const HIGH = "oklch(0.65 0.18 270)";
+    const VERY_HIGH = "oklch(0.55 0.25 15)";
+    const INSULIN = "rgb(30,150,252)";
+    const CARBS = "oklch(0.769 0.188 70)";
+    const INK = "oklch(0.97 0.005 261)";
+    const INK_SOFT = "oklch(0.65 0.02 261)";
+    const INK_FAINT = "oklch(0.50 0.02 261)";
+    const PANEL = "oklch(0.16 0.03 261)";
+    const MONO = "ui-monospace,monospace";
+    const SANS = "system-ui,sans-serif";
 
-    const WEEKLY_BARS: [string, number][] = [["M",0.71],["T",0.58],["W",0.83],["T",0.66],["F",0.74],["S",0.52],["S",0.79]];
+    // Deterministic shapes so the demo renders identically on every load.
+    const WEEK_TIR: [string, number][] = [["M", 0.71], ["T", 0.58], ["W", 0.83], ["T", 0.66], ["F", 0.74], ["S", 0.52], ["S", 0.79]];
+    const MONTHS: [string, number][] = [["Oct", 138], ["Nov", 146], ["Dec", 152], ["Jan", 141], ["Feb", 134], ["Mar", 129]];
+    const STEPS: number[] = [6200, 9800, 4100, 11200, 8400, 12600, 7300];
+    const DAY_TRACES = [
+        "M0,22 C20,10 40,30 60,18 S100,26 130,14 S160,30 180,20",
+        "M0,18 C25,28 45,8 70,16 S110,30 140,12 S165,22 180,16",
+        "M0,26 C20,14 50,32 80,22 S120,8 150,24 S170,18 180,22",
+        "M0,14 C30,24 55,12 85,20 S125,34 150,16 S170,10 180,18",
+        "M0,20 C25,32 50,14 75,24 S115,12 145,26 S165,20 180,14",
+    ];
+    const WEEK_TRACES = [
+        "M20,110 C70,60 120,140 170,90 S270,150 320,80 S380,120 380,100",
+        "M20,120 C70,80 120,120 170,100 S270,130 320,100 S380,110 380,105",
+        "M20,95 C70,55 120,130 170,85 S270,140 320,70 S380,115 380,90",
+        "M20,130 C70,90 120,150 170,110 S270,160 320,95 S380,125 380,110",
+        "M20,105 C70,65 120,125 170,95 S270,145 320,85 S380,118 380,98",
+    ];
 
     interface Props { height?: number; }
     let { height = 340 }: Props = $props();
@@ -27,18 +45,32 @@
         return () => clearInterval(t);
     });
     let current = $derived(REPORTS[idx]);
+
+    // Nineteen rows do not fit the demo's height, so the sidebar scrolls to keep
+    // the highlighted report in view, the way the app's own sidebar would.
+    let sidebarEl: HTMLDivElement | null = $state(null);
+    $effect(() => {
+        const list = sidebarEl;
+        const row = list?.children[idx] as HTMLElement | undefined;
+        if (!list || !row) return;
+        const top = row.offsetTop - list.clientHeight / 2 + row.offsetHeight / 2;
+        list.scrollTo({ top: Math.max(0, top), behavior: "smooth" });
+    });
 </script>
 
 <div class="@container" style:height="{height}px">
 <div
     class="h-full rounded-[14px] overflow-hidden border border-white/10 bg-[oklch(0.10_0.025_261)] grid
-        grid-cols-[96px_minmax(0,1fr)] @sm:grid-cols-[130px_minmax(0,1fr)] @lg:grid-cols-[168px_minmax(0,1fr)]"
+        grid-cols-[104px_minmax(0,1fr)] @sm:grid-cols-[140px_minmax(0,1fr)] @lg:grid-cols-[176px_minmax(0,1fr)]"
 >
-    <!-- Sidebar list -->
-    <div class="bg-[oklch(0.15_0.03_261)] border-r border-white/[0.08] py-3 overflow-hidden flex flex-col">
-        {#each REPORTS as r, i (r.kind)}
+    <!-- Sidebar list: the app's report navigation -->
+    <div
+        bind:this={sidebarEl}
+        class="relative bg-[oklch(0.15_0.03_261)] border-r border-white/[0.08] py-2 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden flex flex-col"
+    >
+        {#each REPORTS as r, i (r.preview)}
             <div
-                class="px-3 @sm:px-4 py-2 text-[12px] @sm:text-[13px] flex items-center justify-between gap-1 transition-all duration-300 border-l-[3px] shrink-0
+                class="px-3 @sm:px-4 py-[3px] text-[11px] @sm:text-[12px] leading-[1.35] flex items-center justify-between gap-1 transition-all duration-300 border-l-[3px] shrink-0
                     {i === idx
                         ? 'text-foreground bg-glucose-in-range/[0.14] border-glucose-in-range font-semibold'
                         : 'text-[oklch(0.65_0.02_261)] border-transparent font-medium'}"
@@ -56,171 +88,244 @@
         <div class="flex items-baseline justify-between gap-2 shrink-0">
             <div class="min-w-0">
                 <div class="text-[17px] font-bold text-foreground truncate">{current.name}</div>
-                <div class="font-mono text-[11px] text-muted-foreground mt-0.5">report · last 14 days</div>
+                <div class="font-mono text-[11px] text-muted-foreground mt-0.5">{current.group} · last 14 days</div>
             </div>
             <span class="font-mono text-[11px] text-muted-foreground shrink-0">
                 {String(idx + 1).padStart(2, '0')} / {REPORTS.length}
             </span>
         </div>
         <div class="flex-1 rounded-lg overflow-hidden bg-[oklch(0.16_0.03_261)] min-h-0">
-            {#if current.kind === "agp"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
+            <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
+                <rect width="400" height="200" fill={PANEL}/>
+
+                {#if current.preview === "summary"}
+                    {#each [["Average", "142", "mg/dL"], ["GMI", "6.7", "%"], ["Time in range", "72", "%"], ["Variability", "33", "% CV"]] as [label, value, unit], i (label)}
+                        <rect x={16 + i * 94} y="22" width="84" height="70" rx="6" fill="oklch(0.20 0.03 261)"/>
+                        <text x={26 + i * 94} y="44" fill={INK_SOFT} font-size="9" font-family={MONO}>{label}</text>
+                        <text x={26 + i * 94} y="74" fill={INK} font-size="22" font-weight="700" font-family={SANS}>{value}</text>
+                        <text x={26 + i * 94} y="86" fill={INK_FAINT} font-size="8" font-family={MONO}>{unit}</text>
+                    {/each}
+                    <rect x="16" y="120" width="14" height="28" fill={VERY_LOW}/>
+                    <rect x="30" y="120" width="26" height="28" fill={LOW}/>
+                    <rect x="56" y="120" width="265" height="28" fill={IN_RANGE}/>
+                    <rect x="321" y="120" width="48" height="28" fill={HIGH}/>
+                    <rect x="369" y="120" width="15" height="28" fill={VERY_HIGH}/>
+                    <text x="16" y="172" fill={INK_SOFT} font-size="10" font-family={MONO}>4% low · 72% in range · 24% high</text>
+
+                {:else if current.preview === "agp"}
                     <rect x="0" y="68" width="400" height="64" fill="oklch(0.6 0.118 184.704 / 12%)"/>
                     <line x1="0" y1="68" x2="400" y2="68" stroke="oklch(0.6 0.118 184.704 / 50%)" stroke-dasharray="2 4"/>
                     <line x1="0" y1="132" x2="400" y2="132" stroke="oklch(0.6 0.118 184.704 / 50%)" stroke-dasharray="2 4"/>
                     <path d="M0,100 C50,40 100,140 150,90 S250,150 300,80 S400,120 400,100 L400,170 C350,180 300,140 250,160 S150,110 100,140 S50,170 0,160 Z" fill="oklch(0.38 0.12 264 / 35%)"/>
                     <path d="M0,100 C50,70 100,120 150,95 S250,120 300,90 S400,110 400,100 L400,150 C350,150 300,130 250,140 S150,120 100,130 S50,150 0,140 Z" fill="oklch(0.75 0.18 264 / 40%)"/>
                     <path d="M0,100 C50,80 100,110 150,95 S250,110 300,95 S400,105 400,100" stroke="oklch(0.85 0.10 264)" stroke-width="2" fill="none"/>
-                    {#each [0,1,2,3,4,5,6] as i (i)}
-                        <text x={i*66+8} y="195" fill="oklch(0.55 0.02 261)" font-size="9" font-family="ui-monospace,monospace">{i*4}:00</text>
+                    {#each [0, 1, 2, 3, 4, 5, 6] as i (i)}
+                        <text x={i * 66 + 8} y="195" fill={INK_FAINT} font-size="9" font-family={MONO}>{i * 4}:00</text>
                     {/each}
-                </svg>
-            {:else if current.kind === "tir"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
-                    <rect x="20" y="68" width="14"  height="64" fill="oklch(0.577 0.245 27.325)"/>
-                    <rect x="34" y="68" width="29"  height="64" fill="oklch(0.646 0.222 41.116)"/>
-                    <rect x="63" y="68" width="259" height="64" fill="oklch(0.6 0.118 184.704)"/>
-                    <rect x="322" y="68" width="43" height="64" fill="oklch(0.65 0.18 270)"/>
-                    <rect x="365" y="68" width="15" height="64" fill="oklch(0.55 0.25 15)"/>
-                    <text x="20" y="50" fill="oklch(0.97 0.005 261)" font-size="26" font-weight="700" font-family="system-ui,sans-serif">72%</text>
-                    <text x="82" y="50" fill="oklch(0.65 0.02 261)" font-size="13" font-family="system-ui,sans-serif">in range</text>
-                    <text x="20" y="155" fill="oklch(0.55 0.02 261)" font-size="9" font-family="ui-monospace,monospace">VLO</text>
-                    <text x="38" y="155" fill="oklch(0.55 0.02 261)" font-size="9" font-family="ui-monospace,monospace">LOW</text>
-                    <text x="90" y="155" fill="oklch(0.55 0.02 261)" font-size="9" font-family="ui-monospace,monospace">IN RANGE 70–180</text>
-                    <text x="305" y="155" fill="oklch(0.55 0.02 261)" font-size="9" font-family="ui-monospace,monospace">HIGH</text>
-                    <text x="360" y="155" fill="oklch(0.55 0.02 261)" font-size="9" font-family="ui-monospace,monospace">VHI</text>
-                </svg>
-            {:else if current.kind === "gri"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
-                    <rect x="50"  y="150" width="56" height="20"  fill="oklch(0.72 0.17 145)"/>
-                    <rect x="110" y="142" width="56" height="28"  fill="oklch(0.78 0.15 120)"/>
-                    <rect x="170" y="134" width="56" height="36"  fill="oklch(0.80 0.16 90)"/>
-                    <rect x="230" y="126" width="56" height="44"  fill="oklch(0.70 0.17 55)"/>
-                    <rect x="290" y="118" width="56" height="52"  fill="oklch(0.60 0.20 25)"/>
-                    <text x="50" y="40" fill="oklch(0.97 0.005 261)" font-size="24" font-weight="700" font-family="system-ui,sans-serif">22.4</text>
-                    <text x="118" y="40" fill="oklch(0.65 0.02 261)" font-size="12">Zone B</text>
-                    <text x="50" y="58" fill="oklch(0.65 0.02 261)" font-size="11" font-family="ui-monospace,monospace">GRI · last 90 days</text>
-                    {#each ["A","B","C","D","E"] as l, i (l)}
-                        <text x={62 + i*60} y="185" fill="oklch(0.55 0.02 261)" font-size="11" font-family="ui-monospace,monospace">{l}</text>
+
+                {:else if current.preview === "distribution"}
+                    <rect x="20" y="68" width="14" height="64" fill={VERY_LOW}/>
+                    <rect x="34" y="68" width="29" height="64" fill={LOW}/>
+                    <rect x="63" y="68" width="259" height="64" fill={IN_RANGE}/>
+                    <rect x="322" y="68" width="43" height="64" fill={HIGH}/>
+                    <rect x="365" y="68" width="15" height="64" fill={VERY_HIGH}/>
+                    <text x="20" y="50" fill={INK} font-size="26" font-weight="700" font-family={SANS}>72%</text>
+                    <text x="82" y="50" fill={INK_SOFT} font-size="13" font-family={SANS}>in range</text>
+                    <text x="20" y="155" fill={INK_FAINT} font-size="9" font-family={MONO}>VLO</text>
+                    <text x="38" y="155" fill={INK_FAINT} font-size="9" font-family={MONO}>LOW</text>
+                    <text x="90" y="155" fill={INK_FAINT} font-size="9" font-family={MONO}>IN RANGE 70-180</text>
+                    <text x="305" y="155" fill={INK_FAINT} font-size="9" font-family={MONO}>HIGH</text>
+                    <text x="360" y="155" fill={INK_FAINT} font-size="9" font-family={MONO}>VHI</text>
+
+                {:else if current.preview === "quality"}
+                    <text x="16" y="36" fill={INK} font-size="20" font-weight="700" font-family={SANS}>96%</text>
+                    <text x="62" y="36" fill={INK_SOFT} font-size="12" font-family={SANS}>of expected readings received</text>
+                    {#each Array.from({ length: 14 }, (_, d) => d) as d (d)}
+                        <rect x="16" y={54 + d * 9} width="368" height="6" rx="1" fill={IN_RANGE} opacity="0.7"/>
+                        {#if d === 3}
+                            <rect x="212" y={54 + d * 9} width="38" height="6" rx="1" fill={VERY_LOW}/>
+                        {:else if d === 9}
+                            <rect x="96" y={54 + d * 9} width="22" height="6" rx="1" fill={VERY_LOW}/>
+                        {/if}
                     {/each}
-                </svg>
-            {:else if current.kind === "calendar"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
-                    {#each Array.from({length: 24}, (_, h) => h) as h (h)}
-                        {@const intensity = Math.sin(h * 0.4) * 0.4 + 0.5}
-                        <rect x={16 + h * 15} y={80 - intensity*40} width="11" height={intensity*80}
-                              fill="oklch(0.6 0.118 184.704)" opacity={0.5 + intensity*0.5} rx="2"/>
-                    {/each}
-                    <text x="16" y="38" fill="oklch(0.97 0.005 261)" font-size="16" font-weight="700">Tuesday, March 12</text>
-                    <text x="16" y="56" fill="oklch(0.65 0.02 261)" font-size="11" font-family="ui-monospace,monospace">122 avg · 78% TIR · 6 entries</text>
-                    {#each [0,6,12,18] as h (h)}
-                        <text x={16 + h*15} y="196" fill="oklch(0.50 0.02 261)" font-size="9" font-family="ui-monospace,monospace">{String(h).padStart(2,'0')}h</text>
-                    {/each}
-                </svg>
-            {:else if current.kind === "heatmap"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
-                    {#each Array.from({length: 7}, (_, r) => r) as r (r)}
-                        {#each Array.from({length: 24}, (_, c) => c) as c (`${r}-${c}`)}
-                            {@const v = (Math.sin(c*0.5 + r) + Math.cos(r*0.7 - c*0.2) + 2) / 4}
-                            <rect x={40 + c*14} y={46 + r*18} width="12" height="16"
-                                  fill={v > 0.6 ? "oklch(0.65 0.18 270)" : "oklch(0.6 0.118 184.704)"}
-                                  opacity={0.25 + v*0.7} rx="1"/>
+                    <text x="16" y="193" fill={INK_SOFT} font-size="10" font-family={MONO}>2 gaps · longest 2h 05m · sensor warm-up</text>
+
+                {:else if current.preview === "year"}
+                    {#each Array.from({ length: 7 }, (_, r) => r) as r (r)}
+                        {#each Array.from({ length: 26 }, (_, c) => c) as c (`${r}-${c}`)}
+                            {@const v = (Math.sin(c * 0.5 + r) + Math.cos(r * 0.7 - c * 0.2) + 2) / 4}
+                            <rect x={40 + c * 13.4} y={46 + r * 18} width="11" height="16"
+                                  fill={v > 0.62 ? HIGH : IN_RANGE} opacity={0.25 + v * 0.7} rx="1"/>
                         {/each}
                     {/each}
-                    <text x="16" y="36" fill="oklch(0.97 0.005 261)" font-size="14" font-weight="700">Hourly Patterns · 30 days</text>
-                    {#each ["M","T","W","T","F","S","S"] as d, i (i)}
-                        <text x="20" y={58 + i*18} fill="oklch(0.65 0.02 261)" font-size="10" font-family="ui-monospace,monospace">{d}</text>
+                    <text x="16" y="36" fill={INK} font-size="14" font-weight="700" font-family={SANS}>Every day since 2023</text>
+                    {#each ["M", "T", "W", "T", "F", "S", "S"] as d, i (i)}
+                        <text x="20" y={58 + i * 18} fill={INK_SOFT} font-size="10" font-family={MONO}>{d}</text>
                     {/each}
-                </svg>
-            {:else if current.kind === "meals"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
-                    {#each [40,70,95,80,60,55,50,45,42] as y, i (i)}
-                        <path d="M{30 + i*42},150 L{38 + i*42},{150 - y*0.8}" stroke="oklch(0.65 0.18 270)" stroke-width="2"/>
-                        <circle cx={38 + i*42} cy={150 - y*0.8} r="3" fill="oklch(0.65 0.18 270)"/>
+                    <text x="40" y="190" fill={INK_FAINT} font-size="9" font-family={MONO}>Jan</text>
+                    <text x="200" y="190" fill={INK_FAINT} font-size="9" font-family={MONO}>Jul</text>
+                    <text x="360" y="190" fill={INK_FAINT} font-size="9" font-family={MONO}>Dec</text>
+
+                {:else if current.preview === "readings"}
+                    {#each DAY_TRACES as d, i (i)}
+                        <text x="16" y={38 + i * 34} fill={INK_SOFT} font-size="10" font-family={MONO}>Mar {12 - i}</text>
+                        <rect x="70" y={22 + i * 34} width="230" height="28" rx="3" fill="oklch(0.20 0.03 261)"/>
+                        <rect x="70" y={30 + i * 34} width="230" height="12" fill="oklch(0.6 0.118 184.704 / 14%)"/>
+                        <g transform="translate(90, {24 + i * 34}) scale(1.05, 0.7)">
+                            <path d={d} stroke={IN_RANGE} stroke-width="2.4" fill="none"/>
+                        </g>
+                        <text x="312" y={41 + i * 34} fill={INK} font-size="11" font-weight="600" font-family={SANS}>{[78, 64, 83, 71, 76][i]}%</text>
+                        <text x="345" y={41 + i * 34} fill={INK_FAINT} font-size="9" font-family={MONO}>{[131, 148, 126, 140, 137][i]} avg</text>
                     {/each}
-                    <rect x="22" y="48" width="6" height="100" fill="oklch(0.769 0.188 70)" opacity="0.7"/>
-                    <text x="38" y="45" fill="oklch(0.97 0.005 261)" font-size="13" font-weight="600">Pasta · 65g carbs</text>
-                    <text x="38" y="60" fill="oklch(0.65 0.02 261)" font-size="11" font-family="ui-monospace,monospace">peak +98 · back in range 2h 40m</text>
-                    {#each [0,1,2,3] as h (h)}
-                        <text x={28 + h*84} y="185" fill="oklch(0.50 0.02 261)" font-size="10" font-family="ui-monospace,monospace">{h}h</text>
+
+                {:else if current.preview === "day"}
+                    {#each Array.from({ length: 24 }, (_, h) => h) as h (h)}
+                        {@const intensity = Math.sin(h * 0.4) * 0.4 + 0.5}
+                        <rect x={16 + h * 15} y={80 - intensity * 40} width="11" height={intensity * 80}
+                              fill={IN_RANGE} opacity={0.5 + intensity * 0.5} rx="2"/>
                     {/each}
-                </svg>
-            {:else if current.kind === "lifecycle"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
-                    {#each [0,1,2,3,4] as i (i)}
-                        <rect x="80" y={46 + i*28} width={180 + i*20} height="16" rx="3" fill="oklch(0.6 0.118 184.704)" opacity="0.65"/>
-                        <text x="20" y={58 + i*28} fill="oklch(0.65 0.02 261)" font-size="10" font-family="ui-monospace,monospace">G7 · #{i+1}</text>
+                    <text x="16" y="38" fill={INK} font-size="16" font-weight="700" font-family={SANS}>Tuesday, March 12</text>
+                    <text x="16" y="56" fill={INK_SOFT} font-size="11" font-family={MONO}>122 avg · 78% in range · 6 treatments</text>
+                    {#each [0, 6, 12, 18] as h (h)}
+                        <text x={16 + h * 15} y="196" fill={INK_FAINT} font-size="9" font-family={MONO}>{String(h).padStart(2, '0')}h</text>
                     {/each}
-                    <text x="20" y="36" fill="oklch(0.97 0.005 261)" font-size="14" font-weight="700">CAGE · last 5 sensors</text>
-                    <text x="20" y="193" fill="oklch(0.65 0.02 261)" font-size="10" font-family="ui-monospace,monospace">avg wear 9.4d · longest 10.5d</text>
-                </svg>
-            {:else if current.kind === "pump"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
+
+                {:else if current.preview === "week"}
+                    <rect x="20" y="78" width="360" height="50" fill="oklch(0.6 0.118 184.704 / 12%)"/>
+                    {#each WEEK_TRACES as d, i (i)}
+                        <path d={d} stroke={INK_SOFT} stroke-width="1.2" fill="none" opacity="0.45"/>
+                    {/each}
+                    <path d="M20,112 C70,72 120,134 170,96 S270,146 320,86 S380,118 380,100" stroke={IN_RANGE} stroke-width="2.6" fill="none"/>
+                    <text x="16" y="32" fill={INK} font-size="14" font-weight="700" font-family={SANS}>Seven days, overlaid</text>
+                    <text x="16" y="48" fill={INK_SOFT} font-size="10" font-family={MONO}>Sunday runs 22 mg/dL higher after lunch</text>
+                    {#each [0, 6, 12, 18, 24] as h, i (h)}
+                        <text x={20 + i * 88} y="190" fill={INK_FAINT} font-size="9" font-family={MONO}>{String(h).padStart(2, '0')}:00</text>
+                    {/each}
+
+                {:else if current.preview === "month"}
+                    {#each MONTHS as [m, avg], i (m)}
+                        {@const h = (avg - 100) * 1.6}
+                        <rect x={28 + i * 60} y={150 - h} width="40" height={h} fill={avg > 145 ? HIGH : IN_RANGE} opacity="0.75" rx="3"/>
+                        <text x={48 + i * 60} y="170" text-anchor="middle" fill={INK_SOFT} font-size="11" font-family={MONO}>{m}</text>
+                        <text x={48 + i * 60} y="185" text-anchor="middle" fill={INK_FAINT} font-size="10" font-family={MONO}>{avg}</text>
+                    {/each}
+                    <text x="20" y="32" fill={INK} font-size="14" font-weight="700" font-family={SANS}>Average glucose by month</text>
+                    <text x="20" y="48" fill={INK_SOFT} font-size="10" font-family={MONO}>down 23 mg/dL since December</text>
+
+                {:else if current.preview === "comparison"}
+                    <rect x="20" y="78" width="360" height="50" fill="oklch(0.6 0.118 184.704 / 12%)"/>
+                    <path d="M20,128 C70,80 120,150 170,104 S270,158 320,96 S380,128 380,112" stroke={INK_SOFT} stroke-width="2" fill="none" stroke-dasharray="5 4"/>
+                    <path d="M20,112 C70,72 120,134 170,96 S270,140 320,86 S380,118 380,100" stroke={IN_RANGE} stroke-width="2.6" fill="none"/>
+                    <text x="16" y="32" fill={INK} font-size="14" font-weight="700" font-family={SANS}>Before vs after the basal change</text>
+                    <line x1="16" y1="48" x2="36" y2="48" stroke={INK_SOFT} stroke-width="2" stroke-dasharray="5 4"/>
+                    <text x="42" y="51" fill={INK_SOFT} font-size="10" font-family={MONO}>Feb 1-14 · 64% in range</text>
+                    <line x1="200" y1="48" x2="220" y2="48" stroke={IN_RANGE} stroke-width="2.6"/>
+                    <text x="226" y="51" fill={INK_SOFT} font-size="10" font-family={MONO}>Feb 15-28 · 76% in range</text>
+
+                {:else if current.preview === "steps"}
+                    {#each STEPS as n, i (i)}
+                        {@const h = n / 100}
+                        <rect x={28 + i * 52} y={160 - h} width="36" height={h} fill={n >= 8000 ? IN_RANGE : INK_FAINT} opacity="0.8" rx="3"/>
+                        <text x={46 + i * 52} y="178" text-anchor="middle" fill={INK_SOFT} font-size="11" font-family={MONO}>{WEEK_TIR[i][0]}</text>
+                    {/each}
+                    <text x="20" y="32" fill={INK} font-size="20" font-weight="700" font-family={SANS}>8,514</text>
+                    <text x="82" y="32" fill={INK_SOFT} font-size="12" font-family={SANS}>steps a day on average</text>
+                    <line x1="20" y1="75" x2="380" y2="75" stroke={INK_SOFT} stroke-dasharray="3 4"/>
+                    <text x="330" y="70" fill={INK_FAINT} font-size="9" font-family={MONO}>8,000 goal</text>
+
+                {:else if current.preview === "heart"}
+                    <path d="M20,120 C50,118 60,90 90,96 S130,60 160,74 S210,130 240,122 S290,80 320,92 S360,124 380,118" stroke={LOW} stroke-width="2.4" fill="none"/>
+                    <path d="M20,120 C50,118 60,90 90,96 S130,60 160,74 S210,130 240,122 S290,80 320,92 S360,124 380,118 L380,165 L20,165 Z" fill="oklch(0.646 0.222 41.116 / 15%)"/>
+                    <line x1="20" y1="140" x2="380" y2="140" stroke={INK_SOFT} stroke-dasharray="3 4"/>
+                    <text x="20" y="34" fill={INK} font-size="20" font-weight="700" font-family={SANS}>58</text>
+                    <text x="48" y="34" fill={INK_SOFT} font-size="12" font-family={SANS}>bpm resting estimate</text>
+                    <text x="300" y="136" fill={INK_FAINT} font-size="9" font-family={MONO}>resting 58 bpm</text>
+                    {#each [0, 6, 12, 18, 24] as h, i (h)}
+                        <text x={20 + i * 88} y="190" fill={INK_FAINT} font-size="9" font-family={MONO}>{String(h).padStart(2, '0')}:00</text>
+                    {/each}
+
+                {:else if current.preview === "sleep"}
+                    <rect x="60" y="56" width="220" height="110" fill="oklch(0.65 0.18 270 / 14%)" rx="4"/>
+                    <rect x="20" y="96" width="360" height="40" fill="oklch(0.6 0.118 184.704 / 12%)"/>
+                    <path d="M20,112 C60,100 90,124 130,116 S200,104 240,110 S300,126 340,108 S370,98 380,100" stroke={IN_RANGE} stroke-width="2.6" fill="none"/>
+                    <text x="16" y="34" fill={INK} font-size="14" font-weight="700" font-family={SANS}>Asleep 23:10 to 06:45</text>
+                    <text x="16" y="50" fill={INK_SOFT} font-size="10" font-family={MONO}>84% in range overnight · no lows</text>
+                    <text x="62" y="180" fill={INK_FAINT} font-size="9" font-family={MONO}>23:00</text>
+                    <text x="262" y="180" fill={INK_FAINT} font-size="9" font-family={MONO}>07:00</text>
+
+                {:else if current.preview === "treatments"}
+                    {#each [
+                        { t: "08:14", e: "Bolus 4.5u", c: INSULIN },
+                        { t: "08:16", e: "Carbs 52g · oatmeal", c: CARBS },
+                        { t: "10:42", e: "Site change", c: IN_RANGE },
+                        { t: "12:30", e: "Bolus 6.2u", c: INSULIN },
+                        { t: "12:35", e: "Carbs 71g · lunch", c: CARBS },
+                        { t: "14:18", e: "Note: walk 30 min", c: INK_SOFT },
+                    ] as row, i (row.t)}
+                        <rect x="14" y={30 + i * 26} width="6" height="16" fill={row.c}/>
+                        <text x="30" y={42 + i * 26} fill={INK_SOFT} font-size="11" font-family={MONO}>{row.t}</text>
+                        <text x="76" y={42 + i * 26} fill={INK} font-size="11" font-family={SANS}>{row.e}</text>
+                    {/each}
+
+                {:else if current.preview === "basal"}
                     <path d="M0,140 L60,140 L60,100 L120,100 L120,140 L180,140 L180,80 L240,80 L240,130 L300,130 L300,110 L360,110 L360,140 L400,140"
-                          stroke="rgb(30,150,252)" stroke-width="2" fill="none"/>
+                          stroke={INSULIN} stroke-width="2" fill="none"/>
                     <path d="M0,140 L60,140 L60,100 L120,100 L120,140 L180,140 L180,80 L240,80 L240,130 L300,130 L300,110 L360,110 L360,140 L400,140 L400,170 L0,170 Z"
                           fill="rgba(100,180,255,0.18)"/>
-                    {#each [[80,3.2],[160,1.8],[240,4.5],[320,2.1]] as [x, u] (`${x}`)}
-                        <rect x={x-2} y="40" width="4" height="14" fill="rgb(30,150,252)"/>
-                        <text x={x-6} y="32" fill="oklch(0.65 0.02 261)" font-size="9" font-family="ui-monospace,monospace">{u}u</text>
+                    <path d="M0,150 L60,150 L60,118 L120,118 L120,146 L180,146 L180,96 L240,96 L240,138 L300,138 L300,124 L360,124 L360,150 L400,150"
+                          stroke={INK_SOFT} stroke-width="1.5" fill="none" stroke-dasharray="4 3"/>
+                    <text x="16" y="24" fill={INK} font-size="13" font-weight="700" font-family={SANS}>Scheduled basal vs what was delivered</text>
+                    <text x="16" y="40" fill={INK_SOFT} font-size="10" font-family={MONO}>03:00 to 06:00 ran 22% above schedule</text>
+
+                {:else if current.preview === "insulin"}
+                    <circle cx="110" cy="105" r="58" fill="none" stroke={INK_FAINT} stroke-width="22" opacity="0.5"/>
+                    <circle cx="110" cy="105" r="58" fill="none" stroke={INSULIN} stroke-width="22"
+                            stroke-dasharray="167.6 196.8" transform="rotate(-90 110 105)"/>
+                    <text x="110" y="101" text-anchor="middle" fill={INK} font-size="16" font-weight="700" font-family={SANS}>38.2u</text>
+                    <text x="110" y="116" text-anchor="middle" fill={INK_SOFT} font-size="9" font-family={MONO}>per day</text>
+                    <rect x="200" y="60" width="12" height="12" fill={INSULIN} rx="2"/>
+                    <text x="220" y="70" fill={INK} font-size="12" font-family={SANS}>Basal 46%</text>
+                    <text x="220" y="84" fill={INK_SOFT} font-size="10" font-family={MONO}>17.6u</text>
+                    <rect x="200" y="106" width="12" height="12" fill={INK_FAINT} rx="2" opacity="0.6"/>
+                    <text x="220" y="116" fill={INK} font-size="12" font-family={SANS}>Bolus 54%</text>
+                    <text x="220" y="130" fill={INK_SOFT} font-size="10" font-family={MONO}>20.6u · 5.2 boluses a day</text>
+
+                {:else if current.preview === "site"}
+                    {#each [[0, 74, 2.8], [1, 70, 3.1], [2, 61, 2.4], [3, 77, 3.0], [4, 68, 3.3]] as [i, tir, days] (i)}
+                        <rect x="90" y={46 + i * 28} width={days * 60} height="16" rx="3" fill={tir >= 70 ? IN_RANGE : LOW} opacity="0.7"/>
+                        <text x="20" y={58 + i * 28} fill={INK_SOFT} font-size="10" font-family={MONO}>Site #{i + 1}</text>
+                        <text x={96 + days * 60} y={58 + i * 28} fill={INK} font-size="10" font-weight="600" font-family={SANS}>{tir}%</text>
                     {/each}
-                    <text x="16" y="22" fill="oklch(0.97 0.005 261)" font-size="13" font-weight="700">Basal + boluses · today</text>
-                </svg>
-            {:else if current.kind === "iob"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
-                    <path d="M30,160 Q80,40 130,80 T260,120 T380,150" stroke="rgb(30,150,252)" stroke-width="3" fill="none"/>
-                    <path d="M30,160 Q80,40 130,80 T260,120 T380,150 L380,170 L30,170 Z" fill="rgba(30,150,252,0.18)"/>
-                    <text x="20" y="40" fill="oklch(0.97 0.005 261)" font-size="20" font-weight="700" font-family="system-ui,sans-serif">2.4u</text>
-                    <text x="70" y="40" fill="oklch(0.65 0.02 261)" font-size="12">on board</text>
-                    <text x="20" y="58" fill="oklch(0.65 0.02 261)" font-size="11" font-family="ui-monospace,monospace">decay over 4h · DIA 4.0</text>
-                </svg>
-            {:else if current.kind === "weekly"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
-                    {#each WEEKLY_BARS as [d, tir], i (`${d}-${i}`)}
-                        <rect x={28 + i*52} y={150 - tir*100} width="36" height={tir*100} fill="oklch(0.6 0.118 184.704)" opacity="0.75" rx="3"/>
-                        <text x={46 + i*52} y="170" text-anchor="middle" fill="oklch(0.65 0.02 261)" font-size="11" font-family="ui-monospace,monospace">{d}</text>
-                        <text x={46 + i*52} y="185" text-anchor="middle" fill="oklch(0.55 0.02 261)" font-size="10" font-family="ui-monospace,monospace">{Math.round(tir*100)}%</text>
-                    {/each}
-                    <text x="20" y="32" fill="oklch(0.97 0.005 261)" font-size="14" font-weight="700">Week of Mar 11</text>
-                </svg>
-            {:else if current.kind === "log"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
+                    <text x="20" y="36" fill={INK} font-size="14" font-weight="700" font-family={SANS}>Time in range per site</text>
+                    <text x="20" y="193" fill={INK_SOFT} font-size="10" font-family={MONO}>day 3 runs 9% lower than day 1</text>
+
+                {:else if current.preview === "idp"}
+                    <text x="16" y="34" fill={INK} font-size="14" font-weight="700" font-family={SANS}>Insulin Dosing Profile</text>
+                    <text x="16" y="50" fill={INK_SOFT} font-size="10" font-family={MONO}>standardised summary for your care team</text>
                     {#each [
-                        { t: "08:14", e: "Bolus 4.5u",          c: "rgb(30,150,252)" },
-                        { t: "08:16", e: "Carbs 52g · oatmeal",  c: "oklch(0.769 0.188 70)" },
-                        { t: "10:42", e: "Sensor change",         c: "oklch(0.6 0.118 184.704)" },
-                        { t: "12:30", e: "Bolus 6.2u",            c: "rgb(30,150,252)" },
-                        { t: "12:35", e: "Carbs 71g · lunch",     c: "oklch(0.769 0.188 70)" },
-                        { t: "14:18", e: "Note: walk 30 min",     c: "oklch(0.65 0.02 261)" },
-                    ] as row, i (row.t)}
-                        <rect x="14" y={30 + i*26} width="6" height="16" fill={row.c}/>
-                        <text x="30" y={42 + i*26} fill="oklch(0.65 0.02 261)" font-size="11" font-family="ui-monospace,monospace">{row.t}</text>
-                        <text x="76" y={42 + i*26} fill="oklch(0.97 0.005 261)" font-size="11" font-family="system-ui,sans-serif">{row.e}</text>
+                        ["Total daily dose", "38.2 u"],
+                        ["Basal", "17.6 u · 46%"],
+                        ["Bolus", "20.6 u · 54%"],
+                        ["Carbohydrates", "182 g / day"],
+                        ["Average glucose", "142 mg/dL"],
+                        ["Time in range", "72%"],
+                    ] as [k, v], i (k)}
+                        <line x1="16" y1={66 + i * 21} x2="384" y2={66 + i * 21} stroke="oklch(1 0 0 / 8%)"/>
+                        <text x="16" y={81 + i * 21} fill={INK_SOFT} font-size="11" font-family={SANS}>{k}</text>
+                        <text x="384" y={81 + i * 21} text-anchor="end" fill={INK} font-size="11" font-weight="600" font-family={MONO}>{v}</text>
                     {/each}
-                </svg>
-            {:else if current.kind === "glp1"}
-                <svg viewBox="0 0 400 200" class="w-full h-full" preserveAspectRatio="xMidYMid meet">
-                    <rect width="400" height="200" fill="oklch(0.16 0.03 261)"/>
-                    <path d="M30,140 C80,140 110,80 160,80 C210,80 220,40 290,40 C330,40 350,30 380,30"
-                          stroke="oklch(0.65 0.18 270)" stroke-width="2" fill="none" stroke-dasharray="4 4"/>
-                    {#each [0,1,2,3,4,5,6,7] as i (i)}
-                        <rect x={40 + i*42} y={140 - i*4} width="28" height={i*4 + 14} fill="oklch(0.6 0.118 184.704)" opacity="0.7" rx="2"/>
-                    {/each}
-                    <text x="20" y="32" fill="oklch(0.97 0.005 261)" font-size="14" font-weight="700">Mounjaro · TIR over 8 weeks</text>
-                    <text x="20" y="193" fill="oklch(0.65 0.02 261)" font-size="10" font-family="ui-monospace,monospace">started 2.5mg · titrated to 7.5mg · TIR +18%</text>
-                </svg>
-            {/if}
+
+                {:else if current.preview === "battery"}
+                    <path d="M20,60 L120,120 L124,60 L230,130 L234,60 L340,138 L344,60 L380,82" stroke={IN_RANGE} stroke-width="2.2" fill="none"/>
+                    <path d="M20,60 L120,120 L124,60 L230,130 L234,60 L340,138 L344,60 L380,82 L380,160 L20,160 Z" fill="oklch(0.6 0.118 184.704 / 14%)"/>
+                    <line x1="20" y1="140" x2="380" y2="140" stroke={LOW} stroke-dasharray="3 4"/>
+                    <text x="16" y="34" fill={INK} font-size="14" font-weight="700" font-family={SANS}>Pump battery</text>
+                    <text x="16" y="50" fill={INK_SOFT} font-size="10" font-family={MONO}>a charge lasts 6.4 days · last change 2 days ago</text>
+                    <text x="300" y="136" fill={INK_FAINT} font-size="9" font-family={MONO}>20% low warning</text>
+                    <text x="16" y="190" fill={INK_FAINT} font-size="9" font-family={MONO}>Feb 20</text>
+                    <text x="350" y="190" fill={INK_FAINT} font-size="9" font-family={MONO}>Mar 12</text>
+                {/if}
+            </svg>
         </div>
     </div>
 </div>

--- a/src/Web/packages/portal/src/lib/data/connectors.ts
+++ b/src/Web/packages/portal/src/lib/data/connectors.ts
@@ -1,0 +1,70 @@
+/**
+ * Everything Nocturne can take readings from or send alerts to, as shown on the
+ * marketing pages. One list feeds the hero marquee, the connector search demo,
+ * and the counts quoted in copy, so a new connector is added here once.
+ *
+ * `comingSoon` entries link to the tracking issue on GitHub.
+ */
+export interface Connector {
+  /** File name under static/logos. */
+  file: string;
+  name: string;
+  kind: string;
+  /** Extra search terms for the connector demo. */
+  aliases?: string[];
+  comingSoon?: true;
+  issue?: number;
+}
+
+export const CONNECTORS: Connector[] = [
+  // Pulled in by a connector: sign in once, readings arrive by themselves.
+  // Eversense and twiist are follower connectors: the wearer shares with the
+  // account you sign in with.
+  { file: "dexcom.png", name: "Dexcom", kind: "CGM", aliases: ["Clarity", "Share", "G6", "G7"] },
+  { file: "libre.png", name: "FreeStyle Libre", kind: "CGM", aliases: ["Libre", "FSL", "Abbott", "LibreLinkUp"] },
+  { file: "eversense.png", name: "Eversense", kind: "CGM", aliases: ["Senseonics"] },
+  { file: "medtronic.jpg", name: "Medtronic", kind: "Pump", aliases: ["CareLink", "MiniMed", "780G"] },
+  { file: "tandem.png", name: "Tandem", kind: "Pump", aliases: ["t:slim", "Mobi", "Tandem Source", "TConnect"] },
+  { file: "twiist.png", name: "twiist", kind: "Pump", aliases: ["Sequel", "Tidepool Loop"] },
+  { file: "mylife.png", name: "myLife", kind: "Pump", aliases: ["CamAPS", "YpsoPump"] },
+  { file: "glooko.png", name: "Glooko", kind: "Cloud" },
+  { file: "tidepool.jpg", name: "Tidepool", kind: "Cloud" },
+  { file: "gluroo.png", name: "Gluroo", kind: "Cloud", aliases: ["Global Connect"] },
+  { file: "nightscout.png", name: "Nightscout", kind: "Cloud", aliases: ["NS"] },
+  // Omnipod data arrives through Glooko, twiist, or a looping app; there is no
+  // Insulet account to sign in to.
+  { file: "omnipod.png", name: "Omnipod", kind: "Pump", aliases: ["Insulet", "DASH", "5"] },
+  { file: "myfitnesspal.jpg", name: "MyFitnessPal", kind: "Food", aliases: ["MFP"] },
+  { file: "home-assistant.png", name: "Home Assistant", kind: "Smart Home", aliases: ["HA"] },
+
+  // Uploaded by an app through the Nightscout-compatible API.
+  { file: "loop.png", name: "Loop", kind: "Looping" },
+  { file: "trio.jpg", name: "Trio", kind: "Looping", aliases: ["iAPS"] },
+  { file: "aaps.png", name: "AndroidAPS", kind: "Looping", aliases: ["AAPS", "Android"] },
+  { file: "xdrip.jpg", name: "xDrip+", kind: "App", aliases: ["xDrip", "Android"] },
+  { file: "spike.png", name: "Spike", kind: "App", aliases: ["iOS"] },
+  { file: "juggluco.png", name: "Juggluco", kind: "App" },
+  { file: "glucotracker.png", name: "GlucoTracker", kind: "App" },
+  { file: "sugarmate.png", name: "Sugarmate", kind: "App" },
+
+  // Where alerts and chat commands go.
+  { file: "discord.png", name: "Discord", kind: "Notify" },
+  { file: "slack.png", name: "Slack", kind: "Notify" },
+  { file: "telegram.png", name: "Telegram", kind: "Notify" },
+  { file: "whatsapp.png", name: "WhatsApp", kind: "Notify", aliases: ["WA"] },
+  { file: "email.jpg", name: "Email", kind: "Notify", aliases: ["Resend"] },
+
+  // Coming soon
+  { file: "medtrum.jpg", name: "Medtrum", kind: "CGM", comingSoon: true, issue: 106 },
+  { file: "n8n.png", name: "n8n", kind: "Cloud", comingSoon: true, issue: 112 },
+  { file: "twilio.png", name: "Twilio / SMS", kind: "Notify", aliases: ["SMS"], comingSoon: true, issue: 137 },
+  { file: "oura.png", name: "Oura", kind: "App", aliases: ["Oura Ring"], comingSoon: true, issue: 151 },
+  { file: "imessage.jpg", name: "iMessage", kind: "Notify", aliases: ["Apple Messages", "iOS"], comingSoon: true, issue: 178 },
+  { file: "google-chat.png", name: "Google Chat", kind: "Notify", aliases: ["GChat"], comingSoon: true, issue: 179 },
+  { file: "teams.png", name: "MS Teams", kind: "Notify", aliases: ["Microsoft Teams"], comingSoon: true, issue: 180 },
+];
+
+export const LIVE_CONNECTORS: Connector[] = CONNECTORS.filter((c) => !c.comingSoon);
+
+/** Kinds that carry glucose, insulin, or food data in; the rest are alert destinations. */
+export const DATA_SOURCES: Connector[] = LIVE_CONNECTORS.filter((c) => c.kind !== "Notify");

--- a/src/Web/packages/portal/src/lib/data/pillars.ts
+++ b/src/Web/packages/portal/src/lib/data/pillars.ts
@@ -1,0 +1,80 @@
+import { DATA_SOURCES } from "./connectors";
+import { AVAILABLE_REPORT_COUNT } from "./reports";
+
+/**
+ * The four headline features. The landing page and /features both render this
+ * list, so the copy lives here once.
+ */
+export interface Pillar {
+  n: number;
+  eyebrow: string;
+  title: string;
+  accent: string;
+  body: string;
+  bullets: readonly string[];
+  color: string;
+}
+
+export const PILLARS: readonly Pillar[] = [
+  {
+    n: 1,
+    eyebrow: "Reports",
+    title: "The reports your clinic asks for.",
+    accent: "Built in.",
+    body:
+      "Executive Summary. Glucose Profile (AGP). Glucose Distribution. Day in Review. Week to Week. " +
+      "Insulin Delivery. Site Change Impact. Sleep. " +
+      `${AVAILABLE_REPORT_COUNT} reports, on the dashboard the day you install.`,
+    bullets: [
+      `${AVAILABLE_REPORT_COUNT} built-in reports, from AGP to pump battery`,
+      "AGP, insulin, and site-change reports laid out for printing",
+      "Your own target range drawn alongside the clinical consensus bands",
+    ],
+    color: "oklch(0.6 0.118 184.704)",
+  },
+  {
+    n: 2,
+    eyebrow: "Connectors",
+    title: "Plays nice with your gear.",
+    accent: "Right out of the box.",
+    body:
+      `${DATA_SOURCES.length} devices, apps, and services already wired in. Dexcom, Libre, Medtronic, Tandem, Omnipod, ` +
+      "Loop, Trio, AndroidAPS, xDrip+, Nightscout, Home Assistant. If your kit is on the list, it works on day one.",
+    bullets: [
+      "Sign in to your CGM account and readings start flowing",
+      "Pull your Nightscout history in and run both while you switch",
+      "Every app that uploads to Nightscout uploads to Nocturne",
+    ],
+    color: "oklch(0.72 0.16 150)",
+  },
+  {
+    n: 3,
+    eyebrow: "Alarms",
+    title: "Tell Nocturne what to do.",
+    accent: "It will.",
+    body:
+      "Build alarms that fit your life. \"When I'm under 70 for ten minutes, message my partner on Telegram " +
+      "and turn the bedroom lights on through Home Assistant.\" Point-and-click rules, no scripts required.",
+    bullets: [
+      "When-this-then-that rules with thresholds, durations, and trends",
+      "Deliver by push, email, Discord, Slack, Telegram, WhatsApp, Home Assistant, or a webhook",
+      "Snooze one alarm, or set quiet hours for the night",
+    ],
+    color: "oklch(0.646 0.222 41.116)",
+  },
+  {
+    n: 4,
+    eyebrow: "Sign in",
+    title: "No password to lose.",
+    accent: "Or to leak.",
+    body:
+      "Sign in with a passkey on your phone, or with Google, GitHub, or your own OpenID Connect provider. " +
+      "Your health data stays on your server, and the Nocturne project never sees it.",
+    bullets: [
+      "Passkeys on every modern phone and laptop",
+      "Google, GitHub, or any OpenID Connect provider",
+      "Apps get their own scoped tokens, never your login",
+    ],
+    color: "oklch(0.65 0.18 270)",
+  },
+] as const;

--- a/src/Web/packages/portal/src/lib/data/reports.ts
+++ b/src/Web/packages/portal/src/lib/data/reports.ts
@@ -1,0 +1,58 @@
+/**
+ * The reports the app ships today, in the order and grouping of its reports
+ * page (src/Web/packages/app/src/lib/navigation/report-navigation.ts). Only
+ * reports marked available there belong here; the marketing pages quote this
+ * list and its length, so it must not run ahead of the product.
+ */
+export type ReportPreview =
+  | "summary"
+  | "agp"
+  | "distribution"
+  | "quality"
+  | "year"
+  | "readings"
+  | "day"
+  | "week"
+  | "month"
+  | "comparison"
+  | "steps"
+  | "heart"
+  | "sleep"
+  | "treatments"
+  | "basal"
+  | "insulin"
+  | "site"
+  | "idp"
+  | "battery";
+
+export interface Report {
+  name: string;
+  /** Sidebar label, as the app abbreviates it. */
+  short: string;
+  group: "The Big Picture" | "Patterns & Trends" | "Lifestyle Impact" | "Treatment Insights";
+  preview: ReportPreview;
+}
+
+export const REPORTS: readonly Report[] = [
+  { name: "Executive Summary", short: "Summary", group: "The Big Picture", preview: "summary" },
+  { name: "Glucose Profile (AGP)", short: "AGP", group: "The Big Picture", preview: "agp" },
+  { name: "Glucose Distribution", short: "Distribution", group: "The Big Picture", preview: "distribution" },
+  { name: "Data Quality", short: "Data Quality", group: "The Big Picture", preview: "quality" },
+  { name: "Data Overview", short: "Year Overview", group: "Patterns & Trends", preview: "year" },
+  { name: "Day-by-Day View", short: "Readings", group: "Patterns & Trends", preview: "readings" },
+  { name: "Day in Review", short: "Day in Review", group: "Patterns & Trends", preview: "day" },
+  { name: "Week to Week", short: "Week to Week", group: "Patterns & Trends", preview: "week" },
+  { name: "Month to Month", short: "Month to Month", group: "Patterns & Trends", preview: "month" },
+  { name: "Comparison", short: "Comparison", group: "Patterns & Trends", preview: "comparison" },
+  { name: "Step Count", short: "Steps", group: "Lifestyle Impact", preview: "steps" },
+  { name: "Heart Rate", short: "Heart Rate", group: "Lifestyle Impact", preview: "heart" },
+  { name: "Sleep & Overnight", short: "Sleep", group: "Lifestyle Impact", preview: "sleep" },
+  { name: "Treatment Log", short: "Treatments", group: "Treatment Insights", preview: "treatments" },
+  { name: "Basal Rate Analysis", short: "Basal Analysis", group: "Treatment Insights", preview: "basal" },
+  { name: "Insulin Delivery", short: "Insulin Delivery", group: "Treatment Insights", preview: "insulin" },
+  { name: "Site Change Impact", short: "Site Changes", group: "Treatment Insights", preview: "site" },
+  { name: "Insulin Dosing Profile", short: "IDP", group: "Treatment Insights", preview: "idp" },
+  { name: "Battery", short: "Battery", group: "Treatment Insights", preview: "battery" },
+] as const;
+
+export const AVAILABLE_REPORT_COUNT = REPORTS.length;

--- a/src/Web/packages/portal/src/lib/sdk/sdks.ts
+++ b/src/Web/packages/portal/src/lib/sdk/sdks.ts
@@ -1,7 +1,7 @@
 // The supported-SDK list is DERIVED from sdk/<lang>/config.yaml at build time
 // (see scripts/generate-sdk-manifest.mjs) so it can never drift from what we
 // actually publish. This module only adds the presentation details that aren't
-// in those configs — display name, registry, and install command — keyed by the
+// in those configs (display name, registry, and install command) keyed by the
 // SDK directory name. A newly added SDK shows up automatically; if it has no
 // presentation entry yet it still lists with its package name and a sane default.
 
@@ -91,7 +91,7 @@ export const SDKS: Sdk[] = (manifest as SdkManifestEntry[]).map((entry) => {
   return {
     ...entry,
     name: p?.name ?? entry.dir,
-    registry: p?.registry ?? "—",
+    registry: p?.registry ?? "n/a",
     registryUrl: p ? p.registryUrl(entry.package) : "#",
     install: p ? p.install(entry.package) : entry.package,
   };

--- a/src/Web/packages/portal/src/lib/utils/aurora-noise.ts
+++ b/src/Web/packages/portal/src/lib/utils/aurora-noise.ts
@@ -1,6 +1,18 @@
 // aurora-noise.ts
-// JS port of the GLSL noise functions from AuroraCanvas.svelte.
-// Kept in sync with the shader so chips respond to the same wave field.
+// JS port of the GLSL in AuroraCanvas.svelte, so the hero chips can sample the
+// exact brightness field the shader is drawing underneath them. Any change to
+// the shader's noise chain must be mirrored here or the chips drift out of step.
+
+const CLOCK_ORIGIN_MS = typeof performance !== "undefined" ? performance.now() : 0;
+
+/**
+ * Seconds elapsed on the clock shared by the canvas and the pool. Both must
+ * read the same origin: the shader's pattern is a function of time, so a
+ * different zero on either side samples a different frame of the animation.
+ */
+export function auroraTime(nowMs: number = performance.now()): number {
+  return (nowMs - CLOCK_ORIGIN_MS) / 1000;
+}
 
 function fract(x: number): number {
   return x - Math.floor(x);
@@ -42,36 +54,86 @@ function fbm(px: number, py: number): number {
   return v;
 }
 
+function smoothstep(e0: number, e1: number, x: number): number {
+  const t = Math.min(1, Math.max(0, (x - e0) / (e1 - e0)));
+  return t * t * (3 - 2 * t);
+}
+
 /**
- * Sample the aurora shader's domain-warp flow vector at a chip position.
+ * The shader's pre-palette brightness `v` at a point in its own p-space
+ * (centred, y up, normalised by height) at time `t` seconds.
  *
- * @param cx  chip center x in container pixels
- * @param cy  chip center y in container pixels
- * @param cw  container width in pixels
- * @param ch  container height in pixels
- * @param t   time in seconds — pass `now / 1000 * speed` to match AuroraCanvas exactly (speed defaults to 1.0)
- * @returns   { rx, ry } — approximately in [0, 1]. Subtract 0.5 and scale for force.
+ * Mirrors main() in AuroraCanvas.svelte up to `ramp(v)`: the colour ramp and
+ * vignette are monotone or static, so `v` is what moves on screen.
  */
-export function sampleFlow(
+function auroraBrightness(px: number, py: number, t: number): number {
+  const st = t * 0.06;
+
+  // q: first warp layer. Time enters y only: vec2(0., t) and vec2(5.2, -t*0.8).
+  const qx = fbm(px * 1.4,       py * 1.4 + st      );
+  const qy = fbm(px * 1.4 + 5.2, py * 1.4 - st * 0.8);
+
+  // r: second warp layer. `+ t*1.3` and `- t*1.1` are scalars added to a vec2,
+  // so they shift both components.
+  const wx = px * 2.1 + 1.8 * qx;
+  const wy = py * 2.1 + 1.8 * qy;
+  const rx = fbm(wx + 1.7 + st * 1.3, wy + 9.2 + st * 1.3);
+  const ry = fbm(wx + 8.3 - st * 1.1, wy + 2.8 - st * 1.1);
+
+  const n = fbm(px * 1.6 + 2.2 * rx, py * 1.6 + 2.2 * ry);
+
+  const yb = py * 1.15 + 0.05;
+  const band = smoothstep(0, 0.55, 1 - yb * yb);
+  return Math.pow(n, 1.15) * (0.55 + 0.6 * band);
+}
+
+export interface SurfaceSample {
+  /** Brightness in [0, ~1]: 0 is the dark trough, 1 the bright crest. */
+  value: number;
+  /** Brightness gradient in container pixels (per px). Points uphill, toward the crest. */
+  slopeX: number;
+  slopeY: number;
+  /**
+   * Apparent velocity of the pattern under this point in container px/s, from
+   * the optical-flow constraint dv/dt + grad(v) . u = 0. This is the direction
+   * the crest is visibly travelling, so a floater riding it moves this way.
+   */
+  flowX: number;
+  flowY: number;
+}
+
+const D_SPACE = 0.004; // p-space finite-difference step (~4 px at 920 px tall)
+const D_TIME = 0.05; // seconds
+const FLOW_EPS = 1e-4; // regulariser: flow is undefined where the field is flat
+
+/**
+ * Sample the drawn field at a container-pixel position. `cw`/`ch` are the
+ * canvas's CSS size, which the shader normalises by height; the y-axis is
+ * flipped because gl_FragCoord runs bottom-up while the DOM runs top-down.
+ */
+export function sampleSurface(
   cx: number, cy: number,
   cw: number, ch: number,
   t: number,
-): { rx: number; ry: number } {
-  // Map container-px → shader p-space: centered, normalised by height.
-  // Matches: vec2 p = (gl_FragCoord.xy - 0.5*u_res) / u_res.y
+): SurfaceSample {
   const px = (cx - cw * 0.5) / ch;
-  const py = (cy - ch * 0.5) / ch;
+  const py = (ch * 0.5 - cy) / ch;
 
-  // Matches shader: float t = u_t * 0.06
-  const st = t * 0.06;
+  const v0 = auroraBrightness(px, py, t);
+  const dvdx = (auroraBrightness(px + D_SPACE, py, t) - v0) / D_SPACE;
+  const dvdy = (auroraBrightness(px, py + D_SPACE, t) - v0) / D_SPACE;
+  const dvdt = (auroraBrightness(px, py, t + D_TIME) - v0) / D_TIME;
 
-  // q — first warp layer (matches shader exactly)
-  const qx = fbm(px * 1.4,       py * 1.4 + st         );
-  const qy = fbm(px * 1.4 + 5.2, py * 1.4 - st * 0.8   );
+  // Normal flow in p-space units per second, then scale to px/s (px = p * ch).
+  const g2 = dvdx * dvdx + dvdy * dvdy + FLOW_EPS;
+  const ux = (-dvdt * dvdx) / g2;
+  const uy = (-dvdt * dvdy) / g2;
 
-  // r — second warp layer (this is the flow vector we use as force)
-  const rx = fbm(px * 2.1 + 1.8 * qx + 1.7 + st * 1.3, py * 2.1 + 1.8 * qy + 9.2      );
-  const ry = fbm(px * 2.1 + 1.8 * qx + 8.3 - st * 1.1, py * 2.1 + 1.8 * qy + 2.8      );
-
-  return { rx, ry };
+  return {
+    value: v0,
+    slopeX: dvdx / ch,
+    slopeY: -dvdy / ch,
+    flowX: ux * ch,
+    flowY: -uy * ch,
+  };
 }

--- a/src/Web/packages/portal/src/routes/+layout.ts
+++ b/src/Web/packages/portal/src/routes/+layout.ts
@@ -31,6 +31,6 @@ export const load: Load = async ({ url }) => {
         locale = preferredLanguage.current
     }
 
-    // WUCHALE-DISABLED: wuchale temporarily disabled — locale dynamic load skipped.
+    // WUCHALE-DISABLED: wuchale temporarily disabled; locale dynamic load skipped.
     void locale
 }

--- a/src/Web/packages/portal/src/routes/+page.svelte
+++ b/src/Web/packages/portal/src/routes/+page.svelte
@@ -6,6 +6,8 @@
     import AuroraPool from "$lib/components/AuroraPool.svelte";
     import FeaturePillars from "$lib/components/features/FeaturePillars.svelte";
     import { getCommunityData } from "$lib/data/portal";
+    import { DATA_SOURCES, LIVE_CONNECTORS } from "$lib/data/connectors";
+    import { AVAILABLE_REPORT_COUNT } from "$lib/data/reports";
 
     let textBlockEl: HTMLElement | null = $state(null);
 
@@ -26,49 +28,10 @@
         communityData ? Math.max(0, communityData.contributors.length - MAX_AVATARS) : 0
     );
 
-    const connectors = [
-        { file: "dexcom.png", name: "Dexcom" },
-        { file: "libre.png", name: "FreeStyle Libre" },
-        { file: "glooko.png", name: "Glooko" },
-        { file: "medtronic.jpg", name: "Medtronic" },
-        { file: "tandem.png", name: "Tandem" },
-        { file: "omnipod.png", name: "Omnipod" },
-        { file: "loop.png", name: "Loop" },
-        { file: "trio.jpg", name: "Trio" },
-        { file: "aaps.png", name: "AAPS" },
-        { file: "xdrip.jpg", name: "xDrip+" },
-        { file: "mylife.png", name: "myLife" },
-        { file: "myfitnesspal.jpg", name: "MyFitnessPal" },
-        { file: "tidepool.jpg", name: "Tidepool" },
-        { file: "sugarmate.png", name: "Sugarmate" },
-        { file: "spike.png", name: "Spike" },
-        { file: "juggluco.png", name: "Juggluco" },
-        { file: "glucotracker.png", name: "GlucoTracker" },
-        { file: "nightscout.png", name: "Nightscout" },
-        { file: "discord.png", name: "Discord" },
-        { file: "slack.png", name: "Slack" },
-        { file: "telegram.png", name: "Telegram" },
-        { file: "home-assistant.png", name: "Home Assistant" },
-    ];
 </script>
 
 <!-- Hero -->
 <section class="relative w-full overflow-hidden -mt-16">
-    <svg class="absolute size-0 overflow-hidden" aria-hidden="true">
-        <defs>
-            <filter id="aurora-water" x="-10%" y="-10%" width="120%" height="120%">
-                <feTurbulence type="fractalNoise" baseFrequency="0.012 0.018"
-                    numOctaves="2" seed="3" result="t">
-                    <animate attributeName="baseFrequency" dur="22s"
-                        repeatCount="indefinite"
-                        values="0.010 0.016; 0.018 0.022; 0.010 0.016" />
-                </feTurbulence>
-                <feDisplacementMap in="SourceGraphic" in2="t" scale="6"
-                    xChannelSelector="R" yChannelSelector="G" />
-            </filter>
-        </defs>
-    </svg>
-
     <AuroraCanvas height={920} />
     <div class="grain-bg absolute inset-0 pointer-events-none opacity-35 mix-blend-overlay" aria-hidden="true"></div>
     <AuroraPool textBlock={textBlockEl} />
@@ -77,11 +40,11 @@
     <div class="absolute inset-0 pt-16 pointer-events-none">
         <div class="absolute top-[calc(4rem+20px)] left-6 hidden md:flex flex-col gap-0.5 font-mono text-[9px] tracking-[0.12em] uppercase text-[oklch(0.6_0.01_261)]">
             <span>NCTRN / HOMEPAGE</span>
-            <span>v0.4 &middot; public preview</span>
+            <span>{communityData?.latestRelease ?? "preview"} &middot; public preview</span>
         </div>
         <div class="absolute top-[calc(4rem+20px)] right-6 hidden md:flex flex-col gap-0.5 font-mono text-[9px] tracking-[0.12em] uppercase text-[oklch(0.6_0.01_261)] text-right">
-            <span>5,250 d &middot; running</span>
-            <span>22 connectors</span>
+            <span>{DATA_SOURCES.length} data sources</span>
+            <span>{AVAILABLE_REPORT_COUNT} reports</span>
         </div>
 
         <div
@@ -89,7 +52,7 @@
             class="absolute bottom-[200px] left-1/2 -translate-x-1/2 w-[min(760px,90vw)] text-center flex flex-col items-center gap-5"
         >
             <span class="inline-flex items-center gap-2 font-mono text-[11px] tracking-[0.16em] uppercase text-[oklch(0.94_0.012_261)] [text-shadow:0_1px_3px_oklch(0_0_0_/_90%),0_2px_12px_oklch(0_0_0_/_75%)]">
-                <span class="eyebrow-dot size-1.5 rounded-full shrink-0 bg-glucose-in-range"></span>The new Nightscout API
+                <span class="eyebrow-dot size-1.5 rounded-full shrink-0 bg-glucose-in-range"></span>Nightscout-compatible, rebuilt
             </span>
             <h1 class="flex flex-col items-center text-[clamp(2.5rem,7vw,4.8rem)] font-bold leading-[1.06] tracking-[-0.025em] text-[oklch(0.97_0.005_261)] m-0 [text-shadow:0_2px_8px_oklch(0_0_0_/_70%),0_4px_40px_oklch(0_0_0_/_80%)]">
                 <span>Every reading.</span>
@@ -97,9 +60,9 @@
                 <span>One dashboard.</span>
             </h1>
             <p class="text-[1.05rem] leading-[1.65] text-[oklch(0.92_0.01_261)] max-w-[540px] m-0 [text-shadow:0_1px_3px_oklch(0_0_0_/_85%),0_2px_24px_oklch(0_0_0_/_70%)]">
-                Nocturne pulls every CGM, pump, and tracker you use into a single
-                self-hosted dashboard. Fast, multitenant, real-time, and built by
-                the diabetes community.
+                Nocturne pulls every CGM, pump, and app you use into one
+                self-hosted dashboard. Real-time, multitenant, open source, and
+                built by the diabetes community.
             </p>
             <div class="flex flex-wrap gap-3 justify-center pointer-events-auto">
                 <Button href="/docs/installation" size="lg" class="gap-2 text-base hero-btn-primary">
@@ -122,10 +85,10 @@
 <!-- 01 Manifesto -->
 <section class="max-w-[1200px] mx-auto px-6 py-20 border-t border-border">
     <div class="mb-[52px]">
-        <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-4">01 &mdash; Why this exists</div>
+        <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-4">01 &middot; Why this exists</div>
         <h2 class="text-[clamp(1.6rem,3.5vw,2.5rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">
-            The diabetes data stack has not moved in a decade.<br />
-            <em class="text-glucose-in-range">This is the rewrite.</em>
+            A decade of Nightscout taught us what the data needs.<br />
+            <em class="text-glucose-in-range">Nocturne is the rebuild.</em>
         </h2>
     </div>
 
@@ -134,8 +97,8 @@
             <div class="font-mono text-[26px] font-bold text-[oklch(1_0_0_/_7%)] leading-none tracking-[-0.02em]">01</div>
             <h3 class="text-base font-semibold text-foreground m-0">Drop-in Nightscout API</h3>
             <p class="text-sm leading-[1.65] text-muted-foreground m-0">
-                Full v1/v2/v3 compatibility. Every existing app, watch face, and
-                follower keeps working &mdash; migration is a connection-string change.
+                Speaks the Nightscout v1, v2, and v3 APIs. The apps, watch faces, and
+                followers you use today keep working; you change the URL they point at.
             </p>
         </div>
         <div class="bg-background py-9 px-8 flex flex-col gap-3.5">
@@ -143,15 +106,15 @@
             <h3 class="text-base font-semibold text-foreground m-0">Multitenant, by default</h3>
             <p class="text-sm leading-[1.65] text-muted-foreground m-0">
                 One install, many people. Run a household, a clinic, or a community
-                on a single deployment with isolated data and per-tenant settings.
+                on a single deployment, with each person's data and settings kept apart.
             </p>
         </div>
         <div class="bg-background py-9 px-8 flex flex-col gap-3.5">
             <div class="font-mono text-[26px] font-bold text-[oklch(1_0_0_/_7%)] leading-none tracking-[-0.02em]">03</div>
-            <h3 class="text-base font-semibold text-foreground m-0">Real-time, sub-second</h3>
+            <h3 class="text-base font-semibold text-foreground m-0">Real-time by design</h3>
             <p class="text-sm leading-[1.65] text-muted-foreground m-0">
-                WebSocket-first. New CGM readings arrive on every device the moment
-                they are written &mdash; no five-minute polling delay.
+                Built around WebSockets and PostgreSQL. A new reading reaches every open
+                dashboard and follower the moment it lands, and years of history stay quick to browse.
             </p>
         </div>
     </div>
@@ -160,8 +123,8 @@
 <!-- 02 Connectors -->
 <section class="max-w-[1200px] mx-auto px-6 py-20 border-t border-border">
     <div class="mb-[52px]">
-        <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-4">02 &mdash; What plugs in</div>
-        <h2 class="text-[clamp(1.6rem,3.5vw,2.5rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">22 sources. <em class="text-glucose-in-range">One API surface.</em></h2>
+        <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-4">02 &middot; What plugs in</div>
+        <h2 class="text-[clamp(1.6rem,3.5vw,2.5rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">{DATA_SOURCES.length} sources. <em class="text-glucose-in-range">One dashboard.</em></h2>
     </div>
 
     <div class="w-full rounded-sm overflow-hidden mb-9 h-1.5">
@@ -170,7 +133,7 @@
 
     <div class="marquee-mask overflow-hidden mb-6">
         <div class="marquee-track flex w-max">
-            {#each [...connectors, ...connectors] as c, i (i)}
+            {#each [...LIVE_CONNECTORS, ...LIVE_CONNECTORS] as c, i (i)}
                 <div class="flex items-center gap-2 px-5 py-2.5 border-r border-border shrink-0">
                     <img src="/logos/{c.file}" alt={c.name} class="size-6 rounded-[5px] object-cover" />
                     <span class="text-[13px] font-medium text-muted-foreground whitespace-nowrap">{c.name}</span>
@@ -180,9 +143,9 @@
     </div>
 
     <div class="flex gap-2.5 items-center font-mono text-[11px] text-muted-foreground">
-        <span>+ a new connector per release on average</span>
+        <span>Missing yours?</span>
         <span>&middot;</span>
-        <span>requests welcome</span>
+        <a href="https://github.com/nightscout/nocturne/issues/new" class="underline-offset-2 hover:underline hover:text-foreground" target="_blank" rel="noopener noreferrer">Ask for a connector</a>
     </div>
 </section>
 
@@ -192,8 +155,8 @@
 <!-- 04 Install -->
 <section class="max-w-[1200px] mx-auto px-6 py-20 border-t border-border">
     <div class="mb-[52px]">
-        <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-4">04 &mdash; Run it tonight</div>
-        <h2 class="text-[clamp(1.6rem,3.5vw,2.5rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">Five minutes from <em class="text-glucose-in-range">git clone</em> to a dashboard.</h2>
+        <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-4">04 &middot; Run it tonight</div>
+        <h2 class="text-[clamp(1.6rem,3.5vw,2.5rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">Two files and a domain name. <em class="text-glucose-in-range">That's the install.</em></h2>
     </div>
 
     <div class="bg-[oklch(0.10_0.025_261)] border border-border rounded-xl overflow-hidden mb-9 max-w-[680px]">
@@ -207,15 +170,18 @@
         </div>
         <pre
             class="p-5 font-mono text-[13px] leading-[1.7] text-[oklch(0.82_0.03_261)] m-0 whitespace-pre overflow-x-auto"
->$ git clone https://github.com/nightscout/nocturne
-$ cd nocturne &amp;&amp; cp .env.example .env
+>$ mkdir nocturne &amp;&amp; cd nocturne
+$ curl -LO https://github.com/nightscout/nocturne/releases/latest/download/docker-compose.yaml
+$ curl -L -o .env https://github.com/nightscout/nocturne/releases/latest/download/default.env.example
+$ nano .env      # BASE_DOMAIN, INSTANCE_KEY, four database passwords
 $ docker compose up -d
 
-  &#10003; postgres        ready in 1.2s
-  &#10003; nocturne-api    ready in 0.8s
-  &#10003; nocturne-web    ready in 0.4s
+  &#10003; postgres        healthy
+  &#10003; nocturne-api    healthy
+  &#10003; nocturne-web    healthy
+  &#10003; caddy           certificate issued
 
-  &rarr; open http://localhost:5173</pre>
+  &rarr; open https://example.com</pre>
     </div>
 
     <div class="flex flex-wrap gap-3">
@@ -228,11 +194,11 @@ $ docker compose up -d
     </div>
 </section>
 
-<!-- 04 Community -->
+<!-- 05 Community -->
 {#if communityData}
     <section class="max-w-[1200px] mx-auto px-6 py-20 border-t border-border">
         <div class="mb-[52px]">
-            <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-4">05 &mdash; Community</div>
+            <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-4">05 &middot; Community</div>
             <h2 class="text-[clamp(1.6rem,3.5vw,2.5rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">Built in the open. <em class="text-glucose-in-range">Maintained by volunteers.</em></h2>
         </div>
 
@@ -278,13 +244,13 @@ $ docker compose up -d
 {/if}
 
 <style>
-    /* SVG grain — data URI can't be expressed as a Tailwind utility */
+    /* SVG grain: a data URI can't be expressed as a Tailwind utility */
     .grain-bg {
         background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E");
         background-size: 200px 200px;
     }
 
-    /* Eyebrow dot — keyframe + color-mix box-shadow */
+    /* Eyebrow dot: keyframe + color-mix box-shadow */
     @keyframes aurora-pulse {
         0%, 100% { box-shadow: 0 0 0 3px color-mix(in oklch, var(--glucose-in-range), transparent 80%); }
         50%       { box-shadow: 0 0 0 7px color-mix(in oklch, var(--glucose-in-range), transparent 92%); }
@@ -294,7 +260,7 @@ $ docker compose up -d
         animation: aurora-pulse 2.4s ease-in-out infinite;
     }
 
-    /* Marquee — keyframe + vendor-prefixed mask */
+    /* Marquee: keyframe + vendor-prefixed mask */
     @keyframes aurora-scroll {
         from { transform: translateX(0); }
         to   { transform: translateX(-50%); }
@@ -305,7 +271,7 @@ $ docker compose up -d
         -webkit-mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
     }
 
-    /* Hero CTAs — :global needed to pierce Button component */
+    /* Hero CTAs: :global needed to pierce the Button component */
     :global(.hero-btn-primary) {
         background: oklch(0.96 0.005 261) !important;
         color: oklch(0.13 0.028 261) !important;

--- a/src/Web/packages/portal/src/routes/demo/+page.svelte
+++ b/src/Web/packages/portal/src/routes/demo/+page.svelte
@@ -13,7 +13,7 @@
         <div class="max-w-xl mx-auto text-center">
             <h1 class="text-3xl font-bold mb-4">Live demo</h1>
             <p class="text-muted-foreground mb-6">
-                A full Nocturne instance you can explore and change — add treatments, edit
+                A full Nocturne instance you can explore and change: add treatments, edit
                 settings, browse reports. It runs on made-up data, not anyone's real
                 readings, and it resets on a schedule, so you can click anything.
             </p>

--- a/src/Web/packages/portal/src/routes/docs/installation/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/+page.svelte
@@ -255,7 +255,7 @@
       </ul>
       <p class="mt-3">
         Submit your request by opening an issue on the <a
-          href="https://github.com/nicknightscout/nocturne"
+          href="https://github.com/nightscout/nocturne/issues/new"
           target="_blank"
           rel="noopener noreferrer"
           class="text-primary hover:underline">Nocturne GitHub repository</a

--- a/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/byo-postgres/+page.svelte
@@ -26,15 +26,15 @@
         </p>
         <ul class="list-disc pl-5 mt-2 space-y-1 text-muted-foreground">
             <li>
-                <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_migrator</code> —
+                <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_migrator</code>:
                 owns the schema and runs migrations.
             </li>
             <li>
-                <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_app</code> —
+                <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_app</code>:
                 runtime connection for the .NET API. Cannot bypass RLS and has no DDL privileges.
             </li>
             <li>
-                <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_web</code> —
+                <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_web</code>:
                 used by the SvelteKit web app's bot framework to store chat-platform state. Owns
                 only its own <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">chat_state_*</code>
                 tables (not tenant-scoped, no PHI).
@@ -69,15 +69,15 @@
             <ul class="list-disc pl-5 mt-2 space-y-1">
                 <li>
                     <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded font-mono">ConnectionStrings__nocturne-postgres</code>
-                    — use the <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_app</code> role.
+                    using the <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_app</code> role.
                 </li>
                 <li>
                     <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded font-mono">ConnectionStrings__nocturne-postgres-migrator</code>
-                    — use the <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_migrator</code> role.
+                    using the <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_migrator</code> role.
                 </li>
                 <li>
-                    <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded font-mono">NOCTURNE_POSTGRES_URI</code>
-                    — a <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">postgresql://</code>
+                    <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded font-mono">NOCTURNE_POSTGRES_URI</code>:
+                    a <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">postgresql://</code>
                     URL for the <code class="text-xs bg-muted/50 px-1 py-0.5 rounded">nocturne_web</code>
                     role (consumed by the SvelteKit bot state adapter).
                 </li>

--- a/src/Web/packages/portal/src/routes/docs/installation/docker-compose/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/docker-compose/+page.svelte
@@ -34,7 +34,7 @@
             (<code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">*.example.com</code>)
             so each tenant subdomain resolves.
         </li>
-        <li>Ports <strong>80</strong> and <strong>443</strong> open to the internet — the bundled proxy uses them to obtain and serve TLS certificates.</li>
+        <li>Ports <strong>80</strong> and <strong>443</strong> open to the internet. The bundled proxy uses them to obtain and serve TLS certificates.</li>
     </ul>
 
     <SystemRequirements />
@@ -45,16 +45,17 @@
         bundle from the
         <a href="https://github.com/nightscout/nocturne/releases/latest" class="text-primary hover:underline">
             latest GitHub Release
-        </a>. The bundle is self-contained — just
+        </a>. The bundle is self-contained: just
         <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">docker-compose.yaml</code>
-        and <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">.env.example</code>.
+        and the environment template, which GitHub lists as
+        <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">default.env.example</code>.
         The database init script and the TLS proxy config are embedded directly in
         the compose file, so there are no extra directories to keep alongside it. The
         bundle also ships a
         <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">docker-compose.byo-proxy.yaml</code>
         override for operators who run their own reverse proxy (see below).
     </p>
-    <CodeBlock code={"mkdir nocturne && cd nocturne\n# Download docker-compose.yaml and .env.example from the release page, then:\ncp .env.example .env"} class="mb-4" />
+    <CodeBlock code={"mkdir nocturne && cd nocturne\ncurl -LO https://github.com/nightscout/nocturne/releases/latest/download/docker-compose.yaml\ncurl -L -o .env https://github.com/nightscout/nocturne/releases/latest/download/default.env.example"} class="mb-4" />
 
     <details class="mb-8">
         <summary class="text-sm font-medium text-muted-foreground cursor-pointer hover:text-foreground">View docker-compose.yaml</summary>
@@ -64,7 +65,7 @@
     <h2 class="text-2xl font-bold mt-8 mb-4">Step 2: Configure environment variables</h2>
     <p class="text-muted-foreground mb-4">
         Edit <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">.env</code> and fill in your
-        values. Required fields are left blank; optional bot integrations are commented out.
+        values. The required fields come first and are left blank; optional bot integrations are commented out.
         Use the generator below for each password field and <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">INSTANCE_KEY</code>.
     </p>
     <PasswordGenerator label="password" />
@@ -79,7 +80,7 @@
     <h2 class="text-2xl font-bold mt-8 mb-4">HTTPS is automatic</h2>
     <p class="text-muted-foreground mb-4">
         The bundled Caddy reverse proxy obtains and renews Let's Encrypt TLS
-        certificates automatically — no API keys or certificate files to manage.
+        certificates automatically, with no API keys or certificate files to manage.
         Set <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">BASE_DOMAIN</code>,
         point your DNS at the server, and open ports 80 and 443. The apex domain
         is issued a certificate on first start, and each tenant subdomain gets one

--- a/src/Web/packages/portal/src/routes/docs/installation/portainer/+page.svelte
+++ b/src/Web/packages/portal/src/routes/docs/installation/portainer/+page.svelte
@@ -123,7 +123,7 @@
         Once running, the bundled Caddy proxy obtains Let's Encrypt TLS certificates
         automatically and serves the stack at
         <code class="text-xs bg-muted/50 px-1.5 py-0.5 rounded">https://your-domain</code>
-        on ports 80 and 443 — no certificate files to manage. Each tenant subdomain
+        on ports 80 and 443, with no certificate files to manage. Each tenant subdomain
         gets its own certificate on demand the first time it is visited.
     </p>
 
@@ -142,7 +142,7 @@
     <h2 class="text-2xl font-bold mt-8 mb-4">Connectors</h2>
     <p class="text-muted-foreground mb-8">
         Data source connectors (Dexcom, LibreLinkUp, Glooko, etc.) are configured through the
-        Nocturne UI after deployment — no compose changes required.
+        Nocturne UI after deployment; no compose changes are required.
     </p>
 
     <h2 class="text-2xl font-bold mt-8 mb-4">Next Steps</h2>

--- a/src/Web/packages/portal/src/routes/faq/+page.svelte
+++ b/src/Web/packages/portal/src/routes/faq/+page.svelte
@@ -11,11 +11,11 @@
             questions: [
                 {
                     question: "What is Nocturne?",
-                    answer: "Nocturne is a modern, open-source rewrite of the Nightscout diabetes management platform. Built on .NET 10 with a SvelteKit frontend, it provides the same API compatibility as Nightscout while offering improved performance, modern architecture, and easier deployment.",
+                    answer: "Nocturne is an open-source, self-hosted diabetes dashboard from the Nightscout Foundation. It speaks the Nightscout API, so the apps and devices that work with Nightscout work with it, and adds built-in connectors, rule-based alarms, multitenancy, and a set of clinical reports.",
                 },
                 {
                     question: "How does Nocturne compare to Nightscout?",
-                    answer: "Nocturne is API-compatible with Nightscout (v1, v2, and v3 APIs), so your existing apps and devices work without changes. The main differences are under the hood: Nocturne uses PostgreSQL instead of MongoDB, is built on .NET for better performance, and includes modern tooling like Aspire for orchestration and observability.",
+                    answer: "Nocturne is API-compatible with Nightscout (v1, v2, and v3), so your existing apps and devices work once you point them at the new URL. The differences are in what surrounds the data: one install serves many people, connectors pull from Dexcom, Libre, CareLink and others without an uploader app, alarms are rules rather than thresholds, and sign-in uses passkeys instead of a shared secret. Under the hood it stores data in PostgreSQL rather than MongoDB.",
                 },
                 {
                     question: "Is Nocturne free?",
@@ -27,7 +27,7 @@
                 },
                 {
                     question: "How does the licensing work?",
-                    answer: "Nocturne is dual-licensed. For individuals and community self-hosters, it is available under the AGPL-3.0 — free to use, modify, and self-host, with the requirement that any modifications you distribute are also open source. For organisations that need to integrate Nocturne into proprietary products or services without those source-disclosure obligations — such as clinics, device manufacturers, or diabetes management platforms — a commercial license is available. This model lets us build a sustainable revenue stream with partnering organisations while fully protecting the rights of individual users and the broader diabetes community.",
+                    answer: "Nocturne is dual-licensed. For individuals and community self-hosters, it is available under the AGPL-3.0: free to use, modify, and self-host, with the requirement that any modifications you distribute are also open source. For organisations that need to integrate Nocturne into proprietary products or services without those source-disclosure obligations (clinics, device manufacturers, or diabetes management platforms, for example) a commercial license is available. This model lets us build a sustainable revenue stream with partnering organisations while fully protecting the rights of individual users and the broader diabetes community.",
                 },
             ],
         },
@@ -38,19 +38,19 @@
             questions: [
                 {
                     question: "What are the system requirements?",
-                    answer: "Nocturne requires Docker to run. Any system that can run Docker (Linux, Windows, macOS) can host Nocturne. For a single user, a small VPS with 1GB RAM is sufficient. For families or multiple users, we recommend 2GB+ RAM.",
+                    answer: "Nocturne runs in Docker, so any system that runs Docker (Linux, Windows, macOS) can host it. For a single user, a small VPS with 1 GB of RAM is enough. For families or several users, 2 GB or more is recommended. You also need a domain name pointed at the server.",
                 },
                 {
                     question: "Can I run Nocturne on a Raspberry Pi?",
-                    answer: "Yes! Nocturne runs well on Raspberry Pi 4 and newer models. The ARM64 Docker images are available for these platforms.",
+                    answer: "Yes. Nocturne runs on Raspberry Pi 4 and newer with 64-bit Raspberry Pi OS; the Docker images are published for ARM64 as well as x86_64.",
                 },
                 {
                     question: "Do I need technical knowledge to set up Nocturne?",
-                    answer: "Basic familiarity with Docker and command line is helpful, but our configuration wizard generates all the files you need. Most users can get up and running by following our getting started guide.",
+                    answer: "Basic familiarity with Docker and the command line is helpful. Each release ships a ready-made compose file and an environment template; you fill in a domain name, an instance key, and four database passwords. Most people get running by following the installation guide.",
                 },
                 {
                     question: "Can I use an existing PostgreSQL database?",
-                    answer: "Yes! While Nocturne includes a PostgreSQL container by default, you can configure it to use any external PostgreSQL database. This is useful if you already have managed database hosting.",
+                    answer: "Yes. The bundle includes a PostgreSQL container, but you can point Nocturne at any PostgreSQL 17 database, including managed services such as RDS, Cloud SQL, Supabase, or Neon. The Bring Your Own PostgreSQL guide covers the one-time role setup.",
                 },
             ],
         },
@@ -61,19 +61,19 @@
             questions: [
                 {
                     question: "Can I migrate my existing Nightscout data?",
-                    answer: "Yes! Nocturne includes built-in migration tools to import your complete history from Nightscout. Your entries, treatments, and profile data can all be imported.",
+                    answer: "Yes. Nocturne has a built-in migration tool that connects to your Nightscout, either through its API with your API secret or directly to its MongoDB database, and imports your glucose entries, treatments, device status, and profiles, optionally limited to a date range. It reads from Nightscout and never writes to it.",
                 },
                 {
                     question: "Will my existing apps still work?",
-                    answer: "Yes! Nocturne is fully API-compatible with Nightscout. xDrip+, Loop, AndroidAPS, and other apps that work with Nightscout will work with Nocturne without any configuration changes (just point them to your new Nocturne URL).",
+                    answer: "Yes. Nocturne implements the Nightscout API, so xDrip+, Loop, AndroidAPS, Trio, and other apps that upload to or read from Nightscout work with Nocturne. Point them at your Nocturne URL and give them a token from the Connectors & Apps settings page.",
                 },
                 {
                     question: "Can I run Nocturne alongside Nightscout?",
-                    answer: "Yes! The Compatibility Proxy mode lets you run Nocturne alongside your existing Nightscout instance. This is great for testing Nocturne before fully migrating.",
+                    answer: "Yes. Add your Nightscout site as a connector and Nocturne keeps pulling readings and treatments from it, so both stay current while you move apps over one at a time. Switch the connector off when you are done.",
                 },
                 {
                     question: "What happens to my Nightscout during migration?",
-                    answer: "Migration is read-only - it copies data from Nightscout without modifying your original instance. You can keep your Nightscout running during and after migration until you're confident in your Nocturne setup.",
+                    answer: "Nothing. Migration is read-only: it copies data from Nightscout without modifying your original instance. You can keep Nightscout running during and after migration until you are confident in your Nocturne setup.",
                 },
             ],
         },
@@ -88,15 +88,15 @@
                 },
                 {
                     question: "How do data connectors work?",
-                    answer: "Connectors are background services that fetch data from external sources like Dexcom Share or LibreView. Each connector authenticates with its data source and periodically syncs glucose readings to your Nocturne instance.",
+                    answer: "Connectors are background services that fetch data from sources like Dexcom Share, LibreLinkUp, CareLink, Glooko, or another Nightscout. You sign in to the source once from the Nocturne UI; the connector then checks for new readings and treatments on a schedule and stores them in your instance.",
                 },
                 {
                     question: "Is there an API?",
-                    answer: "Yes! Nocturne implements the full Nightscout API (v1, v2, and v3) plus additional endpoints. Interactive API documentation is available through Scalar when enabled.",
+                    answer: "Yes. Nocturne implements the Nightscout API (v1, v2, and v3) plus its own v4 endpoints, with OAuth device and PKCE flows for apps. Interactive API documentation is available through Scalar, and official SDKs cover several languages.",
                 },
                 {
                     question: "Can I contribute to Nocturne?",
-                    answer: "Absolutely! Nocturne is open source and welcomes contributions. Check out our GitHub repository for contribution guidelines, or join the community to discuss features and improvements.",
+                    answer: "Yes. Nocturne is open source and welcomes contributions, and not only code: translations, documentation, and helping other self-hosters in Discord all count. See the Get involved page for tasks you can pick up today.",
                 },
             ],
         },
@@ -122,7 +122,7 @@
         {#each faqCategories as category, ci}
             <section class="py-16 border-t border-border">
                 <div class="mb-8">
-                    <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground">0{ci + 1} &mdash; {category.title}</div>
+                    <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground">0{ci + 1} &middot; {category.title}</div>
                 </div>
 
                 <Accordion.Root type="multiple" class="space-y-3">

--- a/src/Web/packages/portal/src/routes/features/+page.svelte
+++ b/src/Web/packages/portal/src/routes/features/+page.svelte
@@ -5,80 +5,44 @@
     import ConnectorsDemo from "$lib/components/features/ConnectorsDemo.svelte";
     import AlarmsDemo from "$lib/components/features/AlarmsDemo.svelte";
     import AuthDemo from "$lib/components/features/AuthDemo.svelte";
-
-    const PILLARS = [
-        {
-            n: 1,
-            eyebrow: "Reports",
-            title: "Every report you actually use.",
-            accent: "Built in.",
-            body: "Time in Range. AGP. Day calendars. Meal impact. Pump activity. Sensor lifecycle. GLP-1 tracking. A dozen reports your endo asks for — already on the dashboard, ready to print or share.",
-            bullets: ["12+ built-in reports", "Print, share, or schedule by email", "Drill from any chart into the raw data"],
-            color: "oklch(0.6 0.118 184.704)",
-        },
-        {
-            n: 2,
-            eyebrow: "Connectors",
-            title: "Plays nice with your gear.",
-            accent: "Right out of the box.",
-            body: "22 devices and services already wired in. Dexcom, Libre, Omnipod, Tandem, Loop, Trio, xDrip, Nightscout, Home Assistant. If your stuff is on the list, it works on day one.",
-            bullets: ["Just sign in to your CGM — no fiddling", "Two-way bridge with Nightscout", "New connector every release on average"],
-            color: "oklch(0.72 0.16 150)",
-        },
-        {
-            n: 3,
-            eyebrow: "Alarms",
-            title: "Tell Nocturne what to do.",
-            accent: "It will.",
-            body: "Build alarms that actually fit your life. \"When my BG dips below 70, call my wife and flash the bedroom lights.\" Drag-and-drop rules, no scripts required.",
-            bullets: ["When-this-then-that recipes", "Send to phone, watch, Discord, Slack, Home Assistant", "Snooze, escalate, or skip when asleep"],
-            color: "oklch(0.646 0.222 41.116)",
-        },
-        {
-            n: 4,
-            eyebrow: "Sign in",
-            title: "No password to lose.",
-            accent: "Or to leak.",
-            body: "Sign in with a passkey on your phone, or with Google, Apple, or GitHub. Your health data stays on your server — Nocturne never sees it, never touches it.",
-            bullets: ["Passkeys on every modern device", "Google · Apple · GitHub · Microsoft", "Self-hosted: nothing leaves your machine"],
-            color: "oklch(0.65 0.18 270)",
-        },
-    ] as const;
+    import { PILLARS } from "$lib/data/pillars";
+    import { DATA_SOURCES } from "$lib/data/connectors";
+    import { AVAILABLE_REPORT_COUNT } from "$lib/data/reports";
 
     const SUPPORTING = [
         {
             title: "Your server, your data",
-            copy: "Self-hosted on Docker, Aspire, or bare metal. No cloud middleman, no third-party tracker. PHI never leaves your infrastructure.",
+            copy: "Self-hosted with Docker Compose, Portainer, or Helm. No cloud middleman and no third-party analytics. Your health data never leaves your infrastructure.",
             icon: "shield",
             color: "oklch(0.577 0.245 27.325)",
         },
         {
             title: "One install, many people",
-            copy: "Run a household, a clinic, or a community on a single deployment. Each tenant fully isolated via row-level security.",
+            copy: "Run a household, a clinic, or a community on a single deployment. Each tenant lives in its own database schema, behind its own subdomain.",
             icon: "users",
             color: "oklch(0.65 0.18 270)",
         },
         {
-            title: "Sub-second updates",
-            copy: "New readings arrive on every device the moment they're written. WebSocket-first — no five-minute polling delay.",
+            title: "Real-time updates",
+            copy: "New readings reach every open dashboard and follower the moment they are written, over WebSockets rather than polling.",
             icon: "zap",
             color: "oklch(0.769 0.188 70)",
         },
         {
             title: "Drop-in Nightscout",
-            copy: "Full v1/v2/v3 API parity. xDrip, Loop, AAPS, watch faces — everything just keeps working after you migrate.",
+            copy: "Speaks the Nightscout v1, v2, and v3 APIs. xDrip+, Loop, AndroidAPS, Trio, and watch faces keep working after you switch.",
             icon: "plug",
             color: "oklch(0.72 0.16 150)",
         },
         {
             title: "Built for years of data",
-            copy: "Modern stack handles years of readings without slowdowns. Search a date from years ago and get an answer in milliseconds.",
+            copy: "PostgreSQL underneath, with the reports written to query years of readings. Jumping to a date from years ago stays quick.",
             icon: "chart",
             color: "oklch(0.6 0.118 184.704)",
         },
         {
-            title: "Always free, always open",
-            copy: "AGPL-3.0 licensed. Auditable, forkable, never going behind a paywall. The community built it; the community owns it.",
+            title: "Free and open source",
+            copy: "AGPL-3.0 licensed, so you can read it, fork it, and self-host it for nothing. Stewarded by the Nightscout Foundation.",
             icon: "sparkle",
             color: "oklch(0.488 0.243 264.376)",
         },
@@ -125,7 +89,7 @@
         </div>
     </div>
 
-    <!-- THE FOUR KILLER FEATURES — alternating pillar layout -->
+    <!-- The four headline features, alternating layout -->
     {#each PILLARS as p, i (p.n)}
         {@const flip = i % 2 === 1}
         <section class="py-20 border-t border-border grid gap-16 items-center
@@ -186,7 +150,7 @@
         </section>
     {/each}
 
-    <!-- SUPPORTING — security, multitenant, developer -->
+    <!-- Supporting: security, multitenant, developer -->
     <section class="py-20 border-t border-border">
         <div class="flex items-center gap-3 text-[17px] font-semibold tracking-[0.02em] uppercase text-muted-foreground mb-4">
             <span class="size-2.5 rounded-full bg-muted-foreground/40 shrink-0"></span>
@@ -215,14 +179,14 @@
         </div>
     </section>
 
-    <!-- COMPARE — plain-English before/after -->
+    <!-- Compare: plain-English before/after -->
     <section class="py-20 border-t border-border">
         <div class="flex items-center gap-3 text-[17px] font-semibold tracking-[0.02em] uppercase text-glucose-in-range mb-4">
             <span class="size-2.5 rounded-full bg-glucose-in-range shrink-0"></span>
             What changes
         </div>
         <h2 class="text-[clamp(1.6rem,3.2vw,2.5rem)] font-bold leading-[1.1] tracking-[-0.025em] text-foreground m-0 mb-10">
-            The same data. <em class="text-glucose-in-range">Better everything else.</em>
+            The same data. <em class="text-glucose-in-range">A new home for it.</em>
         </h2>
 
         <div class="rounded-2xl overflow-hidden border border-border grid md:grid-cols-2">
@@ -231,17 +195,17 @@
                 <div class="font-mono text-[13px] tracking-[0.08em] uppercase text-muted-foreground font-bold">
                     The old way
                 </div>
-                <h3 class="text-[1.5rem] font-bold text-muted-foreground m-0">Nightscout, circa 2014</h3>
+                <h3 class="text-[1.5rem] font-bold text-muted-foreground m-0">Nightscout</h3>
                 {#each [
-                    "A handful of reports, all built in 2014",
-                    "Each device needs a separate uploader app",
-                    "Alarms = an on/off threshold, nothing more",
-                    "API secrets that you can't remember",
-                    "Slows down after a year of readings",
+                    "One instance per person",
+                    "Readings arrive through uploader apps or bridge plugins you configure",
+                    "Alarms are high and low thresholds, with a snooze",
+                    "One shared API secret for every app and follower",
+                    "A fixed set of report pages",
                 ] as line (line)}
                     <div class="flex items-center gap-3 text-[1rem] text-muted-foreground/70">
                         <span class="size-5 rounded-full bg-white/[0.06] grid place-items-center shrink-0
-                                     font-mono text-[13px] text-muted-foreground/50">—</span>
+                                     font-mono text-[13px] text-muted-foreground/50">&middot;</span>
                         {line}
                     </div>
                 {/each}
@@ -255,13 +219,13 @@
                 <div class="font-mono text-[13px] tracking-[0.08em] uppercase text-glucose-in-range font-bold relative">
                     Nocturne
                 </div>
-                <h3 class="text-[1.5rem] font-bold text-foreground m-0 relative">The rewrite, 2026</h3>
+                <h3 class="text-[1.5rem] font-bold text-foreground m-0 relative">Nocturne</h3>
                 {#each [
-                    "12+ reports your endo asks for, on the dashboard",
-                    "22 connectors out of the box — one click each",
-                    "If-this-then-that recipes, send anywhere",
-                    "Passkeys & sign-in-with-Google, no passwords",
-                    "Modern database — years of data, sub-second",
+                    "One install for a household, a clinic, or a community",
+                    `Sign in to ${DATA_SOURCES.length} sources from the dashboard; uploaders still work`,
+                    "Rules with thresholds, durations, and trends, delivered anywhere",
+                    "Passkeys and social sign-in, with a scoped token per app",
+                    `${AVAILABLE_REPORT_COUNT} reports, with your own target range drawn on them`,
                 ] as line (line)}
                     <div class="flex items-center gap-3 text-[1rem] text-foreground/90 font-medium relative">
                         <span class="size-5 rounded-full bg-glucose-in-range/[0.18] border border-glucose-in-range/40
@@ -281,11 +245,11 @@
         <div class="relative max-w-[680px]">
             <h2 class="text-[clamp(2rem,4vw,3.5rem)] font-bold leading-[1.06] tracking-[-0.025em] text-foreground m-0 mb-4">
                 Ready to take a look?<br/>
-                <em class="not-italic text-glucose-in-range font-semibold">Five minutes, tops.</em>
+                <em class="not-italic text-glucose-in-range font-semibold">Start with the demo.</em>
             </h2>
             <p class="text-[1.0625rem] leading-[1.6] text-muted-foreground m-0 mb-8">
-                Run your own copy with Docker, or poke around the demo first.
-                No credit card, no waitlist, never any of that.
+                Poke around the demo, then run your own copy with Docker Compose.
+                No account, no credit card, no waitlist.
             </p>
             <div class="flex flex-wrap gap-3">
                 <Button href="/docs/installation" size="lg" class="gap-2 text-base">

--- a/src/Web/packages/portal/src/routes/get-involved/+page.svelte
+++ b/src/Web/packages/portal/src/routes/get-involved/+page.svelte
@@ -45,7 +45,7 @@
       icon: Globe,
       accent: "oklch(0.65 0.16 250)",
       title: "Translate Nocturne",
-      desc: "Every interface string lives in a gettext .po file, one per language, and most languages are barely started. Edit one on GitHub and open a pull request — no build tools, just words.",
+      desc: "Every interface string lives in a gettext .po file, one per language, and most languages are barely started. Edit one on GitHub and open a pull request: no build tools, just words.",
       cta: "Open the translation files",
       href: LINKS.translationFiles,
       external: true,
@@ -55,7 +55,7 @@
       icon: MessageCircle,
       accent: "oklch(0.62 0.17 280)",
       title: "Answer questions",
-      desc: "New self-hosters get stuck. Hang out in the Discord and help someone get their data flowing — the fastest way to make a real difference today.",
+      desc: "New self-hosters get stuck. Hang out in the Discord and help someone get their data flowing. It is the fastest way to make a real difference today.",
       cta: "Join the Discord",
       href: LINKS.discord,
       external: true,
@@ -114,7 +114,7 @@
       icon: Database,
       accent: "oklch(0.6 0.13 200)",
       title: "Donate anonymized data",
-      desc: "Opt in to share de-identified glucose data so connectors and reports can be tested against real-world patterns — not just synthetic samples.",
+      desc: "Opt in to share de-identified glucose data so connectors and reports can be tested against real-world patterns, not just synthetic samples.",
       cta: "Email research-data@nocturne.run",
       href: LINKS.researchData,
       external: true,
@@ -176,7 +176,7 @@
 
   // GitHub's REST API is public (CORS-enabled, ~60 req/hr per visitor IP),
   // so the feed is fetched live in the browser rather than baked in at build
-  // time — keeping these tasks genuinely grabbable and up to date.
+  // time, keeping these tasks genuinely grabbable and up to date.
   const ISSUES_API =
     "https://api.github.com/repos/nightscout/nocturne/issues?labels=get-involved&state=open&sort=updated&direction=desc&per_page=8";
 
@@ -231,7 +231,7 @@
   <title>Get Involved - Nocturne</title>
   <meta
     name="description"
-    content="Nocturne is built by volunteers. You don't need to write code to contribute — here's where to start."
+    content="Nocturne is built by volunteers. You don't need to write code to contribute. Here's where to start."
   />
 </svelte:head>
 
@@ -254,7 +254,7 @@
       </h1>
       <p class="text-muted-foreground text-[17px] max-w-[520px] mb-[26px]">
         Nocturne is free, open source, and made entirely by volunteers. You
-        don't need to write a line of code to move it forward — here's where to
+        don't need to write a line of code to move it forward. Here's where to
         start.
       </p>
       <div class="flex gap-2.5 flex-wrap">
@@ -413,7 +413,7 @@
         </div>
       {:else if issues.length === 0}
         <div class="px-[22px] py-10 text-center text-sm text-muted-foreground">
-          No open tasks tagged <code>get-involved</code> right now — check back soon,
+          No open tasks tagged <code>get-involved</code> right now. Check back soon,
           or
           <a
             href={LINKS.discord}
@@ -464,7 +464,7 @@
       {/if}
 
       <div class="flex items-center justify-between gap-3 px-[22px] py-4">
-        <span class="text-muted-foreground text-[13px]">Updated continuously — these are real, grabbable tasks.</span>
+        <span class="text-muted-foreground text-[13px]">Updated continuously: these are real, grabbable tasks.</span>
         <a
           href={LINKS.githubLabel}
           target="_blank"
@@ -493,7 +493,7 @@
           Keep Nocturne free and independent
         </h3>
         <p class="text-muted-foreground m-0 max-w-[52ch]">
-          There is no company behind Nocturne — just volunteers and the
+          There is no company behind Nocturne, just volunteers and the
           Nightscout Foundation, a registered non-profit. Donations cover
           servers, test devices, and the work that keeps your data yours. Give
           once, or subscribe monthly.

--- a/src/Web/packages/portal/src/routes/roadmap/+page.svelte
+++ b/src/Web/packages/portal/src/routes/roadmap/+page.svelte
@@ -111,7 +111,7 @@
         {#if grouped.inProgress.length > 0}
             <section class="py-16 border-t border-border">
                 <div class="mb-8">
-                    <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-2.5">01 &mdash; In Progress</div>
+                    <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-2.5">01 &middot; In Progress</div>
                     <h2 class="text-[clamp(1.4rem,2.5vw,2rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">Currently <em class="text-glucose-in-range">building.</em></h2>
                 </div>
                 <div class="grid gap-4">
@@ -126,7 +126,7 @@
         {#if grouped.upcoming.length > 0}
             <section class="py-16 border-t border-border">
                 <div class="mb-8">
-                    <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-2.5">0{grouped.inProgress.length > 0 ? 2 : 1} &mdash; Upcoming</div>
+                    <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-2.5">0{grouped.inProgress.length > 0 ? 2 : 1} &middot; Upcoming</div>
                     <h2 class="text-[clamp(1.4rem,2.5vw,2rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">On the <em class="text-glucose-in-range">horizon.</em></h2>
                 </div>
                 <div class="grid gap-4">
@@ -141,7 +141,7 @@
         {#if grouped.completed.length > 0}
             <section class="py-16 border-t border-border">
                 <div class="mb-8">
-                    <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-2.5">0{[grouped.inProgress.length > 0, grouped.upcoming.length > 0].filter(Boolean).length + 1} &mdash; Completed</div>
+                    <div class="font-brand text-[12px] font-bold tracking-[0.14em] uppercase text-muted-foreground mb-2.5">0{[grouped.inProgress.length > 0, grouped.upcoming.length > 0].filter(Boolean).length + 1} &middot; Completed</div>
                     <h2 class="text-[clamp(1.4rem,2.5vw,2rem)] font-bold leading-[1.2] tracking-[-0.02em] text-foreground m-0">Already <em class="text-glucose-in-range">shipped.</em></h2>
                 </div>
                 <div class="grid gap-4">

--- a/src/Web/packages/portal/src/routes/scalar/+page.svelte
+++ b/src/Web/packages/portal/src/routes/scalar/+page.svelte
@@ -5,12 +5,12 @@
 
     // This embed is for reading. Sending a request needs a tenant to send it to and a
     // credential to send with it, and this page is on a different domain to any Nocturne
-    // instance — so point people at the demo's own copy of the reference, which is
+    // instance, so point people at the demo's own copy of the reference, which is
     // same-origin with the demo API and arrives already authorized.
     const demoScalarUrl = DEMO_ENABLED && DEMO_WEB_URL ? `${DEMO_WEB_URL}/scalar` : null;
 
     // Pinned standalone build. Scalar is a Vue app, so it's loaded at runtime in
-    // the browser rather than bundled — keeps it out of the Svelte SSR/prerender
+    // the browser rather than bundled, which keeps it out of the Svelte SSR/prerender
     // graph (which can't resolve Vue's deps) and off the portal's dependency tree.
     const SCALAR_SCRIPT = "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.57.5";
 
@@ -79,7 +79,7 @@
     <title>API Reference - Nocturne</title>
     <meta
         name="description"
-        content="Interactive Nocturne API documentation powered by Scalar — explore endpoints, test requests, and integrate with Nocturne."
+        content="Interactive Nocturne API documentation powered by Scalar. Explore endpoints, test requests, and integrate with Nocturne."
     />
 </svelte:head>
 
@@ -88,7 +88,7 @@
         class="px-4 py-2 border-b border-border/60 bg-card/50 flex flex-wrap items-center justify-between gap-2 text-sm"
     >
         <span class="text-muted-foreground">
-            Want to send real requests? Open this reference on the demo instance — it comes
+            Want to send real requests? Open this reference on the demo instance; it comes
             already signed in, and the demo resets on a schedule.
         </span>
         <a

--- a/src/Web/packages/screenshots/manifest.json
+++ b/src/Web/packages/screenshots/manifest.json
@@ -254,7 +254,7 @@
 		}
 	},
 	"sharing-public-link": {
-		"alt": "The Public access card, switched on and holding a freshly minted link. The address is spelled out in full — the one time Nocturne shows it — with Copy and Regenerate beside it, then a tile for each kind of data you can share or keep back, a choice between all history and the last 24 hours, and a sentence spelling out what a viewer would see.",
+		"alt": "The Public access card, switched on and holding a freshly minted link. The address is spelled out in full (the one time Nocturne shows it) with Copy and Regenerate beside it, then a tile for each kind of data you can share or keep back, a choice between all history and the last 24 hours, and a sentence spelling out what a viewer would see.",
 		"variants": {
 			"light": {
 				"file": "images/sharing-public-link.light.webp",

--- a/src/Web/packages/screenshots/src/manifest.ts
+++ b/src/Web/packages/screenshots/src/manifest.ts
@@ -201,7 +201,7 @@ export const definitions: ScreenshotDefinition[] = [
 	{
 		id: 'alerts-configuration',
 		route: '/alerts',
-		alt: 'The Alerts page. Three tiles across the top count how many rules are switched on, how many alerts are sounding right now, and how many fired this week. Below them sits the list of rules — an urgent low, a low, a high, and one for the sensor going quiet — each showing the reading it watches for, a switch to turn it off, and a button to send a test alert. A New rule button sits in the top corner.',
+		alt: 'The Alerts page. Three tiles across the top count how many rules are switched on, how many alerts are sounding right now, and how many fired this week. Below them sits the list of rules: an urgent low, a low, a high, and one for the sensor going quiet, each showing the reading it watches for, a switch to turn it off, and a button to send a test alert. A New rule button sits in the top corner.',
 	},
 	{
 		id: 'report-agp',
@@ -229,7 +229,7 @@ export const definitions: ScreenshotDefinition[] = [
 		prepare: revealThePublicLink,
 		clip: '[data-testid="public-access-card"]',
 		// The address is minted per run, so this one image differs every capture.
-		alt: 'The Public access card, switched on and holding a freshly minted link. The address is spelled out in full — the one time Nocturne shows it — with Copy and Regenerate beside it, then a tile for each kind of data you can share or keep back, a choice between all history and the last 24 hours, and a sentence spelling out what a viewer would see.',
+		alt: 'The Public access card, switched on and holding a freshly minted link. The address is spelled out in full (the one time Nocturne shows it) with Copy and Regenerate beside it, then a tile for each kind of data you can share or keep back, a choice between all history and the last 24 hours, and a sentence spelling out what a viewer would see.',
 		anchors: {
 			enable: '[data-testid="public-access-toggle"]',
 			'time-window': '[data-testid="public-access-window"]',


### PR DESCRIPTION
## What

Two commits, separable:

1. **`fix(web)`: unbreak portal CI on main.** Since #1191 the appearance store imported `widget-registry.ts`, whose dynamic loaders drag every dashboard widget (and their `$api/...` imports) into the portal bundle. The portal has no alias for those paths, so `portal-pages` has failed on main since 2026-09-06. The ids now live in a component-free `top-widget-ids.ts`; the registry re-exports them and types its loader map as `Record<TopWidgetId, WidgetLoader>` so the id-set/loader-set guarantee still fails to compile when violated. Behaviour unchanged (`widget-registry.test.ts` and `DashboardWidgetConfigurator.svelte.test.ts` green). `portal-pages.yml` now also triggers on the app modules the portal bundles.

2. **`docs(portal)`: marketing copy refresh + hero physics.**
   - **Reports demo and pillar** list the 19 reports the app marks available (from `report-navigation.ts`), grouped as the app groups them, instead of twelve invented ones (GRI, GLP-1, IOB, "CAGE").
   - **Connectors** come from one shared list that feeds the hero marquee, the search demo and every count in copy. Tandem is live rather than "coming soon"; Eversense, twiist and Gluroo are listed; WhatsApp and email are live channels.
   - **Sign-in copy drops Apple** (cannot complete, #317) in favour of Google, GitHub or any OIDC provider. **Alarm copy** names the channels in `ChannelType` and drops "call my wife", "escalate", "drag-and-drop".
   - **Nightscout claims are accurate**: no more "circa 2014", "slows down after a year", "no five-minute polling delay". The Nightscout connector is pull-only, so "two-way bridge" is gone.
   - **Install section shows the real bundle**: `docker-compose.yaml` + `default.env.example` from the release page, not `git clone` + `localhost:5173`. FAQ no longer promises a configuration wizard or a "Compatibility Proxy mode"; migration answer covers both API and MongoDB modes and the collections the job actually migrates.
   - **Docs**: Next Steps and Quick Start no longer say to set up a reverse proxy for HTTPS or visit `:8443` (bundled Caddy already terminates TLS). Installation page linked the wrong GitHub org.
   - **`.env.example`**: Required section above Configuration, in `publish-release.cs` and both committed bundles (same variables, regrouped). Env-var descriptions in the AppHost and `templates.json` lose their em dashes.
   - **No em dashes** in portal prose, including mdsvex `--`, the OAuth scope description that reaches the consent screen, and screenshot alt text. The placeholder "Coming from Nightscout" post is a draft again.
   - **Hero chips ride the drawn aurora.** They previously took a force from an intermediate warp vector, sampled at a mirrored y (`gl_FragCoord` is bottom-up), on a different clock, with the shader's scalar time offsets ported to one axis. `aurora-noise.ts` now ports the full brightness chain, shares a clock with the canvas, flips y, and exposes value, slope and optical flow. Chips relax toward the pattern's visible velocity, slide from bright crests into dark troughs, and tilt with the surface slope.

## Verification

- `pnpm --filter @nocturne/portal check`: 51 files, 0 errors. `pnpm build`: passes; prerendered HTML grep confirms the corrected strings and no U+2014 outside the embedded `docker-compose.yaml` (comments in the generated bundle, left alone).
- Numeric simulation of `sampleSurface` over 5,760 samples: no non-finite values; a resting chip drifts ~180 px over 30 s at ≤16 px/s.
- Hostile fresh-context review (opus) ran; its confirmed findings (Gluroo missing, migration answer too narrow, stale `templates.json`, print/share overclaim, reports sidebar overflow, roadmap `&mdash;`, tilt sign) are fixed in the second commit.

## Not done

- Em dashes inside the generated compose bundle's CSS/Caddyfile comments (`ByoProxyComposePublisher`, the app's heatmap CSS) are untouched.
- `portal-pages.yml` still has no `pull_request` build, so a portal break only shows on main.
