### PR TITLE
fix(tests): follow the NocturneRemote AccessToken rename

### DIFF
--- a/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs
@@ -91,7 +91,7 @@ public class NocturneRemoteRealtimeListenerTests
         {
             Enabled = false,
             Url = "http://remote.example.com",
-            Token = "test-token",
+            AccessToken = "test-token",
         };
 
         var serviceProvider = BuildServiceProvider(connectionString, config);
@@ -118,7 +118,7 @@ public class NocturneRemoteRealtimeListenerTests
         {
             Enabled = true,
             Url = "",
-            Token = "test-token",
+            AccessToken = "test-token",
         };
 
         var serviceProvider = BuildServiceProvider(connectionString, config);
@@ -145,7 +145,7 @@ public class NocturneRemoteRealtimeListenerTests
         {
             Enabled = true,
             Url = "127.0.0.1:9",
-            Token = "test-token",
+            AccessToken = "test-token",
         };
 
         var logger = new ListLogger<NocturneRemoteConnectorBackgroundService>();
@@ -173,7 +173,7 @@ public class NocturneRemoteRealtimeListenerTests
         {
             Enabled = true,
             Url = "ftp://x",
-            Token = "test-token",
+            AccessToken = "test-token",
         };
 
         var logger = new ListLogger<NocturneRemoteConnectorBackgroundService>();

--- a/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs
@@ -57,7 +57,7 @@ public class NocturneRemoteBackgroundSyncAuthTests
         var tenantConfig = new NocturneRemoteConnectorConfiguration
         {
             Url = "https://remote.nocturne.example.com",
-            Token = "bearer-token",
+            AccessToken = "bearer-token",
             Enabled = true,
             SyncIntervalMinutes = 5,
         };
@@ -157,7 +157,7 @@ public class NocturneRemoteBackgroundSyncAuthTests
     private static NocturneRemoteConnectorConfiguration RemoteConfig => new()
     {
         Url = "https://remote.nocturne.example.com",
-        Token = "bearer-token",
+        AccessToken = "bearer-token",
     };
 
     private static SyncRequest GlucoseSince() =>


### PR DESCRIPTION
`main` does not compile.

#1045 renamed `NocturneRemoteConnectorConfiguration.Token` to `AccessToken`, so the property name matches the `ConnectorProperty` key the reflection binder resolves. No `Token` alias was kept. Two test files were not updated:

- `tests/Unit/Nocturne.API.Tests/Services/BackgroundServices/NocturneRemoteRealtimeListenerTests.cs` (4)
- `tests/Unit/Nocturne.API.Tests/Services/Connectors/NocturneRemoteBackgroundSyncAuthTests.cs` (2)

`Nocturne.API.Tests` has failed to build on `main` ever since, with six `CS0117: 'NocturneRemoteConnectorConfiguration' does not contain a definition for 'Token'`. That reddens CI on every open PR, and it hides the thirteen `NocturneRemote` tests rather than failing them — a non-compiling project reports nothing.

This renames the six assignments. Nothing else changes.

After: `Nocturne.API.Tests` builds clean, the 13 previously-uncompilable `NocturneRemote` tests pass, and the project is green at 6646 passed / 5 skipped.