### PR TITLE
feat(portal): click the hero aurora to drop a red wave that shoves the chips

### DIFF
--- a/src/Web/packages/portal/src/lib/components/AuroraCanvas.svelte
+++ b/src/Web/packages/portal/src/lib/components/AuroraCanvas.svelte
@@ -1,16 +1,25 @@
 <script lang="ts">
     import { onMount } from "svelte";
     import { auroraTime } from "$lib/utils/aurora-noise";
+    import {
+        MAX_RIPPLES,
+        RIPPLE_LIFE,
+        RIPPLE_SPEED,
+        RIPPLE_WIDTH,
+        type RippleField,
+    } from "$lib/utils/aurora-ripples";
 
     let {
         height = 880,
         intensity = 1.0,
         speed = 1.0,
+        ripples = null,
         class: className = "",
     }: {
         height?: number;
         intensity?: number;
         speed?: number;
+        ripples?: RippleField | null;
         class?: string;
     } = $props();
 
@@ -23,6 +32,12 @@ precision highp float;
 uniform vec2  u_res;
 uniform float u_t;
 uniform float u_intensity;
+uniform vec3  u_rip[${MAX_RIPPLES}];
+uniform int   u_ripN;
+
+const float RIP_LIFE  = ${RIPPLE_LIFE.toFixed(4)};
+const float RIP_SPEED = ${RIPPLE_SPEED.toFixed(4)};
+const float RIP_WIDTH = ${RIPPLE_WIDTH.toFixed(4)};
 
 const vec3 C_VLOW  = vec3(0.835, 0.149, 0.192);
 const vec3 C_LOW   = vec3(0.165, 0.608, 0.608);
@@ -50,6 +65,13 @@ vec3 ramp(float t){
   if(t<0.65) return mix(C_IN,C_TIGHT,smoothstep(0.45,0.65,t));
   return mix(C_TIGHT,C_HIGH,smoothstep(0.65,1.,t));
 }
+// Mirrors rippleCrest() in aurora-ripples.ts.
+float crest(float d,float age){
+  if(age<0.||age>=RIP_LIFE) return 0.;
+  float front=(d-age*RIP_SPEED)/RIP_WIDTH;
+  float fade=1.-age/RIP_LIFE;
+  return exp(-front*front)*fade*fade;
+}
 void main(){
   vec2 uv=gl_FragCoord.xy/u_res.xy;
   vec2 p=(gl_FragCoord.xy-0.5*u_res.xy)/u_res.y;
@@ -63,6 +85,19 @@ void main(){
   vec3 col=ramp(v);
   float vign=smoothstep(0.95,0.2,length(p*vec2(0.55,1.05)));
   col=mix(C_BG,col,vign*u_intensity);
+  // Ripples: a red crest at each wavefront, with darker water just behind it.
+  float rip=0.,trough=0.;
+  for(int i=0;i<${MAX_RIPPLES};i++){
+    if(i>=u_ripN) break;
+    float d=length(p-u_rip[i].xy);
+    float age=u_rip[i].z;
+    rip+=crest(d,age);
+    trough+=crest(d+1.6*RIP_WIDTH,age);
+  }
+  rip=clamp(rip,0.,1.);
+  col*=1.-0.45*clamp(trough,0.,1.);
+  col=mix(col,C_VLOW,rip*(0.6+0.4*n));
+  col+=C_VLOW*rip*0.35;
   float g=(hash(gl_FragCoord.xy+u_t*0.001)-0.5)*0.025;
   col+=g;
   gl_FragColor=vec4(col,1.0);
@@ -77,17 +112,27 @@ void main(){
         const gl = canvas.getContext("webgl", { antialias: false, alpha: false });
         if (!gl) return;
 
+        // A shader that fails to compile or link draws a silent black hero; surface why.
         const compile = (type: number, src: string) => {
             const s = gl.createShader(type)!;
             gl.shaderSource(s, src);
             gl.compileShader(s);
-            return s;
+            if (gl.getShaderParameter(s, gl.COMPILE_STATUS)) return s;
+            console.error(gl.getShaderInfoLog(s));
+            return null;
         };
 
+        const vert = compile(gl.VERTEX_SHADER, VERT);
+        const frag = compile(gl.FRAGMENT_SHADER, FRAG);
+        if (!vert || !frag) return;
         const prog = gl.createProgram()!;
-        gl.attachShader(prog, compile(gl.VERTEX_SHADER, VERT));
-        gl.attachShader(prog, compile(gl.FRAGMENT_SHADER, FRAG));
+        gl.attachShader(prog, vert);
+        gl.attachShader(prog, frag);
         gl.linkProgram(prog);
+        if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+            console.error(gl.getProgramInfoLog(prog));
+            return;
+        }
         gl.useProgram(prog);
 
         const buf = gl.createBuffer();
@@ -100,6 +145,9 @@ void main(){
         const uRes = gl.getUniformLocation(prog, "u_res");
         const uT = gl.getUniformLocation(prog, "u_t");
         const uI = gl.getUniformLocation(prog, "u_intensity");
+        const uRip = gl.getUniformLocation(prog, "u_rip[0]");
+        const uRipN = gl.getUniformLocation(prog, "u_ripN");
+        const ripBuf = new Float32Array(MAX_RIPPLES * 3);
 
         let raf: number;
         let running = true;
@@ -117,10 +165,15 @@ void main(){
 
         const tick = () => {
             if (!running) return;
-            const t = auroraTime() * speed;
+            const now = auroraTime();
             gl.uniform2f(uRes, canvas.width, canvas.height);
-            gl.uniform1f(uT, t);
+            gl.uniform1f(uT, now * speed);
             gl.uniform1f(uI, intensity);
+            if (ripples) {
+                // Ripple ages run on the unscaled clock so the pool's physics sees the same radius.
+                gl.uniform1i(uRipN, ripples.pack(now, ripBuf));
+                gl.uniform3fv(uRip, ripBuf);
+            }
             gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
             raf = requestAnimationFrame(tick);
         };

--- a/src/Web/packages/portal/src/lib/components/AuroraPool.svelte
+++ b/src/Web/packages/portal/src/lib/components/AuroraPool.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   interface Props {
     textBlock?: HTMLElement | null;
+    ripples?: RippleField | null;
   }
-  let { textBlock = null }: Props = $props();
+  let { textBlock = null, ripples = null }: Props = $props();
 
   import { auroraTime, sampleSurface } from "$lib/utils/aurora-noise";
+  import type { RippleField } from "$lib/utils/aurora-ripples";
 
   // ── Chip definitions ──────────────────────────────────────────────────────
   // hPos: left or right as % of container width. Preserved from the original
@@ -90,6 +92,7 @@
   const TILT_GAIN = 6000; // deg per (brightness/px) of x-slope
   const TILT_MAX = 14; // deg
   const TILT_K = 6; // 1/s²: spring toward the surface tilt
+  const RIPPLE_PUSH = 1800; // px/s² at a full-strength crest
   const LINEAR_DAMP = 0.03; // fraction of velocity lost per frame (not per second)
   const ANGULAR_DAMP = 0.07; // same for rotation
   const RESTITUTION = 0.2; // bounciness (0 = dead stop, 1 = perfectly elastic)
@@ -427,6 +430,12 @@
         // right lifts the right end, which is a negative CSS rotation (y is down).
         const tilt = Math.max(-TILT_MAX, Math.min(TILT_MAX, -s.slopeX * TILT_GAIN));
         c.rotV += (tilt - c.rot) * TILT_K * dt;
+
+        if (ripples) {
+          const shove = ripples.shove(c.cx, c.cy, cw, ch, t);
+          c.vx += shove.x * RIPPLE_PUSH * dt;
+          c.vy += shove.y * RIPPLE_PUSH * dt;
+        }
       }
       c.vx *= 1 - LINEAR_DAMP;
       c.vy *= 1 - LINEAR_DAMP;
@@ -462,6 +471,14 @@
       grabOffset = { x: pointer.x - cs[i].cx, y: pointer.y - cs[i].cy };
     }
     containerEl?.setPointerCapture(e.pointerId);
+  }
+
+  // Reached only for the background: chips stop propagation of their own pointerdown.
+  // Touch is excluded because a scroll flick through the hero starts with a pointerdown.
+  function onBackgroundPointerDown(e: PointerEvent) {
+    if (!ripples || !containerEl || !e.isPrimary || e.button !== 0 || e.pointerType === "touch") return;
+    const cr = containerEl.getBoundingClientRect();
+    ripples.spawn(e.clientX - cr.left, e.clientY - cr.top, cr.width, cr.height, auroraTime());
   }
 
   function onPointerMove(e: PointerEvent) {
@@ -504,6 +521,7 @@
   class="absolute inset-0 overflow-hidden"
   aria-hidden="true"
   bind:this={containerEl}
+  onpointerdown={onBackgroundPointerDown}
   onpointermove={onPointerMove}
   onpointerup={onPointerUp}
 >

--- a/src/Web/packages/portal/src/lib/utils/aurora-noise.ts
+++ b/src/Web/packages/portal/src/lib/utils/aurora-noise.ts
@@ -107,17 +107,24 @@ const D_TIME = 0.05; // seconds
 const FLOW_EPS = 1e-4; // regulariser: flow is undefined where the field is flat
 
 /**
- * Sample the drawn field at a container-pixel position. `cw`/`ch` are the
- * canvas's CSS size, which the shader normalises by height; the y-axis is
- * flipped because gl_FragCoord runs bottom-up while the DOM runs top-down.
+ * Container pixel to the shader's p-space: centred, normalised by height, y up.
+ * `cw`/`ch` are the canvas's CSS size. The y-axis flips because gl_FragCoord
+ * runs bottom-up while the DOM runs top-down.
  */
+export function toAuroraSpace(
+  cx: number, cy: number,
+  cw: number, ch: number,
+): { px: number; py: number } {
+  return { px: (cx - cw * 0.5) / ch, py: (ch * 0.5 - cy) / ch };
+}
+
+/** Sample the drawn field at a container-pixel position. */
 export function sampleSurface(
   cx: number, cy: number,
   cw: number, ch: number,
   t: number,
 ): SurfaceSample {
-  const px = (cx - cw * 0.5) / ch;
-  const py = (ch * 0.5 - cy) / ch;
+  const { px, py } = toAuroraSpace(cx, cy, cw, ch);
 
   const v0 = auroraBrightness(px, py, t);
   const dvdx = (auroraBrightness(px + D_SPACE, py, t) - v0) / D_SPACE;

--- a/src/Web/packages/portal/src/lib/utils/aurora-ripples.ts
+++ b/src/Web/packages/portal/src/lib/utils/aurora-ripples.ts
@@ -1,0 +1,98 @@
+import { toAuroraSpace } from "./aurora-noise";
+
+/** Uniform array size in the AuroraCanvas shader; the oldest ripple is dropped past this. */
+export const MAX_RIPPLES = 8;
+/** Seconds: a ring has faded to nothing by this age. */
+export const RIPPLE_LIFE = 2.6;
+/** p-units/s. p is height-normalised, so this is roughly 460 px/s on a 920 px hero. */
+export const RIPPLE_SPEED = 0.5;
+/** p-units: half-width of the crest. */
+export const RIPPLE_WIDTH = 0.06;
+
+interface Ripple {
+  /** Origin in the shader's p-space (centred, y up, normalised by height). */
+  x: number;
+  y: number;
+  /** auroraTime() at the drop, in seconds. */
+  born: number;
+}
+
+/**
+ * Strength of a ripple's crest at distance `d` (p-units) from its origin,
+ * `age` seconds after the drop: a gaussian ring at the wavefront that fades
+ * quadratically over the ripple's life. Mirrored by `crest()` in the shader.
+ */
+function rippleCrest(d: number, age: number): number {
+  if (age < 0 || age >= RIPPLE_LIFE) return 0;
+  const front = (d - age * RIPPLE_SPEED) / RIPPLE_WIDTH;
+  const fade = 1 - age / RIPPLE_LIFE;
+  return Math.exp(-front * front) * fade * fade;
+}
+
+/**
+ * The waves a click drops into the aurora. The canvas draws them and the chips
+ * are shoved by them from this one field, so the ring on screen and the push a
+ * chip feels are the same wave at the same radius.
+ */
+export class RippleField {
+  private ripples: Ripple[] = [];
+
+  /** Drop a ripple at a container-pixel position. `t` is auroraTime() now. */
+  spawn(cx: number, cy: number, cw: number, ch: number, t: number): void {
+    if (ch <= 0) return;
+    const { px, py } = toAuroraSpace(cx, cy, cw, ch);
+    this.ripples.push({ x: px, y: py, born: t });
+    if (this.ripples.length > MAX_RIPPLES) this.ripples.shift();
+  }
+
+  private live(t: number): readonly Ripple[] {
+    if (this.ripples.length && t - this.ripples[0].born >= RIPPLE_LIFE) {
+      this.ripples = this.ripples.filter((r) => t - r.born < RIPPLE_LIFE);
+    }
+    return this.ripples;
+  }
+
+  /**
+   * Fill `out` (length MAX_RIPPLES * 3) with [x, y, age] per live ripple for
+   * the shader's `u_rip` uniform. Returns the live count.
+   */
+  pack(t: number, out: Float32Array): number {
+    const live = this.live(t);
+    out.fill(0);
+    for (let i = 0; i < live.length; i++) {
+      out[i * 3] = live[i].x;
+      out[i * 3 + 1] = live[i].y;
+      out[i * 3 + 2] = t - live[i].born;
+    }
+    return live.length;
+  }
+
+  /**
+   * Outward shove on a floater at a container-pixel position: crest strength
+   * under the floater along the unit radial away from each live origin, summed
+   * and capped at unit length so stacked ripples cannot fling a chip. The
+   * caller scales it into an acceleration. Returned in DOM axes (y down).
+   */
+  shove(cx: number, cy: number, cw: number, ch: number, t: number): { x: number; y: number } {
+    const live = this.live(t);
+    let x = 0;
+    let y = 0;
+    if (live.length === 0) return { x, y };
+    const { px, py } = toAuroraSpace(cx, cy, cw, ch);
+    for (const r of live) {
+      const dx = px - r.x;
+      const dy = py - r.y;
+      const d = Math.hypot(dx, dy);
+      if (d < 1e-4) continue;
+      const c = rippleCrest(d, t - r.born) / d;
+      x += dx * c;
+      y -= dy * c; // p-space y is up; the DOM's is down
+    }
+    const mag = Math.hypot(x, y);
+    if (mag > 1) {
+      x /= mag;
+      y /= mag;
+    }
+    return { x, y };
+  }
+}

--- a/src/Web/packages/portal/src/routes/+page.svelte
+++ b/src/Web/packages/portal/src/routes/+page.svelte
@@ -8,8 +8,10 @@
     import { getCommunityData } from "$lib/data/portal";
     import { DATA_SOURCES, LIVE_CONNECTORS } from "$lib/data/connectors";
     import { AVAILABLE_REPORT_COUNT } from "$lib/data/reports";
+    import { RippleField } from "$lib/utils/aurora-ripples";
 
     let textBlockEl: HTMLElement | null = $state(null);
+    const ripples = new RippleField();
 
     let communityData = $state<Awaited<ReturnType<typeof getCommunityData>> | null>(null);
     getCommunityData()
@@ -32,9 +34,9 @@
 
 <!-- Hero -->
 <section class="relative w-full overflow-hidden -mt-16">
-    <AuroraCanvas height={920} />
+    <AuroraCanvas height={920} {ripples} />
     <div class="grain-bg absolute inset-0 pointer-events-none opacity-35 mix-blend-overlay" aria-hidden="true"></div>
-    <AuroraPool textBlock={textBlockEl} />
+    <AuroraPool textBlock={textBlockEl} {ripples} />
     <div class="absolute bottom-0 inset-x-0 h-[280px] pointer-events-none bg-gradient-to-b from-transparent to-background" aria-hidden="true"></div>
 
     <div class="absolute inset-0 pt-16 pointer-events-none">


### PR DESCRIPTION
## What

Clicking the aurora on the portal homepage drops a wave: a red ring expands from the click point across the shader, and the floating connector chips are pushed outward as the crest passes them.

## How

- `aurora-ripples.ts` holds a `RippleField`: the canvas draws from it and the chip pool reads forces from it, so the ring on screen and the shove a chip feels are the same wave at the same radius. `rippleCrest()` in TS mirrors `crest()` in the shader; both share the exported speed, width and lifetime constants (the shader is templated from them).
- `AuroraCanvas.svelte` gains a `u_rip` uniform array (up to 8 live ripples as `[x, y, age]` in the shader's p-space) and draws each as a red crest with a darker trough behind it. Ages run on the unscaled aurora clock, the same one the pool uses.
- `AuroraPool.svelte` spawns a ripple on a background `pointerdown` (chips already stop propagation of theirs) and adds a radial `RIPPLE_PUSH` acceleration per chip per frame. The summed shove is capped at unit length so stacked clicks cannot fling a chip.
- `toAuroraSpace()` is extracted from `sampleSurface()` so the DOM-to-shader mapping and its y-flip live in one place.
- Right-clicks and touch pointers are ignored: a context menu or a scroll flick through the hero must not leave a stray ring.
- Shader compile and link failures are now reported to the console instead of drawing a silent black hero.

## Verification

- `pnpm check` in `packages/portal`: 0 errors.
- `pnpm build` succeeds; served the static output and drove it with Playwright at 1440x900. Click at (1100, 520): red ring visible expanding from the point, chips on that side displaced outward by 100-180px over the following second and settling back into the tidal drift. No console output from the new shader diagnostics.
- The 6px aurora strip further down the page gets no `ripples` prop and is unchanged.

## Not covered

No automated test; the portal package has none and the behaviour is visual and physics-driven. Tuning (`RIPPLE_PUSH`, `RIPPLE_SPEED`, `RIPPLE_WIDTH`, `RIPPLE_LIFE`) is by eye.
