### PR TITLE
fix(state-spans): stop out-of-order supersession inverting and clobbering pump spans

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Repositories/StateSpanRepository.cs
@@ -226,11 +226,17 @@ public class StateSpanRepository : IStateSpanRepository
         // For exclusive categories, close any existing open spans when a new one is inserted
         if (isNew && ExclusiveCategories.Contains(entity.Category))
         {
+            // Supersession closes a PRIOR open span when a newer one starts (a missed resume/switch).
+            // "Prior" is by start time, not insert order: a span that starts AFTER this one is not
+            // superseded by it. Without this bound, a span inserted out of order (historical backfill
+            // of a pump that reports newest-first) closes a later-starting open span at its own
+            // earlier start — inverting it (end < start), and clearing a genuinely active suspension.
             var openSpansQuery = _context.StateSpans
                 .Where(s =>
                     s.Category == entity.Category
                     && s.EndTimestamp == null
-                    && s.Id != entity.Id);
+                    && s.Id != entity.Id
+                    && s.StartTimestamp <= entity.StartTimestamp);
 
             // PumpMode mixes independent dimensions — Automatic/Manual loop mode vs Suspended
             // delivery — which can legitimately overlap, so only the SAME state is mutually exclusive

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/StateSpanRepositoryTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Repositories/StateSpanRepositoryTests.cs
@@ -113,6 +113,44 @@ public class StateSpanRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task UpsertStateSpanAsync_OlderStartingSpan_DoesNotSupersedeALaterOpenSpan()
+    {
+        // Historical backfill can insert a span that starts BEFORE an already-open one (a pump that
+        // reports newest-first, ingested out of order). Superseding the later span would close it at
+        // the earlier span's start — inverting it (end < start) and clearing a live suspension.
+        var laterStart = new DateTime(2026, 1, 1, 11, 0, 0, DateTimeKind.Utc);
+        var laterOpen = new StateSpan
+        {
+            Category = StateSpanCategory.PumpMode,
+            State = PumpModeState.Suspended.ToString(),
+            StartTimestamp = laterStart,
+            EndTimestamp = null,
+            Source = "Trio",
+            OriginalId = "pump-suspended:later",
+        };
+        await _repository.UpsertStateSpanAsync(laterOpen);
+
+        // A backfilled suspension that STARTS EARLIER arrives afterwards.
+        var earlier = new StateSpan
+        {
+            Category = StateSpanCategory.PumpMode,
+            State = PumpModeState.Suspended.ToString(),
+            StartTimestamp = new DateTime(2026, 1, 1, 10, 0, 0, DateTimeKind.Utc),
+            EndTimestamp = new DateTime(2026, 1, 1, 10, 30, 0, DateTimeKind.Utc),
+            Source = "Trio",
+            OriginalId = "pump-suspended:earlier",
+        };
+        await _repository.UpsertStateSpanAsync(earlier);
+
+        var spans = (await _repository.GetStateSpansAsync(category: StateSpanCategory.PumpMode)).ToList();
+
+        var later = spans.First(s => s.OriginalId == "pump-suspended:later");
+        later.EndTimestamp.Should().BeNull("a span that starts after the inserted one must not be superseded");
+        later.SupersededById.Should().BeNullOrEmpty();
+        later.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task UpsertStateSpanAsync_PumpModeAutomatic_DoesNotSupersedeOpenSuspended()
     {
         // Suspended (LGS) and Automatic/Manual loop mode are independent dimensions that can overlap,


### PR DESCRIPTION
## Problem

A real tenant's dashboard showed the pump "Suspended" when it was not, and the tenant had `PumpMode/Suspended` state spans with `end_timestamp < start_timestamp` (inverted). Root cause is in exclusive-category supersession.

`StateSpanRepository.UpsertStateSpanAsync` closes a prior open span when a newer one of an exclusive category (`PumpMode` same-state, or `Override`/`TemporaryTarget`/`Profile`) is inserted — a safety net for a missed resume/mode-switch. It matched open spans by category (and state, for PumpMode) only. So a span **inserted out of order** — a historical device-status backfill of a pump that reports newest-first (Nightscout/Trio crawl) — closed an open span that *starts after it*, setting that span's `end` to the new span's earlier `start`. That both **inverts** spans and **clears a genuinely active suspension** mid-backfill (dashboard flips Suspended → running).

## Fix

Bound supersession to open spans that start at or before the new span:

```
&& s.StartTimestamp <= entity.StartTimestamp
```

That is what "a newer span supersedes the prior one" already meant; closing a later-starting span was only ever reachable via out-of-order inserts. Applies to all exclusive categories.

Added a mutation-proven repository test (`UpsertStateSpanAsync_OlderStartingSpan_DoesNotSupersedeALaterOpenSpan`) against the real `StateSpanRepository`; the existing supersession tests still pass.

## Scope / follow-up

This stops the **inversions** and the **live-suspension clobbering**. It does **not** by itself resolve the separate **open-orphan latch**, where a newest-first backfill leaves the earliest suspend permanently open because the decomposer's prior-snapshot transition heuristic reads every out-of-order suspend as a fresh false→true transition. Fixing that cleanly needs order-independent span reconciliation (the naive forward-look was reviewed and rejected — it mishandles multi-snapshot suspensions and `Suspended == null`), and is best done as its own change. In-order live feeds (direct Trio) do not hit the latch; already-latched rows are cleared by a one-off data repair.

This change was scoped down after a hostile review of an earlier, broader attempt; it implements that review's recommended repository-level guard.

https://claude.ai/code/session_01RU92ganEnFNjGazm5PCthf