### PR TITLE
fix(mylife): a 0 U/h basal is a rate, not a suspension

### DIFF
--- a/src/Connectors/Nocturne.Connectors.MyLife/Mappers/Handlers/BasalAmountHandler.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Mappers/Handlers/BasalAmountHandler.cs
@@ -37,13 +37,10 @@ internal sealed class BasalAmountHandler : IMyLifeStateSpanHandler
         // overall basal delivery timeline.
         var estimatedRate = insulin;
 
-        // Origin is "Scheduled" for basal amount events - these come from the
-        // pump's programmed basal schedule, not from algorithm adjustments
+        // Basal amount events come from the pump's programmed schedule, not from algorithm
+        // adjustments. An hour that delivered 0 U is a zero rate, not a suspension - mylife reports
+        // suspension as its own PumpSuspend/PumpResume event pair.
         var origin = TempBasalOrigin.Scheduled;
-
-        // Check if rate is 0 (suspended)
-        if (estimatedRate <= 0)
-            origin = TempBasalOrigin.Suspended;
 
         var tempBasal = MyLifeStateSpanFactory.CreateTempBasal(ev, estimatedRate, origin);
         return [tempBasal];

--- a/src/Connectors/Nocturne.Connectors.MyLife/Mappers/Handlers/BasalRateHandler.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Mappers/Handlers/BasalRateHandler.cs
@@ -25,19 +25,12 @@ internal sealed class BasalRateHandler : IMyLifeStateSpanHandler
 
         var isTemp = MyLifeMapperHelpers.TryGetInfoBool(info, MyLifeJsonKeys.IsTempBasalRate);
 
-        // Determine origin based on the event context:
-        // - IsTempBasalRate = true means algorithm adjusted (CamAPS, Loop, etc.)
-        // - IsTempBasalRate = false means scheduled basal from pump profile
-        // - Rate = 0 indicates suspended delivery
-        TempBasalOrigin origin;
-        if (rate <= 0)
-            origin = TempBasalOrigin.Suspended;
-        else if (isTemp)
-            // IsTempBasalRate = true indicates algorithm adjustment (e.g., CamAPS)
-            origin = TempBasalOrigin.Algorithm;
-        else
-            // Regular basal rate from pump schedule
-            origin = TempBasalOrigin.Scheduled;
+        // IsTempBasalRate = true is an algorithm adjustment (CamAPS), otherwise the rate comes from
+        // the pump's programmed schedule. A zero rate is still a rate on either path: CamAPS commands
+        // 0 U/h whenever it wants to withhold basal, and a profile segment can be programmed at 0 U/h.
+        // Neither is a suspension - mylife reports that as its own PumpSuspend/PumpResume event pair,
+        // which DeviceEventHandler maps.
+        var origin = isTemp ? TempBasalOrigin.Algorithm : TempBasalOrigin.Scheduled;
 
         var tempBasal = MyLifeStateSpanFactory.CreateTempBasal(ev, rate, origin);
         return [tempBasal];

--- a/src/Connectors/Nocturne.Connectors.MyLife/Mappers/Handlers/TempBasalHandler.cs
+++ b/src/Connectors/Nocturne.Connectors.MyLife/Mappers/Handlers/TempBasalHandler.cs
@@ -32,36 +32,10 @@ internal sealed class TempBasalHandler : IMyLifeStateSpanHandler
         )
             rate = absoluteRate;
 
-        // TempBasal events (event ID 4) are user-initiated temporary basal programs.
-        // This is different from IsTempBasalRate which indicates algorithm adjustments.
-        // Origin is "Manual" for user-initiated temp basal programs.
-        TempBasalOrigin origin;
-        if (rate <= 0)
-        {
-            // Zero rate or percentage indicates suspended delivery
-            // (though percentage-based would be relative to scheduled rate)
-            if (
-                MyLifeMapperHelpers.TryGetInfoDouble(
-                    info,
-                    MyLifeJsonKeys.Percentage,
-                    out var percent
-                )
-                && percent <= 0
-            )
-                origin = TempBasalOrigin.Suspended;
-            else if (
-                rate <= 0
-                && !MyLifeMapperHelpers.TryGetInfoDouble(info, MyLifeJsonKeys.Percentage, out _)
-            )
-                origin = TempBasalOrigin.Suspended;
-            else
-                origin = TempBasalOrigin.Manual;
-        }
-        else
-        {
-            // User-initiated temporary basal rate
-            origin = TempBasalOrigin.Manual;
-        }
+        // TempBasal events (event ID 4) are user-initiated temporary basal programs, so the origin is
+        // Manual whatever the rate. A 0 U/h or 0 % program is still a temp basal the user set, not a
+        // suspension - mylife reports suspension as its own PumpSuspend/PumpResume event pair.
+        var origin = TempBasalOrigin.Manual;
 
         var tempBasal = MyLifeStateSpanFactory.CreateTempBasal(ev, rate, origin);
 

--- a/tests/Unit/Nocturne.Connectors.MyLife.Tests/Mappers/StateSpanMapperTests.cs
+++ b/tests/Unit/Nocturne.Connectors.MyLife.Tests/Mappers/StateSpanMapperTests.cs
@@ -111,23 +111,42 @@ public class StateSpanMapperTests
         record.Origin.Should().Be(TempBasalOrigin.Algorithm);
     }
 
-    [Fact]
-    public void MapTempBasals_ZeroRate_SetsOriginToSuspended()
+    [Theory]
+    [InlineData(false, TempBasalOrigin.Scheduled)]
+    [InlineData(true, TempBasalOrigin.Algorithm)]
+    public void MapTempBasals_ZeroRate_IsARateNotASuspension(bool isTempBasalRate, TempBasalOrigin expected)
     {
-        // Arrange
+        // A CamAPS 0 U/h decision (and a 0 U/h profile segment) used to surface as "Suspended";
+        // mylife reports real suspensions as PumpSuspend/PumpResume events instead.
         var eventTime = DateTime.UtcNow.AddHours(-1);
         var events = new[]
         {
-            CreateBasalRateEvent(ToMyLifeTicks(eventTime), 0)
+            CreateBasalRateEvent(ToMyLifeTicks(eventTime), 0, isTempBasalRate)
         };
 
-        // Act
         var tempBasals = MyLifeStateSpanMapper.MapTempBasals(events, false, 0).ToList();
 
-        // Assert
         tempBasals.Should().HaveCount(1);
         var record = tempBasals[0];
-        record.Origin.Should().Be(TempBasalOrigin.Suspended);
+        record.Rate.Should().Be(0);
+        record.Origin.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0.0, null)]
+    [InlineData(1.0, 0.0)]
+    public void MapTempBasals_ZeroTempBasalProgram_StaysManual(double rate, double? percent)
+    {
+        var eventTime = DateTime.UtcNow.AddHours(-1);
+        var events = new[]
+        {
+            CreateTempBasalEvent(ToMyLifeTicks(eventTime), rate, minutes: 30, percent: percent)
+        };
+
+        var tempBasals = MyLifeStateSpanMapper.MapTempBasals(events, false, 0).ToList();
+
+        tempBasals.Should().HaveCount(1);
+        tempBasals[0].Origin.Should().Be(TempBasalOrigin.Manual);
     }
 
     [Fact]
@@ -329,7 +348,7 @@ public class StateSpanMapperTests
     }
 
     [Fact]
-    public void MapTempBasals_ZeroBasalAmount_SetsOriginToSuspended()
+    public void MapTempBasals_ZeroBasalAmount_StaysScheduled()
     {
         // Arrange
         var eventTime = DateTime.UtcNow.AddHours(-1);
@@ -344,6 +363,7 @@ public class StateSpanMapperTests
         // Assert
         tempBasals.Should().HaveCount(1);
         var record = tempBasals[0];
-        record.Origin.Should().Be(TempBasalOrigin.Suspended);
+        record.Rate.Should().Be(0);
+        record.Origin.Should().Be(TempBasalOrigin.Scheduled);
     }
 }


### PR DESCRIPTION
## Problem

The mylife basal handlers mapped **any** `rate <= 0` to `TempBasalOrigin.Suspended`. So a CamAPS 0 U/h decision (the algorithm withholding basal in auto mode) and a 0 U/h programmed profile segment both surfaced as **"Suspended"** in the delivery-inspection dialog and basal track. A basal rate of zero is not a suspension.

mylife reports a *real* pump suspension as its own `PumpSuspend`/`PumpResume` event pair (event IDs 12/13, mapped by `DeviceEventHandler` → `PumpMode/Suspended` state span), so the zero-rate heuristic was both wrong and redundant.

## Fix

- `BasalRateHandler`: `IsTempBasalRate` → `Algorithm`, otherwise `Scheduled`, whatever the rate.
- `BasalAmountHandler`: always `Scheduled`.
- `TempBasalHandler`: always `Manual` (a user-set 0 U/h or 0% temp basal is still a temp basal the user set).

Tests updated: zero-rate cases now assert the rate is preserved and the origin is `Scheduled`/`Algorithm`/`Manual` rather than `Suspended`.

https://claude.ai/code/session_01RU92ganEnFNjGazm5PCthf