### PR TITLE
fix(dedup): let two sources' temp basal durations disagree by 10s

### DIFF
--- a/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
+++ b/src/Infrastructure/Nocturne.Infrastructure.Data/Services/DeduplicationService.cs
@@ -59,6 +59,18 @@ public class DeduplicationService : IDeduplicationService
     private const double ExactValueEpsilon = 1e-6;
 
     /// <summary>
+    /// How far two sources' temp basal durations may disagree and still describe one delivery.
+    /// Unlike a value, a duration is a measurement each source rounds for itself: mylife reports
+    /// the pump's raw clock quantised to ten seconds while Glooko re-anchors and reports to the
+    /// second, so the same eleven-minute temp basal arrives as 650s from one and 654s from the
+    /// other. Demanding equality refused those outright — on one two-connector tenant that was
+    /// ~2800 unmerged pairs in thirty days against 125 merged, nearly every temp basal doubled.
+    /// Ten seconds covers the quantisation without reaching a neighbouring delivery, which on that
+    /// tenant still leaves the pairs disagreeing by a minute or more refused.
+    /// </summary>
+    private static readonly TimeSpan ExactDurationTolerance = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// Record types eligible for <see cref="WideMatchingWindow"/>. Continuous streams
     /// (<see cref="RecordType.SensorGlucose"/>), free-text records (<see cref="RecordType.Note"/>)
     /// and interval records (<see cref="RecordType.StateSpan"/>) are excluded: repeating the same
@@ -1244,6 +1256,14 @@ public class DeduplicationService : IDeduplicationService
     /// the public surface and would otherwise be an untestable defence.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// True when two temp basal durations describe one delivery. Both must be known: an open-ended
+    /// temp basal carries no duration, and admitting a null would reduce the wide comparison to
+    /// rate alone, which for a stream that repeats the same rate all day is no evidence at all.
+    /// </summary>
+    private static bool DurationsAgree(TimeSpan? a, TimeSpan? b) =>
+        a.HasValue && b.HasValue && (a.Value - b.Value).Duration() <= ExactDurationTolerance;
+
     internal static bool CriteriaMatch(RecordType recordType, MatchCriteria a, MatchCriteria b, bool exact = false)
     {
         if (exact && !WideMatchableTypes.Contains(recordType))
@@ -1255,10 +1275,10 @@ public class DeduplicationService : IDeduplicationService
         return recordType switch
         {
             // An open-ended temp basal carries no duration, and null == null would quietly reduce
-            // the exact comparison to rate alone; both intervals must be known and equal.
+            // the exact comparison to rate alone; both intervals must be known.
             RecordType.TempBasal => a.Rate.HasValue && b.Rate.HasValue
                 && Math.Abs(a.Rate.Value - b.Rate.Value) <= Tolerance(a.RateTolerance, b.RateTolerance)
-                && (!exact || (a.Duration.HasValue && a.Duration == b.Duration)),
+                && (!exact || DurationsAgree(a.Duration, b.Duration)),
             RecordType.SensorGlucose or RecordType.BGCheck => a.GlucoseValue.HasValue && b.GlucoseValue.HasValue
                 && Math.Abs(a.GlucoseValue.Value - b.GlucoseValue.Value) <= Tolerance(a.GlucoseTolerance, b.GlucoseTolerance),
             RecordType.Bolus => a.Insulin.HasValue && b.Insulin.HasValue

--- a/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationServiceTests.cs
+++ b/tests/Unit/Nocturne.Infrastructure.Data.Tests/Services/DeduplicationServiceTests.cs
@@ -1347,6 +1347,60 @@ public class DeduplicationServiceTests : IDisposable
             2, "a soft-deleted note is not a candidate for a live one to join");
     }
 
+    /// <summary>
+    /// A duration is a measurement each source rounds for itself, not a value both report the same
+    /// way: mylife quantises the pump clock to ten seconds while Glooko reports to the second, so
+    /// the same delivery arrives as 650s and 654s. Demanding equality refused nearly every
+    /// cross-source temp basal on a two-connector tenant.
+    /// </summary>
+    [Theory]
+    [InlineData(650, 654, true)]
+    [InlineData(650, 660, true)]
+    [InlineData(650, 650, true)]
+    [InlineData(650, 661, false)]
+    [InlineData(650, 710, false)]
+    [InlineData(1, 650, false)]
+    public void CriteriaMatch_TempBasal_ExactMode_AllowsDurationsToDisagreeByUpToTenSeconds(
+        int aSeconds, int bSeconds, bool expected)
+    {
+        var a = TempBasalCriteria(TimeSpan.FromSeconds(aSeconds));
+        var b = TempBasalCriteria(TimeSpan.FromSeconds(bSeconds));
+
+        DeduplicationService.CriteriaMatch(RecordType.TempBasal, a, b, exact: true).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// An open-ended temp basal carries no duration. Admitting one would reduce the wide comparison
+    /// to rate alone, and a stream that holds the same rate all day makes that no evidence at all.
+    /// </summary>
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void CriteriaMatch_TempBasal_ExactMode_RefusesAnOpenEndedDuration(bool aKnown, bool bKnown)
+    {
+        var a = TempBasalCriteria(aKnown ? TimeSpan.FromSeconds(650) : null);
+        var b = TempBasalCriteria(bKnown ? TimeSpan.FromSeconds(650) : null);
+
+        DeduplicationService.CriteriaMatch(RecordType.TempBasal, a, b, exact: true).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The tolerance is the wide path's alone. The tight path never compared duration, and reaching
+    /// only thirty seconds it does not need to.
+    /// </summary>
+    [Fact]
+    public void CriteriaMatch_TempBasal_ExactMode_StillRefusesADifferentRate()
+    {
+        var a = TempBasalCriteria(TimeSpan.FromSeconds(650), rate: 0.8);
+        var b = TempBasalCriteria(TimeSpan.FromSeconds(654), rate: 1.2);
+
+        DeduplicationService.CriteriaMatch(RecordType.TempBasal, a, b, exact: true).Should().BeFalse();
+    }
+
+    private static MatchCriteria TempBasalCriteria(TimeSpan? duration, double rate = 0.8) =>
+        new() { Rate = rate, Duration = duration };
+
     [Fact]
     public void CriteriaMatch_DeviceEvent_RefusesWhenTheEventTypeIsAbsent()
     {


### PR DESCRIPTION
Cross-source deduplication compares temp basal durations for **exact equality**, while every value field gets a tolerance. A duration is not a value both sources report the same way: mylife reports the pump's raw clock quantised to ten seconds, Glooko re-anchors and reports to the second. The same eleven-minute temp basal arrives as `650s` from one and `654s` from the other, and the pair is refused.

The effect is that nearly every temp basal on a two-connector account is shown twice.

## Evidence

Measured on a live two-connector account (glooko + mylife) over thirty days. Cross-source pairs with an equal rate, offset by 60–120s:

| | pairs |
|---|---|
| merged | 125 |
| **not merged** | **~2800** |

Duration disagreement across the unmerged pairs:

| duration gap | pairs |
|---|---|
| within 10s | 2163 |
| 10–30s | 84 |
| 30–60s | 4 |
| over 60s | 192 |

Worth stating plainly, because it was the obvious suspect and it is wrong: **the 1–2 minute clock offset is not the blocker.** Boluses (335 pairs) and carb intakes (301 pairs) merge happily at that same offset — the wide path already reaches ten minutes. Only temp basals fail, and only on the duration comparison.

## The change

One clause, plus a named constant carrying the reasoning:

```csharp
&& (!exact || DurationsAgree(a.Duration, b.Duration)),
```

Ten seconds covers the quantisation without reaching a neighbouring delivery. Everything that makes a wide match safe is untouched — exact rate equality, the different-source requirement, and the single-candidate guard all still apply.

Deliberately still refused:

- Pairs disagreeing by a minute or more, including the 192 above and the 41 where one source reports a `1s` duration against the other's `650s`. Those are a different kind of record, not clock drift.
- An **open-ended** temp basal, which carries no duration at all. Admitting one would reduce the comparison to rate alone, and a stream that holds the same rate for hours makes that no evidence. Separately, mylife omits the end time on 28.4% of its temp basals where Glooko never does — that is a connector gap worth its own issue, not a reason to loosen the matcher.

## Tests

10 new cases pinning the boundary either side of ten seconds, the `1s` vs `650s` case staying refused, open-ended durations staying refused, and a differing rate staying refused. 973/973 pass in `Nocturne.Infrastructure.Data.Tests`.

Mutation-checked rather than taken on green: widening the tolerance to 120s fails 2 of the new tests, and reverting to exact equality fails 2.

## After merge

This governs records as they are written and reconciled. Existing doubled temp basals need one **Run Deduplication** pass (Settings → Connectors & Apps) to collapse retroactively.
