### PR TITLE
fix(glooko): read the real name and severity off the v3 pumpAlarm series

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSystemEventMapper.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Mappers/GlookoSystemEventMapper.cs
@@ -33,7 +33,16 @@ public class GlookoSystemEventMapper
             foreach (var alarm in series.PumpAlarm)
             {
                 var timestamp = _timeMapper.GetCorrectedGlookoTime(alarm.X);
-                var eventType = DetermineAlarmEventType(alarm.AlarmType, alarm.Data?.AlarmCode);
+
+                // Glooko populates the graph point's `name` (e.g. "Occlusion", "Low Battery") and
+                // `alarmSeverity`; the older `alarmType`/`data.alarmCode`/`label` fields are absent on
+                // this payload, so reading only those produced an Info "Unknown alarm" for every alarm
+                // and lost occlusion/battery hazards entirely. Prefer the real fields, keep the legacy
+                // ones as fallbacks, and fall back to the keyword heuristic only when severity is absent.
+                var name = alarm.Name ?? alarm.Label ?? alarm.AlarmType;
+                var eventType = !string.IsNullOrWhiteSpace(alarm.AlarmSeverity)
+                    ? MapAlarmSeverity(alarm.AlarmSeverity)
+                    : DetermineAlarmEventType(alarm.Name ?? alarm.AlarmType, alarm.Data?.AlarmCode);
 
                 events.Add(
                     new SystemEvent
@@ -41,17 +50,17 @@ public class GlookoSystemEventMapper
                         OriginalId = $"glooko_alarm_{alarm.X}",
                         EventType = eventType,
                         Category = SystemEventCategory.Pump,
-                        Code = alarm.Data?.AlarmCode ?? alarm.AlarmType,
+                        Code = name ?? alarm.Data?.AlarmCode,
                         Description =
-                            alarm.Data?.AlarmDescription
-                            ?? alarm.Label
-                            ?? alarm.AlarmType
+                            name
+                            ?? alarm.Data?.AlarmDescription
                             ?? "Unknown alarm",
                         Mills = new DateTimeOffset(timestamp).ToUnixTimeMilliseconds(),
                         Source = _connectorSource,
                         Metadata = new Dictionary<string, object>
                         {
-                            { "alarmType", alarm.AlarmType ?? "unknown" },
+                            { "severity", alarm.AlarmSeverity ?? "unknown" },
+                            { "alarmType", alarm.AlarmType ?? "" },
                             { "label", alarm.Label ?? "" }
                         }
                     }

--- a/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3Models.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Models/GlookoV3Models.cs
@@ -342,6 +342,20 @@ public class GlookoV3CarbDataPoint : GlookoV3DataPointBase
 /// </summary>
 public class GlookoV3AlarmDataPoint : GlookoV3DataPointBase
 {
+    /// <summary>
+    ///     Human-readable alarm name Glooko actually populates on the v3 <c>pumpAlarm</c> series
+    ///     (e.g. "Occlusion", "Low Battery"). This is the field that carries the alarm identity —
+    ///     <see cref="AlarmType"/> and <see cref="Data"/> are absent on the graph payload.
+    /// </summary>
+    [JsonPropertyName("name")] public string? Name { get; set; }
+
+    /// <summary>
+    ///     Severity Glooko reports alongside the alarm ("hazard"/"warning"/"info"). Drives the
+    ///     <see cref="Nocturne.Core.Models.SystemEventType"/> directly rather than through a
+    ///     keyword heuristic.
+    /// </summary>
+    [JsonPropertyName("alarmSeverity")] public string? AlarmSeverity { get; set; }
+
     [JsonPropertyName("label")] public string? Label { get; set; }
 
     [JsonPropertyName("alarmType")] public string? AlarmType { get; set; }

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoSystemEventMapperV3AlarmTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Mappers/GlookoSystemEventMapperV3AlarmTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Mappers;
+using Nocturne.Connectors.Glooko.Models;
+using Nocturne.Core.Models;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Mappers;
+
+/// <summary>
+/// Covers <see cref="GlookoSystemEventMapper.TransformV3ToSystemEvents"/> — the v3 graph
+/// <c>pumpAlarm</c> series → <see cref="SystemEvent"/>. Glooko populates the point's <c>name</c>
+/// and <c>alarmSeverity</c> (not the older <c>alarmType</c>/<c>data.alarmCode</c>/<c>label</c>
+/// fields), so an alarm must carry its real name and severity through rather than collapsing to an
+/// Info "Unknown alarm".
+/// </summary>
+[Trait("Category", "Unit")]
+public class GlookoSystemEventMapperV3AlarmTests
+{
+    private readonly GlookoSystemEventMapper _mapper;
+
+    public GlookoSystemEventMapperV3AlarmTests()
+    {
+        var logger = Mock.Of<ILogger>();
+        var timeMapper = new GlookoTimeMapper(new GlookoConnectorConfiguration(), logger);
+        _mapper = new GlookoSystemEventMapper("glooko-connector", timeMapper, logger);
+    }
+
+    private static GlookoV3GraphResponse Response(params GlookoV3AlarmDataPoint[] alarms) => new()
+    {
+        Series = new GlookoV3Series { PumpAlarm = alarms },
+    };
+
+    private static GlookoV3AlarmDataPoint Alarm(string? name, string? severity, long x = 1_783_982_636) => new()
+    {
+        X = x,
+        Name = name,
+        AlarmSeverity = severity,
+    };
+
+    [Fact]
+    public void Transform_CarriesNameAndSeverity_NotUnknownAlarm()
+    {
+        var events = _mapper.TransformV3ToSystemEvents(Response(Alarm("Occlusion", "hazard")));
+
+        events.Should().ContainSingle();
+        var e = events[0];
+        e.Code.Should().Be("Occlusion");
+        e.Description.Should().Be("Occlusion");
+        e.Category.Should().Be(SystemEventCategory.Pump);
+        e.EventType.Should().Be(SystemEventType.Hazard);
+        e.Source.Should().Be("glooko-connector");
+        e.Mills.Should().BeGreaterThan(0);
+        e.Metadata!["severity"].Should().Be("hazard");
+    }
+
+    [Theory]
+    [InlineData("hazard", SystemEventType.Hazard)]
+    [InlineData("warning", SystemEventType.Warning)]
+    [InlineData("info", SystemEventType.Info)]
+    [InlineData("critical", SystemEventType.Alarm)] // unknown severity string → most severe default
+    public void Transform_MapsSeverityToEventType(string severity, SystemEventType expected)
+    {
+        var events = _mapper.TransformV3ToSystemEvents(Response(Alarm("Low Battery", severity)));
+
+        events.Should().ContainSingle();
+        events[0].EventType.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Transform_WithoutSeverity_FallsBackToNameKeywordHeuristic()
+    {
+        // A payload missing alarmSeverity still classifies by the alarm name: an occlusion is an
+        // Alarm, a low battery a Warning.
+        var events = _mapper.TransformV3ToSystemEvents(Response(
+            Alarm("Occlusion", severity: null, x: 100),
+            Alarm("Low Battery", severity: null, x: 200)));
+
+        events.Should().HaveCount(2);
+        events.Single(e => e.Code == "Occlusion").EventType.Should().Be(SystemEventType.Alarm);
+        events.Single(e => e.Code == "Low Battery").EventType.Should().Be(SystemEventType.Warning);
+    }
+
+    [Fact]
+    public void Transform_FallsBackToLegacyFields_WhenNameAbsent()
+    {
+        // Older/other payload shapes that only carry data.alarmCode + alarmDescription still map.
+        var events = _mapper.TransformV3ToSystemEvents(Response(new GlookoV3AlarmDataPoint
+        {
+            X = 1_783_982_636,
+            Data = new GlookoV3AlarmData { AlarmCode = "occlusion", AlarmDescription = "Pump occluded" },
+        }));
+
+        events.Should().ContainSingle();
+        var e = events[0];
+        e.Code.Should().Be("occlusion");
+        e.Description.Should().Be("Pump occluded");
+        e.EventType.Should().Be(SystemEventType.Alarm);
+    }
+}


### PR DESCRIPTION
## Problem

Glooko's v3 `graph/data` `pumpAlarm` points carry `name` (e.g. "Occlusion", "Low Battery") and `alarmSeverity` ("hazard"/"warning"/…). The mapper read only `alarmType` / `data.alarmCode` / `label`, which are **absent** on this payload. Result: every pump alarm was stored as an `Info` event with code null and description "Unknown alarm", and occlusion/battery **hazards never surfaced as alarms** in the timeline.

Confirmed live against a real account: the series returns points shaped `{x, y, timestamp, name, alarmSeverity}` with names "Occlusion"/"Low Battery" at severity "hazard", and that tenant's stored `system_events` are 149 rows all reading `Info` / "Unknown alarm".

## Fix

- Add `name` and `alarmSeverity` to `GlookoV3AlarmDataPoint`.
- `TransformV3ToSystemEvents`: use `name` for the code and description, drive the event type from `alarmSeverity` (reusing the SSV2 path's `MapAlarmSeverity`), and fall back to the name-keyword heuristic only when severity is absent. Legacy `data.alarmCode` / `alarmDescription` payloads still map.

Added `GlookoSystemEventMapperV3AlarmTests`.

## Note

This corrects the *mapping*. A tenant whose Glooko sync is otherwise failing (e.g. the connector reporting "Missing Glooko user code") still won't receive new alarms until that sync recovers — that is a separate issue.

https://claude.ai/code/session_01RU92ganEnFNjGazm5PCthf