### PR TITLE
fix(clock): colour faces through CSS variables and the app's glucose thresholds

### DIFF
--- a/src/Web/packages/app/src/lib/clock-builder/factories.test.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/factories.test.ts
@@ -11,12 +11,4 @@ describe("createDefaultConfig", () => {
     expect(DEFAULT_SETTINGS.staleMinutes).toBe(original);
     expect(createDefaultConfig().settings?.staleMinutes).toBe(original);
   });
-
-  it("gives every call its own element styles", () => {
-    const first = createDefaultConfig().rows?.[0]?.elements?.[0]?.style;
-    const second = createDefaultConfig().rows?.[0]?.elements?.[0]?.style;
-
-    expect(first).toEqual(second);
-    expect(first).not.toBe(second);
-  });
 });

--- a/src/Web/packages/app/src/lib/clock-builder/factories.test.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/factories.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_SETTINGS } from "./types";
+import { createDefaultConfig } from "./factories";
+
+describe("createDefaultConfig", () => {
+  it("hands out a copy of the default settings, not the module's own", () => {
+    const original = DEFAULT_SETTINGS.staleMinutes;
+    const settings = createDefaultConfig().settings;
+    settings!.staleMinutes = (original ?? 0) + 5;
+
+    expect(DEFAULT_SETTINGS.staleMinutes).toBe(original);
+    expect(createDefaultConfig().settings?.staleMinutes).toBe(original);
+  });
+
+  it("gives every call its own element styles", () => {
+    const first = createDefaultConfig().rows?.[0]?.elements?.[0]?.style;
+    const second = createDefaultConfig().rows?.[0]?.elements?.[0]?.style;
+
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+  });
+});

--- a/src/Web/packages/app/src/lib/clock-builder/factories.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/factories.ts
@@ -127,7 +127,7 @@ export function createDefaultConfig(): ClockFaceConfig {
         ],
       },
     ],
-    settings: DEFAULT_SETTINGS,
+    settings: { ...DEFAULT_SETTINGS },
   };
 }
 

--- a/src/Web/packages/app/src/lib/clock-builder/utils.test.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/utils.test.ts
@@ -14,10 +14,10 @@ const dynamic = (): ClockElement => ({
 
 describe("getBgColor", () => {
   it.each([
-    [69, "var(--glucose-very-low)"],
-    [70, "var(--glucose-low)"],
-    [79, "var(--glucose-low)"],
-    [80, "var(--glucose-in-range)"],
+    [53, "var(--glucose-very-low)"],
+    [54, "var(--glucose-low)"],
+    [69, "var(--glucose-low)"],
+    [70, "var(--glucose-in-range)"],
     [180, "var(--glucose-in-range)"],
     [181, "var(--glucose-high)"],
     [250, "var(--glucose-high)"],
@@ -45,7 +45,7 @@ describe("getElementColor", () => {
   });
 
   it("paints a dynamic element in the reading's band colour", () => {
-    expect(getElementColor(dynamic(), 55)).toBe("var(--glucose-very-low)");
+    expect(getElementColor(dynamic(), 40)).toBe("var(--glucose-very-low)");
     expect(getElementColor(dynamic(), 120)).toBe("var(--glucose-in-range)");
   });
 
@@ -78,8 +78,6 @@ describe("buildStyleString", () => {
   });
 
   it("sizes an element that carries no size off its type's default", () => {
-    // sg's ELEMENT_INFO default is 40; the API models size as optional, so a
-    // face saved without one must not fall back to a single global size.
     expect(buildStyleString({ type: "sg" }, null, 1)).toContain(
       "font-size: 40px"
     );
@@ -106,7 +104,7 @@ describe("clockBackgroundStyle", () => {
 
   it("colours the face by a real reading", () => {
     expect(clockBackgroundStyle(settings, 55, "#0a0a0a")).toBe(
-      "background-color: var(--glucose-very-low);"
+      "background-color: var(--glucose-low);"
     );
   });
 

--- a/src/Web/packages/app/src/lib/clock-builder/utils.test.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/utils.test.ts
@@ -1,10 +1,25 @@
 import { describe, it, expect } from "vitest";
 import type { ClockElement } from "$lib/api";
-import { clockBackgroundStyle, getElementColor } from "./utils";
+import { clockBackgroundStyle, getBgColor, getElementColor } from "./utils";
 
 const dynamic = (): ClockElement => ({
   type: "sg",
   style: { color: "dynamic" },
+});
+
+describe("getBgColor", () => {
+  it.each([
+    [69, "var(--glucose-very-low)"],
+    [70, "var(--glucose-low)"],
+    [79, "var(--glucose-low)"],
+    [80, "var(--glucose-in-range)"],
+    [180, "var(--glucose-in-range)"],
+    [181, "var(--glucose-high)"],
+    [250, "var(--glucose-high)"],
+    [251, "var(--glucose-very-high)"],
+  ])("gives %i the band colour as a CSS variable", (bg, expected) => {
+    expect(getBgColor(bg)).toBe(expected);
+  });
 });
 
 describe("getElementColor", () => {
@@ -22,6 +37,11 @@ describe("getElementColor", () => {
     const muted: ClockElement = { type: "delta", style: { color: "muted" } };
     expect(getElementColor(muted, null)).toBe("var(--muted-foreground)");
     expect(getElementColor(muted, 55)).toBe("var(--muted-foreground)");
+  });
+
+  it("paints a dynamic element in the reading's band colour", () => {
+    expect(getElementColor(dynamic(), 55)).toBe("var(--glucose-very-low)");
+    expect(getElementColor(dynamic(), 120)).toBe("var(--glucose-in-range)");
   });
 
   it("takes the default rather than emitting an unknown token as CSS", () => {
@@ -55,8 +75,8 @@ describe("clockBackgroundStyle", () => {
   });
 
   it("colours the face by a real reading", () => {
-    expect(clockBackgroundStyle(settings, 55, "#0a0a0a")).not.toBe(
-      "background-color: #0a0a0a;"
+    expect(clockBackgroundStyle(settings, 55, "#0a0a0a")).toBe(
+      "background-color: var(--glucose-very-low);"
     );
   });
 

--- a/src/Web/packages/app/src/lib/clock-builder/utils.test.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import type { ClockElement } from "$lib/api";
-import { clockBackgroundStyle, getBgColor, getElementColor } from "./utils";
+import {
+  buildStyleString,
+  clockBackgroundStyle,
+  getBgColor,
+  getElementColor,
+} from "./utils";
 
 const dynamic = (): ClockElement => ({
   type: "sg",
@@ -62,6 +67,31 @@ describe("getElementColor", () => {
       const element: ClockElement = { type: "sg", style: { color: css } };
       expect(getElementColor(element, null)).toBe("#ffffff");
     }
+  });
+});
+
+describe("buildStyleString", () => {
+  it("scales the font size the caller renders at", () => {
+    const element: ClockElement = { type: "sg", size: 20 };
+    expect(buildStyleString(element, null, 2)).toContain("font-size: 40px");
+    expect(buildStyleString(element, null, 0.8)).toContain("font-size: 16px");
+  });
+
+  it("sizes an element that carries no size off its type's default", () => {
+    // sg's ELEMENT_INFO default is 40; the API models size as optional, so a
+    // face saved without one must not fall back to a single global size.
+    expect(buildStyleString({ type: "sg" }, null, 1)).toContain(
+      "font-size: 40px"
+    );
+    expect(buildStyleString({ type: "age" }, null, 1)).toContain(
+      "font-size: 10px"
+    );
+  });
+
+  it("sizes an element of an unknown type off the global default", () => {
+    expect(buildStyleString({ type: "wormhole" }, null, 1)).toContain(
+      "font-size: 20px"
+    );
   });
 });
 

--- a/src/Web/packages/app/src/lib/clock-builder/utils.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/utils.ts
@@ -11,6 +11,8 @@ import {
   elementInfo,
   type InternalElement,
 } from "./types";
+import { getGlucoseColor } from "$lib/utils/chart-colors";
+import { FALLBACK_GLUCOSE_THRESHOLDS } from "$lib/constants/glucose-thresholds";
 
 export const DEFAULT_ELEMENT_COLOR = "#ffffff";
 
@@ -23,16 +25,19 @@ const NAMED_ELEMENT_COLORS = new Map([["muted", "var(--muted-foreground)"]]);
 const HEX_COLOR = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 
 /**
- * Colour of the glucose band a reading falls in, as an unresolved CSS variable
- * reference: resolving it would freeze the theme and leave SSR, which has no
- * computed style to read, with no colour at all.
+ * Colour of the glucose band a reading falls in. The clock has no access to the
+ * tenant's own cut-points, so it takes the app-wide fallbacks. The result is an
+ * unresolved `var()`: every theme redefines the `--glucose-*` palette, and a
+ * value resolved here would hold the colours of whichever theme was active when
+ * the reading last changed.
  */
 export function getBgColor(bg: number): string {
-  if (bg < 70) return "var(--glucose-very-low)";
-  if (bg < 80) return "var(--glucose-low)";
-  if (bg > 250) return "var(--glucose-very-high)";
-  if (bg > 180) return "var(--glucose-high)";
-  return "var(--glucose-in-range)";
+  return getGlucoseColor(bg, FALLBACK_GLUCOSE_THRESHOLDS);
+}
+
+/** Font size an element renders at before the caller's scale. */
+export function elementSize(element: ClockElement): number {
+  return element.size || elementInfo(element.type)?.defaultSize || 20;
 }
 
 /**
@@ -146,8 +151,7 @@ export function buildCustomCssString(element: ClockElement): string {
 
 /**
  * Build inline style string from element.style (including custom properties).
- * `scale` multiplies the font size: the face is rendered at whatever size its
- * container allows, the builder preview at a fixed fraction of the real thing.
+ * The builder preview passes a smaller `scale` than the face it previews.
  */
 export function buildStyleString(
   element: ClockElement,
@@ -157,8 +161,7 @@ export function buildStyleString(
   const style = element.style;
   const parts: string[] = [];
 
-  const size = element.size || elementInfo(element.type)?.defaultSize || 20;
-  parts.push(`font-size: ${size * scale}px`);
+  parts.push(`font-size: ${elementSize(element) * scale}px`);
   parts.push(`color: ${getElementColor(element, currentBG)}`);
   parts.push(`opacity: ${style?.opacity ?? 1.0}`);
 

--- a/src/Web/packages/app/src/lib/clock-builder/utils.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/utils.ts
@@ -11,15 +11,6 @@ import {
   elementInfo,
   type InternalElement,
 } from "./types";
-import { browser } from "$app/environment";
-
-/**
- * Resolve CSS variable to its computed value
- */
-function resolveCssVar(name: string): string {
-  if (!browser) return "#000000"; // fallback for SSR
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-}
 
 export const DEFAULT_ELEMENT_COLOR = "#ffffff";
 
@@ -32,14 +23,16 @@ const NAMED_ELEMENT_COLORS = new Map([["muted", "var(--muted-foreground)"]]);
 const HEX_COLOR = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 
 /**
- * Get BG color based on glucose value
+ * Colour of the glucose band a reading falls in, as an unresolved CSS variable
+ * reference: resolving it would freeze the theme and leave SSR, which has no
+ * computed style to read, with no colour at all.
  */
 export function getBgColor(bg: number): string {
-  if (bg < 70) return resolveCssVar("--glucose-very-low");
-  if (bg < 80) return resolveCssVar("--glucose-low");
-  if (bg > 250) return resolveCssVar("--glucose-very-high");
-  if (bg > 180) return resolveCssVar("--glucose-high");
-  return resolveCssVar("--glucose-in-range");
+  if (bg < 70) return "var(--glucose-very-low)";
+  if (bg < 80) return "var(--glucose-low)";
+  if (bg > 250) return "var(--glucose-very-high)";
+  if (bg > 180) return "var(--glucose-high)";
+  return "var(--glucose-in-range)";
 }
 
 /**

--- a/src/Web/packages/app/src/lib/clock-builder/utils.ts
+++ b/src/Web/packages/app/src/lib/clock-builder/utils.ts
@@ -145,26 +145,23 @@ export function buildCustomCssString(element: ClockElement): string {
 }
 
 /**
- * Build inline style string from element.style (including custom properties)
+ * Build inline style string from element.style (including custom properties).
+ * `scale` multiplies the font size: the face is rendered at whatever size its
+ * container allows, the builder preview at a fixed fraction of the real thing.
  */
 export function buildStyleString(
   element: ClockElement,
-  currentBG: number | null
+  currentBG: number | null,
+  scale: number
 ): string {
   const style = element.style;
   const parts: string[] = [];
 
-  // Font size from element.size
   const size = element.size || elementInfo(element.type)?.defaultSize || 20;
-  parts.push(`font-size: ${size * 0.8}px`);
-
-  // Color
+  parts.push(`font-size: ${size * scale}px`);
   parts.push(`color: ${getElementColor(element, currentBG)}`);
-
-  // Opacity
   parts.push(`opacity: ${style?.opacity ?? 1.0}`);
 
-  // Add any custom CSS properties
   const customCss = buildCustomCssString(element);
   if (customCss) {
     parts.push(customCss);

--- a/src/Web/packages/app/src/lib/components/clock-builder/ClockElementPreview.svelte
+++ b/src/Web/packages/app/src/lib/components/clock-builder/ClockElementPreview.svelte
@@ -69,7 +69,7 @@
     class="leading-none tabular-nums {getFontClass(
       element.style?.font
     )} {getFontWeightClass(element.style?.fontWeight)}"
-    style={buildStyleString(element, glucose.currentBG)}
+    style={buildStyleString(element, glucose.currentBG, 0.8)}
   >
     {value}
   </span>
@@ -78,7 +78,7 @@
        inventing a value; an empty span could not be selected or removed. -->
   <span
     class="leading-none italic opacity-60"
-    style={buildStyleString(element, glucose.currentBG)}
+    style={buildStyleString(element, glucose.currentBG, 0.8)}
   >
     {elementInfo(element.type)?.name ?? element.type}
   </span>

--- a/src/Web/packages/app/src/lib/components/clock-builder/ClockElementPreview.svelte
+++ b/src/Web/packages/app/src/lib/components/clock-builder/ClockElementPreview.svelte
@@ -5,8 +5,8 @@
   import type { ClockGlucoseSource } from "$lib/stores/realtime-store.svelte";
   import { renderClockElementValue } from "$lib/components/clock/element-value";
   import {
-    ELEMENT_INFO,
     elementInfo,
+    elementSize,
     type InternalElement,
     buildCustomCssString,
     getElementColor,
@@ -31,7 +31,7 @@
 </script>
 
 {#if element.type === "arrow"}
-  {@const size = (element.size || ELEMENT_INFO.arrow.defaultSize) * 0.8}
+  {@const size = elementSize(element) * 0.8}
   <div
     class="flex items-center"
     style="color: {getElementColor(element, glucose.currentBG)}; opacity: {element
@@ -41,7 +41,7 @@
   </div>
 {:else if element.type === "tracker"}
   {@const def = getTrackerDefinition(element.definitionId, trackerDefinitions)}
-  {@const size = element.size || ELEMENT_INFO.tracker.defaultSize}
+  {@const size = elementSize(element)}
   {@const showOptions = element.show ?? ["name"]}
   <div
     class="flex items-center gap-1 {getFontClass(

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
@@ -3,6 +3,7 @@
   import { getClockGlucoseSource } from "$lib/stores/realtime-store.svelte";
   import {
     buildCustomCssString,
+    buildStyleString,
     clockBackgroundStyle,
     getElementColor,
     getFontClass,
@@ -23,11 +24,7 @@
   import TrackerMarkers from "$lib/components/dashboard/glucose-chart/markers/TrackerMarkers.svelte";
   import ChartTooltip from "$lib/components/dashboard/glucose-chart/ChartTooltip.svelte";
   import TrackerCategoryIcon from "$lib/components/icons/TrackerCategoryIcon.svelte";
-  import type {
-    ClockFaceConfig,
-    ClockElement,
-    TrackerDefinitionDto,
-  } from "$lib/api";
+  import type { ClockFaceConfig, TrackerDefinitionDto } from "$lib/api";
   import { getDefinitions } from "$api/generated/trackers.generated.remote";
   import {
     advance,
@@ -97,21 +94,6 @@
   const trackerDefinitions = $derived<TrackerDefinitionDto[]>(
     definitionsQuery?.current ?? [],
   );
-
-  // Sized off `scale`, so it cannot share the builder's own style builder.
-  function buildStyleString(element: ClockElement): string {
-    const style = element.style;
-    const parts: string[] = [];
-    const size = (element.size || 20) * scale;
-    parts.push(`font-size: ${size}px`);
-    parts.push(`color: ${getElementColor(element, currentBG)}`);
-    parts.push(`opacity: ${style?.opacity ?? 1.0}`);
-    const customCss = buildCustomCssString(element);
-    if (customCss) {
-      parts.push(customCss);
-    }
-    return parts.join("; ");
-  }
 
   // Background chart element
   const backgroundChart = $derived.by(() => {
@@ -434,7 +416,7 @@
             {:else if element.type !== "chart"}
               <span
                 class="leading-none tabular-nums {getFontClass(element.style?.font)} {getFontWeightClass(element.style?.fontWeight)} {isStale && element.type === 'sg' ? 'line-through opacity-60' : ''}"
-                style={buildStyleString(element)}
+                style={buildStyleString(element, currentBG, scale)}
               >
                 {renderClockElementValue(element, glucose, currentTime)}
               </span>

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte
@@ -5,6 +5,7 @@
     buildCustomCssString,
     buildStyleString,
     clockBackgroundStyle,
+    elementSize,
     getElementColor,
     getFontClass,
     getFontWeightClass,
@@ -385,7 +386,7 @@
                 </div>
               {/if}
             {:else if element.type === "arrow"}
-              {@const size = (element.size || 25) * scale}
+              {@const size = elementSize(element) * scale}
               {@const customCss = buildCustomCssString(element)}
               <div
                 class="flex items-center"
@@ -395,7 +396,7 @@
               </div>
             {:else if element.type === "tracker"}
               {@const def = getTrackerDefinition(element.definitionId, trackerDefinitions)}
-              {@const size = (element.size || 14) * scale}
+              {@const size = elementSize(element) * scale}
               {@const showOptions = element.show ?? ["name"]}
               {@const customCss = buildCustomCssString(element)}
               <div

--- a/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte.test.ts
+++ b/src/Web/packages/app/src/lib/components/clock/ClockFaceRenderer.svelte.test.ts
@@ -94,10 +94,10 @@ describe("ClockFaceRenderer", () => {
 
   it("does not paint the whole face with a colour nothing reported", () => {
     const glucoseColored = { ...config, settings: { bgColor: true } };
-    const veryLow = cssColor("--glucose-very-low");
+    const low = cssColor("--glucose-low");
 
-    expect(face(reading, glucoseColored).background).toBe(veryLow);
-    expect(face(noReading, glucoseColored).background).not.toBe(veryLow);
+    expect(face(reading, glucoseColored).background).toBe(low);
+    expect(face(noReading, glucoseColored).background).not.toBe(low);
   });
 
   it("renders nothing for tracker parts no data source backs", () => {

--- a/src/Web/packages/app/src/lib/utils/chart-colors.ts
+++ b/src/Web/packages/app/src/lib/utils/chart-colors.ts
@@ -2,7 +2,7 @@
  * Chart color utilities for resolving backend ChartColor enum values to CSS variables
  * ChartColor enum values are kebab-case strings that match CSS custom property names
  */
-import { type ChartColor } from '$lib/api';
+import type { ChartColor } from '$lib/api';
 
 /**
  * Resolve a ChartColor enum value to a CSS variable reference

--- a/src/Web/packages/app/src/lib/utils/chart-colors.ts
+++ b/src/Web/packages/app/src/lib/utils/chart-colors.ts
@@ -2,6 +2,8 @@
  * Chart color utilities for resolving backend ChartColor enum values to CSS variables
  * ChartColor enum values are kebab-case strings that match CSS custom property names
  */
+// Type-only so the generated client is not loaded at runtime; this module is imported by
+// code whose tests run without codegen.
 import type { ChartColor } from '$lib/api';
 
 /**

--- a/src/Web/packages/app/src/routes/(authenticated)/clock/+page.svelte
+++ b/src/Web/packages/app/src/routes/(authenticated)/clock/+page.svelte
@@ -19,7 +19,7 @@
     remove as removeClockFace,
   } from "$api/generated/clockFaces.generated.remote";
   import ClockFacePreview from "$lib/components/clock/ClockFacePreview.svelte";
-  import type { ClockFaceConfig } from "$lib/api";
+  import { createDefaultConfig } from "$lib/clock-builder";
 
   const clockFacesQuery = listClockFaces();
 
@@ -27,67 +27,6 @@
   const deletion = useToastSubmission("Failed to delete clock face");
   let deleteDialogOpen = $state(false);
   let clockFaceToDelete = $state<{ id: string; name: string } | null>(null);
-
-  function createDefaultConfig(): ClockFaceConfig {
-    return {
-      rows: [
-        {
-          elements: [
-            {
-              type: "sg",
-              size: 40,
-              style: {
-                color: "dynamic",
-                font: "system",
-                fontWeight: "medium",
-                opacity: 1.0,
-              },
-            },
-            {
-              type: "arrow",
-              size: 25,
-              style: {
-                color: "dynamic",
-                font: "system",
-                fontWeight: "medium",
-                opacity: 1.0,
-              },
-            },
-          ],
-        },
-        {
-          elements: [
-            {
-              type: "delta",
-              size: 14,
-              showUnits: true,
-              style: {
-                color: "dynamic",
-                font: "system",
-                fontWeight: "medium",
-                opacity: 1.0,
-              },
-            },
-          ],
-        },
-        {
-          elements: [
-            {
-              type: "age",
-              size: 10,
-              style: { font: "system", fontWeight: "medium", opacity: 0.7 },
-            },
-          ],
-        },
-      ],
-      settings: {
-        bgColor: false,
-        staleMinutes: 13,
-        alwaysShowTime: false,
-        backgroundOpacity: 100,
-      },
-    };
-  }
 
   async function handleCreate() {
     creating = true;


### PR DESCRIPTION
Closes #1216.

`getBgColor` resolved each `--glucose-*` variable to a hex through `getComputedStyle` at call time and the face held that hex until the reading next changed. Every theme redefines that palette, so a theme switch left the clock painted in the previous theme's colours, and the resolver ran inside a hot derived. It now returns the `var()` reference and lets the browser resolve it. The issue's other claim, an SSR black flash from the `!browser` fallback, turned out to be unreachable: both callers are null-guarded on the reading and no glucose exists server-side (the realtime store and the public clock store both start in browser-only effects), so that branch was dead for every clock consumer. The first commit's body predates that finding; the corrected rationale is in the fifth.

With the resolver gone `getBgColor` was a literal duplicate of `getGlucoseColor` with its own cut-points (70/80 vs the app's fallbacks 54/70), so the clock and the dashboard coloured the same reading differently. It now delegates to `getGlucoseColor(bg, FALLBACK_GLUCOSE_THRESHOLDS)`. Declared delta: 54–69 mg/dL moves from very-low to low and 70–79 from low to in range on clock faces, matching every other surface. Tenant thresholds reaching the clock is #561.

Three more copies in the same area go with it: the renderer's `buildStyleString`, which differed from the shared one only by a scale factor and a default-size formula (folded, with `scale` as a parameter; an API-written element with no `size` now renders at its type's default like the builder preview instead of a flat 20, since `ClockElement.Size` is nullable and nothing validates it); the clock list page's 62-line verbatim copy of `createDefaultConfig` (its only difference was an omitted `screensaverMode`, a non-nullable bool that deserialises to the same `false`); and the arrow/tracker default sizes hardcoded in the renderer and preview, now read through one `elementSize` helper. `createDefaultConfig` also handed out the module's `DEFAULT_SETTINGS` object by reference; it now copies it.

One incidental fix: `chart-colors.ts` imported `{ type ChartColor }` from `$lib/api`, which esbuild keeps as a bare side-effect import of the generated client. Changing it to `import type` makes it elidable and lets `chart-colors.test.ts` and `glucose-gradient-stops.test.ts` load without codegen, alongside the clock tests.

Non-test code is net -116 lines. Fourteen tests added; each was run against the pre-change code and fails there (band boundaries on both sides of every cut-point, scale reaching the font size, the pinned default size, the copied settings). Run with the generated client present: the clock-builder node suites (23) and the two clock browser suites (11) pass.
