### PR TITLE
fix(glooko): fail a v3 sign-in that resolves no account code

### DIFF
--- a/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoAuthTokenProvider.cs
+++ b/src/Connectors/Nocturne.Connectors.Glooko/Services/GlookoAuthTokenProvider.cs
@@ -169,13 +169,13 @@ public class GlookoAuthTokenProvider(
             return (null, null, false);
         }
 
-        // V3 sign-in doesn't return user data — fetch it from /api/v3/session/users
+        // V3 sign-in doesn't return user data — fetch it from /api/v3/session/users.
         if (config.UseV3Api)
         {
             try
             {
                 var v3User = await FetchV3UserDataAsync(baseUrl, webOrigin, sessionCookie, cancellationToken);
-                if (v3User != null)
+                if (v3User != null && !string.IsNullOrEmpty(v3User.GlookoCode))
                 {
                     userData = new GlookoUserData { User = new GlookoUserLogin { GlookoCode = v3User.GlookoCode } };
                     _logger.LogInformation(
@@ -184,13 +184,21 @@ public class GlookoAuthTokenProvider(
                 }
                 else
                 {
-                    _logger.LogWarning("V3 sign-in succeeded but failed to fetch user profile");
+                    _logger.LogWarning("V3 sign-in succeeded but the user profile carried no Glooko code");
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to fetch V3 user profile after sign-in");
             }
+
+            // The Glooko code is what every patient-scoped data URL is built from, so a session
+            // without it is unusable. Caching it as a success silently poisons the token cache: the
+            // cookie stays "valid" for its whole lifetime, so the sync never re-authenticates and
+            // logs "Missing Glooko user code" every cycle instead. Fail the sign-in as retryable so a
+            // transient profile-fetch hiccup is retried and never cached without the code.
+            if (string.IsNullOrEmpty(userData?.GlookoCode))
+                return (null, null, true);
         }
 
         var metadata = new Dictionary<string, string> { ["SessionCookie"] = sessionCookie };

--- a/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoAuthTokenProviderV3CodeTests.cs
+++ b/tests/Unit/Nocturne.Connectors.Glooko.Tests/Services/GlookoAuthTokenProviderV3CodeTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Nocturne.Connectors.Core.Interfaces;
+using Nocturne.Connectors.Core.Services;
+using Nocturne.Connectors.Glooko.Configurations;
+using Nocturne.Connectors.Glooko.Services;
+using Nocturne.Core.Contracts.Multitenancy;
+using Xunit;
+
+namespace Nocturne.Connectors.Glooko.Tests.Services;
+
+/// <summary>
+/// A V3 sign-in succeeds (cookie) but the account code comes from a follow-up
+/// <c>/api/v3/session/users</c> call. Every patient-scoped data URL is built from that code, so a
+/// session without it is unusable — caching it as a success poisons the token cache (the cookie
+/// stays valid, so the sync never re-authenticates and logs "Missing Glooko user code" forever).
+/// The sign-in must therefore fail, and retry, when the code cannot be resolved.
+/// </summary>
+public class GlookoAuthTokenProviderV3CodeTests
+{
+    [Fact]
+    public async Task GetValidTokenAsync_V3ProfileHasNoCode_FailsAndRetries()
+    {
+        var handler = new V3Handler(NoCodeProfile, NoCodeProfile);
+
+        var token = await AuthenticateAsync(handler, maxRetryAttempts: 2);
+
+        token.Should().BeNull("a session with no Glooko code is unusable and must not be cached");
+        handler.SignInCount.Should().Be(2, "the whole attempt budget is spent re-authenticating");
+        handler.ProfileCount.Should().Be(2, "each attempt re-fetches the profile");
+    }
+
+    [Fact]
+    public async Task GetValidTokenAsync_V3ProfileCodeArrivesOnRetry_Recovers()
+    {
+        // First profile fetch yields no code (transient), the second carries it.
+        var handler = new V3Handler(NoCodeProfile, CodeProfile);
+
+        var token = await AuthenticateAsync(handler, maxRetryAttempts: 3);
+
+        token.Should().Be($"{GlookoConstants.SessionCookieName}=session-abc");
+        handler.SignInCount.Should().Be(2, "it re-authenticated once after the code-less profile");
+    }
+
+    private static async Task<string?> AuthenticateAsync(V3Handler handler, int maxRetryAttempts)
+    {
+        using var httpClient = new HttpClient(handler);
+
+        var tenantAccessor = new Mock<ITenantAccessor>();
+        tenantAccessor.Setup(t => t.IsResolved).Returns(true);
+        tenantAccessor.Setup(t => t.TenantId).Returns(Guid.NewGuid());
+
+        var retryDelay = new Mock<IRetryDelayStrategy>();
+        retryDelay.Setup(r => r.ApplyRetryDelayAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
+
+        var provider = new GlookoAuthTokenProvider(
+            httpClient,
+            new ConnectorTokenCache(),
+            new ConnectorServerResolver<GlookoConnectorConfiguration>(null, null, null),
+            tenantAccessor.Object,
+            NullLogger<GlookoAuthTokenProvider>.Instance,
+            retryDelay.Object);
+
+        var config = new GlookoConnectorConfiguration
+        {
+            Email = "someone@example.com",
+            Password = "hunter2",
+            UseV3Api = true,
+            MaxRetryAttempts = maxRetryAttempts,
+        };
+
+        return await provider.GetValidTokenAsync(config, CancellationToken.None);
+    }
+
+    private static HttpResponseMessage SignInCookie()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"success\":true,\"two_fa_required\":false}"),
+        };
+        response.Headers.TryAddWithoutValidation(
+            "Set-Cookie", $"{GlookoConstants.SessionCookieName}=session-abc; Path=/; HttpOnly");
+        return response;
+    }
+
+    private static HttpResponseMessage CodeProfile() => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent("{\"currentUser\":{\"glookoCode\":\"blue-duke-4165\",\"meterUnits\":\"mgdl\"}}"),
+    };
+
+    private static HttpResponseMessage NoCodeProfile() => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent("{\"currentUser\":{\"meterUnits\":\"mgdl\"}}"),
+    };
+
+    /// <summary>
+    /// Routes sign-in requests to a fresh cookie response and <c>session/users</c> requests to the
+    /// next profile factory (repeating the last), counting each. Factories, not instances, because an
+    /// <see cref="HttpResponseMessage"/> body can only be read once.
+    /// </summary>
+    private sealed class V3Handler(params Func<HttpResponseMessage>[] profiles) : HttpMessageHandler
+    {
+        public int SignInCount;
+        public int ProfileCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path.Contains("sign_in", StringComparison.OrdinalIgnoreCase))
+            {
+                SignInCount++;
+                return Task.FromResult(SignInCookie());
+            }
+
+            var index = Math.Min(ProfileCount, profiles.Length - 1);
+            ProfileCount++;
+            return Task.FromResult(profiles[index]());
+        }
+    }
+}


### PR DESCRIPTION
## Problem

A Glooko **v3** sign-in returns only a session cookie. The account code (`glookoCode`) that every patient-scoped data URL is built from comes from a separate follow-up `GET /api/v3/session/users`. `SignInAsync` always returned the cookie as a success even when that follow-up failed to yield a code — so the token cache stored a **code-less session**.

Because the cached cookie stays valid for its whole lifetime, the sync never re-authenticated to resolve the code. It just logged **"Missing Glooko user code, cannot fetch data"** every cycle and failed the chunk. Live prod evidence: six tenants stuck this way simultaneously, while the same credentials/region authenticate cleanly when run directly.

## Fix

For the v3 path, treat a sign-in that cannot resolve a non-empty `glookoCode` as a **retryable** failure (`return (null, null, true)`), instead of caching a half-good session. A transient profile-fetch hiccup is then retried within the login budget, and a persistent failure surfaces rather than poisoning the cache — so the next sync re-authenticates cleanly.

Also require the code to be non-empty (not just a non-null user object).

## Tests

`GlookoAuthTokenProviderV3CodeTests`:
- a code-less profile fails and re-authenticates across the retry budget;
- a code that arrives on the second attempt recovers.

## Note

This fixes the recurrence. Tenants currently holding a poisoned in-memory cache entry recover on the next API restart (which this deploy performs), after which the new logic keeps a code-less session from being cached again.

https://claude.ai/code/session_01RU92ganEnFNjGazm5PCthf