### PR TITLE
fix(api): reject a missing non-nullable query parameter everywhere

### DIFF
--- a/src/API/Nocturne.API/Configuration/QueryValueTypeBindingMetadataProvider.cs
+++ b/src/API/Nocturne.API/Configuration/QueryValueTypeBindingMetadataProvider.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace Nocturne.API.Configuration;
+
+/// <summary>
+/// Makes every <c>[FromQuery]</c> action parameter of a non-nullable value type that declares no
+/// default value mandatory, so omitting it answers 400 instead of running the action.
+/// </summary>
+/// <remarks>
+/// MVC reports a missing query value as "not set" rather than an error, and then falls back to
+/// <c>default</c> for a value type — an omitted <c>DateTime</c> reads as 0001-01-01. A parameter
+/// opts out by being nullable or by declaring a default.
+/// </remarks>
+public sealed class QueryValueTypeBindingMetadataProvider : IBindingMetadataProvider
+{
+    public void CreateBindingMetadata(BindingMetadataProviderContext context)
+    {
+        if (context.Key.MetadataKind != ModelMetadataKind.Parameter
+            || context.Key.ParameterInfo is not { HasDefaultValue: false }
+            || context.BindingMetadata.BindingSource != BindingSource.Query
+            || !context.BindingMetadata.IsBindingAllowed
+            || !context.Key.ModelType.IsValueType
+            || Nullable.GetUnderlyingType(context.Key.ModelType) is not null)
+        {
+            return;
+        }
+
+        context.BindingMetadata.IsBindingRequired = true;
+    }
+}

--- a/src/API/Nocturne.API/Configuration/QueryValueTypeBindingMetadataProvider.cs
+++ b/src/API/Nocturne.API/Configuration/QueryValueTypeBindingMetadataProvider.cs
@@ -1,25 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 
 namespace Nocturne.API.Configuration;
 
 /// <summary>
-/// Makes every <c>[FromQuery]</c> action parameter of a non-nullable value type that declares no
-/// default value mandatory, so omitting it answers 400 instead of running the action.
+/// Makes an action parameter of a non-nullable value type that declares no default value
+/// mandatory, so omitting it answers 400 instead of running the action.
 /// </summary>
 /// <remarks>
-/// MVC reports a missing query value as "not set" rather than an error, and then falls back to
-/// <c>default</c> for a value type — an omitted <c>DateTime</c> reads as 0001-01-01. A parameter
-/// opts out by being nullable or by declaring a default.
+/// MVC reports a missing query value as "not set" rather than an error and then falls back to
+/// <c>default</c> for a value type, so an omitted <c>DateTime</c> reads as 0001-01-01. The
+/// <c>[FromQuery]</c> attribute is load-bearing: binding metadata carries no source for a
+/// parameter whose query binding is inferred, and this leaves those alone.
 /// </remarks>
 public sealed class QueryValueTypeBindingMetadataProvider : IBindingMetadataProvider
 {
     public void CreateBindingMetadata(BindingMetadataProviderContext context)
     {
-        if (context.Key.MetadataKind != ModelMetadataKind.Parameter
-            || context.Key.ParameterInfo is not { HasDefaultValue: false }
+        if (context.Key.ParameterInfo is not { HasDefaultValue: false }
             || context.BindingMetadata.BindingSource != BindingSource.Query
-            || !context.BindingMetadata.IsBindingAllowed
             || !context.Key.ModelType.IsValueType
             || Nullable.GetUnderlyingType(context.Key.ModelType) is not null)
         {
@@ -28,4 +28,15 @@ public sealed class QueryValueTypeBindingMetadataProvider : IBindingMetadataProv
 
         context.BindingMetadata.IsBindingRequired = true;
     }
+}
+
+public static class BindingConventions
+{
+    /// <summary>
+    /// Applies the binding conventions to an MVC host. Both hosts in this assembly need them:
+    /// the one that serves requests, and <c>NSwagStartup</c>, whose generated spec reads its
+    /// <c>required</c> flags off the same binding metadata.
+    /// </summary>
+    public static void AddNocturneBindingConventions(this MvcOptions options) =>
+        options.ModelMetadataDetailsProviders.Add(new QueryValueTypeBindingMetadataProvider());
 }

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/CgmComparisonController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/CgmComparisonController.cs
@@ -58,7 +58,7 @@ public class CgmComparisonController : ControllerBase
         CancellationToken cancellationToken = default)
     {
         if (startDate == default || endDate == default)
-            return BadRequest(new { error = "startDate and endDate are required." });
+            return BadRequest(new { error = "startDate and endDate must be later than 0001-01-01." });
 
         if (endDate <= startDate)
             return BadRequest(new { error = "endDate must be after startDate." });

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/SensorIntegrityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/SensorIntegrityController.cs
@@ -58,8 +58,7 @@ public class SensorIntegrityController : ControllerBase
         [FromQuery] double windowHours = 3.0,
         CancellationToken cancellationToken = default)
     {
-        // Both bounds are required: an omitted DateTime binds to default(DateTime), which would
-        // otherwise scan the tenant's entire history.
+        // A 0001-01-01 bound sent explicitly would scan the tenant's entire history.
         if (startDate == default || endDate == default)
         {
             return BadRequest(new { error = "startDate and endDate are required." });

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/SensorIntegrityController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/SensorIntegrityController.cs
@@ -58,10 +58,9 @@ public class SensorIntegrityController : ControllerBase
         [FromQuery] double windowHours = 3.0,
         CancellationToken cancellationToken = default)
     {
-        // A 0001-01-01 bound sent explicitly would scan the tenant's entire history.
         if (startDate == default || endDate == default)
         {
-            return BadRequest(new { error = "startDate and endDate are required." });
+            return BadRequest(new { error = "startDate and endDate must be later than 0001-01-01." });
         }
 
         if (endDate <= startDate)

--- a/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
+++ b/src/API/Nocturne.API/Controllers/V4/Analytics/StatisticsController.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.RateLimiting;
 using Nocturne.API.Attributes;
 using Nocturne.API.Extensions;
@@ -369,8 +368,8 @@ public class StatisticsController : ControllerBase
     [RemoteQuery]
     [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
     public async Task<ActionResult<ReportAnalysisResult>> GetRangeAnalytics(
-        [FromQuery, BindRequired] DateTime startDate,
-        [FromQuery, BindRequired] DateTime endDate,
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate,
         [FromQuery] DiabetesPopulation population = DiabetesPopulation.Type1Adult,
         [FromQuery] Guid? patientDeviceId = null,
         CancellationToken cancellationToken = default
@@ -459,8 +458,8 @@ public class StatisticsController : ControllerBase
     [RemoteQuery]
     [ResponseCache(Duration = 60, VaryByQueryKeys = new[] { "*" })]
     public async Task<ActionResult<IEnumerable<WeekdayGlucoseSlot>>> GetWeekdayAverages(
-        [FromQuery, BindRequired] DateTime startDate,
-        [FromQuery, BindRequired] DateTime endDate,
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate,
         CancellationToken cancellationToken = default
     )
     {
@@ -915,8 +914,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<DailyBasalBolusRatioResponse>> GetDailyBasalBolusRatios(
-        [FromQuery, BindRequired] DateTime startDate,
-        [FromQuery, BindRequired] DateTime endDate
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate
     )
     {
         var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
@@ -953,8 +952,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.GlucoseRead)]
     [RemoteQuery]
     public async Task<ActionResult<PunchCardResponse>> GetPunchCardData(
-        [FromQuery, BindRequired] DateTime startDate,
-        [FromQuery, BindRequired] DateTime endDate,
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate,
         CancellationToken cancellationToken = default
     )
     {
@@ -1148,8 +1147,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<InsulinDeliveryStatistics>> GetInsulinDeliveryStatistics(
-        [FromQuery, BindRequired] DateTime startDate,
-        [FromQuery, BindRequired] DateTime endDate
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate
     )
     {
         var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
@@ -1193,8 +1192,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<BasalAnalysisResponse>> GetBasalAnalysis(
-        [FromQuery, BindRequired] DateTime startDate,
-        [FromQuery, BindRequired] DateTime endDate
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate
     )
     {
         // Force UTC kind to avoid DateTimeOffset throwing when the server's local
@@ -1240,8 +1239,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<HourlyInsulinDeliveryResponse>> GetHourlyInsulinDelivery(
-        [FromQuery, BindRequired] DateTime startDate,
-        [FromQuery, BindRequired] DateTime endDate
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate
     )
     {
         var startUtc = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);
@@ -1285,8 +1284,8 @@ public class StatisticsController : ControllerBase
     [RequireScope(Scope.ReportsRead)]
     [RemoteQuery]
     public async Task<ActionResult<AidSystemMetrics>> GetAidSystemMetrics(
-        [FromQuery, BindRequired] DateTime startDate,
-        [FromQuery, BindRequired] DateTime endDate
+        [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate
     )
     {
         var startDt = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -160,6 +160,7 @@ builder.Services.AddControllers(options =>
     options.Filters.Add<TenantCacheVaryFilter>();
     options.Filters.Add<RecreationBlockedFilter>();
     options.Filters.AddService<ReadAccessAuditFilter>();
+    options.ModelMetadataDetailsProviders.Add(new QueryValueTypeBindingMetadataProvider());
 })
 .ConfigureApplicationPartManager(manager =>
     AuthorizationConfiguration.ConfigureControllerDiscovery(

--- a/src/API/Nocturne.API/Program.cs
+++ b/src/API/Nocturne.API/Program.cs
@@ -160,7 +160,7 @@ builder.Services.AddControllers(options =>
     options.Filters.Add<TenantCacheVaryFilter>();
     options.Filters.Add<RecreationBlockedFilter>();
     options.Filters.AddService<ReadAccessAuditFilter>();
-    options.ModelMetadataDetailsProviders.Add(new QueryValueTypeBindingMetadataProvider());
+    options.AddNocturneBindingConventions();
 })
 .ConfigureApplicationPartManager(manager =>
     AuthorizationConfiguration.ConfigureControllerDiscovery(
@@ -648,7 +648,7 @@ internal class NSwagStartup
 {
     public void ConfigureServices(IServiceCollection services)
     {
-        services.AddControllers()
+        services.AddControllers(options => options.AddNocturneBindingConventions())
             .AddApplicationPart(typeof(Nocturne.API.Program).Assembly);
 
         services.AddOpenApiDocument(NSwagDocumentConfiguration.Configure);

--- a/tests/Unit/Nocturne.API.Tests/Configuration/QueryValueTypeBindingMetadataProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Configuration/QueryValueTypeBindingMetadataProviderTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
+using Nocturne.API.Controllers.Authentication;
 using Nocturne.API.Controllers.V4.Audit;
 using Nocturne.API.Controllers.V4.Devices;
 using Nocturne.API.Tests.Infrastructure;
@@ -58,8 +59,9 @@ public sealed class QueryValueTypeBindingMetadataProviderTests
     }
 
     /// <summary>
-    /// The two ways a caller is allowed to omit a query-bound value type. Neither may be made
-    /// mandatory: a nullable range filter reads as "no filter", and a defaulted one as its default.
+    /// The ways a caller is allowed to omit a query parameter. None may be made mandatory: a
+    /// nullable range filter reads as "no filter", a defaulted one as its default, and an absent
+    /// reference type as null.
     /// </summary>
     public static TheoryData<Type, string, string> OptionalParameters => new()
     {
@@ -67,6 +69,8 @@ public sealed class QueryValueTypeBindingMetadataProviderTests
         { typeof(ApsSnapshotController), "GetAll", "from" },
         // int with a default.
         { typeof(AuditController), nameof(AuditController.GetMutationAuditLog), "limit" },
+        // string? with no default: the OIDC provider sends it only when the login failed.
+        { typeof(OidcController), nameof(OidcController.Callback), "error" },
     };
 
     [Theory]
@@ -102,22 +106,28 @@ public sealed class QueryValueTypeBindingMetadataProviderTests
         controller.GetMethod(action)!.GetParameters().Single(p => p.Name == name);
 
     /// <summary>
-    /// Every parameter the convention has to cover: declared on a controller GET action, bound
-    /// from the query by an explicit attribute, a non-nullable value type, and with no default.
-    /// Read off each declaring type so a base-class action is visited once.
+    /// Every parameter the convention has to cover, discovered by the same predicate the provider
+    /// applies: declared on a controller action, bound from the query by the first binding-source
+    /// attribute as <see cref="Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.DefaultBindingMetadataProvider"/>
+    /// reads it, a non-nullable value type, and with no default.
     /// </summary>
+    /// <remarks>
+    /// Read off each declaring type so a base-class action is visited once, which for a generic
+    /// base evaluates the open definition's <see cref="ParameterInfo"/> while MVC binds the closed
+    /// one — equivalent for a concrete parameter type, not for one typed by a type argument.
+    /// </remarks>
     private static IEnumerable<ParameterInfo> MandatoryQueryValueTypes() =>
         typeof(Nocturne.API.Program).Assembly
             .GetTypes()
             .Where(t => typeof(ControllerBase).IsAssignableFrom(t))
             .SelectMany(t => t.GetMethods(
                 BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
-            .Where(m => m.GetCustomAttributes<HttpGetAttribute>().Any())
+            .Where(m => !m.IsSpecialName && m.GetCustomAttribute<NonActionAttribute>() is null)
             .SelectMany(m => m.GetParameters())
             .Where(p => !p.HasDefaultValue
                 && p.ParameterType.IsValueType
                 && Nullable.GetUnderlyingType(p.ParameterType) is null
                 && p.GetCustomAttributes()
                     .OfType<IBindingSourceMetadata>()
-                    .Any(a => a.BindingSource == BindingSource.Query));
+                    .FirstOrDefault()?.BindingSource == BindingSource.Query);
 }

--- a/tests/Unit/Nocturne.API.Tests/Configuration/QueryValueTypeBindingMetadataProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Configuration/QueryValueTypeBindingMetadataProviderTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using Nocturne.API.Controllers.V4.Audit;
+using Nocturne.API.Tests.Infrastructure;
+
+namespace Nocturne.API.Tests.Configuration;
+
+/// <summary>
+/// Pins the convention that a <c>[FromQuery]</c> parameter of a non-nullable value type with no
+/// default is mandatory, and that a nullable one or one with a default is not.
+/// </summary>
+/// <remarks>
+/// MVC's own answer to a missing query value is <c>default</c>, so without the convention an
+/// omitted date reads as 0001-01-01 and the action answers 200 over an empty window. The rule is
+/// registered once, so it holds for every action rather than the ones someone remembered to
+/// attribute.
+/// </remarks>
+[Trait("Category", "Unit")]
+public sealed class QueryValueTypeBindingMetadataProviderTests
+    : IClassFixture<AuthenticationTestFactory>
+{
+    private readonly ModelMetadataProvider _metadata;
+    private readonly HttpClient _client;
+
+    public QueryValueTypeBindingMetadataProviderTests(AuthenticationTestFactory factory)
+    {
+        // GetMetadataForParameter lives on the base class, not on the registered interface.
+        _metadata = (ModelMetadataProvider)factory.Services
+            .GetRequiredService<IModelMetadataProvider>();
+        _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add(
+            "api-secret",
+            TestDatabaseSeeder.Sha1Hex(AuthenticationTestFactory.ApiSecret));
+    }
+
+    public static TheoryData<string, bool> Parameters => new()
+    {
+        // Non-nullable, no default: mandatory.
+        { "from", true },
+        { "to", true },
+        // Nullable, and value types carrying a default: the caller may omit them.
+        { "subjectId", false },
+        { "limit", false },
+        { "offset", false },
+    };
+
+    [Theory]
+    [MemberData(nameof(Parameters))]
+    public void QueryParameterOfAValueType_IsMandatoryOnlyWhenItCannotBeOmitted(
+        string name, bool expected)
+    {
+        var parameter = typeof(AuditController)
+            .GetMethod(nameof(AuditController.GetMutationAuditLog))!
+            .GetParameters()
+            .Single(p => p.Name == name);
+
+        _metadata.GetMetadataForParameter(parameter)
+            .IsBindingRequired.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task AGetMissingItsRequiredDate_Answers400NamingTheParameter()
+    {
+        var response = await _client.GetAsync("/api/v4/audit/mutations?to=2026-01-02T00:00:00Z");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        problem!.Errors.Should().ContainKey("from");
+    }
+
+    [Fact]
+    public async Task AGetCarryingBothDates_ReachesTheAction()
+    {
+        var response = await _client.GetAsync(
+            "/api/v4/audit/mutations?from=2026-01-01T00:00:00Z&to=2026-01-02T00:00:00Z");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/Unit/Nocturne.API.Tests/Configuration/QueryValueTypeBindingMetadataProviderTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Configuration/QueryValueTypeBindingMetadataProviderTests.cs
@@ -1,9 +1,11 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
 using Nocturne.API.Controllers.V4.Audit;
+using Nocturne.API.Controllers.V4.Devices;
 using Nocturne.API.Tests.Infrastructure;
 
 namespace Nocturne.API.Tests.Configuration;
@@ -16,7 +18,7 @@ namespace Nocturne.API.Tests.Configuration;
 /// MVC's own answer to a missing query value is <c>default</c>, so without the convention an
 /// omitted date reads as 0001-01-01 and the action answers 200 over an empty window. The rule is
 /// registered once, so it holds for every action rather than the ones someone remembered to
-/// attribute.
+/// attribute — which is what the repo-wide sweep here reads off the real metadata provider.
 /// </remarks>
 [Trait("Category", "Unit")]
 public sealed class QueryValueTypeBindingMetadataProviderTests
@@ -36,29 +38,44 @@ public sealed class QueryValueTypeBindingMetadataProviderTests
             TestDatabaseSeeder.Sha1Hex(AuthenticationTestFactory.ApiSecret));
     }
 
-    public static TheoryData<string, bool> Parameters => new()
+    [Fact]
+    public void EveryMandatoryQueryValueTypeAcrossTheApi_IsBindingRequired()
     {
-        // Non-nullable, no default: mandatory.
-        { "from", true },
-        { "to", true },
-        // Nullable, and value types carrying a default: the caller may omit them.
-        { "subjectId", false },
-        { "limit", false },
-        { "offset", false },
+        var parameters = MandatoryQueryValueTypes().ToList();
+
+        // A sweep that discovers nothing would pass while guarding nothing.
+        parameters.Should().HaveCountGreaterThan(30,
+            "the scan should discover the query-bound value types across the controllers");
+
+        var unguarded = parameters
+            .Where(p => !_metadata.GetMetadataForParameter(p).IsBindingRequired)
+            .Select(p => $"{p.Member.DeclaringType!.Name}.{p.Member.Name}.{p.Name}")
+            .ToList();
+
+        unguarded.Should().BeEmpty(
+            "an omitted value would bind to default and run the action over a meaningless window "
+            + "or id instead of answering 400. Unguarded: " + string.Join(", ", unguarded));
+    }
+
+    /// <summary>
+    /// The two ways a caller is allowed to omit a query-bound value type. Neither may be made
+    /// mandatory: a nullable range filter reads as "no filter", and a defaulted one as its default.
+    /// </summary>
+    public static TheoryData<Type, string, string> OptionalParameters => new()
+    {
+        // DateTime? with no default: the range filter every V4 list inherits.
+        { typeof(ApsSnapshotController), "GetAll", "from" },
+        // int with a default.
+        { typeof(AuditController), nameof(AuditController.GetMutationAuditLog), "limit" },
     };
 
     [Theory]
-    [MemberData(nameof(Parameters))]
-    public void QueryParameterOfAValueType_IsMandatoryOnlyWhenItCannotBeOmitted(
-        string name, bool expected)
+    [MemberData(nameof(OptionalParameters))]
+    public void AnOmittableQueryParameter_IsNotBindingRequired(
+        Type controller, string action, string name)
     {
-        var parameter = typeof(AuditController)
-            .GetMethod(nameof(AuditController.GetMutationAuditLog))!
-            .GetParameters()
-            .Single(p => p.Name == name);
-
-        _metadata.GetMetadataForParameter(parameter)
-            .IsBindingRequired.Should().Be(expected);
+        _metadata.GetMetadataForParameter(ParameterOf(controller, action, name))
+            .IsBindingRequired.Should().BeFalse();
     }
 
     [Fact]
@@ -80,4 +97,27 @@ public sealed class QueryValueTypeBindingMetadataProviderTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
+
+    private static ParameterInfo ParameterOf(Type controller, string action, string name) =>
+        controller.GetMethod(action)!.GetParameters().Single(p => p.Name == name);
+
+    /// <summary>
+    /// Every parameter the convention has to cover: declared on a controller GET action, bound
+    /// from the query by an explicit attribute, a non-nullable value type, and with no default.
+    /// Read off each declaring type so a base-class action is visited once.
+    /// </summary>
+    private static IEnumerable<ParameterInfo> MandatoryQueryValueTypes() =>
+        typeof(Nocturne.API.Program).Assembly
+            .GetTypes()
+            .Where(t => typeof(ControllerBase).IsAssignableFrom(t))
+            .SelectMany(t => t.GetMethods(
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            .Where(m => m.GetCustomAttributes<HttpGetAttribute>().Any())
+            .SelectMany(m => m.GetParameters())
+            .Where(p => !p.HasDefaultValue
+                && p.ParameterType.IsValueType
+                && Nullable.GetUnderlyingType(p.ParameterType) is null
+                && p.GetCustomAttributes()
+                    .OfType<IBindingSourceMetadata>()
+                    .Any(a => a.BindingSource == BindingSource.Query));
 }

--- a/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
+++ b/tests/Unit/Nocturne.API.Tests/Controllers/V4/Analytics/StatisticsComputeLimitTests.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.RateLimiting;
 using Nocturne.API.Controllers.V4.Analytics;
 using Nocturne.API.Extensions;
@@ -88,34 +87,6 @@ public class StatisticsComputeLimitTests
         perAction.Should().BeEmpty(
             "an action-level copy overrides the controller's and lets the two drift. Copies on: "
             + string.Join(", ", perAction));
-    }
-
-    /// <summary>
-    /// MVC does not reject a <em>missing</em> non-nullable value-type query parameter: it binds
-    /// <c>default</c> and runs the action, so an omitted date silently becomes 0001-01-01 and the
-    /// endpoint answers 200 with an empty report. <c>[BindRequired]</c> is what produces the 400.
-    /// </summary>
-    [Fact]
-    public void EveryRequiredDateOnAGetAction_IsBindRequired()
-    {
-        var dateParams = typeof(StatisticsController)
-            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-            .Where(m => m.GetCustomAttributes<HttpGetAttribute>().Any())
-            .SelectMany(m => m.GetParameters().Select(p => (Action: m.Name, Parameter: p)))
-            .Where(x => x.Parameter.ParameterType == typeof(DateTime))
-            .ToList();
-
-        dateParams.Should().HaveCountGreaterThan(10,
-            "the scan should discover the date-range GETs; zero discoveries would pass while guarding nothing");
-
-        var unguarded = dateParams
-            .Where(x => x.Parameter.GetCustomAttribute<BindRequiredAttribute>() is null)
-            .Select(x => $"{x.Action}.{x.Parameter.Name}")
-            .ToList();
-
-        unguarded.Should().BeEmpty(
-            "an omitted date would bind to DateTime.MinValue and answer 200 over an empty window "
-            + "instead of 400. Unguarded: " + string.Join(", ", unguarded));
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #1206.

MVC binds a missing non-nullable value-type query parameter to `default` and runs the action, so five GET actions (both audit logs, sleep trends, sensor integrity, CGM comparison) answered 200 over the window 0001-01-01..0001-01-01 when a caller dropped a date. `StatisticsController` guarded its own sixteen date parameters with `[BindRequired]` and a reflection test scoped to that one class.

The rule now lives once: `QueryValueTypeBindingMetadataProvider` marks every explicitly `[FromQuery]`-bound non-nullable value-type parameter with no default as binding-required, so omitting it produces the same `ValidationProblemDetails` 400 that `[BindRequired]` did. Nullable parameters, defaulted parameters and reference types are untouched; the attribute is load-bearing, since inferred query binding leaves no source on the metadata. The sixteen attributes and the class-scoped test are deleted.

The spec generator has its own `AddControllers()` in `NSwagStartup`, so registering the provider only in the app host would have dropped `required` from all these parameters in the generated client, zod schemas and SDKs while the runtime enforced them. Both hosts now call one `AddNocturneBindingConventions` helper; the emitted `openapi.json` carries exactly 38 `required: true` query parameters, matching the source scan, and the generated client's "must be defined" guard is back.

Tests: a repo-wide sweep through the app's real `IModelMetadataProvider` asserts `IsBindingRequired` on every qualifying parameter (38 found, floor of 30 so a vacuous scan cannot pass) with the same predicate the provider uses; opt-out rows for a nullable-no-default `DateTime?`, a defaulted `int`, and a reference-type `string?` on the OIDC callback; and an end-to-end audit GET that answers 400 without its date and 200 with it. Each clause of the provider's predicate now has a test that fails when it is removed, as does the registration itself. 6669 API tests pass.

The two `== default` guards in sensor integrity and CGM comparison stay, because an explicitly sent `0001-01-01` still reaches them; their message now says that.

Follow-ups filed: #1254 (V4 analytics refusals are anonymous `{ error }` bodies the web never shows, and three windows have no range cap) and ryceg/openapi-remote-codegen#7 (the generated params object is wrapped in `.optional()` even when a field is required, which this change exposed).
