### PR TITLE
fix(web): stop the date picker breaking hydration on /meals and /time-spans

### DIFF
--- a/src/Web/packages/app/src/lib/components/ui/date-range-picker.svelte
+++ b/src/Web/packages/app/src/lib/components/ui/date-range-picker.svelte
@@ -7,7 +7,7 @@
   import { RangeCalendar } from "$lib/components/ui/range-calendar";
   import { formatLocale } from "$lib/utils/formatting";
   import * as Popover from "$lib/components/ui/popover/index.js";
-  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
+  import { ChevronDown as ChevronDownIcon } from "lucide-svelte";
 
   interface Props {
     showDaysPresets?: boolean;


### PR DESCRIPTION
`/meals` and `/time-spans` — the only two pages using `DateRangePicker` — do not render under `vite dev`. The layout's error boundary catches a hydration failure and shows **"Something went wrong"**, permanently. Both are fine in a production build, which is why this has only ever bitten developers, and the screenshot capture, which photographs the dev server.

## What it is

The chevron in the popover trigger:

```svelte
import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
```

It is the only icon in the app imported from `@lucide/svelte` **and** rendered inside a bits-ui `child` snippet. Under `vite dev` that combination produces different markup on the server and the client, so Svelte throws its hydration sentinel and the route dies.

Bisected down to the single element, each step against a seeded tenant:

| change | result |
|---|---|
| remove `MealsTable` | still broken |
| remove `MealsFilterBar` | **fixed** → it is the filter bar |
| remove `DateRangePicker` | **fixed** |
| remove the presets row | still broken |
| remove `Popover.Content` / `RangeCalendar` | still broken |
| replace the label expression with a static string | still broken |
| remove `<ChevronDownIcon />` | **fixed** → it is the icon |
| import the same icon from `lucide-svelte` | **fixed** |

The same package rendered as a plain child in `sidebar-trigger.svelte` never mismatches, so this is the icon *in this position*, not the package everywhere.

## The change

One import. 298 files already use `lucide-svelte`; this makes it 299.

Verified against a seeded tenant: `/meals` and `/time-spans` hydrate clean, and `/`, `/food`, `/reports/treatments`, `/settings`, `/alerts` and `/clock` stay clean.

## Two things worth separate issues

**1. The app carries two lucide packages.** `@lucide/svelte` 1.14.0 (4 files) alongside `lucide-svelte` 1.0.1 (298). Consolidating is the obvious cleanup, but the direction is a real decision — `@lucide/svelte` is the newer scoped name — so it wants deciding rather than assuming, and is left out of this fix.

**2. The authenticated layout's error boundary turns a recoverable mismatch into a dead page.** Svelte's `hydrate()` catches its own hydration sentinel and silently re-mounts client-side; a `<svelte:boundary>` with a `failed` snippet intercepts it first and renders the fallback instead. Removing the boundary makes this exact mismatch self-heal — verified: the mismatch still fires, the page renders correctly.

That means **any** hydration mismatch anywhere under that boundary, in any environment, becomes a permanent error card rather than a re-render. This PR removes one such mismatch; it does not address the amplifier.
